### PR TITLE
refacto: setup slack connection when sending notification

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
-import { useSetupSlackNotifications, useUserMetadata } from "@app/lib/swr/user";
+import { useSlackNotifications, useUserMetadata } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { setUserMetadataFromClient } from "@app/lib/user";
 import type {
@@ -82,14 +82,12 @@ export const NotificationPreferences = forwardRef<
     "conversations_slack_notifications"
   );
 
-  const {
-    isSlackSetup,
-    isSlackSetupLoading,
-    isConfiguringSlack,
-    setupSlackNotifications,
-  } = useSetupSlackNotifications(owner.sId, {
-    disabled: !hasSlackNotificationsFeature,
-  });
+  const { isSlackSetupLoading, canConfigureSlack } = useSlackNotifications(
+    owner.sId,
+    {
+      disabled: !hasSlackNotificationsFeature,
+    }
+  );
 
   // Novu workflow-specific channel preferences for conversation-unread
   const [conversationPreferences, setConversationPreferences] = useState<
@@ -474,8 +472,14 @@ export const NotificationPreferences = forwardRef<
     channel: keyof ChannelPreference,
     enabled: boolean
   ) => {
-    if (channel === "chat" && enabled && !isSlackSetup) {
-      await setupSlackNotifications();
+    if (channel === "chat" && enabled && !canConfigureSlack) {
+      sendNotification({
+        type: "error",
+        title: "Slack Bot Not Configured",
+        description:
+          "Configure the Slack Bot integration to enable Slack notifications.",
+      });
+      return;
     }
     setConversationPreferences((prev) => {
       if (!prev) {
@@ -491,8 +495,14 @@ export const NotificationPreferences = forwardRef<
     channel: keyof ChannelPreference,
     enabled: boolean
   ) => {
-    if (channel === "chat" && enabled && !isSlackSetup) {
-      await setupSlackNotifications();
+    if (channel === "chat" && enabled && !canConfigureSlack) {
+      sendNotification({
+        type: "error",
+        title: "Slack Bot Not Configured",
+        description:
+          "Configure the Slack Bot integration to enable Slack notifications.",
+      });
+      return;
     }
     setProjectPreferences((prev) => {
       if (!prev) {
@@ -508,8 +518,14 @@ export const NotificationPreferences = forwardRef<
     channel: keyof ChannelPreference,
     enabled: boolean
   ) => {
-    if (channel === "chat" && enabled && !isSlackSetup) {
-      await setupSlackNotifications();
+    if (channel === "chat" && enabled && !canConfigureSlack) {
+      sendNotification({
+        type: "error",
+        title: "Slack Bot Not Configured",
+        description:
+          "Configure the Slack Bot integration to enable Slack notifications.",
+      });
+      return;
     }
     setProjectNewConversationPreferences((prev) => {
       if (!prev) {
@@ -521,7 +537,7 @@ export const NotificationPreferences = forwardRef<
     });
   };
 
-  if (isLoadingPreferences || isSlackSetupLoading || isConfiguringSlack) {
+  if (isLoadingPreferences || isSlackSetupLoading) {
     return <Spinner />;
   }
 
@@ -536,7 +552,7 @@ export const NotificationPreferences = forwardRef<
   const isConversationInAppEnabled =
     conversationPreferences.channels.in_app && conversationPreferences.enabled;
   const isConversationSlackEnabled =
-    isSlackSetup &&
+    canConfigureSlack &&
     conversationPreferences.channels.chat &&
     conversationPreferences.enabled;
   const isConversationEmailEnabled =
@@ -545,7 +561,7 @@ export const NotificationPreferences = forwardRef<
   const isProjectInAppEnabled =
     projectPreferences?.channels.in_app && projectPreferences?.enabled;
   const isProjectSlackEnabled =
-    isSlackSetup &&
+    canConfigureSlack &&
     projectPreferences?.channels.chat &&
     projectPreferences?.enabled;
   const isProjectEmailEnabled =
@@ -555,7 +571,7 @@ export const NotificationPreferences = forwardRef<
     projectNewConversationPreferences?.channels.in_app &&
     projectNewConversationPreferences?.enabled;
   const isProjectNewConversationSlackEnabled =
-    isSlackSetup &&
+    canConfigureSlack &&
     projectNewConversationPreferences?.channels.chat &&
     projectNewConversationPreferences?.enabled;
   const isProjectNewConversationEmailEnabled =

--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -1,3 +1,5 @@
+import logger from "@app/logger/logger";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type {
   NotificationPreferencesDelay,
   WorkflowTriggerId,
@@ -7,13 +9,18 @@ import {
   isNotificationPreferencesDelay,
   makeNotificationPreferencesUserMetadata,
 } from "@app/types/notification_preferences";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { Novu } from "@novu/api";
 import type { ChannelPreference } from "@novu/react";
+import { WebClient } from "@slack/web-api";
 import { createHmac } from "crypto";
 import { Op } from "sequelize";
-
+import config from "../api/config";
 import { Authenticator, getFeatureFlags } from "../auth";
+import { DustError } from "../error";
+import { DataSourceResource } from "../resources/data_source_resource";
 import { UserMetadataModel } from "../resources/storage/models/user";
 
 export type NotificationAllowedTags = Array<"conversations" | "admin">;
@@ -111,7 +118,7 @@ const isSlackNotificationsFeatureEnabled = async (
   return featureFlags.includes("conversations_slack_notifications");
 };
 
-export const isSlackChannelConfigured = async (
+const isSlackChannelConfigured = async (
   subscriberId: string
 ): Promise<boolean> => {
   const novu = await getNovuClient();
@@ -145,25 +152,167 @@ export const isSlackChannelConfigured = async (
   return true;
 };
 
-export const areSlackNotificationsEnabledAndConfigured = async (
+const getSlackToken = async (
+  auth: Authenticator
+): Promise<
+  Result<string, DustError<"connection_not_found" | "internal_error">>
+> => {
+  const slackBotConnections = await DataSourceResource.listByConnectorProvider(
+    auth,
+    "slack_bot"
+  );
+
+  if (slackBotConnections.length === 0) {
+    return new Err(
+      new DustError(
+        "connection_not_found",
+        "Slack Bot is not configured for this workspace."
+      )
+    );
+  }
+
+  const slackConnection = slackBotConnections[0];
+
+  if (!slackConnection.connectorId) {
+    return new Err(
+      new DustError(
+        "connection_not_found",
+        "Slack Bot is not configured for this workspace."
+      )
+    );
+  }
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const connectorRes = await connectorsAPI.getConnector(
+    slackConnection.connectorId
+  );
+
+  if (connectorRes.isErr()) {
+    return new Err(
+      new DustError("connection_not_found", connectorRes.error.message)
+    );
+  }
+
+  const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+  const tokenResult = await oauthApi.getAccessToken({
+    connectionId: connectorRes.value.connectionId,
+  });
+
+  if (tokenResult.isErr()) {
+    return new Err(new DustError("internal_error", tokenResult.error.message));
+  }
+
+  return new Ok(tokenResult.value.access_token);
+};
+
+const configureSlackChannelForUser = async (
+  subscriberId: string | undefined,
+  workspaceId: string
+): Promise<{
+  success: boolean;
+}> => {
+  if (!subscriberId) {
+    return { success: false };
+  }
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    workspaceId
+  );
+  const accessToken = await getSlackToken(auth);
+
+  if (accessToken.isErr()) {
+    return {
+      success: false,
+    };
+  }
+
+  const slackClient = new WebClient(accessToken.value);
+
+  const slackUser = await slackClient.users.lookupByEmail({
+    email: auth.getNonNullableUser().email,
+  });
+
+  if (!slackUser.user?.id) {
+    return {
+      success: false,
+    };
+  }
+
+  const slackWorkspace = await slackClient.team.info();
+
+  if (!slackWorkspace.team?.id) {
+    return {
+      success: false,
+    };
+  }
+
+  const novu = await getNovuClient();
+  const connectionIdentifier = getSlackConnectionIdentifier(subscriberId);
+
+  await novu.channelConnections.create({
+    subscriberId,
+    identifier: connectionIdentifier,
+    integrationIdentifier: "slack",
+    auth: {
+      accessToken: accessToken.value,
+    },
+    workspace: {
+      id: slackWorkspace.team.id,
+      name: slackWorkspace.team?.name,
+    },
+  });
+
+  await novu.channelEndpoints.create({
+    subscriberId,
+    type: "slack_user",
+    integrationIdentifier: "slack",
+    connectionIdentifier,
+    endpoint: {
+      userId: slackUser.user.id,
+    },
+  });
+
+  return {
+    success: true,
+  };
+};
+
+export const ensureSlackNotificationsReady = async (
   subscriberId?: string,
   workspaceId?: string
-): Promise<boolean> => {
+): Promise<{
+  isReady: boolean;
+}> => {
   if (!subscriberId || !workspaceId) {
-    return false;
+    return { isReady: false };
   }
+
   const isFeatureEnabled = await isSlackNotificationsFeatureEnabled(
     subscriberId,
     workspaceId
   );
+
   if (!isFeatureEnabled) {
-    return false;
+    return { isReady: false };
   }
 
   const isChannelConfigured = await isSlackChannelConfigured(subscriberId);
-  if (!isChannelConfigured) {
-    return false;
-  }
 
-  return true;
+  // If the slack channel is not configured, we attempt to configure it automatically.
+  // This will fail if the Dust Slack Bot is not configured for the workspace.
+  if (!isChannelConfigured) {
+    const { success } = await configureSlackChannelForUser(
+      subscriberId,
+      workspaceId
+    );
+    if (!success) {
+      return { isReady: false };
+    }
+  }
+  return { isReady: true };
 };

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -12,7 +12,7 @@ import {
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
 import {
-  areSlackNotificationsEnabledAndConfigured,
+  ensureSlackNotificationsReady,
   getNovuClient,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
@@ -679,12 +679,11 @@ export const conversationUnreadWorkflow = workflow(
           if (!details) {
             return true;
           }
-          const isSlackEnabledAndConfigured =
-            await areSlackNotificationsEnabledAndConfigured(
-              subscriber.subscriberId,
-              payload.workspaceId
-            );
-          if (!isSlackEnabledAndConfigured) {
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
             return true;
           }
           return shouldSkipConversation({

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -3,7 +3,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
 import {
-  areSlackNotificationsEnabledAndConfigured,
+  ensureSlackNotificationsReady,
   getNovuClient,
 } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
@@ -155,12 +155,11 @@ export const projectAddedAsMemberWorkflow = workflow(
       },
       {
         skip: async () => {
-          const isSlackEnabledAndConfigured =
-            await areSlackNotificationsEnabledAndConfigured(
-              subscriber.subscriberId,
-              payload.workspaceId
-            );
-          if (!isSlackEnabledAndConfigured) {
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
             return true;
           }
           return shouldSkipProject({ payload });

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -8,7 +8,7 @@ import {
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
 import {
-  areSlackNotificationsEnabledAndConfigured,
+  ensureSlackNotificationsReady,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -345,12 +345,11 @@ export const projectNewConversationWorkflow = workflow(
           if (!details) {
             return true;
           }
-          const isSlackEnabledAndConfigured =
-            await areSlackNotificationsEnabledAndConfigured(
-              subscriber.subscriberId,
-              payload.workspaceId
-            );
-          if (!isSlackEnabledAndConfigured) {
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
             return true;
           }
           return shouldSkipConversation({

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -1,42 +1,17 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  getNovuClient,
-  getSlackConnectionIdentifier,
-  isSlackChannelConfigured,
-} from "@app/lib/notifications";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { OAuthAPI } from "@app/types/oauth/oauth_api";
-import { WebClient } from "@slack/web-api";
-import assert from "assert";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PostSlackNotificationResponseBody = {
-  oauthUrl: string;
-};
-
-export type PatchSlackNotificationResponseBody = {
-  success: boolean;
-};
-
 export type GetSlackNotificationResponseBody = {
-  isConfigured: boolean;
+  canConfigure: boolean;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<
-      | GetSlackNotificationResponseBody
-      | PostSlackNotificationResponseBody
-      | PatchSlackNotificationResponseBody
-    >
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<GetSlackNotificationResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
   const userResource = auth.user();
@@ -52,134 +27,11 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const isConfigured = await isSlackChannelConfigured(userResource.sId);
-
-      return res.status(200).json({
-        isConfigured,
-      });
-    }
-    case "POST": {
       const slackBotConnections =
         await DataSourceResource.listByConnectorProvider(auth, "slack_bot");
 
-      if (slackBotConnections.length === 0) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "data_source_not_found",
-            message: "Slack Bot is not configured for this workspace.",
-          },
-        });
-      }
-      const novu = await getNovuClient();
-
-      const oauthUrlRes = await novu.integrations.generateChatOAuthUrl({
-        integrationIdentifier: "slack",
-        connectionIdentifier: getSlackConnectionIdentifier(userResource.sId),
-        subscriberId: userResource.sId,
-      });
-      return res.status(200).json({ oauthUrl: oauthUrlRes.result.url });
-    }
-    case "PATCH": {
-      // We want to setup a novu slack channel endpoint for the user,
-      // so that he can receive notifications as private messages in Slack.
-      // To do so, we need to find the user's slack id. We are reusing the
-      // Dust Slack Bot app to send notifications, so we get its token
-      // to be able to call the Slack API and find the user's slack id by his email.
-      const novu = await getNovuClient();
-      const slackBotConnections =
-        await DataSourceResource.listByConnectorProvider(auth, "slack_bot");
-
-      if (slackBotConnections.length === 0) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "data_source_not_found",
-            message: "Slack Bot is not configured for this workspace.",
-          },
-        });
-      }
-
-      assert(
-        slackBotConnections.length === 1,
-        "There should be exactly one Slack bot connection for the workspace."
-      );
-
-      const slackConnection = slackBotConnections[0];
-
-      if (!slackConnection.connectorId) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "connector_not_found_error",
-            message: "Invalid Slack connection configuration.",
-          },
-        });
-      }
-
-      const connectorsAPI = new ConnectorsAPI(
-        config.getConnectorsAPIConfig(),
-        logger
-      );
-
-      const connectorRes = await connectorsAPI.getConnector(
-        slackConnection.connectorId
-      );
-
-      if (connectorRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "connector_not_found_error",
-            message: "Invalid Slack connection configuration.",
-          },
-        });
-      }
-
-      const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-
-      const tokenResult = await oauthApi.getAccessToken({
-        connectionId: connectorRes.value.connectionId,
-      });
-
-      if (tokenResult.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to get Slack token.",
-          },
-        });
-      }
-
-      const slackClient = new WebClient(tokenResult.value.access_token);
-      const userResult = await slackClient.users.lookupByEmail({
-        email: userResource.email,
-      });
-
-      if (!userResult.user?.id) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "user_not_found",
-            message:
-              "No Slack user found with the email of the authenticated user.",
-          },
-        });
-      }
-
-      await novu.channelEndpoints.create({
-        subscriberId: userResource.sId,
-        integrationIdentifier: "slack",
-        connectionIdentifier: getSlackConnectionIdentifier(userResource.sId),
-        type: "slack_user",
-        endpoint: {
-          userId: userResult.user.id,
-        },
-      });
-
       return res.status(200).json({
-        success: true,
+        canConfigure: slackBotConnections.length > 0,
       });
     }
 
@@ -188,8 +40,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, GET, POST or PATCH is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }


### PR DESCRIPTION





## Description

This PR refactors Slack notification setup to automatically configure the connection when sending notifications instead of requiring manual user configuration through an OAuth flow.

- Removed the manual OAuth-based setup flow for Slack notifications
- Introduced automatic Slack channel configuration via `configureSlackChannelForUser` that sets up the connection (if needed and possible) when notifications are sent
- The Slack notifications can be configured if the Dust Slack App is already configured for the workspace.


Note that with this change, **slack notifications will be enabled by default** for users that belong to at least one workspace with the Slack Bot enabled.

For the moment there is no mechanism to reconfigure the slack notifications when the slack token is invalidated.

## Tests

Manually

## Risks
Low. This feature is hidden behind feature flag.

## Deploy Plan

Standard deployment.
