### PR TITLE
Fix landing page mobile spacing, shared testimonials, and UTM tracking

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -188,7 +188,7 @@ export default function LandingLayout({
           className={classNames(
             "flex w-full flex-col",
             fullWidth ? "" : "container",
-            "gap-24 px-6 pb-12",
+            "gap-6 px-6 pb-12 md:gap-24",
             hideNavigation ? "pt-6" : "pt-24",
             "xl:gap-16",
             "2xl:gap-24"

--- a/front/components/home/content/Competitive/ComparisonTableSection.tsx
+++ b/front/components/home/content/Competitive/ComparisonTableSection.tsx
@@ -74,7 +74,7 @@ export function ComparisonTableSection({
 
       <div className="mx-auto max-w-4xl">
         {/* Header - outside the table border */}
-        <div className="grid grid-cols-[1fr,120px,120px] md:grid-cols-[1fr,140px,140px]">
+        <div className="grid grid-cols-[1fr,80px,80px] sm:grid-cols-[1fr,120px,120px] md:grid-cols-[1fr,140px,140px]">
           <div />
           <div className="flex items-center justify-center rounded-tl-xl bg-gradient-to-b from-blue-500 to-blue-600 p-4">
             <Image
@@ -108,7 +108,7 @@ export function ComparisonTableSection({
             <div
               key={feature.name}
               className={cn(
-                "grid grid-cols-[1fr,120px,120px] md:grid-cols-[1fr,140px,140px]",
+                "grid grid-cols-[1fr,80px,80px] sm:grid-cols-[1fr,120px,120px] md:grid-cols-[1fr,140px,140px]",
                 index !== features.length - 1 && "border-b border-gray-100"
               )}
             >
@@ -117,7 +117,7 @@ export function ComparisonTableSection({
                   {feature.name}
                 </span>
                 {feature.description && (
-                  <span className="mt-0.5 text-xs text-gray-500">
+                  <span className="mt-0.5 hidden text-xs text-gray-500 sm:block">
                     {feature.description}
                   </span>
                 )}

--- a/front/components/home/content/Skip/config/skipConfig.tsx
+++ b/front/components/home/content/Skip/config/skipConfig.tsx
@@ -1,3 +1,4 @@
+import { TESTIMONIALS } from "@app/components/home/content/shared/testimonials";
 import type { ReactNode } from "react";
 
 interface VideoConfig {
@@ -70,30 +71,12 @@ export const skipConfig: SkipConfig = {
     chip: "",
     headline: "Welcome, Skip listeners 👋",
     subheadline:
-      "You just heard about Dust on Nikhyl's show. Here's how ambitious tech professionals are using AI agents to level up their impact—and their careers.",
+      "You just heard about Dust on Nikhyl's show. Here's how ambitious tech professionals are using AI agents to level up their impact, and their careers.",
     ctaButtonText: "Get started",
     testimonials: [
-      {
-        quote:
-          "We've reduced our response time by 73% and our team loves using it daily.",
-        name: "Daniel Banet",
-        title: "Head of AI Solutions",
-        logo: "/static/landing/logos/gray/vanta.svg",
-      },
-      {
-        quote:
-          "Dust is the most impactful software we've adopted since building Clay. It delivers immediate value while continuously getting smarter.",
-        name: "Everett Berry",
-        title: "GTM Eng Lead, Clay",
-        logo: "/static/landing/logos/gray/clay.svg",
-      },
-      {
-        quote:
-          "Allows us to create qualitative deliverables, not only search/answer questions.",
-        name: "Ryan Wang",
-        title: "CEO, Assembled",
-        logo: "/static/landing/logos/gray/assembled.svg",
-      },
+      TESTIMONIALS.danielBaralt,
+      TESTIMONIALS.everettBerryImpact,
+      TESTIMONIALS.ryanWang,
     ],
     videos: [
       {
@@ -124,9 +107,9 @@ export const skipConfig: SkipConfig = {
       description:
         "The best PMs, operators, and leaders don't get promoted for working harder. They get promoted for delivering more impact with less effort. While your peers are buried in Slack threads, hunting for data, and updating spreadsheets, you could be:",
       features: [
-        "Shipping faster: Draft PRDs, prep for meetings, and synthesize research in minutes instead of hours",
-        "Making better decisions: Get instant answers from your company's collective knowledge across every tool",
-        "Getting credit for what matters: Automate the busywork so you can focus on the strategic thinking that gets you promoted",
+        "Shipping faster: draft PRDs, prep for meetings, and synthesize research in minutes instead of hours",
+        "Making better decisions: get instant answers from your company's collective knowledge across every tool",
+        "Getting credit for what matters: automate the busywork so you can focus on the strategic thinking that gets you promoted",
       ],
       image: {
         src: "/static/landing/sqagent/feature-1.png",
@@ -138,12 +121,12 @@ export const skipConfig: SkipConfig = {
       title: "Build custom AI agents",
       titleHighlight: "in minutes",
       description:
-        "No coding required. They connect to all your tools (Slack, Notion, Drive, Salesforce, GitHub), understand your company's knowledge, and take action across your entire workflow.",
+        "No coding required. Dust Agents connect to all your tools (Slack, Notion, Drive, Salesforce, GitHub), understand your company's knowledge, and take action across your entire workflow.",
       features: [
         "A support agent that resolves tickets using your help docs and past conversations",
         "An ops agent that updates your CRM, tracks deals, and flags risks automatically",
         "A research agent that synthesizes customer feedback across every channel",
-        "They work across teams—so the whole company gets smarter, not just you",
+        "They work across teams, so the whole company gets smarter, not just you",
       ],
       image: {
         src: "/static/landing/sqagent/feature-2.png",
@@ -158,27 +141,9 @@ export const skipConfig: SkipConfig = {
     title: "Loved by ambitious teams",
     subtitle: "See why leading companies trust Dust to power their operations.",
     testimonials: [
-      {
-        quote:
-          '"We\'ve reduced our response time by 73% and our team loves using it daily."',
-        name: "Daniel Banet",
-        title: "Head of AI Solutions, Vanta",
-        logo: "/static/landing/logos/gray/vanta.svg",
-      },
-      {
-        quote:
-          '"Allows us to create qualitative deliverables, not only search/answer questions"',
-        name: "Ryan Wang",
-        title: "CEO, Assembled",
-        logo: "/static/landing/logos/gray/assembled.svg",
-      },
-      {
-        quote:
-          '"I have Dust agents for vendor research, interviewing, and even to check changes in our knowledge base, endless possibilities with the platform."',
-        name: "Everett Berry",
-        title: "GTM Eng Lead, Clay",
-        logo: "/static/landing/logos/gray/clay.svg",
-      },
+      TESTIMONIALS.danielBaralt,
+      TESTIMONIALS.ryanWang,
+      TESTIMONIALS.everettBerryAgents,
     ],
   },
 

--- a/front/components/home/content/SqAgent/FeatureSection.tsx
+++ b/front/components/home/content/SqAgent/FeatureSection.tsx
@@ -86,34 +86,22 @@ export function FeatureSection({
     <section
       className={cn(
         "w-full",
-        backgroundColor ? "-mx-6 px-6 py-16 md:-mx-8 md:px-8" : "py-8"
-      )}
-      style={
         backgroundColor
-          ? {
-              marginLeft: "calc(-50vw + 50%)",
-              width: "100vw",
-              paddingLeft: "max(1.5rem, calc(50vw - 50% + 1.5rem))",
-              paddingRight: "max(1.5rem, calc(50vw - 50% + 1.5rem))",
-            }
-          : undefined
-      }
+          ? cn(
+              backgroundColor,
+              "-mx-6 px-6 py-8 md:-mx-8 md:px-8 md:py-16"
+            )
+          : "py-4 md:py-8"
+      )}
     >
       <div
         className={cn(
-          backgroundColor ?? "",
-          backgroundColor ? "rounded-none py-16" : ""
+          "mx-auto flex max-w-6xl flex-col gap-6 lg:flex-row lg:gap-16",
+          imagePosition === "left" ? "lg:flex-row-reverse" : ""
         )}
       >
-        <div
-          className={cn(
-            "mx-auto flex max-w-6xl flex-col gap-8 lg:flex-row lg:gap-16",
-            imagePosition === "left" ? "lg:flex-row-reverse" : ""
-          )}
-        >
-          {contentSection}
-          {imageSection}
-        </div>
+        {contentSection}
+        {imageSection}
       </div>
     </section>
   );

--- a/front/components/home/content/SqAgent/FeatureSection.tsx
+++ b/front/components/home/content/SqAgent/FeatureSection.tsx
@@ -87,10 +87,7 @@ export function FeatureSection({
       className={cn(
         "w-full",
         backgroundColor
-          ? cn(
-              backgroundColor,
-              "-mx-6 px-6 py-8 md:-mx-8 md:px-8 md:py-16"
-            )
+          ? cn(backgroundColor, "-mx-6 px-6 py-8 md:-mx-8 md:px-8 md:py-16")
           : "py-4 md:py-8"
       )}
     >

--- a/front/components/home/content/SqAgent/SqAgentHeroSection.tsx
+++ b/front/components/home/content/SqAgent/SqAgentHeroSection.tsx
@@ -64,14 +64,14 @@ export function SqAgentHeroSection({
   return (
     <section className="w-full">
       <div
-        className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen py-16 md:py-24"
+        className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen py-8 md:py-24"
         style={{
           background:
             "linear-gradient(180deg, #FFF 0%, #F0F9FF 40%, #F0F9FF 60%, #FFF 100%)",
         }}
       >
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-16">
             {/* Left side - Content */}
             <div className="flex flex-col items-start lg:w-1/2">
               {/* Chip - only show if not empty */}
@@ -100,7 +100,7 @@ export function SqAgentHeroSection({
               />
 
               {/* Rotating Testimonial */}
-              <div className="mt-10 w-full">
+              <div className="mt-6 w-full md:mt-10">
                 <div className="relative min-h-[140px] overflow-hidden rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
                   <div key={activeTestimonial} className="animate-fade-in-up">
                     <p className="mb-4 text-sm italic text-muted-foreground">

--- a/front/components/home/content/SqAgent/SqCtaSection.tsx
+++ b/front/components/home/content/SqAgent/SqCtaSection.tsx
@@ -18,7 +18,7 @@ export function SqCtaSection({
   return (
     <section className="w-full">
       <div
-        className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen py-16 md:py-20"
+        className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen py-8 md:py-20"
         style={{
           background: "linear-gradient(135deg, #3B82F6 0%, #1D4ED8 100%)",
         }}

--- a/front/components/home/content/SqAgent/SqTestimonialsSection.tsx
+++ b/front/components/home/content/SqAgent/SqTestimonialsSection.tsx
@@ -19,7 +19,7 @@ function TestimonialCard({ quote, name, title, logo }: Testimonial) {
     <div className="flex h-full flex-col rounded-xl bg-gray-50 p-6">
       <div className="mb-4 flex-1">
         <P size="sm" className="text-gray-700">
-          {quote}
+          &ldquo;{quote}&rdquo;
         </P>
       </div>
       <div className="mt-auto flex items-center justify-between border-t border-gray-200 pt-4">
@@ -50,7 +50,7 @@ export function SqTestimonialsSection({
   testimonials,
 }: SqTestimonialsSectionProps) {
   return (
-    <section className="w-full py-16">
+    <section className="w-full py-8 md:py-16">
       <H2 className="mb-2 text-center">{title}</H2>
       <P size="md" className="mb-10 text-center text-muted-foreground">
         {subtitle}

--- a/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
+++ b/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
@@ -1,3 +1,4 @@
+import { TESTIMONIALS } from "@app/components/home/content/shared/testimonials";
 import type { ReactNode } from "react";
 
 interface VideoConfig {
@@ -83,27 +84,9 @@ export const sqAgentConfig: SqAgentConfig = {
       "Spin up AI teammates that know your business, use your tools, and work safely alongside your team.",
     ctaButtonText: "Start Free Trial",
     testimonials: [
-      {
-        quote:
-          "We've reduced our response time by 73% and our team loves using it daily.",
-        name: "Daniel Banet",
-        title: "Head of AI Solutions",
-        logo: "/static/landing/logos/gray/vanta.svg",
-      },
-      {
-        quote:
-          "Dust is the most impactful software we've adopted since building Clay. It delivers immediate value while continuously getting smarter.",
-        name: "Everett Berry",
-        title: "GTM Eng Lead, Clay",
-        logo: "/static/landing/logos/gray/clay.svg",
-      },
-      {
-        quote:
-          "The data analyst job is dead. We'll only have business analysts now.",
-        name: "Inès Delbecq",
-        title: "AI Lead, Electra",
-        logo: "/static/landing/logos/gray/electra.svg",
-      },
+      TESTIMONIALS.danielBaralt,
+      TESTIMONIALS.everettBerryImpact,
+      TESTIMONIALS.inesDelbecq,
     ],
     videos: [
       {
@@ -205,27 +188,9 @@ export const sqAgentConfig: SqAgentConfig = {
     subtitle:
       "See why leading B2B companies trust Dust to power their operations.",
     testimonials: [
-      {
-        quote:
-          '"The data analyst job is dead. We\'ll only have business analysts now."',
-        name: "Inès Delbecq",
-        title: "AI Lead, Electra",
-        logo: "/static/landing/logos/gray/electra.svg",
-      },
-      {
-        quote:
-          '"Allows us to create qualitative deliverables, not only search/answer questions"',
-        name: "Ryan Wang",
-        title: "CEO, Assembled",
-        logo: "/static/landing/logos/gray/assembled.svg",
-      },
-      {
-        quote:
-          '"I have Dust agents for vendor research, interviewing, and even to check changes in our knowledge base, endless possibilities with the platform."',
-        name: "Everett Berry",
-        title: "GTM Eng Lead, Clay",
-        logo: "/static/landing/logos/gray/clay.svg",
-      },
+      TESTIMONIALS.inesDelbecq,
+      TESTIMONIALS.ryanWang,
+      TESTIMONIALS.everettBerryAgents,
     ],
   },
 

--- a/front/components/home/content/shared/testimonials.ts
+++ b/front/components/home/content/shared/testimonials.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared testimonial data used across landing pages.
+ * Single source of truth for person info and quotes.
+ *
+ * When the same person has multiple quotes, they are stored as separate entries
+ * (e.g. everettBerryImpact vs everettBerryAgents).
+ */
+
+export interface TestimonialData {
+  quote: string;
+  name: string;
+  title: string;
+  logo: string;
+}
+
+export const TESTIMONIALS = {
+  danielBaralt: {
+    quote:
+      "We've reduced our response time by 73% and our team loves using it daily.",
+    name: "Daniel Baralt",
+    title: "AI Solutions Lead, GTM, Vanta",
+    logo: "/static/landing/logos/gray/vanta.svg",
+  },
+
+  everettBerryImpact: {
+    quote:
+      "Dust is the most impactful software we've adopted since building Clay. It delivers immediate value while continuously getting smarter.",
+    name: "Everett Berry",
+    title: "Head of GTM Engineering at Clay",
+    logo: "/static/landing/logos/gray/clay.svg",
+  },
+
+  everettBerryAgents: {
+    quote:
+      "I have Dust agents for vendor research, interviewing, and even to check changes in our knowledge base, endless possibilities with the platform.",
+    name: "Everett Berry",
+    title: "Head of GTM Engineering at Clay",
+    logo: "/static/landing/logos/gray/clay.svg",
+  },
+
+  ryanWang: {
+    quote:
+      "Allows us to create qualitative deliverables, not only search/answer questions.",
+    name: "Ryan Wang",
+    title: "CEO, Assembled",
+    logo: "/static/landing/logos/gray/assembled.svg",
+  },
+
+  inesDelbecq: {
+    quote:
+      "The data analyst job is dead. We'll only have business analysts now.",
+    name: "Inès Delbecq",
+    title: "AI Lead, Electra",
+    logo: "/static/landing/logos/gray/electra.svg",
+  },
+} satisfies Record<string, TestimonialData>;

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -394,7 +394,7 @@ const config = {
       {
         source: "/skip",
         destination:
-          "/landing/skip?utm_source=podcast&utm_campaign=skip&utm_event=listener",
+          "/landing/skip?utm_source=podcast&utm_medium=audio&utm_campaign=skip&utm_content=listener",
         permanent: false,
       },
     ];


### PR DESCRIPTION
- Reduce excessive mobile spacing across hero, feature, CTA, and testimonial sections
- Fix background sections not extending edge-to-edge on mobile
- Fix comparison table layout on mobile (narrower columns, hide descriptions)
- Extract shared testimonials to single source of truth
- Fix Daniel Baralt name/title across all configs
- Fix text on /skip page (remove em dashes, lowercase verbs, "Dust Agents")
- Replace invalid utm_event with proper utm_medium and utm_content
