### PR TITLE
Fix Microsoft connector extraConfig

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -283,8 +283,9 @@ function UpdateConnectionOAuthModal({
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
     if (isOpen && !isMetadataLoading && isMicrosoft) {
-      if (metadata) {
+      if (metadata?.client_id) {
         // Convert metadata to string Record
+        // extraConfig is needed only in the Service Principal case) (i.e., when client_id is present in metadata)
         const stringMetadata: Record<string, string> = {};
         for (const [key, value] of Object.entries(metadata)) {
           if (typeof value === "string") {
@@ -292,8 +293,6 @@ function UpdateConnectionOAuthModal({
           }
         }
         setExtraConfig(stringMetadata);
-      } else {
-        setExtraConfig({});
       }
     }
   }, [isOpen, metadata, isMetadataLoading, isMicrosoft, dataSource.sId]);


### PR DESCRIPTION
## Description

Fixes a bug in the Microsoft connector "Edit Permissions" flow where extraConfig was incorrectly set even when the connection mode was not "Service Principal". It should be empty in that case.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
