### PR TITLE
[Projects] Kickoff convo: align list creator with displayed preview

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -62,15 +62,6 @@ export function SpaceConversationListItem({
     return null;
   }
 
-  const creatorName =
-    firstUserMessage.user?.fullName ??
-    firstUserMessage.context?.fullName ??
-    "Unknown";
-  const creatorVisual =
-    firstUserMessage.user?.image ??
-    firstUserMessage.context?.profilePictureUrl ??
-    undefined;
-
   const conversationLabel =
     conversation.title ??
     (moment(conversation.created).isSame(moment(), "day")
@@ -94,6 +85,24 @@ export function SpaceConversationListItem({
     if (firstNonHiddenMessage) {
       firstMessageForDescription = firstNonHiddenMessage;
     }
+  }
+
+  let creatorName = "Unknown";
+  let creatorVisual: string | undefined = undefined;
+
+  if (isUserMessageTypeWithContentFragments(firstMessageForDescription)) {
+    creatorName =
+      firstMessageForDescription.user?.fullName ??
+      firstMessageForDescription.context?.fullName ??
+      "Unknown";
+    creatorVisual =
+      firstMessageForDescription.user?.image ??
+      firstMessageForDescription.context?.profilePictureUrl ??
+      undefined;
+  } else {
+    creatorName = `@${firstMessageForDescription.configuration.name}`;
+    creatorVisual =
+      firstMessageForDescription.configuration.pictureUrl || undefined;
   }
 
   return (


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/21655.

In the space conversations list, the preview description can now come from the first non-hidden message (user or agent) for kickoff conversations, but creator name/avatar still came from the first user message.

This change derives creator name/avatar from the same message used for the preview description, so kickoff rows consistently show the agent identity when the displayed preview message is an agent message.

## Risks
Blast radius: project space conversation list item creator display (name and avatar).
Risk: low

## Deploy Plan
- pmrr
- deploy front
