### PR TITLE
[front] - feat(obs): skills in ES

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -77,12 +77,6 @@
         },
         "status": {
           "type": "keyword"
-        },
-        "skill_id": {
-          "type": "keyword"
-        },
-        "skill_name": {
-          "type": "keyword"
         }
       }
     },

--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -78,9 +78,6 @@
         "status": {
           "type": "keyword"
         },
-        "via_skill": {
-          "type": "boolean"
-        },
         "skill_id": {
           "type": "keyword"
         },

--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -77,6 +77,32 @@
         },
         "status": {
           "type": "keyword"
+        },
+        "via_skill": {
+          "type": "boolean"
+        },
+        "skill_id": {
+          "type": "keyword"
+        },
+        "skill_name": {
+          "type": "keyword"
+        }
+      }
+    },
+    "skills_used": {
+      "type": "nested",
+      "properties": {
+        "skill_id": {
+          "type": "keyword"
+        },
+        "skill_name": {
+          "type": "keyword"
+        },
+        "skill_type": {
+          "type": "keyword"
+        },
+        "source": {
+          "type": "keyword"
         }
       }
     },

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -5,7 +5,6 @@ import {
 import {
   eitherGlobalOrCustomSkillValidation,
   SkillConfigurationModel,
-  type SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -156,12 +155,7 @@ export class AgentMessageSkillModel extends ConversationSkillModel {
   declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
 
   // Eager-loaded association from include.
-  declare customSkill: NonAttribute<
-    | (SkillConfigurationModel & {
-        mcpServerConfigurations?: SkillMCPServerConfigurationModel[];
-      })
-    | null
-  >;
+  declare customSkill: NonAttribute<SkillConfigurationModel | null>;
 }
 
 AgentMessageSkillModel.init(

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -5,12 +5,18 @@ import {
 import {
   eitherGlobalOrCustomSkillValidation,
   SkillConfigurationModel,
+  SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ConversationSkillOrigin } from "@app/types/assistant/conversation_skills";
-import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
+import type {
+  CreationOptional,
+  ForeignKey,
+  ModelAttributes,
+  NonAttribute,
+} from "sequelize";
 import { DataTypes, Op } from "sequelize";
 
 const SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES = {
@@ -148,6 +154,14 @@ ConversationSkillModel.belongsTo(UserModel, {
 
 export class AgentMessageSkillModel extends ConversationSkillModel {
   declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
+
+  // Eager-loaded association from include.
+  declare customSkill: NonAttribute<
+    | (SkillConfigurationModel & {
+        mcpServerConfigurations?: SkillMCPServerConfigurationModel[];
+      })
+    | null
+  >;
 }
 
 AgentMessageSkillModel.init(

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -5,7 +5,7 @@ import {
 import {
   eitherGlobalOrCustomSkillValidation,
   SkillConfigurationModel,
-  SkillMCPServerConfigurationModel,
+  type SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";

--- a/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
+++ b/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
@@ -212,7 +212,6 @@ async function backfillMcpServerConfigurationSidForWorkspace(
           mcp_server_configuration_sid: sid,
           execution_time_ms: action.executionDurationMs,
           status: action.status,
-          via_skill: false,
         });
       }
 

--- a/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
+++ b/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
@@ -212,6 +212,7 @@ async function backfillMcpServerConfigurationSidForWorkspace(
           mcp_server_configuration_sid: sid,
           execution_time_ms: action.executionDurationMs,
           status: action.status,
+          via_skill: false,
         });
       }
 

--- a/front/migrations/20260217_add_skills_used_mapping.ts
+++ b/front/migrations/20260217_add_skills_used_mapping.ts
@@ -1,0 +1,51 @@
+import { getClient } from "@app/lib/api/elasticsearch";
+import { makeScript } from "@app/scripts/helpers";
+import type { estypes } from "@elastic/elasticsearch";
+
+const INDEX_NAME = "front.agent_message_analytics_2";
+
+const SKILLS_USED_MAPPING: Record<string, estypes.MappingProperty> = {
+  skills_used: {
+    type: "nested",
+    properties: {
+      skill_id: { type: "keyword" },
+      skill_name: { type: "keyword" },
+      skill_type: { type: "keyword" },
+      source: { type: "keyword" },
+    },
+  },
+};
+
+makeScript({}, async ({ execute }, logger) => {
+  const client = await getClient();
+
+  const currentMapping = await client.indices.getMapping({
+    index: INDEX_NAME,
+  });
+
+  const properties = currentMapping[INDEX_NAME]?.mappings?.properties ?? {};
+
+  if ("skills_used" in properties) {
+    logger.info("Field 'skills_used' already exists in mapping, skipping.");
+    return;
+  }
+
+  if (!execute) {
+    logger.info(
+      { mapping: SKILLS_USED_MAPPING },
+      "Dry run - would add 'skills_used' mapping to index"
+    );
+    return;
+  }
+
+  const response = await client.indices.putMapping({
+    index: INDEX_NAME,
+    body: { properties: SKILLS_USED_MAPPING },
+  });
+
+  if (!response.acknowledged) {
+    throw new Error(`Failed to update mapping: ${JSON.stringify(response)}`);
+  }
+
+  logger.info("Successfully added 'skills_used' mapping to index");
+});

--- a/front/migrations/20260217_backfill_skills_analytics.ts
+++ b/front/migrations/20260217_backfill_skills_analytics.ts
@@ -1,0 +1,407 @@
+import { subDays } from "date-fns";
+import type { WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
+import { ANALYTICS_ALIAS_NAME, getClient } from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import {
+  SkillConfigurationModel,
+  SkillMCPServerConfigurationModel,
+} from "@app/lib/models/skill";
+import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMCPServerConfigurationResource } from "@app/lib/resources/agent_mcp_server_configuration_resource";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
+import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type {
+  AgentMessageAnalyticsSkillUsed,
+  AgentMessageAnalyticsToolUsed,
+} from "@app/types/assistant/analytics";
+import type { LightWorkspaceType } from "@app/types/user";
+
+const BATCH_SIZE = 500;
+
+type SkillAttribution = {
+  skillId: string;
+  skillName: string;
+};
+
+async function backfillSkillsAnalyticsForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  days: number,
+  execute: boolean
+) {
+  const since = subDays(new Date(), days);
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      since: since.toISOString(),
+    },
+    "Starting skills analytics backfill"
+  );
+
+  // Query the total count of skill records to process.
+  const totalSkillRecords = await AgentMessageSkillModel.count({
+    where: {
+      workspaceId: workspace.id,
+      createdAt: { [Op.gte]: since },
+    } as WhereOptions<AgentMessageSkillModel>,
+  });
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      count: totalSkillRecords,
+    },
+    "Found skill records to process"
+  );
+
+  if (!totalSkillRecords) {
+    return;
+  }
+
+  const es = await getClient();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  let success = 0;
+  let failed = 0;
+  let processed = 0;
+  let lastId: number | null = null;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const where: WhereOptions<AgentMessageSkillModel> = {
+      workspaceId: workspace.id,
+      createdAt: { [Op.gte]: since },
+    };
+
+    if (lastId !== null) {
+      (where as Record<string, unknown>).id = { [Op.gt]: lastId };
+    }
+
+    // Fetch skill records with eager-loaded custom skill and MCP server configurations.
+    const skillRecords = await AgentMessageSkillModel.findAll({
+      where,
+      include: [
+        {
+          model: SkillConfigurationModel,
+          as: "customSkill",
+          attributes: ["id", "name"],
+          required: false,
+          include: [
+            {
+              model: SkillMCPServerConfigurationModel,
+              as: "mcpServerConfigurations",
+              attributes: ["mcpServerViewId"],
+              required: false,
+            },
+          ],
+        },
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          include: [
+            {
+              model: MessageModel,
+              as: "message",
+              required: true,
+            },
+          ],
+        },
+      ],
+      order: [["id", "ASC"]],
+      limit: BATCH_SIZE,
+    });
+
+    if (!skillRecords.length) {
+      break;
+    }
+
+    // Group skill records by agentMessageId.
+    const skillsByAgentMessageId = new Map<number, AgentMessageSkillModel[]>();
+    for (const record of skillRecords) {
+      const list = skillsByAgentMessageId.get(record.agentMessageId) ?? [];
+      list.push(record);
+      skillsByAgentMessageId.set(record.agentMessageId, list);
+    }
+
+    // Fetch global skill definitions for any global skills referenced.
+    const globalSkillIds = new Set<string>();
+    for (const record of skillRecords) {
+      if (record.globalSkillId !== null) {
+        globalSkillIds.add(record.globalSkillId);
+      }
+    }
+
+    const globalSkillsMap = new Map<string, GlobalSkillDefinition>();
+    if (globalSkillIds.size > 0) {
+      const globalSkills = await GlobalSkillsRegistry.findAll(auth, {
+        sId: Array.from(globalSkillIds),
+      });
+      for (const skill of globalSkills) {
+        globalSkillsMap.set(skill.sId, skill);
+      }
+    }
+
+    // Fetch actions for all agent messages in this batch.
+    const agentMessageIds = Array.from(skillsByAgentMessageId.keys());
+    const actions = await AgentMCPActionResource.listByAgentMessageIds(
+      auth,
+      agentMessageIds
+    );
+
+    const actionsByAgentMessageId = new Map<number, AgentMCPActionResource[]>();
+    for (const action of actions) {
+      const list = actionsByAgentMessageId.get(action.agentMessageId) ?? [];
+      list.push(action);
+      actionsByAgentMessageId.set(action.agentMessageId, list);
+    }
+
+    // Fetch MCP server configurations for tool attribution.
+    const uniqueConfigIds = Array.from(
+      new Set(actions.map((a) => a.mcpServerConfigurationId))
+    );
+    const configModelIds = uniqueConfigIds
+      .map((id) => parseInt(id, 10))
+      .filter((id) => !isNaN(id) && id > 0);
+
+    const serverConfigs =
+      await AgentMCPServerConfigurationResource.fetchByModelIds(
+        auth,
+        configModelIds
+      );
+
+    const configIdToSId = new Map(
+      serverConfigs.map((cfg) => [cfg.id.toString(), cfg.sId])
+    );
+    const configIdToMcpServerViewId = new Map(
+      serverConfigs.map((cfg) => [cfg.id.toString(), cfg.mcpServerViewId])
+    );
+
+    const body: unknown[] = [];
+
+    for (const [agentMessageId, msgSkillRecords] of skillsByAgentMessageId) {
+      // Build skills_used array.
+      const skillsUsed: AgentMessageAnalyticsSkillUsed[] = [];
+      const mcpServerViewIdToSkill = new Map<string, SkillAttribution>();
+
+      for (const record of msgSkillRecords) {
+        // Custom skill case.
+        if (record.customSkillId && record.customSkill) {
+          const customSkill = record.customSkill;
+          const skillId = makeSId("skill", {
+            id: customSkill.id,
+            workspaceId: workspace.id,
+          });
+
+          skillsUsed.push({
+            skill_id: skillId,
+            skill_name: customSkill.name,
+            skill_type: "custom",
+            source: record.source,
+          });
+
+          // Map all MCP server views from this skill for tool attribution.
+          for (const mcpConfig of customSkill.mcpServerConfigurations ?? []) {
+            mcpServerViewIdToSkill.set(mcpConfig.mcpServerViewId.toString(), {
+              skillId,
+              skillName: customSkill.name,
+            });
+          }
+          continue;
+        }
+
+        // Global skill case.
+        if (record.globalSkillId) {
+          const globalSkill = globalSkillsMap.get(record.globalSkillId);
+
+          skillsUsed.push({
+            skill_id: record.globalSkillId,
+            skill_name: globalSkill?.name ?? record.globalSkillId,
+            skill_type: "global",
+            source: record.source,
+          });
+          // Note: Global skills have internal MCP servers without mcpServerViewIds in the DB.
+          // Tool attribution for global skills would require matching by internalMCPServerId.
+        }
+      }
+
+      // Build tools_used array with skill attribution.
+      const msgActions = actionsByAgentMessageId.get(agentMessageId) ?? [];
+      const toolsUsed: AgentMessageAnalyticsToolUsed[] = msgActions.map(
+        (actionResource) => {
+          const mcpServerViewId = configIdToMcpServerViewId.get(
+            actionResource.mcpServerConfigurationId
+          );
+          const skillInfo = mcpServerViewId
+            ? mcpServerViewIdToSkill.get(mcpServerViewId.toString())
+            : undefined;
+
+          return {
+            step_index: actionResource.stepContent.step,
+            server_name:
+              actionResource.metadata.internalMCPServerName ??
+              actionResource.metadata.mcpServerId ??
+              "unknown",
+            tool_name:
+              actionResource.functionCallName
+                .split(TOOL_NAME_SEPARATOR)
+                .pop() ?? actionResource.functionCallName,
+            mcp_server_configuration_sid:
+              configIdToSId.get(actionResource.mcpServerConfigurationId) ??
+              undefined,
+            execution_time_ms: actionResource.executionDurationMs,
+            status: actionResource.status,
+            skill_id: skillInfo?.skillId,
+            skill_name: skillInfo?.skillName,
+          };
+        }
+      );
+
+      // Get the message row from one of the skill records (they all share the same agentMessage).
+      // The agentMessage is eager-loaded via include but not declared on the model type.
+      const skillRecord = msgSkillRecords[0] as AgentMessageSkillModel & {
+        agentMessage?: AgentMessageModel & { message?: MessageModel };
+      };
+      const agentMessage = skillRecord.agentMessage;
+      if (!agentMessage?.message) {
+        continue;
+      }
+
+      const documentId = `${workspace.sId}_${agentMessage.message.sId}_${agentMessage.message.version.toString()}`;
+
+      body.push({
+        update: {
+          _index: ANALYTICS_ALIAS_NAME,
+          _id: documentId,
+        },
+      });
+      body.push({
+        doc: {
+          skills_used: skillsUsed,
+          tools_used: toolsUsed,
+        },
+      });
+    }
+
+    if (!body.length) {
+      processed += skillRecords.length;
+      lastId = skillRecords[skillRecords.length - 1].id;
+      continue;
+    }
+
+    if (!execute) {
+      processed += skillRecords.length;
+      lastId = skillRecords[skillRecords.length - 1].id;
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          processed,
+          total: totalSkillRecords,
+          documentsToUpdate: body.length / 2,
+        },
+        "Dry run - would backfill skills analytics for this batch"
+      );
+      continue;
+    }
+
+    const resp = await es.bulk({
+      index: ANALYTICS_ALIAS_NAME,
+      body,
+      refresh: false,
+    });
+
+    if (resp.errors) {
+      for (const item of resp.items ?? []) {
+        const update = item.update;
+        if (!update || !update.error) {
+          continue;
+        }
+        failed++;
+        logger.warn(
+          {
+            error: update.error,
+            id: update._id,
+          },
+          "Failed to update skills_used for analytics document"
+        );
+      }
+    }
+
+    success += skillRecords.length;
+    processed += skillRecords.length;
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        processed,
+        total: totalSkillRecords,
+      },
+      "Processed batch for skills analytics backfill"
+    );
+
+    lastId = skillRecords[skillRecords.length - 1].id;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      success,
+      failed,
+    },
+    "Completed skills analytics backfill"
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: false,
+      description: "Run on a single workspace (optional, sId)",
+    },
+    days: {
+      type: "number",
+      demandOption: false,
+      default: 30,
+      description:
+        "Only backfill messages created in the last N days (default: 30)",
+    },
+  },
+  async ({ execute, workspaceId, days }, logger) => {
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+
+      await backfillSkillsAnalyticsForWorkspace(
+        renderLightWorkspaceType({ workspace }),
+        logger,
+        days,
+        execute
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (ws) => {
+          await backfillSkillsAnalyticsForWorkspace(ws, logger, days, execute);
+        },
+        { concurrency: 5 }
+      );
+    }
+  }
+);

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -103,6 +103,7 @@ async function seedProgrammaticUsage(
       context_origin: "api",
       latency_ms: randomInt(LATENCY_MS_RANGE.min, LATENCY_MS_RANGE.max),
       message_id: messageId,
+      skills_used: [],
       status: "succeeded",
       timestamp: timestamp.toISOString(),
       tokens: {

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -124,6 +124,7 @@ export async function seedAnalytics(
       context_origin: "web",
       latency_ms: agentMessage.modelInteractionDurationMs ?? 0,
       message_id: message.sId,
+      skills_used: [],
       status: agentMessage.status,
       timestamp: new Date(message.createdAt).toISOString(),
       tokens: {

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -352,11 +352,13 @@ async function collectSkillsUsageFromMessage(
 ): Promise<AgentMessageAnalyticsSkillUsed[]> {
   const workspace = auth.getNonNullableWorkspace();
 
+  const where: WhereOptions<AgentMessageSkillModel> = {
+    agentMessageId,
+    workspaceId: workspace.id,
+  };
+
   const skillRecords = await AgentMessageSkillModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      agentMessageId,
-    } as WhereOptions<AgentMessageSkillModel>,
+    where,
     include: [
       {
         model: SkillConfigurationModel,

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -1,5 +1,3 @@
-import type { WhereOptions } from "sequelize";
-
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
@@ -34,8 +32,8 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
-import { makeSId } from "@app/lib/resources/string_ids";
 import { UserModel } from "@app/lib/resources/storage/models/user";
+import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -54,6 +52,7 @@ import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import { sha256 } from "@app/types/shared/utils/hashing";
+import type { WhereOptions } from "sequelize";
 
 export async function storeAgentAnalyticsActivity(
   authType: AuthenticatorType,

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -365,7 +365,6 @@ async function collectToolUsageFromMessage(
         configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
       execution_time_ms: actionResource.executionDurationMs,
       status: actionResource.status,
-      via_skill: !!skillInfo,
       skill_id: skillInfo?.skillId,
       skill_name: skillInfo?.skillName,
     };

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -23,7 +23,6 @@ export interface AgentMessageAnalyticsToolUsed {
   mcp_server_configuration_sid?: string;
   execution_time_ms: number | null;
   status: string;
-  via_skill: boolean;
   skill_id?: string;
   skill_name?: string;
 }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -2,6 +2,7 @@ import type { ThumbReaction } from "@app/components/assistant/conversation/Feedb
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 
 import type { AgentMessageStatus, UserMessageOrigin } from "./conversation";
+import type { ConversationSkillOrigin } from "./conversation_skills";
 
 /**
  * Types for agent analytics data stored in Elasticsearch
@@ -22,6 +23,9 @@ export interface AgentMessageAnalyticsToolUsed {
   mcp_server_configuration_sid?: string;
   execution_time_ms: number | null;
   status: string;
+  via_skill: boolean;
+  skill_id?: string;
+  skill_name?: string;
 }
 
 export interface AgentMessageAnalyticsFeedback {
@@ -34,6 +38,13 @@ export interface AgentMessageAnalyticsFeedback {
   created_at: string; // ISO date string.
 }
 
+export interface AgentMessageAnalyticsSkillUsed {
+  skill_id: string;
+  skill_name: string;
+  skill_type: "custom" | "global";
+  source: ConversationSkillOrigin;
+}
+
 export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_id: string;
   agent_version: string;
@@ -42,6 +53,7 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   context_origin: UserMessageOrigin | null;
   latency_ms: number;
   message_id: string;
+  skills_used: AgentMessageAnalyticsSkillUsed[];
   status: AgentMessageStatus;
   timestamp: string; // ISO date string.
   tokens: AgentMessageAnalyticsTokens;

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -23,8 +23,6 @@ export interface AgentMessageAnalyticsToolUsed {
   mcp_server_configuration_sid?: string;
   execution_time_ms: number | null;
   status: string;
-  skill_id?: string;
-  skill_name?: string;
 }
 
 export interface AgentMessageAnalyticsFeedback {


### PR DESCRIPTION
## Description

Adds skill usage tracking to agent message analytics in Elasticsearch. Extends the analytics data model to capture which skills are used in agent messages and attributes tool invocations to their parent skills. The implementation adds a `skills_used` array field (containing skill ID, name, type, and source) and extends `tools_used` entries with `via_skill`, `skill_id`, and `skill_name` fields.

## Risk

The Elasticsearch mapping changes add optional fields and should not break existing queries.

## Tests

Manual testing to verify analytics data is correctly populated with skill usage information for both custom and global skills.

## Deploy Plan

- Apply the Elasticsearch mapping changes in `agent_message_analytics_2.mappings.json` before deploying the code changes
