### PR TITLE
feat: novu slack preferences

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -89,6 +89,8 @@ export const NotificationPreferences = forwardRef<
     }
   );
 
+  const displaySlackOption = hasSlackNotificationsFeature && canConfigureSlack;
+
   // Novu workflow-specific channel preferences for conversation-unread
   const [conversationPreferences, setConversationPreferences] = useState<
     Preference | undefined
@@ -472,15 +474,6 @@ export const NotificationPreferences = forwardRef<
     channel: keyof ChannelPreference,
     enabled: boolean
   ) => {
-    if (channel === "chat" && enabled && !canConfigureSlack) {
-      sendNotification({
-        type: "error",
-        title: "Slack Bot Not Configured",
-        description:
-          "Configure the Slack Bot integration to enable Slack notifications.",
-      });
-      return;
-    }
     setConversationPreferences((prev) => {
       if (!prev) {
         return undefined;
@@ -495,15 +488,6 @@ export const NotificationPreferences = forwardRef<
     channel: keyof ChannelPreference,
     enabled: boolean
   ) => {
-    if (channel === "chat" && enabled && !canConfigureSlack) {
-      sendNotification({
-        type: "error",
-        title: "Slack Bot Not Configured",
-        description:
-          "Configure the Slack Bot integration to enable Slack notifications.",
-      });
-      return;
-    }
     setProjectPreferences((prev) => {
       if (!prev) {
         return undefined;
@@ -518,15 +502,6 @@ export const NotificationPreferences = forwardRef<
     channel: keyof ChannelPreference,
     enabled: boolean
   ) => {
-    if (channel === "chat" && enabled && !canConfigureSlack) {
-      sendNotification({
-        type: "error",
-        title: "Slack Bot Not Configured",
-        description:
-          "Configure the Slack Bot integration to enable Slack notifications.",
-      });
-      return;
-    }
     setProjectNewConversationPreferences((prev) => {
       if (!prev) {
         return undefined;
@@ -552,18 +527,14 @@ export const NotificationPreferences = forwardRef<
   const isConversationInAppEnabled =
     conversationPreferences.channels.in_app && conversationPreferences.enabled;
   const isConversationSlackEnabled =
-    canConfigureSlack &&
-    conversationPreferences.channels.chat &&
-    conversationPreferences.enabled;
+    conversationPreferences.channels.chat && conversationPreferences.enabled;
   const isConversationEmailEnabled =
     conversationPreferences.channels.email && conversationPreferences.enabled;
 
   const isProjectInAppEnabled =
     projectPreferences?.channels.in_app && projectPreferences?.enabled;
   const isProjectSlackEnabled =
-    canConfigureSlack &&
-    projectPreferences?.channels.chat &&
-    projectPreferences?.enabled;
+    projectPreferences?.channels.chat && projectPreferences?.enabled;
   const isProjectEmailEnabled =
     projectPreferences?.channels.email && projectPreferences?.enabled;
 
@@ -571,7 +542,6 @@ export const NotificationPreferences = forwardRef<
     projectNewConversationPreferences?.channels.in_app &&
     projectNewConversationPreferences?.enabled;
   const isProjectNewConversationSlackEnabled =
-    canConfigureSlack &&
     projectNewConversationPreferences?.channels.chat &&
     projectNewConversationPreferences?.enabled;
   const isProjectNewConversationEmailEnabled =
@@ -650,7 +620,7 @@ export const NotificationPreferences = forwardRef<
               </Label>
             </div>
           )}
-          {hasSlackNotificationsFeature &&
+          {displaySlackOption &&
             conversationPreferences.channels.chat !== undefined && (
               <div className="flex items-center gap-1.5">
                 <Checkbox
@@ -765,7 +735,7 @@ export const NotificationPreferences = forwardRef<
                   </Label>
                 </div>
               )}
-              {hasSlackNotificationsFeature &&
+              {displaySlackOption &&
                 projectPreferences.channels.chat !== undefined && (
                   <div className="flex items-center gap-1.5">
                     <Checkbox
@@ -848,7 +818,7 @@ export const NotificationPreferences = forwardRef<
                   </Label>
                 </div>
               )}
-              {hasSlackNotificationsFeature &&
+              {displaySlackOption &&
                 projectNewConversationPreferences.channels.chat !==
                   undefined && (
                   <div className="flex items-center gap-1.5">

--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -1,3 +1,5 @@
+import logger from "@app/logger/logger";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type {
   NotificationPreferencesDelay,
   WorkflowTriggerId,
@@ -7,13 +9,18 @@ import {
   isNotificationPreferencesDelay,
   makeNotificationPreferencesUserMetadata,
 } from "@app/types/notification_preferences";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { Novu } from "@novu/api";
 import type { ChannelPreference } from "@novu/react";
+import { WebClient } from "@slack/web-api";
 import { createHmac } from "crypto";
 import { Op } from "sequelize";
-
-import { Authenticator } from "../auth";
+import config from "../api/config";
+import { Authenticator, getFeatureFlags } from "../auth";
+import { DustError } from "../error";
+import { DataSourceResource } from "../resources/data_source_resource";
 import { UserMetadataModel } from "../resources/storage/models/user";
 
 export type NotificationAllowedTags = Array<"conversations" | "admin">;
@@ -92,4 +99,220 @@ export const getUserNotificationDelay = async ({
   return isNotificationPreferencesDelay(metadataValue)
     ? metadataValue
     : DEFAULT_NOTIFICATION_DELAY;
+};
+
+export const getSlackConnectionIdentifier = (userSId: string): string => {
+  return `slack_connection_${userSId}`;
+};
+
+const isSlackNotificationsFeatureEnabled = async (
+  subscriberId: string,
+  workspaceId: string
+): Promise<boolean> => {
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    workspaceId
+  );
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
+  return featureFlags.includes("conversations_slack_notifications");
+};
+
+const isNovuSlackChannelConfigured = async (
+  subscriberId: string
+): Promise<boolean> => {
+  const novu = await getNovuClient();
+  const connectionIdentifier = getSlackConnectionIdentifier(subscriberId);
+
+  const slackChannelConnections = await novu.channelConnections.list({
+    subscriberId,
+    integrationIdentifier: "slack",
+    channel: "chat",
+  });
+
+  const slackChannelConnection = slackChannelConnections.result.data.find(
+    (connection) => connection.identifier === connectionIdentifier
+  );
+
+  if (!slackChannelConnection) {
+    return false;
+  }
+
+  const slackChannelEndpoints = await novu.channelEndpoints.list({
+    subscriberId,
+    integrationIdentifier: "slack",
+    connectionIdentifier,
+    channel: "chat",
+  });
+
+  if (slackChannelEndpoints.result.data.length === 0) {
+    return false;
+  }
+
+  return true;
+};
+
+const getSlackToken = async (
+  auth: Authenticator
+): Promise<
+  Result<string, DustError<"connection_not_found" | "internal_error">>
+> => {
+  const slackBotConnections = await DataSourceResource.listByConnectorProvider(
+    auth,
+    "slack_bot"
+  );
+
+  if (slackBotConnections.length === 0) {
+    return new Err(
+      new DustError(
+        "connection_not_found",
+        "Slack Bot is not configured for this workspace."
+      )
+    );
+  }
+
+  const slackConnection = slackBotConnections[0];
+
+  if (!slackConnection.connectorId) {
+    return new Err(
+      new DustError(
+        "connection_not_found",
+        "Slack Bot is not configured for this workspace."
+      )
+    );
+  }
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const connectorRes = await connectorsAPI.getConnector(
+    slackConnection.connectorId
+  );
+
+  if (connectorRes.isErr()) {
+    return new Err(
+      new DustError("connection_not_found", connectorRes.error.message)
+    );
+  }
+
+  const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+  const tokenResult = await oauthApi.getAccessToken({
+    connectionId: connectorRes.value.connectionId,
+  });
+
+  if (tokenResult.isErr()) {
+    return new Err(new DustError("internal_error", tokenResult.error.message));
+  }
+
+  return new Ok(tokenResult.value.access_token);
+};
+
+const configureNovuSlackChannelForUser = async (
+  subscriberId: string | undefined,
+  workspaceId: string
+): Promise<{
+  success: boolean;
+}> => {
+  if (!subscriberId) {
+    return { success: false };
+  }
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    workspaceId
+  );
+  const accessToken = await getSlackToken(auth);
+
+  if (accessToken.isErr()) {
+    return {
+      success: false,
+    };
+  }
+
+  const slackClient = new WebClient(accessToken.value);
+
+  const slackUser = await slackClient.users.lookupByEmail({
+    email: auth.getNonNullableUser().email,
+  });
+
+  if (!slackUser.user?.id) {
+    return {
+      success: false,
+    };
+  }
+
+  const slackWorkspace = await slackClient.team.info();
+
+  if (!slackWorkspace.team?.id) {
+    return {
+      success: false,
+    };
+  }
+
+  const novu = await getNovuClient();
+  const connectionIdentifier = getSlackConnectionIdentifier(subscriberId);
+
+  await novu.channelConnections.create({
+    subscriberId,
+    identifier: connectionIdentifier,
+    integrationIdentifier: "slack",
+    auth: {
+      accessToken: accessToken.value,
+    },
+    workspace: {
+      id: slackWorkspace.team.id,
+      name: slackWorkspace.team?.name,
+    },
+  });
+
+  await novu.channelEndpoints.create({
+    subscriberId,
+    type: "slack_user",
+    integrationIdentifier: "slack",
+    connectionIdentifier,
+    endpoint: {
+      userId: slackUser.user.id,
+    },
+  });
+
+  return {
+    success: true,
+  };
+};
+
+export const ensureSlackNotificationsReady = async (
+  subscriberId?: string,
+  workspaceId?: string
+): Promise<{
+  isReady: boolean;
+}> => {
+  if (!subscriberId || !workspaceId) {
+    return { isReady: false };
+  }
+
+  const isFeatureEnabled = await isSlackNotificationsFeatureEnabled(
+    subscriberId,
+    workspaceId
+  );
+
+  if (!isFeatureEnabled) {
+    return { isReady: false };
+  }
+
+  const isChannelConfigured = await isNovuSlackChannelConfigured(subscriberId);
+
+  // If the slack channel is not configured, we attempt to configure it automatically.
+  // This will fail if the Dust Slack Bot is not configured for the workspace.
+  if (!isChannelConfigured) {
+    const { success } = await configureNovuSlackChannelForUser(
+      subscriberId,
+      workspaceId
+    );
+    if (!success) {
+      return { isReady: false };
+    }
+  }
+  return { isReady: true };
 };

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -2,7 +2,10 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import { getNovuClient } from "@app/lib/notifications";
+import {
+  ensureSlackNotificationsReady,
+  getNovuClient,
+} from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -132,6 +135,39 @@ export const projectAddedAsMemberWorkflow = workflow(
       },
       {
         skip: async () => shouldSkipProject({ payload }),
+      }
+    );
+
+    await step.chat(
+      "slack-notification",
+      async () => {
+        const projectUrl =
+          config.getAppUrl() +
+          getProjectRoute(payload.workspaceId, payload.projectId);
+
+        const baseMessage = `${details.userThatAddedYouFullname} added you to project "${details.projectName}"`;
+
+        const message = `${baseMessage}\n<${projectUrl}|View project>`;
+
+        return {
+          body: message,
+        };
+      },
+      {
+        skip: async () => {
+          const shouldSkip = await shouldSkipProject({ payload });
+          if (shouldSkip) {
+            return true;
+          }
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
+            return true;
+          }
+          return false;
+        },
       }
     );
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -11,9 +11,11 @@ import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 import type { GetUserApprovalsResponseBody } from "@app/pages/api/w/[wId]/me/approvals";
 import type { GetPendingInvitationsResponseBody } from "@app/pages/api/w/[wId]/me/pending-invitations";
+import type { GetSlackNotificationResponseBody } from "@app/pages/api/w/[wId]/me/slack-notifications";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
 import type { LightWorkspaceType } from "@app/types/user";
+import { useMemo } from "react";
 import type { Fetcher, SWRConfiguration } from "swr";
 
 export function useUser(
@@ -190,5 +192,35 @@ export function usePendingInvitations({
     isPendingInvitationsLoading: !error && !data && !disabled,
     isPendingInvitationsError: error,
     mutatePendingInvitations: mutate,
+  };
+}
+
+export function useSlackNotifications(
+  workspaceId: string,
+  options?: {
+    disabled?: boolean;
+  }
+) {
+  const slackNotificationsFetcher: Fetcher<GetSlackNotificationResponseBody> =
+    fetcher;
+
+  const { data, isLoading } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/me/slack-notifications`,
+    slackNotificationsFetcher,
+    { disabled: options?.disabled }
+  );
+
+  const isSlackSetupLoading = useMemo(
+    () => isLoading && !options?.disabled,
+    [isLoading, options?.disabled]
+  );
+
+  const canConfigureSlack = useMemo(() => {
+    return data?.canConfigure === true;
+  }, [data]);
+
+  return {
+    isSlackSetupLoading,
+    canConfigureSlack,
   };
 }

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -210,10 +210,7 @@ export function useSlackNotifications(
     { disabled: options?.disabled }
   );
 
-  const isSlackSetupLoading = useMemo(
-    () => isLoading && !options?.disabled,
-    [isLoading, options?.disabled]
-  );
+  const isSlackSetupLoading = isLoading && !options?.disabled;
 
   const canConfigureSlack = useMemo(() => {
     return data?.canConfigure === true;

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -1,5 +1,5 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -27,6 +27,20 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
+      const featureFlags = await getFeatureFlags(
+        auth.getNonNullableWorkspace()
+      );
+
+      const isFeatureEnabled = featureFlags.includes(
+        "conversations_slack_notifications"
+      );
+
+      if (!isFeatureEnabled) {
+        return res.status(200).json({
+          canConfigure: false,
+        });
+      }
+
       const slackBotConnections =
         await DataSourceResource.listByConnectorProvider(auth, "slack_bot");
 

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -1,0 +1,49 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetSlackNotificationResponseBody = {
+  canConfigure: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSlackNotificationResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const userResource = auth.user();
+  if (!userResource) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "User not authenticated.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const slackBotConnections =
+        await DataSourceResource.listByConnectorProvider(auth, "slack_bot");
+
+      return res.status(200).json({
+        canConfigure: slackBotConnections.length > 0,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR adds Slack notification channel preferences.

- Adds a new endpoint `/api/w/[wId]/me/slack-notifications` to check if Slack bot is configured
- Extends notification preferences UI to include Slack channel checkboxes
- Validates Slack bot configuration before allowing users to enable Slack notifications, displaying an error message if not configured


<img width="1724" height="826" alt="image" src="https://github.com/user-attachments/assets/6450a43d-4ad9-43dd-bae2-cf2e056646bd" />

## Tests

Manually

## Risks

Low risk. Feature is hidden behind feature flag
## Deploy Plan

- Update the novu orgs to have the slack integration configured.