### PR TITLE
Use server api url when available (SPA)

### DIFF
--- a/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
@@ -56,7 +56,6 @@ export async function submitConnectMCPServerDialogForm({
 
   // Step 1: Setup OAuth connection
   const connectionResult = await setupOAuthConnection({
-    dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
     owner,
     provider: authorization.provider,
     // During setup, the use case is always "platform_actions".

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -159,7 +159,6 @@ export async function submitCreateMCPServerDialogForm({
     const scope = authorization.scope;
 
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
       provider: authorization.provider,
       // During setup, the use case is always "platform_actions".

--- a/front/components/labs/transcripts/ProviderSelection.tsx
+++ b/front/components/labs/transcripts/ProviderSelection.tsx
@@ -109,7 +109,6 @@ export function ProviderSelection({
 
   const handleConnectGoogleTranscriptsSource = useCallback(async () => {
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
       provider: "google_drive",
       useCase: "labs_transcripts",

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -86,7 +86,6 @@ export async function setupConnection({
 
   // OAuth flow
   const cRes = await setupOAuthConnection({
-    dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
     owner,
     provider,
     useCase,

--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -53,7 +53,6 @@ export function CreateWebhookSourceWithProviderForm({
     setIsConnectingToProvider(true);
     try {
       const connectionRes = await setupOAuthConnection({
-        dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
         owner,
         provider,
         useCase: "webhooks",

--- a/front/components/workspace/settings/BotToggle.tsx
+++ b/front/components/workspace/settings/BotToggle.tsx
@@ -62,7 +62,6 @@ export function BotToggle({
   const createBotConnectionAndDataSource = async () => {
     // OAuth flow
     const cRes = await setupOAuthConnection({
-      dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
       provider: oauth.provider,
       useCase: oauth.useCase ?? "connection",
@@ -150,7 +149,6 @@ export function BotToggle({
               icon={ArrowPathIcon}
               onClick={async () => {
                 const cRes = await setupOAuthConnection({
-                  dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
                   owner,
                   provider: oauth.provider,
                   useCase: oauth.useCase ?? "connection",

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -896,7 +896,6 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
       }
 
       const cRes = await setupOAuthConnection({
-        dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
         owner,
         provider,
         useCase,

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -1,3 +1,4 @@
+import { getApiBaseUrl } from "@app/lib/egress/client";
 import type {
   OAuthConnectionType,
   OAuthCredentials,
@@ -11,22 +12,22 @@ import { Err, Ok } from "../../shared/result";
 import type { LightWorkspaceType } from "../../user";
 
 export async function setupOAuthConnection({
-  dustClientFacingUrl,
   owner,
   provider,
   useCase,
   extraConfig,
 }: {
-  dustClientFacingUrl: string;
   owner: LightWorkspaceType;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
   extraConfig: OAuthCredentials;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
+    const oauthBaseUrl =
+      getApiBaseUrl() || `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`;
     // Pass opener origin through OAuth flow so finalize page can postMessage back
     const openerOrigin = window.location.origin;
-    let url = `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}&openerOrigin=${encodeURIComponent(openerOrigin)}`;
+    let url = `${oauthBaseUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}&openerOrigin=${encodeURIComponent(openerOrigin)}`;
     if (extraConfig) {
       url += `&extraConfig=${encodeURIComponent(JSON.stringify(extraConfig))}`;
     }
@@ -64,9 +65,9 @@ export async function setupOAuthConnection({
     };
 
     // Method 1: window.postMessage (preferred, direct communication)
-    // Accept messages from dustClientFacingUrl origin (OAuth popup runs on NextJS server)
+    // Accept messages from oauthBaseUrl origin (OAuth popup runs on NextJS server)
     // In dev, bypass origin check as an extra safeguard for cross-port communication
-    const expectedOrigin = new URL(dustClientFacingUrl).origin;
+    const expectedOrigin = new URL(oauthBaseUrl).origin;
     const handleWindowMessage = (event: MessageEvent) => {
       if (!isDevelopment() && event.origin !== expectedOrigin) {
         return;


### PR DESCRIPTION
## Description

Remove the dustClientFacingUrl param as we always pass the same value.
The value is incorrect when using SPA - `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` is resolved statically at build time, and for SPA will always be `dust.tt` . Rather use the `getApiBaseUrl()` which is resolved dynamiclly basedd on the current workspace region. If empty (on nextjs), fallback to `NEXT_PUBLIC_DUST_CLIENT_FACING_URL` .

Note that we can't use getAuthRedirectBaseUrl() as this one is aimed at being used on server , `EnvironmentConfig.getOptionalEnvVariable("DUST_AUTH_REDIRECT_BASE_URL")` will always be null on client.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front

