### PR TITLE
Admin cannot read restricted project.

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1848,9 +1848,22 @@ describe("listSpaceUnreadConversationsForUser", () => {
     agents = await setupTestAgents(workspace, adminUser);
     const space = await SpaceFactory.project(workspace);
 
-    await space.addMembers(adminAuth, {
-      userIds: [regularUser.sId],
+    // Add both admin and regular user as members of the space
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const addMembersRes = await space.addMembers(internalAdminAuth, {
+      userIds: [adminUser.sId, regularUser.sId],
     });
+    if (!addMembersRes.isOk()) {
+      throw new Error("Failed to add users to space");
+    }
+
+    // Refresh adminAuth to get updated permissions
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
 
     userAuth = await Authenticator.fromUserIdAndWorkspaceId(
       regularUser.sId,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1128,7 +1128,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         {
           workspaceId: this.workspaceId,
           roles: [
-            { role: "admin", permissions: ["admin", "read", "write"] },
+            { role: "admin", permissions: ["admin"] },
             { role: "user", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
           ],
           groups: this.groups.reduce((acc, group) => {


### PR DESCRIPTION
## Description

Move admin to "admin" permission only on project (aligned with regular spaces).
Avoid showing restricted project when browsing.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front