### PR TITLE
feat: delete novu slack channel when token is updated

### DIFF
--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -319,7 +319,7 @@ export const ensureSlackNotificationsReady = async (
   return { isReady: true };
 };
 
-export const deleteSlackChannelSetup = async (subscriberId: string) => {
+export const deleteNovuSlackChannelSetup = async (subscriberId: string) => {
   const novu = await getNovuClient();
   const connectionIdentifier = getSlackConnectionIdentifier(subscriberId);
 

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
@@ -4,7 +4,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import config from "@app/lib/api/config";
 import { registerSlackWebhookRouterEntry } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { deleteSlackChannelSetup } from "@app/lib/notifications";
+import { deleteNovuSlackChannelSetup } from "@app/lib/notifications";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
@@ -163,7 +163,7 @@ async function handler(
       // token may have changed. The connection will be re-created with
       // the new token when the user receives a notification.
       if (dataSource.connectorProvider === "slack_bot") {
-        await deleteSlackChannelSetup(user.sId);
+        await deleteNovuSlackChannelSetup(user.sId);
       }
 
       await dataSource.setEditedBy(auth);

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
@@ -4,6 +4,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import config from "@app/lib/api/config";
 import { registerSlackWebhookRouterEntry } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
+import { deleteSlackChannelSetup } from "@app/lib/notifications";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
@@ -156,6 +157,13 @@ async function handler(
             },
           });
         }
+      }
+
+      // We need to delete the novu channel connection because the slack
+      // token may have changed. The connection will be re-created with
+      // the new token when the user receives a notification.
+      if (dataSource.connectorProvider === "slack_bot") {
+        await deleteSlackChannelSetup(user.sId);
       }
 
       await dataSource.setEditedBy(auth);


### PR DESCRIPTION





## Description

This PR adds cleanup logic to delete Novu Slack channel connections when a Slack bot token is updated. 

- Added `deleteSlackChannelSetup` function to handle deletion of Novu Slack channel endpoints and connections
- Integrated cleanup into the data source update endpoint for Slack bot connections

## Tests

Manually

## Risks

Low risk.
## Deploy Plan

Standard deployment.
