### PR TITLE
[cli] fix version display

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -15,6 +15,7 @@ import App from "./ui/App.js";
 const cli = meow({
   importMeta: import.meta,
   autoHelp: false,
+  autoVersion: false,
   flags: {
     version: {
       type: "boolean",

--- a/cli/src/mcp/servers/fsServer.ts
+++ b/cli/src/mcp/servers/fsServer.ts
@@ -2,6 +2,7 @@ import type { DustAPI, Result } from "@dust-tt/client";
 import { DustMcpServerTransport, Err, Ok } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { CLI_VERSION } from "../../utils/version.js";
 import { EditFileTool } from "../tools/editFile.js";
 import { ReadFileTool } from "../tools/readFile.js";
 import { RunCommandTool } from "../tools/runCommand.js";
@@ -30,7 +31,7 @@ export const useFileSystemServer = async (
 
   const server = new McpServer({
     name: "fs-cli",
-    version: process.env.npm_package_version || "0.1.0",
+    version: CLI_VERSION,
   });
 
   const readFileTool = new ReadFileTool();

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -3,6 +3,7 @@ import type { Result } from "meow";
 import type { FC } from "react";
 import React, { useCallback, useState } from "react";
 
+import { CLI_VERSION } from "../utils/version.js";
 import Auth from "./commands/Auth.js";
 import Cache from "./commands/Cache.js";
 import Chat from "./commands/Chat.js";
@@ -90,7 +91,7 @@ const App: FC<AppProps> = ({ cli }) => {
   }, []);
 
   if (flags.version) {
-    return <Text>Dust CLI v{process.env.npm_package_version || "0.1.0"}</Text>;
+    return <Text>Dust CLI v{CLI_VERSION}</Text>;
   }
 
   if (flags.help) {

--- a/cli/src/ui/components/Conversation.tsx
+++ b/cli/src/ui/components/Conversation.tsx
@@ -15,6 +15,7 @@ import React, {
 import { formatFileSize, isImageFile } from "../../utils/fileHandling.js";
 import { useTerminalSize } from "../../utils/hooks/use_terminal_size.js";
 import { clearTerminal } from "../../utils/terminal.js";
+import { CLI_VERSION } from "../../utils/version.js";
 import type { Command } from "../commands/types.js";
 import { CommandSelector } from "./CommandSelector.js";
 import type { UploadedFile } from "./FileUpload.js";
@@ -216,7 +217,7 @@ const StaticConversationItem: FC<StaticConversationItemProps> = ({
           </Box>
           <Box flexDirection="column" justifyContent="center">
             <Text dimColor>
-              Dust CLI v{process.env.npm_package_version || "0.1.0"} ·{" "}
+              Dust CLI v{CLI_VERSION} ·{" "}
               {displayPath}
             </Text>
             <Text dimColor>

--- a/cli/src/ui/components/Conversation.tsx
+++ b/cli/src/ui/components/Conversation.tsx
@@ -217,8 +217,7 @@ const StaticConversationItem: FC<StaticConversationItemProps> = ({
           </Box>
           <Box flexDirection="column" justifyContent="center">
             <Text dimColor>
-              Dust CLI v{CLI_VERSION} ·{" "}
-              {displayPath}
+              Dust CLI v{CLI_VERSION} · {displayPath}
             </Text>
             <Text dimColor>
               Chatting with{" "}

--- a/cli/src/utils/dustClient.ts
+++ b/cli/src/utils/dustClient.ts
@@ -4,6 +4,7 @@ import { DustAPI, Err, Ok } from "@dust-tt/client";
 // biome-ignore lint/suspicious/noImportCycles: I'm too lazy to refactor this right now
 import AuthService from "./authService.js";
 import TokenStorage from "./tokenStorage.js";
+import { CLI_VERSION } from "./version.js";
 
 let dustApiInstance: DustAPI | null = null;
 
@@ -65,7 +66,7 @@ export const getDustClient = async (): Promise<
       },
       workspaceId: (await TokenStorage.getWorkspaceId()) ?? "me",
       extraHeaders: {
-        "X-Dust-CLI-Version": process.env.npm_package_version || "0.1.0",
+        "X-Dust-CLI-Version": CLI_VERSION,
         "User-Agent": "Dust CLI",
       },
     },

--- a/cli/src/utils/version.ts
+++ b/cli/src/utils/version.ts
@@ -1,0 +1,3 @@
+declare const __CLI_VERSION__: string;
+
+export const CLI_VERSION: string = __CLI_VERSION__;

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -1,7 +1,10 @@
 /// <reference types="node" />
 
 import dotenvFlow from "dotenv-flow";
+import { readFileSync } from "fs";
 import { defineConfig } from "tsup";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
 
 const nodeEnv = process.env.NODE_ENV || "development";
 
@@ -20,6 +23,9 @@ export default defineConfig({
   clean: true,
   // Inject environment variables into the build
   env: parsed,
+  define: {
+    __CLI_VERSION__: JSON.stringify(pkg.version),
+  },
   sourcemap: true,
   target: "node16",
 });


### PR DESCRIPTION
## Description

- The version displayed when using the CLI is always set to 0.1.0.
- It's displayed at various locations, when opening the chat next to the logo for instance.
- This PR fixes that, issues comes from the fact that we are running the CLI with node directly instead of doing an `npm run` so `npm_package_version` is never actually set.
- This PR bakes in the version in the built JS file.
- Also fixes the `--version` flag, which used to not output anything due to `meow` overriding it via the `autoVersion` option (doesn't work because `meow` can't find a `package.json` at runtime since we bundle everything into 1 file with `tsup`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Publish new version.
