### PR TITLE
Improve latency of search, include, cat, find_tags, find, list, locate_tree as well as data_warehouses tools by avoid n+1 depending on the number of datasources configurations.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.test.ts
@@ -216,7 +216,7 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isErr()).toBe(true);
     });
 
@@ -229,11 +229,11 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isErr()).toBe(true);
       if (result.isErr()) {
         expect(result.error.message).toContain(
-          "Failed to fetch data source configurations."
+          "Failed to parse data source configurations."
         );
       }
     });
@@ -280,16 +280,18 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.projectId).toBe(folder.dataSource.dustAPIProjectId);
-        expect(result.value.dataSourceId).toBe(
+        expect(result.value[0].projectId).toBe(
+          folder.dataSource.dustAPIProjectId
+        );
+        expect(result.value[0].dataSourceId).toBe(
           folder.dataSource.dustAPIDataSourceId
         );
-        expect(result.value.filter.tags.in).toBeNull();
-        expect(result.value.filter.tags.not).toBeNull();
-        expect(result.value.dataSourceView).toBeDefined();
+        expect(result.value[0].filter.tags.in).toBeNull();
+        expect(result.value[0].filter.tags.not).toBeNull();
+        expect(result.value[0].dataSourceView).toBeDefined();
       }
     });
 
@@ -320,13 +322,17 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toEqual(["tag1", "tag2", "tag3"]);
-        expect(result.value.filter.tags.not).toEqual([]);
-        expect(result.value.filter.parents.in).toBeNull();
-        expect(result.value.filter.parents.not).toBeNull();
+        expect(result.value[0].filter.tags.in).toEqual([
+          "tag1",
+          "tag2",
+          "tag3",
+        ]);
+        expect(result.value[0].filter.tags.not).toEqual([]);
+        expect(result.value[0].filter.parents.in).toBeNull();
+        expect(result.value[0].filter.parents.not).toBeNull();
       }
     });
 
@@ -357,16 +363,16 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toEqual([]);
-        expect(result.value.filter.tags.not).toEqual([
+        expect(result.value[0].filter.tags.in).toEqual([]);
+        expect(result.value[0].filter.tags.not).toEqual([
           "excluded-tag1",
           "excluded-tag2",
         ]);
-        expect(result.value.filter.parents.in).toBeNull();
-        expect(result.value.filter.parents.not).toBeNull();
+        expect(result.value[0].filter.parents.in).toBeNull();
+        expect(result.value[0].filter.parents.not).toBeNull();
       }
     });
 
@@ -397,19 +403,19 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toEqual([
+        expect(result.value[0].filter.tags.in).toEqual([
           "included-tag1",
           "included-tag2",
         ]);
-        expect(result.value.filter.tags.not).toEqual([
+        expect(result.value[0].filter.tags.not).toEqual([
           "excluded-tag1",
           "excluded-tag2",
         ]);
-        expect(result.value.filter.parents.in).toBeNull();
-        expect(result.value.filter.parents.not).toBeNull();
+        expect(result.value[0].filter.parents.in).toBeNull();
+        expect(result.value[0].filter.parents.not).toBeNull();
       }
     });
 
@@ -440,11 +446,14 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toEqual(["auto-tag1", "auto-tag2"]);
-        expect(result.value.filter.tags.not).toEqual(["auto-excluded"]);
+        expect(result.value[0].filter.tags.in).toEqual([
+          "auto-tag1",
+          "auto-tag2",
+        ]);
+        expect(result.value[0].filter.tags.not).toEqual(["auto-excluded"]);
       }
     });
 
@@ -475,13 +484,16 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toBeNull();
-        expect(result.value.filter.tags.not).toBeNull();
-        expect(result.value.filter.parents.in).toEqual(["parent1", "parent2"]);
-        expect(result.value.filter.parents.not).toEqual([]);
+        expect(result.value[0].filter.tags.in).toBeNull();
+        expect(result.value[0].filter.tags.not).toBeNull();
+        expect(result.value[0].filter.parents.in).toEqual([
+          "parent1",
+          "parent2",
+        ]);
+        expect(result.value[0].filter.parents.not).toEqual([]);
       }
     });
 
@@ -512,13 +524,13 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toBeNull();
-        expect(result.value.filter.tags.not).toBeNull();
-        expect(result.value.filter.parents.in).toEqual([]);
-        expect(result.value.filter.parents.not).toEqual([
+        expect(result.value[0].filter.tags.in).toBeNull();
+        expect(result.value[0].filter.tags.not).toBeNull();
+        expect(result.value[0].filter.parents.in).toEqual([]);
+        expect(result.value[0].filter.parents.not).toEqual([
           "excluded-parent1",
           "excluded-parent2",
         ]);
@@ -552,13 +564,18 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toBeNull();
-        expect(result.value.filter.tags.not).toBeNull();
-        expect(result.value.filter.parents.in).toEqual(["parent1", "parent2"]);
-        expect(result.value.filter.parents.not).toEqual(["excluded-parent1"]);
+        expect(result.value[0].filter.tags.in).toBeNull();
+        expect(result.value[0].filter.tags.not).toBeNull();
+        expect(result.value[0].filter.parents.in).toEqual([
+          "parent1",
+          "parent2",
+        ]);
+        expect(result.value[0].filter.parents.not).toEqual([
+          "excluded-parent1",
+        ]);
       }
     });
 
@@ -589,13 +606,13 @@ describe("MCP Internal Actions Server Utils", () => {
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
       };
 
-      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(auth, [dataSourceConfiguration]);
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.filter.tags.in).toEqual(["tag1", "tag2"]);
-        expect(result.value.filter.tags.not).toEqual(["excluded-tag"]);
-        expect(result.value.filter.parents.in).toEqual(["parent1"]);
-        expect(result.value.filter.parents.not).toEqual(["excluded-parent"]);
+        expect(result.value[0].filter.tags.in).toEqual(["tag1", "tag2"]);
+        expect(result.value[0].filter.tags.not).toEqual(["excluded-tag"]);
+        expect(result.value[0].filter.parents.in).toEqual(["parent1"]);
+        expect(result.value[0].filter.parents.not).toEqual(["excluded-parent"]);
       }
     });
 
@@ -645,13 +662,485 @@ describe("MCP Internal Actions Server Utils", () => {
 
       // Try to get core search args with the regular user's auth
       // This should fail because the user cannot read the data source view
-      const result = await getCoreSearchArgs(userAuth, dataSourceConfiguration);
+      const result = await getCoreSearchArgs(userAuth, [
+        dataSourceConfiguration,
+      ]);
       expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        // The error gets wrapped in a generic message, but the underlying issue
-        // is that the data source view is not readable by the user
+        // The error indicates that the data source view is not readable by the user
         expect(result.error.message).toContain(
-          "Failed to fetch data source configurations"
+          "Failed to fetch data source views, some views are not readable."
+        );
+      }
+    });
+
+    it("should handle multiple datasources with no filters", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const space = await SpaceFactory.global(workspace);
+      const folder1 = await DataSourceViewFactory.folder(workspace, space);
+      const folder2 = await DataSourceViewFactory.folder(workspace, space);
+
+      const dataSourceConfig1 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder1.dataSource.id,
+        dataSourceViewId: folder1.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfig2 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder2.dataSource.id,
+        dataSourceViewId: folder2.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfigId1 = makeSId("data_source_configuration", {
+        id: dataSourceConfig1.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId2 = makeSId("data_source_configuration", {
+        id: dataSourceConfig2.id,
+        workspaceId: workspace.id,
+      });
+
+      const dataSourceConfigurations = [
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId1}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId2}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+      ];
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfigurations);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[0].projectId).toBe(
+          folder1.dataSource.dustAPIProjectId
+        );
+        expect(result.value[0].dataSourceId).toBe(
+          folder1.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[0].filter.tags.in).toBeNull();
+        expect(result.value[0].filter.tags.not).toBeNull();
+        expect(result.value[0].filter.parents.in).toBeNull();
+        expect(result.value[0].filter.parents.not).toBeNull();
+
+        expect(result.value[1].projectId).toBe(
+          folder2.dataSource.dustAPIProjectId
+        );
+        expect(result.value[1].dataSourceId).toBe(
+          folder2.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[1].filter.tags.in).toBeNull();
+        expect(result.value[1].filter.tags.not).toBeNull();
+        expect(result.value[1].filter.parents.in).toBeNull();
+        expect(result.value[1].filter.parents.not).toBeNull();
+      }
+    });
+
+    it("should handle multiple datasources with different tag filters", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const space = await SpaceFactory.global(workspace);
+      const folder1 = await DataSourceViewFactory.folder(workspace, space);
+      const folder2 = await DataSourceViewFactory.folder(workspace, space);
+
+      const dataSourceConfig1 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder1.dataSource.id,
+        dataSourceViewId: folder1.id,
+        tagsMode: "custom",
+        tagsIn: ["tag1", "tag2"],
+        tagsNotIn: ["excluded-tag1"],
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfig2 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder2.dataSource.id,
+        dataSourceViewId: folder2.id,
+        tagsMode: "custom",
+        tagsIn: ["tag3", "tag4", "tag5"],
+        tagsNotIn: ["excluded-tag2", "excluded-tag3"],
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfigId1 = makeSId("data_source_configuration", {
+        id: dataSourceConfig1.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId2 = makeSId("data_source_configuration", {
+        id: dataSourceConfig2.id,
+        workspaceId: workspace.id,
+      });
+
+      const dataSourceConfigurations = [
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId1}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId2}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+      ];
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfigurations);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[0].filter.tags.in).toEqual(["tag1", "tag2"]);
+        expect(result.value[0].filter.tags.not).toEqual(["excluded-tag1"]);
+        expect(result.value[0].filter.parents.in).toBeNull();
+        expect(result.value[0].filter.parents.not).toBeNull();
+
+        expect(result.value[1].filter.tags.in).toEqual([
+          "tag3",
+          "tag4",
+          "tag5",
+        ]);
+        expect(result.value[1].filter.tags.not).toEqual([
+          "excluded-tag2",
+          "excluded-tag3",
+        ]);
+        expect(result.value[1].filter.parents.in).toBeNull();
+        expect(result.value[1].filter.parents.not).toBeNull();
+      }
+    });
+
+    it("should handle multiple datasources with different parent filters", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const space = await SpaceFactory.global(workspace);
+      const folder1 = await DataSourceViewFactory.folder(workspace, space);
+      const folder2 = await DataSourceViewFactory.folder(workspace, space);
+
+      const dataSourceConfig1 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder1.dataSource.id,
+        dataSourceViewId: folder1.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+        parentsIn: ["parent1", "parent2"],
+        parentsNotIn: ["excluded-parent1"],
+      });
+
+      const dataSourceConfig2 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder2.dataSource.id,
+        dataSourceViewId: folder2.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+        parentsIn: ["parent3"],
+        parentsNotIn: ["excluded-parent2", "excluded-parent3"],
+      });
+
+      const dataSourceConfigId1 = makeSId("data_source_configuration", {
+        id: dataSourceConfig1.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId2 = makeSId("data_source_configuration", {
+        id: dataSourceConfig2.id,
+        workspaceId: workspace.id,
+      });
+
+      const dataSourceConfigurations = [
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId1}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId2}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+      ];
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfigurations);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[0].filter.parents.in).toEqual([
+          "parent1",
+          "parent2",
+        ]);
+        expect(result.value[0].filter.parents.not).toEqual([
+          "excluded-parent1",
+        ]);
+        expect(result.value[0].filter.tags.in).toBeNull();
+        expect(result.value[0].filter.tags.not).toBeNull();
+
+        expect(result.value[1].filter.parents.in).toEqual(["parent3"]);
+        expect(result.value[1].filter.parents.not).toEqual([
+          "excluded-parent2",
+          "excluded-parent3",
+        ]);
+        expect(result.value[1].filter.tags.in).toBeNull();
+        expect(result.value[1].filter.tags.not).toBeNull();
+      }
+    });
+
+    it("should handle multiple datasources with mixed configurations", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const space = await SpaceFactory.global(workspace);
+      const folder1 = await DataSourceViewFactory.folder(workspace, space);
+      const folder2 = await DataSourceViewFactory.folder(workspace, space);
+      const folder3 = await DataSourceViewFactory.folder(workspace, space);
+      const folder4 = await DataSourceViewFactory.folder(workspace, space);
+
+      // Datasource 1: tags only
+      const dataSourceConfig1 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder1.dataSource.id,
+        dataSourceViewId: folder1.id,
+        tagsMode: "custom",
+        tagsIn: ["tag1"],
+        tagsNotIn: ["excluded-tag1"],
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      // Datasource 2: parents only
+      const dataSourceConfig2 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder2.dataSource.id,
+        dataSourceViewId: folder2.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+        parentsIn: ["parent1"],
+        parentsNotIn: ["excluded-parent1"],
+      });
+
+      // Datasource 3: both tags and parents
+      const dataSourceConfig3 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder3.dataSource.id,
+        dataSourceViewId: folder3.id,
+        tagsMode: "custom",
+        tagsIn: ["tag2", "tag3"],
+        tagsNotIn: ["excluded-tag2"],
+        parentsIn: ["parent2"],
+        parentsNotIn: ["excluded-parent2"],
+      });
+
+      // Datasource 4: no filters
+      const dataSourceConfig4 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder4.dataSource.id,
+        dataSourceViewId: folder4.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfigId1 = makeSId("data_source_configuration", {
+        id: dataSourceConfig1.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId2 = makeSId("data_source_configuration", {
+        id: dataSourceConfig2.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId3 = makeSId("data_source_configuration", {
+        id: dataSourceConfig3.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId4 = makeSId("data_source_configuration", {
+        id: dataSourceConfig4.id,
+        workspaceId: workspace.id,
+      });
+
+      const dataSourceConfigurations = [
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId1}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId2}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId3}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId4}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+      ];
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfigurations);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(4);
+
+        // Datasource 1: tags only
+        expect(result.value[0].filter.tags.in).toEqual(["tag1"]);
+        expect(result.value[0].filter.tags.not).toEqual(["excluded-tag1"]);
+        expect(result.value[0].filter.parents.in).toBeNull();
+        expect(result.value[0].filter.parents.not).toBeNull();
+
+        // Datasource 2: parents only
+        expect(result.value[1].filter.tags.in).toBeNull();
+        expect(result.value[1].filter.tags.not).toBeNull();
+        expect(result.value[1].filter.parents.in).toEqual(["parent1"]);
+        expect(result.value[1].filter.parents.not).toEqual([
+          "excluded-parent1",
+        ]);
+
+        // Datasource 3: both tags and parents
+        expect(result.value[2].filter.tags.in).toEqual(["tag2", "tag3"]);
+        expect(result.value[2].filter.tags.not).toEqual(["excluded-tag2"]);
+        expect(result.value[2].filter.parents.in).toEqual(["parent2"]);
+        expect(result.value[2].filter.parents.not).toEqual([
+          "excluded-parent2",
+        ]);
+
+        // Datasource 4: no filters
+        expect(result.value[3].filter.tags.in).toBeNull();
+        expect(result.value[3].filter.tags.not).toBeNull();
+        expect(result.value[3].filter.parents.in).toBeNull();
+        expect(result.value[3].filter.parents.not).toBeNull();
+
+        // Verify each datasource has correct project and datasource IDs
+        expect(result.value[0].projectId).toBe(
+          folder1.dataSource.dustAPIProjectId
+        );
+        expect(result.value[0].dataSourceId).toBe(
+          folder1.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[1].projectId).toBe(
+          folder2.dataSource.dustAPIProjectId
+        );
+        expect(result.value[1].dataSourceId).toBe(
+          folder2.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[2].projectId).toBe(
+          folder3.dataSource.dustAPIProjectId
+        );
+        expect(result.value[2].dataSourceId).toBe(
+          folder3.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[3].projectId).toBe(
+          folder4.dataSource.dustAPIProjectId
+        );
+        expect(result.value[3].dataSourceId).toBe(
+          folder4.dataSource.dustAPIDataSourceId
+        );
+      }
+    });
+
+    it("should handle multiple datasources and return them in the correct order", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const space = await SpaceFactory.global(workspace);
+      const folder1 = await DataSourceViewFactory.folder(workspace, space);
+      const folder2 = await DataSourceViewFactory.folder(workspace, space);
+      const folder3 = await DataSourceViewFactory.folder(workspace, space);
+
+      const dataSourceConfig1 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder1.dataSource.id,
+        dataSourceViewId: folder1.id,
+        tagsMode: "custom",
+        tagsIn: ["ds1-tag"],
+        tagsNotIn: [],
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfig2 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder2.dataSource.id,
+        dataSourceViewId: folder2.id,
+        tagsMode: "custom",
+        tagsIn: ["ds2-tag"],
+        tagsNotIn: [],
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfig3 = await AgentDataSourceConfigurationModel.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder3.dataSource.id,
+        dataSourceViewId: folder3.id,
+        tagsMode: "custom",
+        tagsIn: ["ds3-tag"],
+        tagsNotIn: [],
+        parentsIn: null,
+        parentsNotIn: null,
+      });
+
+      const dataSourceConfigId1 = makeSId("data_source_configuration", {
+        id: dataSourceConfig1.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId2 = makeSId("data_source_configuration", {
+        id: dataSourceConfig2.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfigId3 = makeSId("data_source_configuration", {
+        id: dataSourceConfig3.id,
+        workspaceId: workspace.id,
+      });
+
+      // Order: ds2, ds1, ds3
+      const dataSourceConfigurations = [
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId2}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId1}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+        {
+          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId3}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+        },
+      ];
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfigurations);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(3);
+        // Verify order matches input order
+        expect(result.value[0].filter.tags.in).toEqual(["ds2-tag"]);
+        expect(result.value[0].dataSourceId).toBe(
+          folder2.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[1].filter.tags.in).toEqual(["ds1-tag"]);
+        expect(result.value[1].dataSourceId).toBe(
+          folder1.dataSource.dustAPIDataSourceId
+        );
+        expect(result.value[2].filter.tags.in).toEqual(["ds3-tag"]);
+        expect(result.value[2].dataSourceId).toBe(
+          folder3.dataSource.dustAPIDataSourceId
         );
       }
     });

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -17,18 +17,22 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  getResourceNameAndIdFromSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import type {
   CoreAPIDatasourceViewFilter,
   CoreAPISearchFilter,
 } from "@app/types/core/core_api";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
+import { Op } from "sequelize";
 
 const NO_DATA_SOURCE_AVAILABLE_ERROR =
   "No data source is available in the current scope. There is no data to " +
@@ -76,40 +80,6 @@ export function makeCoreSearchNodesFilters({
         : {}),
     })
   );
-}
-
-async function fetchAgentDataSourceConfiguration(
-  dataSourceConfigSId: string
-): Promise<Result<AgentDataSourceConfigurationModel, Error>> {
-  const sIdParts = getResourceNameAndIdFromSId(dataSourceConfigSId);
-  if (!sIdParts) {
-    return new Err(
-      new Error(`Invalid data source configuration ID: ${dataSourceConfigSId}`)
-    );
-  }
-  if (sIdParts.resourceName !== "data_source_configuration") {
-    return new Err(
-      new Error(
-        `ID is not a data source configuration ID: ${dataSourceConfigSId}`
-      )
-    );
-  }
-
-  const agentDataSourceConfiguration =
-    await AgentDataSourceConfigurationModel.findOne({
-      where: {
-        id: sIdParts.resourceModelId,
-        workspaceId: sIdParts.workspaceModelId,
-      },
-    });
-
-  if (!agentDataSourceConfiguration) {
-    return new Err(
-      new Error(`Data source configuration ${dataSourceConfigSId} not found`)
-    );
-  }
-
-  return new Ok(agentDataSourceConfiguration);
 }
 
 export async function fetchTableDataSourceConfigurations(
@@ -271,125 +241,232 @@ export async function getAgentDataSourceConfigurations(
   auth: Authenticator,
   dataSources: DataSourcesToolConfigurationType
 ): Promise<Result<ResolvedDataSourceConfiguration[], MCPError>> {
-  const configResults = await concurrentExecutor(
-    dataSources,
-    async (dataSourceConfiguration) => {
-      const configInfoRes = parseDataSourceConfigurationURI(
-        dataSourceConfiguration.uri
-      );
+  const configInfosRes = dataSources.map((dataSourceConfiguration) => {
+    return parseDataSourceConfigurationURI(dataSourceConfiguration.uri);
+  });
 
-      if (configInfoRes.isErr()) {
-        return configInfoRes;
-      }
+  if (configInfosRes.some((res) => res.isErr())) {
+    return new Err(new MCPError("Failed to parse data source configurations."));
+  }
 
-      const configInfo = configInfoRes.value;
-
-      switch (configInfo.type) {
-        case "database": {
-          // Database configuration
-          const r = await fetchAgentDataSourceConfiguration(configInfo.sId);
-          if (r.isErr()) {
-            return r;
-          }
-          const agentConfig = r.value;
-          const dataSourceViewSId = DataSourceViewResource.modelIdToSId({
-            id: agentConfig.dataSourceViewId,
-            workspaceId: agentConfig.workspaceId,
-          });
-
-          const dataSourceView = await DataSourceViewResource.fetchById(
-            auth,
-            dataSourceViewSId
-          );
-          if (!dataSourceView || !dataSourceView.canRead(auth)) {
-            return new Err(
-              new Error(`Data source view not found: ${dataSourceViewSId}`)
-            );
-          }
-
-          const resolved: ResolvedDataSourceConfiguration = {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            dataSourceViewId: dataSourceViewSId,
-            filter: {
-              parents:
-                agentConfig.parentsIn !== null ||
-                agentConfig.parentsNotIn !== null
-                  ? {
-                      in: agentConfig.parentsIn ?? [],
-                      not: agentConfig.parentsNotIn ?? [],
-                    }
-                  : null,
-              tags:
-                agentConfig.tagsIn !== null || agentConfig.tagsNotIn !== null
-                  ? {
-                      in: agentConfig.tagsIn ?? [],
-                      not: agentConfig.tagsNotIn ?? [],
-                      mode: agentConfig.tagsMode ?? "custom",
-                    }
-                  : null,
-            },
-            dataSource: {
-              dustAPIProjectId: dataSourceView.dataSource.dustAPIProjectId,
-              dustAPIDataSourceId:
-                dataSourceView.dataSource.dustAPIDataSourceId,
-              connectorProvider: dataSourceView.dataSource.connectorProvider,
-              name: dataSourceView.dataSource.name,
-            },
-            dataSourceView,
-          };
-          return new Ok(resolved);
-        }
-
-        case "dynamic": {
-          // Dynamic configuration
-          // Verify the workspace ID matches the auth
-          if (
-            configInfo.configuration.workspaceId !==
-            auth.getNonNullableWorkspace().sId
-          ) {
-            return new Err(
-              new Error(
-                "Workspace mismatch: configuration workspace " +
-                  `${configInfo.configuration.workspaceId} does not match authenticated workspace.`
-              )
-            );
-          }
-
-          // Fetch the specific data source view by ID
-          const dataSourceView = await DataSourceViewResource.fetchById(
-            auth,
-            configInfo.configuration.dataSourceViewId
-          );
-
-          if (!dataSourceView || !dataSourceView.canRead(auth)) {
-            return new Err(
-              new Error(
-                `Data source view not found: ${configInfo.configuration.dataSourceViewId}`
-              )
-            );
-          }
-
-          const dataSource = dataSourceView.dataSource;
-
-          const resolved: ResolvedDataSourceConfiguration = {
-            ...configInfo.configuration,
-            dataSource: {
-              dustAPIProjectId: dataSource.dustAPIProjectId,
-              dustAPIDataSourceId: dataSource.dustAPIDataSourceId,
-              connectorProvider: dataSource.connectorProvider,
-              name: dataSource.name,
-            },
-            dataSourceView,
-          };
-          return new Ok(resolved);
-        }
-
-        default:
-          assertNever(configInfo);
-      }
-    },
-    { concurrency: 10 }
+  const configInfos = removeNulls(
+    configInfosRes.map((res) => (res.isOk() ? res.value : null))
   );
+
+  const agentDataSourceConfigurationIDs: ModelId[] = [];
+  for (const configInfo of configInfos) {
+    if (configInfo.type === "database") {
+      const sIdParts = getResourceNameAndIdFromSId(configInfo.sId);
+      if (!sIdParts) {
+        return new Err(
+          new MCPError(
+            `Invalid data source configuration ID: ${configInfo.sId}`
+          )
+        );
+      }
+      if (sIdParts.resourceName !== "data_source_configuration") {
+        return new Err(
+          new MCPError(
+            `ID is not a data source configuration ID: ${configInfo.sId}`
+          )
+        );
+      }
+      agentDataSourceConfigurationIDs.push(sIdParts.resourceModelId);
+    }
+  }
+
+  const agentDataSourceConfigurations =
+    await AgentDataSourceConfigurationModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: {
+          [Op.in]: agentDataSourceConfigurationIDs,
+        },
+      },
+    });
+
+  if (
+    agentDataSourceConfigurations.length !==
+    agentDataSourceConfigurationIDs.length
+  ) {
+    return new Err(
+      new MCPError(
+        "Failed to fetch data source configurations, mismatched number of configurations found."
+      )
+    );
+  }
+
+  const agentDataSourceConfigurationsMap = new Map<
+    string,
+    AgentDataSourceConfigurationModel
+  >();
+  for (const agentDataSourceConfiguration of agentDataSourceConfigurations) {
+    agentDataSourceConfigurationsMap.set(
+      makeSId("data_source_configuration", {
+        id: agentDataSourceConfiguration.id,
+        workspaceId: agentDataSourceConfiguration.workspaceId,
+      }),
+      agentDataSourceConfiguration
+    );
+  }
+
+  const dataSourceViewIDs: ModelId[] = [];
+  for (const agentDataSourceConfiguration of agentDataSourceConfigurations) {
+    dataSourceViewIDs.push(agentDataSourceConfiguration.dataSourceViewId);
+  }
+  for (const configInfo of configInfos) {
+    if (configInfo.type === "dynamic") {
+      const sIdParts = getResourceNameAndIdFromSId(
+        configInfo.configuration.dataSourceViewId
+      );
+      if (!sIdParts) {
+        return new Err(
+          new MCPError(
+            `Invalid data source view ID: ${configInfo.configuration.dataSourceViewId}`
+          )
+        );
+      }
+      dataSourceViewIDs.push(sIdParts.resourceModelId);
+    }
+  }
+
+  const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
+    auth,
+    dataSourceViewIDs
+  );
+
+  if (dataSourceViews.some((dataSourceView) => !dataSourceView.canRead(auth))) {
+    return new Err(
+      new MCPError(
+        "Failed to fetch data source views, some views are not readable."
+      )
+    );
+  }
+
+  if (dataSourceViews.length !== dataSourceViewIDs.length) {
+    return new Err(
+      new MCPError(
+        "Failed to fetch data source views, mismatched number of views found."
+      )
+    );
+  }
+
+  const dataSourceViewsMap = new Map<string, DataSourceViewResource>();
+  for (const dataSourceView of dataSourceViews) {
+    dataSourceViewsMap.set(
+      DataSourceViewResource.modelIdToSId({
+        id: dataSourceView.id,
+        workspaceId: dataSourceView.workspaceId,
+      }),
+      dataSourceView
+    );
+  }
+
+  const configResults = configInfos.map((configInfo) => {
+    switch (configInfo.type) {
+      case "database": {
+        // Database configuration
+        const agentConfig = agentDataSourceConfigurationsMap.get(
+          configInfo.sId
+        );
+        if (!agentConfig) {
+          return new Err(
+            new MCPError(
+              `Data source configuration not found: ${configInfo.sId}`
+            )
+          );
+        }
+        const dataSourceViewSId = DataSourceViewResource.modelIdToSId({
+          id: agentConfig.dataSourceViewId,
+          workspaceId: agentConfig.workspaceId,
+        });
+
+        const dataSourceView = dataSourceViewsMap.get(dataSourceViewSId);
+        if (!dataSourceView || !dataSourceView.canRead(auth)) {
+          return new Err(
+            new Error(`Data source view not found: ${dataSourceViewSId}`)
+          );
+        }
+
+        const resolved: ResolvedDataSourceConfiguration = {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          dataSourceViewId: dataSourceViewSId,
+          filter: {
+            parents:
+              agentConfig.parentsIn !== null ||
+              agentConfig.parentsNotIn !== null
+                ? {
+                    in: agentConfig.parentsIn ?? [],
+                    not: agentConfig.parentsNotIn ?? [],
+                  }
+                : null,
+            tags:
+              agentConfig.tagsIn !== null || agentConfig.tagsNotIn !== null
+                ? {
+                    in: agentConfig.tagsIn ?? [],
+                    not: agentConfig.tagsNotIn ?? [],
+                    mode: agentConfig.tagsMode ?? "custom",
+                  }
+                : null,
+          },
+          dataSource: {
+            dustAPIProjectId: dataSourceView.dataSource.dustAPIProjectId,
+            dustAPIDataSourceId: dataSourceView.dataSource.dustAPIDataSourceId,
+            connectorProvider: dataSourceView.dataSource.connectorProvider,
+            name: dataSourceView.dataSource.name,
+          },
+          dataSourceView,
+        };
+        return new Ok(resolved);
+      }
+
+      case "dynamic": {
+        // Dynamic configuration
+        // Verify the workspace ID matches the auth
+        if (
+          configInfo.configuration.workspaceId !==
+          auth.getNonNullableWorkspace().sId
+        ) {
+          return new Err(
+            new Error(
+              "Workspace mismatch: configuration workspace " +
+                `${configInfo.configuration.workspaceId} does not match authenticated workspace.`
+            )
+          );
+        }
+
+        // Fetch the specific data source view by ID
+        const dataSourceView = dataSourceViewsMap.get(
+          configInfo.configuration.dataSourceViewId
+        );
+
+        if (!dataSourceView || !dataSourceView.canRead(auth)) {
+          return new Err(
+            new Error(
+              `Data source view not found: ${configInfo.configuration.dataSourceViewId}`
+            )
+          );
+        }
+
+        const dataSource = dataSourceView.dataSource;
+
+        const resolved: ResolvedDataSourceConfiguration = {
+          ...configInfo.configuration,
+          dataSource: {
+            dustAPIProjectId: dataSource.dustAPIProjectId,
+            dustAPIDataSourceId: dataSource.dustAPIDataSourceId,
+            connectorProvider: dataSource.connectorProvider,
+            name: dataSource.name,
+          },
+          dataSourceView,
+        };
+        return new Ok(resolved);
+      }
+
+      default:
+        assertNever(configInfo);
+    }
+  });
 
   if (configResults.some((res) => res.isErr())) {
     return new Err(new MCPError("Failed to fetch data source configurations."));
@@ -410,34 +487,37 @@ export async function getAgentDataSourceConfigurations(
 
 export async function getCoreSearchArgs(
   auth: Authenticator,
-  dataSourceConfiguration: DataSourcesToolConfigurationType[number]
-): Promise<Result<CoreSearchArgs, Error>> {
-  const configRes = await getAgentDataSourceConfigurations(auth, [
-    dataSourceConfiguration,
-  ]);
+  dataSourceConfigurations: DataSourcesToolConfigurationType
+): Promise<Result<CoreSearchArgs[], Error>> {
+  const configRes = await getAgentDataSourceConfigurations(
+    auth,
+    dataSourceConfigurations
+  );
 
   if (configRes.isErr()) {
     return configRes;
   }
 
-  const config = configRes.value[0];
+  const configs = configRes.value;
 
-  return new Ok({
-    projectId: config.dataSource.dustAPIProjectId,
-    dataSourceId: config.dataSource.dustAPIDataSourceId,
-    filter: {
-      tags: {
-        in: config.filter.tags?.in ?? null,
-        not: config.filter.tags?.not ?? null,
+  return new Ok(
+    configs.map((config) => ({
+      projectId: config.dataSource.dustAPIProjectId,
+      dataSourceId: config.dataSource.dustAPIDataSourceId,
+      filter: {
+        tags: {
+          in: config.filter.tags?.in ?? null,
+          not: config.filter.tags?.not ?? null,
+        },
+        parents: {
+          in: config.filter.parents?.in ?? null,
+          not: config.filter.parents?.not ?? null,
+        },
       },
-      parents: {
-        in: config.filter.parents?.in ?? null,
-        not: config.filter.parents?.not ?? null,
-      },
-    },
-    view_filter: config.dataSourceView.toViewFilter(),
-    dataSourceView: config.dataSourceView.toJSON(),
-  });
+      view_filter: config.dataSourceView.toViewFilter(),
+      dataSourceView: config.dataSourceView.toJSON(),
+    }))
+  );
 }
 
 export type ProjectConfigInfo = {

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -19,13 +19,11 @@ import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { removeNulls } from "@app/types/shared/utils/general";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
 import {
   parseTimeFrame,
@@ -69,31 +67,19 @@ export async function searchFunction(
     agentLoopContext.runContext.stepContext;
 
   // Get the core search args for each data source, fail if any of them are invalid.
-  const coreSearchArgsResults = await concurrentExecutor(
-    dataSources,
-    async (dataSourceConfiguration) =>
-      getCoreSearchArgs(auth, dataSourceConfiguration),
-    { concurrency: 10 }
-  );
+  const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);
 
   // If any of the data sources are invalid, return an error message.
-  if (coreSearchArgsResults.some((res) => res.isErr())) {
+  if (coreSearchArgsResults.isErr()) {
     return new Err(
       new MCPError(
-        "Invalid data sources: " +
-          removeNulls(
-            coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
-          )
-            .map((error) => error.message)
-            .join("\n"),
+        "Invalid data sources: " + coreSearchArgsResults.error.message,
         { tracked: false }
       )
     );
   }
 
-  const coreSearchArgs = removeNulls(
-    coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
-  );
+  const coreSearchArgs = coreSearchArgsResults.value;
 
   if (coreSearchArgs.length === 0) {
     return new Err(


### PR DESCRIPTION
## Description

Refactor getAgentDataSourceConfigurations() to avoid n+1 query when fetching multiple datasource configuration from on the same agent.
Reduce from N to 2 queries: one for fetching the datasource configs, one for fetching the datasource views.

## Tests

Locally + added

## Risk

Medium

## Deploy Plan

Deploy front