### PR TITLE
[Origin] Propagate userMessageOrigin when relaunching agent loop after UX tool validation

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -43,6 +43,7 @@ import type {
   MessageVisibility,
   RichMentionWithStatus,
   UserMessageContext,
+  UserMessageOrigin,
   UserMessageType,
   UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
@@ -950,6 +951,7 @@ export async function getUserMessageIdFromMessageId(
   userMessageId: string;
   userMessageVersion: number;
   userMessageUserId: number | null;
+  userMessageOrigin: UserMessageOrigin;
 }> {
   // Query 1: Get the message and its parentId.
   const agentMessage = await MessageModel.findOne({
@@ -978,7 +980,7 @@ export async function getUserMessageIdFromMessageId(
         model: UserMessageModel,
         as: "userMessage",
         required: true,
-        attributes: ["userId"],
+        attributes: ["userId", "userContextOrigin"],
       },
     ],
   });
@@ -994,6 +996,7 @@ export async function getUserMessageIdFromMessageId(
     userMessageId: parentMessage.sId,
     userMessageVersion: parentMessage.version,
     userMessageUserId: parentMessage.userMessage.userId,
+    userMessageOrigin: parentMessage.userMessage.userContextOrigin,
   };
 }
 

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -57,6 +57,7 @@ export async function validateAction(
     userMessageId,
     userMessageVersion,
     userMessageUserId,
+    userMessageOrigin,
   } = await getUserMessageIdFromMessageId(auth, {
     messageId,
   });
@@ -199,6 +200,7 @@ export async function validateAction(
       conversationTitle,
       userMessageId,
       userMessageVersion,
+      userMessageOrigin,
     },
     // Resume from the step where the action was created.
     startStep: agentStepContent.step,


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/21746

The UX tool validation path (`validate_actions.ts`) did not propagate the initial `userMessageOrigin`. 

This could cause issues on any flow going through validation that's relying on user message origin (e.g. it  caused `sendEmailReplyOnCompletion` to silently skip because of its reliance on origin)

## Risks

Blast radius: email replies after UX-based tool validation for email-originated conversations
Risk: low

## Deploy Plan
- pmrr
- deploy front