### PR TITLE
Add Gdrive CLI command to full sync a folder

### DIFF
--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -8,6 +8,7 @@ import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/go
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import { markFolderAsVisited } from "@connectors/connectors/google_drive/temporal/activities";
 import {
+  launchGoogleDriveFullSyncWorkflow,
   launchGoogleDriveIncrementalSyncWorkflow,
   launchGoogleFixParentsConsistencyWorkflow,
 } from "@connectors/connectors/google_drive/temporal/client";
@@ -44,6 +45,7 @@ import {
   FILE_ATTRIBUTES_TO_FETCH,
   googleDriveIncrementalSyncWorkflowId,
 } from "@connectors/types";
+import { isString } from "@connectors/types/shared/utils/general";
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse } from "googleapis-common";
 
@@ -294,6 +296,18 @@ export const google_drive = async ({
       return { success: true };
     }
 
+    case "start-full-sync": {
+      const connector = await getConnector(args);
+      const folderId = isString(args.folderId) ? args.folderId : undefined;
+      await throwOnError(
+        launchGoogleDriveFullSyncWorkflow(
+          connector.id,
+          null,
+          folderId ? [folderId] : null
+        )
+      );
+      return { success: true };
+    }
     case "start-incremental-sync": {
       const connector = await getConnector(args);
       await throwOnError(

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -232,6 +232,7 @@ export const GoogleDriveCommandSchema = t.type({
     t.literal("upsert-file"),
     t.literal("update-core-parents"),
     t.literal("restart-google-webhooks"),
+    t.literal("start-full-sync"),
     t.literal("start-incremental-sync"),
     t.literal("restart-all-incremental-sync-workflows"),
     t.literal("skip-file"),


### PR DESCRIPTION
## Description

Add a CLI command to trigger full sync of a folder so we can re-sync a folder without resync the whole datasource

## Tests

no

## Risk

low, it's internal CLI

## Deploy Plan

deploy connector