### PR TITLE
Fix editor crash on empty instruction block tags

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -245,6 +245,11 @@ code block
           isCollapsed: false,
           type: "instructions_toto",
         },
+        content: [
+          {
+            type: "paragraph",
+          },
+        ],
         type: "instructionBlock",
       },
       {
@@ -255,7 +260,7 @@ code block
     const result = editor.getMarkdown();
     expect(result).toBe(`<instructions_toto>
 
-
+&nbsp;
 
 </instructions_toto>
 
@@ -359,6 +364,17 @@ Toto:
 </instructions>
 
 &nbsp;`);
+  });
+
+  it("should not throw on tags with only whitespace content", () => {
+    expect(() => {
+      editor.commands.setContent("<foo>\n</foo>\n\nHello", {
+        contentType: "markdown",
+      });
+    }).not.toThrow();
+
+    const text = editor.getText();
+    expect(text).toContain("Hello");
   });
 
   it("should work on deep-nested instruction blocks with NBSP", () => {

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -555,7 +555,9 @@ export const InstructionBlockExtension =
           type: tagType,
           isCollapsed: false,
         },
-        // Ensure at least one paragraph to satisfy "block+" schema.
+        // When tags contain only whitespace (e.g. "<foo>\n</foo>"), blockTokens("\n") produces
+        // tokens that parseChildren can't convert to valid blocks, returning an empty array. This
+        // violates the "block+" schema and crashes ProseMirror. Fall back to an empty paragraph.
         content: content.length > 0 ? content : [{ type: "paragraph" }],
       };
     },

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -547,6 +547,7 @@ export const InstructionBlockExtension =
 
     parseMarkdown: (token, helpers) => {
       const tagType = token.attrs?.type ?? "instructions";
+      const content = helpers.parseChildren(token.tokens ?? []);
 
       return {
         type: "instructionBlock",
@@ -554,8 +555,8 @@ export const InstructionBlockExtension =
           type: tagType,
           isCollapsed: false,
         },
-        // The content markdown will be parsed by the markdown parser
-        content: helpers.parseChildren(token.tokens ?? []),
+        // Ensure at least one paragraph to satisfy "block+" schema.
+        content: content.length > 0 ? content : [{ type: "paragraph" }],
       };
     },
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C0A6TBTU7JS/p1771330045363239?thread_ts=1771323008.884039&cid=C0A6TBTU7JS).

This PR fixes `Invalid content for node type instructionBlock` crash when agent instructions contain tags with only whitespace content (e.g. `<foo>\n</foo>`). The `marked` tokenizer produces tokens from the whitespace that `parseChildren` can't convert to valid block nodes, returning an empty array which ends up violating the `block+` schema. We add a fall back to an empty paragraph when parsed content is empty

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
