### PR TITLE
[Cost Guardrails] Restore migration_513 and move step-cost index to migration_514

### DIFF
--- a/front/migrations/db/migration_513.sql
+++ b/front/migrations/db/migration_513.sql
@@ -1,4 +1,3 @@
 -- Migration created on Feb 16, 2026
--- Speeds up agentic descendant traversal in cost-threshold logging.
-CREATE INDEX CONCURRENTLY "user_messages_workspace_agentic_origin_idx"
-  ON "user_messages" ("workspaceId", "agenticOriginMessageId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "files_workspace_id_use_case_status_"
+    ON "files" ("workspaceId", "useCase", "status", ("useCaseMetadata" #>> '{spaceId}'));

--- a/front/migrations/db/migration_514.sql
+++ b/front/migrations/db/migration_514.sql
@@ -1,0 +1,4 @@
+-- Migration created on Feb 17, 2026
+-- Speeds up agentic descendant traversal in cost-threshold logging.
+CREATE INDEX CONCURRENTLY "user_messages_workspace_agentic_origin_idx"
+  ON "user_messages" ("workspaceId", "agenticOriginMessageId");


### PR DESCRIPTION
## Description
Fixes regression in https://github.com/dust-tt/dust/pull/21692.

`migration_513.sql` was unintentionally overwritten during rebase conflict resolution.
This PR restores `migration_513.sql` to its original content and moves the step-cost index migration to `migration_514.sql`.

## Risks
Blast radius: front DB migrations only (`migration_513.sql` and new `migration_514.sql`).
Risk: low.

## Deploy Plan
Both migrations were already run, no deployment needed
- pmrr
