### PR TITLE
Update preview proxy+cors

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -166,7 +166,7 @@ jobs:
           component: spa-${{ inputs.app }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          preview_url: ${{ github.ref_name == 'main' && format('https://{0}.dust.tt', inputs.app) || format('https://{0}.{1}-dust-tt.pages.dev', github.ref_name, inputs.app) }}
+          preview_url: ${{ github.ref_name == 'main' && format('https://{0}.dust.tt', inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}
 
       - name: Notify Failure
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -254,23 +254,23 @@ jobs:
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
   deploy-app:
-    if: inputs.component == 'front' && inputs.deploy_spa_app
+    if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_app
     needs: [build, notify-start]
     uses: ./.github/workflows/deploy-spa.yaml
     with:
       app: "app"
-      env: "prod"
+      env: ${{ inputs.component == 'front-edge' && 'edge' || 'prod' }}
       region: "us"
       thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
     secrets: inherit
 
   deploy-poke:
-    if: inputs.component == 'front' && inputs.deploy_spa_poke
+    if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_poke
     needs: [build, notify-start]
     uses: ./.github/workflows/deploy-spa.yaml
     with:
       app: "poke"
-      env: "prod"
+      env: ${{ inputs.component == 'front-edge' && 'edge' || 'prod' }}
       region: "us"
       thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
     secrets: inherit

--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -25,9 +25,8 @@ const STATIC_ALLOWED_ORIGINS = [
 const ALLOWED_ORIGIN_PATTERNS = [
   // Zendesk domains
   new RegExp("^https://.+\\.zendesk\\.com$"),
-  // Staging apps - allow all builds from poke-dust-tt.pages.dev and app-dust-tt.pages.dev.
-  new RegExp("^https://.*\\.poke-dust-tt\\.pages\\.dev$"),
-  new RegExp("^https://.*\\.app-dust-tt\\.pages\\.dev$"),
+  // Staging apps - allow all builds from *.preview.dust.tt .
+  new RegExp("^https://.*\\.preview\\.dust\\.tt$"),
 ] as const;
 
 type StaticAllowedOriginType = (typeof STATIC_ALLOWED_ORIGINS)[number];

--- a/preview-proxy/wrangler.toml
+++ b/preview-proxy/wrangler.toml
@@ -1,6 +1,7 @@
 name = "spa-preview-proxy"
 main = "src/index.js"
 compatibility_date = "2024-01-01"
+account_id = "5a44859b168e553752e336f31cda3ee3"
 
 routes = [
   { pattern = "*.preview.dust.tt/*", zone_id = "96040ce5ff46a72a1861ce0ec63e6154" },


### PR DESCRIPTION
## Description

Updates the SPA preview infrastructure to use `*.preview.dust.tt` with a `--` separator for branch/project routing:

- **Preview proxy**: Updated the Cloudflare Worker to support both app and poke projects using the format `<branch>--<app|poke>.preview.dust.tt` (flattened to stay within wildcard SSL cert coverage)
  - `my-branch--app.preview.dust.tt` → `my-branch.app-dust-tt.pages.dev`
  - `my-branch--poke.preview.dust.tt` → `my-branch.poke-dust-tt.pages.dev`
- **CORS**: Replaced `*.app-dust-tt.pages.dev` / `*.poke-dust-tt.pages.dev` patterns with a single `*.preview.dust.tt` pattern
- **CI**: Updated `deploy-spa.yaml` preview URL to use the new `preview.dust.tt` format

This allows testing SPA branches on a `.dust.tt` subdomain so that cookies (auth, sessions) are sent to the API — which isn't possible with the default `*.pages.dev` domain (cross-domain).

## Tests

- Deploy the worker with `npx wrangler deploy` from `preview-proxy/`
- Verify `<branch>--app.preview.dust.tt` serves the correct Pages preview
- Verify cookies are sent to the API

## Risk

Low. The Worker only affects `*.preview.dust.tt` which was previously pointing to a dead IP (404). CORS change narrows the allowed origins from two `pages.dev` patterns to one `preview.dust.tt` pattern.

## Deploy Plan

1. Merge and deploy the CORS change (front)
2. `cd preview-proxy && npm install && npx wrangler deploy`
3. Verify a branch preview is accessible at `<branch>--<app|poke>.preview.dust.tt`