### PR TITLE
[front] A/B test Opus 4.6 on enterprise plans for dust & deep-dive

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -5,6 +5,7 @@ import {
   DEEP_DIVE_DESC,
   DEEP_DIVE_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import { shouldUseOpus } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import {
   getCompanyDataAction,
   getCompanyDataWarehousesAction,
@@ -20,10 +21,6 @@ import {
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import {
-  isDustCompanyPlan,
-  isEntreprisePlanPrefix,
-} from "@app/lib/plans/plan_codes";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -461,9 +458,7 @@ export function _getDeepDiveGlobalAgent(
   const modelConfig = getModelConfig(owner, "anthropic");
 
   const enterpriseModelConfig =
-    (isEntreprisePlanPrefix(auth.plan()?.code ?? "") ||
-      isDustCompanyPlan(auth.plan()?.code ?? "")) &&
-    isProviderWhitelisted(owner, "anthropic")
+    shouldUseOpus(auth) && isProviderWhitelisted(owner, "anthropic")
       ? {
           modelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
           reasoningEffort: modelConfig?.reasoningEffort ?? ("light" as const),


### PR DESCRIPTION
## Description

Deterministic 50/50 A/B test of Claude Opus 4.6 vs Sonnet 4.5 for the `@dust` and `@deep-dive` global agents on enterprise-plan workspaces.

- **DUST_COMPANY plan**: always gets Opus 4.6
- **Enterprise plans**: deterministic 50/50 split based on workspace `sId` hash (same workspace always gets the same model)
- **All other plans**: unchanged (Sonnet 4.5)

Both agents share the same `shouldUseOpus(auth)` helper so a given workspace always gets the same model for both `@dust` and `@deep-dive`.

Also includes the `featureFlag` → `customAssistantFeatureFlag` change on the Opus 4.6 model config (merged in prior PR) so global agents can use Opus 4.6 without requiring the workspace feature flag.

## Tests

- Type-check passes (`tsc --noEmit`)
- Manual reasoning:
  - DUST_COMPANY workspace → Opus 4.6 always
  - Enterprise workspace (hash even) → Opus 4.6 with "light" reasoning
  - Enterprise workspace (hash odd) → Sonnet 4.5 with "light" reasoning
  - Pro/free workspace → Sonnet 4.5

## Risk

Low. The split is deterministic and consistent across both agents. Rollback by reverting the commit.

## Deploy Plan

Standard deploy. Monitor latency/cost for Opus 4.6 enterprise workspaces.