### PR TITLE
fix: accept application/octet-stream in file upload filter

### DIFF
--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -39,8 +39,14 @@ export const parseUploadRequest = async (
       // Validate the file size.
       maxFileSize: file.fileSize,
 
-      // Ensure the file is of the correct type.
-      filter: (part) => part.mimetype === file.contentType,
+      // Ensure the file is of the correct type. The content type was already
+      // validated at file creation time. Accept when the browser sends
+      // "application/octet-stream" (its default for unrecognized extensions
+      // like) or no MIME type at all.
+      filter: (part) =>
+        !part.mimetype ||
+        part.mimetype === "application/octet-stream" ||
+        part.mimetype === file.contentType,
     });
 
     const [, files] = await form.parse(req);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Contributes to https://github.com/dust-tt/tasks/issues/6553
Closes https://github.com/dust-tt/tasks/issues/6579

This allows to drag and drop markdown files into the convo. It was not possible before and resulted in an error toast. The mimetype of the file was set as application/octet-stream which was filtered out bu the request parser.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front