### PR TITLE
fix: register application/vnd.dust.table in CONTENT_NODE_MIME_TYPES

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -14,7 +14,10 @@ import type {
   ListTablesResponseType,
   UpsertTableResponseType,
 } from "@dust-tt/client";
-import { UpsertDatabaseTableRequestSchema } from "@dust-tt/client";
+import {
+  DUST_TABLE_MIME_TYPE,
+  UpsertDatabaseTableRequestSchema,
+} from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
@@ -312,7 +315,7 @@ async function handler(
             },
           });
         }
-        mimeType = "application/vnd.dust.table";
+        mimeType = DUST_TABLE_MIME_TYPE;
       }
       // If the title is provided, we use it.
       // Otherwise, we default to either:

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -64,6 +64,9 @@ export const DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE =
 export type DataSourceFolderSpreadsheetMimeType =
   typeof DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE;
 
+export const DUST_TABLE_MIME_TYPE = "application/vnd.dust.table" as const;
+type DustTableMimeType = typeof DUST_TABLE_MIME_TYPE;
+
 type DataSourceMimeType = typeof DATA_SOURCE_MIME_TYPE;
 type DataWarehouseMimeType = typeof DATA_WAREHOUSE_MIME_TYPE;
 
@@ -71,6 +74,7 @@ export const CONTENT_NODE_MIME_TYPES = {
   GENERIC: {
     DATA_SOURCE: DATA_SOURCE_MIME_TYPE,
     DATA_WAREHOUSE: DATA_WAREHOUSE_MIME_TYPE,
+    TABLE: DUST_TABLE_MIME_TYPE,
   },
   FOLDER: {
     SPREADSHEET: DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE,
@@ -373,7 +377,8 @@ export type DustMimeType =
   | DustProjectMimeType
   | DataSourceMimeType
   | DataWarehouseMimeType
-  | DataSourceFolderSpreadsheetMimeType;
+  | DataSourceFolderSpreadsheetMimeType
+  | DustTableMimeType;
 
 export function isDustMimeType(mimeType: string): mimeType is DustMimeType {
   return (INTERNAL_MIME_TYPES_VALUES as string[]).includes(mimeType);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

closes https://github.com/dust-tt/tasks/issues/6553
This PR fixes some intricacies with using tables in conversations

 By registering the table MIME type in CONTENT_NODE_MIME_TYPES, it will now be recognized by isDustMimeType() and any logic that iterates over known MIME types. Previously, this MIME type was used but never formally registered, meaning it could fail validation checks or be treated as an unknown type.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front