### PR TITLE
fix: no stale landing auth context

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -14,6 +14,7 @@ import {
   shouldCheckGeolocation,
 } from "@app/lib/cookies";
 import { useGeolocation } from "@app/lib/swr/geo";
+import { useLandingAuthContext } from "@app/lib/swr/website";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames, getFaviconPath } from "@app/lib/utils";
 import { appendUTMParams } from "@app/lib/utils/utm";
@@ -64,6 +65,12 @@ export default function LandingLayout({
   useEffect(() => {
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
+
+  // Verify actual auth state when session cookie is present. SWR deduplicates
+  // this call with the one in OpenDustButton, so there's no extra request.
+  const { isAuthenticated, isLoading: isAuthLoading } = useLandingAuthContext({
+    hasSessionCookie: hasSession,
+  });
 
   const shouldCheckGeo = shouldCheckGeolocation(cookieValue);
 
@@ -138,7 +145,7 @@ export default function LandingLayout({
             </div>
             <MainNavigation />
             <div className="flex flex-grow justify-end gap-4">
-              {hasSession ? (
+              {hasSession && (isAuthLoading || isAuthenticated) ? (
                 <OpenDustButton
                   variant="highlight"
                   size="sm"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Fixes https://github.com/dust-tt/tasks/issues/6589

Root cause: When a user has a stale dust-has-session cookie (session expired but cookie lingers), LandingLayout hides the "Sign in" / "Contact sales" buttons and renders <OpenDustButton> instead. But OpenDustButton fetches /api/auth-context, discovers the session is invalid, and returns null. Result: no buttons rendered at all.

  - Added useLandingAuthContext() to verify actual auth state (SWR deduplicates the request with OpenDustButton, so no extra API call)
  - Changed the condition from hasSession to hasSession && (isAuthLoading || isAuthenticated):
    - No cookie → sign-in buttons (unchanged)
    - Cookie + loading → shows OpenDustButton in loading state (unchanged)
    - Cookie + authenticated → shows OpenDustButton with "Open Dust" (unchanged)
    - Cookie + NOT authenticated → falls back to sign-in buttons (the fix)


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, just homepage

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front