### PR TITLE
[front] Cache KeyResource.fetchBySecret with Redis

### DIFF
--- a/front/lib/resources/key_resource.test.ts
+++ b/front/lib/resources/key_resource.test.ts
@@ -1,0 +1,197 @@
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory cache that replaces the global no-op mock, so we can
+// actually assert on cache hits and invalidation.
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<JsonSerializable<T>> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          const cached = inMemoryCache.get(key);
+          if (cached) {
+            return JSON.parse(cached) as JsonSerializable<T>;
+          }
+          const result = await fn(...args);
+          inMemoryCache.set(key, JSON.stringify(result));
+          return result;
+        };
+      }
+    ),
+  invalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+        };
+      }
+    ),
+  batchInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (argsList: Args[]): Promise<void> => {
+          for (const args of argsList) {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            inMemoryCache.delete(key);
+          }
+        };
+      }
+    ),
+}));
+
+import type { Authenticator } from "@app/lib/auth";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { hash as blake3 } from "blake3";
+
+function getCacheKeyForSecret(secret: string): string {
+  const resolvedKey = `key:secret:${Buffer.from(blake3(secret)).toString("hex")}`;
+  return `cacheWithRedis-_fetchBySecretUncached-${resolvedKey}`;
+}
+
+describe("KeyResource", () => {
+  let authenticator: Authenticator;
+  let globalGroup: GroupResource;
+
+  beforeEach(async () => {
+    inMemoryCache.clear();
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+    globalGroup = testSetup.globalGroup;
+  });
+
+  describe("fetchBySecret", () => {
+    it("returns the key matching the secret", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+
+      const fetched = await KeyResource.fetchBySecret(key.secret);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.id).toBe(key.id);
+      expect(fetched!.name).toBe(key.name);
+      expect(fetched!.workspaceId).toBe(key.workspaceId);
+    });
+
+    it("returns null for an unknown secret", async () => {
+      const fetched = await KeyResource.fetchBySecret("sk-nonexistent");
+
+      expect(fetched).toBeNull();
+    });
+
+    it("returns correct fields from cached data", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+
+      const fetched = await KeyResource.fetchBySecret(key.secret);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.status).toBe("active");
+      expect(fetched!.isSystem).toBe(false);
+      expect(fetched!.role).toBe("builder");
+      expect(fetched!.scope).toBe("default");
+      expect(fetched!.groupId).toBe(globalGroup.id);
+      expect(fetched!.secret).toBe(key.secret);
+    });
+
+    it("serves from cache on second call", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+      const cacheKey = getCacheKeyForSecret(key.secret);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+      await KeyResource.fetchBySecret(key.secret); // miss → populates cache
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      await KeyResource.fetchBySecret(key.secret); // hit → served from cache
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    });
+  });
+
+  describe("setIsDisabled", () => {
+    it("invalidates cache so next fetch sees the new status", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+      await KeyResource.fetchBySecret(key.secret); // populate cache
+
+      await key.setIsDisabled();
+
+      const fetched = await KeyResource.fetchBySecret(key.secret);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.status).toBe("disabled");
+    });
+  });
+
+  describe("rotateSecret", () => {
+    it("invalidates cache for old secret", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+      const oldSecret = key.secret;
+      await KeyResource.fetchBySecret(oldSecret); // populate cache
+
+      await key.rotateSecret({ dangerouslyRotateSecret: true });
+
+      const fetchedOld = await KeyResource.fetchBySecret(oldSecret);
+      expect(fetchedOld).toBeNull();
+
+      const fetchedNew = await KeyResource.fetchBySecret(key.secret);
+      expect(fetchedNew).not.toBeNull();
+      expect(fetchedNew!.id).toBe(key.id);
+    });
+  });
+
+  describe("updateRole", () => {
+    it("invalidates cache so next fetch sees the new role", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+      await KeyResource.fetchBySecret(key.secret); // populate cache
+
+      await key.updateRole({ newRole: "admin" });
+
+      const fetched = await KeyResource.fetchBySecret(key.secret);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.role).toBe("admin");
+    });
+  });
+
+  describe("updateMonthlyCap", () => {
+    it("invalidates cache so next fetch sees the new cap", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+      await KeyResource.fetchBySecret(key.secret); // populate cache
+
+      await key.updateMonthlyCap({ monthlyCapMicroUsd: 500_000 });
+
+      const fetched = await KeyResource.fetchBySecret(key.secret);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.monthlyCapMicroUsd).toBe(500_000);
+    });
+  });
+
+  describe("deleteAllForWorkspace", () => {
+    it("invalidates cache for all deleted keys", async () => {
+      const key1 = await KeyFactory.regular(globalGroup);
+      const key2 = await KeyFactory.regular(globalGroup);
+      await KeyResource.fetchBySecret(key1.secret); // populate cache
+      await KeyResource.fetchBySecret(key2.secret); // populate cache
+
+      await KeyResource.deleteAllForWorkspace(authenticator);
+
+      const fetched1 = await KeyResource.fetchBySecret(key1.secret);
+      const fetched2 = await KeyResource.fetchBySecret(key2.secret);
+      expect(fetched1).toBeNull();
+      expect(fetched2).toBeNull();
+    });
+  });
+});

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -184,17 +184,19 @@ export class KeyResource extends BaseResource<KeyModel> {
     workspace: LightWorkspaceType;
     id: ModelId | string;
   }) {
-    const key = await this.fetchByModelId(id);
+    const parsedId = typeof id === "string" ? parseInt(id, 10) : id;
+    const key = await this.model.findOne({
+      where: {
+        id: parsedId,
+        workspaceId: workspace.id,
+      },
+    });
 
     if (!key) {
       return null;
     }
 
-    if (key.workspaceId !== workspace.id) {
-      return null;
-    }
-
-    return key;
+    return new this(KeyResource.model, key.get());
   }
 
   static async fetchByName(

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -8,6 +8,11 @@ import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import {
+  batchInvalidateCacheWithRedis,
+  cacheWithRedis,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import type { KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -18,6 +23,17 @@ import { hash as blake3 } from "blake3";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
+
+const KEY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes.
+
+type CachedKeyData = Omit<
+  Attributes<KeyModel>,
+  "secret" | "lastUsedAt" | "createdAt" | "updatedAt"
+> & {
+  lastUsedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
 
 export interface KeyAuthType {
   id: ModelId;
@@ -38,11 +54,85 @@ export class KeyResource extends BaseResource<KeyModel> {
 
   private user?: UserModel;
 
+  private static readonly keyCacheKeyResolver = (secret: string) =>
+    `key:secret:${Buffer.from(blake3(secret)).toString("hex")}`;
+
+  private static async _fetchBySecretUncached(
+    secret: string
+  ): Promise<CachedKeyData | null> {
+    const key = await KeyResource.model.findOne({
+      where: { secret },
+      // WORKSPACE_ISOLATION_BYPASS: Used when a request is made from an API Key, at this point we
+      // don't know the workspaceId.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    if (!key) {
+      return null;
+    }
+
+    return {
+      id: key.id,
+      name: key.name,
+      status: key.status,
+      isSystem: key.isSystem,
+      role: key.role,
+      scope: key.scope,
+      monthlyCapMicroUsd: key.monthlyCapMicroUsd,
+      workspaceId: key.workspaceId,
+      groupId: key.groupId,
+      userId: key.userId,
+      lastUsedAt: key.lastUsedAt?.getTime() ?? null,
+      createdAt: key.createdAt.getTime(),
+      updatedAt: key.updatedAt.getTime(),
+    };
+  }
+
+  private static fetchBySecretCached = cacheWithRedis(
+    KeyResource._fetchBySecretUncached,
+    KeyResource.keyCacheKeyResolver,
+    { ttlMs: KEY_CACHE_TTL_MS }
+  );
+
+  private static invalidateKeyCache = invalidateCacheWithRedis(
+    KeyResource._fetchBySecretUncached,
+    KeyResource.keyCacheKeyResolver
+  );
+
+  private static batchInvalidateKeyCache = batchInvalidateCacheWithRedis(
+    KeyResource._fetchBySecretUncached,
+    KeyResource.keyCacheKeyResolver
+  );
+
+  private static fromCachedData(
+    data: CachedKeyData,
+    secret: string
+  ): KeyResource {
+    return new KeyResource(KeyModel, {
+      ...data,
+      secret,
+      lastUsedAt: data.lastUsedAt ? new Date(data.lastUsedAt) : null,
+      createdAt: new Date(data.createdAt),
+      updatedAt: new Date(data.updatedAt),
+    });
+  }
+
   constructor(
     model: ModelStaticWorkspaceAware<KeyModel>,
     blob: Attributes<KeyModel>
   ) {
     super(KeyModel, blob);
+  }
+
+  protected override async update(
+    blob: Partial<Attributes<KeyModel>>,
+    transaction?: Transaction
+  ): Promise<[affectedCount: number]> {
+    const oldSecret = this.secret;
+    const result = await super.update(blob, transaction);
+    await KeyResource.invalidateKeyCache(oldSecret);
+    return result;
   }
 
   static async makeNew(
@@ -80,21 +170,11 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   static async fetchBySecret(secret: string) {
-    const key = await this.model.findOne({
-      where: {
-        secret,
-      },
-      // WORKSPACE_ISOLATION_BYPASS: Used when a request is made from an API Key, at this point we
-      // don't know the workspaceId.
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
-    });
-
-    if (!key) {
+    const data = await this.fetchBySecretCached(secret);
+    if (data === null) {
       return null;
     }
-
-    return new this(KeyResource.model, key.get());
+    return this.fromCachedData(data, secret);
   }
 
   static async fetchByWorkspaceAndId({
@@ -168,14 +248,7 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   async setIsDisabled() {
-    return this.model.update(
-      { status: "disabled" },
-      {
-        where: {
-          id: this.id,
-        },
-      }
-    );
+    return this.update({ status: "disabled" });
   }
 
   async rotateSecret(
@@ -216,11 +289,20 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   static async deleteAllForWorkspace(auth: Authenticator) {
-    return this.model.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const keys = await this.model.findAll({
+      where: { workspaceId },
+      attributes: ["secret"],
     });
+
+    await this.model.destroy({
+      where: { workspaceId },
+    });
+
+    await KeyResource.batchInvalidateKeyCache(
+      keys.map((k) => [k.secret] as [string])
+    );
   }
 
   toJSON(): KeyType {

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -9,7 +9,7 @@ import { DataTypes } from "sequelize";
 export class KeyModel extends WorkspaceAwareModel<KeyModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
-  declare lastUsedAt: CreationOptional<Date>;
+  declare lastUsedAt: CreationOptional<Date | null>;
 
   declare secret: string;
   declare status: "active" | "disabled";

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -59,6 +59,9 @@ vi.mock("@app/lib/utils/cache", () => ({
   invalidateCacheWithRedis: vi.fn().mockImplementation(() => {
     return async () => {};
   }),
+  batchInvalidateCacheWithRedis: vi.fn().mockImplementation(() => {
+    return async () => {};
+  }),
 }));
 
 // Mock Temporal - must be at module level


### PR DESCRIPTION
## Description

- Cache `KeyResource.fetchBySecret` lookups in Redis (10min TTL) to eliminate a DB roundtrip on every API key- authenticated request
- Cache key uses blake3 hash of the secret (secret itself is never stored in Redis)
- Add `batchInvalidateCacheWithRedis` utility to `cache.ts` for single-call multi-key invalidation

### Changes

**`key_resource.ts`**
- `fetchBySecret` now goes through Redis cache (`_fetchBySecretUncached` → `fetchBySecretCached` → `fromCachedData`)
- Override `update()` to invalidate cache on any mutation (covers `rotateSecret`, `updateRole`, `updateMonthlyCap`)
- Fix `setIsDisabled()` to use `this.update()` instead of `this.model.update()` so it triggers invalidation
- `deleteAllForWorkspace()` batch-invalidates all keys in a single Redis `del` call

**`keys.ts`**
- Fix `lastUsedAt` type from `CreationOptional<Date>` to `CreationOptional<Date | null>` to match `allowNull: true`

**`cache.ts`**
- New `batchInvalidateCacheWithRedis` — computes all cache keys and issues a single `redisCli.del(keys)`

### Invalidation coverage

| Mutation | Invalidates? | How |
|---|---|---|
| `makeNew()` | No (not cached yet) | N/A |
| `setIsDisabled()` | Yes | Now uses `this.update()` → override |
| `rotateSecret()` | Yes | Uses `this.update()` → override |
| `updateRole()` | Yes | Uses `this.update()` → override |
| `updateMonthlyCap()` | Yes | Uses `this.update()` → override |
| `markAsUsed()` | No (intentional) | `lastUsedAt` is cached but stale value is harmless |
| `deleteAllForWorkspace()` | Yes | Batch invalidation before destroy |


## Tests

- New test file. 
- Testing locally. 
- Will test on front-edge. 

## Risk

Can be rolled back. 

## Deploy Plan

No migration needed it's just a change in the TS def of the model. 
Deploy front. 