### PR TITLE
[front] fix: Invalidate resource on create to avoid stale null vals

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -107,6 +107,12 @@ export class UserResource extends BaseResource<UserModel> {
     const user = await UserModel.create({ ...blob, email: lowerCaseEmail });
     const userResource = new this(UserModel, user.get());
 
+    if (userResource.workOSUserId) {
+      await UserResource.invalidateUserByWorkOSIdCache(
+        userResource.workOSUserId
+      );
+    }
+
     // Update user search index across all workspaces.
     const workflowResult = await launchIndexUserSearchWorkflow({
       userId: userResource.sId,

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -143,8 +143,11 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     blob: CreationAttributes<WorkspaceModel>
   ): Promise<WorkspaceResource> {
     const workspace = await this.model.create(blob);
+    const workspaceResource = new this(this.model, workspace.get());
 
-    return new this(this.model, workspace.get());
+    await WorkspaceResource.invalidateWorkspaceCache(workspaceResource.sId);
+
+    return workspaceResource;
   }
 
   static async fetchById(


### PR DESCRIPTION
## Description

Slack for context : https://dust4ai.slack.com/archives/C0AFLNCU5DX/p1771337482431059?thread_ts=1771325957.421599&cid=C0AFLNCU5DX

Invalidate cache keys on create as with concurrent read/write on events processing we can have a read + null Key set before the write.


## Tests

N/A

## Risk

Low
Blast radius: User.makeNew && Worskpace.makeNew


## Deploy Plan

- [ ] Deploy front