### PR TITLE
Add error boundary

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,7 +1,9 @@
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
+import { ErrorBoundary } from "@dust-tt/front/components/error_boundary/ErrorBoundary";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import Custom404 from "@dust-tt/front/pages/404";
 import { Spinner, safeLazy } from "@dust-tt/sparkle";
+import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
 import { AppReadyProvider } from "@spa/app/contexts/AppReadyContext";
 import { AdminRouterLayout } from "@spa/app/layouts/AdminRouterLayout";
 import { AppContentRouterLayout } from "@spa/app/layouts/AppContentRouterLayout";
@@ -531,7 +533,9 @@ export default function App() {
     <AppReadyProvider>
       <RegionProvider>
         <RootLayout>
-          <RouterProvider router={router} />
+          <ErrorBoundary fallback={<GlobalErrorFallback />}>
+            <RouterProvider router={router} />
+          </ErrorBoundary>
         </RootLayout>
       </RegionProvider>
     </AppReadyProvider>

--- a/front-spa/src/app/components/GlobalErrorFallback.tsx
+++ b/front-spa/src/app/components/GlobalErrorFallback.tsx
@@ -1,0 +1,30 @@
+import { Button, ExclamationCircleIcon, Icon } from "@dust-tt/sparkle";
+
+export function GlobalErrorFallback() {
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <div className="flex flex-col gap-3 text-center">
+        <div className="flex flex-col items-center">
+          <Icon
+            visual={ExclamationCircleIcon}
+            size="lg"
+            className="text-warning-400"
+          />
+          <p className="heading-xl text-foreground dark:text-foreground-night">
+            Something went wrong
+          </p>
+          <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+            An unexpected error occurred. Please try again.
+          </p>
+        </div>
+        <div>
+          <Button
+            variant="outline"
+            label="Try again"
+            onClick={() => window.location.reload()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Add a global error boundary to `front-spa` so that uncaught React errors show a user-friendly fallback instead of a white screen.

- Created `GlobalErrorFallback` component matching the existing error page style (warning icon, message, reload button)
- Wrapped `RouterProvider` with the existing `ErrorBoundary` component inside `RootLayout` in `App.tsx`

## Tests

Manual: temporarily throw an error in a component and verify the fallback renders correctly.

## Risk

Low — the error boundary only activates on uncaught errors and simply shows a reload page. No change to normal app behavior.

## Deploy Plan

Standard deploy, no special steps needed.