### PR TITLE
LLM: Add event when receiving partial tool call to not tiemout on long tool input generation

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -174,6 +174,7 @@ function* handleContentBlockDelta(
       break;
     case "input_json_delta":
       stateContainer.state.accumulator += event.delta.partial_json;
+      yield { type: "tool_call_delta", metadata };
       break;
     case "signature_delta":
       if (stateContainer.state.accumulatorType === "reasoning") {

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -11,6 +11,13 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     },
   },
   {
+    type: "tool_call_delta",
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
     type: "tool_call",
     content: {
       id: "EmptyToolCall1",

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -41,6 +41,13 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
   },
   {
+    type: "tool_call_delta",
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
     type: "tool_call",
     content: {
       id: "DdHr7L197",

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -29,6 +29,13 @@ export interface ReasoningDeltaEvent {
   metadata: LLMClientMetadata & { encrypted_content?: string };
 }
 
+// Tool call deltas are not streamed to the UI but they are used internally
+// as heartbeat to know the LLM is still active.
+export interface ToolCallDeltaEvent {
+  type: "tool_call_delta";
+  metadata: LLMClientMetadata;
+}
+
 // Output items
 export interface ToolCall {
   id: string;
@@ -105,6 +112,7 @@ export type LLMEvent =
   | ResponseIdEvent
   | TextDeltaEvent
   | ReasoningDeltaEvent
+  | ToolCallDeltaEvent
   | ToolCallEvent
   | TextGeneratedEvent
   | ReasoningGeneratedEvent

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -97,6 +97,7 @@ export async function* streamLLMEvents(
           toolCall.arguments += toolCallDelta.function.arguments;
         }
       }
+      yield { type: "tool_call_delta", metadata };
     }
 
     // Handle finish reason.

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -212,6 +212,8 @@ function toEvents({
 
       return [reasoningDelta("\n\n", metadata)];
     }
+    case "response.function_call_arguments.delta":
+      return [{ type: "tool_call_delta", metadata }];
     default:
       return [];
   }

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
@@ -2,6 +2,34 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 
 export const functionCallLLMEvents: LLMEvent[] = [
   {
+    type: "tool_call_delta",
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
+    type: "tool_call_delta",
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
+    type: "tool_call_delta",
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
+    type: "tool_call_delta",
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
     type: "tool_call",
     content: {
       id: "call_TNG5uqSoWvdMD4MFV6wKCwZT",

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -216,6 +216,11 @@ export async function getOutputFromLLMStream(
           nativeChainOfThought += event.content.delta;
           continue;
         }
+        case "tool_call_delta":
+          // tool_call_delta events act as heartbeat signals during tool call
+          // streaming, preventing the LLM stream timeout when the model is
+          // generating tool call arguments.
+          continue;
         case "reasoning_generated": {
           await updateResourceAndPublishEvent(auth, {
             event: {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6570

We sometime timeout because the LLM don't send event for more than 5 minutes.
This generally happens when generating large input tool calls
But the LLM actually send events, we just ignore them.

This PR generate this events to use them as ping to keep the stream alive.

It does it for Anthropic and OpenAI
As far as I understand, Google and mistral are not sending partial tool calls.

## Tests

Tested locally, I do receive events from anthropic 🥳 
Updated unit tests

## Risk

low

## Deploy Plan

deploy front
