### PR TITLE
Avoid fetching workspaces+orgs

### DIFF
--- a/front/pages/api/auth-context.ts
+++ b/front/pages/api/auth-context.ts
@@ -1,14 +1,14 @@
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { getUserFromSession } from "@app/lib/iam/session";
+import { fetchUserFromSession } from "@app/lib/iam/users";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
+import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetNoWorkspaceAuthContextResponseType = {
-  user: UserTypeWithWorkspaces;
+  user: UserType;
   defaultWorkspaceId: string | null;
 };
 
@@ -42,7 +42,7 @@ async function handler(
     }
   }
 
-  const user = await getUserFromSession(session);
+  const user = await fetchUserFromSession(session);
 
   if (!user) {
     if (session) {
@@ -65,7 +65,7 @@ async function handler(
   }
 
   return res.status(200).json({
-    user,
+    user: user.toJSON(),
     defaultWorkspaceId: session.workspaceId ?? null,
   });
 }


### PR DESCRIPTION
## Description

Optimize the `/api/auth-context` endpoint by replacing `getUserFromSession` with `fetchUserFromSession`. The old function fetched the user **and** all their workspaces + WorkOS organizations, which is unnecessary for this endpoint — the caller only needs the base user data and `defaultWorkspaceId`.

Changes:
- Use `fetchUserFromSession` (returns `UserResource`) instead of `getUserFromSession` (which additionally called `getUserWithWorkspaces`)
- Return `UserType` instead of `UserTypeWithWorkspaces` — drops the `workspaces` and `organizations` fields from the response
- Return `user.toJSON()` to serialize the resource

This avoids extra DB queries and WorkOS API calls on every auth-context request.

## Tests

Manual — endpoint behavior unchanged for callers that only use the `user` and `defaultWorkspaceId` fields.

## Risk

Low. The `workspaces` and `organizations` fields are removed from this endpoint's response. Any client relying on these fields from `/api/auth-context` would need to fetch them separately.

## Deploy Plan

Standard deploy, no migration needed.