### PR TITLE
Make Copilot Client-MCP more robust

### DIFF
--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -275,7 +275,7 @@ export class BrowserMCPTransport implements Transport {
           if (!this.isClosing && this.serverId) {
             void this.connectToRequestsStream().catch((reconnectError) => {
               console.error(
-                "[BrowserMCPTransport] Failed to reconnect:",
+                "[BrowserMCPTransport] Failed to reconnect after error:",
                 reconnectError
               );
             });

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -3,7 +3,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
 const HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes.
-const RECONNECT_DELAY_MS = 1_000; // 1 second.
+const RECONNECT_DELAY_MS = 5_000; // 5 seconds.
 
 /**
  * Browser-specific MCP transport implementation.

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -29,11 +29,17 @@ export class BrowserMCPTransport implements Transport {
   public onerror?: (error: Error) => void;
   public sessionId?: string;
 
+  private readonly handleBeforeUnload = () => {
+    this.isClosing = true;
+  };
+
   constructor(
     private readonly workspaceId: string,
     private readonly serverName: string,
     private readonly onServerIdReceived: (serverId: string) => void
-  ) {}
+  ) {
+    window.addEventListener("beforeunload", this.handleBeforeUnload);
+  }
 
   /**
    * Register the MCP server.
@@ -332,6 +338,8 @@ export class BrowserMCPTransport implements Transport {
    */
   async close(): Promise<void> {
     this.isClosing = true;
+
+    window.removeEventListener("beforeunload", this.handleBeforeUnload);
 
     // Clear heartbeat timer.
     if (this.heartbeatTimer) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR makes the client MCP more robust. It:
- reduces the connect timeout in the agent loop down from 25 seconds default to 5 seconds. This is safe as it's only being used internally.
- updates the browser Transport reconnection logic. The server endpoint closes connections every 1 minute, so we need to ensure we reconnect quickly, without the previous timeout that seems to lead to slower client MCP call.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
