### PR TITLE
Fix getCompletionDuration

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -87,7 +87,10 @@ export function getCompletionDuration(
     const range = executionRanges[i];
     if (range.start <= currentRange.end) {
       // Overlapping or adjacent - merge by extending the end
-      currentRange.end = Math.max(currentRange.end, range.end);
+      currentRange = {
+        start: currentRange.start,
+        end: Math.max(currentRange.end, range.end),
+      };
     } else {
       // Non-overlapping - save current and start new range
       mergedRanges.push(currentRange);

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -102,7 +102,6 @@ export function getCompletionDuration(
     0
   );
 
-  // Wait time = total message time - time spent executing actions
   return totalExecutionTime;
 }
 


### PR DESCRIPTION
## Description

Fixes the `getCompletionDuration` calculation which was producing incorrect or negative values. The previous implementation incorrectly computed wait time by summing (updatedAt - createdAt - executionDurationMs) for each action, which failed to account for overlapping action execution periods. When actions execute in parallel, this approach double-counts execution time. 

The fix introduces proper time range merging: it identifies each action's execution window, sorts and merges overlapping ranges, then returns the total execution time across all merged periods.

## Tests

Tested on a conversation message 

## Risk

Low

## Deploy Plan

Deploy front
