### PR TITLE
Fixed generated URLs

### DIFF
--- a/front-spa/src/app/pages/IndexPage.tsx
+++ b/front-spa/src/app/pages/IndexPage.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@dust-tt/front/lib/egress/client";
+import config from "@dust-tt/front/lib/api/config";
 import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
 import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useEffect } from "react";
@@ -23,7 +23,7 @@ export function IndexPage() {
       } else {
         // No default workspace, redirect to /api/login which will create
         // or find a workspace for the user
-        window.location.href = `${getApiBaseUrl()}/api/login`;
+        window.location.href = `${config.getApiBaseUrl()}/api/login`;
       }
     }
   }, [defaultWorkspaceId, navigate, isAuthContextLoading, isAuthenticated]);

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -2,12 +2,12 @@ import { useConversationDrafts } from "@app/components/assistant/conversation/in
 import { WorkspacePickerRadioGroup } from "@app/components/WorkspacePicker";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePrivacyMask } from "@app/hooks/usePrivacyMask";
+import config from "@app/lib/api/config";
 import {
   forceUserRole,
   sendOnboardingConversation,
   showDebugTools,
 } from "@app/lib/development";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SubscriptionType } from "@app/types/plan";
@@ -207,7 +207,7 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
             window.DD_RUM?.onReady(() => {
               window.DD_RUM?.clearUser();
             });
-            window.location.href = `${getApiBaseUrl()}/api/workos/logout`;
+            window.location.href = `${config.getApiBaseUrl()}/api/workos/logout`;
           }}
         />
 

--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -2,6 +2,7 @@ import "@uiw/react-textarea-code-editor/dist.css";
 
 import { SuspensedCodeEditor } from "@app/components/SuspensedCodeEditor";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import config from "@app/lib/api/config";
 import type { DataSourceType } from "@app/types/data_source";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { SpaceType } from "@app/types/space";
@@ -37,7 +38,7 @@ export function ViewFolderAPIModal({
   const cURLRequest = (type: "upsert" | "search") => {
     switch (type) {
       case "upsert":
-        return `curl "${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/spaces/${space.sId}/data_sources/${dataSource.sId}/documents/YOUR_DOCUMENT_ID" \\
+        return `curl "${config.getApiBaseUrl()}/api/v1/w/${owner.sId}/spaces/${space.sId}/data_sources/${dataSource.sId}/documents/YOUR_DOCUMENT_ID" \\
     -H "Authorization: Bearer YOUR_API_KEY" \\
     -H "Content-Type: application/json" \\
     -d '{
@@ -45,7 +46,7 @@ export function ViewFolderAPIModal({
       "source_url": "https://acme.com"
     }'`;
       case "search":
-        return `curl "${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/spaces/${space.sId}/data_sources/${dataSource.sId}/search?query=foo+bar&top_k=16&full_text=false" \\
+        return `curl "${config.getApiBaseUrl()}/api/v1/w/${owner.sId}/spaces/${space.sId}/data_sources/${dataSource.sId}/search?query=foo+bar&top_k=16&full_text=false" \\
     -H "Authorization: Bearer YOUR_API_KEY"`;
       default:
         assertNever(type);

--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -1,5 +1,5 @@
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import { useAppRouter } from "@app/lib/platform";
 import { isDevelopment } from "@app/types/shared/env";
 import type {
@@ -46,7 +46,7 @@ export const WorkspacePickerRadioGroup = ({
                       lastWorkspaceId: org.externalId,
                     });
                     await router.push(
-                      `${getApiBaseUrl()}/api/workos/login?organizationId=${org.id}`
+                      `${config.getApiBaseUrl()}/api/workos/login?organizationId=${org.id}`
                     );
                   }
                 }}

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -86,7 +86,7 @@ import {
   GET_DATABASE_SCHEMA_TOOL_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import { isValidJSON } from "@app/lib/utils/json";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { isSupportedImageContentType } from "@app/types/files";
@@ -469,7 +469,7 @@ export function GenericActionDetails({
                         >
                           <img
                             className="h-full w-full rounded-xl object-cover"
-                            src={`${getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
+                            src={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
                             alt={`${file.title}`}
                           />
                         </div>
@@ -478,7 +478,7 @@ export function GenericActionDetails({
                     return (
                       <div key={file.fileId}>
                         <a
-                          href={`${getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
+                          href={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
                           target="_blank"
                           rel="noopener noreferrer"
                         >

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -15,8 +15,8 @@ import {
   isWarningResourceType,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import config from "@app/lib/api/config";
 import { getDocumentIcon } from "@app/lib/content_nodes";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -92,7 +92,7 @@ export function ToolGeneratedFileDetails({
 }: ToolGeneratedFileDetailsProps) {
   const file = {
     ...resource,
-    sourceUrl: `${getApiBaseUrl()}/api/w/${owner.sId}/files/${resource.fileId}`,
+    sourceUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${resource.fileId}`,
   };
   return (
     <AttachmentCitation

--- a/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
+++ b/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import {
   Collapsible,
@@ -16,7 +17,7 @@ export function SnowflakeSetupInstructions({
 }: SnowflakeSetupInstructionsProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const redirectUri = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/oauth/snowflake/finalize`;
+  const redirectUri = `${config.getApiBaseUrl()}/oauth/snowflake/finalize`;
 
   return (
     <div className="w-full pt-4">

--- a/front/components/app/ViewAppAPIModal.tsx
+++ b/front/components/app/ViewAppAPIModal.tsx
@@ -2,6 +2,7 @@ import "@uiw/react-textarea-code-editor/dist.css";
 
 import { SuspensedCodeEditor } from "@app/components/SuspensedCodeEditor";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import config from "@app/lib/api/config";
 import type { AppType } from "@app/types/app";
 import type { RunConfig, RunType } from "@app/types/run";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -55,7 +56,7 @@ export function ViewAppAPIModal({
   const cURLRequest = (type: "run") => {
     switch (type) {
       case "run":
-        return `curl ${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/api/v1/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs \\
+        return `curl ${config.getApiBaseUrl()}/api/v1/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs \\
     -H "Authorization: Bearer YOUR_API_KEY" \\
     -H "Content-Type: application/json" \\
     -d '{

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -47,7 +47,6 @@ import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import config from "@app/lib/api/config";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -1108,8 +1107,8 @@ function AgentMessageContent({
       {completedImages.length > 0 && (
         <InteractiveImageGrid
           images={completedImages.map((image) => ({
-            imageUrl: `${getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=view&version=processed`,
-            downloadUrl: `${getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
+            imageUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=view&version=processed`,
+            downloadUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
             alt: image.title,
             title: image.title,
             isLoading: false,
@@ -1144,7 +1143,7 @@ function AgentMessageContent({
               document: {
                 fileId: file.fileId,
                 contentType: file.contentType,
-                href: `${getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`,
+                href: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`,
                 title: file.title,
               },
             })),

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -3,7 +3,7 @@ import { AttachmentCitation } from "@app/components/assistant/conversation/attac
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { useConversationFiles } from "@app/hooks/conversations";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import {
   frameContentType,
@@ -101,7 +101,7 @@ const FileRenderer = ({ files, owner, conversationId }: FileRendererProps) => (
   <CitationGrid variant="grid" className="md:grid-cols-3">
     {files.map((file, index) => {
       const attachmentCitation = markdownCitationToAttachmentCitation({
-        href: `${getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`,
+        href: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`,
         title: file.title,
         contentType: file.contentType,
         fileId: file.fileId,

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -10,6 +10,7 @@ import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useMoveConversationToProject } from "@app/hooks/useMoveConversationToProject";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
@@ -187,16 +188,12 @@ export function ConversationMenu({
   const [showLeaveDialog, setShowLeaveDialog] = useState<boolean>(false);
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
 
-  const baseUrl = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
-  const shareLink =
-    baseUrl !== undefined
-      ? getConversationRoute(
-          owner.sId,
-          activeConversationId,
-          undefined,
-          baseUrl
-        )
-      : undefined;
+  const shareLink = getConversationRoute(
+    owner.sId,
+    activeConversationId,
+    undefined,
+    config.getApiBaseUrl()
+  );
 
   const doDelete = useDeleteConversation(owner);
   const leaveOrDelete = useCallback(

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -3,6 +3,7 @@ import { LeaveProjectDialog } from "@app/components/assistant/conversation/Leave
 import { useLeaveProjectDialog } from "@app/hooks/useLeaveProjectDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -142,11 +143,9 @@ export function ProjectMenu({
 
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
 
-  const baseUrl = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
-  const shareLink =
-    baseUrl !== undefined && activeSpaceId
-      ? `${baseUrl}${getProjectRoute(owner.sId, activeSpaceId)}`
-      : undefined;
+  const shareLink = activeSpaceId
+    ? `${config.getApiBaseUrl()}${getProjectRoute(owner.sId, activeSpaceId)}`
+    : undefined;
 
   const spaceName = space?.name ?? spaceInfo?.name ?? "";
   const userName = user?.fullName ?? user?.username ?? "";

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -8,7 +8,8 @@ import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigati
 import { useVisualizationRevert } from "@app/hooks/conversations";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -132,7 +133,7 @@ function ExportContentDropdown({
 
   const downloadAsCode = () => {
     try {
-      const downloadUrl = `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
+      const downloadUrl = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
       // Open the download URL in a new tab/window. Otherwise we get a CORS error due to the redirection
       // to cloud storage.
       window.open(downloadUrl, "_blank");

--- a/front/components/markdown/Image.tsx
+++ b/front/components/markdown/Image.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { FILE_ID_REGEX } from "@app/lib/files";
 import {
   getFileProcessedUrl,
@@ -29,10 +30,7 @@ export function Img({ src, alt, owner }: ImgProps) {
     return null;
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
-  if (!baseUrl) {
-    return null;
-  }
+  const baseUrl = config.getApiBaseUrl();
 
   const viewSuffix = getFileProcessedUrl(owner, fileId);
   const downloadSuffix = getProcessedFileDownloadUrl(owner, fileId);

--- a/front/components/me/PendingInvitationsTable.tsx
+++ b/front/components/me/PendingInvitationsTable.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import { classNames } from "@app/lib/utils";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { Button, DataTable, Label } from "@dust-tt/sparkle";
@@ -36,7 +36,7 @@ export function PendingInvitationsTable({
             return;
           }
           window.location.assign(
-            `${getApiBaseUrl()}/api/login?inviteToken=${encodeURIComponent(invitation.token)}`
+            `${config.getApiBaseUrl()}/api/login?inviteToken=${encodeURIComponent(invitation.token)}`
           );
         },
       })),

--- a/front/components/pages/SsoEnforcedPage.tsx
+++ b/front/components/pages/SsoEnforcedPage.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { useUser } from "@app/lib/swr/user";
 import { Button, Logo } from "@dust-tt/sparkle";
@@ -19,7 +19,7 @@ export function SsoEnforcedPage() {
     if (!organization) {
       return null;
     }
-    const base = `${getApiBaseUrl()}/api/workos/login?organizationId=${organization.id}`;
+    const base = `${config.getApiBaseUrl()}/api/workos/login?organizationId=${organization.id}`;
     return returnTo ? `${base}&returnTo=${encodeURIComponent(returnTo)}` : base;
   }, [organization, returnTo]);
 

--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import { useUser } from "@app/lib/swr/user";
 import { usePendingInvitations } from "@app/lib/swr/workspaces";
 import {
@@ -19,7 +19,7 @@ export function InviteChoosePage() {
 
   const handleInvitationSelection = useCallback(
     (token: string, regionUrl?: string) => {
-      const baseUrl = regionUrl ?? getApiBaseUrl();
+      const baseUrl = regionUrl ?? config.getApiBaseUrl();
       window.location.assign(
         `${baseUrl}/api/login?inviteToken=${encodeURIComponent(token)}`
       );

--- a/front/components/pages/onboarding/LoginErrorPage.tsx
+++ b/front/components/pages/onboarding/LoginErrorPage.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import { LinkWrapper, useSearchParam } from "@app/lib/platform";
 import {
   Button,
@@ -91,7 +91,7 @@ function getErrorMessage(domain: string | null, reason: string | null) {
             label="Sign in"
             icon={LoginIcon}
             onClick={() => {
-              window.location.href = `${getApiBaseUrl()}/api/workos/login?returnTo=/api/login`;
+              window.location.href = `${config.getApiBaseUrl()}/api/workos/login?returnTo=/api/login`;
             }}
           />
         </>

--- a/front/components/poke/apps/columns.tsx
+++ b/front/components/poke/apps/columns.tsx
@@ -1,5 +1,5 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import type { AppType } from "@app/types/app";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -48,7 +48,7 @@ export function makeColumnsForApps(
         return (
           <>
             <a
-              href={`${getApiBaseUrl()}/api/poke/workspaces/${owner.sId}/apps/${app.sId}/export`}
+              href={`${config.getApiBaseUrl()}/api/poke/workspaces/${owner.sId}/apps/${app.sId}/export`}
               download={`${app.name}.json`}
               target="_blank"
               rel="noopener noreferrer"

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -1,5 +1,6 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
-import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { PokeAgentConfigurationType } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -133,7 +134,7 @@ export function makeColumnsForAssistants(
               }}
             />
             <a
-              href={`${getApiBaseUrl()}/api/poke/workspaces/${owner.sId}/agent_configurations/${assistant.sId}/export`}
+              href={`${config.getApiBaseUrl()}/api/poke/workspaces/${owner.sId}/agent_configurations/${assistant.sId}/export`}
               download={`${assistant.name}.json`}
               target="_blank"
               rel="noopener noreferrer"

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -7,6 +7,7 @@ import { useBrowserNotification } from "@app/hooks/useBrowserNotification";
 import { useDatadogLogs } from "@app/hooks/useDatadogLogs";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
+import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { Head, Script, useAppRouter } from "@app/lib/platform";
@@ -51,8 +52,7 @@ export default function AppRootLayout({
 
   useEffect(() => {
     const setupNotifications = async (novuClient: Novu) => {
-      const dustFacingUrl =
-        process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL ?? "https://dust.tt";
+      const dustFacingUrl = config.getApiBaseUrl();
 
       const unsubscribe = novuClient.on(
         "notifications.notification_received",

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -2,6 +2,7 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import type { WebhookSourceFormValues } from "@app/components/triggers/forms/webhookSourceFormSchema";
 import { WebhookEndpointUsageInfo } from "@app/components/triggers/WebhookEndpointUsageInfo";
 import { useSendNotification } from "@app/hooks/useNotification";
+import config from "@app/lib/api/config";
 import { buildWebhookUrl, normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { WebhookSourceViewForAdminType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
@@ -95,7 +96,7 @@ export function WebhookSourceDetailsInfo({
 
   const webhookUrl = useMemo(() => {
     return buildWebhookUrl({
-      apiBaseUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
+      apiBaseUrl: config.getApiBaseUrl(),
       workspaceId: owner.sId,
       webhookSource: webhookSourceView.webhookSource,
     });

--- a/front/components/workspace/api-keys/APIKeyCreationSheet.tsx
+++ b/front/components/workspace/api-keys/APIKeyCreationSheet.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import type { KeyType } from "@app/types/key";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -33,7 +34,7 @@ export const APIKeyCreationSheet = ({
   const [isCopiedDomain, copyDomain] = useCopyToClipboard();
   const [isCopiedApiKey, copyApiKey] = useCopyToClipboard();
 
-  const domain = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL ?? "";
+  const domain = config.getApiBaseUrl();
 
   return (
     <Sheet

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { GroupType } from "@app/types/groups";
 import { GLOBAL_SPACE_NAME } from "@app/types/groups";
@@ -81,10 +82,7 @@ export const APIKeysList = ({
                           "text-muted-foreground dark:text-muted-foreground-night"
                         )}
                       >
-                        Domain:{" "}
-                        <strong>
-                          {process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}
-                        </strong>
+                        Domain: <strong>{config.getApiBaseUrl()}</strong>
                       </p>
                       <p
                         className={cn(

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -1,5 +1,5 @@
+import config from "@app/lib/api/config";
 import { COMMIT_HASH } from "@app/lib/commit-hash";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const RECONNECT_DELAY_BASE_MS = 3000; // 3 seconds base delay
@@ -51,7 +51,7 @@ const stableEventSourceManager = {
       urlWithCommitHash.hash;
 
     const newSource = new EventSource(
-      `${getApiBaseUrl()}${pathWithQueryAndHash}`,
+      `${config.getApiBaseUrl()}${pathWithQueryAndHash}`,
       { withCredentials: true }
     );
     this.sources.set(uniqueId, newSource);

--- a/front/lib/api/actions/servers/agent_management/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_management/tools/index.ts
@@ -89,7 +89,7 @@ const handlers: ToolHandlers<typeof AGENT_MANAGEMENT_TOOLS_METADATA> = {
     }
 
     const { agentConfiguration: agent, subAgentConfiguration } = result.value;
-    const agentUrl = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${agent.sId}`;
+    const agentUrl = `${apiConfig.getClientFacingUrl()}/w/${owner.sId}/builder/agents/${agent.sId}`;
 
     // Prepare the structured output resource
     const agentCreationResource: AgentCreationResultResourceType = {
@@ -109,7 +109,7 @@ const handlers: ToolHandlers<typeof AGENT_MANAGEMENT_TOOLS_METADATA> = {
             name: subAgentConfiguration.name,
             description: subAgentConfiguration.description,
             pictureUrl: subAgentConfiguration.pictureUrl,
-            url: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${subAgentConfiguration.sId}`,
+            url: `${apiConfig.getClientFacingUrl()}/w/${owner.sId}/builder/agents/${subAgentConfiguration.sId}`,
           }
         : undefined,
     };

--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -1,5 +1,5 @@
+import { setBaseUrlResolver } from "@app/lib/api/config";
 import type { RegionInfo } from "@app/lib/api/regions/config";
-import { setBaseUrlResolver } from "@app/lib/egress/client";
 import {
   createContext,
   useCallback,
@@ -59,7 +59,6 @@ export function RegionProvider({ children }: { children: React.ReactNode }) {
     }
 
     // Set up resolver that reads from ref (so it always gets latest value).
-    // When the ref is undefined, getApiBaseUrl() will fallback to VITE_DUST_CLIENT_FACING_URL.
     setBaseUrlResolver(() => {
       return currentUrlRef.current;
     });

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -1,4 +1,5 @@
-import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
@@ -176,7 +177,7 @@ export class BrowserMCPTransport implements Transport {
     }
 
     // Build URL with query parameters.
-    const base = getApiBaseUrl() || window.location.origin;
+    const base = config.getApiBaseUrl() || window.location.origin;
     const url = new URL(`/api/w/${this.workspaceId}/mcp/requests`, base);
     url.searchParams.set("serverId", this.serverId);
     if (this.lastEventId) {

--- a/front/lib/notifications/email-templates/_layout.tsx
+++ b/front/lib/notifications/email-templates/_layout.tsx
@@ -1,4 +1,5 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
+import config from "@app/lib/api/config";
 import { Html } from "@react-email/html";
 import Head from "next/head";
 import type React from "react";
@@ -32,10 +33,7 @@ export const EmailLayout = ({
           {children}
         </div>
         <div style={{ width: "100%", textAlign: "left", marginTop: "20px" }}>
-          <a
-            href={process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}
-            target="_new"
-          >
+          <a href={config.getClientFacingUrl()} target="_new">
             <img
               alt="Dust Logo"
               style={{ margin: "0 auto", border: "0px" }}
@@ -58,7 +56,7 @@ export const EmailLayout = ({
           <div>
             Manage your notifications in{" "}
             <a
-              href={`${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${workspace.id}/me`}
+              href={`${config.getClientFacingUrl()}/w/${workspace.id}/me`}
               target="_blank"
               style={{ color: "#1C91FF" }}
             >

--- a/front/lib/notifications/email-templates/agent-message-feedback-digest.tsx
+++ b/front/lib/notifications/email-templates/agent-message-feedback-digest.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { render } from "@react-email/render";
@@ -69,7 +70,7 @@ const AgentMessageFeedbackDigestEmailTemplate = ({
               by {feedback.userWhoGaveFeedbackFullName} in{" "}
               <a
                 href={
-                  process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
+                  config.getClientFacingUrl() +
                   getConversationRoute(workspace.id, feedback.conversationId)
                 }
                 target="_blank"

--- a/front/lib/notifications/email-templates/conversation-added-as-participant.tsx
+++ b/front/lib/notifications/email-templates/conversation-added-as-participant.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { render } from "@react-email/render";
@@ -30,7 +31,7 @@ const ConversationAddedAsParticipantEmailTemplate = ({
   conversation,
 }: ConversationAddedAsParticipantEmailTemplateProps) => {
   const url =
-    process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
+    config.getClientFacingUrl() +
     getConversationRoute(workspace.id, conversation.id);
 
   return (

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
@@ -147,7 +148,7 @@ export const projectAddedAsMemberWorkflow = workflow(
           action: {
             label: "View project",
             url:
-              process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
+              config.getClientFacingUrl() +
               getProjectRoute(payload.workspaceId, payload.projectId),
           },
         });

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -1,6 +1,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
-import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
@@ -21,21 +22,21 @@ export const getFileProcessedUrl = (
   owner: LightWorkspaceType,
   fileId: string | null | undefined
 ) =>
-  `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
+  `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
 
 export const getProcessedFileDownloadUrl = (
   owner: LightWorkspaceType,
   fileId: string
 ) =>
-  `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
+  `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
 
 export const getFileDownloadUrl = (owner: LightWorkspaceType, fileId: string) =>
-  `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
+  `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
 
 export const getFileViewUrl = (
   owner: LightWorkspaceType,
   fileId: string | null | undefined
-) => `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;
+) => `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;
 
 export function useFileProcessedContent({
   owner,

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
 import { emptyArray } from "@app/lib/swr/swr";
 import type { ContentNodeWithParent } from "@app/types/connectors/connectors_api";
@@ -94,7 +94,7 @@ export function useUnifiedSearch({
         params.append("cursor", cursor);
       }
 
-      const url = `${getApiBaseUrl()}/api/w/${owner.sId}/search?${params.toString()}`;
+      const url = `${config.getApiBaseUrl()}/api/w/${owner.sId}/search?${params.toString()}`;
       const eventSource = new EventSource(url, { withCredentials: true });
       eventSourceRef.current = eventSource;
 

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -1,5 +1,6 @@
+import config from "@app/lib/api/config";
 import { BUILD_DATE, COMMIT_HASH } from "@app/lib/commit-hash";
-import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
+import { clientFetch } from "@app/lib/egress/client";
 import { isAPIErrorResponse } from "@app/types/error";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import {
@@ -177,7 +178,7 @@ const resHandler = async (res: Response) => {
             window.location.pathname !== "/"
               ? `?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`
               : "";
-          window.location.href = `${getApiBaseUrl()}/api/workos/login${returnTo}`;
+          window.location.href = `${config.getApiBaseUrl()}/api/workos/login${returnTo}`;
           // Return a never-resolving promise to prevent SWR from processing.
           return new Promise(() => {});
         }

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from "@app/lib/egress/client";
+import config from "@app/lib/api/config";
 import type {
   OAuthConnectionType,
   OAuthCredentials,
@@ -23,8 +23,7 @@ export async function setupOAuthConnection({
   extraConfig: OAuthCredentials;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
-    const oauthBaseUrl =
-      getApiBaseUrl() || `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`;
+    const oauthBaseUrl = config.getApiBaseUrl();
     // Pass opener origin through OAuth flow so finalize page can postMessage back
     const openerOrigin = window.location.origin;
     let url = `${oauthBaseUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}&openerOrigin=${encodeURIComponent(openerOrigin)}`;


### PR DESCRIPTION
## Description

Replace all direct `process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL` usage in client-side components with `getApiBaseUrl()` from `@app/lib/egress/client`.

Also simplify `getApiBaseUrl()` itself: remove the `getSpaBaseUrl()` helper (which read `import.meta.env.VITE_DUST_CLIENT_FACING_URL`) and fall back to `config.getClientFacingUrl()` instead. This works in both Next.js and the SPA (Vite rewrites `NEXT_PUBLIC_*` env vars to `process.env.NEXT_PUBLIC_*`), so `getApiBaseUrl()` now always returns a non-empty URL.

**Files changed:**
- `front/lib/egress/client.ts` — removed `getSpaBaseUrl()`, fallback is now `config.getClientFacingUrl()`
- `front/types/oauth/client/setup.ts` — removed manual fallback (no longer needed)
- `front/lib/auth/RegionContext.tsx` — removed stale comment
- 10 component files — replaced `process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL` with `getApiBaseUrl()`

## Tests

Manual — no behavior change, just routing through the proper abstraction.

## Risk

Low. `getApiBaseUrl()` already resolves to the same value in all contexts (Next.js, SPA, region override). The only difference is it now uses `config.getClientFacingUrl()` as fallback instead of reading `VITE_DUST_CLIENT_FACING_URL` via `import.meta.env`. Safe to rollback.

## Deploy Plan

Standard deploy, no special steps.