### PR TITLE
[CLI] Skip update check in non-interactive mode

### DIFF
--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -85,7 +85,9 @@ interface AppProps {
 const App: FC<AppProps> = ({ cli }) => {
   const [updateCheckComplete, setUpdateCheckComplete] = useState(false);
   const { input, flags } = cli;
-  const isNonInteractiveChat = Boolean(flags.message || flags.messageId);
+  const command = input[0] || "chat";
+  const isNonInteractiveChat =
+    command === "chat" && Boolean(flags.message || flags.messageId);
 
   const handleUpdateComplete = useCallback(() => {
     setUpdateCheckComplete(true);
@@ -103,8 +105,6 @@ const App: FC<AppProps> = ({ cli }) => {
   if (!flags.noUpdateCheck && !isNonInteractiveChat && !updateCheckComplete) {
     return <UpdateInfo onComplete={handleUpdateComplete} />;
   }
-
-  const command = input[0] || "chat";
 
   // Handle --resume flag: treat as chat with conversationId
   const resumeId = flags.resume;

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -85,6 +85,7 @@ interface AppProps {
 const App: FC<AppProps> = ({ cli }) => {
   const [updateCheckComplete, setUpdateCheckComplete] = useState(false);
   const { input, flags } = cli;
+  const isNonInteractiveChat = Boolean(flags.message || flags.messageId);
 
   const handleUpdateComplete = useCallback(() => {
     setUpdateCheckComplete(true);
@@ -98,8 +99,8 @@ const App: FC<AppProps> = ({ cli }) => {
     return <Help />;
   }
 
-  // Show update info unless --noUpdateCheck flag is set or check is complete
-  if (!flags.noUpdateCheck && !updateCheckComplete) {
+  // Skip update checks for non-interactive chat mode.
+  if (!flags.noUpdateCheck && !isNonInteractiveChat && !updateCheckComplete) {
     return <UpdateInfo onComplete={handleUpdateComplete} />;
   }
 


### PR DESCRIPTION
## Description
Non-interactive chat mode now skips the CLI update check automatically.

This avoids blocking headless/automated runs on the update prompt while preserving update checks for interactive usage.

## Risks
Blast radius: Dust CLI startup path for `chat --message` and `chat --messageId`.
Risk: low

## Deploy Plan
- pmrr
- publish `@dust-tt/dust-cli` in the next CLI release
