### PR TITLE
fix: duplicate errors logs for temporal

### DIFF
--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -90,30 +90,22 @@ export class ActivityInboundLogInterceptor
       const durationMs = new Date().getTime() - startTime.getTime();
       if (error) {
         let errorType = "unhandled_internal_activity_error";
-        if (error.__is_dust_error !== undefined) {
-          // this is a dust error
+        const isDustError = error.__is_dust_error !== undefined;
+        if (isDustError) {
           errorType = error.type;
-          this.logger.error(
-            {
-              error,
-              dustError: error,
-              durationMs,
-              attempt: this.context.info.attempt,
-            },
-            "Activity failed"
-          );
-        } else {
-          // unknown error type
-          this.logger.error(
-            {
-              error,
-              error_stack: error?.stack,
-              durationMs: durationMs,
-              attempt: this.context.info.attempt,
-            },
-            "Unhandled activity error"
-          );
         }
+
+        this.logger.error(
+          {
+            error,
+            dustError: isDustError ? error : undefined,
+            error_stack: error?.stack,
+            errorType,
+            durationMs,
+            attempt: this.context.info.attempt,
+          },
+          "Activity failed"
+        );
 
         tags.push(`error_type:${errorType}`);
         statsDClient.increment("activity_failed.count", 1, tags);


### PR DESCRIPTION
## Description

  - Unifies duplicate Temporal activity error logs ("Activity failed" / "Unhandled activity error") into a single "Activity failed" message in both front and connectors
  - Adds an errorType field to the log payload to distinguish known Dust errors from unhandled ones
  - Both error_stack and dustError fields are now consistently included (conditionally) in a single log entry

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
