### PR TITLE
fix(upload): force some file type based on extension

### DIFF
--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -16,6 +16,7 @@ import {
   getFileFormatCategory,
   isSupportedFileContentType,
   MAX_FILE_SIZES,
+  resolveFileContentType,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -148,7 +149,9 @@ export function useFileUploaderService({
 
     return selectedFiles.reduce<Result<FileBlob, FileBlobUploadError>[]>(
       (acc, file) => {
-        const fileType = file.type || DEFAULT_FILE_CONTENT_TYPE;
+        const fileType =
+          resolveFileContentType(file.type, file.name) ||
+          DEFAULT_FILE_CONTENT_TYPE;
 
         // File objects are immutable - we can't modify their properties directly.
         // When we need to change the name or type, we must create a new File object.

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -582,6 +582,35 @@ export function getSupportedNonImageMimeTypes() {
   );
 }
 
+// Browsers may report incorrect MIME types for certain file extensions.
+// For example, it seems that it's likely that Windows, with Excel installed,
+// reports .csv files as application/vnd.ms-excel, which causes them
+// to be routed to the Tika text extraction pipeline instead of the native CSV parser.
+const EXTENSION_CONTENT_TYPE_OVERRIDES: Record<
+  string,
+  SupportedFileContentType
+> = {
+  ".csv": "text/csv",
+  ".tsv": "text/tsv",
+};
+
+// This function overrides the browser-reported content type with a more accurate one based on the file extension, if applicable.
+export function resolveFileContentType(
+  browserContentType: string,
+  fileName: string
+): string {
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex !== -1) {
+    const extension = fileName.slice(dotIndex).toLowerCase();
+    const override = EXTENSION_CONTENT_TYPE_OVERRIDES[extension];
+    if (override) {
+      return override;
+    }
+  }
+
+  return browserContentType;
+}
+
 export function isPdfContentType(contentType: string): boolean {
   return contentType === "application/pdf";
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Contributes to https://github.com/dust-tt/tasks/issues/6597

User reports that when uploading a csv file, it's recognized as an excel one. They sent us the file and we can't repro.

I'm guessing it have something to do with their OS having excel as a default opener on CSVs.
TBH, a bit afraid of this pattern, we should probably not extend it much.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front