### PR TITLE
[front] Roll out Opus 4.6 to all enterprise plans with medium reasoning

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -461,7 +461,7 @@ export function _getDeepDiveGlobalAgent(
     shouldUseOpus(auth) && isProviderWhitelisted(owner, "anthropic")
       ? {
           modelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
-          reasoningEffort: modelConfig?.reasoningEffort ?? ("light" as const),
+          reasoningEffort: modelConfig?.reasoningEffort ?? ("medium" as const),
         }
       : null;
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -513,21 +513,7 @@ function _getDustLikeGlobalAgent(
 export function shouldUseOpus(auth: Authenticator): boolean {
   const planCode = auth.plan()?.code ?? "";
 
-  if (isDustCompanyPlan(planCode)) {
-    return true;
-  }
-
-  if (!isEntreprisePlanPrefix(planCode)) {
-    return false;
-  }
-
-  // Deterministic 50/50 split based on workspace sId.
-  const sId = auth.getNonNullableWorkspace().sId;
-  let hash = 0;
-  for (let i = 0; i < sId.length; i++) {
-    hash = (hash * 31 + sId.charCodeAt(i)) | 0;
-  }
-  return (hash & 1) === 0;
+  return isDustCompanyPlan(planCode) || isEntreprisePlanPrefix(planCode);
 }
 
 export function _getDustGlobalAgent(
@@ -540,7 +526,7 @@ export function _getDustGlobalAgent(
     preferredModelConfiguration: shouldUseOpus(auth)
       ? CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG
       : CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
-    preferredReasoningEffort: "light",
+    preferredReasoningEffort: "medium",
   });
 }
 

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -224,7 +224,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   minimumReasoningEffort: "light",
   maximumReasoningEffort: "high",
-  defaultReasoningEffort: "high",
+  defaultReasoningEffort: "medium",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,


### PR DESCRIPTION
## Description


- **Remove A/B split**: All enterprise + Dust company workspaces now get Opus 4.6 (previously was a deterministic 50/50 split based on workspace sId hash).
- **Switch reasoning to medium**: Default reasoning effort for Opus 4.6 model config

## Tests

Verified type-correctness of changes. No behavioral logic change beyond the rollout scope — `shouldUseOpus` now simply checks plan type without hashing.

## Risk

Low — this is an intentional full rollout of what was already an A/B test. Rollback is straightforward by reverting.

## Deploy Plan

Standard deploy. No migration or infra changes needed.