### PR TITLE
Ensure only admins can see copilot even with FF

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import { useCopilotMCPServer } from "@app/components/agent_builder/copilot/useMCPServer";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
+import { useIsAgentBuilderCopilotEnabled } from "@app/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled";
 import {
   PersonalConnectionRequiredDialog,
   useAwaitableDialog,
@@ -582,15 +583,13 @@ function AgentBuilderContent({
   conversationId,
 }: AgentBuilderContentProps) {
   const { owner } = useAgentBuilderContext();
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  const isCopilotEnabled = useIsAgentBuilderCopilotEnabled();
   const confirm = useContext(ConfirmContext);
   const sendNotification = useSendNotification();
   const suggestionsContext = useCopilotSuggestions();
 
-  // Initialize the client-side MCP server for the agent builder copilot.
-  // Only enabled when the agent_builder_copilot feature flag is active.
   const { serverId: clientSideMCPServerId } = useCopilotMCPServer({
-    enabled: hasFeature("agent_builder_copilot"),
+    enabled: isCopilotEnabled,
   });
 
   const handleSaveWithValidation = useCallback(async () => {

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -3,11 +3,11 @@ import { AgentBuilderCopilot } from "@app/components/agent_builder/AgentBuilderC
 import { AgentBuilderInsights } from "@app/components/agent_builder/AgentBuilderInsights";
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import { AgentBuilderTemplate } from "@app/components/agent_builder/AgentBuilderTemplate";
+import { useIsAgentBuilderCopilotEnabled } from "@app/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled";
 import { ObservabilityProvider } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
 import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   BarChartIcon,
   Button,
@@ -219,11 +219,10 @@ export function AgentBuilderRightPanel({
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
-  const { assistantTemplate, owner } = useAgentBuilderContext();
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  const { assistantTemplate } = useAgentBuilderContext();
+  const hasCopilot = useIsAgentBuilderCopilotEnabled();
 
   const hasTemplate = !!assistantTemplate;
-  const hasCopilot = hasFeature("agent_builder_copilot");
 
   // Default tab priority:
   // - Template tab: when building from a template (copilot OFF)

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -1,10 +1,10 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
+import { useIsAgentBuilderCopilotEnabled } from "@app/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled";
 import {
   BLUR_EVENT_NAME,
   INSTRUCTIONS_DEBOUNCE_MS,
-  // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
-} from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
+} from "@app/components/agent_builder/instructions/constants";
 import { getSuggestionPosition } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { stripHtmlAttributes } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
@@ -14,7 +14,7 @@ import {
   useAgentSuggestions,
   usePatchAgentSuggestions,
 } from "@app/lib/swr/agent_suggestions";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { DataSourceViewType } from "@app/types/data_source_view";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   AgentInstructionsSuggestionType,
@@ -90,8 +90,6 @@ export const CopilotSuggestionsProvider = ({
   const { skills } = useSkillsContext();
   const { mcpServerViews, mcpServerViewsWithKnowledge } =
     useMCPServerViewsContext();
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-  const hasCopilot = hasFeature("agent_builder_copilot");
   const { supportedDataSourceViews: dataSourceViews } =
     useDataSourceViewsContext();
   const [isEditorReady, setIsEditorReady] = useState(false);
@@ -114,6 +112,8 @@ export const CopilotSuggestionsProvider = ({
     []
   );
 
+  const hasCopilot = useIsAgentBuilderCopilotEnabled();
+
   const skillsMap = useMemo(
     () => new Map(skills.map((s) => [s.sId, s])),
     [skills]
@@ -125,7 +125,8 @@ export const CopilotSuggestionsProvider = ({
   );
 
   const dataSourceViewsMap = useMemo(
-    () => new Map(dataSourceViews.map((dsv) => [dsv.sId, dsv])),
+    () =>
+      new Map(dataSourceViews.map((dsv: DataSourceViewType) => [dsv.sId, dsv])),
     [dataSourceViews]
   );
 

--- a/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
+++ b/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import { Button, CheckIcon, HoveringBar, XMarkIcon } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";

--- a/front/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled.ts
+++ b/front/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled.ts
@@ -1,0 +1,8 @@
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+
+export function useIsAgentBuilderCopilotEnabled(): boolean {
+  const { owner, isAdmin } = useAgentBuilderContext();
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  return hasFeature("agent_builder_copilot") && isAdmin;
+}

--- a/front/components/agent_builder/instructions/constants.ts
+++ b/front/components/agent_builder/instructions/constants.ts
@@ -1,0 +1,2 @@
+export const BLUR_EVENT_NAME = "agent:instructions:blur";
+export const INSTRUCTIONS_DEBOUNCE_MS = 250;

--- a/front/components/agent_builder/settings/AgentBuilderAvatarSection.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderAvatarSection.tsx
@@ -1,6 +1,6 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
+import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/constants";
 import { AvatarPicker } from "@app/components/agent_builder/settings/avatar_picker/AgentBuilderAvatarPicker";
 import {
   DROID_AVATAR_URLS,

--- a/front/components/agent_builder/settings/AgentBuilderDescriptionSection.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderDescriptionSection.tsx
@@ -1,6 +1,6 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
+import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/constants";
 import { getDescriptionSuggestion } from "@app/components/agent_builder/settings/utils";
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 import { useSendNotification } from "@app/hooks/useNotification";

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -52,7 +52,9 @@ export function NewAgentPage() {
   });
 
   const shouldPassConversationId =
-    hasFeature("agent_builder_copilot") && agentConfiguration === null;
+    hasFeature("agent_builder_copilot") &&
+    isAdmin &&
+    agentConfiguration === null;
 
   const {
     assistantTemplate,


### PR DESCRIPTION
## Description

* Following up on the following thread where we decided to restrict the copilot allowlist to only admins: https://dust4ai.slack.com/archives/C0A6TBTU7JS/p1771020288737009
* Had to fix circular import issue to do this

## Tests

* Validated localhost

## Risk

* Low

## Deploy Plan

* Deploy front