### PR TITLE
[Cost Guardrails] Add $100 hard cap before starting a new step

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -131,6 +131,8 @@ async function _runModelAndCreateActionsActivity({
       },
       "Failed to run cost-threshold check"
     );
+    // Fail closed: do not start the next step when we cannot evaluate cost.
+    throw new Error("Failed to run cost-threshold check");
   }
 
   if (hardCapCheckResult?.hardCapExceeded) {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6599.
Related: https://github.com/dust-tt/tasks/issues/6520.
Follows https://github.com/dust-tt/dust/pull/21692.

This enforces a hard cap at step start for root messages: when cumulative descendant cost is `>= $100`, the loop does not start a new step and publishes an `agent_error` to fail the message.

If the cap check cannot be evaluated (for example on transient DB/read errors), we fail closed and abort the step instead of continuing unguarded.

## Risks
Blast radius: agent loop step-start behavior for root messages only when cumulative cost reaches the cap.
Risk: low

## Deploy Plan
- deploy `front`
