### PR TITLE
[Programmatic Usage] Fix billing period mismatch between header and chart

### DIFF
--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -4,7 +4,7 @@ import { CreditsList, isExpired } from "@app/components/workspace/CreditsList";
 import { ProgrammaticCostChart } from "@app/components/workspace/ProgrammaticCostChart";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
-  getBillingCycle,
+  getBillingCycleFromDay,
   getPriceAsString,
 } from "@app/lib/client/subscription";
 import { useCreditPurchaseInfo, useCredits } from "@app/lib/swr/credits";
@@ -110,6 +110,7 @@ interface UsageSectionProps {
   >;
   totalConsumed: number;
   totalCredits: number;
+  billingCycleStartDay: number | null;
   isLoading: boolean;
   setShowBuyCreditDialog: (show: boolean) => void;
 }
@@ -144,15 +145,16 @@ function UsageSection({
   creditsByType,
   totalConsumed,
   totalCredits,
+  billingCycleStartDay,
   isLoading,
   setShowBuyCreditDialog,
 }: UsageSectionProps) {
   const billingCycle = useMemo(() => {
-    if (!subscription.startDate) {
+    if (!billingCycleStartDay) {
       return null;
     }
-    return getBillingCycle(subscription.startDate);
-  }, [subscription.startDate]);
+    return getBillingCycleFromDay(billingCycleStartDay, new Date(), true);
+  }, [billingCycleStartDay]);
 
   if (isLoading) {
     return (
@@ -461,6 +463,7 @@ export function CreditsUsagePage() {
           creditsByType={creditsByType}
           totalConsumed={totalConsumed}
           totalCredits={totalCredits}
+          billingCycleStartDay={billingCycleStartDay}
           isLoading={isCreditsLoading || isCreditPurchaseInfoLoading}
           setShowBuyCreditDialog={setShowBuyCreditDialog}
         />

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -19,6 +19,7 @@ function PokeProgrammaticCostChartFallback() {
 }
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { resolveBillingCycleStartDay } from "@app/lib/client/subscription";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeCreditsData } from "@app/poke/swr/credits";
 import { usePokeCredits } from "@app/poke/swr/credits";
@@ -63,17 +64,11 @@ export function CreditsDataTable({
   stripeSubscription,
   loadOnInit,
 }: CreditsDataTableProps) {
-  // Get the billing cycle start day from Stripe subscription, fallback to Dust subscription
-  const getBillingCycleStartDay = (): number | null => {
-    if (stripeSubscription?.current_period_start) {
-      return new Date(stripeSubscription.current_period_start * 1000).getDate();
-    }
-    if (subscription.startDate) {
-      return new Date(subscription.startDate).getDate();
-    }
-    return null;
-  };
-  const billingCycleStartDay = getBillingCycleStartDay();
+  const billingCycleStartDay = resolveBillingCycleStartDay({
+    stripeCurrentPeriodStartSeconds:
+      stripeSubscription?.current_period_start ?? null,
+    subscriptionStartDateMs: subscription.startDate,
+  });
 
   return (
     <>

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -17,6 +17,26 @@ export interface BillingCycle {
   cycleEnd: Date;
 }
 
+interface ResolveBillingCycleStartDayArgs {
+  stripeCurrentPeriodStartSeconds?: number | null;
+  subscriptionStartDateMs?: number | null;
+}
+
+export function resolveBillingCycleStartDay({
+  stripeCurrentPeriodStartSeconds,
+  subscriptionStartDateMs,
+}: ResolveBillingCycleStartDayArgs): number | null {
+  if (stripeCurrentPeriodStartSeconds) {
+    return new Date(stripeCurrentPeriodStartSeconds * 1000).getUTCDate();
+  }
+
+  if (subscriptionStartDateMs) {
+    return new Date(subscriptionStartDateMs).getUTCDate();
+  }
+
+  return null;
+}
+
 /**
  * Calculate the billing cycle for a given day of the month.
  * Example: if billing starts on the 4th, the cycle is from the 4th of one month
@@ -69,11 +89,14 @@ export function getBillingCycle(
   subscriptionStartDate: number | null,
   referenceDate: Date = new Date()
 ): BillingCycle | null {
-  if (!subscriptionStartDate) {
+  const billingCycleStartDay = resolveBillingCycleStartDay({
+    subscriptionStartDateMs: subscriptionStartDate,
+  });
+
+  if (!billingCycleStartDay) {
     return null;
   }
 
-  const billingCycleStartDay = new Date(subscriptionStartDate).getUTCDate();
   return getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6171

Fixes a regression introduced in commit `35217aefe68` (Feb 6, 2026): billing calculations were moved to UTC correctly, but billing-day sourcing switched to `subscription.startDate`, which can drift from Stripe's active cycle anchor.

This change makes Stripe `current_period_start` the source of truth (with `subscription.startDate` fallback), and aligns the top header, usage chart, and poke chart to the same resolved billing cycle day.

## Risks
Blast radius: Programmatic usage billing-period display and chart period selection (workspace credits usage page + poke credits view).
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/client/subscription.test.ts`