### PR TITLE
Wait for the client-side MCP server to be registered before starting the conversation

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -216,6 +216,12 @@ export const CopilotPanelProvider = ({
     if (hasStartedRef.current || !targetAgentConfigurationId) {
       return;
     }
+    // Wait for the client-side MCP server to be registered before starting
+    // the conversation. Without this, the copilot won't have access to
+    // agent_builder_copilot_client tools like get_agent_config.
+    if (clientSideMCPServerIds.length === 0) {
+      return;
+    }
     hasStartedRef.current = true;
 
     setIsCreatingConversation(true);


### PR DESCRIPTION
## Description

Here is what's likely happening now:
  1. useCopilotMCPServer starts async initialization, serverId is initially undefined
  2. CopilotPanelProvider receives clientSideMCPServerIds as [] initially
  3. AgentBuilderCopilot mounts and immediately calls startConversation()
  4. startConversation fires with empty clientSideMCPServerIds, so the copilot message is sent without the MCP server reference
  5. When the MCP server finishes registering, it's too late - the conversation was already created

Fix is to not start the conversation if client MCP is not ready.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front