### PR TITLE
Don't show invalid suggestion directives

### DIFF
--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -32,8 +32,6 @@ import {
   ActionCardBlock,
   Avatar,
   Button,
-  ContentMessage,
-  ExclamationCircleIcon,
   EyeIcon,
   FolderIcon,
   LoadingBlock,

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -606,20 +606,3 @@ export function SuggestionCardSkeleton({ kind }: SuggestionCardSkeletonProps) {
     />
   );
 }
-
-export function SuggestionCardNotFound() {
-  return (
-    <div className="mb-2 inline-block w-full max-w-md align-top">
-      <ContentMessage
-        title="Suggestion not found"
-        icon={ExclamationCircleIcon}
-        variant="warning"
-        size="sm"
-      >
-        <span className="text-sm">
-          This suggestion is outdated or has been deleted.
-        </span>
-      </ContentMessage>
-    </div>
-  );
-}

--- a/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
@@ -8,7 +8,6 @@
 import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import {
   CopilotSuggestionCard,
-  SuggestionCardNotFound,
   SuggestionCardSkeleton,
 } from "@app/components/markdown/suggestion/CopilotSuggestionCard";
 import type { AgentSuggestionKind } from "@app/types/suggestions/agent_suggestion";
@@ -91,7 +90,8 @@ export function getCopilotSuggestionPlugin() {
       if (isSuggestionsValidating || !hasAttemptedRefetch(sId)) {
         return <SuggestionCardSkeleton kind={kind} />;
       }
-      return <SuggestionCardNotFound />;
+      // Don't show anything for suggestions that no longer exist (outdated/deleted)
+      return null;
     }
 
     return <CopilotSuggestionCard agentSuggestion={suggestion} />;

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -388,7 +388,7 @@ When creating suggestions:
    - Automatically mark conflicting suggestions as \`outdated\` (see conflict rules below)
    - Emit a notification to render the suggestion chip in the conversation
    - Return a markdown directive that renders the suggestion inline
-   - Only valid, resolvable suggestions appear as cards. This means creating invalid suggestions wastes your response with empty directives that add no value.
+   - Only valid, resolvable suggestions appear as cards. Outputting suggestion directives you did not receive from a \`suggest_*\` tool call wastes your response with empty directives that add no value.
 
 2. The custom markdown component will:
    - Render the suggestion chip in the conversation viewer

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -388,6 +388,7 @@ When creating suggestions:
    - Automatically mark conflicting suggestions as \`outdated\` (see conflict rules below)
    - Emit a notification to render the suggestion chip in the conversation
    - Return a markdown directive that renders the suggestion inline
+   - Only valid, resolvable suggestions appear as cards. This means creating invalid suggestions wastes your response with empty directives that add no value.
 
 2. The custom markdown component will:
    - Render the suggestion chip in the conversation viewer


### PR DESCRIPTION
## Description

* No longer showing invalid suggestions as a card. Adding prompting

## Tests

* Validated cards still show as expected

## Risk

* Low

## Deploy Plan

* Deploy front