### PR TITLE
fix: dedupe novu notifications if multiple tabs

### DIFF
--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -87,6 +87,7 @@ export default function AppRootLayout({
           ) {
             notify(notification.result.subject ?? "New notification", {
               body: notification.result.body.replaceAll("\n", " ").trim(),
+              tag: notification.result.id,
               icon:
                 notification.result.avatar ??
                 `${dustFacingUrl}/static/landing/logos/dust/Dust_LogoSquare.svg`,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/6590

 By setting tag: notification.result.id on the browser notification, the Web Notification API will deduplicate across tabs. If a notification with the same tag already exists, it gets replaced rather than creating a new one. So even if 5 tabs each call new Notification(), the user sees only one.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Need to test on front-edge with @matteotrab's browser or @philipperolet's one

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front