### PR TITLE
Improve flow, ensure app is deployed after api

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -47,6 +47,11 @@ on:
         type: string
         default: ""
         required: false
+      promote:
+        description: "If false, deploy as preview only (assets propagate but production alias unchanged)"
+        type: boolean
+        default: true
+        required: false
 
 concurrency:
   group: deploy-spa-${{ inputs.app }}
@@ -112,7 +117,7 @@ jobs:
           if [ "${{ github.ref_name }}" == "main" ]; then
             export NEXT_PUBLIC_DUST_APP_URL=https://app.dust.tt
           else
-            export NEXT_PUBLIC_DUST_APP_URL=https://${{ github.ref_name }}.app-dust-tt.pages.dev
+            export NEXT_PUBLIC_DUST_APP_URL=https://${{ github.ref_name }}--app.preview.dust.tt
           fi
           export NEXT_PUBLIC_BUILD_DATE=$(date +%s)
           # Map all NEXT_PUBLIC_* to VITE_* for SPA
@@ -123,6 +128,7 @@ jobs:
           npm run build:${{ inputs.app }}
 
       - name: Upload sourcemaps to Datadog
+        if: ${{ inputs.env != 'edge' }}
         working-directory: front-spa
         env:
           DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -139,7 +145,18 @@ jobs:
             --release-version=${{ github.sha }} \
             --service=${{ inputs.app }}-spa-browser
 
-      - name: Deploy
+      - name: Deploy to preview branch
+        if: ${{ inputs.promote == false }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: front-spa
+          command: pages deploy dist/${{ inputs.app }} --project-name=${{ inputs.app }}-dust-tt --branch=staging-${{ github.sha }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to production
+        if: ${{ inputs.promote == true }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -147,6 +164,14 @@ jobs:
           workingDirectory: front-spa
           command: pages deploy dist/${{ inputs.app }} --project-name=${{ inputs.app }}-dust-tt
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload dist artifact
+        if: ${{ inputs.promote == false }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: spa-dist-${{ inputs.app }}
+          path: front-spa/dist/${{ inputs.app }}
+          retention-days: 1
 
       - name: Summary
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,24 +253,148 @@ jobs:
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
+  # Phase 1: Upload SPA to CF Pages as preview (assets propagate, production alias unchanged).
+  # Starts in parallel with Docker build to save time.
   deploy-app:
     if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_app
-    needs: [build, notify-start]
+    needs: [notify-start]
     uses: ./.github/workflows/deploy-spa.yaml
     with:
       app: "app"
       env: ${{ inputs.component == 'front-edge' && 'edge' || 'prod' }}
       region: "us"
       thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
+      promote: false
     secrets: inherit
 
   deploy-poke:
     if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_poke
-    needs: [build, notify-start]
+    needs: [notify-start]
     uses: ./.github/workflows/deploy-spa.yaml
     with:
       app: "poke"
       env: ${{ inputs.component == 'front-edge' && 'edge' || 'prod' }}
       region: "us"
       thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
+      promote: false
     secrets: inherit
+
+  # Phase 2: Promote SPA to production after the API is live with the new version.
+  # Polls /api/healthz/ready until commitHash matches the expected SHA.
+  promote-app:
+    if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_app
+    needs: [prepare, deploy, deploy-app]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for API to be live
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.short_sha }}
+          COMPONENT: ${{ inputs.component }}
+          REGIONS: ${{ inputs.regions }}
+        run: |
+          # Build list of URLs to poll based on component and regions.
+          URLS=""
+          if [ "$COMPONENT" = "front-edge" ]; then
+            BASE="front-edge.dust.tt"
+          else
+            BASE="dust.tt"
+          fi
+          if [ "$REGIONS" = "us-central1" ] || [ "$REGIONS" = "all" ]; then
+            URLS="$URLS https://$BASE/api/healthz/ready"
+          fi
+          if [ "$REGIONS" = "europe-west1" ] || [ "$REGIONS" = "all" ]; then
+            URLS="$URLS https://eu.$BASE/api/healthz/ready"
+          fi
+
+          echo "Waiting for API to serve commitHash=$EXPECTED_SHA on:$URLS"
+          for URL in $URLS; do
+            echo "Polling $URL ..."
+            for i in $(seq 1 60); do
+              RESPONSE=$(curl -sf "$URL" 2>/dev/null || echo '{}')
+              LIVE_HASH=$(echo "$RESPONSE" | jq -r '.commitHash // empty')
+              if [ "$LIVE_HASH" = "$EXPECTED_SHA" ]; then
+                echo "$URL is live with expected version after $((i * 10))s"
+                break
+              fi
+              echo "  Attempt $i/60: got commitHash=$LIVE_HASH, waiting 10s..."
+              sleep 10
+              if [ "$i" = "60" ]; then
+                echo "::warning::$URL did not reach expected version after 10 minutes. Promoting SPA anyway."
+              fi
+            done
+          done
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spa-dist-app
+          path: front-spa/dist/app
+
+      - name: Promote to production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: front-spa
+          command: pages deploy dist/app --project-name=app-dust-tt
+
+  promote-poke:
+    if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_poke
+    needs: [prepare, deploy, deploy-poke]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for API to be live
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.short_sha }}
+          COMPONENT: ${{ inputs.component }}
+          REGIONS: ${{ inputs.regions }}
+        run: |
+          # Build list of URLs to poll based on component and regions.
+          URLS=""
+          if [ "$COMPONENT" = "front-edge" ]; then
+            BASE="front-edge.dust.tt"
+          else
+            BASE="dust.tt"
+          fi
+          if [ "$REGIONS" = "us-central1" ] || [ "$REGIONS" = "all" ]; then
+            URLS="$URLS https://$BASE/api/healthz/ready"
+          fi
+          if [ "$REGIONS" = "europe-west1" ] || [ "$REGIONS" = "all" ]; then
+            URLS="$URLS https://eu.$BASE/api/healthz/ready"
+          fi
+
+          echo "Waiting for API to serve commitHash=$EXPECTED_SHA on:$URLS"
+          for URL in $URLS; do
+            echo "Polling $URL ..."
+            for i in $(seq 1 60); do
+              RESPONSE=$(curl -sf "$URL" 2>/dev/null || echo '{}')
+              LIVE_HASH=$(echo "$RESPONSE" | jq -r '.commitHash // empty')
+              if [ "$LIVE_HASH" = "$EXPECTED_SHA" ]; then
+                echo "$URL is live with expected version after $((i * 10))s"
+                break
+              fi
+              echo "  Attempt $i/60: got commitHash=$LIVE_HASH, waiting 10s..."
+              sleep 10
+              if [ "$i" = "60" ]; then
+                echo "::warning::$URL did not reach expected version after 10 minutes. Promoting SPA anyway."
+              fi
+            done
+          done
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spa-dist-poke
+          path: front-spa/dist/poke
+
+      - name: Promote to production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: front-spa
+          command: pages deploy dist/poke --project-name=poke-dust-tt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,26 +223,58 @@ jobs:
 
       - name: Trigger dust-infra workflow
         uses: actions/github-script@v6
+        env:
+          OWNER: ${{ github.repository_owner }}
+          COMPONENT: ${{ inputs.component }}
+          REGIONS: ${{ inputs.regions }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.short_sha }}
+          SLACK_THREAD_TS: ${{ needs.notify-start.outputs.thread_ts }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
+          DEPLOY_SPA_APP: ${{ inputs.deploy_spa_app }}
+          DEPLOY_SPA_POKE: ${{ inputs.deploy_spa_poke }}
+          RUN_ID: ${{ github.run_id }}
+          PLAYWRIGHT_SHA: ${{ github.sha }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
+            const component = process.env.COMPONENT;
+            const isFront = component === 'front' || component === 'front-edge';
+            const deploySpaApp = process.env.DEPLOY_SPA_APP === 'true';
+            const deploySpaAppPoke = process.env.DEPLOY_SPA_POKE === 'true';
+
+            const payload = {
+              regions: process.env.REGIONS,
+              component,
+              image_tag: process.env.IMAGE_TAG,
+              slack_thread_ts: process.env.SLACK_THREAD_TS,
+              slack_channel: process.env.SLACK_CHANNEL,
+              playwright_sha: process.env.PLAYWRIGHT_SHA,
+            };
+
+            // When deploying front/front-edge with SPA enabled, tell dust-infra to dispatch back
+            // after a successful rollout so the SPA is promoted to production only once the API is
+            // live.
+            if (isFront && (deploySpaApp || deploySpaAppPoke)) {
+              const app = deploySpaApp && deploySpaAppPoke ? 'all'
+                : deploySpaApp ? 'app' : 'poke';
+
+              payload.on_success_dispatch = JSON.stringify({
+                owner: process.env.OWNER,
+                repo: 'dust',
+                event_type: 'promote-spa',
+                payload: {
+                  app,
+                  run_id: process.env.RUN_ID,
+                },
+              });
+            }
+
             await github.rest.repos.createDispatchEvent({
-              owner: '${{ github.repository_owner }}',
+              owner: process.env.OWNER,
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
-              client_payload: {
-                regions: '${{ inputs.regions }}',
-                component: '${{ inputs.component }}',
-                image_tag: '${{ needs.prepare.outputs.short_sha }}',
-                slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
-                slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}',
-                run_playwright: '${{ inputs.run_playwright_tests }}',
-                playwright_sha: '${{ github.sha }}',
-                spa_run_id: '${{ github.run_id }}',
-                spa_promote_app: '${{ inputs.deploy_spa_app }}',
-                spa_promote_poke: '${{ inputs.deploy_spa_poke }}'
-              }
-            })
+              client_payload: payload,
+            });
 
       - name: Notify Failure
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -237,7 +237,10 @@ jobs:
                 slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}',
                 run_playwright: '${{ inputs.run_playwright_tests }}',
-                playwright_sha: '${{ github.sha }}'
+                playwright_sha: '${{ github.sha }}',
+                spa_run_id: '${{ github.run_id }}',
+                spa_promote_app: '${{ inputs.deploy_spa_app }}',
+                spa_promote_poke: '${{ inputs.deploy_spa_poke }}'
               }
             })
 
@@ -278,123 +281,3 @@ jobs:
       thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
       promote: false
     secrets: inherit
-
-  # Phase 2: Promote SPA to production after the API is live with the new version.
-  # Polls /api/healthz/ready until commitHash matches the expected SHA.
-  promote-app:
-    if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_app
-    needs: [prepare, deploy, deploy-app]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Wait for API to be live
-        env:
-          EXPECTED_SHA: ${{ needs.prepare.outputs.short_sha }}
-          COMPONENT: ${{ inputs.component }}
-          REGIONS: ${{ inputs.regions }}
-        run: |
-          # Build list of URLs to poll based on component and regions.
-          URLS=""
-          if [ "$COMPONENT" = "front-edge" ]; then
-            BASE="front-edge.dust.tt"
-          else
-            BASE="dust.tt"
-          fi
-          if [ "$REGIONS" = "us-central1" ] || [ "$REGIONS" = "all" ]; then
-            URLS="$URLS https://$BASE/api/healthz/ready"
-          fi
-          if [ "$REGIONS" = "europe-west1" ] || [ "$REGIONS" = "all" ]; then
-            URLS="$URLS https://eu.$BASE/api/healthz/ready"
-          fi
-
-          echo "Waiting for API to serve commitHash=$EXPECTED_SHA on:$URLS"
-          for URL in $URLS; do
-            echo "Polling $URL ..."
-            for i in $(seq 1 60); do
-              RESPONSE=$(curl -sf "$URL" 2>/dev/null || echo '{}')
-              LIVE_HASH=$(echo "$RESPONSE" | jq -r '.commitHash // empty')
-              if [ "$LIVE_HASH" = "$EXPECTED_SHA" ]; then
-                echo "$URL is live with expected version after $((i * 10))s"
-                break
-              fi
-              echo "  Attempt $i/60: got commitHash=$LIVE_HASH, waiting 10s..."
-              sleep 10
-              if [ "$i" = "60" ]; then
-                echo "::warning::$URL did not reach expected version after 10 minutes. Promoting SPA anyway."
-              fi
-            done
-          done
-
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: spa-dist-app
-          path: front-spa/dist/app
-
-      - name: Promote to production
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: front-spa
-          command: pages deploy dist/app --project-name=app-dust-tt
-
-  promote-poke:
-    if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_poke
-    needs: [prepare, deploy, deploy-poke]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Wait for API to be live
-        env:
-          EXPECTED_SHA: ${{ needs.prepare.outputs.short_sha }}
-          COMPONENT: ${{ inputs.component }}
-          REGIONS: ${{ inputs.regions }}
-        run: |
-          # Build list of URLs to poll based on component and regions.
-          URLS=""
-          if [ "$COMPONENT" = "front-edge" ]; then
-            BASE="front-edge.dust.tt"
-          else
-            BASE="dust.tt"
-          fi
-          if [ "$REGIONS" = "us-central1" ] || [ "$REGIONS" = "all" ]; then
-            URLS="$URLS https://$BASE/api/healthz/ready"
-          fi
-          if [ "$REGIONS" = "europe-west1" ] || [ "$REGIONS" = "all" ]; then
-            URLS="$URLS https://eu.$BASE/api/healthz/ready"
-          fi
-
-          echo "Waiting for API to serve commitHash=$EXPECTED_SHA on:$URLS"
-          for URL in $URLS; do
-            echo "Polling $URL ..."
-            for i in $(seq 1 60); do
-              RESPONSE=$(curl -sf "$URL" 2>/dev/null || echo '{}')
-              LIVE_HASH=$(echo "$RESPONSE" | jq -r '.commitHash // empty')
-              if [ "$LIVE_HASH" = "$EXPECTED_SHA" ]; then
-                echo "$URL is live with expected version after $((i * 10))s"
-                break
-              fi
-              echo "  Attempt $i/60: got commitHash=$LIVE_HASH, waiting 10s..."
-              sleep 10
-              if [ "$i" = "60" ]; then
-                echo "::warning::$URL did not reach expected version after 10 minutes. Promoting SPA anyway."
-              fi
-            done
-          done
-
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: spa-dist-poke
-          path: front-spa/dist/poke
-
-      - name: Promote to production
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: front-spa
-          command: pages deploy dist/poke --project-name=poke-dust-tt

--- a/.github/workflows/promote-spa.yaml
+++ b/.github/workflows/promote-spa.yaml
@@ -18,9 +18,8 @@ on:
         type: string
         required: true
 
-# repository_dispatch payload (from dust-infra):
-#   client_payload.app: "app" | "poke" | "all"
-#   client_payload.run_id: GitHub Actions run ID that uploaded the SPA dist artifacts
+permissions:
+  actions: read
 
 jobs:
   promote:

--- a/.github/workflows/promote-spa.yaml
+++ b/.github/workflows/promote-spa.yaml
@@ -1,0 +1,52 @@
+name: Promote SPA to production
+
+on:
+  repository_dispatch:
+    types: [promote-spa]
+  workflow_dispatch:
+    inputs:
+      app:
+        description: "SPA to promote (app, poke, or all)"
+        type: choice
+        options:
+          - app
+          - poke
+          - all
+        required: true
+      run_id:
+        description: "Run ID of the deploy workflow that uploaded the SPA artifacts"
+        type: string
+        required: true
+
+# repository_dispatch payload (from dust-infra):
+#   client_payload.app: "app" | "poke" | "all"
+#   client_payload.run_id: GitHub Actions run ID that uploaded the SPA dist artifacts
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: ${{ fromJson(
+          (github.event.client_payload.app || inputs.app) == 'all'
+            && '["app","poke"]'
+            || format('["{0}"]', github.event.client_payload.app || inputs.app)
+          ) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spa-dist-${{ matrix.app }}
+          path: front-spa/dist/${{ matrix.app }}
+          run-id: ${{ github.event.client_payload.run_id || inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote to production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: front-spa
+          command: pages deploy dist/${{ matrix.app }} --project-name=${{ matrix.app }}-dust-tt

--- a/front/pages/api/healthz/ready.ts
+++ b/front/pages/api/healthz/ready.ts
@@ -1,3 +1,4 @@
+import { COMMIT_HASH } from "@app/lib/commit-hash";
 import { isInShutdown } from "@app/lib/shutdown_signal";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -34,7 +35,7 @@ export default async function handler(
   }
 
   // Simple check, just verify process is responsive.
-  res.status(200).json({ status: "ready" });
+  res.status(200).json({ status: "ready", commitHash: COMMIT_HASH });
 
   const durationMs = performance.now() - startMs;
   statsDClient.distribution("healthz.ready.duration_ms", durationMs);


### PR DESCRIPTION
## Summary

- Split SPA deploy into two phases: **upload** (preview branch) and **promote** (production)
- SPA build starts in parallel with the Docker build (instead of waiting for it)
- Promotion is triggered by dust-infra via `repository_dispatch` (`promote-spa` event) once the API deployment is complete
- New `promote-spa.yaml` workflow that downloads the dist artifact from the original deploy run and deploys to CF Pages production
- Deploy payload to dust-infra now includes `spa_run_id`, `spa_promote_app`, `spa_promote_poke` for the callback
- Adds `commitHash` to the `/api/healthz/ready` response
- Removes `/* /index.html 200` catch-all from `_redirects` (relies on CF Pages built-in SPA mode instead)
- Skips Datadog sourcemap upload for front-edge deploys to avoid conflicts with prod sourcemaps

## Motivation

After a SPA deploy to Cloudflare Pages, there's a propagation window where chunks may not be available on all edge nodes, causing "Failed to fetch dynamically imported module" errors. By uploading SPA assets as a preview first and only promoting to production after the API is live, we ensure:
1. Assets have time to propagate across CF edge nodes before users see them (promote re-deploys 0 files since they're already uploaded — instant pointer switch)
2. SPA and API versions are in sync

## Deploy flow

```
notify-start ──┬── build ── deploy (API dispatch to dust-infra) ──┐
               │                                                   │
               ├── deploy-app (SPA preview, parallel with build)   │  dust-infra deploys API,
               │                                                   │  then triggers promote-spa
               ├── deploy-poke (SPA preview, parallel with build)  │
               │                                                   │
               └───────────────── promote-spa.yaml ◄───────────────┘
                                  (downloads artifact, deploys to CF Pages production)
```

dust-infra calls back with:
```json
{
  "event_type": "promote-spa",
  "client_payload": {
    "app": "app|poke|all",
    "run_id": "<spa_run_id from deploy payload>"
  }
}
```

## Tests

Verified on preview deploy that promote uploads 0 files (0.43s) vs preview uploading 348 files (5.88s), confirming CF Pages deduplicates by content hash.

## Risk

Low. If dust-infra doesn't trigger the promote, SPA stays on the previous production version (safe). Manual promote available via `workflow_dispatch`.

## Deploy Plan

1. Merge this PR
2. Update dust-infra to send `promote-spa` dispatch after API deployment completes
3. Deploy front — SPA will upload as preview, then dust-infra promotes after API is live