### PR TITLE
Fix duplicate agent freeze

### DIFF
--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -334,7 +334,7 @@ export function AgentDetailsDropdownMenu({
           <DropdownMenuContent>{menuItems}</DropdownMenuContent>
         </DropdownMenu>
       ) : showTrigger ? (
-        <DropdownMenu>
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <Button icon={MoreIcon} size="sm" variant="ghost" />
           </DropdownMenuTrigger>


### PR DESCRIPTION
## Description

Hypothesis on issue:

Radix’s DropdownMenu has a modal option that changes how the overlay and body are handled.
With modal={true} (default)
When the menu opens, Radix:
Adds an invisible overlay over the rest of the page
Sets body to pointer-events: none so only the menu gets clicks
Uses DismissableLayer to manage this overlay
On close, it should revert body’s pointer-events
What goes wrong
When you click Duplicate and navigate immediately, the dropdown is torn down before it can clean up. Its DismissableLayer may not run its unmount logic in time, so body keeps pointer-events: none and the page stays unclickable.
With modal={false}
Radix:
Does not set body’s pointer-events
Does not add the overlay that blocks clicks
Relies on other behavior (e.g. click-outside) to close the menu
No DismissableLayer cleanup on body
Because the body is never touched, there’s no stuck state when the dropdown unmounts during navigation.
Summary
modal={true} makes the body non-interactive via pointer-events; if cleanup is skipped on unmount, the page stays frozen. modal={false} never modifies the body, so navigation doesn’t leave it in a bad state.

https://github.com/dust-tt/tasks/issues/6601

## Tests

* I was only able to replicate on my localhost, not prod, but validated that this fixed the issue

## Risk

* Low

## Deploy Plan

* Deploy front