### PR TITLE
Remove usage of AgentMessageRow in getAgentLoopData

### DIFF
--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -38,7 +38,7 @@ async function fetchAllAgentsById(
 ): Promise<AgentParticipantType[]> {
   const agents = await getAgentConfigurations(auth, {
     agentIds: agentConfigurationIds,
-    variant: "light",
+    variant: "extra_light",
   });
 
   return agents.map((a) => ({

--- a/front/migrations/20251024_mark_blocked_auth_agent_messages_failed.ts.ts
+++ b/front/migrations/20251024_mark_blocked_auth_agent_messages_failed.ts.ts
@@ -1,3 +1,4 @@
+/* Commented out as the code has changed since the migration was run.
 import { Op } from "sequelize";
 
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
@@ -62,14 +63,18 @@ async function processBlockedAuthAgentMessages(
     // Process each agent message
     for (const agentMessage of agentMessages) {
       if (execute) {
-        await markAgentMessageAsFailed(agentMessage, {
-          code: "personal_authentication_required",
-          message:
-            "Agent message failed due to missing personal authentication.",
-          metadata: {
-            category: "migration",
-            reason: "blocked_authentication_required_cleanup",
-            migrationDate: new Date().toISOString(),
+        await markAgentMessageAsFailed(auth, {
+          workspaceId: agentMessage.workspaceId,
+          agentMessageId: agentMessage.id,
+          error: {
+            code: "personal_authentication_required",
+            message:
+              "Agent message failed due to missing personal authentication.",
+            metadata: {
+              category: "migration",
+              reason: "blocked_authentication_required_cleanup",
+              migrationDate: new Date().toISOString(),
+            },
           },
         });
 
@@ -114,3 +119,4 @@ makeScript({}, async ({ execute }, logger) => {
     "Completed migration to mark blocked authentication agent messages as failed"
   );
 });
+*/

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1,0 +1,938 @@
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { AgentMessageSuccessEvent } from "@app/types/assistant/agent";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  processEventForDatabase,
+  updateAgentMessageDBAndMemory,
+} from "./common";
+
+// Helper to create an event with runIds for testing
+function createEventWithRunIds(
+  baseEvent: AgentMessageSuccessEvent,
+  runIds: string[]
+): AgentMessageEvents {
+  return {
+    ...baseEvent,
+    runIds,
+  } as AgentMessageEvents;
+}
+
+describe("processEventForDatabase", () => {
+  let auth: Awaited<ReturnType<typeof createResourceTest>>["authenticator"];
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+  });
+
+  describe("modelInteractionDurationMs", () => {
+    it("should accumulate modelInteractionDurationMs when provided", async () => {
+      // Arrange: Create agent message and conversation
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      const initialMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(initialMessage?.modelInteractionDurationMs).toBeNull();
+
+      // Act: Process event with modelInteractionDurationMs
+      const event: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+        modelInteractionDurationMs: 100,
+      });
+
+      // Assert: Duration should be accumulated
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.modelInteractionDurationMs).toBe(100);
+    });
+
+    it("should accumulate modelInteractionDurationMs on top of existing value", async () => {
+      // Arrange: Create agent message with existing duration
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial duration
+      await AgentMessageModel.update(
+        { modelInteractionDurationMs: 50 },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+
+      // Act: Process event with additional duration
+      const event: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+        modelInteractionDurationMs: 75,
+      });
+
+      // Assert: Duration should be accumulated (50 + 75 = 125)
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.modelInteractionDurationMs).toBe(125);
+    });
+
+    it("should round modelInteractionDurationMs to nearest integer", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Act: Process event with non-integer duration
+      const event: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+        modelInteractionDurationMs: 99.7,
+      });
+
+      // Assert: Duration should be rounded to 100
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.modelInteractionDurationMs).toBe(100);
+    });
+
+    it("should not update modelInteractionDurationMs when not provided", async () => {
+      // Arrange: Create agent message with existing duration
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial duration
+      await AgentMessageModel.update(
+        { modelInteractionDurationMs: 100 },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+
+      // Act: Process event without modelInteractionDurationMs
+      const event: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+      });
+
+      // Assert: Duration should remain unchanged
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.modelInteractionDurationMs).toBe(100);
+    });
+  });
+
+  describe("runIds", () => {
+    it("should merge runIds when event contains runIds", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      const initialMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(initialMessage?.runIds).toBeNull();
+
+      // Act: Process event with runIds
+      const baseEvent: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+      const event = createEventWithRunIds(baseEvent, ["run1", "run2"]);
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+      });
+
+      // Assert: runIds should be merged
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.runIds).toEqual(["run1", "run2"]);
+    });
+
+    it("should merge runIds with existing runIds", async () => {
+      // Arrange: Create agent message with existing runIds
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial runIds
+      await AgentMessageModel.update(
+        { runIds: ["run1", "run2"] },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+
+      // Act: Process event with additional runIds
+      const baseEvent: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+      const event = createEventWithRunIds(baseEvent, ["run2", "run3"]);
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+      });
+
+      // Assert: runIds should be merged and deduplicated
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.runIds).toEqual(
+        expect.arrayContaining(["run1", "run2", "run3"])
+      );
+      expect(updatedMessage?.runIds?.length).toBe(3);
+    });
+
+    it("should not update runIds when event does not contain runIds", async () => {
+      // Arrange: Create agent message with existing runIds
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial runIds
+      await AgentMessageModel.update(
+        { runIds: ["run1", "run2"] },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+
+      // Act: Process event without runIds
+      const event: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+      });
+
+      // Assert: runIds should remain unchanged
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.runIds).toEqual(["run1", "run2"]);
+    });
+
+    it("should not update runIds when event has empty runIds array", async () => {
+      // Arrange: Create agent message with existing runIds
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial runIds
+      await AgentMessageModel.update(
+        { runIds: ["run1", "run2"] },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+
+      // Act: Process event with empty runIds array
+      const baseEvent: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+      const event = createEventWithRunIds(baseEvent, []);
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+      });
+
+      // Assert: runIds should remain unchanged
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.runIds).toEqual(["run1", "run2"]);
+    });
+  });
+
+  describe("combined updates", () => {
+    it("should update both modelInteractionDurationMs and runIds in the same call", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Act: Process event with both modelInteractionDurationMs and runIds
+      const baseEvent: AgentMessageSuccessEvent = {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentConfig.sId,
+        messageId: agentMessage.sId,
+        message: agentMessage,
+        runIds: [],
+      };
+      const event = createEventWithRunIds(baseEvent, ["run1", "run2"]);
+
+      await processEventForDatabase(auth, {
+        event,
+        agentMessage,
+        step: 0,
+        conversation,
+        modelInteractionDurationMs: 150,
+      });
+
+      // Assert: Both should be updated
+      const updatedMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMessage?.modelInteractionDurationMs).toBe(150);
+      expect(updatedMessage?.runIds).toEqual(["run1", "run2"]);
+    });
+  });
+});
+
+describe("updateAgentMessageDBAndMemory", () => {
+  let auth: Awaited<ReturnType<typeof createResourceTest>>["authenticator"];
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+  });
+
+  describe("error update", () => {
+    it("should update status to failed and set error fields", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      expect(agentMessage.status).toBe("created");
+      expect(agentMessage.completedTs).toBeNull();
+      expect(agentMessage.error).toBeNull();
+
+      const error = {
+        code: "test_error",
+        message: "Test error message",
+        metadata: { category: "test_category" },
+      };
+
+      // Act: Update with error
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "error",
+          error,
+        },
+      });
+
+      // Assert: Database should be updated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.status).toBe("failed");
+      expect(dbMessage?.errorCode).toBe("test_error");
+      expect(dbMessage?.errorMessage).toBe("Test error message");
+      expect(dbMessage?.errorMetadata).toEqual({ category: "test_category" });
+      expect(dbMessage?.completedAt).toBeDefined();
+
+      // Assert: In-memory object should be updated
+      expect(agentMessage.status).toBe("failed");
+      expect(agentMessage.completedTs).toBeDefined();
+      expect(agentMessage.error).toEqual(error);
+    });
+  });
+
+  describe("status update", () => {
+    it("should update status to succeeded", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      expect(agentMessage.status).toBe("created");
+      expect(agentMessage.completedTs).toBeNull();
+
+      // Act: Update status to succeeded
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "status",
+          status: "succeeded",
+        },
+      });
+
+      // Assert: Database should be updated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.status).toBe("succeeded");
+      expect(dbMessage?.completedAt).toBeDefined();
+
+      // Assert: In-memory object should be updated
+      expect(agentMessage.status).toBe("succeeded");
+      expect(agentMessage.completedTs).toBeDefined();
+    });
+
+    it("should update status to cancelled", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Act: Update status to cancelled
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "status",
+          status: "cancelled",
+        },
+      });
+
+      // Assert: Database should be updated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.status).toBe("cancelled");
+      expect(dbMessage?.completedAt).toBeDefined();
+
+      // Assert: In-memory object should be updated
+      expect(agentMessage.status).toBe("cancelled");
+      expect(agentMessage.completedTs).toBeDefined();
+    });
+  });
+
+  describe("modelInteractionDurationMs update", () => {
+    it("should accumulate modelInteractionDurationMs from null", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      expect(agentMessage.modelInteractionDurationMs).toBeNull();
+
+      // Act: Update with duration
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "modelInteractionDurationMs",
+          modelInteractionDurationMs: 100,
+        },
+      });
+
+      // Assert: Database should be updated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.modelInteractionDurationMs).toBe(100);
+
+      // Assert: In-memory object should be updated
+      expect(agentMessage.modelInteractionDurationMs).toBe(100);
+    });
+
+    it("should accumulate modelInteractionDurationMs on top of existing value", async () => {
+      // Arrange: Create agent message with existing duration
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial duration in DB and memory
+      await AgentMessageModel.update(
+        { modelInteractionDurationMs: 50 },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+      agentMessage.modelInteractionDurationMs = 50;
+
+      // Act: Update with additional duration
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "modelInteractionDurationMs",
+          modelInteractionDurationMs: 75,
+        },
+      });
+
+      // Assert: Database should be accumulated (50 + 75 = 125)
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.modelInteractionDurationMs).toBe(125);
+
+      // Assert: In-memory object should be accumulated
+      expect(agentMessage.modelInteractionDurationMs).toBe(125);
+    });
+
+    it("should round modelInteractionDurationMs to nearest integer", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Act: Update with non-integer duration
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "modelInteractionDurationMs",
+          modelInteractionDurationMs: 99.7,
+        },
+      });
+
+      // Assert: Database should be rounded to 100
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.modelInteractionDurationMs).toBe(100);
+
+      // Assert: In-memory object should be rounded
+      expect(agentMessage.modelInteractionDurationMs).toBe(100);
+    });
+  });
+
+  describe("runIds update", () => {
+    it("should merge runIds from empty array", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      const initialMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(initialMessage?.runIds).toBeNull();
+
+      // Act: Update with runIds
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "runIds",
+          runIds: ["run1", "run2"],
+        },
+      });
+
+      // Assert: Database should be updated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.runIds).toEqual(
+        expect.arrayContaining(["run1", "run2"])
+      );
+      expect(dbMessage?.runIds?.length).toBe(2);
+    });
+
+    it("should merge runIds with existing runIds and deduplicate", async () => {
+      // Arrange: Create agent message with existing runIds
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Set initial runIds
+      await AgentMessageModel.update(
+        { runIds: ["run1", "run2"] },
+        { where: { id: agentMessage.agentMessageId } }
+      );
+
+      // Act: Update with additional runIds (including duplicate)
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "runIds",
+          runIds: ["run2", "run3"],
+        },
+      });
+
+      // Assert: Database should be merged and deduplicated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.runIds).toEqual(
+        expect.arrayContaining(["run1", "run2", "run3"])
+      );
+      expect(dbMessage?.runIds?.length).toBe(3);
+    });
+  });
+
+  describe("prunedContext update", () => {
+    it("should update prunedContext to true", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage({
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+      // Verify initial state
+      expect(agentMessage.prunedContext).toBeUndefined();
+
+      // Act: Update prunedContext
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "prunedContext",
+          prunedContext: true,
+        },
+      });
+
+      // Assert: Database should be updated
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.prunedContext).toBe(true);
+
+      // Assert: In-memory object should be updated
+      expect(agentMessage.prunedContext).toBe(true);
+    });
+  });
+});

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,4 +1,7 @@
-import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
+import {
+  fetchMessageInConversation,
+  getCompletionDuration,
+} from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
@@ -8,46 +11,198 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
-import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
-import type { ToolErrorEvent } from "@app/types/assistant/agent";
+import type {
+  LightAgentConfigurationType,
+  ToolErrorEvent,
+} from "@app/types/assistant/agent";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
   getAgentLoopData,
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  AgentMessageType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
+import {
+  fn,
+  type InferAttributes,
+  literal,
+  type WhereOptions,
+} from "sequelize";
+
+/** 
+ * Update in database as well as in-memory agent message.
+ * Note that we are mutating the agentMessage object in memory and not returning a new object.
+ * This is because we want to make sure that all functions using this object have the latest state.
+ */
+export async function updateAgentMessageDBAndMemory(
+  auth: Authenticator,
+  {
+    agentMessage,
+    update,
+  }: {
+    agentMessage: AgentMessageType;
+    update:
+      | {
+          type: "status";
+          status: "succeeded" | "cancelled";
+        }
+      | {
+          type: "error";
+          error: ToolErrorEvent["error"];
+        }
+      | {
+          type: "runIds";
+          runIds: string[];
+        }
+      | {
+          type: "modelInteractionDurationMs";
+          modelInteractionDurationMs: number;
+        }
+      | {
+          type: "prunedContext";
+          prunedContext: true;
+        };
+  }
+): Promise<void> {
+  const updateType = update.type;
+  const where: WhereOptions<InferAttributes<AgentMessageModel>> = {
+    id: agentMessage.agentMessageId,
+    workspaceId: auth.getNonNullableWorkspace().id,
+  };
+
+  switch (updateType) {
+    case "error":
+      {
+        const completedAt = new Date();
+        await AgentMessageModel.update(
+          {
+            status: "failed",
+            completedAt,
+            errorCode: update.error.code,
+            errorMessage: update.error.message,
+            errorMetadata: update.error.metadata,
+          },
+          { where }
+        );
+        agentMessage.status = "failed";
+        agentMessage.completedTs = completedAt.getTime();
+        agentMessage.error = update.error;
+      }
+      break;
+
+    case "status":
+      {
+        const completedAt = new Date();
+        await AgentMessageModel.update(
+          {
+            status: update.status,
+            completedAt,
+          },
+          { where }
+        );
+        agentMessage.status = update.status;
+        agentMessage.completedTs = completedAt.getTime();
+      }
+      break;
+
+    case "modelInteractionDurationMs":
+      {
+        const roundedModelInteractionDurationMs = Math.round(
+          update.modelInteractionDurationMs
+        );
+        // Note: we update the modelInteractionDurationMs directly in the database using a function to ensure
+        // an atomic update.
+        await AgentMessageModel.update(
+          {
+            modelInteractionDurationMs: literal(
+              `COALESCE("modelInteractionDurationMs", 0) + ${roundedModelInteractionDurationMs}`
+            ),
+          },
+          { where }
+        );
+
+        agentMessage.modelInteractionDurationMs =
+          (agentMessage.modelInteractionDurationMs ?? 0) +
+          roundedModelInteractionDurationMs;
+      }
+      break;
+
+    case "runIds":
+      {
+        // Note: we update the runIds directly in the database using a function to ensure
+        // an atomic update.
+        await AgentMessageModel.update(
+          {
+            runIds: fn(
+              "ARRAY",
+              literal(
+                `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${update.runIds.join("','")}']::text[])`
+              )
+            ),
+          },
+          { where }
+        );
+      }
+      break;
+
+    case "prunedContext":
+      {
+        await AgentMessageModel.update(
+          {
+            prunedContext: update.prunedContext,
+          },
+          { where }
+        );
+        agentMessage.prunedContext = update.prunedContext;
+      }
+      break;
+
+    default:
+      assertNever(updateType);
+  }
+}
 
 export async function markAgentMessageAsFailed(
-  agentMessageRow: AgentMessageModel,
-  error: ToolErrorEvent["error"]
+  auth: Authenticator,
+  {
+    agentMessage,
+    error,
+  }: {
+    agentMessage: AgentMessageType;
+    error: ToolErrorEvent["error"];
+  }
 ): Promise<void> {
-  await agentMessageRow.update({
-    completedAt: new Date(),
-    errorCode: error.code,
-    errorMessage: error.message,
-    errorMetadata: error.metadata,
-    status: "failed",
+  await updateAgentMessageDBAndMemory(auth, {
+    agentMessage,
+    update: {
+      type: "error",
+      error,
+    },
   });
 }
 
 // Process database operations for agent events before publishing to Redis.
-async function processEventForDatabase(
+export async function processEventForDatabase(
   auth: Authenticator,
   {
     event,
-    agentMessageRow,
+    agentMessage,
     step,
     conversation,
     modelInteractionDurationMs,
   }: {
     event: AgentMessageEvents;
-    agentMessageRow: AgentMessageModel;
+    agentMessage: AgentMessageType;
     step: number;
     conversation: ConversationWithoutContentType;
     modelInteractionDurationMs?: number;
@@ -55,28 +210,34 @@ async function processEventForDatabase(
 ): Promise<void> {
   // If we have a model interaction duration, store it.
   if (modelInteractionDurationMs) {
-    await agentMessageRow.update({
-      modelInteractionDurationMs:
-        (agentMessageRow.modelInteractionDurationMs ?? 0) +
-        Math.round(modelInteractionDurationMs),
+    await updateAgentMessageDBAndMemory(auth, {
+      agentMessage,
+      update: {
+        type: "modelInteractionDurationMs",
+        modelInteractionDurationMs,
+      },
     });
   }
 
   // Merge runIds from events that include them. This ensures runIds are persisted
   // incrementally as events are published.
   if ("runIds" in event && event.runIds && event.runIds.length > 0) {
-    const existingRunIds = agentMessageRow.runIds ?? [];
-    // Merge and deduplicate runIds
-    const mergedRunIds = [...new Set([...existingRunIds, ...event.runIds])];
-    await agentMessageRow.update({
-      runIds: mergedRunIds,
+    await updateAgentMessageDBAndMemory(auth, {
+      agentMessage,
+      update: {
+        type: "runIds",
+        runIds: event.runIds,
+      },
     });
   }
 
   switch (event.type) {
     case "agent_error":
       // Store error in database.
-      await markAgentMessageAsFailed(agentMessageRow, event.error);
+      await markAgentMessageAsFailed(auth, {
+        agentMessage,
+        error: event.error,
+      });
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -84,8 +245,8 @@ async function processEventForDatabase(
       });
 
       await AgentStepContentResource.createNewVersion({
-        workspaceId: agentMessageRow.workspaceId,
-        agentMessageId: agentMessageRow.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentMessageId: agentMessage.agentMessageId,
         step,
         index: 0, // Errors are the only content for this step
         type: "error",
@@ -104,7 +265,10 @@ async function processEventForDatabase(
       break;
 
     case "tool_error":
-      await markAgentMessageAsFailed(agentMessageRow, event.error);
+      await markAgentMessageAsFailed(auth, {
+        agentMessage,
+        error: event.error,
+      });
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -114,18 +278,24 @@ async function processEventForDatabase(
 
     case "agent_generation_cancelled":
       // Store cancellation in database.
-      await agentMessageRow.update({
-        status: "cancelled",
-        completedAt: new Date(),
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "status",
+          status: "cancelled",
+        },
       });
       break;
 
     case "agent_message_success":
       await Promise.all([
         // Store success in database. runIds are already merged above.
-        agentMessageRow.update({
-          status: "succeeded",
-          completedAt: new Date(),
+        updateAgentMessageDBAndMemory(auth, {
+          agentMessage,
+          update: {
+            type: "status",
+            status: "succeeded",
+          },
         }),
         // Mark the conversation as updated
         ConversationResource.markAsUpdated(auth, { conversation }),
@@ -171,13 +341,13 @@ export async function updateResourceAndPublishEvent(
   auth: Authenticator,
   {
     event,
-    agentMessageRow,
+    agentMessage,
     conversation,
     step,
     modelInteractionDurationMs,
   }: {
     event: AgentMessageEvents;
-    agentMessageRow: AgentMessageModel;
+    agentMessage: AgentMessageType;
     conversation: ConversationWithoutContentType;
     step: number;
     modelInteractionDurationMs?: number;
@@ -187,7 +357,7 @@ export async function updateResourceAndPublishEvent(
   await Promise.all([
     processEventForDatabase(auth, {
       event,
-      agentMessageRow,
+      agentMessage,
       step,
       conversation,
       modelInteractionDurationMs,
@@ -282,9 +452,43 @@ export async function notifyWorkflowError(
     runIds: messageRow.agentMessage.runIds ?? [],
   };
 
+  const agentMessage: AgentMessageType = {
+    id: messageRow.id,
+    agentMessageId: messageRow.agentMessage.id,
+    created: messageRow.agentMessage.createdAt.getTime(),
+    completedTs: messageRow.agentMessage.completedAt?.getTime() ?? null,
+    sId: messageRow.sId,
+    type: "agent_message",
+    visibility: messageRow.visibility,
+    version: messageRow.version,
+
+    status: messageRow.agentMessage.status,
+    actions: [],
+    content: null,
+    chainOfThought: null,
+    error: null,
+    rank: messageRow.rank,
+    skipToolsValidation: messageRow.agentMessage.skipToolsValidation,
+    contents: [],
+    modelInteractionDurationMs:
+      messageRow.agentMessage.modelInteractionDurationMs,
+    completionDurationMs: getCompletionDuration(
+      messageRow.agentMessage.createdAt.getTime(),
+      messageRow.agentMessage.completedAt?.getTime() ?? null,
+      []
+    ),
+    richMentions: [],
+    reactions: [],
+
+    // HACKY: These last 3 fields are not used in the workflow error case but required in the type.
+    configuration: null as unknown as LightAgentConfigurationType,
+    parentMessageId: null as unknown as string,
+    parentAgentMessageId: null as unknown as string,
+  };
+
   await updateResourceAndPublishEvent(auth, {
     event: errorEvent,
-    agentMessageRow: messageRow.agentMessage,
+    agentMessage,
     conversation,
     step: 0, // Workflow-level error, not tied to a specific step
   });
@@ -313,13 +517,8 @@ export async function finalizeCancellation(
       `Failed to get run agent data: ${runAgentDataRes.error.message}`
     );
   }
-  const {
-    auth,
-    agentConfiguration,
-    agentMessage,
-    conversation,
-    agentMessageRow,
-  } = runAgentDataRes.value;
+  const { auth, agentConfiguration, agentMessage, conversation } =
+    runAgentDataRes.value;
 
   // get the last step of the agent message
   const step = _.maxBy(agentMessage.contents, "step")?.step ?? 0;
@@ -334,7 +533,7 @@ export async function finalizeCancellation(
   for await (const tokenEvent of contentParser.flushTokens()) {
     await updateResourceAndPublishEvent(auth, {
       event: tokenEvent,
-      agentMessageRow,
+      agentMessage,
       conversation,
       step,
     });
@@ -346,7 +545,7 @@ export async function finalizeCancellation(
       configurationId: agentConfiguration.sId,
       messageId: agentMessage.sId,
     },
-    agentMessageRow,
+    agentMessage,
     conversation,
     step,
   });

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -272,7 +272,7 @@ async function publishAgentLoopCostCapExceededError(
       },
       runIds,
     },
-    agentMessageRow: runAgentData.agentMessageRow,
+    agentMessage: runAgentData.agentMessage,
     conversation: runAgentData.conversation,
     step,
   });
@@ -295,7 +295,7 @@ async function getExistingActionsAndBlobs(
   // Find function_call step contents for this step.
   const stepContents = await AgentStepContentModel.findAll({
     where: {
-      workspaceId: runAgentArgs.agentMessageRow.workspaceId,
+      workspaceId: auth.getNonNullableWorkspace().id,
       agentMessageId: agentMessage.agentMessageId,
       step,
       type: "function_call",

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -81,7 +81,6 @@ export async function runToolActivity(
     agentConfiguration,
     conversation: originalConversation,
     agentMessage: originalAgentMessage,
-    agentMessageRow,
   } = runAgentDataRes.value;
 
   const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
@@ -121,7 +120,6 @@ export async function runToolActivity(
         action,
         agentConfiguration,
         agentMessage,
-        agentMessageRow,
         conversation,
         deferredEvents,
         runIds,
@@ -138,7 +136,6 @@ async function executeToolStreaming(
     action,
     agentConfiguration,
     agentMessage,
-    agentMessageRow,
     conversation,
     deferredEvents,
     runIds,
@@ -147,7 +144,6 @@ async function executeToolStreaming(
     action: AgentMCPActionResource;
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     agentMessage: AgentLoopExecutionData["agentMessage"];
-    agentMessageRow: AgentLoopExecutionData["agentMessageRow"];
     conversation: AgentLoopExecutionData["conversation"];
     deferredEvents: ToolExecutionResult["deferredEvents"];
     runIds?: string[];
@@ -196,7 +192,7 @@ async function executeToolStreaming(
             },
             isLastBlockingEventForStep: true,
           },
-          agentMessageRow,
+          agentMessage,
           conversation,
           step,
         });
@@ -275,7 +271,7 @@ async function executeToolStreaming(
                 runIds: runIds ?? [],
               },
 
-          agentMessageRow,
+          agentMessage,
           conversation,
           step,
         });
@@ -298,7 +294,7 @@ async function executeToolStreaming(
           event,
           context: {
             agentMessageId: agentMessage.sId,
-            agentMessageRowId: agentMessageRow.id,
+            agentMessageRowId: agentMessage.agentMessageId,
             conversationId: conversation.sId,
             step,
             workspaceId: conversation.owner.id,
@@ -328,7 +324,7 @@ async function executeToolStreaming(
             messageId: agentMessage.sId,
             action: event.action,
           },
-          agentMessageRow,
+          agentMessage,
           conversation,
           step,
         });
@@ -337,7 +333,7 @@ async function executeToolStreaming(
       case "tool_notification":
         await updateResourceAndPublishEvent(auth, {
           event,
-          agentMessageRow,
+          agentMessage,
           conversation,
           step,
         });

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -11,7 +11,6 @@ import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
@@ -56,8 +55,7 @@ export async function createToolActionsActivity(
     runIds: string[];
   }
 ): Promise<CreateToolActionsResult> {
-  const { agentConfiguration, agentMessage, agentMessageRow, conversation } =
-    runAgentData;
+  const { agentConfiguration, agentMessage, conversation } = runAgentData;
 
   const actionBlobs: ActionBlob[] = [];
   const approvalEvents: Omit<
@@ -75,7 +73,6 @@ export async function createToolActionsActivity(
       actionConfiguration,
       agentConfiguration,
       agentMessage,
-      agentMessageRow,
       conversation,
       stepContentId,
       stepContext: stepContexts[index],
@@ -100,7 +97,7 @@ export async function createToolActionsActivity(
         ...eventData,
         isLastBlockingEventForStep: isLastApproval,
       },
-      agentMessageRow,
+      agentMessage,
       conversation,
       step,
     });
@@ -117,7 +114,6 @@ async function createActionForTool(
     actionConfiguration,
     agentConfiguration,
     agentMessage,
-    agentMessageRow,
     conversation,
     stepContentId,
     stepContext,
@@ -127,7 +123,6 @@ async function createActionForTool(
     actionConfiguration: MCPToolConfigurationType;
     agentConfiguration: AgentConfigurationType;
     agentMessage: AgentMessageType;
-    agentMessageRow: AgentMessageModel;
     conversation: ConversationWithoutContentType;
     stepContentId: ModelId;
     stepContext: StepContext;
@@ -200,7 +195,7 @@ async function createActionForTool(
         // blocking nature of the event, which is not the case here.
         isLastBlockingEventForStep: false,
       },
-      agentMessageRow,
+      agentMessage,
       conversation,
       step,
     });
@@ -234,7 +229,7 @@ async function createActionForTool(
       action: { ...action.toJSON(), output: null, generatedFiles: [] },
       runIds,
     },
-    agentMessageRow,
+    agentMessage,
     conversation,
     step,
   });

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -132,7 +132,6 @@ export async function getOutputFromLLMStream(
     specifications,
     flushParserTokens,
     contentParser,
-    agentMessageRow,
     step,
     agentConfiguration,
     agentMessage,
@@ -191,7 +190,7 @@ export async function getOutputFromLLMStream(
           )) {
             await updateResourceAndPublishEvent(auth, {
               event: tokenEvent,
-              agentMessageRow,
+              agentMessage,
               conversation,
               step,
             });
@@ -208,7 +207,7 @@ export async function getOutputFromLLMStream(
               messageId: agentMessage.sId,
               text: event.content.delta,
             },
-            agentMessageRow,
+            agentMessage,
             conversation,
             step,
           });
@@ -231,7 +230,7 @@ export async function getOutputFromLLMStream(
               messageId: agentMessage.sId,
               text: "\n\n",
             },
-            agentMessageRow,
+            agentMessage,
             conversation,
             step,
           });

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -234,7 +234,6 @@ async function publishSuccessAndFinish(
     agentConfiguration,
     conversation: originalConversation,
     agentMessage: originalAgentMessage,
-    agentMessageRow,
   } = runAgentData;
 
   const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
@@ -269,7 +268,7 @@ async function publishSuccessAndFinish(
       completedTs,
       agentMessage.actions
     ),
-    prunedContext: agentMessageRow.prunedContext ?? false,
+    prunedContext: agentMessage.prunedContext ?? false,
   } satisfies AgentMessageType;
 
   await updateResourceAndPublishEvent(auth, {
@@ -281,7 +280,7 @@ async function publishSuccessAndFinish(
       message: updatedAgentMessage,
       runIds: [],
     },
-    agentMessageRow,
+    agentMessage,
     conversation,
     step,
   });
@@ -436,7 +435,6 @@ async function handleToolRunFirstStep(
     conversation: originalConversation,
     userMessage,
     agentMessage: originalAgentMessage,
-    agentMessageRow,
   } = runAgentData;
 
   const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
@@ -468,7 +466,7 @@ async function handleToolRunFirstStep(
         error,
         runIds,
       },
-      agentMessageRow,
+      agentMessage,
       conversation,
       step,
     });

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -4,7 +4,6 @@ import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
 import type { SystemPromptSections } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessageContentParser } from "@app/lib/llms/agent_message_content_parser";
-import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentFunctionCallContentType,
@@ -45,7 +44,6 @@ export type GetOutputRequestParams = {
   specifications: AgentActionSpecification[];
   flushParserTokens: () => Promise<void>;
   contentParser: AgentMessageContentParser;
-  agentMessageRow: AgentMessageModel;
   step: number;
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
@@ -60,13 +58,13 @@ export type GetOutputRequestParams = {
     auth: Authenticator,
     {
       event,
-      agentMessageRow,
+      agentMessage,
       conversation,
       step,
       modelInteractionDurationMs,
     }: {
       event: AgentMessageEvents;
-      agentMessageRow: AgentMessageModel;
+      agentMessage: AgentMessageType;
       conversation: ConversationWithoutContentType;
       step: number;
       modelInteractionDurationMs?: number;

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -12,7 +12,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
-  AgentMessageTypeWithoutMentions,
+  AgentMessageType,
   ConversationType,
   ConversationVisibility,
   ConversationWithoutContentType,
@@ -254,7 +254,7 @@ export class ConversationFactory {
     agentConfig: LightAgentConfigurationType;
   }): Promise<{
     messageRow: MessageModel;
-    agentMessage: AgentMessageTypeWithoutMentions;
+    agentMessage: AgentMessageType;
   }> {
     const agentMessageRow = await AgentMessageModel.create({
       status: "created",
@@ -273,7 +273,7 @@ export class ConversationFactory {
       workspaceId: workspace.id,
     });
 
-    const agentMessage: AgentMessageTypeWithoutMentions = {
+    const agentMessage: AgentMessageType = {
       id: messageRow.id,
       agentMessageId: agentMessageRow.id,
       created: agentMessageRow.createdAt.getTime(),
@@ -296,6 +296,7 @@ export class ConversationFactory {
       modelInteractionDurationMs: null,
       completionDurationMs: null,
       rank: messageRow.rank,
+      richMentions: [],
     };
 
     return { messageRow, agentMessage };


### PR DESCRIPTION
## Description

Remove usage of AgentMessageModel in `getAgentLoopData()` and all downstream dependancies.
Goal is to:
- remove a useless query
- prepare so that `getAgentLoopData()` output can be easily cached (because fully serializable) 

## Tests

Added

## Risk

Medium, part of the agent loop.

## Deploy Plan

Deploy front