### PR TITLE
[front] fix: Invalidate subscription cache on makeNew

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -118,6 +118,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       { ...blob },
       { transaction }
     );
+    await SubscriptionResource.invalidateSubscriptionCache(
+      subscription.workspaceId
+    );
     return new SubscriptionResource(
       SubscriptionModel,
       subscription.get(),


### PR DESCRIPTION
## Description

Invalidate cache on subscription.makeNew in case there was a lookup before write (possible because we index cache by workspaceId)


## Tests

- Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front