### PR TITLE
Preserve all blocks in multi-block copilot suggestions targeting instructions root

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -5,8 +5,8 @@ import { Extension } from "@tiptap/core";
 import type { Node as PMNode, Schema } from "@tiptap/pm/model";
 import {
   DOMSerializer,
-  DOMParser as PMDOMParser,
   Fragment,
+  DOMParser as PMDOMParser,
 } from "@tiptap/pm/model";
 import type { EditorState } from "@tiptap/pm/state";
 import { Plugin, PluginKey } from "@tiptap/pm/state";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C0A6TBTU7JS/p1771405824868299).

This PR fixes `parseHTMLToBlock` dropping all blocks except the first when a copilot suggestion targets `instructions-root` with multi-block content (e.g. `<div><h2>Role</h2><p>Hello</p></div>` only showed "Role", losing "Hello"). Current addition decorations (blue highlights) were not rendering when inserted content contains block-level nodes. Refactored it by using a `<div>` wrapper instead of `<span>` for block content

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
