### PR TITLE
[connectors] feat(Zendesk): add CLI command to set rate limit

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -513,6 +513,18 @@ export const zendesk = async ({
 
       return { success: true, message };
     }
+    case "set-rate-limit": {
+      const rateLimitTps = args.rateLimitTps;
+      if (rateLimitTps === undefined) {
+        throw new Error("Missing --rateLimitTps argument");
+      }
+      const manager = new ZendeskConnectorManager(connectorId);
+      await manager.setConfigurationKey({
+        configKey: ZENDESK_CONFIG_KEYS.RATE_LIMIT_TPS,
+        configValue: rateLimitTps.toString(),
+      });
+      return { success: true };
+    }
     default: {
       throw new Error(`Unknown command: ${command}`);
     }

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -776,6 +776,7 @@ export const ZendeskCommandSchema = t.type({
     t.literal("remove-organization-tag"),
     t.literal("add-ticket-tag"),
     t.literal("remove-ticket-tag"),
+    t.literal("set-rate-limit"),
   ]),
   args: t.type({
     wId: t.union([t.string, t.undefined]),
@@ -787,6 +788,7 @@ export const ZendeskCommandSchema = t.type({
     ticketId: t.union([t.number, t.undefined]),
     ticketUrl: t.union([t.string, t.undefined]),
     retentionPeriodDays: t.union([t.number, t.undefined]),
+    rateLimitTps: t.union([t.number, t.undefined]),
     tag: t.union([t.string, t.undefined]),
     include: t.union([t.literal("true"), t.undefined]),
     exclude: t.union([t.literal("true"), t.undefined]),

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -729,6 +729,7 @@ export const ZendeskCommandSchema = t.type({
     t.literal("remove-organization-tag"),
     t.literal("add-ticket-tag"),
     t.literal("remove-ticket-tag"),
+    t.literal("set-rate-limit"),
   ]),
   args: t.type({
     wId: t.union([t.string, t.undefined]),
@@ -740,6 +741,7 @@ export const ZendeskCommandSchema = t.type({
     ticketId: t.union([t.number, t.undefined]),
     ticketUrl: t.union([t.string, t.undefined]),
     retentionPeriodDays: t.union([t.number, t.undefined]),
+    rateLimitTps: t.union([t.number, t.undefined]),
     tag: t.union([t.string, t.undefined]),
     include: t.union([t.literal("true"), t.undefined]),
     exclude: t.union([t.literal("true"), t.undefined]),


### PR DESCRIPTION
## Description

- This PR adds a CLI command to set a rate limit for a Zendesk connector.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors (to get the command available on new pods)
