### PR TITLE
[front] enh: Switch caching singleton to REDIS_CACHE_URI

### DIFF
--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,6 +1,6 @@
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { USER_USAGE_ORIGINS } from "@app/lib/api/programmatic_usage/common";
-import { getRedisClient } from "@app/lib/api/redis";
+import { getRedisStreamClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -59,7 +59,8 @@ export async function getAgentsUsage({
 
   const agentMessageCountKey = _getUsageKey(workspaceId);
 
-  redis = providedRedis ?? (await getRedisClient({ origin: "agent_usage" }));
+  redis =
+    providedRedis ?? (await getRedisStreamClient({ origin: "agent_usage" }));
   const agentMessageCountTTL = await redis.ttl(agentMessageCountKey);
 
   // agent mention count doesn't exist or wasn't set to expire
@@ -269,7 +270,7 @@ export async function signalAgentUsage({
 }) {
   let redis: RedisClientType | null = null;
 
-  redis = await getRedisClient({ origin: "agent_usage" });
+  redis = await getRedisStreamClient({ origin: "agent_usage" });
   const agentMessageCountKey = _getUsageKey(workspaceId);
   const agentMessageCountTTL = await redis.ttl(agentMessageCountKey);
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -11,7 +11,7 @@ import { sendEmail } from "@app/lib/api/email";
 import { generateValidationToken } from "@app/lib/api/email/validation_token";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
-import { getRedisClient } from "@app/lib/api/redis";
+import { getRedisStreamClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -92,7 +92,7 @@ export async function storeEmailReplyContext(
   agentMessageId: string,
   context: EmailReplyContext
 ): Promise<void> {
-  const redis = await getRedisClient({ origin: REDIS_ORIGIN });
+  const redis = await getRedisStreamClient({ origin: REDIS_ORIGIN });
   const key = makeEmailReplyContextKey(context.workspaceId, agentMessageId);
 
   await redis.set(key, JSON.stringify(context), {
@@ -143,7 +143,7 @@ export async function getEmailReplyContext(
   workspaceId: string,
   agentMessageId: string
 ): Promise<EmailReplyContext | null> {
-  const redis = await getRedisClient({ origin: REDIS_ORIGIN });
+  const redis = await getRedisStreamClient({ origin: REDIS_ORIGIN });
   const key = makeEmailReplyContextKey(workspaceId, agentMessageId);
 
   const value = await redis.get(key);
@@ -161,7 +161,7 @@ export async function deleteEmailReplyContext(
   workspaceId: string,
   agentMessageId: string
 ): Promise<void> {
-  const redis = await getRedisClient({ origin: REDIS_ORIGIN });
+  const redis = await getRedisStreamClient({ origin: REDIS_ORIGIN });
   const key = makeEmailReplyContextKey(workspaceId, agentMessageId);
   await redis.del(key);
 }

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -346,6 +346,12 @@ const config = {
   getApolloApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("APOLLO_API_KEY");
   },
+  getRedisUri: (): string => {
+    return EnvironmentConfig.getEnvVariable("REDIS_URI");
+  },
+  getRedisCacheUri: (): string => {
+    return EnvironmentConfig.getEnvVariable("REDIS_CACHE_URI");
+  },
   getContentfulSpaceId: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("CONTENTFUL_SPACE_ID");
   },

--- a/front/lib/api/redis.test.ts
+++ b/front/lib/api/redis.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.unmock("@app/lib/api/redis");
+
+vi.mock("redis", () => ({
+  createClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    quit: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@app/logger/statsDClient", () => ({
+  statsDClient: {
+    increment: vi.fn(),
+    decrement: vi.fn(),
+  },
+}));
+
+describe("getRedisStreamClient", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.REDIS_URI = "redis://localhost:6379";
+    process.env.REDIS_CACHE_URI = "redis://localhost:6380";
+  });
+
+  afterEach(async () => {
+    const { closeRedisClients } = await import("./redis");
+    await closeRedisClients();
+    vi.clearAllMocks();
+  });
+
+  it("returns same client on repeated calls", async () => {
+    const { getRedisStreamClient } = await import("./redis");
+    const client1 = await getRedisStreamClient({ origin: "lock" });
+    const client2 = await getRedisStreamClient({ origin: "agent_usage" });
+    expect(client1).toBe(client2);
+  });
+
+  it("throws when REDIS_URI not defined", async () => {
+    delete process.env.REDIS_URI;
+    const { getRedisStreamClient } = await import("./redis");
+    await expect(getRedisStreamClient({ origin: "lock" })).rejects.toThrow(
+      "REDIS_URI is required but not set"
+    );
+  });
+});
+
+describe("getRedisCacheClient", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.REDIS_URI = "redis://localhost:6379";
+    process.env.REDIS_CACHE_URI = "redis://localhost:6380";
+  });
+
+  afterEach(async () => {
+    const { closeRedisClients } = await import("./redis");
+    await closeRedisClients();
+    vi.clearAllMocks();
+  });
+
+  it("returns same client on repeated calls", async () => {
+    const { getRedisCacheClient } = await import("./redis");
+    const client1 = await getRedisCacheClient({ origin: "cache_with_redis" });
+    const client2 = await getRedisCacheClient({ origin: "cache_with_redis" });
+    expect(client1).toBe(client2);
+  });
+
+  it("returns different client than stream client", async () => {
+    const { getRedisStreamClient, getRedisCacheClient } = await import(
+      "./redis"
+    );
+    const streamClient = await getRedisStreamClient({ origin: "lock" });
+    const cacheClient = await getRedisCacheClient({
+      origin: "cache_with_redis",
+    });
+    expect(streamClient).not.toBe(cacheClient);
+  });
+
+  it("throws when REDIS_CACHE_URI not defined", async () => {
+    delete process.env.REDIS_CACHE_URI;
+    const { getRedisCacheClient } = await import("./redis");
+    await expect(
+      getRedisCacheClient({ origin: "cache_with_redis" })
+    ).rejects.toThrow("REDIS_CACHE_URI is required but not set");
+  });
+});
+
+describe("closeRedisClients", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.REDIS_URI = "redis://localhost:6379";
+    process.env.REDIS_CACHE_URI = "redis://localhost:6380";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("closes all cached clients", async () => {
+    const { getRedisStreamClient, getRedisCacheClient, closeRedisClients } =
+      await import("./redis");
+    const streamClient = await getRedisStreamClient({ origin: "lock" });
+    const cacheClient = await getRedisCacheClient({
+      origin: "cache_with_redis",
+    });
+    await closeRedisClients();
+    expect(streamClient.quit).toHaveBeenCalled();
+    expect(cacheClient.quit).toHaveBeenCalled();
+  });
+
+  it("allows new clients after close", async () => {
+    const redis = await import("./redis");
+    await redis.getRedisStreamClient({ origin: "lock" });
+    await redis.closeRedisClients();
+    const { createClient } = await import("redis");
+    vi.mocked(createClient).mockClear();
+    await redis.getRedisStreamClient({ origin: "lock" });
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runOnRedis", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.REDIS_URI = "redis://localhost:6379";
+  });
+
+  afterEach(async () => {
+    const { closeRedisClients } = await import("./redis");
+    await closeRedisClients();
+    vi.clearAllMocks();
+  });
+
+  it("uses stream client", async () => {
+    const { getRedisStreamClient, runOnRedis } = await import("./redis");
+    const streamClient = await getRedisStreamClient({ origin: "lock" });
+    const result = await runOnRedis({ origin: "lock" }, async (client) => {
+      expect(client).toBe(streamClient);
+      return "result";
+    });
+    expect(result).toBe("result");
+  });
+});
+
+describe("runOnRedisCache", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.REDIS_CACHE_URI = "redis://localhost:6380";
+  });
+
+  afterEach(async () => {
+    const { closeRedisClients } = await import("./redis");
+    await closeRedisClients();
+    vi.clearAllMocks();
+  });
+
+  it("uses cache client", async () => {
+    const { getRedisCacheClient, runOnRedisCache } = await import("./redis");
+    const cacheClient = await getRedisCacheClient({
+      origin: "cache_with_redis",
+    });
+    const result = await runOnRedisCache(
+      { origin: "cache_with_redis" },
+      async (client) => {
+        expect(client).toBe(cacheClient);
+        return "result";
+      }
+    );
+    expect(result).toBe("result");
+  });
+});

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -1,9 +1,33 @@
+import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { RedisClientType } from "redis";
+export type { RedisClientType };
+
 import { createClient } from "redis";
 
-let client: RedisClientType;
+const clients = new Map<string, RedisClientType>();
+
+export interface RedisClientOptions {
+  socket?: {
+    reconnectStrategy?: (retries: number) => number | Error;
+  };
+  isolationPoolOptions?: {
+    min?: number;
+    max?: number;
+    acquireTimeoutMillis?: number;
+    evictionRunIntervalMillis?: number;
+    idleTimeoutMillis?: number;
+  };
+}
+
+const DEFAULT_ISOLATION_POOL_OPTIONS = {
+  acquireTimeoutMillis: 10000,
+  min: 1,
+  max: 8000,
+  evictionRunIntervalMillis: 15000,
+  idleTimeoutMillis: 30000,
+};
 
 export type RedisUsageTagsType =
   | "agent_recent_authors"
@@ -21,6 +45,7 @@ export type RedisUsageTagsType =
   | "message_events"
   | "notion_url_sync"
   | "public_api_limits"
+  | "rate_limiter"
   | "reasoning_generation"
   | "retry_agent_message"
   | "update_authors"
@@ -28,49 +53,101 @@ export type RedisUsageTagsType =
   | "poke_cache_lookup"
   | "user_message_events";
 
-export async function getRedisClient({
+async function createRedisClient({
+  origin,
+  redisUri,
+  options,
+}: {
+  origin: RedisUsageTagsType;
+  redisUri: string;
+  options?: RedisClientOptions;
+}): Promise<RedisClientType> {
+  const newClient: RedisClientType = createClient({
+    url: redisUri,
+    socket: options?.socket,
+    isolationPoolOptions:
+      options?.isolationPoolOptions ?? DEFAULT_ISOLATION_POOL_OPTIONS,
+  });
+  newClient.on("error", (err) => logger.info({ err }, "Redis Client Error"));
+  newClient.on("ready", () => logger.info({}, "Redis Client Ready"));
+  newClient.on("connect", () => {
+    logger.info({ origin }, "Redis Client Connected");
+    statsDClient.increment("redis.connection.count", 1, [`origin:${origin}`]);
+  });
+  newClient.on("end", () => {
+    logger.info({ origin }, "Redis Client End");
+    statsDClient.decrement("redis.connection.count", 1, [`origin:${origin}`]);
+  });
+
+  await newClient.connect();
+  return newClient;
+}
+
+async function getRedisClientByUri({
+  origin,
+  redisUri,
+}: {
+  origin: RedisUsageTagsType;
+  redisUri: string;
+}): Promise<RedisClientType> {
+  const existingClient = clients.get(redisUri);
+  if (existingClient) {
+    return existingClient;
+  }
+
+  const newClient = await createRedisClient({ origin, redisUri });
+  clients.set(redisUri, newClient);
+  return newClient;
+}
+
+export async function createRedisStreamClient({
+  origin,
+  options,
+}: {
+  origin: RedisUsageTagsType;
+  options?: RedisClientOptions;
+}): Promise<RedisClientType> {
+  const redisUri = config.getRedisUri();
+  return createRedisClient({ origin, redisUri, options });
+}
+
+export async function getRedisStreamClient({
   origin,
 }: {
   origin: RedisUsageTagsType;
 }): Promise<RedisClientType> {
-  if (!client) {
-    const { REDIS_URI } = process.env;
-    if (!REDIS_URI) {
-      throw new Error("REDIS_URI is not defined");
-    }
+  const redisUri = config.getRedisUri();
+  return getRedisClientByUri({ origin, redisUri });
+}
 
-    client = createClient({
-      url: REDIS_URI,
-      isolationPoolOptions: {
-        acquireTimeoutMillis: 10000, // Max time to wait for a connection: 10 seconds.
-        min: 1,
-        max: 8000, // Maximum number of concurrent connections for streaming.
-        evictionRunIntervalMillis: 15000, // Check for idle connections every 15 seconds.
-        idleTimeoutMillis: 30000, // Connections idle for more than 30 seconds will be eligible for eviction.
-      },
-    });
-    client.on("error", (err) => logger.info({ err }, "Redis Client Error"));
-    client.on("ready", () => logger.info({}, "Redis Client Ready"));
-    client.on("connect", () => {
-      logger.info({ origin }, "Redis Client Connected");
-      statsDClient.increment("redis.connection.count", 1, [`origin:${origin}`]);
-    });
-    client.on("end", () => {
-      logger.info({ origin }, "Redis Client End");
-      statsDClient.decrement("redis.connection.count", 1, [`origin:${origin}`]);
-    });
-
-    await client.connect();
-  }
-
-  return client;
+export async function getRedisCacheClient({
+  origin,
+}: {
+  origin: RedisUsageTagsType;
+}): Promise<RedisClientType> {
+  const redisCacheUri = config.getRedisCacheUri();
+  return getRedisClientByUri({ origin, redisUri: redisCacheUri });
 }
 
 export async function runOnRedis<T>(
   opts: { origin: RedisUsageTagsType },
   fn: (client: RedisClientType) => PromiseLike<T>
 ): Promise<T> {
-  const client = await getRedisClient(opts);
-
+  const client = await getRedisStreamClient(opts);
   return fn(client);
+}
+
+export async function runOnRedisCache<T>(
+  opts: { origin: RedisUsageTagsType },
+  fn: (client: RedisClientType) => PromiseLike<T>
+): Promise<T> {
+  const client = await getRedisCacheClient(opts);
+  return fn(client);
+}
+
+export async function closeRedisClients(): Promise<void> {
+  for (const [, client] of clients) {
+    await client.quit();
+  }
+  clients.clear();
 }

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,11 +1,9 @@
-import type { redisClient } from "@app/lib/utils/redis_client";
-
-import { getRedisClient } from "./api/redis";
+import { getRedisStreamClient, type RedisClientType } from "./api/redis";
 
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
 export async function distributedLock(
-  redisCli: Awaited<ReturnType<typeof redisClient>>,
+  redisCli: RedisClientType,
   key: string
 ): Promise<string | undefined> {
   const lockKey = `lock:${key}`;
@@ -28,7 +26,7 @@ export async function distributedLock(
 }
 
 export async function distributedUnlock(
-  redisCli: Awaited<ReturnType<typeof redisClient>>,
+  redisCli: RedisClientType,
   key: string,
   lockValue: string
 ): Promise<void> {
@@ -56,7 +54,7 @@ export const executeWithLock = async <T>(
   callback: () => Promise<T>,
   timeoutMs: number = 30_000
 ): Promise<T> => {
-  const client = await getRedisClient({ origin: "lock" });
+  const client = await getRedisStreamClient({ origin: "lock" });
 
   const start = Date.now();
   let lockValue: string | undefined;

--- a/front/scripts/warm_workspace_region_cache.ts
+++ b/front/scripts/warm_workspace_region_cache.ts
@@ -1,4 +1,4 @@
-import { getRedisClient } from "@app/lib/api/redis";
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { makeScript } from "@app/scripts/helpers";
 import * as fs from "fs";
@@ -43,7 +43,7 @@ makeScript(
       return;
     }
 
-    const redisCli = await getRedisClient({ origin: "cache_with_redis" });
+    const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
 
     let count = 0;
     for (const sId of sIds) {


### PR DESCRIPTION
## Description

Currently we don't use REDIS_CACHE_URI at all on front. Posing serious risk of performance impact as we lean more and more on caching. This PR aims at changing that:

- Add cache and streaming redis client factories
- Add singletons (used everywhere except RedisHybridManager which is already a singleton)
- Maintain backward compatibility
   - Some unused options (like redisUri) => Happy to be challenged on that
   - runOnRedis => Stays on streaming instance because we use it for rate limiting with some TTL O(days), very scary move to put this on caching client

## Tests

- [ ] Test on front-edge
- Unit tests

## Risk

Standard
Blast radius: Large ~entire application
  - SSE 
  - fromSession

## Deploy Plan

- [ ] Deploy front