### PR TITLE
fix: stops SWR from refetching metadata on every tab focus/reconnect

### DIFF
--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -53,11 +53,12 @@ export function useUserMetadata(
     url += `?workspaceId=${encodeURIComponent(swrOptions.workspaceId)}`;
   }
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    url,
-    userMetadataFetcher,
-    swrOptions
-  );
+  const { data, error, mutate } = useSWRWithDefaults(url, userMetadataFetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+    ...swrOptions,
+  });
 
   return {
     metadata: data ? data.metadata : null,


### PR DESCRIPTION
## Description

  - Disable SWR automatic revalidation (revalidateOnFocus, revalidateOnReconnect, revalidateIfStale) on useUserMetadata, matching the pattern already used by useUser
  - This addresses /api/user/metadata/agentBrowserSelection-2 being called ~7k times per 15 minutes — user metadata is only written on explicit user action and doesn't need background refetching

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
