### PR TITLE
[Front] fix(temporal): update schedule ID and fix pending agent cleanup

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -26,6 +26,7 @@ import {
   AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
+import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -1451,6 +1452,12 @@ export async function batchHardDeletePendingAgentConfigurations(
         transaction: t,
       });
     }
+
+    // Delete agent suggestions before agents (FK constraint)
+    await AgentSuggestionModel.destroy({
+      where: { agentConfigurationId: agentIds, workspaceId },
+      transaction: t,
+    });
 
     await AgentConfigurationModel.destroy({
       where: { id: agentIds, workspaceId },

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -9,7 +9,7 @@ export function isSequelizeForeignKeyConstraintError(err: unknown) {
  */
 
 export function getHardDeleteScheduleId() {
-  return "purge-run-executions-schedule";
+  return "hard-delete-schedule";
 }
 
 export const RUN_EXECUTIONS_RETENTION_DAYS_THRESHOLD = 30;


### PR DESCRIPTION
## Description

PR #21698 renamed workflow to `hardDeleteCronWorkflow` and expanded scope to include pending agents, but kept old schedule ID `"purge-run-executions-schedule"`.

**Changes:**
- Updated schedule ID to `"hard-delete-schedule"` (reflects broader scope)
- Schedule migrated manually via Temporal UI
- Fixed pending agent cleanup failing with FK constraint error by deleting agent suggestions first

Related: https://github.com/dust-tt/dust/pull/21698