### PR TITLE
fix: gh mcp requestedReviewer teams support

### DIFF
--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -1474,6 +1474,9 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                         ... on User {
                           login
                         }
+                        ... on Team {
+                          slug
+                        }
                       }
                     }
                   }
@@ -1576,8 +1579,9 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                   reviewRequests: {
                     nodes: Array<{
                       requestedReviewer: {
-                        login: string;
-                      };
+                        login?: string;
+                        slug?: string;
+                      } | null;
                     }>;
                   };
                   comments: {
@@ -1621,9 +1625,17 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
               additions: node.additions,
               deletions: node.deletions,
               changedFiles: node.changedFiles,
-              reviewRequests: node.reviewRequests.nodes.map(
-                (request) => request.requestedReviewer.login
-              ),
+              reviewRequests: node.reviewRequests.nodes
+                .map((request) => {
+                  if (!request.requestedReviewer) {
+                    return null;
+                  }
+                  return (
+                    request.requestedReviewer.login ??
+                    request.requestedReviewer.slug
+                  );
+                })
+                .filter(Boolean),
               reviewCount: node.reviews.totalCount,
             };
           } else {
@@ -1729,6 +1741,9 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                         ... on User {
                           login
                         }
+                        ... on Team {
+                          slug
+                        }
                       }
                     }
                   }
@@ -1804,8 +1819,9 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
                 reviewRequests: {
                   nodes: {
                     requestedReviewer: {
-                      login: string;
-                    };
+                      login?: string;
+                      slug?: string;
+                    } | null;
                   }[];
                 };
                 comments: {
@@ -1839,9 +1855,17 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
               color: label.color,
             })),
             assignees: pr.assignees.nodes.map((assignee) => assignee.login),
-            reviewRequests: pr.reviewRequests.nodes.map(
-              (request) => request.requestedReviewer.login
-            ),
+            reviewRequests: pr.reviewRequests.nodes
+              .map((request) => {
+                if (!request.requestedReviewer) {
+                  return null;
+                }
+                return (
+                  request.requestedReviewer.login ??
+                  request.requestedReviewer.slug
+                );
+              })
+              .filter(Boolean),
             commentCount: pr.comments.totalCount,
             reviewCount: pr.reviews.totalCount,
           }));


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Fixes https://github.com/dust-tt/tasks/issues/6603 - search_advanced crashes with "Cannot read properties of null (reading 'login')" when searching PRs that have team review requests.

 The bug has two root causes:

  1. requestedReviewer can be null — happens when a reviewer was requested but later removed. The GraphQL API still returns the node with a null reviewer.
  2. requestedReviewer can be a Team object — GitHub's RequestedReviewer is a union type (User | Team). The original GraphQL query only used ... on User { login }, so when the reviewer is a Team, the login field is undefined, and accessing it returns undefined (or crashes if chained further).
  
This fixes both places where requestedreviewer is checked (in both search_advanced and list_pull_requests) 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front