### PR TITLE
Warm up script for region cache

### DIFF
--- a/front/scripts/warm_workspace_region_cache.ts
+++ b/front/scripts/warm_workspace_region_cache.ts
@@ -1,0 +1,62 @@
+import { getRedisClient } from "@app/lib/api/redis";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
+import { makeScript } from "@app/scripts/helpers";
+import * as fs from "fs";
+
+const WORKSPACE_REGION_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours.
+
+function getCacheKey(wId: string): string {
+  return `cacheWithRedis-_lookupWorkspaceUncached-workspace-region:${wId}`;
+}
+
+makeScript(
+  {
+    jsonFile: {
+      alias: "f",
+      type: "string" as const,
+      demandOption: true,
+      describe:
+        'Path to a JSON file with workspace sIds (e.g., [{"sId":"abc"},{"sId":"def"}])',
+    },
+    region: {
+      alias: "r",
+      type: "string" as const,
+      choices: SUPPORTED_REGIONS,
+      demandOption: true,
+      describe: "The region to associate with these workspaces in the cache",
+    },
+  },
+  async ({ jsonFile, region, execute }, logger) => {
+    if (!isRegionType(region)) {
+      logger.error("Invalid region.");
+      return;
+    }
+
+    const raw = fs.readFileSync(jsonFile, "utf-8");
+    const entries: { sId: string }[] = JSON.parse(raw);
+
+    const sIds = entries.map((e) => e.sId).filter(Boolean);
+    logger.info(`Found ${sIds.length} workspace(s) to warm.`);
+
+    if (!execute) {
+      logger.info("Dry run — pass --execute to write to cache.");
+      return;
+    }
+
+    const redisCli = await getRedisClient({ origin: "cache_with_redis" });
+
+    let count = 0;
+    for (const sId of sIds) {
+      const key = getCacheKey(sId);
+      await redisCli.set(key, JSON.stringify(region), {
+        PX: WORKSPACE_REGION_CACHE_TTL_MS,
+      });
+      count++;
+      if (count % 100 === 0) {
+        logger.info(`Warmed ${count}/${sIds.length}`);
+      }
+    }
+
+    logger.info(`Done — warmed ${count} workspace region cache entries.`);
+  }
+);


### PR DESCRIPTION
## Description

Adds a script to warm the workspace region Redis cache from a JSON export (e.g., Metabase).

This is a companion to #21858 which increased the workspace region cache TTL to 24 hours. This script allows pre-filling the cache for all known workspaces so they don't need a cross-region lookup on first access.

Usage:
```bash
npx ts-node front/scripts/warm_workspace_region_cache.ts \
  --jsonFile workspaces.json \
  --region europe-west1 \
  --execute
```

Where `workspaces.json` is a Metabase-style JSON export:
```json
[{"sId": "HhiohmB7rO"}, {"sId": "Bzj2wgylHm"}]
```

## Tests

Manual — script-only change, no production code modified.

## Risk

None. This is a standalone script that writes to the Redis cache using the same key format and TTL as `_lookupWorkspaceCached`. Worst case: a stale entry that expires after 24h.

## Deploy Plan

No deploy needed — run the script manually when needed.