### PR TITLE
[front] enh(Ashby): fix rendering for reports that are in-progress/failed

### DIFF
--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -35,7 +35,7 @@ export async function renderReport(
     return [
       {
         type: "text" as const,
-        text: `Report ${reportId} is not complete (status: ${status}).`,
+        text: `Generation of report ${reportId} is not complete (status: ${status}).`,
       },
     ];
   }

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -45,21 +45,29 @@ export type AshbyReportSynchronousRequest = z.infer<
 export const AshbyReportSynchronousResponseSchema = z.object({
   success: z.boolean(),
   results: z
-    .object({
-      requestId: z.string(),
-      status: z.string(),
-      reportData: z.object({
-        data: z.array(z.array(z.union([z.string(), z.number()]))),
-        columnNames: z.array(z.string()),
-        metadata: z
-          .object({
-            updatedAt: z.string(),
-            title: z.string(),
-          })
-          .passthrough(),
+    .union([
+      z.object({
+        requestId: z.string(),
+        status: z.literal("complete"),
+        reportData: z.object({
+          data: z.array(z.array(z.union([z.string(), z.number()]))),
+          columnNames: z.array(z.string()),
+          metadata: z
+            .object({
+              updatedAt: z.string(),
+              title: z.string(),
+            })
+            .passthrough(),
+        }),
+        failureReason: z.string().nullable(),
       }),
-      failureReason: z.string().nullable(),
-    })
+      z.object({
+        requestId: z.string(),
+        status: z.enum(["failed", "in_progress"]),
+        reportData: z.null(),
+        failureReason: z.string().nullable(),
+      }),
+    ])
     .optional(),
 });
 


### PR DESCRIPTION
## Description

- Logs [here](https://app.datadoghq.eu/logs?query=%22%5BAshby%5D%20Invalid%20API%20response%20format%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZxob114NWY4ZQAAABhBWnhvYjJtOEFBQWpoSnZwRWhwdnhRQUgAAAAkMDE5YzY4NzYtYTI1Ny00ZTc4LTgzY2QtNjhjMDc3MGI2MmVmAAau8g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=200152&storage=hot&stream_sort=service%2Casc&viz=stream&from_ts=1770807379943&to_ts=1771412179943&live=true).
- Documentation [here](https://developers.ashbyhq.com/reference/reportsynchronous).
- This PR improves the handling of reports whose generation has failed/is in progress.
- Instead of erroring (zod validation too strict) we expose the current status to the model.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
