### PR TITLE
Remove redundant calls, parallelize

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1214,21 +1214,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       };
     }
 
-    const participant = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: auth.getNonNullableUser().id,
-      },
-    });
-
-    const conversationRead = await UserConversationReadsModel.findOne({
-      where: {
-        conversationId: id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: auth.getNonNullableUser().id,
-      },
-    });
+    const [participant, conversationRead] = await Promise.all([
+      ConversationParticipantModel.findOne({
+        where: {
+          conversationId: id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          userId: auth.getNonNullableUser().id,
+        },
+      }),
+      UserConversationReadsModel.findOne({
+        where: {
+          conversationId: id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          userId: auth.getNonNullableUser().id,
+        },
+      }),
+    ]);
 
     return {
       actionRequired: participant?.actionRequired ?? false,


### PR DESCRIPTION
## Description

Optimize the `GET /api/w/[wId]/assistant/conversations/[cId]` endpoint by reducing redundant DB queries:

- **Remove upfront `canAccess` check**: it was fully redundant with the permission filtering already done inside `fetchConversationWithoutContent` (both fetch the conversation + spaces independently). The `canAccess` call is now only made on the error path to distinguish 404 vs 403 for the UI.
- **Parallelize participant + reads lookups** in `getActionRequiredAndLastReadAtForUser` using `Promise.all`.

This reduces the happy path from 6 sequential DB queries to 3 sequential rounds (4 queries, 2 in parallel).

## Tests

- [ ] Verify loading a conversation the user has access to still works correctly
- [ ] Verify loading a conversation the user does NOT have access to shows "You don't have access to this page" (403), not "Conversation not found" (404)
- [ ] Verify loading a truly non-existent conversation shows "Conversation Not Found" (404)

## Risk

Low — the permission logic is unchanged (`baseFetchWithAuthorization` still does the same filtering). The only behavioral change is that `canAccess` is called on the error path instead of upfront, which preserves the same 403/404 distinction for the UI.

## Deploy Plan

Standard deploy, no migration needed.