### PR TITLE
feat: move agent browser selection to local storage

### DIFF
--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -222,11 +222,8 @@ export function AgentBrowser({
     workspaceId: owner.sId,
   });
 
-  const {
-    selectedTagId: persistedSelectedTagId,
-    setSelectedTagId,
-    isLoading: isPersistedSelectionLoading,
-  } = usePersistedAgentBrowserSelection(owner.sId);
+  const { selectedTagId: persistedSelectedTagId, setSelectedTagId } =
+    usePersistedAgentBrowserSelection(owner.sId);
 
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
@@ -364,20 +361,14 @@ export function AgentBrowser({
 
   // Persist selectedTag when they change (and tags exist).
   useEffect(() => {
-    if (noTagsDefined || isPersistedSelectionLoading) {
+    if (noTagsDefined) {
       return;
     }
 
     if (persistedSelectedTagId !== selectedTag) {
-      void setSelectedTagId(selectedTag);
+      setSelectedTagId(selectedTag);
     }
-  }, [
-    selectedTag,
-    noTagsDefined,
-    isPersistedSelectionLoading,
-    persistedSelectedTagId,
-    setSelectedTagId,
-  ]);
+  }, [selectedTag, noTagsDefined, persistedSelectedTagId, setSelectedTagId]);
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {


### PR DESCRIPTION
## Description

We were saving in the user metadata which agents tab the user was seeing on the front page. 

<img width="462" height="191" alt="image" src="https://github.com/user-attachments/assets/26aaa3b2-a0bb-4e64-9153-7205775e8f76" />


This did ~7k/15 minutes calls to the API, just to save user preferences. 

We already have a few preferences in the browser local storage, so this is moved there

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
