### PR TITLE
fix(slack): whitelist bot on connector with active bot

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -311,13 +311,33 @@ export const slack = async ({
         connector.id
       );
 
-      if (slackConfig) {
-        // Handle groupId as either a single string or comma-separated string of group IDs
-        const groupIds = groupId.includes(",")
-          ? groupId.split(",").map((id) => id.trim())
-          : [groupId];
-        await slackConfig.whitelistBot(botName, groupIds, whitelistType);
+      if (!slackConfig) {
+        throw new Error(
+          `Could not find Slack configuration for connector ${connector.id}`
+        );
       }
+
+      // For summon_agent, the runtime check (isBotAllowed) finds the connector
+      // via fetchByActiveBot (the config with botEnabled: true). We must store
+      // the whitelist entry on that same config, otherwise the lookup at runtime
+      // will miss it when botEnabled: true is on a different connector than the
+      // one selected in Poke (e.g. "slack" vs "slack_bot").
+      let targetConfig = slackConfig;
+      if (whitelistType === "summon_agent") {
+        const activeBotConfig =
+          await SlackConfigurationResource.fetchByActiveBot(
+            slackConfig.slackTeamId
+          );
+        if (activeBotConfig) {
+          targetConfig = activeBotConfig;
+        }
+      }
+
+      // Handle groupId as either a single string or comma-separated string of group IDs
+      const groupIds = groupId.includes(",")
+        ? groupId.split(",").map((id) => id.trim())
+        : [groupId];
+      await targetConfig.whitelistBot(botName, groupIds, whitelistType);
 
       return { success: true };
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Fixes https://github.com/dust-tt/tasks/issues/6565

  - Fix `whitelist-bot` CLI command to store `summon_agent` whitelist entries on the connector that has `botEnabled: true`, matching the runtime lookup in `isBotAllowed()`
  - Previously, the entry was stored on whichever connector matched the `providerType` arg (e.g. `slack_bot`), but the runtime check uses `fetchByActiveBot()` which may resolve to a different connector (e.g. `slack`) — causing the whitelist to silently not work

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front