### PR TITLE
feat: move convo/project selection to local storage

### DIFF
--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -222,11 +222,8 @@ export function AgentBrowser({
     workspaceId: owner.sId,
   });
 
-  const {
-    selectedTagId: persistedSelectedTagId,
-    setSelectedTagId,
-    isLoading: isPersistedSelectionLoading,
-  } = usePersistedAgentBrowserSelection(owner.sId);
+  const { selectedTagId: persistedSelectedTagId, setSelectedTagId } =
+    usePersistedAgentBrowserSelection(owner.sId);
 
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
@@ -364,20 +361,14 @@ export function AgentBrowser({
 
   // Persist selectedTag when they change (and tags exist).
   useEffect(() => {
-    if (noTagsDefined || isPersistedSelectionLoading) {
+    if (noTagsDefined) {
       return;
     }
 
     if (persistedSelectedTagId !== selectedTag) {
-      void setSelectedTagId(selectedTag);
+      setSelectedTagId(selectedTag);
     }
-  }, [
-    selectedTag,
-    noTagsDefined,
-    isPersistedSelectionLoading,
-    persistedSelectedTagId,
-    setSelectedTagId,
-  ]);
+  }, [selectedTag, noTagsDefined, persistedSelectedTagId, setSelectedTagId]);
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1218,11 +1218,8 @@ function NavigationListWithInbox({
   loadMore,
   isLoadingMore,
 }: NavigationListWithInboxProps) {
-  const {
-    hideTriggeredConversations,
-    setHideTriggeredConversations,
-    isLoading: isHideTriggeredLoading,
-  } = useHideTriggeredConversations();
+  const { hideTriggeredConversations, setHideTriggeredConversations } =
+    useHideTriggeredConversations();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { readConversations, inboxConversations } = useMemo(() => {
     return getGroupConversationsByUnreadAndActionRequired(
@@ -1327,9 +1324,7 @@ function NavigationListWithInbox({
                         : "Hide triggered"
                     }
                     icon={hideTriggeredConversations ? BoltIcon : BoltOffIcon}
-                    disabled={
-                      isHideTriggeredLoading || !hasTriggeredConversations
-                    }
+                    disabled={!hasTriggeredConversations}
                     onClick={() =>
                       setHideTriggeredConversations(!hideTriggeredConversations)
                     }

--- a/front/hooks/useHideTriggeredConversations.ts
+++ b/front/hooks/useHideTriggeredConversations.ts
@@ -1,33 +1,30 @@
-import { useUserMetadata } from "@app/lib/swr/user";
-import { setUserMetadataFromClient } from "@app/lib/user";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
-const HIDE_TRIGGERED_CONVERSATIONS_KEY = "hideTriggeredConversations";
+const LOCAL_STORAGE_KEY = "hideTriggeredConversations";
 
 export const useHideTriggeredConversations = () => {
-  const { metadata, isMetadataLoading, isMetadataError, mutateMetadata } =
-    useUserMetadata(HIDE_TRIGGERED_CONVERSATIONS_KEY, {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    });
+  const [hideTriggeredConversations, setHideState] = useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    try {
+      return localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
 
-  const hideTriggeredConversations = metadata?.value === "true";
-
-  const setHideTriggeredConversations = useCallback(
-    async (hide: boolean) => {
-      await setUserMetadataFromClient({
-        key: HIDE_TRIGGERED_CONVERSATIONS_KEY,
-        value: hide ? "true" : "false",
-      });
-      void mutateMetadata();
-    },
-    [mutateMetadata]
-  );
+  const setHideTriggeredConversations = useCallback((hide: boolean) => {
+    setHideState(hide);
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, hide ? "true" : "false");
+    } catch {
+      // localStorage may be full or unavailable — silently ignore.
+    }
+  }, []);
 
   return {
     hideTriggeredConversations,
     setHideTriggeredConversations,
-    isLoading: isMetadataLoading,
-    isError: isMetadataError,
   };
 };


### PR DESCRIPTION
## Description

Similar to the previous PR, we were saving in the user metadata if we have the project/convo list folded. So need to save this in the DB, it can stay in the local storage.

As we already have a few preferences in the browser local storage, so this is moved there

It's called 3k per hour 
<img width="383" height="52" alt="image" src="https://github.com/user-attachments/assets/3faa1baa-9c22-4845-b37f-2266b441f1c2" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
