### PR TITLE
[front] - feat(obs): add skills insights

### DIFF
--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -16,6 +16,7 @@ export interface ToolUsageTooltipProps
   extends TooltipContentProps<number, string> {
   topTools: string[];
   hoveredTool?: string | null;
+  showLabel?: boolean;
 }
 
 export function ChartsTooltip({
@@ -23,6 +24,7 @@ export function ChartsTooltip({
   payload,
   topTools,
   hoveredTool,
+  showLabel,
 }: ToolUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -40,6 +42,7 @@ export function ChartsTooltip({
 
   const toolPayload = filtered[0];
   const toolName = toolPayload.name ?? "";
+  const barLabel = showLabel ? toolPayload.payload?.label : undefined;
   const data = toolPayload.payload?.values?.[toolName];
 
   if (!data || (data.count ?? 0) <= 0) {
@@ -90,6 +93,11 @@ export function ChartsTooltip({
         role="tooltip"
         className="flex max-h-60 min-w-32 flex-col overflow-hidden rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
       >
+        {barLabel && (
+          <div className="mb-1 text-muted-foreground dark:text-muted-foreground-night">
+            {barLabel}
+          </div>
+        )}
         <div className="mb-2 flex items-center gap-2">
           <LegendDot className={colorClassName} />
           <Label>{toolName}</Label>
@@ -123,6 +131,11 @@ export function ChartsTooltip({
       role="tooltip"
       className="flex max-h-60 min-w-32 flex-col overflow-hidden rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
     >
+      {barLabel && (
+        <div className="mb-1 text-muted-foreground dark:text-muted-foreground-night">
+          {barLabel}
+        </div>
+      )}
       <div className="mb-1.5 flex items-center gap-2">
         <LegendDot className={colorClassName} />
         <Label>{toolName}</Label>

--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -2,10 +2,7 @@ import {
   FEEDBACK_DISTRIBUTION_LEGEND,
   FEEDBACK_DISTRIBUTION_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
-import {
-  isSkillSourceItem,
-  isToolChartUsagePayload,
-} from "@app/components/agent_builder/observability/types";
+import { isToolChartUsagePayload } from "@app/components/agent_builder/observability/types";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import {
   ChartTooltipCard,
@@ -206,68 +203,5 @@ export function FeedbackDistributionTooltip(
         colorClassName: FEEDBACK_DISTRIBUTION_PALETTE[key],
       }))}
     />
-  );
-}
-
-export interface SkillSourceTooltipProps
-  extends TooltipContentProps<number, string> {
-  skillNames: string[];
-}
-
-export function SkillSourceTooltip({
-  active,
-  payload,
-  skillNames,
-}: SkillSourceTooltipProps) {
-  if (!active || !payload || payload.length === 0) {
-    return null;
-  }
-
-  const first = payload[0];
-  if (!first?.payload || !isSkillSourceItem(first.payload)) {
-    return null;
-  }
-
-  const item = first.payload;
-  const colorClassName = getIndexedColor(item.skillName, skillNames);
-
-  const sourceEntries = Object.entries(item.sources)
-    .map(([key, val]): [string, number] => [key, Number(val)])
-    .sort(([, a], [, b]) => b - a);
-
-  return (
-    <div
-      role="tooltip"
-      className="flex min-w-32 flex-col rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
-    >
-      <div className="mb-2 flex items-center gap-2">
-        <LegendDot className={colorClassName} />
-        <Label>{item.skillName}</Label>
-        <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-          {item.totalCount}
-        </span>
-      </div>
-      <div className="space-y-1.5">
-        {sourceEntries.map(([sourceLabel, count]) => {
-          const percent =
-            item.totalCount > 0
-              ? Math.round((count / item.totalCount) * 100)
-              : 0;
-          return (
-            <div key={sourceLabel} className="flex items-center gap-2">
-              <span className="text-muted-foreground dark:text-muted-foreground-night">
-                {sourceLabel}
-              </span>
-              <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-                {count}
-              </span>
-              <span className="text-muted-foreground dark:text-muted-foreground-night">
-                ({percent}%)
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
   );
 }

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -80,18 +80,20 @@ export function SkillUsageChart({
       errorMessage={errorMessage}
       emptyMessage={chartData.length === 0 ? emptyMessage : undefined}
       additionalControls={
-        <ButtonsSwitchList defaultValue={skillMode} size="xs">
-          <ButtonsSwitch
-            value="version"
-            label="By version"
-            onClick={() => setSkillMode("version")}
-          />
-          <ButtonsSwitch
-            value="source"
-            label="By source"
-            onClick={() => setSkillMode("source")}
-          />
-        </ButtonsSwitchList>
+        isCustomAgent && (
+          <ButtonsSwitchList defaultValue={skillMode} size="xs">
+            <ButtonsSwitch
+              value="version"
+              label="By version"
+              onClick={() => setSkillMode("version")}
+            />
+            <ButtonsSwitch
+              value="source"
+              label="By source"
+              onClick={() => setSkillMode("source")}
+            />
+          </ButtonsSwitchList>
+        )
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -28,16 +28,6 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
-const TOOLTIP_STYLES = {
-  wrapperStyle: { outline: "none", zIndex: 50 },
-  contentStyle: {
-    background: "transparent",
-    border: "none",
-    padding: 0,
-    boxShadow: "none",
-  },
-} as const;
-
 interface SkillUsageChartProps {
   workspaceId: string;
   agentConfigurationId: string;
@@ -216,7 +206,7 @@ export function SkillUsageChart({
           <Tooltip
             cursor={false}
             content={renderVersionTooltip}
-            {...TOOLTIP_STYLES}
+            wrapperStyle={{ outline: "none", zIndex: 50 }}
           />
           {isCustomAgent &&
             mode === "version" &&
@@ -274,7 +264,7 @@ export function SkillUsageChart({
           <Tooltip
             cursor={false}
             content={renderSourceTooltip}
-            {...TOOLTIP_STYLES}
+            wrapperStyle={{ outline: "none", zIndex: 50 }}
           />
           <Bar dataKey="totalCount" radius={[4, 4, 0, 0]}>
             {sourceData.items.map((item) => (

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -67,7 +67,12 @@ export function SkillUsageChart({
 
   const renderSkillUsageTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
-      <ChartsTooltip {...props} topTools={topTools} hoveredTool={hoveredTool} />
+      <ChartsTooltip
+        {...props}
+        topTools={topTools}
+        hoveredTool={hoveredTool}
+        showLabel
+      />
     ),
     [topTools, hoveredTool]
   );

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -1,0 +1,172 @@
+import { ChartsTooltip } from "@app/components/agent_builder/observability/charts/ChartsTooltip";
+import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
+import { useSkillUsageData } from "@app/components/agent_builder/observability/hooks";
+import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import type {
+  ChartDatum,
+  SkillChartModeType,
+} from "@app/components/agent_builder/observability/types";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import { RoundedBarShape } from "@app/components/charts/ChartShapes";
+import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceLine,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+interface SkillUsageChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  isCustomAgent: boolean;
+}
+
+export function SkillUsageChart({
+  workspaceId,
+  agentConfigurationId,
+  isCustomAgent,
+}: SkillUsageChartProps) {
+  const { period, mode, selectedVersion } = useObservabilityContext();
+  const [skillMode, setSkillMode] = useState<SkillChartModeType>(
+    isCustomAgent ? "version" : "source"
+  );
+  const [hoveredTool, setHoveredTool] = useState<string | null>(null);
+
+  const {
+    chartData,
+    topTools,
+    xAxisLabel,
+    emptyMessage,
+    legendDescription,
+    isLoading,
+    errorMessage,
+  } = useSkillUsageData({
+    workspaceId,
+    agentConfigurationId,
+    period,
+    mode: skillMode,
+    filterVersion: mode === "version" ? selectedVersion?.version : undefined,
+  });
+
+  const legendItems = useMemo(
+    () =>
+      topTools.map((t) => ({
+        key: t,
+        label: t,
+        colorClassName: getIndexedColor(t, topTools),
+      })),
+    [topTools]
+  );
+
+  const renderSkillUsageTooltip = useCallback(
+    (props: TooltipContentProps<number, string>) => (
+      <ChartsTooltip {...props} topTools={topTools} hoveredTool={hoveredTool} />
+    ),
+    [topTools, hoveredTool]
+  );
+
+  return (
+    <ChartContainer
+      title="Skills"
+      description={legendDescription}
+      isLoading={isLoading}
+      errorMessage={errorMessage}
+      emptyMessage={chartData.length === 0 ? emptyMessage : undefined}
+      additionalControls={
+        <ButtonsSwitchList defaultValue={skillMode} size="xs">
+          <ButtonsSwitch
+            value="version"
+            label="By version"
+            onClick={() => setSkillMode("version")}
+          />
+          <ButtonsSwitch
+            value="source"
+            label="By source"
+            onClick={() => setSkillMode("source")}
+          />
+        </ButtonsSwitchList>
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <BarChart
+        data={chartData}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+        stackOffset="expand"
+      >
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="label"
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          label={{
+            value: xAxisLabel,
+            position: "insideBottom",
+            offset: -8,
+            style: { textAnchor: "middle" },
+          }}
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          domain={[0, 1]}
+          ticks={[0, 0.2, 0.4, 0.6, 0.8, 1]}
+          tickFormatter={(value) => `${Math.round(value * 100)}%`}
+        />
+        <Tooltip
+          cursor={false}
+          content={renderSkillUsageTooltip}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        {isCustomAgent &&
+          mode === "version" &&
+          skillMode === "version" &&
+          selectedVersion &&
+          chartData.length > 0 && (
+            <ReferenceLine
+              x={`v${selectedVersion.version}`}
+              stroke="hsl(var(--primary))"
+              strokeDasharray="5 5"
+              strokeWidth={2}
+              ifOverflow="extendDomain"
+            />
+          )}
+        {topTools.map((toolName) => (
+          <Bar
+            key={toolName}
+            dataKey={(row: ChartDatum) => row.values[toolName]?.count ?? 0}
+            stackId="a"
+            fill="currentColor"
+            className={getIndexedColor(toolName, topTools)}
+            name={toolName}
+            shape={
+              <RoundedBarShape seriesKey={toolName} stackOrderKeys={topTools} />
+            }
+            onMouseEnter={() => setHoveredTool(toolName)}
+            onMouseLeave={() => setHoveredTool(null)}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/types.ts
+++ b/front/components/agent_builder/observability/types.ts
@@ -1,9 +1,12 @@
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TOOL_CHART_MODES = ["version", "step"] as const;
 
 export type ToolChartModeType = (typeof TOOL_CHART_MODES)[number];
+
+const SKILL_CHART_MODES = ["version", "source"] as const;
+
+export type SkillChartModeType = (typeof SKILL_CHART_MODES)[number];
 
 export type ToolChartUsageDatum = {
   percent: number;

--- a/front/components/agent_builder/observability/types.ts
+++ b/front/components/agent_builder/observability/types.ts
@@ -46,6 +46,27 @@ export type SourceChartDatum = {
   label: string;
 };
 
+export type SkillSourceItem = {
+  skillName: string;
+  totalCount: number;
+  sources: Record<string, number>;
+};
+
+export function isSkillSourceItem(data: unknown): data is SkillSourceItem {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  return (
+    "skillName" in data &&
+    typeof data.skillName === "string" &&
+    "totalCount" in data &&
+    typeof data.totalCount === "number" &&
+    "sources" in data &&
+    typeof data.sources === "object" &&
+    data.sources !== null
+  );
+}
+
 export function isChartDatum(data: unknown): data is ChartDatum {
   if (typeof data !== "object" || data === null) {
     return false;

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -39,6 +39,13 @@ const SourceChart = safeLazy(() =>
     })
   )
 );
+const SkillUsageChart = safeLazy(() =>
+  import(
+    "@app/components/agent_builder/observability/charts/SkillUsageChart"
+  ).then((mod) => ({
+    default: mod.SkillUsageChart,
+  }))
+);
 const ToolUsageChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/ToolUsageChart"
@@ -227,6 +234,13 @@ export function AgentObservability({
         </Suspense>
         <Suspense fallback={<ChartFallback />}>
           <ToolUsageChart
+            workspaceId={owner.sId}
+            agentConfigurationId={agentConfigurationId}
+            isCustomAgent={isCustomAgent}
+          />
+        </Suspense>
+        <Suspense fallback={<ChartFallback />}>
+          <SkillUsageChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}

--- a/front/lib/api/assistant/observability/skill_execution.ts
+++ b/front/lib/api/assistant/observability/skill_execution.ts
@@ -1,0 +1,139 @@
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type SkillExecutionByVersion = {
+  version: string;
+  skills: Record<string, { count: number }>;
+};
+
+export type SkillExecutionBySource = {
+  skillName: string;
+  sources: Record<string, number>;
+};
+
+type TermBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type SkillNameBucket = TermBucket & {
+  sources?: estypes.AggregationsMultiBucketAggregateBase<TermBucket>;
+};
+
+type VersionBucket = TermBucket & {
+  skills?: {
+    skill_names?: estypes.AggregationsMultiBucketAggregateBase<TermBucket>;
+  };
+  first_seen?: estypes.AggregationsMinAggregate;
+};
+
+type SkillExecutionAggs = {
+  by_version?: estypes.AggregationsMultiBucketAggregateBase<VersionBucket>;
+  by_skill_source?: {
+    skill_names?: estypes.AggregationsMultiBucketAggregateBase<SkillNameBucket>;
+  };
+};
+
+export async function fetchSkillExecutionMetrics(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<
+  Result<
+    {
+      byVersion: SkillExecutionByVersion[];
+      bySource: SkillExecutionBySource[];
+    },
+    Error
+  >
+> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_version: {
+      terms: {
+        field: "agent_version",
+        size: 100,
+        order: { first_seen: "asc" },
+      },
+      aggs: {
+        first_seen: {
+          min: { field: "timestamp" },
+        },
+        skills: {
+          nested: { path: "skills_used" },
+          aggs: {
+            skill_names: {
+              terms: {
+                field: "skills_used.skill_name",
+                size: 50,
+              },
+            },
+          },
+        },
+      },
+    },
+    by_skill_source: {
+      nested: { path: "skills_used" },
+      aggs: {
+        skill_names: {
+          terms: {
+            field: "skills_used.skill_name",
+            size: 50,
+          },
+          aggs: {
+            sources: {
+              terms: { field: "skills_used.source" },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, SkillExecutionAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const versionBuckets = bucketsToArray<VersionBucket>(
+    result.value.aggregations?.by_version?.buckets
+  );
+
+  const byVersion: SkillExecutionByVersion[] = versionBuckets.map((vb) => {
+    const skillBuckets = bucketsToArray<TermBucket>(
+      vb.skills?.skill_names?.buckets
+    );
+
+    const skills: Record<string, { count: number }> = {};
+    for (const sb of skillBuckets) {
+      skills[sb.key] = { count: sb.doc_count };
+    }
+
+    return {
+      version: vb.key,
+      skills,
+    };
+  });
+
+  const skillNameBuckets = bucketsToArray<SkillNameBucket>(
+    result.value.aggregations?.by_skill_source?.skill_names?.buckets
+  );
+
+  const bySource: SkillExecutionBySource[] = skillNameBuckets.map((snb) => {
+    const sourceBuckets = bucketsToArray<TermBucket>(snb.sources?.buckets);
+    const sources: Record<string, number> = {};
+    for (const sb of sourceBuckets) {
+      sources[sb.key] = sb.doc_count;
+    }
+
+    return {
+      skillName: snb.key,
+      sources,
+    };
+  });
+
+  return new Ok({ byVersion, bySource });
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -26,6 +26,7 @@ import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agen
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
 import type { GetAgentOverviewResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview";
+import type { GetSkillExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution";
 import type { GetContextOriginResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source";
 import type { GetAgentSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
@@ -1064,6 +1065,37 @@ export function useAgentToolExecution({
     isToolExecutionLoading: !error && !data && !disabled,
     isToolExecutionError: error,
     isToolExecutionValidating: isValidating,
+  };
+}
+
+export function useAgentSkillExecution({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  version,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  version?: string;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetSkillExecutionResponse> = fetcher;
+  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/skill-execution?days=${days}${versionParam}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    skillExecutionByVersion: data?.byVersion ?? emptyArray(),
+    skillExecutionBySource: data?.bySource ?? emptyArray(),
+    isSkillExecutionLoading: !error && !data && !disabled,
+    isSkillExecutionError: error,
+    isSkillExecutionValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution.ts
@@ -1,0 +1,116 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type {
+  SkillExecutionBySource,
+  SkillExecutionByVersion,
+} from "@app/lib/api/assistant/observability/skill_execution";
+import { fetchSkillExecutionMetrics } from "@app/lib/api/assistant/observability/skill_execution";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  version: z.string().optional(),
+});
+
+export type GetSkillExecutionResponse = {
+  byVersion: SkillExecutionByVersion[];
+  bySource: SkillExecutionBySource[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSkillExecutionResponse>>,
+  auth: Authenticator
+) {
+  if (!isString(req.query.aId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days, version } = q.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        agentId: assistant.sId,
+        days,
+        version,
+      });
+
+      const skillExecutionResult = await fetchSkillExecutionMetrics(baseQuery);
+
+      if (skillExecutionResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve skill execution metrics: ${fromError(skillExecutionResult.error).toString()}`,
+          },
+        });
+      }
+
+      return res.status(200).json(skillExecutionResult.value);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR adds a new "Skills" chart to agent observability that visualizes skill execution metrics by version and source. The chart displays which skills are being used across different agent versions and whether they were invoked from agent configuration or conversation context. Building on the recently added skill tracking in Elasticsearch (PR #21879), this introduces a new API endpoint, data fetching logic, and a chart component following the same patterns as the existing tool usage observability.

## Risk

Medium 

## Tests

- [x] Locally
- [ ] Front edge

## Deploy Plan

- Run skills backfill migration
- Deploy front