### PR TITLE
Revert "[front] perf: Cache memberships for fromSession"

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1871,9 +1871,8 @@ async function isMessagesLimitReached(
   }
 
   // Checking rate limit
-  const activeSeats = await MembershipResource.countActiveSeatsInWorkspace(
-    owner.sId
-  );
+  const activeSeats =
+    await MembershipResource.countActiveSeatsInWorkspaceCached(owner.sId);
 
   const userMessagesLimit = 10 * activeSeats;
   const remainingMessages = await rateLimiter({

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -86,9 +86,8 @@ export async function getMessageUsageCount(auth: Authenticator): Promise<{
     return { count: 0, limit: -1 };
   }
 
-  const activeSeats = await MembershipResource.countActiveSeatsInWorkspace(
-    workspace.sId
-  );
+  const activeSeats =
+    await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
   const effectiveLimit = computeEffectiveMessageLimit({
     planCode: plan.code,
     maxMessages,

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -37,9 +37,10 @@ export class ServerSideTracking {
       const seatsByWorkspaceId = _.keyBy(
         await Promise.all(
           user.workspaces.map(async (workspace) => {
-            const seats = await MembershipResource.countActiveSeatsInWorkspace(
-              workspace.sId
-            );
+            const seats =
+              await MembershipResource.countActiveSeatsInWorkspaceCached(
+                workspace.sId
+              );
             return { sId: workspace.sId, seats };
           })
         ),

--- a/front/lib/triggers/rate_limits.ts
+++ b/front/lib/triggers/rate_limits.ts
@@ -23,9 +23,8 @@ export async function checkWebhookRequestForRateLimit(
   const { maxMessages, maxMessagesTimeframe } = plan.limits.assistant;
 
   if (maxMessages !== -1) {
-    const activeSeats = await MembershipResource.countActiveSeatsInWorkspace(
-      workspace.sId
-    );
+    const activeSeats =
+      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
     const effectiveMaxMessages = computeEffectiveMessageLimit({
       planCode: plan.code,
       maxMessages,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -476,7 +476,7 @@ async function handler(
       // Enforce plan limits: Datasource quota
       try {
         const [activeSeats, quotaUsed] = await Promise.all([
-          MembershipResource.countActiveSeatsInWorkspace(owner.sId),
+          MembershipResource.countActiveSeatsInWorkspaceCached(owner.sId),
           computeWorkspaceOverallSizeCached(auth),
         ]);
 


### PR DESCRIPTION
This reverts commit 1a4986f216ac5a20c5242ac94e751a5ae3bf6f3a.

## Description

https://dust4ai.slack.com/archives/C05B529FHV1/p1771422253228049

Thanks to encapsulating caching logic, we now cache more than we used to on  `countActiveSeatsInWorkspaceCached` without matching in cache invalidations. Reverting until a proper fix is done

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
