### PR TITLE
Return text content for empty query results in executeQuery

### DIFF
--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -32,6 +32,16 @@ type TablesQueryOutputResources =
   | ToolGeneratedFileType
   | ToolMarkerResourceType;
 
+type TablesQueryContentItem =
+  | {
+      type: "resource";
+      resource: TablesQueryOutputResources;
+    }
+  | {
+      type: "text";
+      text: string;
+    };
+
 /**
  * Get the prefix for a row in a section file.
  * This prefix is used to identify the row in the section file.
@@ -118,10 +128,7 @@ export async function executeQuery(
     );
   }
 
-  const content: {
-    type: "resource";
-    resource: TablesQueryOutputResources;
-  }[] = [];
+  const content: TablesQueryContentItem[] = [];
 
   const results: CSVRecord[] = queryResult.value.results
     .map((r) => r.value)
@@ -214,6 +221,11 @@ export async function executeQuery(
         },
       });
     }
+  } else {
+    content.push({
+      type: "text",
+      text: "Query executed successfully but returned no results. No files were generated.",
+    });
   }
 
   return new Ok(content);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR updates `executeQuery` return type to support both resource and text content items. We've seen [examples](https://dust4ai.slack.com/archives/C050SM8NSPK/p1771423602670269) were the model assumes that the file has been created. The goal here is to flag that the query was successful but no results were returned.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
