### PR TITLE
[front] Switch dust to sonnet 4.6 and dust-ant* to opus 4.6

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -43,7 +43,6 @@ import {
 } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
-  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
@@ -524,9 +523,7 @@ export function _getDustGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
-    preferredModelConfiguration: shouldUseOpus(auth)
-      ? CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG
-      : CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "medium",
   });
 }
@@ -550,7 +547,7 @@ export function _getDustAntGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_ANT,
     name: "dust-ant",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }
@@ -562,7 +559,7 @@ export function _getDustAntMediumGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM,
     name: "dust-ant-medium",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "medium",
   });
 }
@@ -574,7 +571,7 @@ export function _getDustAntHighGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_ANT_HIGH,
     name: "dust-ant-high",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "high",
   });
 }


### PR DESCRIPTION
## Description

Switch model configurations for global agents:
- **dust**: Changed from opus 4.6 (enterprise/Dust plans) / sonnet 4.5 (others) to **sonnet 4.6 with medium reasoning** for all upgraded plans
- **dust-ant**: Switched from sonnet 4.6 to **opus 4.6 with light reasoning**
- **dust-ant-medium**: Switched from sonnet 4.6 to **opus 4.6 with medium reasoning**
- **dust-ant-high**: Switched from sonnet 4.6 to **opus 4.6 with high reasoning**

## Tests

No tests needed — config-only change affecting model selection for global agents.

## Risk

Low. Straightforward model swap. The `shouldUseOpus` helper is retained as it's still used by deep-dive.

## Deploy Plan

Standard deploy. Changes take effect immediately for new conversations.