### PR TITLE
[front] fix placeholder display

### DIFF
--- a/extension/ui/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/ui/components/input_bar/editor/useCustomEditor.tsx
@@ -288,9 +288,14 @@ const useCustomEditor = ({
       },
     }),
     Placeholder.configure({
-      placeholder: "Ask an @agent a question, or get some @help",
+      placeholder: ({ node }) => {
+        if (node.type.name !== "paragraph") {
+          return "";
+        }
+        return "Ask an @agent a question, or get some @help";
+      },
       emptyNodeClass:
-        "first:before:text-gray-400 first:before:float-left first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:h-0",
+        "first:before:text-gray-400 first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
     }),
     MarkdownStyleExtension,
     ParagraphExtension,

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -273,9 +273,14 @@ export const buildEditorExtensions = ({
     }),
     EmojiExtension,
     Placeholder.configure({
-      placeholder: "Ask an @agent a question, or get some @help",
+      placeholder: ({ node }) => {
+        if (node.type.name !== "paragraph") {
+          return "";
+        }
+        return "Ask an @agent a question, or get some @help";
+      },
       emptyNodeClass:
-        "first:before:text-gray-400 first:before:float-left first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:h-0",
+        "first:before:text-gray-400 first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
     }),
     PastedAttachmentExtension.configure({
       onInlineText,


### PR DESCRIPTION
## Description
This PR is to fix weird tiptap placeholder display issue when you start with markdown directive such as `>`. Fixes https://github.com/dust-tt/tasks/issues/6463#issuecomment-3913164354

before:
<img width="1818" height="470" alt="CleanShot 2026-02-18 at 15 34 31@2x" src="https://github.com/user-attachments/assets/29fe6d50-a3de-4250-a416-2d1fe832725b" />

<img width="1640" height="482" alt="CleanShot 2026-02-18 at 15 34 26@2x" src="https://github.com/user-attachments/assets/45b3cb16-ecc1-4081-9ab0-be8791e0a599" />

after:
<img width="1762" height="530" alt="CleanShot 2026-02-18 at 15 34 37@2x" src="https://github.com/user-attachments/assets/6938f5b4-9ed6-452a-8de5-a0442ae78290" />

<img width="1650" height="602" alt="CleanShot 2026-02-18 at 15 34 41@2x" src="https://github.com/user-attachments/assets/f4d65009-ddb6-4a13-bc30-00433f91cc97" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
