### PR TITLE
[RUNNER] Fix Gemini 3 Pro input token price 

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -200,7 +200,7 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
   // Conservative: pricing is 2/12 for first 200k tokens
   // then 4/18 beyond that.
   "gemini-3-pro-preview": {
-    input: 2,
+    input: 4,
     output: 18,
   },
   "gemini-3-flash-preview": {


### PR DESCRIPTION
## Description

Saw a small incoherence in `gemini-3-pro-preview` input token price to be conservative. In practice we can go over 200k input tokens.

## Tests

no

## Risk

no

## Deploy Plan

front
