### PR TITLE
[Agent Loop] Shift max actions-per-step profile to 8/8/4/2

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -206,7 +206,7 @@ async function _runModelAndCreateActionsActivity({
     stepContexts,
   } = modelResult;
 
-  // Enforce a limit on actions per step, halving at each depth level (16/8/4/2)
+  // Enforce a limit on actions per step, reducing by depth (8/8/4/2)
   // to contain cascading fan-out from nested run_agent calls.
   const actionsToRun = actions.slice(
     0,

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -193,14 +193,23 @@ export function isTemplateAgentConfiguration(
 }
 
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 64;
-export const MAX_ACTIONS_PER_STEP = 16;
+export const MAX_ACTIONS_PER_STEP = 8;
 const MIN_ACTIONS_PER_STEP = 2;
+const DEPTH_THRESHOLD_BEFORE_REDUCING_ACTIONS = 1;
 
 // Returns the max actions per step for a given conversation depth.
-// Halves at each depth level: 16 → 8 → 4 → 2, capping total concurrent
-// agent loop activities at 512 for a single user message.
+// Keeps max actions for the first 2 depth levels, then halves: 8 → 8 → 4 → 2,
+// capping total concurrent agent loop activities at 512 for a single user message.
 export function getMaxActionsPerStep(depth: number): number {
-  return Math.max(MIN_ACTIONS_PER_STEP, MAX_ACTIONS_PER_STEP >> depth);
+  const depthAfterThreshold = Math.max(
+    0,
+    depth - DEPTH_THRESHOLD_BEFORE_REDUCING_ACTIONS
+  );
+
+  return Math.max(
+    MIN_ACTIONS_PER_STEP,
+    MAX_ACTIONS_PER_STEP >> depthAfterThreshold
+  );
 }
 
 /**

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -207,9 +207,10 @@ const MAX_DEPTH_WITH_ACTION_LIMIT = ACTIONS_PER_STEP_BY_DEPTH.length - 1;
 // Keeps max actions for the first 2 depth levels, then halves: 8 → 8 → 4 → 2,
 // capping total concurrent agent loop activities at 512 for a single user message.
 export function getMaxActionsPerStep(depth: number): number {
+  const normalizedDepth = Math.trunc(depth);
   const boundedDepth = Math.max(
     0,
-    Math.min(depth, MAX_DEPTH_WITH_ACTION_LIMIT)
+    Math.min(normalizedDepth, MAX_DEPTH_WITH_ACTION_LIMIT)
   );
 
   return ACTIONS_PER_STEP_BY_DEPTH[boundedDepth];

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -207,9 +207,12 @@ const MAX_DEPTH_WITH_ACTION_LIMIT = ACTIONS_PER_STEP_BY_DEPTH.length - 1;
 // Keeps max actions for the first 2 depth levels, then halves: 8 → 8 → 4 → 2,
 // capping total concurrent agent loop activities at 512 for a single user message.
 export function getMaxActionsPerStep(depth: number): number {
-  return ACTIONS_PER_STEP_BY_DEPTH[
+  const boundedDepth = Math.max(
+    0,
     Math.min(depth, MAX_DEPTH_WITH_ACTION_LIMIT)
-  ];
+  );
+
+  return ACTIONS_PER_STEP_BY_DEPTH[boundedDepth];
 }
 
 /**

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -193,14 +193,7 @@ export function isTemplateAgentConfiguration(
 }
 
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 64;
-export const MAX_ACTIONS_PER_STEP = 8;
-const MIN_ACTIONS_PER_STEP = 2;
-const ACTIONS_PER_STEP_BY_DEPTH = [
-  MAX_ACTIONS_PER_STEP,
-  MAX_ACTIONS_PER_STEP,
-  4,
-  MIN_ACTIONS_PER_STEP,
-] as const;
+const ACTIONS_PER_STEP_BY_DEPTH = [8, 8, 4, 2] as const;
 const MAX_DEPTH_WITH_ACTION_LIMIT = ACTIONS_PER_STEP_BY_DEPTH.length - 1;
 
 // Returns the max actions per step for a given conversation depth.

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -200,7 +200,7 @@ const MAX_DEPTH_WITH_ACTION_LIMIT = ACTIONS_PER_STEP_BY_DEPTH.length - 1;
 // Keeps max actions for the first 2 depth levels, then halves: 8 → 8 → 4 → 2,
 // capping total concurrent agent loop activities at 512 for a single user message.
 export function getMaxActionsPerStep(depth: number): number {
-  const normalizedDepth = Math.trunc(depth);
+  const normalizedDepth = Number.isFinite(depth) ? Math.trunc(depth) : 0;
   const boundedDepth = Math.max(
     0,
     Math.min(normalizedDepth, MAX_DEPTH_WITH_ACTION_LIMIT)

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -195,21 +195,21 @@ export function isTemplateAgentConfiguration(
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 64;
 export const MAX_ACTIONS_PER_STEP = 8;
 const MIN_ACTIONS_PER_STEP = 2;
-const DEPTH_THRESHOLD_BEFORE_REDUCING_ACTIONS = 1;
+const ACTIONS_PER_STEP_BY_DEPTH = [
+  MAX_ACTIONS_PER_STEP,
+  MAX_ACTIONS_PER_STEP,
+  4,
+  MIN_ACTIONS_PER_STEP,
+] as const;
+const MAX_DEPTH_WITH_ACTION_LIMIT = ACTIONS_PER_STEP_BY_DEPTH.length - 1;
 
 // Returns the max actions per step for a given conversation depth.
 // Keeps max actions for the first 2 depth levels, then halves: 8 → 8 → 4 → 2,
 // capping total concurrent agent loop activities at 512 for a single user message.
 export function getMaxActionsPerStep(depth: number): number {
-  const depthAfterThreshold = Math.max(
-    0,
-    depth - DEPTH_THRESHOLD_BEFORE_REDUCING_ACTIONS
-  );
-
-  return Math.max(
-    MIN_ACTIONS_PER_STEP,
-    MAX_ACTIONS_PER_STEP >> depthAfterThreshold
-  );
+  return ACTIONS_PER_STEP_BY_DEPTH[
+    Math.min(depth, MAX_DEPTH_WITH_ACTION_LIMIT)
+  ];
 }
 
 /**


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/21482.

Updates `getMaxActionsPerStep` from `16/8/4/2` to `8/8/4/2`.

This bounds total tasks in parallel per step to `512` (`8 × 8 × 4 × 2` with the current conversation depth cap), while reducing root-level fan-out; also it's an indirect way to bound the maximum subagents per step (at 512), related: https://github.com/dust-tt/dust/pull/21895

Also updates the corresponding agent loop inline comment to match the new limit profile.

## Risks

Blast radius: agent loop action slicing before tool-action creation
Risk: low

## Deploy Plan
- deploy front