### PR TITLE
[connectors] chore(Gong): add script to delete private transcripts

### DIFF
--- a/connectors/migrations/20260218_delete_private_gong_transcripts.ts
+++ b/connectors/migrations/20260218_delete_private_gong_transcripts.ts
@@ -115,7 +115,7 @@ async function deletePrivateTranscripts(
     }
 
     nextId = transcripts[transcripts.length - 1]?.id;
-    hasMore = transcripts.length < BATCH_SIZE;
+    hasMore = transcripts.length === BATCH_SIZE;
   } while (hasMore);
 
   logger.info({ totalChecked, totalPrivate, execute }, "Done.");

--- a/connectors/migrations/20260218_delete_private_gong_transcripts.ts
+++ b/connectors/migrations/20260218_delete_private_gong_transcripts.ts
@@ -1,6 +1,5 @@
 import { makeGongTranscriptInternalId } from "@connectors/connectors/gong/lib/internal_ids";
 import {
-  fetchGongConfiguration,
   fetchGongConnector,
   getGongClient,
 } from "@connectors/connectors/gong/lib/utils";
@@ -28,7 +27,6 @@ async function deletePrivateTranscripts(
   const logger = parentLogger.child({ connectorId });
 
   const connector = await fetchGongConnector({ connectorId });
-  const configuration = await fetchGongConfiguration(connector);
   const gongClient = await getGongClient(connector);
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
@@ -61,8 +59,6 @@ async function deletePrivateTranscripts(
       const { callsMetadata, nextPageCursor } =
         await gongClient.getCallsMetadata({
           callIds,
-          trackersEnabled: configuration.trackersEnabled,
-          accountsEnabled: configuration.accountsEnabled,
           pageCursor: cursor,
         });
       for (const meta of callsMetadata) {

--- a/connectors/migrations/20260218_delete_private_gong_transcripts.ts
+++ b/connectors/migrations/20260218_delete_private_gong_transcripts.ts
@@ -13,7 +13,7 @@ import { Op } from "sequelize";
 import type { Logger } from "pino";
 
 const BATCH_SIZE = 100;
-const DELETION_CONCURRENCY = 10;
+const CORE_DELETION_CONCURRENCY = 10;
 
 async function deletePrivateTranscripts(
   connectorId: number,
@@ -106,7 +106,7 @@ async function deletePrivateTranscripts(
             }
           );
         },
-        { concurrency: DELETION_CONCURRENCY }
+        { concurrency: CORE_DELETION_CONCURRENCY }
       );
 
       // Delete from connectors DB.

--- a/connectors/migrations/20260218_delete_private_gong_transcripts.ts
+++ b/connectors/migrations/20260218_delete_private_gong_transcripts.ts
@@ -1,0 +1,133 @@
+import { makeGongTranscriptInternalId } from "@connectors/connectors/gong/lib/internal_ids";
+import {
+  fetchGongConfiguration,
+  fetchGongConnector,
+  getGongClient,
+} from "@connectors/connectors/gong/lib/utils";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
+import { GongTranscriptModel } from "@connectors/lib/models/gong";
+import { makeScript } from "scripts/helpers";
+import { Op } from "sequelize";
+import type { Logger } from "pino";
+
+const BATCH_SIZE = 100;
+const DELETION_CONCURRENCY = 10;
+
+async function deletePrivateTranscripts(
+  connectorId: number,
+  {
+    execute,
+    logger: parentLogger,
+  }: {
+    execute: boolean;
+    logger: Logger;
+  }
+) {
+  const logger = parentLogger.child({ connectorId });
+
+  const connector = await fetchGongConnector({ connectorId });
+  const configuration = await fetchGongConfiguration(connector);
+  const gongClient = await getGongClient(connector);
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  let nextId: number | undefined = 0;
+  let totalChecked = 0;
+  let totalPrivate = 0;
+  let hasMore = true;
+
+  do {
+    // Using the model directly for pagination.
+    const transcripts: GongTranscriptModel[] =
+      await GongTranscriptModel.findAll({
+        where: {
+          connectorId,
+          id: { [Op.gt]: nextId },
+        },
+        limit: BATCH_SIZE,
+        order: [["id", "ASC"]],
+      });
+
+    if (transcripts.length === 0) {
+      break;
+    }
+
+    const callIds = transcripts.map((t) => t.callId);
+    const callMetadataMap = new Map<string, { isPrivate: boolean }>();
+
+    let cursor = null;
+    do {
+      const { callsMetadata, nextPageCursor } =
+        await gongClient.getCallsMetadata({
+          callIds,
+          trackersEnabled: configuration.trackersEnabled,
+          accountsEnabled: configuration.accountsEnabled,
+          pageCursor: cursor,
+        });
+      for (const meta of callsMetadata) {
+        callMetadataMap.set(meta.metaData.id, {
+          isPrivate: meta.metaData.isPrivate === true,
+        });
+      }
+      cursor = nextPageCursor;
+    } while (cursor);
+
+    const privateTranscripts = transcripts.filter(
+      (t) => callMetadataMap.get(t.callId)?.isPrivate === true
+    );
+
+    totalChecked += transcripts.length;
+    totalPrivate += privateTranscripts.length;
+
+    logger.info(
+      {
+        batch: transcripts.length,
+        privateInBatch: privateTranscripts.length,
+        totalChecked,
+        totalPrivate,
+      },
+      "Processed batch."
+    );
+
+    if (privateTranscripts.length > 0 && execute) {
+      // Delete from core.
+      await concurrentExecutor(
+        privateTranscripts,
+        async (transcript) => {
+          await deleteDataSourceDocument(
+            dataSourceConfig,
+            makeGongTranscriptInternalId(connector, transcript.callId),
+            {
+              workspaceId: dataSourceConfig.workspaceId,
+              dataSourceId: dataSourceConfig.dataSourceId,
+              provider: "gong",
+              callId: transcript.callId,
+            }
+          );
+        },
+        { concurrency: DELETION_CONCURRENCY }
+      );
+
+      // Delete from connectors DB.
+      await GongTranscriptModel.destroy({
+        where: {
+          callId: privateTranscripts.map((t) => t.callId),
+          connectorId: connector.id,
+        },
+      });
+    }
+
+    nextId = transcripts[transcripts.length - 1]?.id;
+    hasMore = transcripts.length < BATCH_SIZE;
+  } while (hasMore);
+
+  logger.info({ totalChecked, totalPrivate, execute }, "Done.");
+}
+
+makeScript(
+  { connectorId: { type: "number", required: true } },
+  async ({ connectorId, execute }, logger) => {
+    await deletePrivateTranscripts(connectorId, { execute, logger });
+  }
+);


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/6588.
- This PR adds a script that deletes the private transcripts already synced by a Gong connector.
- Follow up on https://github.com/dust-tt/dust/pull/21443, which skips the private transcripts from the sync.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
