### PR TITLE
feat: poke cache lookup by raw Redis key

### DIFF
--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -2,6 +2,7 @@ import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { AppPage } from "@dust-tt/front/components/poke/pages/AppPage";
 import { AssistantDetailsPage } from "@dust-tt/front/components/poke/pages/AssistantDetailsPage";
 import { AssistantInstructionsPage } from "@dust-tt/front/components/poke/pages/AssistantInstructionsPage";
+import { CacheLookupPage } from "@dust-tt/front/components/poke/pages/CacheLookupPage";
 import { ConnectorRedirectPage } from "@dust-tt/front/components/poke/pages/ConnectorRedirectPage";
 import { ConversationPage } from "@dust-tt/front/components/poke/pages/ConversationPage";
 import { DashboardPage } from "@dust-tt/front/components/poke/pages/DashboardPage";
@@ -65,6 +66,7 @@ const router = createBrowserRouter(
         { path: "templates", element: <TemplatesListPage /> },
         { path: "templates/:tId", element: <TemplateDetailPage /> },
         { path: "plugins", element: <PluginsPage /> },
+        { path: "cache", element: <CacheLookupPage /> },
         { path: "connectors/:connectorId", element: <ConnectorRedirectPage /> },
       ],
     },

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -77,6 +77,7 @@ function PokeNavbar({
           <Button href="/poke/templates" variant="ghost" label="Templates" />
           <Button href="/poke/plugins" variant="ghost" label="Plugins" />
           <Button href="/poke/kill" variant="ghost" label="Kill Switches" />
+          <Button href="/poke/cache" variant="ghost" label="Cache" />
           <Button href="/poke/pokefy" variant="ghost" label="Pokefy URL" />
           <Button
             href="/poke/production-checks"

--- a/front/components/poke/pages/CacheLookupPage.tsx
+++ b/front/components/poke/pages/CacheLookupPage.tsx
@@ -1,0 +1,110 @@
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
+import { usePokeCacheLookup } from "@app/poke/swr/cache";
+import { Button, Input, Spinner } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+export function CacheLookupPage() {
+  useSetPokePageTitle("Cache Lookup");
+
+  const [rawKey, setRawKey] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const canLookup = rawKey.trim().length > 0;
+
+  const { data, isCacheLoading, isCacheError } = usePokeCacheLookup({
+    rawKey: rawKey.trim(),
+    disabled: !submitted || !canLookup,
+  });
+
+  function handleLookup() {
+    setSubmitted(true);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && canLookup) {
+      handleLookup();
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+      <div className="py-12">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Redis Cache Lookup
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Inspect cached values in Redis
+          </p>
+        </div>
+
+        <div className="mx-auto mt-8 max-w-2xl">
+          <div className="space-y-6 rounded-lg bg-white p-6 shadow-sm">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Redis Key
+              </label>
+              <Input
+                placeholder="e.g. cacheWithRedis-_fetchByIdUncached-workspace:sid:abc123"
+                value={rawKey}
+                onChange={(e) => {
+                  setRawKey(e.target.value);
+                  setSubmitted(false);
+                }}
+                onKeyDown={handleKeyDown}
+                name="rawKey"
+              />
+            </div>
+
+            <Button
+              label="Lookup"
+              onClick={handleLookup}
+              disabled={!canLookup}
+              variant="primary"
+            />
+          </div>
+
+          {/* Results */}
+          {submitted && canLookup && (
+            <div className="mt-6 rounded-lg bg-white p-6 shadow-sm">
+              {isCacheLoading ? (
+                <div className="flex justify-center">
+                  <Spinner />
+                </div>
+              ) : isCacheError ? (
+                <p className="text-sm text-red-600">
+                  Error fetching cache value.
+                </p>
+              ) : data ? (
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500">
+                      Redis Key
+                    </label>
+                    <code className="mt-1 block break-all rounded bg-gray-100 p-2 text-sm">
+                      {data.key}
+                    </code>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500">
+                      Value
+                    </label>
+                    {data.value !== null ? (
+                      <pre className="mt-1 max-h-96 overflow-auto rounded bg-gray-100 p-3 text-xs">
+                        {JSON.stringify(data.value, null, 2)}
+                      </pre>
+                    ) : (
+                      <p className="mt-1 text-sm text-gray-500">
+                        Key not found
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -25,6 +25,7 @@ export type RedisUsageTagsType =
   | "retry_agent_message"
   | "update_authors"
   | "cache_with_redis"
+  | "poke_cache_lookup"
   | "user_message_events";
 
 export async function getRedisClient({

--- a/front/pages/api/poke/cache.ts
+++ b/front/pages/api/poke/cache.ts
@@ -1,0 +1,86 @@
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { runOnRedis } from "@app/lib/api/redis";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetPokeCacheResponseBody = {
+  key: string;
+  value: unknown | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetPokeCacheResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { rawKey } = req.query;
+
+      if (!isString(rawKey)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The 'rawKey' query parameter must be provided.",
+          },
+        });
+      }
+
+      const value = await runOnRedis(
+        { origin: "poke_cache_lookup" },
+        async (client) => {
+          const rawValue = await client.get(rawKey);
+
+          if (rawValue === null) {
+            return null;
+          }
+
+          try {
+            return JSON.parse(rawValue);
+          } catch {
+            return rawValue;
+          }
+        }
+      );
+
+      logger.info(
+        { redisKey: rawKey, found: value !== null },
+        "Poke cache lookup performed"
+      );
+
+      return res.status(200).json({
+        key: rawKey,
+        value,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/cache.ts
+++ b/front/poke/swr/cache.ts
@@ -1,0 +1,32 @@
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetPokeCacheResponseBody } from "@app/pages/api/poke/cache";
+import type { Fetcher } from "swr";
+
+interface UsePokeCacheLookupParams {
+  rawKey?: string;
+  disabled?: boolean;
+}
+
+export function usePokeCacheLookup({
+  rawKey,
+  disabled,
+}: UsePokeCacheLookupParams) {
+  const cacheFetcher: Fetcher<GetPokeCacheResponseBody> = fetcher;
+
+  const queryParams = new URLSearchParams();
+  if (rawKey) {
+    queryParams.set("rawKey", rawKey);
+  }
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/poke/cache?${queryParams.toString()}`,
+    cacheFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isCacheLoading: !error && !data && !disabled,
+    isCacheError: error,
+  };
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Add a new poke page to inspect Redis cache values by entering a raw key. Includes API endpoint, SWR hook, and UI page with value display.

<img width="1608" height="1045" alt="Capture d’écran 2026-02-18 à 16 15 17" src="https://github.com/user-attachments/assets/d798031b-f49a-451a-a393-afbc9de650cd" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy poke