### PR TITLE
feat:  add structured cache lookup with registry 

### DIFF
--- a/front/components/poke/pages/CacheLookupPage.tsx
+++ b/front/components/poke/pages/CacheLookupPage.tsx
@@ -1,7 +1,17 @@
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
+import {
+  PokeSelect,
+  PokeSelectContent,
+  PokeSelectItem,
+  PokeSelectTrigger,
+  PokeSelectValue,
+} from "@app/components/poke/shadcn/ui/select";
+import { CACHE_REGISTRY } from "@app/lib/poke/cache_registry";
 import { usePokeCacheLookup } from "@app/poke/swr/cache";
-import { Button, Input, Spinner } from "@dust-tt/sparkle";
+import { Button, Chip, Input, Spinner } from "@dust-tt/sparkle";
 import { useState } from "react";
+
+type LookupMode = "structured" | "raw";
 
 function formatTtl(ttlSeconds: number): string {
   if (ttlSeconds === -2) {
@@ -21,15 +31,38 @@ function formatTtl(ttlSeconds: number): string {
 export function CacheLookupPage() {
   useSetPokePageTitle("Cache Lookup");
 
+  const [mode, setMode] = useState<LookupMode>("structured");
+  const [selectedType, setSelectedType] = useState<string>("");
+  const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [rawKey, setRawKey] = useState("");
   const [submitted, setSubmitted] = useState(false);
 
-  const canLookup = rawKey.trim().length > 0;
+  const entry = selectedType ? CACHE_REGISTRY[selectedType] : null;
+
+  const allParamsFilled = entry
+    ? entry.params.every((p) => paramValues[p.name]?.trim())
+    : false;
+
+  const canLookup =
+    mode === "raw" ? rawKey.trim().length > 0 : selectedType && allParamsFilled;
 
   const { data, isCacheLoading, isCacheError } = usePokeCacheLookup({
-    rawKey: rawKey.trim(),
+    type: mode === "structured" ? selectedType : undefined,
+    params: mode === "structured" ? paramValues : undefined,
+    rawKey: mode === "raw" ? rawKey.trim() : undefined,
     disabled: !submitted || !canLookup,
   });
+
+  function handleTypeChange(value: string) {
+    setSelectedType(value);
+    setParamValues({});
+    setSubmitted(false);
+  }
+
+  function handleParamChange(name: string, value: string) {
+    setParamValues((prev) => ({ ...prev, [name]: value }));
+    setSubmitted(false);
+  }
 
   function handleLookup() {
     setSubmitted(true);
@@ -55,21 +88,97 @@ export function CacheLookupPage() {
 
         <div className="mx-auto mt-8 max-w-2xl">
           <div className="space-y-6 rounded-lg bg-white p-6 shadow-sm">
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Redis Key
-              </label>
-              <Input
-                placeholder="e.g. cacheWithRedis-_fetchByIdUncached-workspace:sid:abc123"
-                value={rawKey}
-                onChange={(e) => {
-                  setRawKey(e.target.value);
+            {/* Mode toggle */}
+            <div className="flex gap-2">
+              <Chip
+                color={mode === "structured" ? "blue" : "primary"}
+                onClick={() => {
+                  setMode("structured");
                   setSubmitted(false);
                 }}
-                onKeyDown={handleKeyDown}
-                name="rawKey"
-              />
+              >
+                Structured
+              </Chip>
+              <Chip
+                color={mode === "raw" ? "blue" : "primary"}
+                onClick={() => {
+                  setMode("raw");
+                  setSubmitted(false);
+                }}
+              >
+                Raw Key
+              </Chip>
             </div>
+
+            {mode === "structured" ? (
+              <>
+                {/* Cache type selector */}
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    Cache Type
+                  </label>
+                  <PokeSelect
+                    value={selectedType}
+                    onValueChange={handleTypeChange}
+                  >
+                    <PokeSelectTrigger>
+                      <PokeSelectValue placeholder="Select a cache type..." />
+                    </PokeSelectTrigger>
+                    <PokeSelectContent>
+                      {Object.entries(CACHE_REGISTRY).map(([key, e]) => (
+                        <PokeSelectItem key={key} value={key}>
+                          {e.label}
+                        </PokeSelectItem>
+                      ))}
+                    </PokeSelectContent>
+                  </PokeSelect>
+                  {entry && (
+                    <p className="mt-1 text-xs text-gray-500">
+                      {entry.description}
+                    </p>
+                  )}
+                </div>
+
+                {/* Dynamic parameter fields */}
+                {entry &&
+                  entry.params.map((param) => (
+                    <div key={param.name}>
+                      <label className="mb-1 block text-sm font-medium text-gray-700">
+                        {param.label}
+                        <span className="ml-1 text-xs text-gray-400">
+                          ({param.type})
+                        </span>
+                      </label>
+                      <Input
+                        placeholder={param.label}
+                        value={paramValues[param.name] ?? ""}
+                        onChange={(e) =>
+                          handleParamChange(param.name, e.target.value)
+                        }
+                        onKeyDown={handleKeyDown}
+                        name={param.name}
+                      />
+                    </div>
+                  ))}
+              </>
+            ) : (
+              /* Raw key input */
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                  Redis Key
+                </label>
+                <Input
+                  placeholder="e.g. cacheWithRedis-_fetchByIdUncached-workspace:sid:abc123"
+                  value={rawKey}
+                  onChange={(e) => {
+                    setRawKey(e.target.value);
+                    setSubmitted(false);
+                  }}
+                  onKeyDown={handleKeyDown}
+                  name="rawKey"
+                />
+              </div>
+            )}
 
             <Button
               label="Lookup"

--- a/front/lib/api/programmatic_usage/key_cap.ts
+++ b/front/lib/api/programmatic_usage/key_cap.ts
@@ -34,7 +34,7 @@ async function fetchKeyMonthlyCap({
   return key.monthlyCapMicroUsd;
 }
 
-const keyCapCacheResolver = ({ keyId }: { keyId: ModelId }) =>
+export const keyCapCacheResolver = ({ keyId }: { keyId: ModelId }) =>
   `key-cap:${keyId}`;
 
 /**

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -162,15 +162,18 @@ async function _lookupWorkspaceUncached(
   return data.workspace ? name : null;
 }
 
+export const workspaceRegionCacheKeyResolver = (wId: string) =>
+  `workspace-region:${wId}`;
+
 const _lookupWorkspaceCached = cacheWithRedis(
   _lookupWorkspaceUncached,
-  (wId) => `workspace-region:${wId}`,
+  workspaceRegionCacheKeyResolver,
   { ttlMs: WORKSPACE_REGION_CACHE_TTL_MS }
 );
 
 const _invalidateWorkspaceRegionCache = invalidateCacheWithRedis(
   _lookupWorkspaceUncached,
-  (wId) => `workspace-region:${wId}`
+  workspaceRegionCacheKeyResolver
 );
 
 export async function invalidateWorkspaceRegionCache(

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -92,11 +92,15 @@ async function getDustStatus(): Promise<AppStatusComponent | null> {
   return null;
 }
 
+export const providerStatusCacheKeyResolver = (region: string) =>
+  `provider-status-${region}`;
+
+export const dustStatusCacheKeyResolver = (region: string) =>
+  `dust-status-${region}`;
+
 export const getProviderStatusMemoized = cacheWithRedis(
   getProvidersStatus,
-  () => {
-    return `provider-status-${regionConfig.getCurrentRegion()}`;
-  },
+  () => providerStatusCacheKeyResolver(regionConfig.getCurrentRegion()),
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
   {
@@ -106,9 +110,7 @@ export const getProviderStatusMemoized = cacheWithRedis(
 
 export const getDustStatusMemoized = cacheWithRedis(
   getDustStatus,
-  () => {
-    return `dust-status-${regionConfig.getCurrentRegion()}`;
-  },
+  () => dustStatusCacheKeyResolver(regionConfig.getCurrentRegion()),
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
   {

--- a/front/lib/api/workos/organization_membership.ts
+++ b/front/lib/api/workos/organization_membership.ts
@@ -29,11 +29,12 @@ async function findWorkOSOrganizationsForUserIdUncached(userId: string) {
   return orgs;
 }
 
+export const workOSOrganizationsCacheKeyResolver = (userId: string) =>
+  `workos-orgs-${userId}`;
+
 export const findWorkOSOrganizationsForUserId = cacheWithRedis(
   findWorkOSOrganizationsForUserIdUncached,
-  (userId: string) => {
-    return `workos-orgs-${userId}`;
-  },
+  workOSOrganizationsCacheKeyResolver,
   {
     ttlMs: WORKOS_ORG_CACHE_TTL_MS,
   }
@@ -42,7 +43,5 @@ export const findWorkOSOrganizationsForUserId = cacheWithRedis(
 export const invalidateWorkOSOrganizationsCacheForUserId =
   invalidateCacheWithRedis(
     findWorkOSOrganizationsForUserIdUncached,
-    (userId: string) => {
-      return `workos-orgs-${userId}`;
-    }
+    workOSOrganizationsCacheKeyResolver
   );

--- a/front/lib/poke/cache_registry.ts
+++ b/front/lib/poke/cache_registry.ts
@@ -1,0 +1,103 @@
+interface CacheParamDef {
+  name: string;
+  label: string;
+  type: "string" | "number";
+}
+
+interface CacheRegistryEntry {
+  label: string;
+  description: string;
+  fnName: string;
+  params: CacheParamDef[];
+  buildResolverKey: (params: Record<string, string>) => string;
+}
+
+export const CACHE_REGISTRY: Record<string, CacheRegistryEntry> = {
+  workspace: {
+    label: "Workspace",
+    description: "Workspace fetched by sId",
+    fnName: "_fetchByIdUncached",
+    params: [{ name: "wId", label: "Workspace sId", type: "string" }],
+    buildResolverKey: (p) => `workspace:sid:${p.wId}`,
+  },
+  subscription: {
+    label: "Subscription",
+    description: "Active subscription by workspace model ID",
+    fnName: "_fetchActiveByWorkspaceModelIdUncached",
+    params: [
+      {
+        name: "workspaceModelId",
+        label: "Workspace Model ID",
+        type: "number",
+      },
+    ],
+    buildResolverKey: (p) =>
+      `subscription:active:workspaceId:${p.workspaceModelId}`,
+  },
+  user_by_workos_id: {
+    label: "User by WorkOS ID",
+    description: "User fetched by WorkOS user ID",
+    fnName: "_fetchByWorkOSUserIdUncached",
+    params: [{ name: "workOSUserId", label: "WorkOS User ID", type: "string" }],
+    buildResolverKey: (p) => `user:workos:${p.workOSUserId}`,
+  },
+  membership_role: {
+    label: "Membership Role",
+    description: "Active role for a user in a workspace",
+    fnName: "_getActiveRoleForUserInWorkspaceUncached",
+    params: [
+      { name: "userId", label: "User ID", type: "number" },
+      { name: "workspaceId", label: "Workspace ID", type: "number" },
+    ],
+    buildResolverKey: (p) => `role:user:${p.userId}:workspace:${p.workspaceId}`,
+  },
+  active_seats: {
+    label: "Active Seats",
+    description: "Count of active seats in a workspace",
+    fnName: "_countActiveSeatsInWorkspaceUncached",
+    params: [{ name: "wId", label: "Workspace sId", type: "string" }],
+    buildResolverKey: (p) => `count-active-seats-in-workspace:${p.wId}`,
+  },
+  key_monthly_cap: {
+    label: "Key Monthly Cap",
+    description: "Monthly cap for an API key",
+    fnName: "fetchKeyMonthlyCap",
+    params: [{ name: "keyId", label: "Key ID", type: "number" }],
+    buildResolverKey: (p) => `key-cap:${p.keyId}`,
+  },
+  workos_organizations: {
+    label: "WorkOS Organizations",
+    description: "WorkOS organizations for a user",
+    fnName: "findWorkOSOrganizationsForUserIdUncached",
+    params: [{ name: "userId", label: "User ID", type: "string" }],
+    buildResolverKey: (p) => `workos-orgs-${p.userId}`,
+  },
+  workspace_region: {
+    label: "Workspace Region",
+    description: "Region lookup for a workspace",
+    fnName: "_lookupWorkspaceUncached",
+    params: [{ name: "wId", label: "Workspace sId", type: "string" }],
+    buildResolverKey: (p) => `workspace-region:${p.wId}`,
+  },
+  provider_status: {
+    label: "Provider Status",
+    description: "Provider status for a region",
+    fnName: "getProvidersStatus",
+    params: [{ name: "region", label: "Region", type: "string" }],
+    buildResolverKey: (p) => `provider-status-${p.region}`,
+  },
+  dust_status: {
+    label: "Dust Status",
+    description: "Dust status for a region",
+    fnName: "getDustStatus",
+    params: [{ name: "region", label: "Region", type: "string" }],
+    buildResolverKey: (p) => `dust-status-${p.region}`,
+  },
+};
+
+export function buildCacheRedisKey(
+  entry: CacheRegistryEntry,
+  params: Record<string, string>
+): string {
+  return `cacheWithRedis-${entry.fnName}-${entry.buildResolverKey(params)}`;
+}

--- a/front/lib/poke/cache_registry.ts
+++ b/front/lib/poke/cache_registry.ts
@@ -77,8 +77,7 @@ export const CACHE_REGISTRY: Record<string, CacheRegistryEntry> = {
     description: "WorkOS organizations for a user",
     fnName: "findWorkOSOrganizationsForUserIdUncached",
     params: [{ name: "userId", label: "User ID", type: "string" }],
-    buildResolverKey: (p) =>
-      workOSOrganizationsCacheKeyResolver(p.userId),
+    buildResolverKey: (p) => workOSOrganizationsCacheKeyResolver(p.userId),
   },
   workspace_region: {
     label: "Workspace Region",

--- a/front/lib/poke/cache_registry.ts
+++ b/front/lib/poke/cache_registry.ts
@@ -1,3 +1,16 @@
+import { keyCapCacheResolver } from "@app/lib/api/programmatic_usage/key_cap";
+import { workspaceRegionCacheKeyResolver } from "@app/lib/api/regions/lookup";
+import {
+  dustStatusCacheKeyResolver,
+  providerStatusCacheKeyResolver,
+} from "@app/lib/api/status";
+import { workOSOrganizationsCacheKeyResolver } from "@app/lib/api/workos/organization_membership";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+
 interface CacheParamDef {
   name: string;
   label: string;
@@ -18,7 +31,7 @@ export const CACHE_REGISTRY: Record<string, CacheRegistryEntry> = {
     description: "Workspace fetched by sId",
     fnName: "_fetchByIdUncached",
     params: [{ name: "wId", label: "Workspace sId", type: "string" }],
-    buildResolverKey: (p) => `workspace:sid:${p.wId}`,
+    buildResolverKey: (p) => WorkspaceResource.workspaceCacheKeyResolver(p.wId),
   },
   subscription: {
     label: "Subscription",
@@ -32,66 +45,61 @@ export const CACHE_REGISTRY: Record<string, CacheRegistryEntry> = {
       },
     ],
     buildResolverKey: (p) =>
-      `subscription:active:workspaceId:${p.workspaceModelId}`,
+      SubscriptionResource.subscriptionCacheKeyResolver(
+        Number(p.workspaceModelId) as ModelId
+      ),
   },
   user_by_workos_id: {
     label: "User by WorkOS ID",
     description: "User fetched by WorkOS user ID",
     fnName: "_fetchByWorkOSUserIdUncached",
     params: [{ name: "workOSUserId", label: "WorkOS User ID", type: "string" }],
-    buildResolverKey: (p) => `user:workos:${p.workOSUserId}`,
-  },
-  membership_role: {
-    label: "Membership Role",
-    description: "Active role for a user in a workspace",
-    fnName: "_getActiveRoleForUserInWorkspaceUncached",
-    params: [
-      { name: "userId", label: "User ID", type: "number" },
-      { name: "workspaceId", label: "Workspace ID", type: "number" },
-    ],
-    buildResolverKey: (p) => `role:user:${p.userId}:workspace:${p.workspaceId}`,
+    buildResolverKey: (p) =>
+      UserResource.userByWorkOSIdCacheKeyResolver(p.workOSUserId),
   },
   active_seats: {
     label: "Active Seats",
     description: "Count of active seats in a workspace",
-    fnName: "_countActiveSeatsInWorkspaceUncached",
+    fnName: "countActiveSeatsInWorkspace",
     params: [{ name: "wId", label: "Workspace sId", type: "string" }],
-    buildResolverKey: (p) => `count-active-seats-in-workspace:${p.wId}`,
+    buildResolverKey: (p) => MembershipResource.seatsCacheKeyResolver(p.wId),
   },
   key_monthly_cap: {
     label: "Key Monthly Cap",
     description: "Monthly cap for an API key",
     fnName: "fetchKeyMonthlyCap",
     params: [{ name: "keyId", label: "Key ID", type: "number" }],
-    buildResolverKey: (p) => `key-cap:${p.keyId}`,
+    buildResolverKey: (p) =>
+      keyCapCacheResolver({ keyId: Number(p.keyId) as ModelId }),
   },
   workos_organizations: {
     label: "WorkOS Organizations",
     description: "WorkOS organizations for a user",
     fnName: "findWorkOSOrganizationsForUserIdUncached",
     params: [{ name: "userId", label: "User ID", type: "string" }],
-    buildResolverKey: (p) => `workos-orgs-${p.userId}`,
+    buildResolverKey: (p) =>
+      workOSOrganizationsCacheKeyResolver(p.userId),
   },
   workspace_region: {
     label: "Workspace Region",
     description: "Region lookup for a workspace",
     fnName: "_lookupWorkspaceUncached",
     params: [{ name: "wId", label: "Workspace sId", type: "string" }],
-    buildResolverKey: (p) => `workspace-region:${p.wId}`,
+    buildResolverKey: (p) => workspaceRegionCacheKeyResolver(p.wId),
   },
   provider_status: {
     label: "Provider Status",
     description: "Provider status for a region",
     fnName: "getProvidersStatus",
     params: [{ name: "region", label: "Region", type: "string" }],
-    buildResolverKey: (p) => `provider-status-${p.region}`,
+    buildResolverKey: (p) => providerStatusCacheKeyResolver(p.region),
   },
   dust_status: {
     label: "Dust Status",
     description: "Dust status for a region",
     fnName: "getDustStatus",
     params: [{ name: "region", label: "Region", type: "string" }],
-    buildResolverKey: (p) => `dust-status-${p.region}`,
+    buildResolverKey: (p) => dustStatusCacheKeyResolver(p.region),
   },
 };
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -500,7 +500,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   // Seat counting with caching - used to track active seats in a workspace
-  private static readonly seatsCacheKeyResolver = (workspaceId: string) =>
+  static readonly seatsCacheKeyResolver = (workspaceId: string) =>
     `count-active-seats-in-workspace:${workspaceId}`;
 
   static async countActiveSeatsInWorkspace(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -128,9 +128,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     );
   }
 
-  static readonly subscriptionCacheKeyResolver = (
-    workspaceModelId: ModelId
-  ) => `subscription:active:workspaceId:${workspaceModelId}`;
+  static readonly subscriptionCacheKeyResolver = (workspaceModelId: ModelId) =>
+    `subscription:active:workspaceId:${workspaceModelId}`;
 
   private static async _fetchActiveByWorkspaceModelIdUncached(
     workspaceModelId: ModelId

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -128,7 +128,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     );
   }
 
-  private static readonly subscriptionCacheKeyResolver = (
+  static readonly subscriptionCacheKeyResolver = (
     workspaceModelId: ModelId
   ) => `subscription:active:workspaceId:${workspaceModelId}`;
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -178,7 +178,7 @@ export class UserResource extends BaseResource<UserModel> {
     return user ? new UserResource(UserModel, user.get()) : null;
   }
 
-  private static readonly userByWorkOSIdCacheKeyResolver = (
+  static readonly userByWorkOSIdCacheKeyResolver = (
     workOSUserId: string
   ) => `user:workos:${workOSUserId}`;
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -178,9 +178,8 @@ export class UserResource extends BaseResource<UserModel> {
     return user ? new UserResource(UserModel, user.get()) : null;
   }
 
-  static readonly userByWorkOSIdCacheKeyResolver = (
-    workOSUserId: string
-  ) => `user:workos:${workOSUserId}`;
+  static readonly userByWorkOSIdCacheKeyResolver = (workOSUserId: string) =>
+    `user:workos:${workOSUserId}`;
 
   private static async _fetchByWorkOSUserIdUncached(
     workOSUserId: string

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -71,7 +71,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     this.blob = blob;
   }
 
-  private static readonly workspaceCacheKeyResolver = (wId: string) =>
+  static readonly workspaceCacheKeyResolver = (wId: string) =>
     `workspace:sid:${wId}`;
 
   private static async _fetchByIdUncached(

--- a/front/pages/api/poke/cache.ts
+++ b/front/pages/api/poke/cache.ts
@@ -2,6 +2,10 @@ import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { runOnRedis } from "@app/lib/api/redis";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import {
+  buildCacheRedisKey,
+  CACHE_REGISTRY,
+} from "@app/lib/poke/cache_registry";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -33,14 +37,47 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { rawKey } = req.query;
+      const { rawKey, type } = req.query;
 
-      if (!isString(rawKey)) {
+      let redisKey: string;
+
+      if (isString(rawKey)) {
+        redisKey = rawKey;
+      } else if (isString(type)) {
+        const entry = CACHE_REGISTRY[type];
+        if (!entry) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Unknown cache type: ${type}`,
+            },
+          });
+        }
+
+        const params: Record<string, string> = {};
+        for (const param of entry.params) {
+          const value = req.query[param.name];
+          if (!isString(value)) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: `Missing required parameter: ${param.name}`,
+              },
+            });
+          }
+          params[param.name] = value;
+        }
+
+        redisKey = buildCacheRedisKey(entry, params);
+      } else {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The 'rawKey' query parameter must be provided.",
+            message:
+              "Either 'rawKey' or 'type' query parameter must be provided.",
           },
         });
       }
@@ -49,8 +86,8 @@ async function handler(
         { origin: "poke_cache_lookup" },
         async (client) => {
           const [rawValue, ttl] = await Promise.all([
-            client.get(rawKey),
-            client.ttl(rawKey),
+            client.get(redisKey),
+            client.ttl(redisKey),
           ]);
 
           let parsed: unknown | null = null;
@@ -67,12 +104,12 @@ async function handler(
       );
 
       logger.info(
-        { redisKey: rawKey, found: value !== null },
+        { redisKey, found: value !== null },
         "Poke cache lookup performed"
       );
 
       return res.status(200).json({
-        key: rawKey,
+        key: redisKey,
         value,
         ttlSeconds,
       });

--- a/front/poke/swr/cache.ts
+++ b/front/poke/swr/cache.ts
@@ -3,11 +3,15 @@ import type { GetPokeCacheResponseBody } from "@app/pages/api/poke/cache";
 import type { Fetcher } from "swr";
 
 interface UsePokeCacheLookupParams {
+  type?: string;
+  params?: Record<string, string>;
   rawKey?: string;
   disabled?: boolean;
 }
 
 export function usePokeCacheLookup({
+  type,
+  params,
   rawKey,
   disabled,
 }: UsePokeCacheLookupParams) {
@@ -16,6 +20,13 @@ export function usePokeCacheLookup({
   const queryParams = new URLSearchParams();
   if (rawKey) {
     queryParams.set("rawKey", rawKey);
+  } else if (type) {
+    queryParams.set("type", type);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        queryParams.set(key, value);
+      }
+    }
   }
 
   const { data, error } = useSWRWithDefaults(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Add a cache registry mapping known cache types (workspace, subscription, membership role, etc.) to their Redis key patterns. The UI now has a structured mode with a type selector and dynamic parameter fields, in addition to the raw key mode.

<img width="1608" height="1045" alt="Capture d’écran 2026-02-18 à 16 14 17" src="https://github.com/user-attachments/assets/e9f6b37b-da81-43fb-aadd-2974ed2ca642" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy poke