### PR TITLE
[Infra rate limit] Add 512 subagent hard cap before starting a new step

### DIFF
--- a/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
+++ b/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
@@ -26,7 +26,7 @@ interface CostThresholdEventData {
   step: number;
 }
 
-export async function checkAndLogAgentLoopCostThresholds({
+export async function checkCostAndSubagentsThresholds({
   auth,
   isRootAgentMessage,
   eventData,

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -11,7 +11,7 @@ import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activiti
 import {
   AGENT_LOOP_COST_HARD_CAP_USD,
   AGENT_LOOP_SUBAGENT_HARD_CAP,
-  checkAndLogAgentLoopCostThresholds,
+  checkCostAndSubagentsThresholds,
 } from "@app/temporal/agent_loop/activities/cost_threshold_warnings";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
@@ -115,7 +115,7 @@ async function _runModelAndCreateActionsActivity({
     subagentHardCapExceeded: boolean;
   } | null = null;
   try {
-    hardCapCheckResult = await checkAndLogAgentLoopCostThresholds({
+    hardCapCheckResult = await checkCostAndSubagentsThresholds({
       auth,
       isRootAgentMessage,
       eventData: {

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -10,6 +10,7 @@ import tracer from "@app/logger/tracer";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import {
   AGENT_LOOP_COST_HARD_CAP_USD,
+  AGENT_LOOP_SUBAGENT_HARD_CAP,
   checkAndLogAgentLoopCostThresholds,
 } from "@app/temporal/agent_loop/activities/cost_threshold_warnings";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
@@ -36,7 +37,8 @@ export type RunModelAndCreateActionsResult = {
 };
 
 const AGENT_LOOP_COST_CAP_ERROR_CODE = "agent_loop_cost_cap_exceeded";
-const AGENT_LOOP_COST_CAP_ERROR_MESSAGE =
+const AGENT_LOOP_SUBAGENT_CAP_ERROR_CODE = "agent_loop_subagent_cap_exceeded";
+const AGENT_LOOP_RESOURCE_CAP_ERROR_MESSAGE =
   "This message used too many resources to continue. Start a new message with a narrower request.";
 
 /**
@@ -109,6 +111,8 @@ async function _runModelAndCreateActionsActivity({
   let hardCapCheckResult: {
     totalCostMicroUsd: number;
     hardCapExceeded: boolean;
+    subagentLaunchCount: number;
+    subagentHardCapExceeded: boolean;
   } | null = null;
   try {
     hardCapCheckResult = await checkAndLogAgentLoopCostThresholds({
@@ -129,10 +133,10 @@ async function _runModelAndCreateActionsActivity({
         step,
         error,
       },
-      "Failed to run cost-threshold check"
+      "Failed to run guardrail checks"
     );
     // Fail closed: do not start the next step when we cannot evaluate cost.
-    throw new Error("Failed to run cost-threshold check");
+    throw new Error("Failed to run guardrail checks");
   }
 
   if (hardCapCheckResult?.hardCapExceeded) {
@@ -147,11 +151,43 @@ async function _runModelAndCreateActionsActivity({
       "Agent loop hard cost cap exceeded before starting a new step"
     );
 
-    await publishAgentLoopCostCapExceededError(auth, {
+    await publishAgentLoopGuardrailExceededError(auth, {
       runAgentData,
       runIds,
       step,
-      totalCostMicroUsd: hardCapCheckResult.totalCostMicroUsd,
+      errorCode: AGENT_LOOP_COST_CAP_ERROR_CODE,
+      errorMetadata: {
+        category: "cost_cap",
+        thresholdUsd: AGENT_LOOP_COST_HARD_CAP_USD,
+        totalCostMicroUsd: hardCapCheckResult.totalCostMicroUsd,
+      },
+    });
+
+    return null;
+  }
+
+  if (hardCapCheckResult?.subagentHardCapExceeded) {
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        agentMessageId: runAgentArgs.agentMessageId,
+        conversationId: runAgentArgs.conversationId,
+        step,
+        subagentLaunchCount: hardCapCheckResult.subagentLaunchCount,
+      },
+      "Agent loop hard subagent cap exceeded before starting a new step"
+    );
+
+    await publishAgentLoopGuardrailExceededError(auth, {
+      runAgentData,
+      runIds,
+      step,
+      errorCode: AGENT_LOOP_SUBAGENT_CAP_ERROR_CODE,
+      errorMetadata: {
+        category: "subagent_cap",
+        thresholdCount: AGENT_LOOP_SUBAGENT_HARD_CAP,
+        subagentLaunchCount: hardCapCheckResult.subagentLaunchCount,
+      },
     });
 
     return null;
@@ -241,18 +277,20 @@ async function _runModelAndCreateActionsActivity({
   };
 }
 
-async function publishAgentLoopCostCapExceededError(
+async function publishAgentLoopGuardrailExceededError(
   auth: Authenticator,
   {
     runAgentData,
     runIds,
     step,
-    totalCostMicroUsd,
+    errorCode,
+    errorMetadata,
   }: {
     runAgentData: AgentLoopExecutionData;
     runIds: string[];
     step: number;
-    totalCostMicroUsd: number;
+    errorCode: string;
+    errorMetadata: Record<string, string | number | boolean>;
   }
 ): Promise<void> {
   await updateResourceAndPublishEvent(auth, {
@@ -262,13 +300,9 @@ async function publishAgentLoopCostCapExceededError(
       configurationId: runAgentData.agentConfiguration.sId,
       messageId: runAgentData.agentMessage.sId,
       error: {
-        code: AGENT_LOOP_COST_CAP_ERROR_CODE,
-        message: AGENT_LOOP_COST_CAP_ERROR_MESSAGE,
-        metadata: {
-          category: "cost_cap",
-          thresholdUsd: AGENT_LOOP_COST_HARD_CAP_USD,
-          totalCostMicroUsd,
-        },
+        code: errorCode,
+        message: AGENT_LOOP_RESOURCE_CAP_ERROR_MESSAGE,
+        metadata: errorMetadata,
       },
       runIds,
     },


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6606.
Related: https://github.com/dust-tt/tasks/issues/6520.
Follows https://github.com/dust-tt/dust/pull/21828.

Adds a root-message hard cap on total subagent launches at step start.

512 is chosen, see https://dust.tt/share/frame/96be0ea0-f1d6-4b4e-9288-791117e113b5 => long tail.

Implementation details:
- Reuses the existing descendant traversal in `cost_threshold_warnings` to compute both cumulative cost and descendant agentic launch count.
- Stops before starting a new step when descendant launch count is `>= 512`.
- Publishes an `agent_error` with the same non-technical user-facing copy style as the cost cap.
- Keeps fail-closed behavior when guardrail checks cannot be evaluated.

## Risks
Blast radius: agent loop step-start guardrails for root messages only.
Risk: low

## Deploy Plan
- deploy `front`

## Test
- [x] Non-interactive local CLI baseline: `dust` agent responds normally (`--noUpdateCheck`, `--details`).
- [x] Deterministic guardrail trigger with temporary local override `AGENT_LOOP_SUBAGENT_HARD_CAP=1`, then non-interactive `deep-dive` CLI prompt returns expected user-facing cap error.
- [x] DB verification on local front DB confirms latest row with `errorCode=agent_loop_subagent_cap_exceeded` and metadata containing `category=subagent_cap`, `thresholdCount`, `subagentLaunchCount`.
- [x] Local constant restored to `AGENT_LOOP_SUBAGENT_HARD_CAP=512` after verification.
