### PR TITLE
Anthropic streaming: allow eager input streaming to avoid hanging for 5 minutes without answer

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -149,6 +149,10 @@ export function toTool(tool: AgentActionSpecification): Tool {
   return {
     name: tool.name,
     description: tool.description,
+    // Eager input streaming allows the LLM to start streaming tool call arguments before
+    // the full input is generated, which avoid hanging for long tool call arguments generation.
+    // This is at the cost that JSON input can no longer be validated by Anthropic.
+    eager_input_streaming: true,
     input_schema: { ...tool.inputSchema, type: "object" },
   };
 }


### PR DESCRIPTION
## Description

Should solve https://github.com/dust-tt/tasks/issues/6570

Tested locally
The tool call is now streamed immediatly and progressively

https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming

## Tests

Manual tests

## Risk

May receive invalid JSON 
We do parse it to check it is a valid JSON with `parseToolArguments` method, so it is a reasonable risk IMHO

## Deploy Plan

deploy front
