### PR TITLE
refresh cookie in background

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -119,7 +119,14 @@ const getRefreshedCookie = cacheWithRedis(
     return `workos_session_refresh:${sha256(workOSSessionCookie)}`;
   },
   {
-    ttlMs: 60 * 10 * 1000,
+    // Fresh for 3min, stale for up to 4.5min.
+    // Must stay under the WorkOS access token lifetime (5min) so that
+    // the stale cookie's token is still valid when returned, avoiding
+    // recursive refresh chains.
+    // Between 3-4.5min: one request refreshes in the background,
+    // others return the stale (but still valid) cookie instantly.
+    ttlMs: 3 * 60 * 1000,
+    staleTtlMs: 4.5 * 60 * 1000,
     useDistributedLock: true,
   }
 );


### PR DESCRIPTION
## Description

The session refresh endpoint (`withSessionAuthentication`) was slow (~1s) due to Redis lock contention on `getRefreshedCookie`. The root causes:

1. **Cache TTL (10min) exceeded the WorkOS access token lifetime (5min):** After 5min, the cached refreshed cookie's token was expired, causing recursive refresh chains where the stale cached cookie triggered another full refresh cycle.

2. **Thundering herd on cache expiry:** When the cache expired, all concurrent requests for the same user blocked on a distributed lock spin-wait (100ms polling), while only one performed the actual WorkOS refresh.

### Changes

**`cacheWithRedis` — stale-while-revalidate support (`staleTtlMs` option):**
- New opt-in `staleTtlMs` parameter. When set, the value is stored with the longer `staleTtlMs` TTL, and a separate `fresh:<key>` marker tracks freshness with `ttlMs`.
- When the fresh marker expires but the value is still cached (stale window), **all requests return the stale value immediately** — zero blocking. One request acquires the lock and refreshes in the background via fire-and-forget.
- On full cache miss (first call or after `staleTtlMs` expires), falls back to synchronous refresh with distributed lock (existing behavior).
- `invalidateCacheWithRedis` and `batchInvalidateCacheWithRedis` now clean up the `fresh:` key alongside the main key.

**`cacheWithRedis` — reduced spin-wait (100ms → 20ms):**
- When requests must spin-wait for the lock owner (full cache miss path), the polling interval is reduced from 100ms to 20ms, cutting worst-case added latency per spin cycle.

**`getRefreshedCookie` — tuned TTLs:**
- `ttlMs`: 10min → 3min (fresh period)
- `staleTtlMs`: 4.5min (stale period, new)
- Both stay under the 5min WorkOS access token lifetime, ensuring the stale cookie's token is always valid when returned. This prevents the recursive refresh chains caused by the old 10min TTL.

### Timeline for a user's requests

| Time | What happens |
|------|-------------|
| 0-3min | Cache hit (fresh) → instant return |
| 3-4.5min | Cache hit (stale) → instant return for all. One background refresh updates cache. |
| >4.5min | Cache miss → synchronous refresh with lock (rare: only if no requests in the 1.5min stale window) |

## Tests

- [ ] Verify session authentication works normally (fresh cache path)
- [ ] Verify concurrent requests during stale window don't block
- [ ] Verify cache invalidation cleans up both value and `fresh:` keys
- [ ] Monitor DD traces for reduced latency on `withSessionAuthentication`

## Risk

Low-medium. The `staleTtlMs` feature is opt-in and only enabled for `getRefreshedCookie`. The stale cookie is guaranteed to have a valid token (< 5min old) thanks to the TTL constraint. The 30s buffer between `staleTtlMs` (4.5min) and token lifetime (5min) accounts for network latency.

Worst case if timing is off: a stale cookie's token expires, causing one recursive refresh (same as current behavior, not worse).

## Deploy Plan

Standard deploy, no migration needed. Monitor `withSessionAuthentication` latency in DD traces after deploy.