### PR TITLE
feat: bold project title when unread conversations

### DIFF
--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -115,7 +115,7 @@ const ProjectListItem = memo(
         icon={getSpaceIcon(space)}
         selected={isSpaceSelected && !isDragOver}
         label={space.name}
-        status={hasUnread ? "unread" : undefined}
+        hasActivity={hasUnread}
         count={unreadCount > 0 ? unreadCount : undefined}
         onClick={async () => {
           // Side bar is the floating sidebar that appears when the screen is small.


### PR DESCRIPTION






## Description

This PR updates the visual indication of unread conversations in projects

- Replaced the `status` with `hasActivity` prop in the `ProjectListItem` component, which will make project titles bold when there are unread conversations instead of using a blue dot.
<img width="366" height="124" alt="Capture d’écran 2026-02-18 à 16 45 02" src="https://github.com/user-attachments/assets/eeae60fe-9b46-4a25-9c84-8477e873338e" />

## Tests

Manually

## Risks

Low.
## Deploy Plan

Standard deployment.
