### PR TITLE
[Front] feat(copilot): use fastest whitelisted model for template search

### DIFF
--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -2,7 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { TemplateResource } from "@app/lib/resources/template_resource";
-import { getSmallWhitelistedModel } from "@app/types/assistant/assistant";
+import { getFastestWhitelistedModel } from "@app/types/assistant/assistant";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
@@ -68,7 +68,7 @@ export async function getSuggestedTemplatesForQuery(
 ): Promise<Result<TemplateResource[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = getSmallWhitelistedModel(owner);
+  const model = getFastestWhitelistedModel(owner);
   if (!model) {
     return new Err(
       new Error(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -4,6 +4,7 @@ import {
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
+  GEMINI_2_5_FLASH_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
   GEMINI_3_PRO_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
@@ -28,6 +29,18 @@ import {
   GROK_4_MODEL_CONFIG,
 } from "@app/types/assistant/models/xai";
 import type { WorkspaceType } from "@app/types/user";
+
+export function getFastestWhitelistedModel(
+  owner: WorkspaceType
+): ModelConfigurationType | null {
+  if (isProviderWhitelisted(owner, "mistral")) {
+    return MISTRAL_SMALL_MODEL_CONFIG;
+  }
+  if (isProviderWhitelisted(owner, "google_ai_studio")) {
+    return GEMINI_2_5_FLASH_MODEL_CONFIG;
+  }
+  return getSmallWhitelistedModel(owner);
+}
 
 export function getSmallWhitelistedModel(
   owner: WorkspaceType


### PR DESCRIPTION
## Description

Add `getFastestWhitelistedModel()` that prioritizes Mistral Small and Gemini 2.5 Flash instead of using `getSmallWhitelistedModel()` for template search.

Model choice based on [langfuse latencies observed](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc?dateRange=1d). For copilot, prioritize speed over slight quality differences—template search is trivial and benefits from low latency.