### PR TITLE
feat(front): Snowflake keypair auth via generic static credential registry

### DIFF
--- a/front/components/actions/mcp/MCPServerAuthConnection.tsx
+++ b/front/components/actions/mcp/MCPServerAuthConnection.tsx
@@ -87,7 +87,7 @@ export interface StaticCredentialConfig {
   >;
 }
 
-interface MCPServerOAuthConnexionProps {
+interface MCPServerAuthConnectionProps {
   toolName: string;
   // Authorization is always passed as a prop from the parent dialog.
   // It's managed via useState in the dialog (workflow state), not in form state.
@@ -99,12 +99,12 @@ interface MCPServerOAuthConnexionProps {
   staticCredentialConfig?: StaticCredentialConfig;
 }
 
-export function MCPServerOAuthConnexion({
+export function MCPServerAuthConnection({
   toolName,
   authorization,
   documentationUrl,
   staticCredentialConfig,
-}: MCPServerOAuthConnexionProps) {
+}: MCPServerAuthConnectionProps) {
   const { setError, clearErrors, setValue, control } =
     useFormContext<MCPServerOAuthFormValues>();
 
@@ -271,106 +271,13 @@ export function MCPServerOAuthConnexion({
           onCredentialCreated={staticCredentialConfig.onCredentialCreated}
         />
       ) : (
-        <>
-          <ProviderSetupInstructions
-            provider={authorization.provider}
-            useCase={useCase}
-          />
-
-          {inputs && (
-            <div className="w-full space-y-4 pt-4">
-              {Object.entries(inputs).map(([key, inputData]) => {
-                if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
-                  return null;
-                }
-
-                if (inputData.value || !isSupportedOAuthCredential(key)) {
-                  return null; // Skip pre-filled or unsupported credentials.
-                }
-
-                const value = authCredentials?.[key] ?? "";
-                const hasValidationError =
-                  value.length > 0 &&
-                  inputData.validator &&
-                  !inputData.validator(value);
-
-                return (
-                  <div key={key} className="w-full space-y-1">
-                    <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                      {inputData.label}
-                    </Label>
-                    <Input
-                      id={key}
-                      value={value}
-                      onChange={(e) =>
-                        handleCredentialChange(key, e.target.value)
-                      }
-                      message={inputData.helpMessage}
-                      messageStatus={hasValidationError ? "error" : undefined}
-                    />
-                  </div>
-                );
-              })}
-              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
-                <div className="w-full space-y-2">
-                  <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                    {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
-                  </Label>
-                  <div>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          isSelect
-                          label={
-                            TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.find(
-                              (option) =>
-                                option.value ===
-                                (authCredentials?.[
-                                  TOKEN_ENDPOINT_AUTH_METHOD_KEY
-                                ] ??
-                                  TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value)
-                            )?.label ??
-                            TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].label
-                          }
-                        />
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent>
-                        <DropdownMenuRadioGroup
-                          value={
-                            authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
-                            TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value
-                          }
-                        >
-                          {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => (
-                            <DropdownMenuRadioItem
-                              key={option.value}
-                              value={option.value}
-                              label={option.label}
-                              onClick={() =>
-                                handleCredentialChange(
-                                  TOKEN_ENDPOINT_AUTH_METHOD_KEY,
-                                  option.value
-                                )
-                              }
-                            />
-                          ))}
-                        </DropdownMenuRadioGroup>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
-                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-
-          <ProviderAuthNote provider={authorization.provider} />
-        </>
+        <OAuthCredentialFields
+          authorization={authorization}
+          useCase={useCase}
+          inputs={inputs}
+          authCredentials={authCredentials}
+          onCredentialChange={handleCredentialChange}
+        />
       )}
 
       {documentationUrl && (
@@ -383,6 +290,121 @@ export function MCPServerOAuthConnexion({
         </div>
       )}
     </div>
+  );
+}
+
+interface OAuthCredentialFieldsProps {
+  authorization: AuthorizationInfo;
+  useCase: MCPOAuthUseCase | null;
+  inputs: OAuthCredentialInputs | null;
+  authCredentials: OAuthCredentials | null;
+  onCredentialChange: (key: string, value: string) => void;
+}
+
+function OAuthCredentialFields({
+  authorization,
+  useCase,
+  inputs,
+  authCredentials,
+  onCredentialChange,
+}: OAuthCredentialFieldsProps) {
+  return (
+    <>
+      <ProviderSetupInstructions
+        provider={authorization.provider}
+        useCase={useCase}
+      />
+
+      {inputs && (
+        <div className="w-full space-y-4 pt-4">
+          {Object.entries(inputs).map(([key, inputData]) => {
+            if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
+              return null;
+            }
+
+            if (inputData.value || !isSupportedOAuthCredential(key)) {
+              return null; // Skip pre-filled or unsupported credentials.
+            }
+
+            const value = authCredentials?.[key] ?? "";
+            const hasValidationError =
+              value.length > 0 &&
+              inputData.validator &&
+              !inputData.validator(value);
+
+            return (
+              <div key={key} className="w-full space-y-1">
+                <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                  {inputData.label}
+                </Label>
+                <Input
+                  id={key}
+                  value={value}
+                  onChange={(e) => onCredentialChange(key, e.target.value)}
+                  message={inputData.helpMessage}
+                  messageStatus={hasValidationError ? "error" : undefined}
+                />
+              </div>
+            );
+          })}
+          {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
+            <div className="w-full space-y-2">
+              <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
+              </Label>
+              <div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      isSelect
+                      label={
+                        TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.find(
+                          (option) =>
+                            option.value ===
+                            (authCredentials?.[
+                              TOKEN_ENDPOINT_AUTH_METHOD_KEY
+                            ] ?? TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value)
+                        )?.label ?? TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].label
+                      }
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuRadioGroup
+                      value={
+                        authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
+                        TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value
+                      }
+                    >
+                      {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => (
+                        <DropdownMenuRadioItem
+                          key={option.value}
+                          value={option.value}
+                          label={option.label}
+                          onClick={() =>
+                            onCredentialChange(
+                              TOKEN_ENDPOINT_AUTH_METHOD_KEY,
+                              option.value
+                            )
+                          }
+                        />
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <ProviderAuthNote provider={authorization.provider} />
+    </>
   );
 }
 

--- a/front/components/actions/mcp/MCPServerAuthConnection.tsx
+++ b/front/components/actions/mcp/MCPServerAuthConnection.tsx
@@ -70,18 +70,16 @@ export const AUTH_CREDENTIALS_ERROR_KEY = "authCredentials" as const;
 export interface StaticCredentialFormProps {
   owner: LightWorkspaceType;
   onValidityChange: (isValid: boolean) => void;
-  onCredentialCreated: (credentialId: string) => void;
 }
 
 export interface StaticCredentialFormHandle {
-  submit: () => Promise<boolean>;
+  submit: () => Promise<string | null>;
 }
 
 export interface StaticCredentialConfig {
   owner: LightWorkspaceType;
   formRef: RefObject<StaticCredentialFormHandle>;
   onValidityChange: (isValid: boolean) => void;
-  onCredentialCreated: (credentialId: string) => void;
   FormComponent: ForwardRefExoticComponent<
     StaticCredentialFormProps & RefAttributes<StaticCredentialFormHandle>
   >;
@@ -268,7 +266,6 @@ export function MCPServerAuthConnection({
           ref={staticCredentialConfig.formRef}
           owner={staticCredentialConfig.owner}
           onValidityChange={staticCredentialConfig.onValidityChange}
-          onCredentialCreated={staticCredentialConfig.onCredentialCreated}
         />
       ) : (
         <OAuthCredentialFields

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -13,6 +13,7 @@ import {
   getProviderRequiredOAuthCredentialInputs,
   isSupportedOAuthCredential,
 } from "@app/types/oauth/lib";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   Card,
@@ -30,6 +31,11 @@ import {
   Tooltip,
   UserIcon,
 } from "@dust-tt/sparkle";
+import type {
+  ForwardRefExoticComponent,
+  RefAttributes,
+  RefObject,
+} from "react";
 import { useEffect, useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
@@ -61,18 +67,43 @@ const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
 // Parent components can check formState.errors[AUTH_CREDENTIALS_ERROR_KEY].
 export const AUTH_CREDENTIALS_ERROR_KEY = "authCredentials" as const;
 
+export interface StaticCredentialFormProps {
+  owner: LightWorkspaceType;
+  onValidityChange: (isValid: boolean) => void;
+  onCredentialCreated: (credentialId: string) => void;
+}
+
+export interface StaticCredentialFormHandle {
+  submit: () => Promise<boolean>;
+}
+
+export interface StaticCredentialConfig {
+  owner: LightWorkspaceType;
+  formRef: RefObject<StaticCredentialFormHandle>;
+  onValidityChange: (isValid: boolean) => void;
+  onCredentialCreated: (credentialId: string) => void;
+  FormComponent: ForwardRefExoticComponent<
+    StaticCredentialFormProps & RefAttributes<StaticCredentialFormHandle>
+  >;
+}
+
 interface MCPServerOAuthConnexionProps {
   toolName: string;
   // Authorization is always passed as a prop from the parent dialog.
   // It's managed via useState in the dialog (workflow state), not in form state.
   authorization: AuthorizationInfo;
   documentationUrl?: string;
+  // When provided, renders the FormComponent from this config in place of the
+  // OAuth credential inputs. The parent resolves the component (e.g. via a
+  // registry) and passes it here — no provider-specific logic in this file.
+  staticCredentialConfig?: StaticCredentialConfig;
 }
 
 export function MCPServerOAuthConnexion({
   toolName,
   authorization,
   documentationUrl,
+  staticCredentialConfig,
 }: MCPServerOAuthConnexionProps) {
   const { setError, clearErrors, setValue, control } =
     useFormContext<MCPServerOAuthFormValues>();
@@ -205,6 +236,9 @@ export function MCPServerOAuthConnexion({
     authorization.supported_use_cases.includes("platform_actions");
   const supportsBoth = supportsPersonalActions && supportsPlatformActions;
 
+  // The parent resolves the form component and includes it in the config.
+  const StaticFormComp = staticCredentialConfig?.FormComponent ?? null;
+
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="w-full space-y-4">
@@ -229,100 +263,115 @@ export function MCPServerOAuthConnexion({
         </div>
       </div>
 
-      <ProviderSetupInstructions
-        provider={authorization.provider}
-        useCase={useCase}
-      />
+      {StaticFormComp && staticCredentialConfig ? (
+        <StaticFormComp
+          ref={staticCredentialConfig.formRef}
+          owner={staticCredentialConfig.owner}
+          onValidityChange={staticCredentialConfig.onValidityChange}
+          onCredentialCreated={staticCredentialConfig.onCredentialCreated}
+        />
+      ) : (
+        <>
+          <ProviderSetupInstructions
+            provider={authorization.provider}
+            useCase={useCase}
+          />
 
-      {inputs && (
-        <div className="w-full space-y-4 pt-4">
-          {Object.entries(inputs).map(([key, inputData]) => {
-            if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
-              return null;
-            }
+          {inputs && (
+            <div className="w-full space-y-4 pt-4">
+              {Object.entries(inputs).map(([key, inputData]) => {
+                if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
+                  return null;
+                }
 
-            if (inputData.value || !isSupportedOAuthCredential(key)) {
-              return null; // Skip pre-filled or unsupported credentials.
-            }
+                if (inputData.value || !isSupportedOAuthCredential(key)) {
+                  return null; // Skip pre-filled or unsupported credentials.
+                }
 
-            const value = authCredentials?.[key] ?? "";
-            const hasValidationError =
-              value.length > 0 &&
-              inputData.validator &&
-              !inputData.validator(value);
+                const value = authCredentials?.[key] ?? "";
+                const hasValidationError =
+                  value.length > 0 &&
+                  inputData.validator &&
+                  !inputData.validator(value);
 
-            return (
-              <div key={key} className="w-full space-y-1">
-                <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                  {inputData.label}
-                </Label>
-                <Input
-                  id={key}
-                  value={value}
-                  onChange={(e) => handleCredentialChange(key, e.target.value)}
-                  message={inputData.helpMessage}
-                  messageStatus={hasValidationError ? "error" : undefined}
-                />
-              </div>
-            );
-          })}
-          {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
-            <div className="w-full space-y-2">
-              <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
-              </Label>
-              <div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      isSelect
-                      label={
-                        TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.find(
-                          (option) =>
-                            option.value ===
-                            (authCredentials?.[
-                              TOKEN_ENDPOINT_AUTH_METHOD_KEY
-                            ] ?? TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value)
-                        )?.label ?? TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].label
+                return (
+                  <div key={key} className="w-full space-y-1">
+                    <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                      {inputData.label}
+                    </Label>
+                    <Input
+                      id={key}
+                      value={value}
+                      onChange={(e) =>
+                        handleCredentialChange(key, e.target.value)
                       }
+                      message={inputData.helpMessage}
+                      messageStatus={hasValidationError ? "error" : undefined}
                     />
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    <DropdownMenuRadioGroup
-                      value={
-                        authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
-                        TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value
-                      }
-                    >
-                      {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => (
-                        <DropdownMenuRadioItem
-                          key={option.value}
-                          value={option.value}
-                          label={option.label}
-                          onClick={() =>
-                            handleCredentialChange(
-                              TOKEN_ENDPOINT_AUTH_METHOD_KEY,
-                              option.value
-                            )
+                  </div>
+                );
+              })}
+              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
+                <div className="w-full space-y-2">
+                  <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                    {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
+                  </Label>
+                  <div>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          isSelect
+                          label={
+                            TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.find(
+                              (option) =>
+                                option.value ===
+                                (authCredentials?.[
+                                  TOKEN_ENDPOINT_AUTH_METHOD_KEY
+                                ] ??
+                                  TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value)
+                            )?.label ??
+                            TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].label
                           }
                         />
-                      ))}
-                    </DropdownMenuRadioGroup>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
-                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        <DropdownMenuRadioGroup
+                          value={
+                            authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
+                            TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value
+                          }
+                        >
+                          {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => (
+                            <DropdownMenuRadioItem
+                              key={option.value}
+                              value={option.value}
+                              label={option.label}
+                              onClick={() =>
+                                handleCredentialChange(
+                                  TOKEN_ENDPOINT_AUTH_METHOD_KEY,
+                                  option.value
+                                )
+                              }
+                            />
+                          ))}
+                        </DropdownMenuRadioGroup>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
+                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
+                    </div>
+                  )}
                 </div>
               )}
             </div>
           )}
-        </div>
-      )}
 
-      <ProviderAuthNote provider={authorization.provider} />
+          <ProviderAuthNote provider={authorization.provider} />
+        </>
+      )}
 
       {documentationUrl && (
         <div className="w-full pt-6 text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -2,7 +2,7 @@ import { ConnectMCPServerDialog } from "@app/components/actions/mcp/create/Conne
 import {
   OAUTH_USE_CASE_TO_DESCRIPTION,
   OAUTH_USE_CASE_TO_LABEL,
-} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+} from "@app/components/actions/mcp/MCPServerAuthConnection";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   useDeleteMCPServerConnection,

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -272,6 +272,7 @@ export function ConnectMCPServerDialog({
       }
 
       setIsOpen(false);
+      resetState();
     } finally {
       setIsLoading(false);
       setExternalIsLoading(false);

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -6,11 +6,11 @@ import { getConnectMCPServerDialogDefaultValues } from "@app/components/actions/
 import type {
   StaticCredentialConfig,
   StaticCredentialFormHandle,
-} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+} from "@app/components/actions/mcp/MCPServerAuthConnection";
 import {
   AUTH_CREDENTIALS_ERROR_KEY,
-  MCPServerOAuthConnexion,
-} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+  MCPServerAuthConnection,
+} from "@app/components/actions/mcp/MCPServerAuthConnection";
 import type {
   CustomResourceIconType,
   InternalAllowedIconType,
@@ -72,7 +72,7 @@ export function ConnectMCPServerDialog({
     shouldUnregister: false,
   });
 
-  // Check for credential validation errors set by MCPServerOAuthConnexion.
+  // Check for credential validation errors set by MCPServerAuthConnection.
   const hasCredentialErrors =
     !!form.formState.errors[AUTH_CREDENTIALS_ERROR_KEY];
 
@@ -316,7 +316,7 @@ export function ConnectMCPServerDialog({
           </DialogHeader>
           <DialogContainer>
             {authorization && (
-              <MCPServerOAuthConnexion
+              <MCPServerAuthConnection
                 toolName={toolName}
                 authorization={authorization}
                 documentationUrl={

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -43,7 +43,7 @@ import {
   DialogTitle,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 interface ConnectMCPServerDialogProps {
@@ -217,51 +217,6 @@ export function ConnectMCPServerDialog({
     resetState();
   };
 
-  const handleStaticCredentialCreated = useCallback(
-    async (credentialId: string) => {
-      if (!authorization || !useCase) {
-        return;
-      }
-
-      setIsLoading(true);
-      setExternalIsLoading(true);
-
-      const connectionCreationRes = await createMCPServerConnection({
-        credentialId,
-        mcpServerId: mcpServerView.server.sId,
-        mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
-        provider: authorization.provider,
-      });
-      if (!connectionCreationRes) {
-        setIsLoading(false);
-        setExternalIsLoading(false);
-        return;
-      }
-
-      const updateServerViewRes = await updateServerView({
-        oAuthUseCase: useCase,
-      });
-      if (!updateServerViewRes) {
-        setIsLoading(false);
-        setExternalIsLoading(false);
-        return;
-      }
-
-      setExternalIsLoading(false);
-      setIsLoading(false);
-      setIsOpen(false);
-    },
-    [
-      authorization,
-      useCase,
-      mcpServerView,
-      setIsOpen,
-      setExternalIsLoading,
-      createMCPServerConnection,
-      updateServerView,
-    ]
-  );
-
   const staticFormRef = useRef<StaticCredentialFormHandle>(null);
   const [isStaticFormValid, setIsStaticFormValid] = useState(false);
 
@@ -280,20 +235,60 @@ export function ConnectMCPServerDialog({
         owner,
         formRef: staticFormRef,
         onValidityChange: setIsStaticFormValid,
-        onCredentialCreated: handleStaticCredentialCreated,
         FormComponent: staticFormComponent,
       };
-    }, [owner, handleStaticCredentialCreated, staticFormComponent]);
+    }, [owner, staticFormComponent]);
 
   // Form is valid when: use case selected AND either OAuth or static form is valid.
   const isFormValid =
     !!useCase && (hasStaticForm ? isStaticFormValid : !hasCredentialErrors);
 
+  const handleStaticCredentialSave = async () => {
+    if (!authorization || !useCase) {
+      return;
+    }
+
+    setIsLoading(true);
+    setExternalIsLoading(true);
+
+    const credentialId = await staticFormRef.current?.submit();
+    if (!credentialId) {
+      setIsLoading(false);
+      setExternalIsLoading(false);
+      return;
+    }
+
+    const connectionCreationRes = await createMCPServerConnection({
+      credentialId,
+      mcpServerId: mcpServerView.server.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
+      provider: authorization.provider,
+    });
+    if (!connectionCreationRes) {
+      setIsLoading(false);
+      setExternalIsLoading(false);
+      return;
+    }
+
+    const updateServerViewRes = await updateServerView({
+      oAuthUseCase: useCase,
+    });
+    if (!updateServerViewRes) {
+      setIsLoading(false);
+      setExternalIsLoading(false);
+      return;
+    }
+
+    setExternalIsLoading(false);
+    setIsLoading(false);
+    setIsOpen(false);
+  };
+
   const handleRightButtonClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (hasStaticForm) {
-      void staticFormRef.current?.submit();
+      void handleStaticCredentialSave();
     } else {
       void form.handleSubmit(handleOAuthSave)();
     }

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -1,7 +1,12 @@
+import { getStaticCredentialForm } from "@app/components/actions/mcp/create/static_credential_forms";
 import { submitConnectMCPServerDialogForm } from "@app/components/actions/mcp/forms/submitConnectMCPServerDialogForm";
 import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms/types";
 import { mcpServerOAuthFormSchema } from "@app/components/actions/mcp/forms/types";
 import { getConnectMCPServerDialogDefaultValues } from "@app/components/actions/mcp/forms/utils";
+import type {
+  StaticCredentialConfig,
+  StaticCredentialFormHandle,
+} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import {
   AUTH_CREDENTIALS_ERROR_KEY,
   MCPServerOAuthConnexion,
@@ -38,7 +43,7 @@ import {
   DialogTitle,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 interface ConnectMCPServerDialogProps {
@@ -84,6 +89,7 @@ export function ConnectMCPServerDialog({
   const [authorization, setAuthorization] = useState<AuthorizationInfo | null>(
     null
   );
+
   const { createMCPServerConnection } = useCreateMCPServerConnection({
     owner,
     connectionType: "workspace",
@@ -173,11 +179,12 @@ export function ConnectMCPServerDialog({
     setExternalIsLoading(false);
     form.reset(defaultValues);
     setIsLoading(false);
+    setIsStaticFormValid(false);
     setRemoteMCPServerOAuthDiscoveryDone(false);
     setAuthorization(null);
   };
 
-  const handleSave = async (values: MCPServerOAuthFormValues) => {
+  const handleOAuthSave = async (values: MCPServerOAuthFormValues) => {
     if (!authorization) {
       return;
     }
@@ -210,8 +217,87 @@ export function ConnectMCPServerDialog({
     resetState();
   };
 
-  // Form is valid when: use case selected AND no credential validation errors.
-  const isFormValid = !!useCase && !hasCredentialErrors;
+  const handleStaticCredentialCreated = useCallback(
+    async (credentialId: string) => {
+      if (!authorization || !useCase) {
+        return;
+      }
+
+      setIsLoading(true);
+      setExternalIsLoading(true);
+
+      const connectionCreationRes = await createMCPServerConnection({
+        credentialId,
+        mcpServerId: mcpServerView.server.sId,
+        mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
+        provider: authorization.provider,
+      });
+      if (!connectionCreationRes) {
+        setIsLoading(false);
+        setExternalIsLoading(false);
+        return;
+      }
+
+      const updateServerViewRes = await updateServerView({
+        oAuthUseCase: useCase,
+      });
+      if (!updateServerViewRes) {
+        setIsLoading(false);
+        setExternalIsLoading(false);
+        return;
+      }
+
+      setExternalIsLoading(false);
+      setIsLoading(false);
+      setIsOpen(false);
+    },
+    [
+      authorization,
+      useCase,
+      mcpServerView,
+      setIsOpen,
+      setExternalIsLoading,
+      createMCPServerConnection,
+      updateServerView,
+    ]
+  );
+
+  const staticFormRef = useRef<StaticCredentialFormHandle>(null);
+  const [isStaticFormValid, setIsStaticFormValid] = useState(false);
+
+  const staticFormComponent =
+    authorization && useCase
+      ? getStaticCredentialForm(authorization.provider, useCase)
+      : null;
+  const hasStaticForm = !!staticFormComponent;
+
+  const staticCredentialConfig: StaticCredentialConfig | undefined =
+    useMemo(() => {
+      if (!staticFormComponent) {
+        return undefined;
+      }
+      return {
+        owner,
+        formRef: staticFormRef,
+        onValidityChange: setIsStaticFormValid,
+        onCredentialCreated: handleStaticCredentialCreated,
+        FormComponent: staticFormComponent,
+      };
+    }, [owner, handleStaticCredentialCreated, staticFormComponent]);
+
+  // Form is valid when: use case selected AND either OAuth or static form is valid.
+  const isFormValid =
+    !!useCase && (hasStaticForm ? isStaticFormValid : !hasCredentialErrors);
+
+  const handleRightButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (hasStaticForm) {
+      void staticFormRef.current?.submit();
+    } else {
+      void form.handleSubmit(handleOAuthSave)();
+    }
+  };
 
   return (
     <Dialog
@@ -236,6 +322,7 @@ export function ConnectMCPServerDialog({
                 documentationUrl={
                   mcpServerView.server?.documentationUrl ?? undefined
                 }
+                staticCredentialConfig={staticCredentialConfig}
               />
             )}
           </DialogContainer>
@@ -249,14 +336,9 @@ export function ConnectMCPServerDialog({
               authorization
                 ? {
                     isLoading: isLoading,
-                    label: "Setup connection",
+                    label: hasStaticForm ? "Connect" : "Setup connection",
                     variant: "primary",
-                    onClick: (e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      // handleSubmit gates on form validity (including errors set via setError).
-                      void form.handleSubmit(handleSave)();
-                    },
+                    onClick: handleRightButtonClick,
                     disabled: !isFormValid || isLoading,
                   }
                 : undefined

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -227,17 +227,14 @@ export function ConnectMCPServerDialog({
   const hasStaticForm = !!staticFormComponent;
 
   const staticCredentialConfig: StaticCredentialConfig | undefined =
-    useMemo(() => {
-      if (!staticFormComponent) {
-        return undefined;
-      }
-      return {
-        owner,
-        formRef: staticFormRef,
-        onValidityChange: setIsStaticFormValid,
-        FormComponent: staticFormComponent,
-      };
-    }, [owner, staticFormComponent]);
+    staticFormComponent
+      ? {
+          owner,
+          formRef: staticFormRef,
+          onValidityChange: setIsStaticFormValid,
+          FormComponent: staticFormComponent,
+        }
+      : undefined;
 
   // Form is valid when: use case selected AND either OAuth or static form is valid.
   const isFormValid =
@@ -251,37 +248,34 @@ export function ConnectMCPServerDialog({
     setIsLoading(true);
     setExternalIsLoading(true);
 
-    const credentialId = await staticFormRef.current?.submit();
-    if (!credentialId) {
+    try {
+      const credentialId = await staticFormRef.current?.submit();
+      if (!credentialId) {
+        return;
+      }
+
+      const connectionCreationRes = await createMCPServerConnection({
+        credentialId,
+        mcpServerId: mcpServerView.server.sId,
+        mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
+        provider: authorization.provider,
+      });
+      if (!connectionCreationRes) {
+        return;
+      }
+
+      const updateServerViewRes = await updateServerView({
+        oAuthUseCase: useCase,
+      });
+      if (!updateServerViewRes) {
+        return;
+      }
+
+      setIsOpen(false);
+    } finally {
       setIsLoading(false);
       setExternalIsLoading(false);
-      return;
     }
-
-    const connectionCreationRes = await createMCPServerConnection({
-      credentialId,
-      mcpServerId: mcpServerView.server.sId,
-      mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
-      provider: authorization.provider,
-    });
-    if (!connectionCreationRes) {
-      setIsLoading(false);
-      setExternalIsLoading(false);
-      return;
-    }
-
-    const updateServerViewRes = await updateServerView({
-      oAuthUseCase: useCase,
-    });
-    if (!updateServerViewRes) {
-      setIsLoading(false);
-      setExternalIsLoading(false);
-      return;
-    }
-
-    setExternalIsLoading(false);
-    setIsLoading(false);
-    setIsOpen(false);
   };
 
   const handleRightButtonClick = (e: React.MouseEvent) => {

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -302,6 +302,7 @@ export function CreateMCPServerDialog({
       });
       setMCPServerToShow(createdServer);
       setIsOpen(false);
+      resetState();
     } finally {
       setIsLoading(false);
       setExternalIsLoading(false);

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -45,7 +45,7 @@ import {
   DialogTitle,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 function getSubmitButtonLabel(
@@ -121,8 +121,6 @@ export function CreateMCPServerDialog({
     setRemoteMCPServerOAuthDiscoveryDone,
   ] = useState(false);
 
-  const createdServerRef = useRef<MCPServerType | null>(null);
-
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
   const { createInternalMCPServer } = useCreateInternalMCPServer(owner);
@@ -151,7 +149,6 @@ export function CreateMCPServerDialog({
     setAuthorization(null);
     setRemoteMCPServerOAuthDiscoveryDone(false);
     setIsStaticFormValid(false);
-    createdServerRef.current = null;
     // Reset form state.
     form.reset(defaultValues);
   };
@@ -236,48 +233,30 @@ export function CreateMCPServerDialog({
     return DEFAULT_MCP_SERVER_ICON;
   }, [internalMCPServer, defaultServerConfig]);
 
-  const handleStaticCredentialCreated = useCallback(
-    async (credentialId: string) => {
-      const createdServer = createdServerRef.current;
-      if (!authorization || !useCase || !createdServer) {
-        return;
-      }
+  const staticFormRef = useRef<StaticCredentialFormHandle>(null);
+  const [isStaticFormValid, setIsStaticFormValid] = useState(false);
 
-      const connectionCreationRes = await createMCPServerConnection({
-        credentialId,
-        mcpServerId: createdServer.sId,
-        mcpServerDisplayName: getMcpServerDisplayName(createdServer),
-        provider: authorization.provider,
-      });
-      if (!connectionCreationRes) {
-        setIsLoading(false);
-        setExternalIsLoading(false);
-        return;
-      }
+  const staticFormComponent =
+    authorization && useCase
+      ? getStaticCredentialForm(authorization.provider, useCase)
+      : null;
+  const hasStaticForm = !!staticFormComponent;
 
-      sendNotification({
-        title: "Success",
-        type: "success",
-        description: `${getMcpServerDisplayName(createdServer)} added successfully.`,
-      });
-      setMCPServerToShow(createdServer);
-      setExternalIsLoading(false);
-      setIsLoading(false);
-      setIsOpen(false);
-    },
-    [
-      authorization,
-      useCase,
-      setIsOpen,
-      setExternalIsLoading,
-      setMCPServerToShow,
-      createMCPServerConnection,
-      sendNotification,
-    ]
-  );
+  const staticCredentialConfig: StaticCredentialConfig | undefined =
+    useMemo(() => {
+      if (!staticFormComponent) {
+        return undefined;
+      }
+      return {
+        owner,
+        formRef: staticFormRef,
+        onValidityChange: setIsStaticFormValid,
+        FormComponent: staticFormComponent,
+      };
+    }, [owner, staticFormComponent]);
 
   const handleCreateServerAndSubmitStaticCredentials = async () => {
-    if (!internalMCPServer || !useCase) {
+    if (!internalMCPServer || !authorization || !useCase) {
       return;
     }
 
@@ -302,39 +281,38 @@ export function CreateMCPServerDialog({
       return;
     }
 
-    // Store created server so handleStaticCredentialCreated can use it.
-    createdServerRef.current = createRes.value.server;
+    const createdServer = createRes.value.server;
 
-    // Trigger the static form submission (creates credential, calls onCredentialCreated).
-    const success = await staticFormRef.current?.submit();
-    if (!success) {
+    // Submit the static credential form — returns credentialId or null.
+    const credentialId = await staticFormRef.current?.submit();
+    if (!credentialId) {
       setIsLoading(false);
       setExternalIsLoading(false);
+      return;
     }
+
+    const connectionCreationRes = await createMCPServerConnection({
+      credentialId,
+      mcpServerId: createdServer.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(createdServer),
+      provider: authorization.provider,
+    });
+    if (!connectionCreationRes) {
+      setIsLoading(false);
+      setExternalIsLoading(false);
+      return;
+    }
+
+    sendNotification({
+      title: "Success",
+      type: "success",
+      description: `${getMcpServerDisplayName(createdServer)} added successfully.`,
+    });
+    setMCPServerToShow(createdServer);
+    setExternalIsLoading(false);
+    setIsLoading(false);
+    setIsOpen(false);
   };
-
-  const staticFormRef = useRef<StaticCredentialFormHandle>(null);
-  const [isStaticFormValid, setIsStaticFormValid] = useState(false);
-
-  const staticFormComponent =
-    authorization && useCase
-      ? getStaticCredentialForm(authorization.provider, useCase)
-      : null;
-  const hasStaticForm = !!staticFormComponent;
-
-  const staticCredentialConfig: StaticCredentialConfig | undefined =
-    useMemo(() => {
-      if (!staticFormComponent) {
-        return undefined;
-      }
-      return {
-        owner,
-        formRef: staticFormRef,
-        onValidityChange: setIsStaticFormValid,
-        onCredentialCreated: handleStaticCredentialCreated,
-        FormComponent: staticFormComponent,
-      };
-    }, [owner, handleStaticCredentialCreated, staticFormComponent]);
 
   // When OAuth is required (authorization is set), form is valid when:
   // - use case is selected AND either static form or OAuth credentials are valid.

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -1,6 +1,7 @@
 import { CustomHeadersConfigurationSection } from "@app/components/actions/mcp/create/CustomHeadersConfigurationSection";
 import { InternalBearerTokenSection } from "@app/components/actions/mcp/create/InternalBearerTokenSection";
 import { RemoteMCPServerConfigurationSection } from "@app/components/actions/mcp/create/RemoteMCPServerConfigurationSection";
+import { getStaticCredentialForm } from "@app/components/actions/mcp/create/static_credential_forms";
 import { submitCreateMCPServerDialogForm } from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
 import { createMCPServerDialogFormSchema } from "@app/components/actions/mcp/forms/types";
@@ -8,6 +9,10 @@ import {
   getCreateMCPServerDialogDefaultValues,
   handleCreateMCPServerDialogSubmitError,
 } from "@app/components/actions/mcp/forms/utils";
+import type {
+  StaticCredentialConfig,
+  StaticCredentialFormHandle,
+} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import {
   AUTH_CREDENTIALS_ERROR_KEY,
   MCPServerOAuthConnexion,
@@ -26,6 +31,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
   useCreateInternalMCPServer,
+  useCreateMCPServerConnection,
   useCreateRemoteMCPServer,
   useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
@@ -39,7 +45,7 @@ import {
   DialogTitle,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 
 function getSubmitButtonLabel(
@@ -115,9 +121,15 @@ export function CreateMCPServerDialog({
     setRemoteMCPServerOAuthDiscoveryDone,
   ] = useState(false);
 
+  const createdServerRef = useRef<MCPServerType | null>(null);
+
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
   const { createInternalMCPServer } = useCreateInternalMCPServer(owner);
+  const { createMCPServerConnection } = useCreateMCPServerConnection({
+    owner,
+    connectionType: "workspace",
+  });
 
   useEffect(() => {
     if (isOpen) {
@@ -138,6 +150,8 @@ export function CreateMCPServerDialog({
     // Reset workflow state (useState).
     setAuthorization(null);
     setRemoteMCPServerOAuthDiscoveryDone(false);
+    setIsStaticFormValid(false);
+    createdServerRef.current = null;
     // Reset form state.
     form.reset(defaultValues);
   };
@@ -222,10 +236,112 @@ export function CreateMCPServerDialog({
     return DEFAULT_MCP_SERVER_ICON;
   }, [internalMCPServer, defaultServerConfig]);
 
+  const handleStaticCredentialCreated = useCallback(
+    async (credentialId: string) => {
+      const createdServer = createdServerRef.current;
+      if (!authorization || !useCase || !createdServer) {
+        return;
+      }
+
+      const connectionCreationRes = await createMCPServerConnection({
+        credentialId,
+        mcpServerId: createdServer.sId,
+        mcpServerDisplayName: getMcpServerDisplayName(createdServer),
+        provider: authorization.provider,
+      });
+      if (!connectionCreationRes) {
+        setIsLoading(false);
+        setExternalIsLoading(false);
+        return;
+      }
+
+      sendNotification({
+        title: "Success",
+        type: "success",
+        description: `${getMcpServerDisplayName(createdServer)} added successfully.`,
+      });
+      setMCPServerToShow(createdServer);
+      setExternalIsLoading(false);
+      setIsLoading(false);
+      setIsOpen(false);
+    },
+    [
+      authorization,
+      useCase,
+      setIsOpen,
+      setExternalIsLoading,
+      setMCPServerToShow,
+      createMCPServerConnection,
+      sendNotification,
+    ]
+  );
+
+  const handleCreateServerAndSubmitStaticCredentials = async () => {
+    if (!internalMCPServer || !useCase) {
+      return;
+    }
+
+    setIsLoading(true);
+    setExternalIsLoading(true);
+
+    // Create the internal server without an OAuth connection.
+    const createRes = await createInternalMCPServer({
+      name: internalMCPServer.name,
+      useCase,
+      includeGlobal: true,
+    });
+
+    if (createRes.isErr()) {
+      sendNotification({
+        type: "error",
+        title: "Failed to create server",
+        description: createRes.error.message,
+      });
+      setIsLoading(false);
+      setExternalIsLoading(false);
+      return;
+    }
+
+    // Store created server so handleStaticCredentialCreated can use it.
+    createdServerRef.current = createRes.value.server;
+
+    // Trigger the static form submission (creates credential, calls onCredentialCreated).
+    const success = await staticFormRef.current?.submit();
+    if (!success) {
+      setIsLoading(false);
+      setExternalIsLoading(false);
+    }
+  };
+
+  const staticFormRef = useRef<StaticCredentialFormHandle>(null);
+  const [isStaticFormValid, setIsStaticFormValid] = useState(false);
+
+  const staticFormComponent =
+    authorization && useCase
+      ? getStaticCredentialForm(authorization.provider, useCase)
+      : null;
+  const hasStaticForm = !!staticFormComponent;
+
+  const staticCredentialConfig: StaticCredentialConfig | undefined =
+    useMemo(() => {
+      if (!staticFormComponent) {
+        return undefined;
+      }
+      return {
+        owner,
+        formRef: staticFormRef,
+        onValidityChange: setIsStaticFormValid,
+        onCredentialCreated: handleStaticCredentialCreated,
+        FormComponent: staticFormComponent,
+      };
+    }, [owner, handleStaticCredentialCreated, staticFormComponent]);
+
   // When OAuth is required (authorization is set), form is valid when:
-  // - use case is selected AND no credential validation errors.
+  // - use case is selected AND either static form or OAuth credentials are valid.
   // When no OAuth needed (no authorization), form is always valid for OAuth fields.
-  const isOAuthValid = authorization ? !!useCase && !hasCredentialErrors : true;
+  const isOAuthValid = authorization
+    ? !!useCase && (hasStaticForm ? isStaticFormValid : !hasCredentialErrors)
+    : true;
   const isSubmitDisabled = !isOAuthValid || isLoading;
 
   return (
@@ -260,6 +376,7 @@ export function CreateMCPServerDialog({
                   documentationUrl={
                     internalMCPServer?.documentationUrl ?? undefined
                   }
+                  staticCredentialConfig={staticCredentialConfig}
                 />
               )}
 
@@ -287,18 +404,24 @@ export function CreateMCPServerDialog({
             }}
             rightButtonProps={{
               isLoading: isLoading,
-              label: getSubmitButtonLabel(
-                isLoading,
-                authorization,
-                defaultServerConfig
-              ),
+              label: hasStaticForm
+                ? "Connect"
+                : getSubmitButtonLabel(
+                    isLoading,
+                    authorization,
+                    defaultServerConfig
+                  ),
               variant: "primary",
               disabled: isSubmitDisabled,
               onClick: (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                // handleSubmit gates on form validity (including errors set via setError).
-                void form.handleSubmit(handleSave)();
+                if (hasStaticForm) {
+                  void handleCreateServerAndSubmitStaticCredentials();
+                } else {
+                  // handleSubmit gates on form validity (including errors set via setError).
+                  void form.handleSubmit(handleSave)();
+                }
               },
             }}
           />

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -12,11 +12,11 @@ import {
 import type {
   StaticCredentialConfig,
   StaticCredentialFormHandle,
-} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+} from "@app/components/actions/mcp/MCPServerAuthConnection";
 import {
   AUTH_CREDENTIALS_ERROR_KEY,
-  MCPServerOAuthConnexion,
-} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+  MCPServerAuthConnection,
+} from "@app/components/actions/mcp/MCPServerAuthConnection";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -99,7 +99,7 @@ export function CreateMCPServerDialog({
     shouldUnregister: false,
   });
 
-  // Check for credential validation errors set by MCPServerOAuthConnexion.
+  // Check for credential validation errors set by MCPServerAuthConnection.
   const hasCredentialErrors =
     !!form.formState.errors[AUTH_CREDENTIALS_ERROR_KEY];
 
@@ -370,7 +370,7 @@ export function CreateMCPServerDialog({
                 )}
 
               {authorization && (
-                <MCPServerOAuthConnexion
+                <MCPServerAuthConnection
                   toolName={toolName}
                   authorization={authorization}
                   documentationUrl={

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -243,17 +243,14 @@ export function CreateMCPServerDialog({
   const hasStaticForm = !!staticFormComponent;
 
   const staticCredentialConfig: StaticCredentialConfig | undefined =
-    useMemo(() => {
-      if (!staticFormComponent) {
-        return undefined;
-      }
-      return {
-        owner,
-        formRef: staticFormRef,
-        onValidityChange: setIsStaticFormValid,
-        FormComponent: staticFormComponent,
-      };
-    }, [owner, staticFormComponent]);
+    staticFormComponent
+      ? {
+          owner,
+          formRef: staticFormRef,
+          onValidityChange: setIsStaticFormValid,
+          FormComponent: staticFormComponent,
+        }
+      : undefined;
 
   const handleCreateServerAndSubmitStaticCredentials = async () => {
     if (!internalMCPServer || !authorization || !useCase) {
@@ -263,55 +260,52 @@ export function CreateMCPServerDialog({
     setIsLoading(true);
     setExternalIsLoading(true);
 
-    // Create the internal server without an OAuth connection.
-    const createRes = await createInternalMCPServer({
-      name: internalMCPServer.name,
-      useCase,
-      includeGlobal: true,
-    });
-
-    if (createRes.isErr()) {
-      sendNotification({
-        type: "error",
-        title: "Failed to create server",
-        description: createRes.error.message,
+    try {
+      // Create the internal server without an OAuth connection.
+      const createRes = await createInternalMCPServer({
+        name: internalMCPServer.name,
+        useCase,
+        includeGlobal: true,
       });
+
+      if (createRes.isErr()) {
+        sendNotification({
+          type: "error",
+          title: "Failed to create server",
+          description: createRes.error.message,
+        });
+        return;
+      }
+
+      const createdServer = createRes.value.server;
+
+      // Submit the static credential form — returns credentialId or null.
+      const credentialId = await staticFormRef.current?.submit();
+      if (!credentialId) {
+        return;
+      }
+
+      const connectionCreationRes = await createMCPServerConnection({
+        credentialId,
+        mcpServerId: createdServer.sId,
+        mcpServerDisplayName: getMcpServerDisplayName(createdServer),
+        provider: authorization.provider,
+      });
+      if (!connectionCreationRes) {
+        return;
+      }
+
+      sendNotification({
+        title: "Success",
+        type: "success",
+        description: `${getMcpServerDisplayName(createdServer)} added successfully.`,
+      });
+      setMCPServerToShow(createdServer);
+      setIsOpen(false);
+    } finally {
       setIsLoading(false);
       setExternalIsLoading(false);
-      return;
     }
-
-    const createdServer = createRes.value.server;
-
-    // Submit the static credential form — returns credentialId or null.
-    const credentialId = await staticFormRef.current?.submit();
-    if (!credentialId) {
-      setIsLoading(false);
-      setExternalIsLoading(false);
-      return;
-    }
-
-    const connectionCreationRes = await createMCPServerConnection({
-      credentialId,
-      mcpServerId: createdServer.sId,
-      mcpServerDisplayName: getMcpServerDisplayName(createdServer),
-      provider: authorization.provider,
-    });
-    if (!connectionCreationRes) {
-      setIsLoading(false);
-      setExternalIsLoading(false);
-      return;
-    }
-
-    sendNotification({
-      title: "Success",
-      type: "success",
-      description: `${getMcpServerDisplayName(createdServer)} added successfully.`,
-    });
-    setMCPServerToShow(createdServer);
-    setExternalIsLoading(false);
-    setIsLoading(false);
-    setIsOpen(false);
   };
 
   // When OAuth is required (authorization is set), form is valid when:

--- a/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
+++ b/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
@@ -1,0 +1,178 @@
+import type { StaticCredentialFormHandle } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { PostCredentialsResponseBody } from "@app/pages/api/w/[wId]/credentials";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isAPIErrorResponse } from "@app/types/error";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Input, TextArea } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+const snowflakeKeypairFormSchema = z.object({
+  account: z.string().min(1, "Account is required."),
+  username: z.string().min(1, "Username is required."),
+  role: z.string().min(1, "Role is required."),
+  warehouse: z.string().min(1, "Warehouse is required."),
+  privateKey: z.string().min(1, "Private key is required."),
+  privateKeyPassphrase: z.string().optional(),
+});
+
+type SnowflakeKeypairFormValues = z.infer<typeof snowflakeKeypairFormSchema>;
+
+interface SnowflakeKeypairCredentialFormProps {
+  owner: LightWorkspaceType;
+  onValidityChange: (isValid: boolean) => void;
+  onCredentialCreated: (credentialId: string) => void;
+}
+
+export const SnowflakeKeypairCredentialForm = forwardRef<
+  StaticCredentialFormHandle,
+  SnowflakeKeypairCredentialFormProps
+>(function SnowflakeKeypairCredentialForm(
+  { owner, onValidityChange, onCredentialCreated },
+  ref
+) {
+  const sendNotification = useSendNotification();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const lastReportedValidity = useRef<boolean | null>(null);
+
+  const form = useForm<SnowflakeKeypairFormValues>({
+    resolver: zodResolver(snowflakeKeypairFormSchema),
+    defaultValues: {
+      account: "",
+      username: "",
+      role: "",
+      warehouse: "",
+      privateKey: "",
+      privateKeyPassphrase: "",
+    },
+    mode: "onChange",
+  });
+
+  const isValid = form.formState.isValid && !isSubmitting;
+
+  useEffect(() => {
+    if (lastReportedValidity.current !== isValid) {
+      lastReportedValidity.current = isValid;
+      onValidityChange(isValid);
+    }
+  }, [isValid, onValidityChange]);
+
+  const handleSave = async (
+    values: SnowflakeKeypairFormValues
+  ): Promise<boolean> => {
+    setIsSubmitting(true);
+
+    try {
+      const response = await clientFetch(`/api/w/${owner.sId}/credentials`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: "snowflake",
+          credentials: {
+            auth_type: "keypair",
+            username: values.username,
+            account: values.account,
+            role: values.role,
+            warehouse: values.warehouse,
+            private_key: values.privateKey,
+            private_key_passphrase: values.privateKeyPassphrase,
+          },
+        }),
+      });
+
+      const result: WithAPIErrorResponse<PostCredentialsResponseBody> =
+        await response.json();
+
+      if (!response.ok || isAPIErrorResponse(result)) {
+        sendNotification({
+          type: "error",
+          title: "Failed to save Snowflake credentials",
+          description: isAPIErrorResponse(result)
+            ? result.error.message
+            : "An error occurred.",
+        });
+        return false;
+      }
+
+      onCredentialCreated(result.credentials.id);
+      return true;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  useImperativeHandle(ref, () => ({
+    submit: async () => {
+      let success = false;
+      await form.handleSubmit(async (values) => {
+        success = await handleSave(values);
+      })();
+      return success;
+    },
+  }));
+
+  return (
+    <div className="w-full space-y-5 text-foreground dark:text-foreground-night">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Enter credentials for a Snowflake service user configured for key-pair
+        authentication.
+      </p>
+
+      <Input
+        {...form.register("account")}
+        label="Account"
+        placeholder="abc123.us-east-1"
+        isError={!!form.formState.errors.account}
+        message={form.formState.errors.account?.message}
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <Input
+          {...form.register("username")}
+          label="Username"
+          isError={!!form.formState.errors.username}
+          message={form.formState.errors.username?.message}
+        />
+        <Input
+          {...form.register("role")}
+          label="Role"
+          isError={!!form.formState.errors.role}
+          message={form.formState.errors.role?.message}
+        />
+      </div>
+      <Input
+        {...form.register("warehouse")}
+        label="Warehouse"
+        isError={!!form.formState.errors.warehouse}
+        message={form.formState.errors.warehouse?.message}
+      />
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Private key (PEM format)</label>
+        <TextArea
+          {...form.register("privateKey")}
+          placeholder="-----BEGIN PRIVATE KEY-----"
+          rows={8}
+        />
+        {form.formState.errors.privateKey?.message && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {form.formState.errors.privateKey.message}
+          </p>
+        )}
+      </div>
+      <Input
+        {...form.register("privateKeyPassphrase")}
+        label="Private key passphrase (optional)"
+        type="password"
+      />
+    </div>
+  );
+});

--- a/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
+++ b/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
@@ -31,16 +31,12 @@ type SnowflakeKeypairFormValues = z.infer<typeof snowflakeKeypairFormSchema>;
 interface SnowflakeKeypairCredentialFormProps {
   owner: LightWorkspaceType;
   onValidityChange: (isValid: boolean) => void;
-  onCredentialCreated: (credentialId: string) => void;
 }
 
 export const SnowflakeKeypairCredentialForm = forwardRef<
   StaticCredentialFormHandle,
   SnowflakeKeypairCredentialFormProps
->(function SnowflakeKeypairCredentialForm(
-  { owner, onValidityChange, onCredentialCreated },
-  ref
-) {
+>(function SnowflakeKeypairCredentialForm({ owner, onValidityChange }, ref) {
   const sendNotification = useSendNotification();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const lastReportedValidity = useRef<boolean | null>(null);
@@ -69,7 +65,7 @@ export const SnowflakeKeypairCredentialForm = forwardRef<
 
   const handleSave = async (
     values: SnowflakeKeypairFormValues
-  ): Promise<boolean> => {
+  ): Promise<string | null> => {
     setIsSubmitting(true);
 
     try {
@@ -101,11 +97,10 @@ export const SnowflakeKeypairCredentialForm = forwardRef<
             ? result.error.message
             : "An error occurred.",
         });
-        return false;
+        return null;
       }
 
-      onCredentialCreated(result.credentials.id);
-      return true;
+      return result.credentials.id;
     } finally {
       setIsSubmitting(false);
     }
@@ -113,11 +108,11 @@ export const SnowflakeKeypairCredentialForm = forwardRef<
 
   useImperativeHandle(ref, () => ({
     submit: async () => {
-      let success = false;
+      let credentialId: string | null = null;
       await form.handleSubmit(async (values) => {
-        success = await handleSave(values);
+        credentialId = await handleSave(values);
       })();
-      return success;
+      return credentialId;
     },
   }));
 

--- a/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
+++ b/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
@@ -1,4 +1,4 @@
-import type { StaticCredentialFormHandle } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import type { StaticCredentialFormHandle } from "@app/components/actions/mcp/MCPServerAuthConnection";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PostCredentialsResponseBody } from "@app/pages/api/w/[wId]/credentials";

--- a/front/components/actions/mcp/create/static_credential_forms.ts
+++ b/front/components/actions/mcp/create/static_credential_forms.ts
@@ -2,7 +2,7 @@ import { SnowflakeKeypairCredentialForm } from "@app/components/actions/mcp/crea
 import type {
   StaticCredentialFormHandle,
   StaticCredentialFormProps,
-} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+} from "@app/components/actions/mcp/MCPServerAuthConnection";
 import type { MCPOAuthUseCase, OAuthProvider } from "@app/types/oauth/lib";
 import type { ForwardRefExoticComponent, RefAttributes } from "react";
 

--- a/front/components/actions/mcp/create/static_credential_forms.ts
+++ b/front/components/actions/mcp/create/static_credential_forms.ts
@@ -1,0 +1,27 @@
+import { SnowflakeKeypairCredentialForm } from "@app/components/actions/mcp/create/SnowflakeKeypairCredentialForm";
+import type {
+  StaticCredentialFormHandle,
+  StaticCredentialFormProps,
+} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import type { MCPOAuthUseCase, OAuthProvider } from "@app/types/oauth/lib";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+
+export type StaticCredentialFormComponent = ForwardRefExoticComponent<
+  StaticCredentialFormProps & RefAttributes<StaticCredentialFormHandle>
+>;
+
+const STATIC_CREDENTIAL_FORMS: Record<string, StaticCredentialFormComponent> = {
+  "snowflake:platform_actions": SnowflakeKeypairCredentialForm,
+};
+
+/**
+ * Registry lookup: returns a form component for providers that use
+ * static credentials for a given use case, or null if the standard
+ * OAuth flow should be used.
+ */
+export function getStaticCredentialForm(
+  provider: OAuthProvider,
+  useCase: MCPOAuthUseCase
+): StaticCredentialFormComponent | null {
+  return STATIC_CREDENTIAL_FORMS[`${provider}:${useCase}`] ?? null;
+}

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -7,6 +7,7 @@ import type { MCPConnectionType } from "@app/lib/swr/mcp_servers";
 import type { CreateMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp";
 import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
+import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { sanitizeHeadersArray } from "@app/types/shared/utils/http_headers";
@@ -63,13 +64,18 @@ type CreateRemoteMCPServerFn = (args: {
   customHeaders?: { key: string; value: string }[];
 }) => Promise<Result<CreateMCPServerResponseBody, Error>>;
 
-type CreateInternalMCPServerFn = (args: {
-  name: string;
-  oauthConnection?: MCPConnectionType;
-  includeGlobal: boolean;
-  sharedSecret?: string;
-  customHeaders?: Array<{ key: string; value: string }>;
-}) => Promise<Result<CreateMCPServerResponseBody, Error>>;
+type CreateInternalMCPServerFn = (
+  args: {
+    name: string;
+    includeGlobal: boolean;
+    sharedSecret?: string;
+    customHeaders?: Array<{ key: string; value: string }>;
+  } & (
+    | { oauthConnection: MCPConnectionType; useCase?: never }
+    | { oauthConnection?: never; useCase: MCPOAuthUseCase }
+    | { oauthConnection?: never; useCase?: never }
+  )
+) => Promise<Result<CreateMCPServerResponseBody, Error>>;
 
 interface SubmitCreateMCPServerDialogFormParams {
   owner: WorkspaceType;
@@ -201,11 +207,8 @@ export async function submitCreateMCPServerDialogForm({
         ? sanitizeHeadersArray(values.customHeaders)
         : undefined;
 
-    const createRes = await createInternalMCPServer({
-      name: internalMCPServer.name,
-      oauthConnection,
-      includeGlobal: true,
-      ...(requiresBearerTokenConfiguration(internalMCPServer) &&
+    const optionalFields =
+      requiresBearerTokenConfiguration(internalMCPServer) &&
       (values.sharedSecret !== undefined ||
         (sanitizedHeaders && sanitizedHeaders.length > 0))
         ? {
@@ -215,8 +218,20 @@ export async function submitCreateMCPServerDialogForm({
                 ? sanitizedHeaders
                 : undefined,
           }
-        : {}),
-    });
+        : {};
+
+    const createRes = oauthConnection
+      ? await createInternalMCPServer({
+          name: internalMCPServer.name,
+          oauthConnection,
+          includeGlobal: true,
+          ...optionalFields,
+        })
+      : await createInternalMCPServer({
+          name: internalMCPServer.name,
+          includeGlobal: true,
+          ...optionalFields,
+        });
 
     if (createRes.isErr()) {
       return new Err(

--- a/front/components/poke/mcp_server_views/view.tsx
+++ b/front/components/poke/mcp_server_views/view.tsx
@@ -1,4 +1,4 @@
-import { OAUTH_USE_CASE_TO_LABEL } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import { OAUTH_USE_CASE_TO_LABEL } from "@app/components/actions/mcp/MCPServerAuthConnection";
 import {
   PokeTable,
   PokeTableBody,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -281,12 +281,14 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
   const createInternalMCPServer = async ({
     name,
     oauthConnection,
+    useCase,
     includeGlobal,
     sharedSecret,
     customHeaders,
   }: {
     name: string;
     oauthConnection?: MCPConnectionType;
+    useCase?: MCPOAuthUseCase;
     includeGlobal: boolean;
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
@@ -297,7 +299,7 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
       body: JSON.stringify({
         name,
         serverType: "internal",
-        useCase: oauthConnection?.useCase,
+        useCase: useCase ?? oauthConnection?.useCase,
         connectionId: oauthConnection?.connectionId,
         includeGlobal,
         ...(sharedSecret !== undefined ? { sharedSecret } : {}),
@@ -661,15 +663,24 @@ export function useCreateMCPServerConnection({
   const sendNotification = useSendNotification();
   const createMCPServerConnection = async ({
     connectionId,
+    credentialId,
     mcpServerId,
     mcpServerDisplayName,
     provider,
   }: {
-    connectionId: string;
+    connectionId?: string;
+    credentialId?: string;
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
   }): Promise<PostConnectionResponseBody | null> => {
+    if (!connectionId && !credentialId) {
+      throw new Error("Missing connectionId or credentialId.");
+    }
+    if (connectionId && credentialId) {
+      throw new Error("Only one of connectionId or credentialId must be set.");
+    }
+
     const response = await clientFetch(
       `/api/w/${owner.sId}/mcp/connections/${connectionType}`,
       {
@@ -679,6 +690,7 @@ export function useCreateMCPServerConnection({
         },
         body: JSON.stringify({
           connectionId,
+          credentialId,
           mcpServerId,
           provider,
         }),

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -293,13 +293,19 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
   }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
+    if (oauthConnection && useCase) {
+      throw new Error(
+        "Only one of oauthConnection or useCase should be provided."
+      );
+    }
+
     const response = await clientFetch(`/api/w/${owner.sId}/mcp`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         name,
         serverType: "internal",
-        useCase: useCase ?? oauthConnection?.useCase,
+        useCase: oauthConnection?.useCase ?? useCase,
         connectionId: oauthConnection?.connectionId,
         includeGlobal,
         ...(sharedSecret !== undefined ? { sharedSecret } : {}),
@@ -668,19 +674,13 @@ export function useCreateMCPServerConnection({
     mcpServerDisplayName,
     provider,
   }: {
-    connectionId?: string;
-    credentialId?: string;
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
-  }): Promise<PostConnectionResponseBody | null> => {
-    if (!connectionId && !credentialId) {
-      throw new Error("Missing connectionId or credentialId.");
-    }
-    if (connectionId && credentialId) {
-      throw new Error("Only one of connectionId or credentialId must be set.");
-    }
-
+  } & (
+    | { connectionId: string; credentialId?: never }
+    | { connectionId?: never; credentialId: string }
+  )): Promise<PostConnectionResponseBody | null> => {
     const response = await clientFetch(
       `/api/w/${owner.sId}/mcp/connections/${connectionType}`,
       {

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -287,18 +287,14 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
     customHeaders,
   }: {
     name: string;
-    oauthConnection?: MCPConnectionType;
-    useCase?: MCPOAuthUseCase;
     includeGlobal: boolean;
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
-  }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
-    if (oauthConnection && useCase) {
-      throw new Error(
-        "Only one of oauthConnection or useCase should be provided."
-      );
-    }
-
+  } & (
+    | { oauthConnection: MCPConnectionType; useCase?: never }
+    | { oauthConnection?: never; useCase: MCPOAuthUseCase }
+    | { oauthConnection?: never; useCase?: never }
+  )): Promise<Result<CreateMCPServerResponseBody, Error>> => {
     const response = await clientFetch(`/api/w/${owner.sId}/mcp`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -387,7 +387,7 @@ export function getProviderRequiredOAuthCredentialInputs({
       }
       return null;
     case "snowflake":
-      if (useCase === "personal_actions" || useCase === "platform_actions") {
+      if (useCase === "personal_actions") {
         const result: OAuthCredentialInputs = {
           snowflake_account: {
             label: "Snowflake Account",
@@ -414,9 +414,7 @@ export function getProviderRequiredOAuthCredentialInputs({
             label: "Default Snowflake Role",
             value: undefined,
             helpMessage:
-              useCase === "platform_actions"
-                ? "The Snowflake role for all users (e.g., ANALYST)."
-                : "The default Snowflake role (e.g., ANALYST). Users can override this during their personal authentication.",
+              "The default Snowflake role (e.g., ANALYST). Users can override this during their personal authentication.",
             validator: isValidSnowflakeRole,
             overridableAtPersonalAuth: true,
             personalAuthLabel: "Snowflake Role",
@@ -432,6 +430,7 @@ export function getProviderRequiredOAuthCredentialInputs({
         };
         return result;
       }
+      // platform_actions uses static credentials via the registry.
       return null;
     default:
       assertNever(provider);


### PR DESCRIPTION
## Description

When an admin adds the Snowflake tool from Administration > Tools, they choose between "Personal accounts" (standard OAuth) and "Shared account" (keypair credentials). Previously all Snowflake connections went through a standalone keypair dialog, bypassing this choice and requiring provider-specific conditionals in generic UI components.

This PR introduces a generic static credential form registry (`getStaticCredentialForm(provider, useCase)`) that maps provider+useCase to a custom form component. Both `CreateMCPServerDialog` (first-time add) and `ConnectMCPServerDialog` (reconnection) check this registry to decide whether to render a static credential form or the standard OAuth flow — no provider-specific conditionals needed.

Key changes:
- `MCPServerOAuthConnexion` accepts a `staticCredentialConfig` prop: when provided, replaces OAuth inputs with the custom form while keeping the use case picker cards
- `ConnectMCPServerDialog` and `CreateMCPServerDialog` both resolve and wire up static credential forms from the registry
- `useCreateInternalMCPServer` accepts an optional `useCase` param independent of `oauthConnection`, needed for creating servers with static credentials
- `StaticCredentialFormHandle.submit` returns a boolean so callers can detect failure and clear loading state
- `MCPServerSettings` shows auth type generically from `connection.authType`

## Tests

Extensively tested locally

## Risk

Low — UI-only changes scoped to the Snowflake admin setup dialog. The static credential registry is additive and doesn't change behavior for any other provider. No backend changes.

## Deploy Plan

Standard front deploy, no migrations or feature flags needed.