### PR TITLE
Github connector - Retry on Bad credentials

### DIFF
--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -177,9 +177,10 @@ export async function githubExtractToGcsActivity({
             "Bad credentials: OAuth token is invalid or revoked."
           );
 
+          const retryDelayMs = 20 * 60 * 1000; // 20 minutes
           throw ApplicationFailure.create({
             message: `${error.message}. Retry after 20 minutes`,
-            nextRetryDelay: 20 * 60 * 1000, // 20 minutes
+            nextRetryDelay: retryDelayMs,
             cause: error,
           });
         }

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -39,7 +39,7 @@ import {
   type WhereOptions,
 } from "sequelize";
 
-/** 
+/**
  * Update in database as well as in-memory agent message.
  * Note that we are mutating the agentMessage object in memory and not returning a new object.
  * This is because we want to make sure that all functions using this object have the latest state.


### PR DESCRIPTION
## Description

Handles transient "Bad credentials" errors from GitHub by retrying instead of pausing the connector. When `githubExtractToGcsActivity` encounters a "Bad credentials" error while downloading repository tarballs, it now throws a Temporal ApplicationFailure with a 20-minute retry delay instead of throwing `ExternalOAuthTokenError`. This prevents connectors from being incorrectly paused when GitHub returns spurious authentication errors for valid OAuth tokens.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
