### PR TITLE
[Agent Email] Deduplicate and filter recipients for successful replies

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -1,0 +1,70 @@
+import {
+  ASSISTANT_EMAIL_SUBDOMAIN,
+  buildSuccessReplyRecipients,
+} from "@app/lib/api/assistant/email/email_trigger";
+import { describe, expect, it } from "vitest";
+
+describe("buildSuccessReplyRecipients", () => {
+  it("returns sender-only recipients when no human to/cc recipients exist", () => {
+    const recipients = buildSuccessReplyRecipients({
+      subject: "Test",
+      text: "Hello",
+      auth: { SPF: "pass", dkim: "pass" },
+      envelope: {
+        from: "sender@dust.tt",
+        full: "Sender <sender@dust.tt>",
+        to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`],
+        cc: [],
+        bcc: ["hidden@dust.tt"],
+      },
+      attachments: [],
+    });
+
+    expect(recipients).toEqual({
+      to: ["sender@dust.tt"],
+      cc: [],
+    });
+  });
+
+  it("includes original human to/cc recipients and excludes assistant recipients", () => {
+    const recipients = buildSuccessReplyRecipients({
+      subject: "Test",
+      text: "Hello",
+      auth: { SPF: "pass", dkim: "pass" },
+      envelope: {
+        from: "sender@dust.tt",
+        full: "Sender <sender@dust.tt>",
+        to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "teammate@dust.tt"],
+        cc: [`other-agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "observer@dust.tt"],
+        bcc: ["hidden@dust.tt"],
+      },
+      attachments: [],
+    });
+
+    expect(recipients).toEqual({
+      to: ["sender@dust.tt", "teammate@dust.tt"],
+      cc: ["observer@dust.tt"],
+    });
+  });
+
+  it("deduplicates recipients across to and cc", () => {
+    const recipients = buildSuccessReplyRecipients({
+      subject: "Test",
+      text: "Hello",
+      auth: { SPF: "pass", dkim: "pass" },
+      envelope: {
+        from: "sender@dust.tt",
+        full: "Sender <sender@dust.tt>",
+        to: ["Sender@dust.tt", "teammate@dust.tt", "teammate@dust.tt"],
+        cc: ["teammate@dust.tt", "observer@dust.tt", "observer@dust.tt"],
+        bcc: [],
+      },
+      attachments: [],
+    });
+
+    expect(recipients).toEqual({
+      to: ["sender@dust.tt", "teammate@dust.tt"],
+      cc: ["observer@dust.tt"],
+    });
+  });
+});

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -224,16 +224,15 @@ function deduplicateEmailAddresses(emails: string[]): string[] {
   const deduplicated: string[] = [];
 
   for (const email of emails) {
-    const trimmedEmail = email.trim();
-    if (trimmedEmail.length === 0) {
+    const normalizedEmail = normalizeEmailAddress(email);
+    if (normalizedEmail.length === 0) {
       continue;
     }
-    const normalizedEmail = normalizeEmailAddress(trimmedEmail);
     if (seen.has(normalizedEmail)) {
       continue;
     }
     seen.add(normalizedEmail);
-    deduplicated.push(trimmedEmail);
+    deduplicated.push(email.trim());
   }
 
   return deduplicated;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/21907.

Adds recipient cleanup for successful final email replies:
- deduplicate `to/cc` (case-insensitive)
- remove assistant-domain recipients from `to/cc`
- ensure `cc` does not repeat recipients already in `to`

Validation and error emails remain sender-only.

## Risks
Blast radius: Successful agent email recipient normalization before SendGrid send.
Risk: low

## Deploy Plan
- deploy front
- deploy front-worker

## Test
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run ./lib/api/assistant/email/email_trigger.test.ts`
