### PR TITLE
Fix new convo does not appear to sidebar

### DIFF
--- a/front/hooks/conversations/useConversations.ts
+++ b/front/hooks/conversations/useConversations.ts
@@ -96,15 +96,15 @@ export function useConversations({
           return prevPages;
         }
 
-        let remaining = [...updatedConversations];
-        return prevPages.map((page) => {
-          const pageSize = page.conversations.length;
-          const pageConversations = remaining.slice(0, pageSize);
-          remaining = remaining.slice(pageSize);
-          return {
-            ...page,
-            conversations: pageConversations,
-          };
+        let offset = 0;
+        return prevPages.map((page, index) => {
+          const isLastPage = index === prevPages.length - 1;
+          const conversations = updatedConversations.slice(
+            offset,
+            isLastPage ? undefined : offset + page.conversations.length
+          );
+          offset += page.conversations.length;
+          return { ...page, conversations };
         });
       }, swrOptions);
     },


### PR DESCRIPTION
## Description

PR #21662 introduced pagination for `useConversations` via `useSWRInfiniteWithDefaults`. The `mutateConversations` wrapper flattens all pages, applies the updater, then re-distributes conversations back into pages using each page's original size.

When the updater adds a new conversation (e.g. after creating one), the extra item overflows past the last page and is silently dropped — so the new conversation never appears in the sidebar.

The fix replaces the slice-and-shrink re-pagination with an offset-based approach where the last page takes all remaining items (`slice(offset, undefined)`), so additions are never lost.

## Tests

Locally.

## Risk

Can be rolled back.

## Deploy Plan

Deploy front.