### PR TITLE
[front] perf: remove extra fetch on agent data sources in search

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -481,6 +481,27 @@ export async function getAgentDataSourceConfigurations(
   return new Ok(configs);
 }
 
+export function toCoreSearchArgs(
+  configs: ResolvedDataSourceConfiguration[]
+): CoreSearchArgs[] {
+  return configs.map((config) => ({
+    projectId: config.dataSource.dustAPIProjectId,
+    dataSourceId: config.dataSource.dustAPIDataSourceId,
+    filter: {
+      tags: {
+        in: config.filter.tags?.in ?? null,
+        not: config.filter.tags?.not ?? null,
+      },
+      parents: {
+        in: config.filter.parents?.in ?? null,
+        not: config.filter.parents?.not ?? null,
+      },
+    },
+    view_filter: config.dataSourceView.toViewFilter(),
+    dataSourceView: config.dataSourceView.toJSON(),
+  }));
+}
+
 export async function getCoreSearchArgs(
   auth: Authenticator,
   dataSourceConfigurations: DataSourcesToolConfigurationType
@@ -494,26 +515,7 @@ export async function getCoreSearchArgs(
     return configRes;
   }
 
-  const configs = configRes.value;
-
-  return new Ok(
-    configs.map((config) => ({
-      projectId: config.dataSource.dustAPIProjectId,
-      dataSourceId: config.dataSource.dustAPIDataSourceId,
-      filter: {
-        tags: {
-          in: config.filter.tags?.in ?? null,
-          not: config.filter.tags?.not ?? null,
-        },
-        parents: {
-          in: config.filter.parents?.in ?? null,
-          not: config.filter.parents?.not ?? null,
-        },
-      },
-      view_filter: config.dataSourceView.toViewFilter(),
-      dataSourceView: config.dataSourceView.toJSON(),
-    }))
-  );
+  return new Ok(toCoreSearchArgs(configRes.value));
 }
 
 export type ProjectConfigInfo = {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -4,8 +4,8 @@ import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rende
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
   getAgentDataSourceConfigurations,
-  getCoreSearchArgs,
   makeCoreSearchNodesFilters,
+  toCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type {
   SearchWithNodesInputType,
@@ -72,8 +72,6 @@ export async function search(
   const agentDataSourceConfigurations =
     agentDataSourceConfigurationsResult.value;
 
-  const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);
-
   // Set to avoid O(n^2) complexity below.
   const dataSourceIds = new Set<string>(
     removeNulls(
@@ -85,16 +83,8 @@ export async function search(
   const regularNodeIds =
     nodeIds?.filter((nodeId: string) => !isDataSourceNodeId(nodeId)) ?? [];
 
-  if (coreSearchArgsResults.isErr()) {
-    return new Err(
-      new MCPError(
-        "Invalid data sources: " + coreSearchArgsResults.error.message
-      )
-    );
-  }
-
   const coreSearchArgs = removeNulls(
-    coreSearchArgsResults.value.map((coreSearchArgs) => {
+    toCoreSearchArgs(agentDataSourceConfigurations).map((coreSearchArgs) => {
       if (!nodeIds || dataSourceIds.has(coreSearchArgs.dataSourceId)) {
         // If the agent doesn't provide nodeIds, or if it provides the node id
         // of this data source, we keep the default filter.


### PR DESCRIPTION
## Description

- This PR prevents doing the exact same fetch twice in a row in the search.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
