### PR TITLE
fix: channel dropdown label project notifications

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -451,15 +451,15 @@ export const NotificationPreferences = forwardRef<
   ) => {
     const displayedChannels: string[] = [];
     if (preference.channels.in_app) {
-      displayedChannels.push("In-app popup");
+      displayedChannels.push("in-app popup");
     }
     if (preference.channels.chat && displaySlackOption) {
       displayedChannels.push("Slack");
     }
     if (preference.channels.email) {
-      displayedChannels.push("Email");
+      displayedChannels.push("email");
     }
-    return displayedChannels.length > 0 ? displayedChannels.join(", ") : "None";
+    return displayedChannels.length > 0 ? displayedChannels.join(", ") : "none";
   };
 
   if (isLoadingPreferences || isSlackSetupLoading) {
@@ -530,7 +530,10 @@ export const NotificationPreferences = forwardRef<
             <Tooltip
               label="You'll still be notified if you're the only participant in a conversation."
               trigger={
-                <InformationCircleIcon className="h-4 w-4 text-muted-foreground dark:text-muted-foreground-night" />
+                <InformationCircleIcon
+                  onClick={(e) => e.preventDefault()}
+                  className="h-4 w-4 text-muted-foreground dark:text-muted-foreground-night"
+                />
               }
             />
           )}
@@ -557,7 +560,7 @@ export const NotificationPreferences = forwardRef<
             <DropdownMenuContent>
               {conversationPreferences.channels.in_app !== undefined && (
                 <DropdownMenuCheckboxItem
-                  label="In-app popup"
+                  label="in-app popup"
                   checked={isConversationInAppEnabled}
                   onCheckedChange={(checked) =>
                     updateConversationChannelPreference("in_app", checked)
@@ -578,7 +581,7 @@ export const NotificationPreferences = forwardRef<
                 )}
               {conversationPreferences.channels.email !== undefined && (
                 <DropdownMenuCheckboxItem
-                  label="Email"
+                  label="email"
                   checked={isConversationEmailEnabled}
                   onCheckedChange={(checked) =>
                     updateConversationChannelPreference("email", checked)
@@ -653,7 +656,7 @@ export const NotificationPreferences = forwardRef<
                 {projectNewConversationPreferences.channels.in_app !==
                   undefined && (
                   <DropdownMenuCheckboxItem
-                    label="In-app popup"
+                    label="in-app popup"
                     checked={isProjectNewConversationInAppEnabled}
                     onCheckedChange={(checked) =>
                       updateProjectNewConversationChannelPreference(
@@ -680,7 +683,7 @@ export const NotificationPreferences = forwardRef<
                 {projectNewConversationPreferences.channels.email !==
                   undefined && (
                   <DropdownMenuCheckboxItem
-                    label="Email"
+                    label="email"
                     checked={isProjectNewConversationEmailEnabled}
                     onCheckedChange={(checked) =>
                       updateProjectNewConversationChannelPreference(

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -449,9 +449,6 @@ export const NotificationPreferences = forwardRef<
     preference: Preference,
     displaySlackOption: boolean
   ) => {
-    if (notifyCondition === "never") {
-      return "-";
-    }
     const displayedChannels: string[] = [];
     if (preference.channels.in_app) {
       displayedChannels.push("In-app popup");


### PR DESCRIPTION
## Description

This PR fixes some bugs related to notification preferences.

- Removes the conditional check that returned "-" for "never" notify conditions, allowing the actual configured channels to be displayed (the notification preference should be checked only for the "new messages" dropdown, as we already do, see line 548)
- Standardizes channel labels to lowercase ("in-app popup", "email", "none") for consistency
- Clicking on the tooltip does not save the preferences anymore.

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment.
