### PR TITLE
Disable tooLongIndexName to get clean CI

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -10,8 +10,7 @@
     "./biome-plugins/noMcpServerInstructions.grit",
     "./biome-plugins/enforceClientTypesInPublicApi.grit",
     "./biome-plugins/nextjsPageComponentNaming.grit",
-    "./biome-plugins/nextjsNoDataFetchingInGetssp.grit",
-    "./biome-plugins/tooLongIndexName.grit"
+    "./biome-plugins/nextjsNoDataFetchingInGetssp.grit"
   ],
   "vcs": {
     "enabled": true,

--- a/front/lib/notifications/email-templates/project-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/project-new-conversation.tsx
@@ -2,7 +2,6 @@ import config from "@app/lib/api/config";
 import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { render } from "@react-email/render";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import * as React from "react";
 import { z } from "zod";
 


### PR DESCRIPTION
## Description

Was causing a lot of errors like:

```
  ℹ Ensure Sequelize index names don't exceed PostgreSQL's 63-character limit. Auto-generated names follow the pattern: {modelName}s_{field1}_{field2}.

    44 │   {
    45 │     sequelize: connectorsSequelize,
  > 46 │     modelName: "google_drive_configs",
       │                ^^^^^^^^^^^^^^^^^^^^^^
    47 │     indexes: [{ fields: ["connectorId"], unique: true }],
    48 │     relationship: "hasOne",
```

Also, removed comment that was causing:
```
Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
