### PR TITLE
fix: notification dropdown opening on mobile

### DIFF
--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuShortcut,
   DropdownMenuTrigger,
   Input,
@@ -293,23 +294,25 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
                   className="w-fit"
                 />
               </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem
-                  icon={SunIcon}
-                  onClick={() => themeField.onChange("light")}
-                  label="Light"
-                />
-                <DropdownMenuItem
-                  icon={MoonIcon}
-                  onClick={() => themeField.onChange("dark")}
-                  label="Dark"
-                />
-                <DropdownMenuItem
-                  icon={LightModeIcon}
-                  onClick={() => themeField.onChange("system")}
-                  label="System"
-                />
-              </DropdownMenuContent>
+              <DropdownMenuPortal>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    icon={SunIcon}
+                    onClick={() => themeField.onChange("light")}
+                    label="Light"
+                  />
+                  <DropdownMenuItem
+                    icon={MoonIcon}
+                    onClick={() => themeField.onChange("dark")}
+                    label="Dark"
+                  />
+                  <DropdownMenuItem
+                    icon={LightModeIcon}
+                    onClick={() => themeField.onChange("system")}
+                    label="System"
+                  />
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
             </DropdownMenu>
           </div>
           <div className="flex-1">
@@ -330,20 +333,22 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
                   />
                 </div>
               </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem
-                  onClick={() => submitKeyField.onChange("enter")}
-                >
-                  Enter
-                  <DropdownMenuShortcut>↵</DropdownMenuShortcut>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => submitKeyField.onChange("cmd+enter")}
-                >
-                  Cmd + Enter
-                  <DropdownMenuShortcut>⌘ + ↵</DropdownMenuShortcut>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
+              <DropdownMenuPortal>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    onClick={() => submitKeyField.onChange("enter")}
+                  >
+                    Enter
+                    <DropdownMenuShortcut>↵</DropdownMenuShortcut>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => submitKeyField.onChange("cmd+enter")}
+                  >
+                    Cmd + Enter
+                    <DropdownMenuShortcut>⌘ + ↵</DropdownMenuShortcut>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
             </DropdownMenu>
           </div>
         </div>

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuTrigger,
   InformationCircleIcon,
   Label,
@@ -511,20 +512,22 @@ export const NotificationPreferences = forwardRef<
                 label={NOTIFICATION_CONDITION_LABELS[notifyCondition]}
               />
             </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem
-                label={NOTIFICATION_CONDITION_LABELS["all_messages"]}
-                onClick={() => setNotifyCondition("all_messages")}
-              />
-              <DropdownMenuItem
-                label={NOTIFICATION_CONDITION_LABELS["only_mentions"]}
-                onClick={() => setNotifyCondition("only_mentions")}
-              />
-              <DropdownMenuItem
-                label={NOTIFICATION_CONDITION_LABELS["never"]}
-                onClick={() => setNotifyCondition("never")}
-              />
-            </DropdownMenuContent>
+            <DropdownMenuPortal>
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  label={NOTIFICATION_CONDITION_LABELS["all_messages"]}
+                  onClick={() => setNotifyCondition("all_messages")}
+                />
+                <DropdownMenuItem
+                  label={NOTIFICATION_CONDITION_LABELS["only_mentions"]}
+                  onClick={() => setNotifyCondition("only_mentions")}
+                />
+                <DropdownMenuItem
+                  label={NOTIFICATION_CONDITION_LABELS["never"]}
+                  onClick={() => setNotifyCondition("never")}
+                />
+              </DropdownMenuContent>
+            </DropdownMenuPortal>
           </DropdownMenu>
           {notifyCondition === "only_mentions" && (
             <Tooltip
@@ -557,39 +560,42 @@ export const NotificationPreferences = forwardRef<
                 }
               />
             </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {conversationPreferences.channels.in_app !== undefined && (
-                <DropdownMenuCheckboxItem
-                  label="in-app popup"
-                  checked={isConversationInAppEnabled}
-                  onCheckedChange={(checked) =>
-                    updateConversationChannelPreference("in_app", checked)
-                  }
-                  disabled={notifyCondition === "never"}
-                />
-              )}
-              {conversationPreferences.channels.chat !== undefined &&
-                displaySlackOption && (
+
+            <DropdownMenuPortal>
+              <DropdownMenuContent>
+                {conversationPreferences.channels.in_app !== undefined && (
                   <DropdownMenuCheckboxItem
-                    label="Slack"
-                    checked={isConversationSlackEnabled}
+                    label="in-app popup"
+                    checked={isConversationInAppEnabled}
                     onCheckedChange={(checked) =>
-                      updateConversationChannelPreference("chat", checked)
+                      updateConversationChannelPreference("in_app", checked)
                     }
                     disabled={notifyCondition === "never"}
                   />
                 )}
-              {conversationPreferences.channels.email !== undefined && (
-                <DropdownMenuCheckboxItem
-                  label="email"
-                  checked={isConversationEmailEnabled}
-                  onCheckedChange={(checked) =>
-                    updateConversationChannelPreference("email", checked)
-                  }
-                  disabled={notifyCondition === "never"}
-                />
-              )}
-            </DropdownMenuContent>
+                {conversationPreferences.channels.chat !== undefined &&
+                  displaySlackOption && (
+                    <DropdownMenuCheckboxItem
+                      label="Slack"
+                      checked={isConversationSlackEnabled}
+                      onCheckedChange={(checked) =>
+                        updateConversationChannelPreference("chat", checked)
+                      }
+                      disabled={notifyCondition === "never"}
+                    />
+                  )}
+                {conversationPreferences.channels.email !== undefined && (
+                  <DropdownMenuCheckboxItem
+                    label="email"
+                    checked={isConversationEmailEnabled}
+                    onCheckedChange={(checked) =>
+                      updateConversationChannelPreference("email", checked)
+                    }
+                    disabled={notifyCondition === "never"}
+                  />
+                )}
+              </DropdownMenuContent>
+            </DropdownMenuPortal>
           </DropdownMenu>
           {isConversationEmailEnabled && notifyCondition !== "never" && (
             <>
@@ -609,15 +615,18 @@ export const NotificationPreferences = forwardRef<
                     }
                   />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
-                    <DropdownMenuItem
-                      key={delay}
-                      label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
-                      onClick={() => setConversationEmailDelay(delay)}
-                    />
-                  ))}
-                </DropdownMenuContent>
+
+                <DropdownMenuPortal>
+                  <DropdownMenuContent>
+                    {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
+                      <DropdownMenuItem
+                        key={delay}
+                        label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
+                        onClick={() => setConversationEmailDelay(delay)}
+                      />
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenuPortal>
               </DropdownMenu>
             </>
           )}
@@ -652,48 +661,51 @@ export const NotificationPreferences = forwardRef<
                   )}
                 />
               </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                {projectNewConversationPreferences.channels.in_app !==
-                  undefined && (
-                  <DropdownMenuCheckboxItem
-                    label="in-app popup"
-                    checked={isProjectNewConversationInAppEnabled}
-                    onCheckedChange={(checked) =>
-                      updateProjectNewConversationChannelPreference(
-                        "in_app",
-                        checked
-                      )
-                    }
-                  />
-                )}
-                {projectNewConversationPreferences.channels.chat !==
-                  undefined &&
-                  displaySlackOption && (
+
+              <DropdownMenuPortal>
+                <DropdownMenuContent>
+                  {projectNewConversationPreferences.channels.in_app !==
+                    undefined && (
                     <DropdownMenuCheckboxItem
-                      label="Slack"
-                      checked={isProjectNewConversationSlackEnabled}
+                      label="in-app popup"
+                      checked={isProjectNewConversationInAppEnabled}
                       onCheckedChange={(checked) =>
                         updateProjectNewConversationChannelPreference(
-                          "chat",
+                          "in_app",
                           checked
                         )
                       }
                     />
                   )}
-                {projectNewConversationPreferences.channels.email !==
-                  undefined && (
-                  <DropdownMenuCheckboxItem
-                    label="email"
-                    checked={isProjectNewConversationEmailEnabled}
-                    onCheckedChange={(checked) =>
-                      updateProjectNewConversationChannelPreference(
-                        "email",
-                        checked
-                      )
-                    }
-                  />
-                )}
-              </DropdownMenuContent>
+                  {projectNewConversationPreferences.channels.chat !==
+                    undefined &&
+                    displaySlackOption && (
+                      <DropdownMenuCheckboxItem
+                        label="Slack"
+                        checked={isProjectNewConversationSlackEnabled}
+                        onCheckedChange={(checked) =>
+                          updateProjectNewConversationChannelPreference(
+                            "chat",
+                            checked
+                          )
+                        }
+                      />
+                    )}
+                  {projectNewConversationPreferences.channels.email !==
+                    undefined && (
+                    <DropdownMenuCheckboxItem
+                      label="email"
+                      checked={isProjectNewConversationEmailEnabled}
+                      onCheckedChange={(checked) =>
+                        updateProjectNewConversationChannelPreference(
+                          "email",
+                          checked
+                        )
+                      }
+                    />
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
             </DropdownMenu>
             {isProjectNewConversationEmailEnabled && (
               <>
@@ -713,17 +725,20 @@ export const NotificationPreferences = forwardRef<
                       }
                     />
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
-                      <DropdownMenuItem
-                        key={delay}
-                        label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
-                        onClick={() =>
-                          setProjectNewConversationEmailDelay(delay)
-                        }
-                      />
-                    ))}
-                  </DropdownMenuContent>
+
+                  <DropdownMenuPortal>
+                    <DropdownMenuContent>
+                      {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
+                        <DropdownMenuItem
+                          key={delay}
+                          label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
+                          onClick={() =>
+                            setProjectNewConversationEmailDelay(delay)
+                          }
+                        />
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenuPortal>
                 </DropdownMenu>
               </>
             )}


### PR DESCRIPTION
## Description

This PR fixes notification and settings dropdowns not opening properly on mobile devices. When trying to open a dropdown on mobile, the following error would appear
<img width="455" height="419" alt="Capture d’écran 2026-02-19 à 10 32 14" src="https://github.com/user-attachments/assets/59355b05-7e56-4b1a-9d66-008e627d1b1b" />

To ensure that the content is contained in the body, all the `DropdownMenuContent` components are wrapped with a `DropdownMenuPortal`.

## Tests

Manually tested.

## Risks

Low risk. 

## Deploy Plan

Standard deployment.
