### PR TITLE
[cli] Replace mention of deep dive with dust in Dust skill

### DIFF
--- a/cli/src/ui/commands/SkillInit.tsx
+++ b/cli/src/ui/commands/SkillInit.tsx
@@ -15,7 +15,7 @@ description: Call a Dust agent to get information (read a slack thread, a notion
 
 Access Dust agents that have context on all the company, e.g. recent projects, engineering, sales, marketing, etc., via the Dust CLI non-interactively, e.g.:
 \`$ dust chat -a issueBot -m "create an issue for this: ..."\`
-\`$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks.\`
+\`$ dust chat -a dust -m "Research all the info we have on Kubernetes probe failures in recent weeks.\`
 
 A conversation with an agent can be continued after the first message using the argument \`-c CONVERSATION_STRING_ID\`. The conversation id will be returned in the JSON result from the initial call.
 \`$ dust chat -a issueBot -c 'TdWyn4aDt1' -m "also add a subsequent issue about this: ..."\`


### PR DESCRIPTION
## Description

- This PR updates the CC/Codex skill created using the CLI via `skills:init` to replace the mention of deep-dive with dust.
- Had cases where deep-dive would almost always be called even for very simple questions.

## Tests

- Tested the new skill locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
