### PR TITLE
[core,front] Add custom error handling for invalid pagination cursors in node search

### DIFF
--- a/core/src/api/nodes.rs
+++ b/core/src/api/nodes.rs
@@ -1,5 +1,7 @@
 use crate::api::api_state::APIState;
-use crate::search_stores::search_store::{NodesSearchFilter, NodesSearchOptions};
+use crate::search_stores::search_store::{
+    NodesSearchFilter, NodesSearchOptions, SearchNodesError,
+};
 use crate::utils::{error_response, APIResponse};
 use axum::extract::State;
 use axum::Json;
@@ -37,6 +39,14 @@ pub async fn nodes_search(
             warning_code,
         ),
         Err(e) => {
+            if e.downcast_ref::<SearchNodesError>().is_some() {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "cursor_sort_mismatch",
+                    "The cursor was generated with a different sort configuration",
+                    Some(e),
+                );
+            }
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_server_error",

--- a/core/src/api/nodes.rs
+++ b/core/src/api/nodes.rs
@@ -1,7 +1,5 @@
 use crate::api::api_state::APIState;
-use crate::search_stores::search_store::{
-    NodesSearchFilter, NodesSearchOptions, SearchNodesError,
-};
+use crate::search_stores::search_store::{NodesSearchFilter, NodesSearchOptions, SearchNodesError};
 use crate::utils::{error_response, APIResponse};
 use axum::extract::State;
 use axum::Json;

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -150,8 +150,8 @@ export async function list(
     if (searchResult.error.code === "cursor_sort_mismatch") {
       return new Err(
         new MCPError(
-          "The nextPageCursor was generated with a different sortBy value. " +
-            "When paginating, you must pass the same sortBy on every page request.",
+          "The nextPageCursor passed was generated with a different sortBy value. You " +
+            "may reuse the same nextPageCursor with the same sortBy that was used to generate it.",
           { tracked: false }
         )
       );

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -147,6 +147,16 @@ export async function list(
   }
 
   if (searchResult.isErr()) {
+    if (searchResult.error.code === "cursor_sort_mismatch") {
+      return new Err(
+        new MCPError(
+          "The nextPageCursor was generated with a different sortBy value. " +
+            "When paginating, you must pass the same sortBy on every page request.",
+          { tracked: false }
+        )
+      );
+    }
+
     return new Err(
       new MCPError(
         `Failed to list node contents: ${searchResult.error.message}`

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -150,8 +150,9 @@ export async function list(
     if (searchResult.error.code === "cursor_sort_mismatch") {
       return new Err(
         new MCPError(
-          "The nextPageCursor passed was generated with a different sortBy value. You " +
-            "may reuse the same nextPageCursor with the same sortBy that was used to generate it.",
+          "The nextPageCursor passed was generated with a different sortBy value. " +
+            "This nextPageCursor can be used if passed with the same sortBy that was used to " +
+            "generate it.",
           { tracked: false }
         )
       );


### PR DESCRIPTION
## Description

- We sometimes get the error `Failed to search nodes: {\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":\"search_after has 3 value(s) but sort has 2.\"}]...`
- Example [here](https://poke.dust.tt/mXq7pMWMnl/conversation/8A6sEU7svS).
- This PR fixes that by showing an explicit error to the model; the issues comes from the model using a search cursor that had been generated with a different sort, in the example above the model sorts by title and then uses the cursor generated in a query that does not uses the same sorting.
- The error is untracked to avoid triggering a monitor.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Deploy core.
