### PR TITLE
[front] - fix(insights): update permission checks for agent observability access

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -61,16 +61,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -61,12 +61,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -51,16 +51,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -51,12 +51,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -54,16 +54,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -54,12 +54,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
@@ -50,12 +50,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
@@ -50,16 +50,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -54,16 +54,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -54,12 +54,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -60,12 +60,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -60,16 +60,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
@@ -54,16 +54,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
@@ -54,12 +54,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
@@ -51,16 +51,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
@@ -51,12 +51,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -51,16 +51,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -51,12 +51,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
@@ -64,12 +64,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
@@ -64,16 +64,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
@@ -51,16 +51,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
@@ -51,12 +51,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -58,16 +58,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -58,12 +58,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -49,16 +49,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only builders can access agent observability.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -49,12 +49,12 @@ async function handler(
     });
   }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
+  if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "app_auth_error",
-        message: "Only editors can get agent observability.",
+        message: "Only builders can access agent observability.",
       },
     });
   }


### PR DESCRIPTION
## Description

This PR adjusts permission checks to allow builders to access agent observability features instead of only editors or admins

**References:**
- Closes https://github.com/dust-tt/tasks/issues/6628

## Tests

Locally

## Risk

Medium as it touches permissions/roles

## Deploy Plan

Deploy front
