### PR TITLE
[front] Enable filesystem-like search by default

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -430,6 +430,7 @@ function KnowledgeConfigurationSheetContent({
                     targetMCPServerName={SEARCH_SERVER_NAME}
                     selectedMCPServerView={mcpServerView ?? undefined}
                     configurationKey={ADVANCED_SEARCH_SWITCH}
+                    defaultEnabled
                   />
                 </CollapsibleContent>
               </Collapsible>

--- a/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
@@ -10,6 +10,7 @@ interface CustomCheckboxSectionProps {
   configurationKey: string;
   selectedMCPServerView?: MCPServerViewType;
   targetMCPServerName: InternalMCPServerNameType;
+  defaultEnabled?: boolean;
 }
 
 /**
@@ -21,10 +22,11 @@ export function CustomCheckboxSection({
   selectedMCPServerView,
   targetMCPServerName,
   configurationKey,
+  defaultEnabled = false,
 }: CustomCheckboxSectionProps) {
   const { field } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configurationKey}`,
-    defaultValue: false,
+    defaultValue: defaultEnabled,
   });
 
   const isTargetServer =


### PR DESCRIPTION
## Description

- This PR enabled the filesystem-like search by default on new search configured on an agent.
- Thought we already had this for a while.

## Tests

- Tested locally.

## Risk

## Deploy Plan

- Deploy front.
