### PR TITLE
fix: project mark all as read

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -952,7 +952,7 @@ interface InboxConversationListProps {
   dateLabel: string;
   isMultiSelect: boolean;
   isMarkingAllAsRead: boolean;
-  onMarkAllAsRead: (conversations: ConversationWithoutContentType[]) => void;
+  onMarkAllAsRead: (conversationIds: string[]) => void;
   selectedConversations: ConversationWithoutContentType[];
   toggleConversationSelection: (c: ConversationWithoutContentType) => void;
   activeConversationId: string | null;
@@ -1002,7 +1002,9 @@ const InboxConversationList = ({
             variant="ghost"
             icon={CheckDoubleIcon}
             tooltip="Mark all as read"
-            onClick={() => onMarkAllAsRead(inboxConversations)}
+            onClick={() =>
+              onMarkAllAsRead(inboxConversations.map((c) => c.sId))
+            }
             isLoading={isMarkingAllAsRead}
           />
         ) : null

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -8,6 +8,7 @@ import { getGroupConversationsByDate } from "@app/components/assistant/conversat
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
+import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
 import { useAppRouter } from "@app/lib/platform";
@@ -82,6 +83,10 @@ export function SpaceConversationsTab({
     owner,
     spaceId: spaceInfo.sId,
   });
+  const { unreadConversationIds } = useSpaceUnreadConversationIds({
+    workspaceId: owner.sId,
+    spaceId: spaceInfo.sId,
+  });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
 
@@ -107,10 +112,6 @@ export function SpaceConversationsTab({
           }) as Record<GroupLabel, LightConversationType[]>)
         : ({} as Record<GroupLabel, typeof conversations>);
     }, [conversations]);
-
-  const unreadConversations = useMemo(() => {
-    return conversations.filter((c) => c.unread);
-  }, [conversations]);
 
   const navigateToConversation = useCallback(
     (conversation: ConversationWithoutContentType) => {
@@ -241,9 +242,9 @@ export function SpaceConversationsTab({
                   size="sm"
                   variant="outline"
                   label="Mark all as read"
-                  onClick={() => markAllAsRead(unreadConversations)}
+                  onClick={() => markAllAsRead(unreadConversationIds)}
                   isLoading={isMarkingAllAsRead}
-                  disabled={unreadConversations.length === 0}
+                  disabled={unreadConversationIds.length === 0}
                 />
               </div>
               <div className="flex flex-col">

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -29,6 +29,7 @@ export { useSearchProjectConversations } from "./useSearchProjectConversations";
 export {
   useSpaceConversations,
   useSpaceConversationsSummary,
+  useSpaceUnreadConversationIds,
 } from "./useSpaceConversations";
 export { useVisualizationRetry } from "./useVisualizationRetry";
 export { useVisualizationRevert } from "./useVisualizationRevert";

--- a/front/hooks/conversations/useSpaceConversations.ts
+++ b/front/hooks/conversations/useSpaceConversations.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/swr/swr";
 import type { GetBySpacesSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces";
 import type { GetSpaceConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]";
+import type { GetSpaceUnreadConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/unread";
 import type { LightConversationType } from "@app/types/assistant/conversation";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
@@ -98,5 +99,41 @@ export function useSpaceConversations({
     hasMore,
     loadMore,
     mutateConversations: mutate,
+  };
+}
+
+export function useSpaceUnreadConversationIds({
+  workspaceId,
+  spaceId,
+  options,
+}: {
+  workspaceId: string;
+  spaceId: string | null;
+  options?: { disabled: boolean };
+}) {
+  const conversationsFetcher: Fetcher<GetSpaceUnreadConversationsResponseBody> =
+    fetcher;
+
+  const { data, isLoading, mutate } = useSWRWithDefaults(
+    spaceId
+      ? `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}/unread`
+      : null,
+    conversationsFetcher,
+    {
+      disabled: options?.disabled ?? !spaceId,
+    }
+  );
+
+  const unreadConversationIds = useMemo(() => {
+    if (!data) {
+      return emptyArray<string>();
+    }
+    return data.unreadConversationIds;
+  }, [data]);
+
+  return {
+    unreadConversationIds,
+    isLoading: isLoading && !options?.disabled,
+    mutateUnreadConversationIds: mutate,
   };
 }

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -2,10 +2,10 @@ import {
   useConversations,
   useSpaceConversations,
   useSpaceConversationsSummary,
+  useSpaceUnreadConversationIds,
 } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 
@@ -33,16 +33,20 @@ export function useMarkAllConversationsAsRead({
       spaceId: spaceId ?? null,
     });
 
+  const { mutateUnreadConversationIds } = useSpaceUnreadConversationIds({
+    workspaceId: owner.sId,
+    spaceId: spaceId ?? null,
+  });
+
   const markAllAsRead = useCallback(
-    async (conversations: ConversationWithoutContentType[]) => {
-      if (conversations.length === 0) {
+    async (conversationIds: string[]) => {
+      if (conversationIds.length === 0) {
         return;
       }
 
       setIsMarkingAllAsRead(true);
 
-      const total = conversations.length;
-      const conversationIds = conversations.map((c) => c.sId);
+      const total = conversationIds.length;
 
       try {
         const response = await clientFetch(
@@ -72,6 +76,7 @@ export function useMarkAllConversationsAsRead({
         void mutateConversations();
         void mutateSpaceSummary();
         void mutateSpaceConversations();
+        void mutateUnreadConversationIds();
 
         sendNotification({
           type: "success",
@@ -94,6 +99,7 @@ export function useMarkAllConversationsAsRead({
       mutateSpaceSummary,
       mutateSpaceConversations,
       sendNotification,
+      mutateUnreadConversationIds,
     ]
   );
 

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
@@ -1,0 +1,67 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetSpaceUnreadConversationsResponseBody = {
+  unreadConversationIds: string[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetSpaceUnreadConversationsResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET": {
+      const { spaceId } = req.query;
+
+      if (!isString(spaceId)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "spaceId is required",
+          },
+        });
+      }
+
+      const space = await SpaceResource.fetchById(auth, spaceId);
+      if (!space || !space.canReadOrAdministrate(auth)) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: "Space not found or access denied",
+          },
+        });
+      }
+
+      const unreadConversationIds =
+        await ConversationResource.getSpaceUnreadConversationIds(
+          auth,
+          space.id
+        );
+
+      return res.status(200).json({
+        unreadConversationIds,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR fixes the "mark all as read" functionality for projects, which was previously only marking fetched conversations as read instead of all unread conversations in the space.

- Adds a new API endpoint `/api/w/[wId]/assistant/conversations/spaces/[spaceId]/unread` to fetch all unread conversation IDs for a space
- Updates UI components to use the new approach

## Tests

Manually

## Risks

Low risk. Fixes a bug where only paginated results were being marked as read.

## Deploy Plan

Standard deployment.
