### PR TITLE
feat(mcp): allow none token_endpoint_auth_method

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -113,6 +113,11 @@ impl Provider for MCPConnectionProvider {
             Some("client_secret_basic")
         ) && client_secret.is_some();
 
+        let use_none_auth = matches!(
+            metadata.token_endpoint_auth_method.as_deref(),
+            Some("none")
+        );
+
         let mut form_data = vec![
             ("grant_type", grant_type),
             ("code", code),
@@ -123,9 +128,11 @@ impl Provider for MCPConnectionProvider {
         if !use_basic_auth {
             form_data.push(("client_id", &client_id));
 
-            // Only include client_secret if it's provided
-            if let Some(ref secret) = client_secret {
-                form_data.push(("client_secret", secret));
+            // Never send client_secret when auth method is "none" (PKCE public clients).
+            if !use_none_auth {
+                if let Some(ref secret) = client_secret {
+                    form_data.push(("client_secret", secret));
+                }
             }
         }
 
@@ -213,6 +220,11 @@ impl Provider for MCPConnectionProvider {
             Some("client_secret_basic")
         ) && client_secret.is_some();
 
+        let use_none_auth = matches!(
+            metadata.token_endpoint_auth_method.as_deref(),
+            Some("none")
+        );
+
         let mut form_data = vec![
             ("grant_type", grant_type),
             ("refresh_token", &refresh_token),
@@ -221,9 +233,11 @@ impl Provider for MCPConnectionProvider {
         if !use_basic_auth {
             form_data.push(("client_id", &client_id));
 
-            // Only include client_secret if it's provided
-            if let Some(ref secret) = client_secret {
-                form_data.push(("client_secret", secret));
+            // Never send client_secret when auth method is "none" (PKCE public clients).
+            if !use_none_auth {
+                if let Some(ref secret) = client_secret {
+                    form_data.push(("client_secret", secret));
+                }
             }
         }
 

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -55,6 +55,10 @@ const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
     value: "client_secret_basic",
     label: "Basic auth header",
   },
+  {
+    value: "none",
+    label: "None (PKCE only)",
+  },
 ] as const;
 
 // Error key used for credential validation errors.

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -457,7 +457,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         ? "client_secret_post"
         : supportedTokenAuthMethods?.includes("client_secret_basic")
           ? "client_secret_basic"
-          : undefined;
+          : supportedTokenAuthMethods?.includes("none")
+            ? "none"
+            : undefined;
 
       const connectionMetadata: MCPOAuthConnectionMetadataType = {
         authorization_endpoint: metadata.authorization_endpoint,

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -502,7 +502,7 @@ export function isValidUrl(s: unknown): s is string {
 export function isValidTokenEndpointAuthMethod(s: unknown): s is string {
   return (
     typeof s === "string" &&
-    (s === "client_secret_post" || s === "client_secret_basic")
+    (s === "client_secret_post" || s === "client_secret_basic" || s === "none")
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Should allow using https://github.com/dust-tt/tasks/issues/6613

Summary

  - Add token_endpoint_auth_method: "none" support for PKCE public clients (e.g., Azure/Power BI MCP)
  - When auth method is "none", client_secret is never sent in token exchange requests, even if one was accidentally configured
  - Add "None (PKCE only)" option to the OAuth configuration UI
  - Auto-detect "none" from server-advertised auth methods during DCR discovery

  Context

  https://datatracker.ietf.org/doc/html/rfc7591#section-2 defines token_endpoint_auth_method as a client metadata field, where "none" means the client is a public client with no client secret. Azure/Microsoft identity platform registers public clients (like Power BI MCP) with this value.

  When Dust sent a client_secret parameter in the token request — even an empty one — Azure rejected it because public clients must not authenticate with a secret.

  Previously, Dust only supported "client_secret_post" and "client_secret_basic", so there was no way to configure a PKCE-only flow via mcp_static. The system would default to "client_secret_post" behavior and include the secret in the form body regardless.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Lowish

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front & oauth