### PR TITLE
[front] Allow searching for remote db tables in skill knowledge search

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -209,8 +209,9 @@ function KnowledgeSearchComponent({
       query: searchQuery,
       pageSize: 10,
       spaceIds,
-      // Tables can't be attached to a skill.
-      viewType: "document",
+      // Use "all" to include remote database tables (Snowflake/BigQuery).
+      viewType: "all",
+      excludeNonRemoteDatabaseTables: true,
       includeDataSources: false,
       searchSourceUrls: true,
       includeTools: false,

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -37,6 +37,15 @@ export const FOLDERS_SELECTION_PREVENTED_MIME_TYPES = [
   INTERNAL_MIME_TYPES.NOTION.SYNCING_FOLDER,
 ] as readonly string[];
 
+// Table-like mime types that are NOT remote databases (Snowflake/BigQuery).
+export const NON_REMOTE_DATABASE_TABLE_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.NOTION.DATABASE,
+  INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+  INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
+  INTERNAL_MIME_TYPES.FOLDER.SPREADSHEET,
+  INTERNAL_MIME_TYPES.GENERIC.TABLE,
+] as readonly string[];
+
 export const UNTITLED_TITLE = "Untitled Document";
 
 export function getContentNodeInternalIdFromTableId(

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -2,6 +2,7 @@
 import config from "@app/lib/api/config";
 import {
   getContentNodeFromCoreNode,
+  NON_REMOTE_DATABASE_TABLE_MIME_TYPES,
   NON_SEARCHABLE_NODES_MIME_TYPES,
 } from "@app/lib/api/content_nodes";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
@@ -80,6 +81,7 @@ const BaseSearchBody = t.refinement(
        * Used to allow admins to useSpaces on global
        */
       allowAdminSearch: t.boolean,
+      excludeNonRemoteDatabaseTables: t.boolean,
       parentId: t.string,
       searchSort: SearchSort,
       /**
@@ -173,6 +175,7 @@ export async function handleSearch(
   {
     allowAdminSearch,
     dataSourceViewIdsBySpaceId,
+    excludeNonRemoteDatabaseTables,
     includeDataSources,
     nodeIds,
     parentId,
@@ -241,8 +244,12 @@ export async function handleSearch(
       )
     : allDatasourceViews;
 
-  const excludedNodeMimeTypes =
-    nodeIds || searchSourceUrls ? [] : NON_SEARCHABLE_NODES_MIME_TYPES;
+  const excludedNodeMimeTypes = [
+    ...(nodeIds || searchSourceUrls ? [] : NON_SEARCHABLE_NODES_MIME_TYPES),
+    ...(excludeNonRemoteDatabaseTables
+      ? NON_REMOTE_DATABASE_TABLE_MIME_TYPES
+      : []),
+  ];
 
   const searchFilterRes = getSearchFilterFromDataSourceViews(
     filteredDatasourceViews,

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -31,6 +31,7 @@ export function useUnifiedSearch({
   disabled = false,
   spaceIds,
   viewType = "all",
+  excludeNonRemoteDatabaseTables = false,
   includeDataSources = true,
   searchSourceUrls = false,
   includeTools = true,
@@ -42,6 +43,7 @@ export function useUnifiedSearch({
   disabled?: boolean;
   spaceIds?: string[];
   viewType?: Exclude<ContentNodesViewType, "data_warehouse">;
+  excludeNonRemoteDatabaseTables?: boolean;
   includeDataSources?: boolean;
   searchSourceUrls?: boolean;
   includeTools?: boolean;
@@ -88,6 +90,10 @@ export function useUnifiedSearch({
 
       if (spaceIds && spaceIds.length > 0) {
         params.append("spaceIds", spaceIds.join(","));
+      }
+
+      if (excludeNonRemoteDatabaseTables) {
+        params.append("excludeNonRemoteDatabaseTables", "true");
       }
 
       if (cursor) {
@@ -146,6 +152,7 @@ export function useUnifiedSearch({
     },
     [
       disabled,
+      excludeNonRemoteDatabaseTables,
       includeDataSources,
       includeTools,
       owner.sId,
@@ -185,6 +192,7 @@ export function useUnifiedSearch({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     disabled,
+    excludeNonRemoteDatabaseTables,
     includeDataSources,
     includeTools,
     owner.sId,

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -47,6 +47,7 @@ async function handleStreamingSearch(
     cursor,
     viewType = "all",
     spaceIds: spaceIdsParam,
+    excludeNonRemoteDatabaseTables: excludeNonRemoteDatabaseTablesParam,
     includeDataSources = "true",
     searchSourceUrls,
     includeTools = "true",
@@ -74,6 +75,8 @@ async function handleStreamingSearch(
       isString(spaceIdsParam) && spaceIdsParam.length > 0
         ? spaceIdsParam.split(",")
         : [],
+    excludeNonRemoteDatabaseTables:
+      excludeNonRemoteDatabaseTablesParam === "true",
     includeDataSources: includeDataSources === "true",
     limit,
     searchSourceUrls: searchSourceUrls === "true" ? true : undefined,


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/21651.
- This PR adds a way to search and thus attach tables that come from remote databases (Snowflake/BigQuery) in the skill knowledge search.
- Rationale is that being able to reference these tables is highly useful and that the other tables are not supported with data warehouse.
- Relies on a filtering on the mime type to exclude other table types. Not a great long-term solution, but the future of Snowflake/BigQuery as connectors versus tools is uncertain, we don't iterate on connectors all that much and we want to unlock the ability to add tables.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
