### PR TITLE
feat(dusthivecat): make terminal app configurable

### DIFF
--- a/x/daph/dust-hive-cat/DustHiveCat/App/AppDelegate.swift
+++ b/x/daph/dust-hive-cat/DustHiveCat/App/AppDelegate.swift
@@ -235,6 +235,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         radiusItem.submenu = radiusMenu
         statusBarMenu?.addItem(radiusItem)
 
+        // Terminal submenu
+        let terminalItem = NSMenuItem(title: "Terminal", action: nil, keyEquivalent: "")
+        let terminalMenu = NSMenu()
+        for name in ["Alacritty", "Ghostty", "iTerm2", "Terminal", "Kitty", "Warp", "WezTerm"] {
+            let item = NSMenuItem(title: name, action: #selector(selectTerminal(_:)), keyEquivalent: "")
+            item.representedObject = name
+            terminalMenu.addItem(item)
+        }
+        terminalItem.submenu = terminalMenu
+        statusBarMenu?.addItem(terminalItem)
+
         // Launch at login
         let launchItem = NSMenuItem(title: "Launch at Login", action: #selector(toggleLaunchAtLogin(_:)), keyEquivalent: "")
         statusBarMenu?.addItem(launchItem)
@@ -327,6 +338,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         CatPreferences.shared.roamingRadius = CGFloat(value)
     }
 
+    @objc private func selectTerminal(_ sender: NSMenuItem) {
+        guard let name = sender.representedObject as? String else { return }
+        CatPreferences.shared.terminalApp = name
+    }
+
     @objc private func toggleLaunchAtLogin(_ sender: NSMenuItem) {
         CatPreferences.shared.launchAtLogin = !CatPreferences.shared.launchAtLogin
     }
@@ -388,6 +404,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 if let value = item.representedObject as? Double {
                     item.state = abs(value - Double(prefs.roamingRadius)) < 1 ? .on : .off
                 }
+            }
+        }
+
+        // Update checkmarks for Terminal submenu
+        if let terminalItem = menu.item(withTitle: "Terminal"), let terminalMenu = terminalItem.submenu {
+            for item in terminalMenu.items {
+                item.state = (item.representedObject as? String) == prefs.terminalApp ? .on : .off
             }
         }
 

--- a/x/daph/dust-hive-cat/DustHiveCat/Models/CatPreferences.swift
+++ b/x/daph/dust-hive-cat/DustHiveCat/Models/CatPreferences.swift
@@ -17,6 +17,7 @@ class CatPreferences {
         static let roamingRadius = "roamingRadius"
         static let hotkeyEnabled = "hotkeyEnabled"
         static let tooltipEnabled = "tooltipEnabled"
+        static let terminalApp = "terminalApp"
     }
 
     // MARK: - Properties
@@ -94,6 +95,15 @@ class CatPreferences {
         set {
             defaults.set(newValue, forKey: Keys.hotkeyEnabled)
             NotificationCenter.default.post(name: .catHotkeyPreferenceChanged, object: nil)
+        }
+    }
+
+    /// The terminal app to activate and detect as focused (e.g. "Alacritty", "Ghostty")
+    var terminalApp: String {
+        get { defaults.string(forKey: Keys.terminalApp) ?? "Alacritty" }
+        set {
+            defaults.set(newValue, forKey: Keys.terminalApp)
+            NotificationCenter.default.post(name: .catPreferencesChanged, object: nil)
         }
     }
 

--- a/x/daph/dust-hive-cat/DustHiveCat/Views/CatWindowController.swift
+++ b/x/daph/dust-hive-cat/DustHiveCat/Views/CatWindowController.swift
@@ -273,7 +273,7 @@ class CatWindowController: NSWindowController {
             var error: NSDictionary?
             guard let appleScript = NSAppleScript(source: frontmostScript),
                   let result = appleScript.executeAndReturnError(&error).stringValue,
-                  result.lowercased() == "alacritty" else {
+                  result.lowercased() == self?.prefs.terminalApp.lowercased() else {
                 return
             }
 
@@ -333,9 +333,10 @@ class CatWindowController: NSWindowController {
             task.waitUntilExit()
         }
 
-        // Bring Alacritty to the front
+        // Bring the configured terminal to the front
+        let terminalApp = prefs.terminalApp
         let script = """
-        tell application "Alacritty"
+        tell application "\(terminalApp)"
             activate
         end tell
         """

--- a/x/daph/dust-hive-cat/Scripts/dustcat-notify.sh
+++ b/x/daph/dust-hive-cat/Scripts/dustcat-notify.sh
@@ -32,12 +32,16 @@ if tmux list-sessions &>/dev/null; then
         ACTIVE_WINDOW=$(tmux display-message -t "${TARGET}" -p '#{window_active}' 2>/dev/null)
         ACTIVE_PANE=$(tmux display-message -t "${TARGET}" -p '#{pane_active}' 2>/dev/null)
 
-        # Check if Alacritty is the frontmost app
+        # Read configured terminal app from preferences
+        TERMINAL_APP=$(defaults read com.dust.dusthivecat terminalApp 2>/dev/null || echo "Alacritty")
+        TERMINAL_LOWER=$(echo "$TERMINAL_APP" | tr '[:upper:]' '[:lower:]')
+
+        # Check if the configured terminal is the frontmost app
         FRONTMOST=$(osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' 2>/dev/null)
         FRONTMOST_LOWER=$(echo "$FRONTMOST" | tr '[:upper:]' '[:lower:]')
 
-        # If pane is active AND Alacritty is focused, user is already looking — skip
-        if [ "$ACTIVE_WINDOW" = "1" ] && [ "$ACTIVE_PANE" = "1" ] && [ "$FRONTMOST_LOWER" = "alacritty" ]; then
+        # If pane is active AND terminal is focused, user is already looking — skip
+        if [ "$ACTIVE_WINDOW" = "1" ] && [ "$ACTIVE_PANE" = "1" ] && [ "$FRONTMOST_LOWER" = "$TERMINAL_LOWER" ]; then
             exit 0
         fi
     else


### PR DESCRIPTION
## Summary

- Add a `terminalApp` user preference (defaults to Alacritty) so users of other terminals can use DustHiveCat
- Replace all hardcoded "Alacritty" references in `CatWindowController` (focus detection + activation) and `dustcat-notify.sh`
- Add a "Terminal" submenu in the status bar menu with common options: Alacritty, Ghostty, iTerm2, Terminal, Kitty, Warp, WezTerm

<img width="319" height="381" alt="image" src="https://github.com/user-attachments/assets/15876642-ea0f-47ec-9c78-92195d3fc0a7" />


## Test plan

- [x] Build the app (`swift build`)
- [x] Right-click status bar icon → "Terminal" submenu appears with 7 options
- [x] Select a different terminal → preference persists across relaunch
- [x] Trigger notification → click cat → selected terminal gets activated (not Alacritty)
- [ ] Verify auto-dismiss works when selected terminal is frontmost and target pane is active
- [ ] Verify `dustcat-notify.sh` reads the preference and skips notification when selected terminal is focused