### PR TITLE
fix: click on project breadcrumb in datasource selector

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -38,7 +38,7 @@ import {
   Separator,
 } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 type DataSourceBuilderSelectorProps = {
   viewType: ContentNodesViewType;
@@ -59,6 +59,7 @@ export const DataSourceBuilderSelector = ({
   const { systemSpace } = useSystemSpace({ workspaceId: owner.sId });
   const currentNavigationEntry =
     navigationHistory[navigationHistory.length - 1];
+  const prevHistoryLengthRef = useRef(navigationHistory.length);
 
   const {
     inputValue: searchTerm,
@@ -132,14 +133,24 @@ export const DataSourceBuilderSelector = ({
 
   // Automatically select the managed category if we are in a "project" kind of space
   useEffect(() => {
+    const prevLength = prevHistoryLengthRef.current;
+    prevHistoryLengthRef.current = navigationHistory.length;
+
+    const isNavigatingForward = navigationHistory.length > prevLength;
     if (
+      isNavigatingForward &&
       currentSpace &&
       currentSpace.kind === "project" &&
       currentNavigationEntry.type === "space"
     ) {
       setCategoryEntry("managed");
     }
-  }, [currentSpace, currentNavigationEntry, setCategoryEntry]);
+  }, [
+    currentSpace,
+    currentNavigationEntry,
+    setCategoryEntry,
+    navigationHistory.length,
+  ]);
 
   const [searchScope, setSearchScope] = useState<"node" | "space">("space");
 


### PR DESCRIPTION
## Description

This PR fixes a bug where clicking on project name breadcrumbs in the datasource selector would not do anything

The useEffect was automatically selecting the "managed" category whenever the current space was a project, without distinguishing between forward navigation (entering a project space) and backward navigation (clicking breadcrumbs to go back). 


https://github.com/user-attachments/assets/5e39ba25-ab47-45b4-8e24-794655f12d20


## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment - no special considerations needed.
