### PR TITLE
[front] - refacto(insights): adapt color palette

### DIFF
--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -105,7 +105,7 @@ export function ChartsTooltip({
                   {b.label}
                 </span>
                 <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-                  {b.value}
+                  {b.value.toLocaleString()}
                 </span>
                 <span className="text-muted-foreground dark:text-muted-foreground-night">
                   ({b.percent}%)
@@ -136,7 +136,7 @@ export function ChartsTooltip({
             {toolName}
           </span>
           <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-            {data.count}
+            {data.count.toLocaleString()}
           </span>
         </div>
       </div>

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -111,7 +111,9 @@ export function SourceChart({
             dominantBaseline="middle"
             className="fill-foreground dark:fill-foreground-night"
           >
-            <tspan className="text-2xl font-semibold">{total}</tspan>
+            <tspan className="text-2xl font-semibold">
+              {total.toLocaleString()}
+            </tspan>
             <tspan x="50%" dy="1.2em" className="text-sm">
               Messages
             </tspan>

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -65,6 +65,11 @@ export const INDEXED_BASE_COLORS = [
   "green",
   "violet",
   "rose",
+  "blue",
+  "lime",
+  "emerald",
+  "pink",
+  "red",
 ] as const;
 
 export type IndexedBaseColor = (typeof INDEXED_BASE_COLORS)[number];
@@ -73,8 +78,12 @@ export function buildColorClass(baseColor: string, shade: number): string {
   return `text-${baseColor}-${shade} dark:text-${baseColor}-${shade}-night`;
 }
 
-export const INDEXED_COLORS = INDEXED_BASE_COLORS.map((color) =>
-  buildColorClass(color, 500)
+export const INDEXED_SHADES = [
+  500, 300, 700, 200, 800, 100, 900, 400, 600, 50, 950,
+] as const;
+
+export const INDEXED_COLORS = INDEXED_SHADES.flatMap((shade) =>
+  INDEXED_BASE_COLORS.map((color) => buildColorClass(color, shade))
 );
 
 export const CONVERSATION_FILES_AGGREGATE_KEY = "__conversation_files__";
@@ -107,82 +116,43 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   UserMessageOrigin,
   { label: string; color: string }
 > = {
-  api: { label: "API", color: "text-blue-500 dark:text-blue-500-night" },
-  cli: { label: "CLI", color: "text-gray-500 dark:text-gray-500-night" },
-  cli_programmatic: {
-    label: "CLI",
-    color: "text-gray-500 dark:text-gray-500-night",
-  },
-  email: {
-    label: "Email",
-    color: "text-violet-500 dark:text-violet-500-night",
-  },
-  excel: { label: "Excel", color: "text-rose-500 dark:text-rose-500-night" },
+  web: { label: "Conversation", color: buildColorClass("blue", 500) },
   extension: {
     label: "Chrome extension",
-    color: "text-golden-500 dark:text-golden-500-night",
+    color: buildColorClass("orange", 500),
   },
-  gsheet: {
-    label: "Google Sheets",
-    color: "text-green-500 dark:text-green-500-night",
-  },
-  make: { label: "Make", color: "text-gray-600 dark:text-gray-600-night" },
-  n8n: {
-    label: "n8n",
-    color: "text-success-muted dark:text-success-muted-night",
-  },
-  powerpoint: {
-    label: "PowerPoint",
-    color: "text-violet-500 dark:text-violet-500-night",
-  },
-  raycast: {
-    label: "Raycast",
-    color: "rose-500 dark:rose-500-night",
-  },
-  slack: { label: "Slack", color: "text-green-500 dark:text-green-500-night" },
-  slack_workflow: {
-    label: "Slack",
-    color: "text-green-500 dark:text-green-500-night",
-  },
-  teams: {
-    label: "Teams",
-    color: "text-highlight-muted dark:text-highlight-muted-night",
-  },
-  transcript: {
-    label: "Transcript",
-    color: "text-warning-muted dark:text-warning-muted-night",
-  },
+  slack: { label: "Slack", color: buildColorClass("green", 500) },
+  slack_workflow: { label: "Slack", color: buildColorClass("green", 500) },
+  api: { label: "API", color: buildColorClass("violet", 500) },
+  cli: { label: "CLI", color: buildColorClass("gray", 500) },
+  cli_programmatic: { label: "CLI", color: buildColorClass("gray", 500) },
+  gsheet: { label: "Google Sheets", color: buildColorClass("emerald", 500) },
+  email: { label: "Email", color: buildColorClass("pink", 500) },
+  excel: { label: "Excel", color: buildColorClass("rose", 500) },
+  teams: { label: "Teams", color: buildColorClass("blue", 300) },
+  make: { label: "Make", color: buildColorClass("gray", 700) },
+  n8n: { label: "n8n", color: buildColorClass("lime", 500) },
+  raycast: { label: "Raycast", color: buildColorClass("red", 500) },
+  zapier: { label: "Zapier", color: buildColorClass("blue", 700) },
+  zendesk: { label: "Zendesk", color: buildColorClass("golden", 700) },
+  powerpoint: { label: "PowerPoint", color: buildColorClass("violet", 300) },
+  transcript: { label: "Transcript", color: buildColorClass("golden", 500) },
+  triggered: { label: "Trigger", color: buildColorClass("orange", 300) },
   triggered_programmatic: {
     label: "Trigger",
-    color: "text-info-muted dark:text-info-muted-night",
-  },
-  triggered: {
-    label: "Trigger",
-    color: "text-info-muted dark:text-info-muted-night",
-  },
-  web: {
-    label: "Conversation",
-    color: "text-blue-500 dark:text-blue-500-night",
-  },
-  zapier: { label: "Zapier", color: "text-blue-800 dark:text-blue-800-night" },
-  zendesk: {
-    label: "Zendesk",
-    color: "text-blue-800 dark:text-blue-800-night",
+    color: buildColorClass("orange", 300),
   },
   onboarding_conversation: {
     label: "Onboarding",
-    color: "info-muted dark:info-muted-night",
+    color: buildColorClass("rose", 300),
   },
-  agent_copilot: {
-    label: "Copilot",
-    color: "text-info-muted dark:text-info-muted-night",
-  },
+  agent_copilot: { label: "Copilot", color: buildColorClass("emerald", 300) },
   project_butler: {
     label: "Project Butler",
-    color: "text-gray-400 dark:text-gray-400-night",
+    color: buildColorClass("gray", 400),
   },
   project_kickoff: {
     label: "Project Kickoff",
-    color: "text-info-muted dark:text-info-muted-night",
+    color: buildColorClass("lime", 300),
   },
 };

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -137,7 +137,7 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   zendesk: { label: "Zendesk", color: buildColorClass("golden", 700) },
   powerpoint: { label: "PowerPoint", color: buildColorClass("violet", 300) },
   transcript: { label: "Transcript", color: buildColorClass("golden", 500) },
-  triggered: { label: "Trigger", color: buildColorClass("orange", 300) },
+  triggered: { label: "Trigger", color: buildColorClass("orange", 700) },
   triggered_programmatic: {
     label: "Trigger",
     color: buildColorClass("orange", 300),
@@ -149,7 +149,7 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   agent_copilot: { label: "Copilot", color: buildColorClass("emerald", 300) },
   project_butler: {
     label: "Project Butler",
-    color: buildColorClass("gray", 400),
+    color: buildColorClass("gray", 300),
   },
   project_kickoff: {
     label: "Project Kickoff",

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -1,6 +1,7 @@
 import {
+  buildColorClass,
   INDEXED_BASE_COLORS,
-  INDEXED_COLORS,
+  INDEXED_SHADES,
   OTHER_LABEL,
   UNKNOWN_LABEL,
   USER_MESSAGE_ORIGIN_LABELS,
@@ -43,7 +44,13 @@ export function getIndexedColor(label: string, allLabels: string[]): string {
   }
 
   const idx = allLabels.indexOf(label);
-  return INDEXED_COLORS[(idx >= 0 ? idx : 0) % INDEXED_COLORS.length];
+  const i = idx >= 0 ? idx : 0;
+  const baseColor = INDEXED_BASE_COLORS[i % INDEXED_BASE_COLORS.length];
+  const shade =
+    INDEXED_SHADES[
+      Math.floor(i / INDEXED_BASE_COLORS.length) % INDEXED_SHADES.length
+    ];
+  return buildColorClass(baseColor, shade);
 }
 
 export function getIndexedBaseColor(

--- a/front/components/charts/ChartTooltip.tsx
+++ b/front/components/charts/ChartTooltip.tsx
@@ -51,7 +51,7 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
               {r.label}
             </span>
             <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-              {r.value}
+              {r.value.toLocaleString()}
             </span>
             {typeof r.percent === "number" && (
               <span className="text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/charts/DatasourceRetrievalTreemapContent.tsx
+++ b/front/components/charts/DatasourceRetrievalTreemapContent.tsx
@@ -118,7 +118,9 @@ export function DatasourceRetrievalTreemapContent({
   const groupName = root?.name ?? "";
   const groupValue = typeof root?.value === "number" ? root.value : null;
   const groupLabel =
-    groupValue !== null ? `${groupName} — ${groupValue}` : groupName;
+    groupValue !== null
+      ? `${groupName} — ${groupValue.toLocaleString()}`
+      : groupName;
   const shouldShowGroupLabel =
     shouldShowGroupOutline &&
     groupName.length > 0 &&
@@ -187,7 +189,7 @@ export function DatasourceRetrievalTreemapContent({
                 buildColorClass(baseColor, VALUE_COLOR_VARIANT)
               )}
             >
-              {value}
+              {value.toLocaleString()}
             </div>
           </div>
         </foreignObject>

--- a/front/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart.tsx
+++ b/front/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart.tsx
@@ -1,8 +1,8 @@
 import {
   CHART_HEIGHT,
   DEFAULT_PERIOD_DAYS,
-  INDEXED_COLORS,
 } from "@app/components/agent_builder/observability/constants";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
@@ -35,12 +35,13 @@ export function WorkspaceDatasourceRetrievalTreemapPluginChart({
       return null;
     }
 
+    const allLabels = datasourceRetrieval.map((d) => d.displayName);
     return datasourceRetrieval.map(
-      (ds, index): DatasourceRetrievalTreemapNode => ({
+      (ds): DatasourceRetrievalTreemapNode => ({
         name: ds.displayName,
         dataSourceId: ds.dataSourceId,
         size: ds.count,
-        color: INDEXED_COLORS[index % INDEXED_COLORS.length],
+        color: getIndexedColor(ds.displayName, allLabels),
         baseColor: "sky",
         connectorProvider: ds.connectorProvider,
       })

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -1,9 +1,9 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
-  CHART_HEIGHT,
-  INDEXED_COLORS,
-} from "@app/components/agent_builder/observability/constants";
-import { getTimeRangeBounds } from "@app/components/agent_builder/observability/utils";
+  getIndexedColor,
+  getTimeRangeBounds,
+} from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
@@ -44,11 +44,6 @@ interface ToolUsageChartPoint {
   values: Record<string, number>;
 }
 
-function getToolColor(toolName: string, allTools: string[]): string {
-  const idx = allTools.indexOf(toolName);
-  return INDEXED_COLORS[(idx >= 0 ? idx : 0) % INDEXED_COLORS.length];
-}
-
 function getToolSelectorLabel(selectedTools: string[]): string {
   if (selectedTools.length === 0) {
     return "Select tools";
@@ -87,7 +82,7 @@ function ToolUsageTooltip({
   const rows = toolsForChart.map((tool, idx) => ({
     label: asDisplayToolName(tool),
     value: values[idx].toLocaleString(),
-    colorClassName: getToolColor(tool, toolsForChart),
+    colorClassName: getIndexedColor(tool, toolsForChart),
   }));
 
   if (toolsForChart.length > 1) {
@@ -235,7 +230,7 @@ export function WorkspaceToolUsageChart({
   const legendItems: LegendItem[] = toolsForChart.map((tool) => ({
     key: tool,
     label: asDisplayToolName(tool),
-    colorClassName: getToolColor(tool, toolsForChart),
+    colorClassName: getIndexedColor(tool, toolsForChart),
   }));
 
   const toolSelector = (
@@ -360,7 +355,7 @@ export function WorkspaceToolUsageChart({
             strokeWidth={2}
             dataKey={(point: ToolUsageChartPoint) => point.values[tool] ?? 0}
             name={asDisplayToolName(tool)}
-            className={getToolColor(tool, toolsForChart)}
+            className={getIndexedColor(tool, toolsForChart)}
             stroke="currentColor"
             dot={false}
           />

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -68,7 +68,7 @@ function makeColumns(workspaceId: string): ColumnDef<TopAgentRowData>[] {
       cell: (info: TopAgentInfo) => (
         <DataTable.BasicCellContent
           className="text-center"
-          label={`${info.row.original.messageCount}`}
+          label={info.row.original.messageCount.toLocaleString()}
         />
       ),
     },
@@ -80,7 +80,9 @@ function makeColumns(workspaceId: string): ColumnDef<TopAgentRowData>[] {
         sizeRatio: 15,
       },
       cell: (info: TopAgentInfo) => (
-        <DataTable.BasicCellContent label={`${info.row.original.userCount}`} />
+        <DataTable.BasicCellContent
+          label={info.row.original.userCount.toLocaleString()}
+        />
       ),
     },
   ];

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -48,7 +48,9 @@ const columns: ColumnDef<TopUserRowData>[] = [
       sizeRatio: 15,
     },
     cell: (info: TopUserInfo) => (
-      <DataTable.BasicCellContent label={`${info.row.original.messageCount}`} />
+      <DataTable.BasicCellContent
+        label={info.row.original.messageCount.toLocaleString()}
+      />
     ),
   },
   {
@@ -59,7 +61,9 @@ const columns: ColumnDef<TopUserRowData>[] = [
       sizeRatio: 15,
     },
     cell: (info: TopUserInfo) => (
-      <DataTable.BasicCellContent label={`${info.row.original.agentCount}`} />
+      <DataTable.BasicCellContent
+        label={info.row.original.agentCount.toLocaleString()}
+      />
     ),
   },
 ];


### PR DESCRIPTION
## Description

Refactors the color assignment strategy for charts and observability visualizations to provide a more diverse and scalable palette. Expands `INDEXED_BASE_COLORS` from 5 to 9 colors (adding blue, lime, emerald, pink, red) and introduces 11 shade variants per color (50-950). Updates `getIndexedColor` to cycle through both base colors and shades, significantly increasing the available color combinations

Also adds locale-based number formatting with `toLocaleString()` across all charts, tooltips, and tables for improved readability.

## Risk

Low - purely visual changes to color assignment and number formatting that don't affect data computation or business logic.

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan

Deploy front