### PR TITLE
Display HTML instructions in agent details

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -1,14 +1,17 @@
+import { buildAgentInstructionsReadOnlyExtensions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
 import { AssistantKnowledgeSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection";
 import { AssistantSkillsToolsSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection";
+import { preprocessMarkdownForEditor } from "@app/components/editor/lib/preprocessMarkdownForEditor";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
-import { isString } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
 import { Avatar, Chip, cn, Markdown, Page } from "@dust-tt/sparkle";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { useEffect, useMemo, useRef } from "react";
 
 export function AgentInfoTab({
   agentConfiguration,
@@ -25,10 +28,11 @@ export function AgentInfoTab({
 
   const isGlobalAgent = agentConfiguration.scope === "global";
   const displayKnowledge = !isGlobalAgent || isDustAgent;
+
+  const instructions = agentConfiguration.instructions ?? "";
+  const instructionsHtml = agentConfiguration.instructionsHtml ?? null;
   const displayInstructions =
-    !isGlobalAgent &&
-    isString(agentConfiguration?.instructions) &&
-    agentConfiguration.instructions.length > 0;
+    !isGlobalAgent && (!!instructionsHtml || instructions.length > 0);
 
   const model = SUPPORTED_MODEL_CONFIGS.find(
     (m) =>
@@ -55,7 +59,7 @@ export function AgentInfoTab({
         </div>
       )}
 
-      {displayInstructions && isString(agentConfiguration.instructions) && (
+      {displayInstructions && (
         <div className="dd-privacy-mask flex flex-col gap-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Instructions
@@ -66,12 +70,19 @@ export function AgentInfoTab({
                 "dark:border-border-night dark:bg-muted-background-night"
             )}
           >
-            <AgentMessageMarkdown
-              content={agentConfiguration.instructions}
-              owner={owner}
-              compactSpacing={true}
-              isInstructions={true}
-            />
+            {instructionsHtml || !instructions ? (
+              <ReadOnlyInstructionsEditor
+                instructions={instructions}
+                instructionsHtml={instructionsHtml}
+              />
+            ) : (
+              <AgentMessageMarkdown
+                content={instructions}
+                owner={owner}
+                compactSpacing={true}
+                isInstructions={true}
+              />
+            )}
           </div>
         </div>
       )}
@@ -108,4 +119,63 @@ export function AgentInfoTab({
       )}
     </div>
   );
+}
+
+interface ReadOnlyInstructionsEditorProps {
+  instructions: string;
+  instructionsHtml: string | null;
+}
+
+function ReadOnlyInstructionsEditor({
+  instructions,
+  instructionsHtml,
+}: ReadOnlyInstructionsEditorProps) {
+  const extensions = useMemo(
+    () => buildAgentInstructionsReadOnlyExtensions(),
+    []
+  );
+
+  const initialContentSetRef = useRef(false);
+
+  const editor = useEditor(
+    {
+      extensions,
+      editable: false,
+      immediatelyRender: false,
+    },
+    [extensions]
+  );
+
+  useEffect(() => {
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      initialContentSetRef.current ||
+      (!instructions && !instructionsHtml)
+    ) {
+      return;
+    }
+
+    initialContentSetRef.current = true;
+
+    requestAnimationFrame(() => {
+      if (editor && !editor.isDestroyed) {
+        if (instructionsHtml) {
+          editor.commands.setContent(instructionsHtml, {
+            emitUpdate: false,
+          });
+        } else if (instructions) {
+          editor.commands.setContent(
+            preprocessMarkdownForEditor(instructions),
+            {
+              emitUpdate: false,
+              contentType: "markdown",
+            }
+          );
+        }
+      }
+    });
+  }, [editor, instructions, instructionsHtml]);
+
+  return <EditorContent editor={editor} />;
 }

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -1,5 +1,4 @@
 import { buildAgentInstructionsReadOnlyExtensions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
-import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
 import { AssistantKnowledgeSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection";
 import { AssistantSkillsToolsSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection";
 import { preprocessMarkdownForEditor } from "@app/components/editor/lib/preprocessMarkdownForEditor";
@@ -70,19 +69,10 @@ export function AgentInfoTab({
                 "dark:border-border-night dark:bg-muted-background-night"
             )}
           >
-            {instructionsHtml !== null || instructions.length === 0 ? (
-              <ReadOnlyInstructionsEditor
-                instructions={instructions}
-                instructionsHtml={instructionsHtml}
-              />
-            ) : (
-              <AgentMessageMarkdown
-                content={instructions}
-                owner={owner}
-                compactSpacing={true}
-                isInstructions={true}
-              />
-            )}
+            <ReadOnlyInstructionsEditor
+              instructions={instructions}
+              instructionsHtml={instructionsHtml}
+            />
           </div>
         </div>
       )}

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -32,7 +32,7 @@ export function AgentInfoTab({
   const instructions = agentConfiguration.instructions ?? "";
   const instructionsHtml = agentConfiguration.instructionsHtml ?? null;
   const displayInstructions =
-    !isGlobalAgent && (!!instructionsHtml || instructions.length > 0);
+    !isGlobalAgent && (instructionsHtml !== null || instructions.length > 0);
 
   const model = SUPPORTED_MODEL_CONFIGS.find(
     (m) =>
@@ -70,7 +70,7 @@ export function AgentInfoTab({
                 "dark:border-border-night dark:bg-muted-background-night"
             )}
           >
-            {instructionsHtml || !instructions ? (
+            {instructionsHtml !== null || instructions.length === 0 ? (
               <ReadOnlyInstructionsEditor
                 instructions={instructions}
                 instructionsHtml={instructionsHtml}


### PR DESCRIPTION
## Description

For consistency with Agent Builder, display the HTML instructions in Agent Details (when available). The code matches what we have for Poke in components/poke/pages/AssistantInstructionsPage.tsx. I considered sharing some logic, but it didn't seem worth it.

Fixes https://github.com/dust-tt/tasks/issues/6467

## Tests

Manual

## Risk

Low

## Deploy Plan

Front