### PR TITLE
feat: change caching strategy for feature flags

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1228,7 +1228,7 @@ export const getFeatureFlags = memoizer.sync({
     return `feature_flags_${workspace.id}`;
   },
 
-  itemMaxAge: () => 3000,
+  itemMaxAge: () => 60_000, // 60 seconds.
 });
 
 export async function isRestrictedFromAgentCreation(

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -378,7 +378,9 @@ export function useFeatureFlags({
     featureFlagsFetcher,
     {
       disabled,
-      focusThrottleInterval: 30 * 60 * 1000, // 30 minutes
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 5 * 60 * 1000, // 5 minutes.
     }
   );
 


### PR DESCRIPTION
## Description

  - Increase server-side feature flag memoizer TTL from 3 seconds to 60 seconds, reducing DB queries from ~1 every 3s to at most 1/min per workspace per server instance                                                                                                                                                  
  - Disable SWR `revalidateOnFocus` and `revalidateOnReconnect` for the `useFeatureFlags` hook — feature flags change so rarely that refetching on tab focus or network reconnect is unnecessary
  - Set a 5-minute `dedupingInterval` on the SWR hook so that page navigations, component remounts, and other triggers within the same 5-minute window are served from the client-side cache


  We observed [a single user generating 33 feature flag fetches in 4 hours](https://app.datadoghq.eu/logs?query=%40route%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Ffeature-flags%22%20%40workspaceId%3AgckqalBONy%20%40user.sId%3AbYiFhNHHkF&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1771488449165&to_ts=1771502849165&live=false). It's ~600 hits for the whole user workspace, and 80_000 for all workspaces. In comparaison, the conversation endpoint is called 300_000 during the same time frame

The existing `focusThrottleInterval: 30min` only throttled tab-focus revalidation, but did not prevent fetches triggered by:
  1. Page navigations — Next.js Pages Router creates a fresh React tree and SWR cache on each navigation, so every page with useFeatureFlags triggered a new fetch
  2. Component mounts — SWR's default dedupingInterval is only 2 seconds, so closely spaced mounts resulted in separate requests
  3. Network reconnects — revalidateOnReconnect defaults to true
  4. Server-side calls — the getFeatureFlags memoizer had a 3-second TTL, causing frequent DB queries across the ~35 server-side call sites

Changes from a few seconds to 5 minutes, I think that's ok for feature flags (in most cases)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
