### PR TITLE
Don't cache null users

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -215,7 +215,7 @@ export class UserResource extends BaseResource<UserModel> {
   private static fetchByWorkOSUserIdCached = cacheWithRedis(
     UserResource._fetchByWorkOSUserIdUncached,
     UserResource.userByWorkOSIdCacheKeyResolver,
-    { ttlMs: USER_CACHE_TTL_MS }
+    { ttlMs: USER_CACHE_TTL_MS, cacheNullValues: false }
   );
 
   private static invalidateUserByWorkOSIdCache = invalidateCacheWithRedis(


### PR DESCRIPTION
## Description

Fix a bug where the Redis cache for `fetchByWorkOSUserId` could cache `null` results, causing existing users to not be found during login. When a cached `null` was returned, `createOrUpdateUser` would attempt to create a duplicate user, hitting a `SequelizeUniqueConstraintError` on the `workOSUserId` unique constraint.

Adds a `cacheNullValues` option to `cacheWithRedis` (defaults to `true` for backward compatibility) and sets it to `false` for the WorkOS user lookup cache. This ensures that when a user is not found, the result is never cached — subsequent lookups always hit the database and find the user if they exist.

## Tests

Manual verification of the cache behavior. The change is minimal and isolated to the caching layer.

## Risk

Low. The `cacheNullValues` option defaults to `true`, so all existing caches are unaffected. Only the WorkOS user ID lookup skips caching null results, which means slightly more DB queries for truly non-existent WorkOS user IDs — acceptable since this only happens during login flows.

## Deploy Plan

Standard deploy. No migration needed. Existing stale `null` cache entries will expire naturally (30 min TTL) after deploy.