### PR TITLE
Delete membership instead of invalidating it

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -700,7 +700,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           });
 
         if (workOSMemberships.data.length > 0) {
-          await workos.userManagement.deactivateOrganizationMembership(
+          await workos.userManagement.deleteOrganizationMembership(
             workOSMemberships.data[0].id
           );
         }
@@ -711,7 +711,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
             userId: user.id,
             error,
           },
-          "Failed to deactivate WorkOS membership"
+          "Failed to delete WorkOS membership"
         );
       }
     }

--- a/front/migrations/20260219_delete_disabled_workos_memberships.ts
+++ b/front/migrations/20260219_delete_disabled_workos_memberships.ts
@@ -1,0 +1,128 @@
+import type { OrganizationMembership } from "@workos-inc/node";
+
+import { getWorkOS } from "@app/lib/api/workos/client";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+
+async function fetchDisabledMemberships(
+  organizationId: string
+): Promise<OrganizationMembership[]> {
+  const workos = getWorkOS();
+  const memberships: OrganizationMembership[] = [];
+
+  while (true) {
+    const page = await workos.userManagement.listOrganizationMemberships({
+      organizationId,
+      statuses: ["inactive"],
+      limit: 100,
+      after:
+        memberships.length > 0
+          ? memberships[memberships.length - 1].id
+          : undefined,
+    });
+
+    memberships.push(...page.data);
+    if (page.data.length < 100) {
+      break;
+    }
+  }
+
+  return memberships;
+}
+
+async function deleteDisabledMembershipsForWorkspace(
+  workspace: LightWorkspaceType,
+  logger: typeof Logger,
+  execute: boolean
+) {
+  const workspaceLogger = logger.child({ workspaceId: workspace.sId });
+
+  if (!workspace.workOSOrganizationId) {
+    return;
+  }
+
+  const memberships = await fetchDisabledMemberships(
+    workspace.workOSOrganizationId
+  );
+
+  if (memberships.length === 0) {
+    return;
+  }
+
+  workspaceLogger.info(
+    { count: memberships.length },
+    "Found disabled WorkOS memberships"
+  );
+
+  for (const membership of memberships) {
+    workspaceLogger.info(
+      {
+        membershipId: membership.id,
+        userId: membership.userId,
+        status: membership.status,
+      },
+      execute
+        ? "Deleting disabled WorkOS membership"
+        : "Dry run: would delete disabled WorkOS membership"
+    );
+  }
+
+  if (execute) {
+    await concurrentExecutor(
+      memberships,
+      async (membership) => {
+        await getWorkOS().userManagement.deleteOrganizationMembership(
+          membership.id
+        );
+      },
+      { concurrency: 10 }
+    );
+
+    workspaceLogger.info(
+      { count: memberships.length },
+      "Deleted disabled WorkOS memberships"
+    );
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      alias: "w",
+      description:
+        "Workspace sId (optional, if not provided will run on all workspaces)",
+      demandOption: false,
+    },
+  },
+  async ({ workspaceId, execute }, scriptLogger) => {
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      await deleteDisabledMembershipsForWorkspace(
+        renderLightWorkspaceType({ workspace }),
+        scriptLogger,
+        execute
+      );
+    } else {
+      await runOnAllWorkspaces(
+        (workspace) =>
+          deleteDisabledMembershipsForWorkspace(
+            workspace,
+            scriptLogger,
+            execute
+          ),
+        { concurrency: 5 }
+      );
+    }
+
+    scriptLogger.info("Done");
+  }
+);


### PR DESCRIPTION
## Description

When revoking a user's membership in Dust, the WorkOS organization membership was being **deactivated** (`deactivateOrganizationMembership`) instead of **deleted** (`deleteOrganizationMembership`). This left the user in a broken "disabled" state in the WorkOS organization.

A disabled user still belongs to the WorkOS organization, which prevents WorkOS from seamlessly re-adding them when they authenticate via SSO again. By deleting the membership instead, the user is fully removed from the WorkOS organization. When they later re-authenticate via SSO (e.g., after receiving a new invitation), WorkOS can automatically recreate their organization membership, allowing them to rejoin the workspace without issues.

## Tests

Manual verification. The WorkOS SDK method `deleteOrganizationMembership` is already used elsewhere in the codebase (e.g., workspace cleanup).

## Risk

Low. Deleting the WorkOS org membership is the correct behavior — it matches what other cleanup paths in the codebase already do. Users who are revoked should not remain in the WorkOS organization.

## Deploy Plan

Standard deploy. No migration needed. Previously deactivated (but not deleted) WorkOS memberships from past revocations will remain as-is — they can be cleaned up manually if needed.