### PR TITLE
Add poke plugin to force reload client

### DIFF
--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   actions: read
+  contents: write
 
 jobs:
   deploy-production:
@@ -49,6 +50,24 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: front-spa
           command: pages deploy dist/${{ matrix.app }} --project-name=${{ matrix.app }}-dust-tt
+
+      - name: Create deploy tag
+        if: ${{ github.event.client_payload.sha && github.event.client_payload.image_tag }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const tag = `refs/tags/spa/${{ matrix.app }}/${{ github.event.client_payload.image_tag }}`;
+            try {
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: tag,
+                sha: '${{ github.event.client_payload.sha }}',
+              });
+            } catch (e) {
+              // Tag already exists (redeployment of same commit) — ignore.
+              if (e.status !== 422) throw e;
+            }
 
       - name: Notify Deploy Success
         if: ${{ github.event.client_payload.slack_thread_ts }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,6 +266,8 @@ jobs:
                 payload: {
                   app,
                   run_id: process.env.RUN_ID,
+                  image_tag: process.env.IMAGE_TAG,
+                  sha: process.env.PLAYWRIGHT_SHA,
                   slack_thread_ts: process.env.SLACK_THREAD_TS,
                   slack_channel: process.env.SLACK_CHANNEL,
                 },

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -87,7 +87,7 @@ export function RunPluginDialog({
       <DialogContent
         className={cn(
           "w-auto overflow-visible",
-          "s-bg-muted-background dark:s-bg-muted-background-night",
+          "bg-muted-background dark:bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]"
         )}
       >

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -87,11 +87,11 @@ export function RunPluginDialog({
       <DialogContent
         className={cn(
           "w-auto overflow-visible",
-          "bg-muted-background dark:bg-muted-background-night",
+          "s-bg-muted-background dark:s-bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]"
         )}
       >
-        <DialogHeader>
+        <DialogHeader className="bg-structure-100 dark:bg-structure-100-night rounded-t-2xl pb-4">
           <DialogTitle>Run {plugin.name} plugin</DialogTitle>
           <DialogDescription>{plugin.description}</DialogDescription>
         </DialogHeader>

--- a/front/lib/api/force_client_reload.ts
+++ b/front/lib/api/force_client_reload.ts
@@ -1,0 +1,103 @@
+import { runOnRedis } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+import { Octokit } from "@octokit/core";
+
+const REDIS_KEY = "force_reload_commits";
+const CACHE_REFRESH_INTERVAL_MS = 60_000; // 60 seconds.
+
+let cachedCommits: Set<string> = new Set();
+let lastRefreshMs = 0;
+
+async function refreshCache(): Promise<void> {
+  const now = Date.now();
+  if (now - lastRefreshMs < CACHE_REFRESH_INTERVAL_MS) {
+    return;
+  }
+
+  cachedCommits = new Set(await getFlaggedCommits());
+  lastRefreshMs = now;
+}
+
+export async function shouldForceClientReload(
+  commitHash: string
+): Promise<boolean> {
+  await refreshCache();
+
+  return cachedCommits.has(commitHash);
+}
+
+export async function getFlaggedCommits(): Promise<string[]> {
+  return runOnRedis({ origin: "force_reload_commits" }, (client) =>
+    client.sMembers(REDIS_KEY)
+  );
+}
+
+export async function addFlaggedCommits(commits: string[]): Promise<void> {
+  if (commits.length === 0) {
+    return;
+  }
+  await runOnRedis({ origin: "force_reload_commits" }, (client) =>
+    client.sAdd(REDIS_KEY, commits)
+  );
+}
+
+export async function removeFlaggedCommits(commits: string[]): Promise<void> {
+  if (commits.length === 0) {
+    return;
+  }
+  await runOnRedis({ origin: "force_reload_commits" }, (client) =>
+    client.sRem(REDIS_KEY, commits)
+  );
+}
+
+/**
+ * Retrieve the most recent deploy tags from GitHub, which indicate which commits have been
+ * deployed to production.
+ */
+
+const github = new Octokit();
+
+// Fetch deploy tags from GitHub (created by deploy-spa-production workflow).
+// Cross-reference with recent commits to build labels with dates and titles.
+export async function getDeployedTags(): Promise<
+  { shortHash: string; title: string; date: string }[]
+> {
+  try {
+    // 1. Get all spa/app/* tags. These are the actually-deployed commits.
+    const { data: refs } = await github.request(
+      "GET /repos/{owner}/{repo}/git/matching-refs/{ref}",
+      { owner: "dust-tt", repo: "dust", ref: "tags/spa/app/" }
+    );
+    const deployedShas = new Set(
+      refs.map((r) => r.ref.replace("refs/tags/spa/app/", ""))
+    );
+
+    // 2. Fetch recent commits to get dates and messages for deployed SHAs.
+    const tags: { shortHash: string; title: string; date: string }[] = [];
+    const { data: commits } = await github.request(
+      "GET /repos/{owner}/{repo}/commits",
+      { owner: "dust-tt", repo: "dust", sha: "main", per_page: 100 }
+    );
+    for (const commit of commits) {
+      const shortHash = commit.sha.substring(0, 7);
+      if (deployedShas.has(shortHash)) {
+        tags.push({
+          shortHash,
+          title: (commit.commit.message ?? "").split("\n")[0].substring(0, 80),
+          date: (commit.commit.committer?.date ?? "").substring(0, 10),
+        });
+        deployedShas.delete(shortHash);
+      }
+    }
+
+    // Include deployed tags whose commits are older than the recent 100.
+    for (const shortHash of deployedShas) {
+      tags.push({ shortHash, title: "", date: "" });
+    }
+
+    return tags;
+  } catch (err) {
+    logger.error({ err }, "Failed to fetch deploy tags from GitHub");
+    return [];
+  }
+}

--- a/front/lib/api/poke/plugins/global/force_client_reload.ts
+++ b/front/lib/api/poke/plugins/global/force_client_reload.ts
@@ -1,0 +1,88 @@
+import {
+  addFlaggedCommits,
+  getDeployedTags,
+  getFlaggedCommits,
+  removeFlaggedCommits,
+} from "@app/lib/api/force_client_reload";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Ok } from "@app/types/shared/result";
+
+export const forceClientReloadPlugin = createPlugin({
+  manifest: {
+    id: "force-client-reload",
+    name: "Force Client Reload",
+    description:
+      "Force clients running specific commits to reload. " +
+      "Clients sending a flagged X-Commit-Hash will receive X-Reload-Required: true.",
+    resourceTypes: ["global"],
+    args: {
+      commits: {
+        type: "enum",
+        label: "Deployed image tags",
+        description:
+          "Select deployed image tags that should trigger a forced client reload",
+        async: true,
+        values: [],
+        multiple: true,
+      },
+    },
+  },
+  populateAsyncArgs: async () => {
+    const [flaggedCommits, deployedTags] = await Promise.all([
+      getFlaggedCommits(),
+      getDeployedTags(),
+    ]);
+    const flaggedSet = new Set(flaggedCommits);
+
+    const commitValues = deployedTags.map((tag) => ({
+      label: tag.date
+        ? `[${tag.shortHash}] ${tag.date} — ${tag.title}`
+        : `[${tag.shortHash}] (older deploy)`,
+      value: tag.shortHash,
+      checked: flaggedSet.has(tag.shortHash),
+    }));
+
+    // Include flagged commits that are no longer in the recent list.
+    for (const hash of flaggedSet) {
+      if (!commitValues.some((c) => c.value === hash)) {
+        commitValues.push({
+          label: `[${hash}] (older deploy)`,
+          value: hash,
+          checked: true,
+        });
+      }
+    }
+
+    return new Ok({ commits: commitValues });
+  },
+  execute: async (_auth, _resource, args) => {
+    const selectedCommits = new Set(args.commits);
+    const flaggedCommits = await getFlaggedCommits();
+    const currentlyFlagged = new Set(flaggedCommits);
+
+    const toAdd = args.commits.filter((c) => !currentlyFlagged.has(c));
+    const toRemove = [...currentlyFlagged].filter(
+      (c) => !selectedCommits.has(c)
+    );
+
+    await addFlaggedCommits(toAdd);
+    await removeFlaggedCommits(toRemove);
+
+    const actions: string[] = [];
+    for (const commit of toAdd) {
+      actions.push(`Added: ${commit}`);
+    }
+    for (const commit of toRemove) {
+      actions.push(`Removed: ${commit}`);
+    }
+
+    if (actions.length === 0) {
+      actions.push("No changes made.");
+    }
+
+    return new Ok({
+      display: "markdown",
+      value: actions.join("\n\n"),
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/global/index.ts
+++ b/front/lib/api/poke/plugins/global/index.ts
@@ -1,4 +1,5 @@
 export * from "./batch_downgrade";
 export * from "./create_workspace";
+export * from "./force_client_reload";
 export * from "./get_admins_for_workspaces";
 export * from "./relocate_user";

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -33,10 +33,12 @@ export type RedisUsageTagsType =
   | "agent_recent_authors"
   | "agent_usage"
   | "assistant_generation"
+  | "cache_with_redis"
   | "cancel_message_generation"
   | "conversation_events"
   | "daily_usage_tracking"
   | "email_context"
+  | "force_reload_commits"
   | "key_usage_tracking"
   | "lock"
   | "mcp_client_side_request"
@@ -44,13 +46,12 @@ export type RedisUsageTagsType =
   | "mentions_count"
   | "message_events"
   | "notion_url_sync"
+  | "poke_cache_lookup"
   | "public_api_limits"
   | "rate_limiter"
   | "reasoning_generation"
   | "retry_agent_message"
   | "update_authors"
-  | "cache_with_redis"
-  | "poke_cache_lookup"
   | "user_message_events";
 
 async function createRedisClient({

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,4 +1,5 @@
 import { getSession } from "@app/lib/auth";
+import { shouldForceClientReload } from "@app/lib/api/force_client_reload";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import type {
   CustomGetServerSideProps,
@@ -141,6 +142,12 @@ export function withLogging<T>(
       req.headers["x-dust-extension-version"] ?? req.query.extensionVersion;
     const cliVersion =
       req.headers["x-dust-cli-version"] ?? req.query.cliVersion;
+
+    if (typeof commitHash === "string" && commitHash.length > 0) {
+      if (await shouldForceClientReload(commitHash)) {
+        res.setHeader("X-Reload-Required", "true");
+      }
+    }
 
     try {
       await handler(req, res, {

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,5 +1,5 @@
-import { getSession } from "@app/lib/auth";
 import { shouldForceClientReload } from "@app/lib/api/force_client_reload";
+import { getSession } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import type {
   CustomGetServerSideProps,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a global Poke plugin to force reload client app based on the commit hash value. To achieve this, we have to tweak the current deploy of the SPA.

From now on:
- When the SPA build it actually deployed in production, tag the commit with `spa/app/<short_sha>`
- The poke plugin uses those tags to know which client-app has been deployed. It populates the dropdown values from this one.
- If any is selected, it's being saved in the Redis
- Each calls on an endpoint checks if the commit hash is flagged, if it is, we set the right headers, which are handled on the client-side to hard reload the app. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
