### PR TITLE
[front] fix: Do not cache null workspace/subscription values

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -192,7 +192,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   private static fetchActiveByWorkspaceModelIdCached = cacheWithRedis(
     SubscriptionResource._fetchActiveByWorkspaceModelIdUncached,
     SubscriptionResource.subscriptionCacheKeyResolver,
-    { ttlMs: SUBSCRIPTION_CACHE_TTL_MS }
+    { ttlMs: SUBSCRIPTION_CACHE_TTL_MS, cacheNullValues: false }
   );
 
   static async fetchActiveByWorkspaceModelId(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -103,7 +103,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   private static fetchByIdCached = cacheWithRedis(
     WorkspaceResource._fetchByIdUncached,
     WorkspaceResource.workspaceCacheKeyResolver,
-    { ttlMs: WORKSPACE_CACHE_TTL_MS }
+    { ttlMs: WORKSPACE_CACHE_TTL_MS, cacheNullValues: false }
   );
 
   private static invalidateWorkspaceCache = invalidateCacheWithRedis(


### PR DESCRIPTION
## Description

Currently we risk caching null values for subscription & workspace that can lead to constrain errors or break fromSession.

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front