### PR TITLE
[front] perf: speed up join query on tool metadata

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -460,8 +460,7 @@ describe("MCPServerViewResource", () => {
       });
 
       // Fetch the system view through baseFetch (via listForSystemSpace).
-      const views =
-        await MCPServerViewResource.listForSystemSpace(adminAuth);
+      const views = await MCPServerViewResource.listForSystemSpace(adminAuth);
       const view = views.find(
         (v) => v.internalMCPServerId === internalServer.id
       );
@@ -490,11 +489,10 @@ describe("MCPServerViewResource", () => {
       });
 
       // Fetch the system view through baseFetch.
-      const view =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          adminAuth,
-          remoteServer.sId
-        );
+      const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        adminAuth,
+        remoteServer.sId
+      );
       expect(view).not.toBeNull();
 
       const json = view!.toJSON();
@@ -509,11 +507,10 @@ describe("MCPServerViewResource", () => {
     it("should return empty toolsMetadata when no metadata exists", async () => {
       const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-      const view =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          adminAuth,
-          remoteServer.sId
-        );
+      const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        adminAuth,
+        remoteServer.sId
+      );
       expect(view).not.toBeNull();
 
       const json = view!.toJSON();

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -1,6 +1,7 @@
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
+import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -8,6 +9,7 @@ import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -405,6 +407,117 @@ describe("MCPServerViewResource", () => {
 
       expect(systemView).not.toBeNull();
       expect(globalView).not.toBeNull();
+    });
+  });
+
+  describe("toolsMetadata", () => {
+    let workspace: WorkspaceType;
+    let adminAuth: Authenticator;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      await SpaceFactory.defaults(adminAuth);
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
+    });
+
+    it("should populate toolsMetadata for internal server views", async () => {
+      const originalConfig = INTERNAL_MCP_SERVERS["primitive_types_debugger"];
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: {
+          ...originalConfig,
+          availability: "auto",
+          isRestricted: ({
+            featureFlags,
+          }: {
+            plan: PlanType;
+            featureFlags: WhitelistableFeature[];
+          }) => !featureFlags.includes("dev_mcp_actions"),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        { name: "primitive_types_debugger", useCase: null }
+      );
+
+      // Create tool metadata for the internal server.
+      await RemoteMCPServerToolMetadataModel.create({
+        workspaceId: workspace.id,
+        internalMCPServerId: internalServer.id,
+        toolName: "test_tool",
+        permission: "low",
+        enabled: true,
+      });
+      await RemoteMCPServerToolMetadataModel.create({
+        workspaceId: workspace.id,
+        internalMCPServerId: internalServer.id,
+        toolName: "disabled_tool",
+        permission: "high",
+        enabled: false,
+      });
+
+      // Fetch the system view through baseFetch (via listForSystemSpace).
+      const views =
+        await MCPServerViewResource.listForSystemSpace(adminAuth);
+      const view = views.find(
+        (v) => v.internalMCPServerId === internalServer.id
+      );
+      expect(view).toBeDefined();
+
+      const json = view!.toJSON();
+      expect(json.toolsMetadata).toHaveLength(2);
+      expect(json.toolsMetadata).toEqual(
+        expect.arrayContaining([
+          { toolName: "test_tool", permission: "low", enabled: true },
+          { toolName: "disabled_tool", permission: "high", enabled: false },
+        ])
+      );
+    });
+
+    it("should populate toolsMetadata for remote server views", async () => {
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      // Create tool metadata for the remote server.
+      await RemoteMCPServerToolMetadataModel.create({
+        workspaceId: workspace.id,
+        remoteMCPServerId: remoteServer.id,
+        toolName: "remote_tool",
+        permission: "medium",
+        enabled: true,
+      });
+
+      // Fetch the system view through baseFetch.
+      const view =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          adminAuth,
+          remoteServer.sId
+        );
+      expect(view).not.toBeNull();
+
+      const json = view!.toJSON();
+      expect(json.toolsMetadata).toHaveLength(1);
+      expect(json.toolsMetadata?.[0]).toEqual({
+        toolName: "remote_tool",
+        permission: "medium",
+        enabled: true,
+      });
+    });
+
+    it("should return empty toolsMetadata when no metadata exists", async () => {
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      const view =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          adminAuth,
+          remoteServer.sId
+        );
+      expect(view).not.toBeNull();
+
+      const json = view!.toJSON();
+      expect(json.toolsMetadata).toEqual([]);
     });
   });
 });

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -297,9 +297,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     const internalServerIds = removeNulls(
       views.map((v) => v.internalMCPServerId)
     );
-    const remoteServerIds = removeNulls(
-      views.map((v) => v.remoteMCPServerId)
-    );
+    const remoteServerIds = removeNulls(views.map((v) => v.remoteMCPServerId));
 
     const [internalMetadata, remoteMetadata] = await Promise.all([
       internalServerIds.length > 0

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -331,7 +331,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     }
 
     const metadataByRemoteId = new Map<
-      number,
+      ModelId,
       Attributes<RemoteMCPServerToolMetadataModel>[]
     >();
     for (const m of remoteMetadata) {


### PR DESCRIPTION
## Description

- This PR speeds up a widely used query in `MCPServerViewResource.baseFetch`.
- The query included two `LEFT JOINs` on `remote_mcp_server_metadata` on all calls causing row multiplication and slow queries.
- This PR removes the two Sequelize include clauses from `baseFetch` and moves them to separate queries in a new method `populateToolsMetadata`.   
- Example of trace where the query is slow [here](https://app.datadoghq.eu/apm/traces?query=env%3Aprod%20%40http.route%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Fassistant%2Fconversations%2F%5BcId%5D%2Fskills%22&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=waterfall&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=6020204949172789553&spanType=all&spanViewType=databases&storage=hot&timeHint=1771506820879&trace=69970c82000000003f26698aeef4047d4550440518939837565&traceID=69970c82000000003f26698aeef4047d&traceQuery=&view=spans&start=1771508519798&end=1771509419798&paused=false) (this query took 1.15s there).
- Potential next step to not fetch the metadata when not needed.

## Tests

- Tested locally, added some tests specific to metadata.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
