### PR TITLE
[Projects] Improve kickoff convo prompt + Use sender mention token

### DIFF
--- a/front/hooks/useProjectKickoff.ts
+++ b/front/hooks/useProjectKickoff.ts
@@ -34,7 +34,6 @@ export function useProjectKickoff({
     const prompt = buildProjectKickoffPrompt({
       projectName: space.name,
       userFullName: user.fullName,
-      userSId: user.sId,
     });
 
     const result = await createConversationWithMessage({

--- a/front/lib/api/assistant/project_kickoff.test.ts
+++ b/front/lib/api/assistant/project_kickoff.test.ts
@@ -1,28 +1,27 @@
 import { buildProjectKickoffPrompt } from "@app/lib/api/assistant/project_kickoff";
-import { serializeMention } from "@app/lib/mentions/format";
 import { describe, expect, it } from "vitest";
 
 describe("buildProjectKickoffPrompt", () => {
   const userFullName = "Test User";
   const userSId = "user_123";
-  const userMention = serializeMention({
-    id: userSId,
-    type: "user",
-    label: userFullName,
-  });
 
   const prompt = buildProjectKickoffPrompt({
     projectName: "Test Kickstart",
     userFullName,
-    userSId,
   });
 
   it("should enforce the first message format and avoid fake search claims", () => {
-    expect(prompt).toContain("Your first message MUST be exactly:");
-    expect(prompt).toContain(":mention_user[");
-    expect(prompt).toContain(userMention);
+    expect(prompt).toContain("Your first message MUST:");
+    expect(prompt).toContain("Start with this exact first line:");
     expect(prompt).toContain(
-      `Hey ${userMention}; happy to help you kickstart \`Test Kickstart\`.`
+      "Hey <sender mention>; happy to help you kickstart `Test Kickstart`."
+    );
+    expect(prompt).toContain(
+      "Use as `<sender mention>` the exact mention token from the Sender metadata line"
+    );
+    expect(prompt).toContain(`Do NOT use plain \`@${userFullName}\``);
+    expect(prompt).not.toContain(
+      `:mention_user[${userFullName}]{sId=${userSId}}`
     );
     expect(prompt).toContain(
       "Do not claim that you already searched anything in this first message."

--- a/front/lib/api/assistant/project_kickoff.ts
+++ b/front/lib/api/assistant/project_kickoff.ts
@@ -1,30 +1,28 @@
-import { serializeMention } from "@app/lib/mentions/format";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 export function buildProjectKickoffPrompt({
   projectName,
   userFullName,
-  userSId,
 }: {
   projectName: string;
   userFullName: string;
-  userSId: string;
 }): string {
-  const userMention = serializeMention({
-    id: userSId,
-    type: "user",
-    label: userFullName,
-  });
-
   return `<dust_system>
 You are helping a user kickstart a new project in Dust.
 
-## YOUR FIRST MESSAGE (respond now)
+## YOUR FIRST MESSAGE
 
-Your first message MUST be exactly:
-Hey ${userMention}; happy to help you kickstart \`${projectName}\`.
+Your first message MUST:
+- Start with this exact first line: Hey <sender mention>; happy to help you kickstart \`${projectName}\`.
+- Use as \`<sender mention>\` the exact mention token from the Sender metadata line in the \`<dust_system>\` context above (the token in parentheses right after \`- Sender:\`). Reuse that sender mention token verbatim
+- Do NOT use plain \`@${userFullName}\` or invent mention syntax. Only copy the sender mention token verbatim
 
-If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I can help update the project's description, find related data, and create an initial project document.
+It should then follow with:
+\"\"\"
+If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files.
+
+I can then help update the **project's description**, find **related data**, create an **initial project document**, etc.
+\"\"\"
 
 Do not claim that you already searched anything in this first message.
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/21616.


For project kickoff conversations, improve the prompt; also update the `dust_system` prompt to instruct the agent to copy the sender mention token from the Sender metadata, instead of embedding a pre-serialized user mention from the frontend.

This keeps kickoff mention rendering on the agent-message path while preserving proper mention highlighting.
<img width="1755" height="289" alt="image" src="https://github.com/user-attachments/assets/35c41574-77d8-4aa0-aa6a-29c7fdab264a" />


## Risks
Blast radius: project kickoff conversation initialization and the first assistant reply.
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `cd front && NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run project_kickoff.test.ts`
