### PR TITLE
feat: move enable browser notifications to local storage

### DIFF
--- a/front/hooks/useEnableBrowserNotification.tsx
+++ b/front/hooks/useEnableBrowserNotification.tsx
@@ -1,11 +1,33 @@
 import { ConfirmContext } from "@app/components/Confirm";
-import { useUser, useUserMetadata } from "@app/lib/swr/user";
-import { setUserMetadataFromClient } from "@app/lib/user";
+import { useUser } from "@app/lib/swr/user";
 import { useCallback, useContext, useMemo, useRef } from "react";
 
-const BROWSER_NOTIFICATION_LAST_ASKED_FOR_KEY =
-  "browser-notification-last-asked-for";
+const LOCAL_STORAGE_KEY = "browser-notification-last-asked-for";
 const DELAY_BEFORE_ASKING_AGAIN = 1000 * 60 * 60 * 24 * 7; // One week
+
+function getLastAskedTimestamp(): number | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (raw) {
+      const ts = parseInt(raw, 10);
+      return Number.isNaN(ts) ? null : ts;
+    }
+  } catch {
+    // localStorage unavailable.
+  }
+  return null;
+}
+
+function setLastAskedTimestamp(ts: number): void {
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY, `${ts}`);
+  } catch {
+    // localStorage may be full or unavailable — silently ignore.
+  }
+}
 
 export const useEnableBrowserNotification = () => {
   const { user } = useUser();
@@ -15,18 +37,8 @@ export const useEnableBrowserNotification = () => {
   const shownRef = useRef<boolean>(false);
   const confirm = useContext(ConfirmContext);
 
-  const { metadata, isMetadataLoading, mutateMetadata } = useUserMetadata(
-    BROWSER_NOTIFICATION_LAST_ASKED_FOR_KEY,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      disabled: !notificationsEnabled,
-    }
-  );
-
   const canAsk = useMemo(() => {
     if (
-      isMetadataLoading ||
       typeof Notification === "undefined" ||
       Notification.permission !== "default" ||
       !notificationsEnabled
@@ -34,15 +46,13 @@ export const useEnableBrowserNotification = () => {
       return false;
     }
 
-    if (!metadata) {
+    const lastAsked = getLastAskedTimestamp();
+    if (lastAsked === null) {
       return true;
     }
 
-    // eslint-disable-next-line react-hooks/purity
-    const delay = Date.now() - parseInt(metadata.value);
-
-    return delay > DELAY_BEFORE_ASKING_AGAIN;
-  }, [isMetadataLoading, metadata, notificationsEnabled]);
+    return Date.now() - lastAsked > DELAY_BEFORE_ASKING_AGAIN;
+  }, [notificationsEnabled]);
 
   const askForPermission = useCallback(async () => {
     if (!canAsk || shownRef.current) {
@@ -53,19 +63,7 @@ export const useEnableBrowserNotification = () => {
     // Couldn't make it work with a simple useState().
     shownRef.current = true;
 
-    await setUserMetadataFromClient({
-      key: BROWSER_NOTIFICATION_LAST_ASKED_FOR_KEY,
-      value: `${Date.now()}`,
-    });
-    await mutateMetadata((current) => {
-      if (current) {
-        return {
-          ...current,
-          value: Date.now(),
-        };
-      }
-      return current;
-    });
+    setLastAskedTimestamp(Date.now());
 
     const confirmed = await confirm({
       title: (
@@ -81,7 +79,7 @@ export const useEnableBrowserNotification = () => {
     }
 
     shownRef.current = false;
-  }, [canAsk, confirm, mutateMetadata]);
+  }, [canAsk, confirm]);
 
   return { askForPermission };
 };


### PR DESCRIPTION
## Description

We were saving server side if a user enabled browser notifications so we can ask them to enable it or not. 

That doesn't make a lot of sense as it's linked to the browser not the user as a whole. And it has the nice side effect of reducing calls to the API

I was celled [4k times in 1 hour](https://app.datadoghq.eu/logs?query=%40route%3A%22%2Fapi%2Fuser%2Fmetadata%2F%5Bkey%5D%22&agg_m=count&agg_m_source=base&agg_q=%40url&agg_t=count&cols=host%2Cservice%2C%40durationMs&flat_group_bys=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=%40durationMs%2Cdesc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1771506584186&to_ts=1771510184186&live=true)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
