### PR TITLE
Rename getAttachmentFromToolOutput to getAttachmentFromFile

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -3,7 +3,7 @@ import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversa
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
-  getAttachmentFromToolOutput,
+  getAttachmentFromFile,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { Authenticator } from "@app/lib/auth";
@@ -73,7 +73,7 @@ export async function getFileFromConversationAttachment(
         }
 
         if (f.fileId === fileId) {
-          attachment = getAttachmentFromToolOutput({
+          attachment = getAttachmentFromFile({
             fileId: f.fileId,
             contentType: f.contentType,
             title: f.title,

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -8,7 +8,7 @@ import {
   isToolMarkerResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
-  getAttachmentFromToolOutput,
+  getAttachmentFromFile,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { ProcessAndStoreFileError } from "@app/lib/api/files/processing";
@@ -93,7 +93,7 @@ export function rewriteContentForModel(
     isToolGeneratedFile(content) &&
     isSupportedFileContentType(content.resource.contentType)
   ) {
-    const attachment = getAttachmentFromToolOutput({
+    const attachment = getAttachmentFromFile({
       fileId: content.resource.fileId,
       contentType: content.resource.contentType,
       title: content.resource.title,

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -15,7 +15,7 @@ import {
 import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_manager/metadata";
 import { formatConversationsForDisplay } from "@app/lib/api/actions/servers/project_manager/tools/conversation_formatting";
 import {
-  getAttachmentFromToolOutput,
+  getAttachmentFromFile,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
@@ -90,7 +90,7 @@ export function createProjectManagerTools(
         }
 
         const attachments = supportedFiles.map((file) =>
-          getAttachmentFromToolOutput({
+          getAttachmentFromFile({
             fileId: file.sId,
             contentType: file.contentType,
             title: file.fileName,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -193,7 +193,7 @@ export function getAttachmentFromFileContentFragment(
   };
 }
 
-export function getAttachmentFromToolOutput({
+export function getAttachmentFromFile({
   fileId,
   contentType,
   title,

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -6,7 +6,7 @@ import type {
 } from "@app/lib/api/assistant/conversation/attachments";
 import {
   getAttachmentFromContentFragment,
-  getAttachmentFromToolOutput,
+  getAttachmentFromFile,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
@@ -49,7 +49,7 @@ export function listAttachments(
         }
 
         attachments.push(
-          getAttachmentFromToolOutput({
+          getAttachmentFromFile({
             fileId: f.fileId,
             contentType: f.contentType,
             title: f.title,

--- a/front/migrations/20250702_move_conversation_include_file_actions_to_mcp.ts
+++ b/front/migrations/20250702_move_conversation_include_file_actions_to_mcp.ts
@@ -4,7 +4,7 @@
 // import { Op } from "sequelize";
 //
 // import type { ActionBaseParams } from "@app/lib/actions/mcp";
-// import { getAttachmentFromToolOutput } from "@app/lib/api/assistant/conversation/attachments";
+// import { getAttachmentFromFile } from "@app/lib/api/assistant/conversation/attachments";
 // import { getGlobalAgents } from "@app/lib/api/assistant/global_agents";
 // import { getWorkspaceInfos } from "@app/lib/api/workspace";
 // import { getSupportedModelConfig } from "@app/lib/assistant";
@@ -122,7 +122,7 @@
 //   const { sId, fileName, contentType, snippet } = file;
 //
 //   // Copied from `listAttachments`.
-//   const attachment = getAttachmentFromToolOutput({
+//   const attachment = getAttachmentFromFile({
 //     fileId: sId,
 //     contentType,
 //     title: fileName,


### PR DESCRIPTION
## Description

Simple rename to clarify.

## Tests

Green

## Risk

Low

## Deploy Plan

Deploy front