### PR TITLE
List images from uploads & frames in conversation__list_files.

### DIFF
--- a/front/components/assistant/conversation/attachment/types.ts
+++ b/front/components/assistant/conversation/attachment/types.ts
@@ -1,7 +1,7 @@
 import type { SupportedContentFragmentType } from "@app/types/content_fragment";
 import type {
+  AllSupportedFileContentType,
   AllSupportedWithDustSpecificFileContentType,
-  SupportedFileContentType,
 } from "@app/types/files";
 import type React from "react";
 
@@ -12,7 +12,7 @@ export type FileAttachment = {
   // key like "tool-{serverViewId}-{externalId}".
   id: string;
   title: string;
-  contentType: SupportedFileContentType;
+  contentType: AllSupportedFileContentType;
   isUploading: boolean;
   onRemove?: () => void;
   description?: string;

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -11,7 +11,6 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import { isInteractiveContentFileContentType } from "@app/types/files";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
@@ -68,10 +67,6 @@ export async function getFileFromConversationAttachment(
       const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);
 
       for (const f of generatedFiles) {
-        if (isInteractiveContentFileContentType(f.contentType)) {
-          continue;
-        }
-
         if (f.fileId === fileId) {
           attachment = getAttachmentFromFile({
             fileId: f.fileId,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -21,7 +21,7 @@ import {
 } from "@app/types/content_fragment";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
-import type { SupportedFileContentType } from "@app/types/files";
+import type { AllSupportedFileContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
@@ -200,7 +200,7 @@ export function getAttachmentFromFile({
   snippet,
 }: {
   fileId: string;
-  contentType: SupportedFileContentType;
+  contentType: AllSupportedFileContentType;
   title: string;
   snippet: string | null;
 }): FileAttachmentType {

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -11,10 +11,6 @@ import {
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import {
-  isInteractiveContentFileContentType,
-  isLLMVisionSupportedImageContentType,
-} from "@app/types/files";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
 
@@ -25,11 +21,6 @@ export function listAttachments(
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
     if (isContentFragmentType(m)) {
-      // Skip images handled by vision APIs; SVG is text-based so we list it.
-      if (isLLMVisionSupportedImageContentType(m.contentType)) {
-        continue;
-      }
-
       // Only list the latest version of a content fragment.
       if (m.contentFragmentVersion !== "latest") {
         continue;
@@ -43,11 +34,6 @@ export function listAttachments(
       const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);
 
       for (const f of generatedFiles) {
-        // Interactive Content files should not be shown in the JIT.
-        if (isInteractiveContentFileContentType(f.contentType)) {
-          continue;
-        }
-
         attachments.push(
           getAttachmentFromFile({
             fileId: f.fileId,

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -16,10 +16,12 @@ import {
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
+import { isInteractiveContentFileContentType } from "@app/types/files";
 import { isArrayOf } from "@app/types/shared/typescipt_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   AgentMessagePublicType,
+  ContentFragmentType as ContentFragmentPublicType,
   ConversationPublicType,
   ConversationWithoutContentPublicType,
   // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
@@ -82,6 +84,22 @@ export function addBackwardCompatibleConversationWithoutContentFields(
   };
 }
 
+export function filterOutInteractiveContentFileContentTypes(
+  c: ContentFragmentType[]
+): ContentFragmentPublicType[] {
+  const result: ContentFragmentPublicType[] = [];
+  for (const m of c) {
+    if (isInteractiveContentFileContentType(m.contentType)) {
+      continue;
+    }
+    result.push({
+      ...m,
+      contentType: m.contentType,
+    });
+  }
+  return result;
+}
+
 export function addBackwardCompatibleConversationFields(
   conversation: ConversationType
 ): ConversationPublicType {
@@ -102,7 +120,7 @@ export function addBackwardCompatibleConversationFields(
       } else if (
         isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
       ) {
-        return c.map((m) => m);
+        return filterOutInteractiveContentFileContentTypes(c);
       }
       assertNever(c[0]);
     }),

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -419,10 +419,7 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   get isInteractiveContent(): boolean {
-    return (
-      this.useCase === "conversation" &&
-      isInteractiveContentFileContentType(this.contentType)
-    );
+    return isInteractiveContentFileContentType(this.contentType);
   }
 
   // Cloud storage logic.

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -421,7 +421,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
   it("should reject access when file is not a frame", async () => {
     // Frame from conversation.
     const frameFile = await FileFactory.create(workspace, null, {
-      contentType: frameContentType,
+      contentType: "image/png",
       fileName: "frame.html",
       fileSize: 1000,
       status: "ready",

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -43,6 +43,7 @@ import type {
 import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isInteractiveContentFileContentType } from "@app/types/files";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import type {
   GetConversationsResponseType,
@@ -500,7 +501,14 @@ async function handler(
       res.status(200).json({
         conversation: addBackwardCompatibleConversationFields(conversation),
         message: newMessage ?? undefined,
-        contentFragment: newContentFragment ?? undefined,
+        contentFragment:
+          !newContentFragment ||
+          isInteractiveContentFileContentType(newContentFragment.contentType)
+            ? undefined
+            : {
+                ...newContentFragment,
+                contentType: newContentFragment.contentType,
+              },
       });
       return;
     case "GET":

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -11,7 +11,7 @@ import type {
 } from "./assistant/conversation";
 import type { ContentNodeType } from "./core/content_node";
 import type { DataSourceViewContentNode } from "./data_source_view";
-import type { SupportedFileContentType } from "./files";
+import type { AllSupportedFileContentType } from "./files";
 import type { ModelId } from "./shared/model_id";
 
 export type ContentFragmentExpiredReason = "data_source_deleted";
@@ -26,7 +26,7 @@ export type ContentFragmentContextType = {
 export type ContentFragmentVersion = "superseded" | "latest";
 
 export type SupportedContentFragmentType =
-  | SupportedFileContentType
+  | AllSupportedFileContentType
   | DustMimeType
   | "dust-application/slack"; // Legacy
 


### PR DESCRIPTION
## Description

Expose uploaded images and frames in the JIT list files.
Images generated were already listed.
Frames were not just to avoid cluttering the list but we will need them to be able to merge files from project and conversation.
Made v1 api backward compatible.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front