### PR TITLE
Remove instructions and instructionsHtml from default get agent_configurations 

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -96,6 +96,7 @@ async function handler(
         withAuthors,
         withFeedbacks,
         withEditors,
+        withInstructions,
         sort,
       } = queryValidation.right;
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -193,6 +194,14 @@ async function handler(
                   f.thumbDirection === "down"
               )?.count ?? 0,
           },
+        }));
+      }
+
+      if (withInstructions !== "true") {
+        agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
+          ...agentConfiguration,
+          instructions: null,
+          instructionsHtml: null,
         }));
       }
 

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -30,6 +30,11 @@ export const GetAgentConfigurationsQuerySchema = t.type({
   withAuthors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
   withEditors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
   withFeedbacks: t.union([t.literal("true"), t.literal("false"), t.undefined]),
+  withInstructions: t.union([
+    t.literal("true"),
+    t.literal("false"),
+    t.undefined,
+  ]),
   limit: t.union([LimitCodec, t.undefined]),
   sort: t.union([
     t.literal("priority"),


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6596

instructions and instructionsHtlm are very large field which are never used when retrieving multiple agents in the UI.
When instructions are displayed it is always when visualizing one agent.
Removing both instructions will considerably reduce the size of the payload.

I tried to remove instructions and instructionsHtml from the LightAgentConfigurationType but this introduces way more complexity for no benefit.

## Tests

 - unit tests
 - tested manually most pages displaying agents

## Risk

low, maybe a page I forgot to check

## Deploy Plan

deploy front
