### PR TITLE
[Front] fix(agent-builder): remove cancelled flag that breaks pending agent in strict mode

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -335,7 +335,6 @@ export default function AgentBuilder({
 
   // Create pending agent on mount for NEW agents only
   useEffect(() => {
-    // Only create pending agent for new agents (not editing or duplicating)
     if (
       agentConfiguration ||
       duplicateAgentId ||
@@ -346,17 +345,12 @@ export default function AgentBuilder({
     }
     hasPendingCreationRef.current = true;
 
-    let cancelled = false;
-
     const createPendingAgent = async () => {
       try {
         const response = await clientFetch(
           `/api/w/${owner.sId}/assistant/agent_configurations/create-pending`,
           { method: "POST" }
         );
-        if (cancelled) {
-          return;
-        }
         if (response.ok) {
           const data = await response.json();
           setPendingAgentId(data.sId);
@@ -374,10 +368,6 @@ export default function AgentBuilder({
       }
     };
     void createPendingAgent();
-
-    return () => {
-      cancelled = true;
-    };
   }, [agentConfiguration, duplicateAgentId, owner.sId, pendingAgentId]);
 
   const handleSubmit = async (formData: AgentBuilderFormData) => {


### PR DESCRIPTION
## Description

Follow-up to #21872 which introduced both `hasPendingCreationRef` and a `cancelled` flag to prevent double pending agent creation in React strict mode. These two mechanisms conflict:

1. Ref persists across strict mode remounts → prevents duplicate API calls (correct)
2. Cleanup sets `cancelled=true` → discards the API response when it resolves after remount
3. `setPendingAgentId` never called → copilot tab conversation never starts

Fix: remove the `cancelled` flag and cleanup, relying solely on the ref.