### PR TITLE
perf: reduce /api/app-status call frequency

### DIFF
--- a/front/lib/swr/useAppStatus.ts
+++ b/front/lib/swr/useAppStatus.ts
@@ -9,7 +9,10 @@ export function useAppStatus() {
     "/api/app-status",
     appStatusFetcher,
     {
-      focusThrottleInterval: 10 * 60 * 1000, // 10 minutes
+      refreshInterval: 5 * 60 * 1000, // Poll every 5 minutes.
+      focusThrottleInterval: 30 * 60 * 1000, // Throttle focus revalidation to 30 minutes.
+      revalidateOnReconnect: false,
+      dedupingInterval: 5 * 60 * 1000, // Dedupe identical requests within 5 minutes.
     }
   );
 


### PR DESCRIPTION
## Description

  The /api/app-status endpoint (used to show incident banners in the navbar) is called frequently due to SWR revalidation on every mount, tab focus, and reconnect — multiplied across all active users. The response is identical for all users in the same region since it only returns StatusPage incident data.         
                                                                                                                                                                                                                                                                                                                            
  This PR reduces the call volume with three complementary changes:                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  - Tune SWR revalidation: switch from event-driven (mount + focus every 10min + reconnect) to a `refreshInterval` of 5 minutes, throttle focus revalidation to 30 minutes, disable reconnect revalidation, and set a 5-minute deduping interval.
  - Add Cache-Control header: `public, max-age=120, stale-while-revalidate=300` lets the browser (and any CDN/proxy) serve cached responses for 2 minutes, with stale responses allowed for up to 5 minutes while revalidating in the background. This aligns with the existing 2-minute Redis cache TTL.                     
  - Remove session authentication: the data is not user-specific (same for everyone in the same region), so the endpoint no longer requires a session. Replaced withSessionAuthentication with withLogging (standard pattern for public endpoints). This also enables the public cache directive, allowing shared caching.  
                                                                                                                                                                                                                                                                                                                            
  Also fixes the 405 error message which incorrectly said "POST is expected" instead of "GET is expected".                                                                                                                                                                                                                  
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
