### PR TITLE
[Kill Switch] Add workspace-level emergency API blocking capability

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -407,6 +407,7 @@ export async function deleteWorkspace(
 
 export interface WorkspaceMetadata {
   maintenance?: "relocation" | "relocation-done";
+  killSwitched?: "full" | { conversationIds: string[] };
   allowContentCreationFileSharing?: boolean;
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;


### PR DESCRIPTION
## Description
This PR adds the workspace-level emergency kill switch capability, without adding operator commands yet.

Changes in this PR:
- Adds typed workspace metadata support for `killSwitched` (`"full" | { conversationIds: string[] }`).
- Enforces `killSwitched === "full"` in the existing workspace auth wrappers (`withSessionAuthenticationForWorkspace` and `withPublicAPIAuthentication`) and returns:
  - status: `503`
  - error type: `service_unavailable`
  - message: `Access to this workspace has been disabled for emergency maintenance.`
- Intentionally does not change endpoints that bypass these wrappers.

Rollout plan across PRs:
1. This PR: create the workspace kill-switch capability.
2. Follow-up PR: add `front` admin CLI commands to block/unblock a workspace.
3. Follow-up PR: add conversation-level kill-switch behavior.

## Risks
Blast radius: workspace-scoped API routes using `withSessionAuthenticationForWorkspace` and `withPublicAPIAuthentication`.
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] Local CLI baseline succeeds after adding local credits (`npm run start -- chat -a gpt5-mini -m 'hi' --noUpdateCheck`).
- [x] Local CLI call is blocked with `service_unavailable` and message `Access to this workspace has been disabled for emergency maintenance.` when workspace metadata has `killSwitched: "full"`.
- [x] Local CLI call succeeds again after removing `killSwitched`.

Notes:
- For this local validation, workspace metadata was toggled directly in SQL, so Redis workspace cache was manually invalidated (`cacheWithRedis-_fetchByIdUncached-workspace:sid:<wId>`).
- Follow-up admin commands will use app-level metadata update helpers (which invalidate this cache path).
