### PR TITLE
[front] perf: exclude tool metadata fetching when loading skills

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -409,7 +409,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           },
         },
       },
-      { includeMetadata}
+      { includeMetadata }
     );
 
     return views ?? [];

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -241,7 +241,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   private static async baseFetch(
     auth: Authenticator,
-    options: ResourceFindOptions<MCPServerViewModel> = {}
+    options: ResourceFindOptions<MCPServerViewModel> = {},
+    { includeMetadata = true }: { includeMetadata?: boolean } = {}
   ) {
     const views = await this.baseFetchWithAuthorization(auth, {
       ...options,
@@ -278,7 +279,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       );
     }
 
-    if (filteredViews.length > 0) {
+    if (includeMetadata && filteredViews.length > 0) {
       await this.populateToolsMetadata(auth, filteredViews);
     }
 
@@ -394,17 +395,21 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return views[0];
   }
 
-  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { includeMetadata = true }: { includeMetadata?: boolean } = {}
+  ) {
     const views = await this.baseFetch(
       auth,
-
       {
         where: {
           id: {
             [Op.in]: ids,
           },
         },
-      }
+      },
+      { includeMetadata}
     );
 
     return views ?? [];

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -583,7 +583,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
         auth,
-        removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId))
+        removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
+        { includeMetadata: false }
       );
 
       allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {


### PR DESCRIPTION
## Description

- This PR skips the fetch of the tool metadata (table: `remote_mcp_server_tool_metadata`) when loading skills.
- Skills can rely on several tools, but don't actually use their metadata.
- Will check if there are other call paths that may benefit from that.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
