### PR TITLE
Remove the intructions from the LightAgentConfigurationType

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -55,7 +55,7 @@ import { emptyArray } from "@app/lib/swr/swr";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -99,7 +99,7 @@ function processAdditionalConfigurationFromStorage(
 }
 
 interface AgentBuilderProps {
-  agentConfiguration?: LightAgentConfigurationType;
+  agentConfiguration?: AgentConfigurationType;
   duplicateAgentId?: string | null;
   conversationId?: string;
   onSaved?: () => void;
@@ -565,7 +565,7 @@ export default function AgentBuilder({
  * Inner component that has access to FormContext and can use the MCP server hook.
  */
 interface AgentBuilderContentProps {
-  agentConfiguration?: LightAgentConfigurationType;
+  agentConfiguration?: AgentConfigurationType;
   pendingAgentId: string | null;
   title: string;
   handleCancel: () => Promise<void>;

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -5,7 +5,7 @@ import { AdvancedSettings } from "@app/components/agent_builder/instructions/Adv
 import { AgentBuilderInstructionsEditor } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 import { AgentInstructionsHistory } from "@app/components/agent_builder/instructions/AgentInstructionsHistory";
 import { useAgentConfigurationHistory } from "@app/lib/swr/assistants";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import {
   ArrowPathIcon,
   Button,
@@ -28,7 +28,7 @@ export function AgentBuilderInstructionsBlock({
   const { owner } = useAgentBuilderContext();
   const { setValue } = useFormContext<AgentBuilderFormData>();
   const [compareVersion, setCompareVersion] =
-    useState<LightAgentConfigurationType | null>(null);
+    useState<AgentConfigurationType | null>(null);
   const [isInstructionDiffMode, setIsInstructionDiffMode] = useState(false);
 
   const { agentConfigurationHistory } = useAgentConfigurationHistory({

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -29,7 +29,7 @@ import {
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { createMentionSuggestion } from "@app/components/editor/input_bar/mentionSuggestion";
 import { preprocessMarkdownForEditor } from "@app/components/editor/lib/preprocessMarkdownForEditor";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { ContainerWithTopBar, cn, markdownStyles } from "@dust-tt/sparkle";
 import type { Editor as CoreEditor, Extensions } from "@tiptap/core";
 import { CharacterCount, Placeholder } from "@tiptap/extensions";
@@ -162,7 +162,7 @@ function ToolbarSlot({ children }: { children: ReactNode }) {
 }
 
 interface AgentBuilderInstructionsEditorProps {
-  compareVersion?: LightAgentConfigurationType | null;
+  compareVersion?: AgentConfigurationType | null;
   isInstructionDiffMode?: boolean;
   children?: ReactNode;
 }

--- a/front/components/agent_builder/instructions/AgentInstructionsHistory.tsx
+++ b/front/components/agent_builder/instructions/AgentInstructionsHistory.tsx
@@ -1,5 +1,5 @@
 import { useMembersLookup } from "@app/lib/swr/memberships";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -19,9 +19,9 @@ import { format } from "date-fns/format";
 import React, { useCallback, useMemo } from "react";
 
 interface AgentInstructionsHistoryProps {
-  history: LightAgentConfigurationType[];
-  selectedConfig: LightAgentConfigurationType | null;
-  onSelect: (config: LightAgentConfigurationType) => void;
+  history: AgentConfigurationType[];
+  selectedConfig: AgentConfigurationType | null;
+  onSelect: (config: AgentConfigurationType) => void;
   owner: LightWorkspaceType;
 }
 
@@ -58,7 +58,7 @@ export function AgentInstructionsHistory({
   }, [authorLookupMembers]);
 
   const formatVersionLabel = useCallback(
-    (config: LightAgentConfigurationType) => {
+    (config: AgentConfigurationType) => {
       return config.versionCreatedAt
         ? format(config.versionCreatedAt, "Pp")
         : `v${config.version}`;
@@ -67,7 +67,7 @@ export function AgentInstructionsHistory({
   );
 
   const getAuthorName = useCallback(
-    (config: LightAgentConfigurationType) => {
+    (config: AgentConfigurationType) => {
       if (!config.versionAuthorId) {
         return "System";
       }
@@ -88,7 +88,7 @@ export function AgentInstructionsHistory({
         )
       );
 
-    const result: LightAgentConfigurationType[] = [];
+    const result: AgentConfigurationType[] = [];
 
     let lastRawInstructions: string | null = null;
 

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -1,7 +1,7 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { getLargeWhitelistedModel } from "@app/types/assistant/assistant";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
 import { CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
@@ -16,7 +16,7 @@ import uniqueId from "lodash/uniqueId";
  * as they will be populated reactively in the component.
  */
 export function transformAgentConfigurationToFormData(
-  agentConfiguration: LightAgentConfigurationType
+  agentConfiguration: AgentConfigurationType
 ): AgentBuilderFormData {
   return {
     agentSettings: {
@@ -177,7 +177,7 @@ export function convertActionsForFormData(
  * resets editors to current user, and defaults to private scope.
  */
 export function transformDuplicateAgentToFormData(
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentConfigurationType,
   user: UserType
 ): AgentBuilderFormData {
   const baseFormData =

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -747,7 +747,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     // Fetch the latest version of the agent configuration.
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId: agentConfigurationId,
-      variant: "light",
+      variant: "light_with_instructions",
     });
 
     if (!agentConfiguration) {

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -7,7 +7,7 @@ import apiConfig from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { LightAgentConfigurationWithInstructionsType } from "@app/types/assistant/agent";
 import { getHeaderFromGroupIds } from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
@@ -87,7 +87,8 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
     if (getAgentsRes.isErr()) {
       return new Err(new MCPError("Error fetching agent configurations"));
     }
-    const agents = getAgentsRes.value as LightAgentConfigurationType[];
+    const agents =
+      getAgentsRes.value as LightAgentConfigurationWithInstructionsType[];
 
     const suggestedAgentsRes = await getSuggestedAgentsForContent(auth, {
       agents,

--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -69,7 +69,9 @@ const SUGGEST_AGENTS_FUNCTION_SPECIFICATIONS: AgentActionSpecification[] = [
   },
 ];
 
-export async function getSuggestedAgentsForContent(
+export async function getSuggestedAgentsForContent<
+  T extends LightAgentConfigurationType,
+>(
   auth: Authenticator,
   {
     content,
@@ -77,10 +79,10 @@ export async function getSuggestedAgentsForContent(
     conversationId,
   }: {
     content: string;
-    agents: LightAgentConfigurationType[];
+    agents: T[];
     conversationId?: string;
   }
-): Promise<Result<LightAgentConfigurationType[], Error>> {
+): Promise<Result<T[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 
   let model = getSmallWhitelistedModel(owner);

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -5,7 +5,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
-  LightAgentConfigurationType,
+  LightAgentConfigurationWithInstructionsType,
 } from "@app/types/assistant/agent";
 import type {
   InstructionsSuggestionSchemaType,
@@ -348,7 +348,7 @@ function getDescendantBlockIds(
  */
 export async function pruneConflictingInstructionSuggestions(
   auth: Authenticator,
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: LightAgentConfigurationWithInstructionsType,
   newSuggestions: Array<{ sId: string; targetBlockId: string }>
 ): Promise<void> {
   if (newSuggestions.length === 0) {

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -126,10 +126,12 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     tagsPerAgent,
   ] = await Promise.all([
     fetchMCPServerActionConfigurations(auth, { configurationIds, variant }),
-    user && variant !== "extra_light"
+    user &&
+    variant !== "extra_light" &&
+    variant !== "extra_light_with_instructions"
       ? getFavoriteStates(auth, { configurationIds: configurationSIds })
       : Promise.resolve(new Map<string, boolean>()),
-    variant !== "extra_light"
+    variant !== "extra_light" && variant !== "extra_light_with_instructions"
       ? TagResource.listForAgents(auth, configurationIds)
       : Promise.resolve([]),
   ]);
@@ -147,6 +149,11 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const isAuthor = agent.authorId === auth.user()?.id;
     const isMember = editorIds.includes(agent.id);
 
+    const includeInstructions =
+      variant === "full" ||
+      variant === "light_with_instructions" ||
+      variant === "extra_light_with_instructions";
+
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,
       sId: agent.sId,
@@ -157,8 +164,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       name: agent.name,
       pictureUrl: agent.pictureUrl,
       description: agent.description,
-      instructions: agent.instructions,
-      instructionsHtml: agent.instructionsHtml,
+      instructions: includeInstructions ? agent.instructions : null,
+      instructionsHtml: includeInstructions ? agent.instructionsHtml : null,
       model,
       status: agent.status,
       actions,

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -13,10 +13,10 @@ import {
 } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type {
+  AgentConfigurationsByVariant,
   AgentConfigurationType,
   AgentFetchVariant,
   AgentsGetViewType,
-  LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -331,9 +331,7 @@ export async function getAgentConfigurationsForView<
   limit?: number;
   sort?: SortStrategyType;
   dangerouslySkipPermissionFiltering?: boolean;
-}): Promise<
-  V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
-> {
+}): Promise<AgentConfigurationsByVariant<V>> {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
     throw new Error("Unexpected `auth` without `workspace`.");
@@ -373,7 +371,10 @@ export async function getAgentConfigurationsForView<
       variant,
     });
 
-    return applySortAndLimit(allGlobalAgents);
+    // Safe cast: AgentConfigurationType extends all variant return types.
+    return applySortAndLimit(
+      allGlobalAgents
+    ) as AgentConfigurationsByVariant<V>;
   }
 
   // Only workspace agents are filtered by requested spaces (unless dangerouslySkipPermissionFiltering is true)
@@ -394,5 +395,8 @@ export async function getAgentConfigurationsForView<
     }),
   ]);
 
-  return applySortAndLimit(allAgentConfigurations.flat());
+  // Safe cast: AgentConfigurationType extends all variant return types.
+  return applySortAndLimit(
+    allAgentConfigurations.flat()
+  ) as AgentConfigurationsByVariant<V>;
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -599,7 +599,7 @@ export async function postUserMessage(
       agentIds: mentions
         .filter(isAgentMention)
         .map((mention) => mention.configurationId),
-      variant: "extra_light",
+      variant: "extra_light_with_instructions",
     }),
     (() => {
       // If the origin of the user message is "run_agent", we do not want to update the
@@ -900,7 +900,7 @@ export async function editUserMessage(
       mentions.filter(isAgentMention).map((mention) =>
         getAgentConfiguration(auth, {
           agentId: mention.configurationId,
-          variant: "light",
+          variant: "extra_light_with_instructions",
         })
       )
     ),

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -45,7 +45,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgenticMessageData,
   ConversationType,
@@ -63,8 +63,8 @@ describe("createAgentMessages", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
   let conversation: ConversationWithoutContentType;
-  let agentConfig1: LightAgentConfigurationType;
-  let agentConfig2: LightAgentConfigurationType;
+  let agentConfig1: AgentConfigurationType;
+  let agentConfig2: AgentConfigurationType;
 
   beforeEach(async () => {
     // Reset mocks before each test
@@ -612,7 +612,7 @@ describe("createAgentMessages", () => {
     const agentConfigWithSpaces = await getAgentConfiguration(auth, {
       agentId: agentConfig.sId,
       agentVersion: agentConfig.version,
-      variant: "light",
+      variant: "light_with_instructions",
     });
     expect(agentConfigWithSpaces).not.toBeNull();
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space1.sId);
@@ -739,7 +739,7 @@ describe("createAgentMessages", () => {
     const agentConfigWithSpaces = await getAgentConfiguration(auth, {
       agentId: agentConfig.sId,
       agentVersion: agentConfig.version,
-      variant: "light",
+      variant: "light_with_instructions",
     });
     expect(agentConfigWithSpaces).not.toBeNull();
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space1.sId);
@@ -866,7 +866,7 @@ describe("createAgentMessages", () => {
     const agentConfigWithSpaces = await getAgentConfiguration(auth, {
       agentId: agentConfig.sId,
       agentVersion: agentConfig.version,
-      variant: "light",
+      variant: "light_with_instructions",
     });
     expect(agentConfigWithSpaces).not.toBeNull();
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space1.sId);
@@ -1034,7 +1034,7 @@ describe("createAgentMessages", () => {
       const updatedAgentConfig = await getAgentConfiguration(auth, {
         agentId: agentConfig.sId,
         agentVersion: agentConfig.version,
-        variant: "light",
+        variant: "light_with_instructions",
       });
       expect(updatedAgentConfig).not.toBeNull();
 
@@ -1165,7 +1165,7 @@ describe("createAgentMessages", () => {
       // Manually construct the updated agent config with requestedSpaceIds as sIds
       // We can't use getAgentConfiguration because it filters by space access,
       // and the agent now has restricted space requirements
-      const updatedAgentConfig: LightAgentConfigurationType = {
+      const updatedAgentConfig: AgentConfigurationType = {
         ...agentConfig,
         requestedSpaceIds: [
           conversationSpace.sId,
@@ -1291,7 +1291,7 @@ describe("createAgentMessages", () => {
       // Manually construct the updated agent config with requestedSpaceIds as sIds
       // We can't use getAgentConfiguration because it filters by space access,
       // and the agent now has global space requirements
-      const updatedAgentConfig: LightAgentConfigurationType = {
+      const updatedAgentConfig: AgentConfigurationType = {
         ...agentConfig,
         requestedSpaceIds: [refreshedConversationSpace!.sId, globalSpace.sId],
       };
@@ -1437,7 +1437,7 @@ describe("createAgentMessages", () => {
       );
 
       // Manually construct the updated agent config with requestedSpaceIds as sIds
-      const updatedAgentConfig: LightAgentConfigurationType = {
+      const updatedAgentConfig: AgentConfigurationType = {
         ...agentConfig,
         requestedSpaceIds: [
           refreshedConversationSpace!.sId,
@@ -2024,7 +2024,7 @@ describe("createUserMentions", () => {
       const updatedAgentConfig = await getAgentConfiguration(auth, {
         agentId: agentConfig.sId,
         agentVersion: agentConfig.version,
-        variant: "light",
+        variant: "light_with_instructions",
       });
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).toContain(mentionedUser.sId);
@@ -2127,7 +2127,7 @@ describe("createUserMentions", () => {
       const updatedAgentConfig = await getAgentConfiguration(auth, {
         agentId: agentConfig.sId,
         agentVersion: agentConfig.version,
-        variant: "light",
+        variant: "light_with_instructions",
       });
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).not.toContain(mentionedUser.sId);
@@ -2230,7 +2230,7 @@ describe("createUserMentions", () => {
       const updatedAgentConfig = await getAgentConfiguration(auth, {
         agentId: agentConfig.sId,
         agentVersion: agentConfig.version,
-        variant: "light",
+        variant: "light_with_instructions",
       });
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).toBeNull();
@@ -3060,7 +3060,7 @@ describe("createUserMentions", () => {
       const updatedAgentConfig = await getAgentConfiguration(auth, {
         agentId: triggerAgentConfig.sId,
         agentVersion: triggerAgentConfig.version,
-        variant: "light",
+        variant: "light_with_instructions",
       });
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).toContain(mentionedUser.sId);
@@ -3095,7 +3095,7 @@ describe("createUserMessage", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
   let conversation: ConversationWithoutContentType;
-  let agentConfig1: LightAgentConfigurationType;
+  let agentConfig1: AgentConfigurationType;
 
   beforeEach(async () => {
     // Create workspace, user, spaces, and groups using the helper

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -33,7 +33,10 @@ import { isEmailValid } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger, { auditLog } from "@app/logger/logger";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  LightAgentConfigurationType,
+  LightAgentConfigurationWithInstructionsType,
+} from "@app/types/assistant/agent";
 import type {
   AgenticMessageData,
   AgentMessageType,
@@ -639,7 +642,7 @@ export const createAgentMessages = async (
       | {
           type: "create";
           mentions: MentionType[];
-          agentConfigurations: LightAgentConfigurationType[];
+          agentConfigurations: LightAgentConfigurationWithInstructionsType[];
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
@@ -656,7 +659,7 @@ export const createAgentMessages = async (
       agentMessageRow: AgentMessageModel;
       messageRow: MessageModel;
     } | null;
-    configuration: LightAgentConfigurationType;
+    configuration: LightAgentConfigurationWithInstructionsType;
     parentMessageId: string;
     parentAgentMessageId: string | null;
     mentionRow: MentionModel | null;

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -346,7 +346,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     agentConfigurationIds.length > 0
       ? getAgentConfigurations(auth, {
           agentIds: [...agentConfigurationIds],
-          variant: "extra_light",
+          variant: "extra_light_with_instructions",
         })
       : [],
   ]);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -4,14 +4,14 @@ import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { LightAgentConfigurationWithInstructionsType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import assert from "assert";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type ExportAgentConfigurationResponseBody = {
   assistant: Omit<
-    LightAgentConfigurationType,
+    LightAgentConfigurationWithInstructionsType,
     | "id"
     | "versionCreatedAt"
     | "sId"

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -130,7 +130,7 @@ async function handler(
       let agentConfigurations = await getAgentConfigurationsForView({
         auth,
         agentsGetView: normalizeAgentView(agentsGetView),
-        variant: "light",
+        variant: "light_with_instructions",
       });
 
       if (withAuthors) {

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -131,9 +131,9 @@ async function handler(
 
   // Validate variant parameter if provided
   const configVariant =
-    typeof variant === "string" && (variant === "light" || variant === "full")
+    typeof variant === "string" && variant === "full"
       ? variant
-      : "light";
+      : "light_with_instructions";
 
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId: sId,

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -72,7 +72,7 @@ async function handler(
       const agents = await getAgentConfigurationsForView({
         auth,
         agentsGetView: "list",
-        variant: "extra_light",
+        variant: "extra_light_with_instructions",
       });
 
       const formattedAgents = agents

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -17,7 +17,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
 import type {
-  LightAgentConfigurationType,
+  LightAgentConfigurationWithInstructionsType,
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -481,7 +481,8 @@ export async function notifyWorkflowError(
     reactions: [],
 
     // HACKY: These last 3 fields are not used in the workflow error case but required in the type.
-    configuration: null as unknown as LightAgentConfigurationType,
+    configuration:
+      null as unknown as LightAgentConfigurationWithInstructionsType,
     parentMessageId: null as unknown as string,
     parentAgentMessageId: null as unknown as string,
   };

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -10,7 +10,7 @@ import { ContentFragmentResource } from "@app/lib/resources/content_fragment_res
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { LightAgentConfigurationWithInstructionsType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
   ConversationType,
@@ -251,7 +251,7 @@ export class ConversationFactory {
   }: {
     workspace: WorkspaceType;
     conversation: ConversationType | ConversationWithoutContentType;
-    agentConfig: LightAgentConfigurationType;
+    agentConfig: LightAgentConfigurationWithInstructionsType;
   }): Promise<{
     messageRow: MessageModel;
     agentMessage: AgentMessageType;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -103,7 +103,20 @@ export type AgentModelConfigurationType = {
   responseFormat?: string;
 };
 
-export type AgentFetchVariant = "light" | "full" | "extra_light";
+/**
+ * Variants control which fields are included when fetching agent configurations:
+ * - "light": No instructions, includes favorites and tags. Used for list/manage views.
+ * - "light_with_instructions": Includes instructions, favorites and tags.
+ * - "extra_light": No instructions, skips favorites and tags. Used for mentions rendering in user messages.
+ * - "extra_light_with_instructions": Includes instructions, skips favorites and tags. Used for agent message rendering.
+ * - "full": Everything including actions and skills. Used for agent builder/editing.
+ */
+export type AgentFetchVariant =
+  | "extra_light"
+  | "extra_light_with_instructions"
+  | "light"
+  | "light_with_instructions"
+  | "full";
 
 export type LightAgentConfigurationType = {
   id: ModelId;
@@ -114,9 +127,6 @@ export type LightAgentConfigurationType = {
   version: number;
   // Global agents have a null authorId, others have a non-null authorId
   versionAuthorId: ModelId | null;
-
-  instructions: string | null;
-  instructionsHtml: string | null;
 
   model: AgentModelConfigurationType;
 
@@ -159,11 +169,25 @@ export type LightAgentConfigurationType = {
   canEdit: boolean;
 };
 
-export type AgentConfigurationType = LightAgentConfigurationType & {
-  // If empty, no actions are performed, otherwise the actions are performed.
-  actions: MCPServerConfigurationType[];
-  skills?: GlobalSkillId[];
-};
+export type LightAgentConfigurationWithInstructionsType =
+  LightAgentConfigurationType & {
+    instructions: string | null;
+    instructionsHtml: string | null;
+  };
+
+export type AgentConfigurationsByVariant<V extends AgentFetchVariant> =
+  V extends "full"
+    ? AgentConfigurationType[]
+    : V extends "light_with_instructions" | "extra_light_with_instructions"
+      ? LightAgentConfigurationWithInstructionsType[]
+      : LightAgentConfigurationType[];
+
+export type AgentConfigurationType =
+  LightAgentConfigurationWithInstructionsType & {
+    // If empty, no actions are performed, otherwise the actions are performed.
+    actions: MCPServerConfigurationType[];
+    skills?: GlobalSkillId[];
+  };
 
 export interface TemplateAgentConfigurationType {
   name: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -10,7 +10,7 @@ import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
   GenericErrorContent,
-  LightAgentConfigurationType,
+  LightAgentConfigurationWithInstructionsType,
 } from "./agent";
 import type { MentionType, RichMention } from "./mentions";
 
@@ -232,7 +232,7 @@ export type AgentMessageType = BaseAgentMessageType & {
   agentMessageId: ModelId;
   created: number;
   visibility: MessageVisibility;
-  configuration: LightAgentConfigurationType;
+  configuration: LightAgentConfigurationWithInstructionsType;
   skipToolsValidation: boolean;
   actions: AgentMCPActionWithOutputType[];
   contents: Array<{ step: number; content: AgentContentItemType }>;


### PR DESCRIPTION
## Description

Remove the intructions from the `LightAgentConfigurationType`. This reduces the payload of sent to the front end as these are very long.
Introduces a new `LightAgentConfigurationWithInstructionsType`

Introduce 2 new variant for AgentFetchVariant:
```
export type AgentFetchVariant =
  | "extra_light"
  | "extra_light_with_instructions"
  | "light"
  | "light_with_instructions"
  | "full";
```

## Tests

Manually tested many endpoints

## Risk

low

## Deploy Plan

deploy front
