### PR TITLE
[Kill Switch] Add admin CLI commands to block/unblock workspace

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -6,6 +6,10 @@ import {
   getDataSources,
   softDeleteDataSourceAndLaunchScrubWorkflow,
 } from "@app/lib/api/data_sources";
+import {
+  FULL_WORKSPACE_KILL_SWITCH_VALUE,
+  KILL_SWITCH_METADATA_KEY,
+} from "@app/lib/api/workspace";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
@@ -44,9 +48,6 @@ import path from "path";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
 const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
-  const KILL_SWITCH_METADATA_KEY = "killSwitched";
-  const FULL_KILL_SWITCH_VALUE = "full";
-
   switch (command) {
     case "create": {
       if (!args.name) {
@@ -199,7 +200,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const metadata = {
         ...(w.metadata ?? {}),
-        [KILL_SWITCH_METADATA_KEY]: FULL_KILL_SWITCH_VALUE,
+        [KILL_SWITCH_METADATA_KEY]: FULL_WORKSPACE_KILL_SWITCH_VALUE,
       };
 
       const updateResult = await WorkspaceResource.updateMetadata(
@@ -210,7 +211,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(updateResult.error.message);
       }
 
-      console.log(`Workspace blocked: wId=${w.sId}`);
+      logger.info({ wId: w.sId }, "Workspace blocked");
       return;
     }
 
@@ -235,7 +236,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(updateResult.error.message);
       }
 
-      console.log(`Workspace unblocked: wId=${w.sId}`);
+      logger.info({ wId: w.sId }, "Workspace unblocked");
       return;
     }
 

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -6,11 +6,11 @@ import {
   getDataSources,
   softDeleteDataSourceAndLaunchScrubWorkflow,
 } from "@app/lib/api/data_sources";
+import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import {
   FULL_WORKSPACE_KILL_SWITCH_VALUE,
   KILL_SWITCH_METADATA_KEY,
 } from "@app/lib/api/workspace";
-import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -405,9 +405,14 @@ export async function deleteWorkspace(
   return new Ok(undefined);
 }
 
+export const KILL_SWITCH_METADATA_KEY = "killSwitched";
+export const FULL_WORKSPACE_KILL_SWITCH_VALUE = "full";
+
 export interface WorkspaceMetadata {
   maintenance?: "relocation" | "relocation-done";
-  killSwitched?: "full" | { conversationIds: string[] };
+  killSwitched?:
+    | typeof FULL_WORKSPACE_KILL_SWITCH_VALUE
+    | { conversationIds: string[] };
   allowContentCreationFileSharing?: boolean;
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/21966.

Adds `front` admin CLI workspace commands for the emergency workspace kill switch:
- `./admin/cli.sh workspace block --wId <workspaceId>`
- `./admin/cli.sh workspace unblock --wId <workspaceId>`

Implementation details:
- `block` sets `metadata.killSwitched = "full"`.
- `unblock` removes `metadata.killSwitched` from workspace metadata.
- Both paths use `WorkspaceResource.updateMetadata(...)`, which goes through resource update + cache invalidation.

This PR is stacked on top of #21966 and only adds the operational command surface.

## Risks
Blast radius: `front/admin/cli.ts` admin-only command behavior for workspace metadata updates.
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] `./admin/checks.sh`
- [x] End-to-end with local CLI (`gpt5-mini`) + admin commands:
  - Baseline: `npm run start -- chat --noUpdateCheck -a gpt5-mini -m "hi before block"` succeeds.
  - Block: `./admin/cli.sh workspace block --wId DevWkSpace` sets `metadata.killSwitched = "full"`.
  - While blocked: `npm run start -- chat --noUpdateCheck -a gpt5-mini -m "hi while blocked"` returns `service_unavailable` with message `Access to this workspace has been disabled for emergency maintenance.`
  - Unblock: `./admin/cli.sh workspace unblock --wId DevWkSpace` removes `killSwitched`.
  - Post-unblock: `npm run start -- chat --noUpdateCheck -a gpt5-mini -m "hi after unblock"` succeeds again.

Note:
- Non-interactive CLI currently exits with status `0` even when API returns an error payload; assertions are based on response payload/message.
