### PR TITLE
Merge files from conversation and project in the list.

### DIFF
--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -82,6 +82,7 @@ export function createPlaceholderUserMessage({
             expiredReason: null,
             sourceProvider: null,
             sourceIcon: null,
+            isInProjectContext: false,
           }) satisfies FileContentFragmentType
       ),
       ...(contentFragments?.contentNodes ?? []).map(

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -388,6 +388,7 @@ export async function processToolResults(
         fileId: c.file.sId,
         snippet: c.file.snippet,
         title: c.file.fileName,
+        isInProjectContext: c.file.useCase === "project_context",
         ...(isHidden ? { hidden: true } : {}),
       } satisfies ActionGeneratedFileType;
     })

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -423,7 +423,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "add_file": "low",
     "edit_description": "low",
     "get_information": "never_ask",
-    "list_files": "never_ask",
     "search_unread": "never_ask",
     "update_file": "medium",
   },

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -51,6 +51,7 @@ const ToolGeneratedFileSchema = z.object({
   snippet: z.string().nullable(),
   // Optional UI hint to hide file from generic generated files sections.
   hidden: z.boolean().optional(),
+  isInProjectContext: z.boolean().optional(),
 });
 
 export type ToolGeneratedFileType = z.infer<typeof ToolGeneratedFileSchema>;

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -8,6 +8,7 @@ import {
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -41,6 +42,7 @@ function isUserSideError(error: APIError): boolean {
 
 export async function getOrCreateConversation(
   api: DustAPI,
+  auth: Authenticator,
   agentLoopContext: AgentLoopRunContextType,
   {
     childAgentBlob,
@@ -106,7 +108,9 @@ export async function getOrCreateConversation(
 
   if (fileOrContentFragmentIds) {
     // Get all files from the current conversation and filter which one to pass to the sub agent
-    const attachments = listAttachments(mainConversation);
+    const attachments = await listAttachments(auth, {
+      conversation: mainConversation,
+    });
     for (const attachment of attachments) {
       if (
         isFileAttachmentType(attachment) &&

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -73,6 +73,7 @@ export async function getFileFromConversationAttachment(
             contentType: f.contentType,
             title: f.title,
             snippet: f.snippet,
+            isInProjectContext: f.isInProjectContext ?? false,
           });
           break;
         }

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -98,6 +98,7 @@ export function rewriteContentForModel(
       contentType: content.resource.contentType,
       title: content.resource.title,
       snippet: content.resource.snippet,
+      isInProjectContext: content.resource.isInProjectContext ?? false,
     });
     const xml = renderAttachmentXml({ attachment });
     let text = content.resource.text;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -51,6 +51,7 @@ export type ActionGeneratedFileType = {
   hidden?: boolean;
   createdAt?: number;
   updatedAt?: number;
+  isInProjectContext?: boolean;
 };
 
 export type AgentLoopRunContextType = {

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -171,6 +171,7 @@ export async function generateProcessToolOutput({
     title: fileTitle,
     contentType: jsonFile.contentType,
     snippet: jsonSnippet,
+    isInProjectContext: jsonFile.useCase === "project_context",
   };
   const timeFrameAsString = timeFrame
     ? "the last " +

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -10,21 +10,6 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const PROJECT_MANAGER_SERVER_NAME = "project_manager" as const;
 
 export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
-  list_files: {
-    description:
-      "List all files in the project context. Returns file metadata including names, IDs, and content types.",
-    schema: {
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Listing project files",
-      done: "List project files",
-    },
-  },
   add_file: {
     description:
       "Add a new file to the project context. The file will be available to all conversations in this project. " +

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -205,6 +205,7 @@ const runAgent = async (
 
   const convRes = await getOrCreateConversation(
     api,
+    auth,
     agentLoopContext.runContext,
     {
       childAgentBlob,

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -168,6 +168,7 @@ export function getLightAgentMessageFromAgentMessage(
         fileId: f.fileId,
         title: f.title,
         contentType: f.contentType,
+        isInProjectContext: f.isInProjectContext,
         ...(f.hidden ? { hidden: true } : {}),
       })),
     richMentions: agentMessage.richMentions,

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -40,6 +40,7 @@ function createMockContentFragment(
     textBytes: 100,
     sourceProvider: null,
     sourceIcon: null,
+    isInProjectContext: false,
   };
 }
 

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -35,6 +35,7 @@ export type BaseConversationAttachmentType = {
   isIncludable: boolean;
   isSearchable: boolean;
   isQueryable: boolean;
+  isInProjectContext: boolean;
 };
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
@@ -135,6 +136,7 @@ export function getAttachmentFromContentNodeContentFragment(
     isIncludable,
     isQueryable,
     isSearchable,
+    isInProjectContext: false, // For now, content nodes can only be from the conversation, not the project. To be revisited if/when we allow connected data in the projects.
   };
 
   return {
@@ -185,6 +187,7 @@ export function getAttachmentFromFileContentFragment(
     isIncludable,
     isQueryable,
     isSearchable,
+    isInProjectContext: cf.isInProjectContext,
   };
 
   return {
@@ -198,11 +201,13 @@ export function getAttachmentFromFile({
   contentType,
   title,
   snippet,
+  isInProjectContext,
 }: {
   fileId: string;
   contentType: AllSupportedFileContentType;
   title: string;
   snippet: string | null;
+  isInProjectContext: boolean;
 }): FileAttachmentType {
   const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
@@ -220,6 +225,7 @@ export function getAttachmentFromFile({
     isIncludable,
     isQueryable,
     isSearchable,
+    isInProjectContext,
   };
 }
 
@@ -245,6 +251,7 @@ export function renderAttachmentXml({
     `type="${attachment.contentType}"`,
     `title="${attachment.title}"`,
     `version="${attachment.contentFragmentVersion}"`,
+    `isInProjectContext="${attachment.isInProjectContext}"`,
     `isIncludable="${attachment.isIncludable}"`,
     `isQueryable="${attachment.isQueryable}"`,
     `isSearchable="${attachment.isSearchable}"`,

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -102,6 +102,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: true,
           isQueryable: true,
+          isInProjectContext: false,
         },
       ];
 
@@ -356,6 +357,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: true,
           isQueryable: true,
+          isInProjectContext: false,
         },
       ];
 
@@ -407,6 +409,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: true,
           isQueryable: false,
+          isInProjectContext: false,
         },
       ];
 
@@ -454,6 +457,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: true,
           isQueryable: false,
+          isInProjectContext: false,
         },
       ];
 
@@ -492,6 +496,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: false,
           isQueryable: true,
+          isInProjectContext: false,
         },
       ];
 
@@ -532,6 +537,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: true,
           isQueryable: true,
+          isInProjectContext: false,
         },
       ];
 
@@ -609,6 +615,7 @@ describe("getJITServers", () => {
           isIncludable: true,
           isSearchable: true,
           isQueryable: true,
+          isInProjectContext: false,
         },
       ];
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -731,6 +731,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                   snippet: file.snippet,
                   createdAt: file.createdAt.getTime(),
                   updatedAt: file.updatedAt.getTime(),
+                  isInProjectContext: file.useCase === "project_context",
                   ...(hidden ? { hidden: true } : {}),
                 };
               })

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -357,6 +357,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           textBytes: null,
           sourceProvider: null,
           sourceIcon: null,
+          isInProjectContext: null,
         };
       } else if (contentFragmentType === "content_node") {
         return {
@@ -385,6 +386,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let generatedTables: string[] = [];
       let sourceProvider: string | null = null;
       let sourceIcon: string | null = null;
+      let isInProjectContext: boolean = false;
 
       // Use pre-fetched file if provided, otherwise fetch it (for backward compatibility)
       const fileResource =
@@ -399,6 +401,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         generatedTables = fileResource.useCaseMetadata?.generatedTables ?? [];
         sourceProvider = fileResource.useCaseMetadata?.sourceProvider ?? null;
         sourceIcon = fileResource.useCaseMetadata?.sourceIcon ?? null;
+        isInProjectContext = !!fileResource.useCaseMetadata?.spaceId;
       }
 
       return {
@@ -412,6 +415,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         textBytes: this.textBytes,
         sourceProvider,
         sourceIcon,
+        isInProjectContext,
       } satisfies FileContentFragmentType;
     } else if (contentFragmentType === "content_node") {
       assert(

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -162,7 +162,7 @@ async function handler(
       const userMessage: UserMessageType = lastUserMessage;
 
       // Build tools list and prompt similar to the agent loop.
-      const attachments = listAttachments(conversation);
+      const attachments = await listAttachments(auth, { conversation });
       const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration,
         conversation,

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -160,7 +160,7 @@ async function listAvailableTools(
       step,
     });
 
-  const attachments = listAttachments(conversation);
+  const attachments = await listAttachments(auth, { conversation });
   const { servers: jitServers } = await getJITServers(auth, {
     agentConfiguration,
     conversation,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -196,7 +196,7 @@ export async function runModel(
     mcpActions,
     mcpToolsListingError,
   } = await startActiveObservation("resolve-tools", async () => {
-    const attachments = listAttachments(conversation);
+    const attachments = await listAttachments(auth, { conversation });
     const { servers: jitServers, hasConditionalJITTools } = await getJITServers(
       auth,
       {

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -86,6 +86,7 @@ export type FileContentFragmentType = BaseContentFragmentType & {
         textBytes: number | null;
         sourceProvider: string | null;
         sourceIcon: string | null;
+        isInProjectContext: boolean;
       }
     | {
         expiredReason: ContentFragmentExpiredReason;
@@ -96,6 +97,7 @@ export type FileContentFragmentType = BaseContentFragmentType & {
         textBytes: null;
         sourceProvider: null;
         sourceIcon: null;
+        isInProjectContext: null;
       }
   );
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -788,6 +788,7 @@ const ActionGeneratedFileSchema = z.object({
   contentType: ActionGeneratedFileContentTypeSchema,
   snippet: z.string().nullable(),
   hidden: z.boolean().optional(),
+  isInProjectContext: z.boolean().optional(),
 });
 
 export type ActionGeneratedFileType = z.infer<typeof ActionGeneratedFileSchema>;


### PR DESCRIPTION
## Description

Merge the list of attachments from project and conversation in the conversation__list_files.

Why:
- because viz is prompted to use this tool and I don't want to alter the prompt (+ it would have to be dynamic)
- because i think it makes sense to list them all in one place
- it avoids multiple tool calls to get all the files
- will work better when search will operate on (optionally) both

## Tests

Locally + using a frame.

## Risk

Low for conversation outside of projects.

## Deploy Plan

Deploy front