### PR TITLE
[front] Add option to stop using `CLIENT SETINFO` Redis commands

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -68,6 +68,7 @@ async function createRedisClient({
     socket: options?.socket,
     isolationPoolOptions:
       options?.isolationPoolOptions ?? DEFAULT_ISOLATION_POOL_OPTIONS,
+    disableClientInfo: true,
   });
   newClient.on("error", (err) => logger.info({ err }, "Redis Client Error"));
   newClient.on("ready", () => logger.info({}, "Redis Client Ready"));


### PR DESCRIPTION
## Description

- We are running a somewhat old version of Redis that does not support certain commands such as `CLIENT SETINFO LIB-VER <version>`.
- We are using a version of the node SDK that runs this command on connection, polluting our traces.
- This PR prevents running this command (see https://redis.github.io/ioredis/interfaces/CommonRedisOptions.html#disableClientInfo).

## Tests

## Risk

- Low-ish

## Deploy Plan

- Deploy front.
