### PR TITLE
[front] perf: improve performances of conversation feedback fetching

### DIFF
--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -408,13 +408,9 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     });
 
     return feedbackRows.map((feedback) => {
-      return new AgentMessageFeedbackResource(
-        AgentMessageFeedbackModel,
-        feedback.get(),
-        {
-          message: feedback.agentMessage?.message,
-        }
-      );
+      return new this(this.model, feedback.get(), {
+        message: feedback.agentMessage?.message,
+      });
     });
   }
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -377,41 +377,41 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     conversation: ConversationWithoutContentType
   ) {
     const user = auth.getNonNullableUser();
-    const workspace = auth.getNonNullableWorkspace();
 
-    const feedbacks = await AgentMessageFeedbackModel.findAll({
+    // Start from feedbacks (filtered by userId + workspaceId) and join back to
+    // messages (filtered by conversationId). This is more selective than scanning
+    // all messages in the conversation.
+    const feedbackRows = await AgentMessageFeedbackModel.findAll({
       where: {
         userId: user.id,
-        workspaceId: workspace.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          attributes: ["id"],
+          required: true,
+          include: [
+            {
+              model: MessageModel,
+              as: "message",
+              attributes: ["id", "sId"],
+              required: true,
+              where: {
+                conversationId: conversation.id,
+              },
+            },
+          ],
+        },
+      ],
     });
 
-    if (feedbacks.length === 0) {
-      return [];
-    }
-
-    const agentMessageIds = feedbacks.map((f) => f.agentMessageId);
-    const messages = await MessageModel.findAll({
-      where: {
-        conversationId: conversation.id,
-        workspaceId: workspace.id,
-        agentMessageId: { [Op.in]: agentMessageIds },
-      },
-      attributes: ["id", "sId", "agentMessageId"],
+    return feedbackRows.map((feedback) => {
+      return new this(this.model, feedback.get(), {
+        message: feedback.agentMessage?.message,
+      });
     });
-
-    const messageByAgentMessageId = new Map(
-      messages.map((m) => [m.agentMessageId, m])
-    );
-
-    return feedbacks
-      .filter((f) => messageByAgentMessageId.has(f.agentMessageId))
-      .map(
-        (f) =>
-          new this(this.model, f.get(), {
-            message: messageByAgentMessageId.get(f.agentMessageId),
-          })
-      );
   }
 
   static async getFeedbackWithConversationContext({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.test.ts
@@ -1,0 +1,160 @@
+import type { Authenticator } from "@app/lib/auth";
+import { MessageModel } from "@app/lib/models/agent/conversation";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelId } from "@app/types/shared/model_id";
+import { describe, expect, it } from "vitest";
+
+import handler from "./feedbacks";
+
+async function getMessageByRank(
+  auth: Authenticator,
+  conversationId: ModelId,
+  rank: number
+): Promise<MessageModel> {
+  const message = await MessageModel.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId,
+      rank,
+    },
+  });
+  if (!message) {
+    throw new Error(`No message found at rank ${rank}`);
+  }
+  return message;
+}
+
+describe("GET /api/w/[wId]/assistant/conversations/[cId]/feedbacks", () => {
+  it("returns empty feedbacks when none exist", async () => {
+    const { req, res, authenticator } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    req.query.cId = conversation.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().feedbacks).toEqual([]);
+  });
+
+  it("returns feedbacks for the current user only", async () => {
+    const { req, res, authenticator, workspace } =
+      await createPrivateApiMockRequest({ method: "GET" });
+    const user = authenticator.getNonNullableUser();
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date(), new Date()],
+    });
+
+    // rank 1 = first agent message, rank 3 = second agent message.
+    const msg1 = await getMessageByRank(authenticator, conversation.id, 1);
+    const msg2 = await getMessageByRank(authenticator, conversation.id, 3);
+    const { agentMessage: am1 } = await ConversationFactory.getMessage(
+      authenticator,
+      msg1.id
+    );
+    const { agentMessage: am2 } = await ConversationFactory.getMessage(
+      authenticator,
+      msg2.id
+    );
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      agentMessageId: am1!.id,
+      userId: user.id,
+      thumbDirection: "up",
+      content: "good",
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      agentMessageId: am2!.id,
+      userId: user.id,
+      thumbDirection: "down",
+      content: "bad",
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    req.query.cId = conversation.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const feedbacks = res._getJSONData().feedbacks;
+    expect(feedbacks).toHaveLength(2);
+
+    const directions = feedbacks.map(
+      (f: { thumbDirection: string }) => f.thumbDirection
+    );
+    expect(directions).toContain("up");
+    expect(directions).toContain("down");
+  });
+
+  it("does not return feedbacks from other conversations", async () => {
+    const { req, res, authenticator, workspace } =
+      await createPrivateApiMockRequest({ method: "GET" });
+    const user = authenticator.getNonNullableUser();
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent" }
+    );
+
+    const conversation1 = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversation2 = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const msg = await getMessageByRank(authenticator, conversation2.id, 1);
+    const { agentMessage } = await ConversationFactory.getMessage(
+      authenticator,
+      msg.id
+    );
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      agentMessageId: agentMessage!.id,
+      userId: user.id,
+      thumbDirection: "up",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    // Query feedbacks for conversation1: should be empty.
+    req.query.cId = conversation1.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().feedbacks).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

- This PR improves the performances of the `/feedbacks` endpoint by speeding up the SQL query to fetch conversation feedback for a given user.
- Current query plan [here](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=PT1H;trace=a069d5b68b63317b94104cc35789d084;span=22b6cb2874ad1bb8;route='%252Fapi%252Fw%252F%255BwId%255D%252Fassistant%252Fconversations%252F%255BcId%255D%252Ffeedbacks';sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209).
- The query scans all the messages in the conversation (highest cost node (27.95), sped up by an index but still), then filters out non-agent ones, then for each does nested loop joins.
- This PR does it the other way around, by starting from feedback since these are far more selective than scanning all messages in a conversation and then probing the agent messages and then messages.

## Tests

- Tested locally, added some tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
