### PR TITLE
Remove panic log

### DIFF
--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -173,7 +173,7 @@ export async function githubExtractToGcsActivity({
 
         if (isBadCredentials(error)) {
           logger.error(
-            { err: error, repoLogin, repoName, repoId, panic: true },
+            { err: error, repoLogin, repoName, repoId },
             "Bad credentials: OAuth token is invalid or revoked."
           );
 


### PR DESCRIPTION
## Description

This PR removes the panic log on Github "Bad credentials" error.

## Tests

This error is handled by retrying the activity 20 minutes later. In the meantime, the token is refreshed. 
Monitored a whole day and it worked fine.

## Risk

Low

## Deploy Plan

Deploy connectors
