### PR TITLE
conversation_files__semantic_search will search in project context files as well as conversation files.

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -22,10 +22,10 @@ export const PROCESS_ACTION_TOP_K = 768;
 export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME =
   "query_conversation_tables";
 
-export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
-  "search_conversation_files";
+export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME = "conversation_files";
 
-export const DEFAULT_PROJECT_SEARCH_ACTION_NAME = "search_project_context";
+export const DEFAULT_PROJECT_SEARCH_ACTION_NAME =
+  "project_context_and_conversations";
 
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -423,7 +423,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "add_file": "low",
     "edit_description": "low",
     "get_information": "never_ask",
-    "search_unread": "never_ask",
+    "list_unread": "never_ask",
     "update_file": "medium",
   },
   "query_tables_v2": {

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -109,9 +109,9 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Get project information",
     },
   },
-  search_unread: {
+  list_unread: {
     description:
-      "Search for unread conversations in the project. Returns conversations that have been updated since the user last read them, " +
+      "List unread conversations in the project. Returns conversations that have been updated since the user last read them, " +
       "within an optional time window (defaults to 30 days).",
     schema: {
       daysBack: z

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -389,7 +389,7 @@ export function createProjectManagerTools(
       }, "Failed to get project information");
     },
 
-    search_unread: async (params) => {
+    list_unread: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_PROJECT_SEARCH_ACTION_NAME } from "@app/lib/actions/constants";
+import { PROJECT_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/project_manager/metadata";
 import {
   constructProjectContextSection,
   constructPromptMultiActions,
@@ -84,8 +86,8 @@ This conversation is associated with a project. The project provides:
 
 ## Using Project Tools
 
-**project_manager**: Use these tools to manage persistent project files, metadata, and conversations
-**search_project_context**: Use this tool to semantically search across all project files when you need to:
+**${PROJECT_MANAGER_SERVER_NAME}**: Use these tools to manage persistent project files, metadata, and conversations
+**${DEFAULT_PROJECT_SEARCH_ACTION_NAME}**: Use this tool to semantically search across all project files when you need to:
 - Find relevant information within the project
 - Locate specific content across multiple files
 - Answer questions based on project knowledge
@@ -93,8 +95,8 @@ This conversation is associated with a project. The project provides:
 ## Tool Usage Priority
 
 When answering questions that require searching for information, follow this priority order:
-1. **First**, use \`search_project_context\` to search within the project's files. Project context is the most relevant source of information for this conversation.
-2. **Second**, use \`project_manager\` to gather more context on the project.
+1. **First**, use \`${DEFAULT_PROJECT_SEARCH_ACTION_NAME}\` to search within the project's files. Project context is the most relevant source of information for this conversation.
+2. **Second**, use \`${PROJECT_MANAGER_SERVER_NAME}\` to gather more context on the project.
 2. **Then**, if the project context is insufficient, use \`company_data_*\` tools and \`search\` to search across the broader company data sources.
 
 ## Project Files vs Conversation Attachments

--- a/front/lib/api/assistant/jit/projects.ts
+++ b/front/lib/api/assistant/jit/projects.ts
@@ -67,7 +67,7 @@ export async function getProjectSearchServer(
     sId: generateRandomModelSId(),
     type: "mcp_server_configuration",
     name: DEFAULT_PROJECT_SEARCH_ACTION_NAME,
-    description: `Semantic search over the project context`,
+    description: `Semantic search over the project context and conversations.`,
     dataSources,
     tables: null,
     childAgentId: null,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -107,7 +107,6 @@ async function getConditionalJITServers(
 
   const conversationFilesServer = await getConversationFilesServer(
     auth,
-
     attachments
   );
   servers.push(conversationFilesServer);

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -76,7 +76,7 @@ export async function listAttachments(
             fileId: f.sId,
             contentType: f.contentType,
             title: f.fileName,
-            snippet: null,
+            snippet: f.snippet,
             isInProjectContext: true,
           })
         );


### PR DESCRIPTION
## Description

Make it so project's context files can be found in the conversation_files semantic search (aligned with the fact that we list them in conversation_files list).
Tweak servers names a tiny bit.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front