### PR TITLE
[front] feat: Backfill firstUsedAt and use it for seat counting

### DIFF
--- a/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
+++ b/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
@@ -1,0 +1,160 @@
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { getUsageToReportForSubscriptionItem } from "@app/lib/plans/usage";
+import { isMauReportUsage } from "@app/lib/plans/usage/types";
+import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { ActionLink, CheckFunction } from "@app/types/production_checks";
+import { QueryTypes } from "sequelize";
+
+interface WorkspaceWithSubscription {
+  workspaceId: number;
+  workspaceSId: string;
+  workspaceName: string;
+  planCode: string;
+  stripeSubscriptionId: string | null;
+  activeMembershipCount: number;
+  activeUsersByMessagesCount: number;
+}
+
+interface WorkspaceMismatch {
+  workspaceId: number;
+  workspaceSId: string;
+  workspaceName: string;
+  activeMembershipCount: number;
+  activeUsersByMessagesCount: number;
+}
+
+export const checkMembershipActiveUsersConsistency: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  const frontDb = getFrontReplicaDbConnection();
+
+  // Query workspaces with active subscriptions and their membership/user counts
+  const workspaces: WorkspaceWithSubscription[] =
+    // biome-ignore lint/plugin/noRawSql: Production check using read replica
+    await frontDb.query(
+      `
+      WITH active_memberships AS (
+        SELECT
+          m."workspaceId",
+          COUNT(DISTINCT m."userId")::int as "activeMembershipCount"
+        FROM memberships m
+        WHERE m."firstUsedAt" IS NOT NULL
+          AND m."endAt" IS NULL
+        GROUP BY m."workspaceId"
+      ),
+      users_with_messages AS (
+        SELECT
+          msg."workspaceId",
+          COUNT(DISTINCT um."userId")::int as "activeUsersByMessagesCount"
+        FROM messages msg
+        JOIN user_messages um ON msg."userMessageId" = um.id
+        GROUP BY msg."workspaceId"
+      )
+      SELECT
+        w.id as "workspaceId",
+        w."sId" as "workspaceSId",
+        w."name" as "workspaceName",
+        p."code" as "planCode",
+        s."stripeSubscriptionId",
+        COALESCE(am."activeMembershipCount", 0) as "activeMembershipCount",
+        COALESCE(uwm."activeUsersByMessagesCount", 0) as "activeUsersByMessagesCount"
+      FROM workspaces w
+      JOIN subscriptions s ON w.id = s."workspaceId" AND s."status" = 'active'
+      JOIN plans p ON s."planId" = p.id
+      LEFT JOIN active_memberships am ON w.id = am."workspaceId"
+      LEFT JOIN users_with_messages uwm ON w.id = uwm."workspaceId"
+      WHERE COALESCE(am."activeMembershipCount", 0) <> COALESCE(uwm."activeUsersByMessagesCount", 0)
+      ORDER BY ABS(COALESCE(am."activeMembershipCount", 0) - COALESCE(uwm."activeUsersByMessagesCount", 0)) DESC
+      LIMIT 200
+      `,
+      { type: QueryTypes.SELECT }
+    );
+
+  if (workspaces.length === 0) {
+    reportSuccess();
+    return;
+  }
+
+  heartbeat();
+
+  // Filter out MAU-billed enterprise workspaces
+  const mismatchedWorkspaces: WorkspaceMismatch[] = [];
+
+  await concurrentExecutor(
+    workspaces,
+    async (workspace) => {
+      // For enterprise plans with a Stripe subscription, check if it's MAU billing
+      if (
+        isEntreprisePlanPrefix(workspace.planCode) &&
+        workspace.stripeSubscriptionId
+      ) {
+        const stripeSubscription = await getStripeSubscription(
+          workspace.stripeSubscriptionId
+        );
+
+        if (stripeSubscription) {
+          const activeItems = stripeSubscription.items.data.filter(
+            (item) => !item.deleted
+          );
+
+          const hasMauBilling = activeItems.some((item) => {
+            const usageRes = getUsageToReportForSubscriptionItem(item);
+            return (
+              usageRes.isOk() &&
+              usageRes.value !== null &&
+              isMauReportUsage(usageRes.value)
+            );
+          });
+
+          if (hasMauBilling) {
+            logger.info(
+              {
+                workspaceSId: workspace.workspaceSId,
+                planCode: workspace.planCode,
+              },
+              "Skipping MAU-billed enterprise workspace"
+            );
+            return;
+          }
+        }
+      }
+
+      mismatchedWorkspaces.push({
+        workspaceId: workspace.workspaceId,
+        workspaceSId: workspace.workspaceSId,
+        workspaceName: workspace.workspaceName,
+        activeMembershipCount: workspace.activeMembershipCount,
+        activeUsersByMessagesCount: workspace.activeUsersByMessagesCount,
+      });
+    },
+    { concurrency: 10 }
+  );
+
+  if (mismatchedWorkspaces.length === 0) {
+    reportSuccess();
+    return;
+  }
+
+  const actionLinks: ActionLink[] = mismatchedWorkspaces
+    .slice(0, 20)
+    .map((w) => ({
+      label: `${w.workspaceName} (seats: ${w.activeMembershipCount}, users: ${w.activeUsersByMessagesCount})`,
+      url: `/poke/${w.workspaceSId}`,
+    }));
+
+  logger.warn(
+    { workspaces: mismatchedWorkspaces },
+    `${mismatchedWorkspaces.length} workspace(s) have membership/active-user count mismatches`
+  );
+
+  reportFailure(
+    { workspaces: mismatchedWorkspaces, actionLinks },
+    `${mismatchedWorkspaces.length} workspace(s) have active membership count different from users with messages`
+  );
+};

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -1,0 +1,258 @@
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("MembershipResource", () => {
+  describe("firstUsedAt behavior", () => {
+    let workspace: WorkspaceType;
+    let lightWorkspace: LightWorkspaceType;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      lightWorkspace = renderLightWorkspaceType({ workspace });
+    });
+
+    describe("createMembership origin-based activation", () => {
+      it("should activate immediately for 'invited' origin", async () => {
+        const user = await UserFactory.withoutLastLogin();
+        const beforeCreate = new Date();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        expect(membership.firstUsedAt).not.toBeNull();
+        expect(membership.firstUsedAt?.getTime()).toBeGreaterThanOrEqual(
+          beforeCreate.getTime()
+        );
+      });
+
+      it("should activate immediately for 'auto-joined' origin", async () => {
+        const user = await UserFactory.withoutLastLogin();
+        const beforeCreate = new Date();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "auto-joined",
+        });
+
+        expect(membership.firstUsedAt).not.toBeNull();
+        expect(membership.firstUsedAt?.getTime()).toBeGreaterThanOrEqual(
+          beforeCreate.getTime()
+        );
+      });
+
+      it("should NOT activate for 'provisioned' origin", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        expect(membership.firstUsedAt).toBeNull();
+      });
+
+      it("should default to 'invited' origin when not specified", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+        });
+
+        expect(membership.origin).toBe("invited");
+        expect(membership.firstUsedAt).not.toBeNull();
+      });
+    });
+
+    describe("markMembershipFirstUse", () => {
+      it("should activate provisioned membership when accessing workspace", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        const beforeActivation = new Date();
+        const activated =
+          await MembershipResource.markMembershipFirstUse({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(activated).toBe(true);
+
+        const membership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(membership?.firstUsedAt).not.toBeNull();
+        expect(membership?.firstUsedAt?.getTime()).toBeGreaterThanOrEqual(
+          beforeActivation.getTime()
+        );
+      });
+
+      it("should NOT re-activate already activated membership", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        const originalActivatedAt = membership.firstUsedAt;
+        expect(originalActivatedAt).not.toBeNull();
+
+        const activated =
+          await MembershipResource.markMembershipFirstUse({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(activated).toBe(false);
+
+        const updatedMembership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(updatedMembership?.firstUsedAt?.getTime()).toBe(
+          originalActivatedAt?.getTime()
+        );
+      });
+
+      it("should return false if no membership exists", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const activated =
+          await MembershipResource.markMembershipFirstUse({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(activated).toBe(false);
+      });
+
+      it("should not activate revoked memberships", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        await MembershipResource.revokeMembership({
+          user,
+          workspace: lightWorkspace,
+        });
+
+        const activated =
+          await MembershipResource.markMembershipFirstUse({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(activated).toBe(false);
+      });
+    });
+
+    describe("getMembersCountForWorkspace", () => {
+      it("should count only activated members when activeOnly is true", async () => {
+        const activatedUser = await UserFactory.withoutLastLogin();
+        const provisionedUser = await UserFactory.withoutLastLogin();
+
+        await MembershipResource.createMembership({
+          user: activatedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        await MembershipResource.createMembership({
+          user: provisionedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        const count = await MembershipResource.getMembersCountForWorkspace({
+          workspace: lightWorkspace,
+          activeOnly: true,
+        });
+
+        expect(count).toBe(1);
+      });
+
+      it("should count all members regardless of activation when activeOnly is false", async () => {
+        const invitedUser = await UserFactory.withoutLastLogin();
+        const provisionedUser = await UserFactory.withoutLastLogin();
+
+        await MembershipResource.createMembership({
+          user: invitedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        await MembershipResource.createMembership({
+          user: provisionedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        const count = await MembershipResource.getMembersCountForWorkspace({
+          workspace: lightWorkspace,
+          activeOnly: false,
+        });
+
+        expect(count).toBe(2);
+      });
+
+      it("should not count revoked memberships even if activated", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        await MembershipResource.revokeMembership({
+          user,
+          workspace: lightWorkspace,
+        });
+
+        const count = await MembershipResource.getMembersCountForWorkspace({
+          workspace: lightWorkspace,
+          activeOnly: true,
+        });
+
+        expect(count).toBe(0);
+      });
+    });
+  });
+});

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -448,6 +448,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           startAt: {
             [Op.lte]: toDate,
           },
+          firstUsedAt: {
+            [Op.ne]: null,
+          },
         }
       : {};
 
@@ -463,17 +466,6 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       where,
       distinct: true,
       col: "userId",
-      include: [
-        {
-          model: UserModel,
-          required: true,
-          where: {
-            lastLoginAt: {
-              [Op.ne]: null,
-            },
-          },
-        },
-      ],
       transaction,
     });
   }

--- a/front/migrations/20260219_backfill_membership_first_used_at.ts
+++ b/front/migrations/20260219_backfill_membership_first_used_at.ts
@@ -1,0 +1,105 @@
+import readline from "readline";
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 1000;
+
+const DISCLAIMER = `
+================================================================================
+⚠️  WARNING: THIS SCRIPT AFFECTS WORKSPACE BILLING
+
+    Setting 'firstUsedAt' on memberships will change the count of active
+    members for workspaces, which directly impacts billing calculations.
+
+    - Members with firstUsedAt set are counted as active seats
+    - This backfill uses users' lastLoginAt as the firstUsedAt value
+    - All affected workspaces may see changes in their billed seat count
+
+    MAKE SURE YOU UNDERSTAND THE BILLING IMPLICATIONS BEFORE PROCEEDING.
+================================================================================
+`;
+
+async function confirmExecution(message: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`\n⚠️  ${message} [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y");
+    });
+  });
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  // eslint-disable-next-line no-console
+  console.log(DISCLAIMER);
+
+  if (execute) {
+    const confirmed = await confirmExecution(
+      "This will backfill firstUsedAt for all memberships and may affect billing. Continue?"
+    );
+    if (!confirmed) {
+      logger.info("Aborted by user.");
+      return;
+    }
+  }
+
+  let processedCount = 0;
+  let lastId = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch = await frontSequelize.query<{
+      membershipId: number;
+      lastLoginAt: Date;
+    }>(
+      `SELECT m.id as "membershipId", u."lastLoginAt"
+       FROM memberships m
+       JOIN users u ON m."userId" = u.id
+       WHERE m.id > :lastId
+         AND m."firstUsedAt" IS NULL
+         AND u."lastLoginAt" IS NOT NULL
+       ORDER BY m.id ASC
+       LIMIT :batchSize`,
+      {
+        replacements: { lastId, batchSize: BATCH_SIZE },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (batch.length === 0) {
+      break;
+    }
+
+    logger.info(
+      { batchSize: batch.length, processedCount },
+      "Processing batch"
+    );
+
+    if (execute) {
+      const membershipIds = batch.map((row) => row.membershipId);
+      const lastLoginAts = batch.map((row) => row.lastLoginAt);
+
+      await frontSequelize.query(
+        `UPDATE memberships m
+         SET "firstUsedAt" = data."lastLoginAt"
+         FROM unnest(:membershipIds::bigint[], :lastLoginAts::timestamp with time zone[]) AS data(id, "lastLoginAt")
+         WHERE m.id = data.id`,
+        {
+          replacements: { membershipIds, lastLoginAts },
+          type: QueryTypes.UPDATE,
+        }
+      );
+    }
+
+    processedCount += batch.length;
+    lastId = batch[batch.length - 1].membershipId;
+  }
+
+  logger.info({ totalProcessed: processedCount }, "Backfill completed");
+});

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -5,6 +5,7 @@ import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/c
 import { checkEndedBackendOnlySubscriptions } from "@app/lib/production_checks/checks/check_ended_backend_only_subscriptions";
 import { checkExcessCredits } from "@app/lib/production_checks/checks/check_excess_credits";
 import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
+import { checkMembershipActiveUsersConsistency } from "@app/lib/production_checks/checks/check_membership_active_users_consistency";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
 import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_paused_connectors";
 import { checkWebcrawlerSchedulerActiveWorkflow } from "@app/lib/production_checks/checks/check_webcrawler_scheduler_active_workflow";
@@ -74,6 +75,11 @@ export const REGISTERED_CHECKS: Check[] = [
   {
     name: "check_ended_backend_only_subscriptions",
     check: checkEndedBackendOnlySubscriptions,
+    everyHour: 24,
+  },
+  {
+    name: "check_membership_active_users_consistency",
+    check: checkMembershipActiveUsersConsistency,
     everyHour: 24,
   },
 ];

--- a/front/tests/utils/UserFactory.ts
+++ b/front/tests/utils/UserFactory.ts
@@ -15,9 +15,14 @@ export class UserFactory {
     return UserResource.makeNew(this.defaultParams(false, createdAt));
   }
 
+  static async withoutLastLogin() {
+    return UserResource.makeNew(this.defaultParams(false, new Date(), null));
+  }
+
   private static defaultParams = (
     superUser: boolean = false,
-    createdAt: Date = new Date()
+    createdAt: Date = new Date(),
+    lastLoginAt: Date | null = new Date()
   ) => {
     return {
       sId: generateRandomModelSId(),
@@ -35,7 +40,7 @@ export class UserFactory {
 
       isDustSuperUser: superUser,
       createdAt,
-      lastLoginAt: new Date(),
+      lastLoginAt,
     };
   };
 }


### PR DESCRIPTION
## Description

- Split of the previous PR (https://github.com/dust-tt/dust/pull/21917)
- Backfills the new columns, and actually use it for logic

## Tests

- Unit tests
- [ ] front-edge

## Risk

Low
Blast radius: Auth, rate limit so quite large

## Deploy Plan

- [ ] Run backfill
- [ ] Deploy