### PR TITLE
[Agent Email] Preserve threading headers on email replies

### DIFF
--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -31,6 +31,11 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
     subject: context.subject,
     text: context.originalText,
     auth: { SPF: "", dkim: "" },
+    threadingHeaders: {
+      messageId: context.threadingMessageId,
+      inReplyTo: context.threadingInReplyTo,
+      references: context.threadingReferences,
+    },
     envelope: {
       to: [],
       cc: [],

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -28,6 +28,7 @@ import type { SupportedFileContentType } from "@app/types/files";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString, isStringArray } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import fs from "fs";
 import sanitizeHtml from "sanitize-html";
@@ -61,14 +62,8 @@ export type EmailReplyContext = {
   conversationId: string;
 };
 
-function isStringArray(value: unknown): value is string[] {
-  return (
-    Array.isArray(value) && value.every((entry) => typeof entry === "string")
-  );
-}
-
 function isNullableString(value: unknown): value is string | null {
-  return value === null || typeof value === "string";
+  return value === null || isString(value);
 }
 
 function isEmailReplyContext(value: unknown): value is EmailReplyContext {
@@ -77,13 +72,13 @@ function isEmailReplyContext(value: unknown): value is EmailReplyContext {
   }
   return (
     "subject" in value &&
-    typeof value.subject === "string" &&
+    isString(value.subject) &&
     "originalText" in value &&
-    typeof value.originalText === "string" &&
+    isString(value.originalText) &&
     "fromEmail" in value &&
-    typeof value.fromEmail === "string" &&
+    isString(value.fromEmail) &&
     "fromFull" in value &&
-    typeof value.fromFull === "string" &&
+    isString(value.fromFull) &&
     "replyTo" in value &&
     isStringArray(value.replyTo) &&
     "replyCc" in value &&
@@ -95,11 +90,11 @@ function isEmailReplyContext(value: unknown): value is EmailReplyContext {
     "threadingReferences" in value &&
     isNullableString(value.threadingReferences) &&
     "agentConfigurationId" in value &&
-    typeof value.agentConfigurationId === "string" &&
+    isString(value.agentConfigurationId) &&
     "workspaceId" in value &&
-    typeof value.workspaceId === "string" &&
+    isString(value.workspaceId) &&
     "conversationId" in value &&
-    typeof value.conversationId === "string"
+    isString(value.conversationId)
   );
 }
 
@@ -296,6 +291,20 @@ export function buildReplyThreadingHeaders(email: InboundEmail): {
   });
 
   return { inReplyTo, references };
+}
+
+function buildSendgridThreadingHeaders(
+  email: InboundEmail
+): Record<string, string> {
+  const threadingHeaders = buildReplyThreadingHeaders(email);
+  return {
+    ...(threadingHeaders.inReplyTo
+      ? { "In-Reply-To": threadingHeaders.inReplyTo }
+      : {}),
+    ...(threadingHeaders.references
+      ? { References: threadingHeaders.references }
+      : {}),
+  };
 }
 
 export function buildSuccessReplyRecipients(email: InboundEmail): {
@@ -871,15 +880,7 @@ export async function sendToolValidationEmail({
     `</blockquote>\n` +
     "<div>\n";
 
-  const threadingHeaders = buildReplyThreadingHeaders(email);
-  const headers = {
-    ...(threadingHeaders.inReplyTo
-      ? { "In-Reply-To": threadingHeaders.inReplyTo }
-      : {}),
-    ...(threadingHeaders.references
-      ? { References: threadingHeaders.references }
-      : {}),
-  };
+  const headers = buildSendgridThreadingHeaders(email);
 
   const msg = {
     from: {
@@ -951,15 +952,7 @@ export async function replyToEmail({
     `</blockquote>\n` +
     "<div>\n";
 
-  const threadingHeaders = buildReplyThreadingHeaders(email);
-  const headers = {
-    ...(threadingHeaders.inReplyTo
-      ? { "In-Reply-To": threadingHeaders.inReplyTo }
-      : {}),
-    ...(threadingHeaders.references
-      ? { References: threadingHeaders.references }
-      : {}),
-  };
+  const headers = buildSendgridThreadingHeaders(email);
 
   const msg = {
     from: {

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -19,7 +19,7 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { removeNulls } from "@app/types/shared/utils/general";
+import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -35,8 +35,10 @@ function parseHeaderValue(
   headerName: string
 ): string | null {
   const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match the header name at line start, capture the first line value then any
+  // RFC 5322 folded continuation lines (lines starting with whitespace).
   const headerPattern = new RegExp(
-    `^${escapedHeaderName}:\\s*([\\s\\S]*?)(?=\\r?\\n[^\\s][^\\r\\n]*:|$)`,
+    `^${escapedHeaderName}:\\s*((?:.*(?:\\r?\\n[ \\t]+.*)*))`,
     "im"
   );
   const match = rawHeaders.match(headerPattern);
@@ -44,6 +46,7 @@ function parseHeaderValue(
     return null;
   }
 
+  // Unfold RFC 5322 continuation lines (CRLF/LF followed by spaces/tabs).
   const unfoldedHeaderValue = match[1].replace(/\r?\n[ \t]+/g, " ").trim();
 
   return unfoldedHeaderValue.length > 0 ? unfoldedHeaderValue : null;
@@ -122,7 +125,7 @@ const parseSendgridWebhookContent = async (
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       auth: { SPF: SPF || "", dkim: dkim || "" },
       threadingHeaders: parseThreadingHeaders(
-        typeof rawHeaders === "string" ? rawHeaders : null
+        isString(rawHeaders) ? rawHeaders : null
       ),
       envelope: {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing


### PR DESCRIPTION
## Description
Fixes regression introduced by recipient expansion in https://github.com/dust-tt/dust/pull/21907.
Follows https://github.com/dust-tt/dust/pull/21910.

Why this regressed: threading previously relied on mailbox heuristics (subject + participants) because we were not setting `In-Reply-To` / `References`; after expanding successful replies to include original `to/cc`, some clients treated replies as a new thread.

This keeps inbound threading metadata from SendGrid (Message-ID / In-Reply-To / References) and sets `In-Reply-To` + `References` on outbound assistant replies so mailbox clients keep replies in the same thread.

## Risks
Blast radius: Agent email reply path (successful replies, error replies, tool validation replies)
Risk: low

## Deploy Plan
- deploy front
