### PR TITLE
fix: also upload source maps for front-sse

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -150,6 +150,10 @@ runs:
           build_args+=("--build-arg NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=${{ inputs.dd_client_token }}")
           build_args+=("--build-arg NEXT_PUBLIC_DATADOG_SERVICE=$COMPONENT")
           build_args+=("--build-arg NEXT_PUBLIC_BUILD_DATE=$(date +%s)")
+          # Upload source maps for front-sse too (same image, different DD service name)
+          if [[ "$COMPONENT" == "front" ]]; then
+            build_args+=("--build-arg DATADOG_ADDITIONAL_SERVICES=front-sse")
+          fi
         fi
 
         # Only set Contentful credentials for front and front-edge builds (needed for ISR)

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -64,6 +64,7 @@ ARG NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER
 ARG NEXT_PUBLIC_NOVU_API_URL
 ARG NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL
 ARG NEXT_PUBLIC_BUILD_DATE
+ARG DATADOG_ADDITIONAL_SERVICES
 ARG CONTENTFUL_SPACE_ID
 ARG CONTENTFUL_ACCESS_TOKEN
 
@@ -107,6 +108,20 @@ RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
   --project-path=front \
   --release-version=$COMMIT_HASH \
   --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
+  for svc in $DATADOG_ADDITIONAL_SERVICES; do \
+  npx --yes @datadog/datadog-ci sourcemaps upload ./.next/static \
+  --minified-path-prefix=/_next/static/ \
+  --repository-url=https://github.com/dust-tt/dust \
+  --project-path=front \
+  --release-version=$COMMIT_HASH \
+  --service=${svc}-browser && \
+  npx --yes @datadog/datadog-ci sourcemaps upload ./.next/server \
+  --minified-path-prefix=/app/front/.next/server/ \
+  --repository-url=https://github.com/dust-tt/dust \
+  --project-path=front \
+  --release-version=$COMMIT_HASH \
+  --service=${svc} || exit 1; \
+  done && \
   find .next -type f -name "*.map" -print -delete; \
   fi
 


### PR DESCRIPTION
## Description

We don't have [source maps for front-sse,](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZx21-FrvrMtfwAAABhBWngyMS1yU0FBQV9CSExjZ1hLeDhRQWwAAAAkMDE5Yzc2ZDctZmNjOS00NTE3LWI5ZGEtYTFmZjA0YjNmYjI3AABm7A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1771510283209&to_ts=1771524683209&live=true) and that makes @ElPicador unhappy. 


  dockerfiles/front.Dockerfile:                                                                                                                                                                                  
  - Added ARG DATADOG_ADDITIONAL_SERVICES build arg                                                                                                                                                              
  - After uploading source maps for the primary service (front), loops over DATADOG_ADDITIONAL_SERVICES and uploads the same source maps under each additional service name (both -browser and server variants)  
  - The loop is a no-op when the arg is empty, so no impact on front-edge or other builds                                                                                                                        
                                                                                                                                                                                                               
  .github/actions/build-image/action.yml:
  - When building the front component, passes DATADOG_ADDITIONAL_SERVICES=front-sse so source maps are also uploaded under front-sse and front-sse-browser
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
