### PR TITLE
[front] feat: Backfill firstUsedAt and use it for seat counting

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -42,9 +42,21 @@ vi.mock("@app/lib/api/actions/servers/agent_copilot_helpers", () => ({
   getAgentConfigurationIdFromContext: vi.fn(),
 }));
 
-// Reset mocks between tests to prevent interference.
-beforeEach(() => {
-  vi.resetAllMocks();
+// Reset only file-local mocks between tests.
+// Avoid vi.resetAllMocks() as it resets global mocks like the Redis mock from vite.setup.ts.
+beforeEach(async () => {
+  const [overview, feedback, templateSuggestion, copilotHelpers] =
+    await Promise.all([
+      import("@app/lib/api/assistant/observability/overview"),
+      import("@app/lib/api/assistant/feedback"),
+      import("@app/lib/api/assistant/template_suggestion"),
+      import("@app/lib/api/actions/servers/agent_copilot_helpers"),
+    ]);
+
+  vi.mocked(overview.fetchAgentOverview).mockReset();
+  vi.mocked(feedback.getAgentFeedbacks).mockReset();
+  vi.mocked(templateSuggestion.getSuggestedTemplatesForQuery).mockReset();
+  vi.mocked(copilotHelpers.getAgentConfigurationIdFromContext).mockReset();
 });
 
 function getToolByName(name: string) {

--- a/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
+++ b/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
@@ -1,0 +1,126 @@
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { ActionLink, CheckFunction } from "@app/types/production_checks";
+import { QueryTypes } from "sequelize";
+
+interface WorkspaceWithSubscription {
+  workspaceModelId: number;
+  workspaceId: string;
+  workspaceName: string;
+  planCode: string;
+  stripeSubscriptionId: string | null;
+  activeMembershipCount: number;
+  activeUsersByMessagesCount: number;
+}
+
+interface WorkspaceMismatch {
+  workspaceModelId: number;
+  workspaceId: string;
+  workspaceName: string;
+  activeMembershipCount: number;
+  activeUsersByMessagesCount: number;
+}
+
+export const checkMembershipActiveUsersConsistency: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  const frontDb = getFrontReplicaDbConnection();
+
+  // Query workspaces with active subscriptions and their membership/user counts
+  const workspaces: WorkspaceWithSubscription[] =
+    // biome-ignore lint/plugin/noRawSql: Production check using read replica
+    await frontDb.query(
+      `
+      WITH active_memberships AS (
+        SELECT
+          m."workspaceId",
+          COUNT(DISTINCT m."userId")::int as "activeMembershipCount"
+        FROM memberships m
+        WHERE m."firstUsedAt" IS NOT NULL
+          AND m."endAt" IS NULL
+        GROUP BY m."workspaceId"
+      ),
+      users_with_messages AS (
+        SELECT
+          msg."workspaceId",
+          COUNT(DISTINCT um."userId")::int as "activeUsersByMessagesCount"
+        FROM messages msg
+        JOIN user_messages um ON msg."userMessageId" = um.id
+        GROUP BY msg."workspaceId"
+      )
+      SELECT
+        w.id as "workspaceId",
+        w."sId" as "workspaceSId",
+        w."name" as "workspaceName",
+        p."code" as "planCode",
+        s."stripeSubscriptionId",
+        COALESCE(am."activeMembershipCount", 0) as "activeMembershipCount",
+        COALESCE(uwm."activeUsersByMessagesCount", 0) as "activeUsersByMessagesCount"
+      FROM workspaces w
+      JOIN subscriptions s ON w.id = s."workspaceId" AND s."status" = 'active'
+      JOIN plans p ON s."planId" = p.id
+      LEFT JOIN active_memberships am ON w.id = am."workspaceId"
+      LEFT JOIN users_with_messages uwm ON w.id = uwm."workspaceId"
+      WHERE COALESCE(am."activeMembershipCount", 0) <> COALESCE(uwm."activeUsersByMessagesCount", 0)
+      ORDER BY ABS(COALESCE(am."activeMembershipCount", 0) - COALESCE(uwm."activeUsersByMessagesCount", 0)) DESC
+      LIMIT 200
+      `,
+      { type: QueryTypes.SELECT }
+    );
+
+  if (workspaces.length === 0) {
+    reportSuccess();
+    return;
+  }
+
+  heartbeat();
+
+  // Filter out MAU-billed enterprise workspaces
+  const mismatchedWorkspaces: WorkspaceMismatch[] = [];
+
+  await concurrentExecutor(
+    workspaces,
+    async (workspace) => {
+      // For enterprise plans with a Stripe subscription, check if it's MAU billing
+      if (isEntreprisePlanPrefix(workspace.planCode)) {
+        return;
+      }
+
+      mismatchedWorkspaces.push({
+        workspaceModelId: workspace.workspaceModelId,
+        workspaceId: workspace.workspaceId,
+        workspaceName: workspace.workspaceName,
+        activeMembershipCount: workspace.activeMembershipCount,
+        activeUsersByMessagesCount: workspace.activeUsersByMessagesCount,
+      });
+    },
+    { concurrency: 10 }
+  );
+
+  if (mismatchedWorkspaces.length === 0) {
+    reportSuccess();
+    return;
+  }
+
+  const actionLinks: ActionLink[] = mismatchedWorkspaces
+    .slice(0, 20)
+    .map((w) => ({
+      label: `${w.workspaceName} (seats: ${w.activeMembershipCount}, users: ${w.activeUsersByMessagesCount})`,
+      url: `/poke/${w.workspaceId}`,
+    }));
+
+  logger.warn(
+    { workspaces: mismatchedWorkspaces },
+    `${mismatchedWorkspaces.length} workspace(s) have membership/active-user count mismatches`
+  );
+
+  reportFailure(
+    { workspaces: mismatchedWorkspaces, actionLinks },
+    `${mismatchedWorkspaces.length} workspace(s) have active membership count different from users with messages`
+  );
+};

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,3 +1,4 @@
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -14,6 +15,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
@@ -43,6 +45,7 @@ import { Op, QueryTypes } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
+const GROUP_IDS_CACHE_TTL_MS = 1000 * 60 * 5; // 5 minutes
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -71,6 +74,223 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   constructor(model: ModelStatic<GroupModel>, blob: Attributes<GroupModel>) {
     super(GroupModel, blob);
+  }
+
+  // Default group kinds for auth (excludes system groups).
+  private static readonly defaultAuthGroupKinds: GroupKind[] =
+    GROUP_KINDS.filter((k) => k !== "system");
+
+  private static readonly groupIdsCacheKeyResolver = ({
+    user,
+    workspace,
+  }: {
+    user: UserResource;
+    workspace: LightWorkspaceType;
+  }) => `groups:user:${user.id}:workspace:${workspace.id}`;
+
+  private static async listUserGroupsForAuthUncached({
+    user,
+    workspace,
+  }: {
+    user: UserResource;
+    workspace: LightWorkspaceType;
+  }): Promise<ModelId[]> {
+    return GroupResource.listUserGroupModelIdsInWorkspace({
+      user,
+      workspace,
+      groupKinds: GroupResource.defaultAuthGroupKinds,
+      dangerouslySkipMembershipCheck: true,
+    });
+  }
+
+  private static listUserGroupsForAuthCached = cacheWithRedis(
+    ({
+      user,
+      workspace,
+    }: {
+      user: UserResource;
+      workspace: LightWorkspaceType;
+    }) => GroupResource.listUserGroupsForAuthUncached({ user, workspace }),
+    GroupResource.groupIdsCacheKeyResolver,
+    { ttlMs: GROUP_IDS_CACHE_TTL_MS, cacheNullValues: false }
+  );
+
+  static async invalidateGroupIdsCacheForUser(
+    userId: ModelId,
+    workspaceId: ModelId
+  ): Promise<void> {
+    const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
+    const key = `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`;
+    await redisCli.del(key);
+  }
+
+  static async batchInvalidateGroupIdsCacheForUsers(
+    userWorkspacePairs: Array<{ userId: ModelId; workspaceId: ModelId }>
+  ): Promise<void> {
+    if (userWorkspacePairs.length === 0) {
+      return;
+    }
+    const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
+    const keys = userWorkspacePairs.map(
+      ({ userId, workspaceId }) =>
+        `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`
+    );
+    await redisCli.del(keys);
+  }
+
+  static async listUserGroupsForAuth({
+    user,
+    workspace,
+  }: {
+    user: UserResource;
+    workspace: LightWorkspaceType;
+  }): Promise<ModelId[]> {
+    return this.listUserGroupsForAuthCached({ user, workspace });
+  }
+
+  /**
+   * Suspends all active members of the specified groups.
+   * Returns array of affected user ModelIds.
+   */
+  static async suspendMembersForGroups(
+    groupIds: ModelId[],
+    workspaceId: ModelId,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ModelId[]> {
+    if (groupIds.length === 0) {
+      return [];
+    }
+
+    const affectedMemberships = await GroupMembershipModel.findAll({
+      where: {
+        groupId: { [Op.in]: groupIds },
+        workspaceId,
+        status: "active",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+      attributes: ["userId"],
+      transaction,
+    });
+    const affectedUserIds = [
+      ...new Set(affectedMemberships.map((m) => m.userId)),
+    ];
+
+    await GroupMembershipModel.update(
+      { status: "suspended" },
+      {
+        where: {
+          groupId: { [Op.in]: groupIds },
+          workspaceId,
+          status: "active",
+          startAt: { [Op.lte]: new Date() },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+        },
+        transaction,
+      }
+    );
+
+    // Always invalidate - safe even if transaction rolls back (just causes cache miss)
+    if (affectedUserIds.length > 0) {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        affectedUserIds.map((userId) => ({ userId, workspaceId }))
+      );
+    }
+
+    return affectedUserIds;
+  }
+
+  /**
+   * Restores all suspended members of the specified groups.
+   * Returns array of affected user ModelIds.
+   */
+  static async restoreMembersForGroups(
+    groupIds: ModelId[],
+    workspaceId: ModelId,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ModelId[]> {
+    if (groupIds.length === 0) {
+      return [];
+    }
+
+    const affectedMemberships = await GroupMembershipModel.findAll({
+      where: {
+        groupId: { [Op.in]: groupIds },
+        workspaceId,
+        status: "suspended",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+      attributes: ["userId"],
+      transaction,
+    });
+    const affectedUserIds = [
+      ...new Set(affectedMemberships.map((m) => m.userId)),
+    ];
+
+    await GroupMembershipModel.update(
+      { status: "active" },
+      {
+        where: {
+          groupId: { [Op.in]: groupIds },
+          workspaceId,
+          status: "suspended",
+          startAt: { [Op.lte]: new Date() },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+        },
+        transaction,
+      }
+    );
+
+    // Always invalidate
+    if (affectedUserIds.length > 0) {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        affectedUserIds.map((userId) => ({ userId, workspaceId }))
+      );
+    }
+
+    return affectedUserIds;
+  }
+
+  /**
+   * Migrates all group memberships from one user to another within a workspace.
+   * Handles duplicate memberships by destroying them first.
+   */
+  static async migrateUserMemberships({
+    primaryUser,
+    secondaryUser,
+    workspace,
+  }: {
+    primaryUser: UserResource;
+    secondaryUser: UserResource;
+    workspace: LightWorkspaceType;
+  }): Promise<void> {
+    const primaryMemberships = await GroupMembershipModel.findAll({
+      where: { userId: primaryUser.id, workspaceId: workspace.id },
+      attributes: ["groupId"],
+    });
+    const primaryGroupIds = primaryMemberships.map((m) => m.groupId);
+
+    if (primaryGroupIds.length > 0) {
+      await GroupMembershipModel.destroy({
+        where: {
+          userId: secondaryUser.id,
+          groupId: primaryGroupIds,
+          workspaceId: workspace.id,
+        },
+      });
+    }
+
+    await GroupMembershipModel.update(
+      { userId: primaryUser.id },
+      { where: { userId: secondaryUser.id, workspaceId: workspace.id } }
+    );
+
+    // Always invalidate
+    await GroupResource.batchInvalidateGroupIdsCacheForUsers([
+      { userId: primaryUser.id, workspaceId: workspace.id },
+      { userId: secondaryUser.id, workspaceId: workspace.id },
+    ]);
   }
 
   static async makeNew(
@@ -1202,6 +1422,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       { transaction }
     );
 
+    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
+    await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+      users.map((u) => ({ userId: u.id, workspaceId: owner.id }))
+    );
+
     return new Ok(undefined);
   }
 
@@ -1350,6 +1575,11 @@ export class GroupResource extends BaseResource<GroupModel> {
         },
         transaction,
       }
+    );
+
+    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
+    await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+      users.map((u) => ({ userId: u.id, workspaceId: owner.id }))
     );
 
     return new Ok(undefined);
@@ -1588,6 +1818,20 @@ export class GroupResource extends BaseResource<GroupModel> {
   ): Promise<Result<undefined, Error>> {
     const owner = auth.getNonNullableWorkspace();
     try {
+      // Fetch active member user IDs before deletion for cache invalidation
+      const activeMemberships = await GroupMembershipModel.findAll({
+        where: {
+          groupId: this.id,
+          workspaceId: owner.id,
+          status: "active",
+          startAt: { [Op.lte]: new Date() },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+        },
+        attributes: ["userId"],
+        transaction,
+      });
+      const memberUserIds = activeMemberships.map((m) => m.userId);
+
       await KeyModel.destroy({
         where: {
           groupId: this.id,
@@ -1627,6 +1871,13 @@ export class GroupResource extends BaseResource<GroupModel> {
         },
         transaction,
       });
+
+      // Always invalidate cache for all former members - safe even if transaction rolls back (just causes cache miss)
+      if (memberUserIds.length > 0) {
+        await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+          memberUserIds.map((userId) => ({ userId, workspaceId: owner.id }))
+        );
+      }
 
       return new Ok(undefined);
     } catch (err) {

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -55,149 +55,417 @@ vi.mock("@app/lib/utils/cache", () => ({
 
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { LightWorkspaceType } from "@app/types/user";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 
 function getCacheKeyForWorkspace(workspaceSid: string): string {
   return `cacheWithRedis-countActiveSeatsInWorkspace-count-active-seats-in-workspace:${workspaceSid}`;
 }
 
 describe("MembershipResource", () => {
-  let authenticator: Authenticator;
-  let workspace: LightWorkspaceType;
+  describe("caching behavior", () => {
+    let authenticator: Authenticator;
+    let workspace: LightWorkspaceType;
 
-  beforeEach(async () => {
-    inMemoryCache.clear();
-    const testSetup = await createResourceTest({ role: "admin" });
-    authenticator = testSetup.authenticator;
-    workspace = testSetup.workspace;
-  });
-
-  describe("countActiveSeatsInWorkspaceCached", () => {
-    it("caches the seat count on first call", async () => {
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    beforeEach(async () => {
+      inMemoryCache.clear();
+      const testSetup = await createResourceTest({ role: "admin" });
+      authenticator = testSetup.authenticator;
+      workspace = testSetup.workspace;
     });
 
-    it("serves from cache on second call", async () => {
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+    describe("countActiveSeatsInWorkspaceCached", () => {
+      it("caches the seat count on first call", async () => {
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
 
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
 
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+      it("serves from cache on second call", async () => {
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+    });
+
+    describe("markFirstUse (instance update)", () => {
+      it("invalidates cache after update", async () => {
+        const user = await UserFactory.basic();
+        const membership = await MembershipFactory.associate(workspace, user, {
+          role: "user",
+          origin: "provisioned",
+        });
+
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await membership.markFirstUse();
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("delete()", () => {
+      it("invalidates cache after deletion", async () => {
+        const user = await UserFactory.basic();
+        const membership = await MembershipFactory.associate(workspace, user, {
+          role: "user",
+        });
+
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await membership.delete(authenticator, {});
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("deleteAllForWorkspace()", () => {
+      it("invalidates cache for the workspace", async () => {
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await MembershipResource.deleteAllForWorkspace(authenticator);
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("createMembership()", () => {
+      it("invalidates cache when new membership created", async () => {
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        const newUser = await UserFactory.basic();
+        await MembershipResource.createMembership({
+          user: newUser,
+          workspace,
+          role: "user",
+        });
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("revokeMembership()", () => {
+      it("invalidates cache when membership revoked", async () => {
+        const user = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, user, {
+          role: "user",
+        });
+
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await MembershipResource.revokeMembership({
+          user,
+          workspace,
+        });
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("updateMembershipRole()", () => {
+      it("invalidates cache when role updated", async () => {
+        const user = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, user, {
+          role: "user",
+        });
+
+        const cacheKey = getCacheKeyForWorkspace(workspace.sId);
+        await MembershipResource.countActiveSeatsInWorkspaceCached(
+          workspace.sId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await MembershipResource.updateMembershipRole({
+          user,
+          workspace,
+          newRole: "builder",
+          author: "no-author",
+        });
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
     });
   });
 
-  describe("markFirstUse (instance update)", () => {
-    it("invalidates cache after update", async () => {
-      const user = await UserFactory.basic();
-      const membership = await MembershipFactory.associate(workspace, user, {
-        role: "user",
-        origin: "provisioned",
-      });
+  describe("firstUsedAt behavior", () => {
+    let workspace: WorkspaceType;
+    let lightWorkspace: LightWorkspaceType;
 
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
-
-      await membership.markFirstUse();
-
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      lightWorkspace = renderLightWorkspaceType({ workspace });
     });
-  });
 
-  describe("delete()", () => {
-    it("invalidates cache after deletion", async () => {
-      const user = await UserFactory.basic();
-      const membership = await MembershipFactory.associate(workspace, user, {
-        role: "user",
+    describe("createMembership origin-based activation", () => {
+      it("should activate immediately for 'invited' origin", async () => {
+        const user = await UserFactory.withoutLastLogin();
+        const beforeCreate = new Date();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        expect(membership.firstUsedAt).not.toBeNull();
+        expect(membership.firstUsedAt?.getTime()).toBeGreaterThanOrEqual(
+          beforeCreate.getTime()
+        );
       });
 
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+      it("should activate immediately for 'auto-joined' origin", async () => {
+        const user = await UserFactory.withoutLastLogin();
+        const beforeCreate = new Date();
 
-      await membership.delete(authenticator, {});
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "auto-joined",
+        });
 
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
+        expect(membership.firstUsedAt).not.toBeNull();
+        expect(membership.firstUsedAt?.getTime()).toBeGreaterThanOrEqual(
+          beforeCreate.getTime()
+        );
+      });
+
+      it("should NOT activate for 'provisioned' origin", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        expect(membership.firstUsedAt).toBeNull();
+      });
+
+      it("should default to 'invited' origin when not specified", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+        });
+
+        expect(membership.origin).toBe("invited");
+        expect(membership.firstUsedAt).not.toBeNull();
+      });
     });
-  });
 
-  describe("deleteAllForWorkspace()", () => {
-    it("invalidates cache for the workspace", async () => {
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    describe("markFirstUse", () => {
+      it("should activate provisioned membership when accessing workspace", async () => {
+        const user = await UserFactory.withoutLastLogin();
 
-      await MembershipResource.deleteAllForWorkspace(authenticator);
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
 
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
+        const beforeActivation = new Date();
+        const activated = await membership.markFirstUse();
+
+        expect(activated).toBe(true);
+
+        const updatedMembership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(updatedMembership?.firstUsedAt).not.toBeNull();
+        expect(
+          updatedMembership?.firstUsedAt?.getTime()
+        ).toBeGreaterThanOrEqual(beforeActivation.getTime());
+      });
+
+      it("should NOT re-activate already activated membership", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        const originalActivatedAt = membership.firstUsedAt;
+        expect(originalActivatedAt).not.toBeNull();
+
+        const activated = await membership.markFirstUse();
+
+        expect(activated).toBe(false);
+
+        const updatedMembership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(updatedMembership?.firstUsedAt?.getTime()).toBe(
+          originalActivatedAt?.getTime()
+        );
+      });
+
+      it("should return false if already activated", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        const activated = await membership.markFirstUse();
+
+        expect(activated).toBe(false);
+      });
+
+      it("should activate provisioned membership", async () => {
+        const user = await UserFactory.withoutLastLogin();
+
+        const membership = await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        expect(membership.firstUsedAt).toBeNull();
+
+        const activated = await membership.markFirstUse();
+
+        expect(activated).toBe(true);
+
+        const updatedMembership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: lightWorkspace,
+          });
+
+        expect(updatedMembership?.firstUsedAt).not.toBeNull();
+      });
     });
-  });
 
-  describe("createMembership()", () => {
-    it("invalidates cache when new membership created", async () => {
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    describe("getMembersCountForWorkspace", () => {
+      it("should count only activated members when activeOnly is true", async () => {
+        const activatedUser = await UserFactory.withoutLastLogin();
+        const provisionedUser = await UserFactory.withoutLastLogin();
 
-      const newUser = await UserFactory.basic();
-      await MembershipResource.createMembership({
-        user: newUser,
-        workspace,
-        role: "user",
+        await MembershipResource.createMembership({
+          user: activatedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        await MembershipResource.createMembership({
+          user: provisionedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        const count = await MembershipResource.getMembersCountForWorkspace({
+          workspace: lightWorkspace,
+          activeOnly: true,
+        });
+
+        expect(count).toBe(1);
       });
 
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
-    });
-  });
+      it("should count all members regardless of activation when activeOnly is false", async () => {
+        const invitedUser = await UserFactory.withoutLastLogin();
+        const provisionedUser = await UserFactory.withoutLastLogin();
 
-  describe("revokeMembership()", () => {
-    it("invalidates cache when membership revoked", async () => {
-      const user = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, user, {
-        role: "user",
+        await MembershipResource.createMembership({
+          user: invitedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        await MembershipResource.createMembership({
+          user: provisionedUser,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "provisioned",
+        });
+
+        const count = await MembershipResource.getMembersCountForWorkspace({
+          workspace: lightWorkspace,
+          activeOnly: false,
+        });
+
+        expect(count).toBe(2);
       });
 
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
+      it("should not count revoked memberships even if activated", async () => {
+        const user = await UserFactory.withoutLastLogin();
 
-      await MembershipResource.revokeMembership({
-        user,
-        workspace,
+        await MembershipResource.createMembership({
+          user,
+          workspace: lightWorkspace,
+          role: "user",
+          origin: "invited",
+        });
+
+        await MembershipResource.revokeMembership({
+          user,
+          workspace: lightWorkspace,
+        });
+
+        const count = await MembershipResource.getMembersCountForWorkspace({
+          workspace: lightWorkspace,
+          activeOnly: true,
+        });
+
+        expect(count).toBe(0);
       });
-
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
-    });
-  });
-
-  describe("updateMembershipRole()", () => {
-    it("invalidates cache when role updated", async () => {
-      const user = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, user, {
-        role: "user",
-      });
-
-      const cacheKey = getCacheKeyForWorkspace(workspace.sId);
-      await MembershipResource.countActiveSeatsInWorkspaceCached(workspace.sId);
-      expect(inMemoryCache.has(cacheKey)).toBe(true);
-
-      await MembershipResource.updateMembershipRole({
-        user,
-        workspace,
-        newRole: "builder",
-        author: "no-author",
-      });
-
-      expect(inMemoryCache.has(cacheKey)).toBe(false);
     });
   });
 });

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -448,6 +448,9 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           startAt: {
             [Op.lte]: toDate,
           },
+          firstUsedAt: {
+            [Op.ne]: null,
+          },
         }
       : {};
 
@@ -463,17 +466,6 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       where,
       distinct: true,
       col: "userId",
-      include: [
-        {
-          model: UserModel,
-          required: true,
-          where: {
-            lastLoginAt: {
-              [Op.ne]: null,
-            },
-          },
-        },
-      ],
       transaction,
     });
   }

--- a/front/migrations/20260219_backfill_membership_first_used_at.ts
+++ b/front/migrations/20260219_backfill_membership_first_used_at.ts
@@ -1,0 +1,105 @@
+import readline from "readline";
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 1000;
+
+const DISCLAIMER = `
+================================================================================
+⚠️  WARNING: THIS SCRIPT AFFECTS WORKSPACE BILLING
+
+    Setting 'firstUsedAt' on memberships will change the count of active
+    members for workspaces, which directly impacts billing calculations.
+
+    - Members with firstUsedAt set are counted as active seats
+    - This backfill uses membership's startAt as the firstUsedAt value
+    - All affected workspaces may see changes in their billed seat count
+
+    MAKE SURE YOU UNDERSTAND THE BILLING IMPLICATIONS BEFORE PROCEEDING.
+================================================================================
+`;
+
+async function confirmExecution(message: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`\n⚠️  ${message} [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y");
+    });
+  });
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info(DISCLAIMER);
+
+  if (execute) {
+    const confirmed = await confirmExecution(
+      "This will backfill firstUsedAt for all memberships and may affect billing. Continue?"
+    );
+    if (!confirmed) {
+      logger.info("Aborted by user.");
+      return;
+    }
+  }
+
+  let processedCount = 0;
+  let lastId = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch = await frontSequelize.query<{
+      membershipId: number;
+    }>(
+      `SELECT m.id as "membershipId"
+       FROM memberships m
+       JOIN users u ON m."userId" = u.id
+       WHERE m.id > :lastId
+         AND m."firstUsedAt" IS NULL
+         AND m."startAt" IS NOT NULL
+         AND u."lastLoginAt" IS NOT NULL
+       ORDER BY m.id ASC
+       LIMIT :batchSize`,
+      {
+        replacements: { lastId, batchSize: BATCH_SIZE },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (batch.length === 0) {
+      break;
+    }
+
+    logger.info(
+      { batchSize: batch.length, processedCount },
+      "Processing batch"
+    );
+
+    if (execute) {
+      const membershipIds = batch.map((row) => row.membershipId);
+
+      await frontSequelize.query(
+        `UPDATE memberships m
+         SET "firstUsedAt" = "startAt"
+         FROM (
+           SELECT UNNEST(ARRAY[:membershipIds]::bigint[]) AS id
+         ) ids
+         WHERE m.id = ids.id`,
+        {
+          replacements: { membershipIds },
+          type: QueryTypes.UPDATE,
+        }
+      );
+    }
+
+    processedCount += batch.length;
+    lastId = batch[batch.length - 1].membershipId;
+  }
+
+  logger.info({ totalProcessed: processedCount }, "Backfill completed");
+});

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -5,6 +5,7 @@ import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/c
 import { checkEndedBackendOnlySubscriptions } from "@app/lib/production_checks/checks/check_ended_backend_only_subscriptions";
 import { checkExcessCredits } from "@app/lib/production_checks/checks/check_excess_credits";
 import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
+import { checkMembershipActiveUsersConsistency } from "@app/lib/production_checks/checks/check_membership_active_users_consistency";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
 import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_paused_connectors";
 import { checkWebcrawlerSchedulerActiveWorkflow } from "@app/lib/production_checks/checks/check_webcrawler_scheduler_active_workflow";
@@ -74,6 +75,11 @@ export const REGISTERED_CHECKS: Check[] = [
   {
     name: "check_ended_backend_only_subscriptions",
     check: checkEndedBackendOnlySubscriptions,
+    everyHour: 24,
+  },
+  {
+    name: "check_membership_active_users_consistency",
+    check: checkMembershipActiveUsersConsistency,
     everyHour: 24,
   },
 ];

--- a/front/tests/utils/UserFactory.ts
+++ b/front/tests/utils/UserFactory.ts
@@ -15,9 +15,14 @@ export class UserFactory {
     return UserResource.makeNew(this.defaultParams(false, createdAt));
   }
 
+  static async withoutLastLogin() {
+    return UserResource.makeNew(this.defaultParams(false, new Date(), null));
+  }
+
   private static defaultParams = (
     superUser: boolean = false,
-    createdAt: Date = new Date()
+    createdAt: Date = new Date(),
+    lastLoginAt: Date | null = new Date()
   ) => {
     return {
       sId: generateRandomModelSId(),
@@ -35,7 +40,7 @@ export class UserFactory {
 
       isDustSuperUser: superUser,
       createdAt,
-      lastLoginAt: new Date(),
+      lastLoginAt,
     };
   };
 }


### PR DESCRIPTION
## Description

- Split of the previous PR (https://github.com/dust-tt/dust/pull/21917)
- Backfills the new columns, and actually use it for logic

## Tests

- Unit tests
- [ ] front-edge

## Risk

Low
Blast radius: Auth, rate limit so quite large

## Deploy Plan

- [ ] Run backfill
- [ ] Deploy