### PR TITLE
fix: re-enable tooLongIndexName.grit

### DIFF
--- a/biome-plugins/tooLongIndexName.grit
+++ b/biome-plugins/tooLongIndexName.grit
@@ -3,19 +3,18 @@ language js
 
 // Validates Sequelize model index names don't exceed PostgreSQL's 63-char limit.
 //
-// Note: The original ESLint rule performs string manipulation (camelCase to
-// snake_case conversion) and length calculation to validate auto-generated
-// index names. GritQL cannot perform these computations.
+// Auto-generated index names follow: {tableName}_{field1}_{field2}
+// where tableName is typically modelName + 's', and fields are snake_cased.
 //
-// This simplified version flags any explicit index name property that appears
-// to be very long (pattern-based heuristic only). For full validation of
-// auto-generated index names, keep the ESLint rule or use a custom script.
-//
-// Matches explicit index name properties inside model definitions and warns
-// about the PostgreSQL 63-character limit.
+// GritQL cannot compute camelCase→snake_case conversion or string lengths,
+// so this rule uses a heuristic: only flag models whose name is >= 40 chars,
+// where auto-generated index names are likely to exceed the 63-char limit
+// (e.g. 40-char model + "s_" + two 12-char fields = 67 chars).
 `$_.init($schema, { $options })` as $call where {
     $options <: contains `indexes: [ $_ ]`,
-    $options <: contains `modelName: $name`,
+    $options <: contains `modelName: $name` where {
+        $name <: r".{42,}"
+    },
     register_diagnostic(
         span = $name,
         message = "Ensure Sequelize index names don't exceed PostgreSQL's 63-character limit. Auto-generated names follow the pattern: {modelName}s_{field1}_{field2}.",

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,8 @@
     "./biome-plugins/noMcpServerInstructions.grit",
     "./biome-plugins/enforceClientTypesInPublicApi.grit",
     "./biome-plugins/nextjsPageComponentNaming.grit",
-    "./biome-plugins/nextjsNoDataFetchingInGetssp.grit"
+    "./biome-plugins/nextjsNoDataFetchingInGetssp.grit",
+    "./biome-plugins/tooLongIndexName.grit"
   ],
   "vcs": {
     "enabled": true,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -483,6 +483,7 @@ NotionConnectorResourcesToCheckCacheEntryModel.init(
   },
   {
     sequelize: connectorsSequelize,
+    // biome-ignore lint/plugin/tooLongIndexName: previous error
     modelName: "notion_connector_resources_to_check_cache_entries",
     indexes: [
       {


### PR DESCRIPTION
## Description

Fix tooLongIndexName biome plugin

I'll add tests on the plugins it'll be easier to understand them



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
