### PR TITLE
Remove the instructionsHtml from the LightAgentConfigurationType

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -39,7 +39,6 @@ import type {
   AdditionalConfigurationInBuilderType,
   BuilderAction,
 } from "@app/components/shared/tools_picker/types";
-import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -39,6 +39,7 @@ import type {
   AdditionalConfigurationInBuilderType,
   BuilderAction,
 } from "@app/components/shared/tools_picker/types";
+import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -55,7 +56,7 @@ import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { TemplateInfo } from "@app/types/assistant/templates";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
@@ -100,7 +101,7 @@ function processAdditionalConfigurationFromStorage(
 }
 
 interface AgentBuilderProps {
-  agentConfiguration?: LightAgentConfigurationType;
+  agentConfiguration?: AgentConfigurationType;
   duplicateAgentId?: string | null;
   conversationId?: string;
   onSaved?: () => void;
@@ -567,7 +568,7 @@ export default function AgentBuilder({
  * Inner component that has access to FormContext and can use the MCP server hook.
  */
 interface AgentBuilderContentProps {
-  agentConfiguration?: LightAgentConfigurationType;
+  agentConfiguration?: AgentConfigurationType;
   pendingAgentId: string | null;
   title: string;
   handleCancel: () => void;

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -1,7 +1,7 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { getLargeWhitelistedModel } from "@app/types/assistant/assistant";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
 import { CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
@@ -16,7 +16,7 @@ import uniqueId from "lodash/uniqueId";
  * as they will be populated reactively in the component.
  */
 export function transformAgentConfigurationToFormData(
-  agentConfiguration: LightAgentConfigurationType
+  agentConfiguration: AgentConfigurationType
 ): AgentBuilderFormData {
   return {
     agentSettings: {
@@ -177,7 +177,7 @@ export function convertActionsForFormData(
  * resets editors to current user, and defaults to private scope.
  */
 export function transformDuplicateAgentToFormData(
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentConfigurationType,
   user: UserType
 ): AgentBuilderFormData {
   const baseFormData =

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -652,10 +652,11 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
     }
 
-    // Fetch the latest version of the agent configuration.
+    // Fetch the latest version of the agent configuration (full variant needed
+    // for instructionsHtml used in conflict pruning).
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId: agentConfigurationId,
-      variant: "light",
+      variant: "full",
     });
 
     if (!agentConfiguration) {

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -3,10 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
-import type {
-  AgentConfigurationType,
-  LightAgentConfigurationType,
-} from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   InstructionsSuggestionSchemaType,
   ModelSuggestionType,
@@ -348,7 +345,7 @@ function getDescendantBlockIds(
  */
 export async function pruneConflictingInstructionSuggestions(
   auth: Authenticator,
-  agentConfiguration: LightAgentConfigurationType,
+  agentConfiguration: AgentConfigurationType,
   newSuggestions: Array<{ sId: string; targetBlockId: string }>
 ): Promise<void> {
   if (newSuggestions.length === 0) {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -768,7 +768,6 @@ export async function createAgentConfiguration(
       name: agent.name,
       description: agent.description,
       instructions: agent.instructions,
-      instructionsHtml: agent.instructionsHtml,
       userFavorite,
       model: {
         providerId: agent.providerId,

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -158,7 +158,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       pictureUrl: agent.pictureUrl,
       description: agent.description,
       instructions: agent.instructions,
-      instructionsHtml: agent.instructionsHtml,
+      instructionsHtml: variant === "full" ? agent.instructionsHtml : null,
       model,
       status: agent.status,
       actions,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -4,14 +4,14 @@ import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import assert from "assert";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type ExportAgentConfigurationResponseBody = {
   assistant: Omit<
-    LightAgentConfigurationType,
+    AgentConfigurationType,
     | "id"
     | "versionCreatedAt"
     | "sId"
@@ -23,6 +23,8 @@ export type ExportAgentConfigurationResponseBody = {
     | "userFavorite"
     | "requestedGroupIds"
     | "requestedSpaceIds"
+    | "actions"
+    | "skills"
   > & {
     // If empty, no actions are performed, otherwise the actions are performed.
     actions: Omit<MCPServerConfigurationType, "id" | "sId">[];

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -1,5 +1,5 @@
-import { Authenticator } from "@app/lib/auth";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -446,10 +446,7 @@ describe("GET /api/w/[wId]/assistant/agent_configurations - instructionsHtml", (
     expect(lightAgent).not.toBeNull();
     // instructionsHtml is not part of LightAgentConfigurationType but we verify
     // the runtime value is null (not leaked from the DB).
-    expect(
-      (lightAgent as unknown as { instructionsHtml: string | null })
-        .instructionsHtml
-    ).toBeNull();
+    expect(lightAgent).toHaveProperty("instructionsHtml", null);
 
     // Full variant (via getAgentConfiguration) should include instructionsHtml.
     const fullAgent = await getAgentConfiguration(authenticator, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -485,6 +485,7 @@ export async function createOrUpgradeAgentConfiguration({
 
   const agentConfiguration: AgentConfigurationType = {
     ...agentConfigurationRes.value,
+    instructionsHtml: assistant.instructionsHtml ?? null,
     actions: actionConfigs,
   };
 

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -54,7 +54,7 @@ export class AgentConfigurationFactory {
       throw result.error;
     }
 
-    return { ...result.value, actions: [] };
+    return { ...result.value, instructionsHtml: null, actions: [] };
   }
 
   /**
@@ -98,6 +98,10 @@ export class AgentConfigurationFactory {
       throw result.error;
     }
 
-    return { ...result.value, actions: [] };
+    return {
+      ...result.value,
+      instructionsHtml: overrides.instructionsHtml ?? null,
+      actions: [],
+    };
   }
 }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -116,7 +116,6 @@ export type LightAgentConfigurationType = {
   versionAuthorId: ModelId | null;
 
   instructions: string | null;
-  instructionsHtml: string | null;
 
   model: AgentModelConfigurationType;
 
@@ -160,6 +159,8 @@ export type LightAgentConfigurationType = {
 };
 
 export type AgentConfigurationType = LightAgentConfigurationType & {
+  instructionsHtml: string | null;
+
   // If empty, no actions are performed, otherwise the actions are performed.
   actions: MCPServerConfigurationType[];
   skills?: GlobalSkillId[];


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6596

instructionsHtml is never used when we get the Light agent configuration
instructionsHtml is now only in the full AgentConfigurationType

instructions field is untouched 

```diff
type LightAgentConfigurationType = {
instructions: string | null;
- instructionsHtml: string | null;
...
}

type AgentConfigurationType = = LightAgentConfigurationType & {
+ instructionsHtml: string | null;
...
}
```

## Tests

unit test added

## Risk

low

## Deploy Plan

deploy front
