### PR TITLE
[front] Remove style override on DataTable in Agent Builder space selection

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -203,21 +203,13 @@ export function SpaceSelectionPageContent({
           <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
             Spaces
           </div>
-          <DataTable
-            data={spacesTableData}
-            columns={columns}
-            className="[&_thead]:hidden [&_td]:pl-0"
-          />
+          <DataTable data={spacesTableData} columns={columns} />
           {isProjectsEnabled && (
             <>
               <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
                 Projects
               </div>
-              <DataTable
-                data={projectsTableData}
-                columns={columns}
-                className="[&_thead]:hidden [&_td]:pl-0"
-              />
+              <DataTable data={projectsTableData} columns={columns} />
             </>
           )}
         </div>

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -116,7 +116,7 @@ export function KnowledgeFooter() {
         </span>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="rounded-xl bg-muted dark:bg-muted-night">
+        <div className="rounded-xl bg-muted dark:bg-muted-night mt-2">
           <ContextItem.List className="max-h-40 overflow-y-auto">
             {field.value.in.length > 0 ? (
               field.value.in.map((item) => (


### PR DESCRIPTION
## Description

- This PR removes the style override we have on the DataTable displayed in the Agent Builder space selection.
- Goal is to let sparkle handle the styling of its own components and add some left padding.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
