### PR TITLE
[Kill Switch] Add admin CLI commands to block/unblock conversations

### DIFF
--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -153,6 +153,8 @@ export function ExtensionAuthProvider({
       subscription: EXTENSION_SUBSCRIPTION,
       isAdmin: isAdmin(workspace),
       isBuilder: isBuilder(workspace),
+      featureFlags: [],
+      vizUrl: "",
     };
   }, [user, workspace]);
 

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -10,7 +10,6 @@ import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/dat
 import {
   FULL_WORKSPACE_KILL_SWITCH_VALUE,
   KILL_SWITCH_METADATA_KEY,
-  updateWorkspaceConversationKillSwitch,
 } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
@@ -407,10 +406,13 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Conversation not found: cId='${conversationId}'`);
       }
 
-      const updateResult = await updateWorkspaceConversationKillSwitch(w, {
-        conversationId,
-        operation: "block",
-      });
+      const updateResult = await WorkspaceResource.updateConversationKillSwitch(
+        w,
+        {
+          conversationId,
+          operation: "block",
+        }
+      );
       if (updateResult.isErr()) {
         throw new Error(updateResult.error.message);
       }
@@ -453,10 +455,13 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       if (!isString(conversationId)) {
         throw new Error("Invalid --cId argument: must be a string");
       }
-      const updateResult = await updateWorkspaceConversationKillSwitch(w, {
-        conversationId,
-        operation: "unblock",
-      });
+      const updateResult = await WorkspaceResource.updateConversationKillSwitch(
+        w,
+        {
+          conversationId,
+          operation: "unblock",
+        }
+      );
       if (updateResult.isErr()) {
         throw new Error(updateResult.error.message);
       }

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -406,13 +406,10 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Conversation not found: cId='${conversationId}'`);
       }
 
-      const updateResult = await WorkspaceResource.updateConversationKillSwitch(
-        w,
-        {
-          conversationId,
-          operation: "block",
-        }
-      );
+      const updateResult = await w.updateConversationKillSwitch({
+        conversationId,
+        operation: "block",
+      });
       if (updateResult.isErr()) {
         throw new Error(updateResult.error.message);
       }
@@ -455,13 +452,10 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       if (!isString(conversationId)) {
         throw new Error("Invalid --cId argument: must be a string");
       }
-      const updateResult = await WorkspaceResource.updateConversationKillSwitch(
-        w,
-        {
-          conversationId,
-          operation: "unblock",
-        }
-      );
+      const updateResult = await w.updateConversationKillSwitch({
+        conversationId,
+        operation: "unblock",
+      });
       if (updateResult.isErr()) {
         throw new Error(updateResult.error.message);
       }

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -7,10 +7,6 @@ import {
   softDeleteDataSourceAndLaunchScrubWorkflow,
 } from "@app/lib/api/data_sources";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
-import {
-  FULL_WORKSPACE_KILL_SWITCH_VALUE,
-  KILL_SWITCH_METADATA_KEY,
-} from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
@@ -201,7 +197,8 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const metadata = {
         ...(w.metadata ?? {}),
-        [KILL_SWITCH_METADATA_KEY]: FULL_WORKSPACE_KILL_SWITCH_VALUE,
+        [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
+          WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
       };
 
       const updateResult = await WorkspaceResource.updateMetadata(
@@ -227,7 +224,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
       }
 
       const metadata = { ...(w.metadata ?? {}) };
-      delete metadata[KILL_SWITCH_METADATA_KEY];
+      delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
 
       const updateResult = await WorkspaceResource.updateMetadata(
         w.id,

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -41,7 +41,7 @@ import {
 import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { isRoleType } from "@app/types/user";
 import fs from "fs/promises";
 import parseArgs from "minimist";
@@ -395,9 +395,6 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
       const conversationId = args.cId;
-      if (!isString(conversationId)) {
-        throw new Error("Invalid --cId argument: must be a string");
-      }
       const conversation = await ConversationResource.fetchById(
         auth,
         conversationId
@@ -449,9 +446,6 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       }
 
       const conversationId = args.cId;
-      if (!isString(conversationId)) {
-        throw new Error("Invalid --cId argument: must be a string");
-      }
       const updateResult = await w.updateConversationKillSwitch({
         conversationId,
         operation: "unblock",

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -1,10 +1,6 @@
 import { getUserWithWorkspaces } from "@app/lib/api/user";
 import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import {
-  isWorkspaceConversationKillSwitched,
-  isWorkspaceKillSwitchedForAllAPIs,
-} from "@app/lib/api/workspace";
-import {
   Authenticator,
   getAPIKey,
   getApiKeyNameFromHeaders,
@@ -14,6 +10,7 @@ import {
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -98,7 +95,10 @@ function getConversationKillSwitchErrorForRequest(
     return null;
   }
 
-  return isWorkspaceConversationKillSwitched(killSwitched, conversationId)
+  return WorkspaceResource.isWorkspaceConversationKillSwitched(
+    killSwitched,
+    conversationId
+  )
     ? getConversationKillSwitchError()
     : null;
 }
@@ -296,7 +296,11 @@ export function withSessionAuthenticationForWorkspace<T>(
       if (maintenance) {
         return apiError(req, res, getMaintenanceError(maintenance));
       }
-      if (isWorkspaceKillSwitchedForAllAPIs(owner.metadata?.killSwitched)) {
+      if (
+        WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+          owner.metadata?.killSwitched
+        )
+      ) {
         return apiError(req, res, getWorkspaceKillSwitchError());
       }
       const conversationKillSwitchError =
@@ -457,7 +461,7 @@ export function withPublicAPIAuthentication<T>(
             return apiError(req, res, getMaintenanceError(maintenance));
           }
           if (
-            isWorkspaceKillSwitchedForAllAPIs(
+            WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
               auth.workspace()?.metadata?.killSwitched
             )
           ) {
@@ -527,7 +531,11 @@ export function withPublicAPIAuthentication<T>(
       if (maintenance) {
         return apiError(req, res, getMaintenanceError(maintenance));
       }
-      if (isWorkspaceKillSwitchedForAllAPIs(owner.metadata?.killSwitched)) {
+      if (
+        WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+          owner.metadata?.killSwitched
+        )
+      ) {
         return apiError(req, res, getWorkspaceKillSwitchError());
       }
       const conversationKillSwitchError =

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -410,7 +410,6 @@ export const FULL_WORKSPACE_KILL_SWITCH_VALUE = "full";
 export type WorkspaceConversationKillSwitchValue = {
   conversationIds: string[];
 };
-export type WorkspaceConversationKillSwitchOperation = "block" | "unblock";
 export type WorkspaceKillSwitchValue =
   | typeof FULL_WORKSPACE_KILL_SWITCH_VALUE
   | WorkspaceConversationKillSwitchValue;
@@ -453,105 +452,6 @@ export function isWorkspaceConversationKillSwitched(
   }
 
   return killSwitched.conversationIds.includes(conversationId);
-}
-
-export type UpdateWorkspaceConversationKillSwitchResult = {
-  wasBlockedBefore: boolean;
-  wasUpdated: boolean;
-};
-
-const WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE =
-  "Workspace is fully blocked. Use `workspace unblock` before managing conversation blocks.";
-
-const INVALID_WORKSPACE_KILL_SWITCH_METADATA_ERROR_PREFIX =
-  "Invalid workspace kill switch metadata:";
-
-export async function updateWorkspaceConversationKillSwitch(
-  workspace: Pick<WorkspaceResource, "id" | "metadata">,
-  {
-    conversationId,
-    operation,
-  }: {
-    conversationId: string;
-    operation: WorkspaceConversationKillSwitchOperation;
-  }
-): Promise<Result<UpdateWorkspaceConversationKillSwitchResult, Error>> {
-  const currentKillSwitch = workspace.metadata?.[KILL_SWITCH_METADATA_KEY];
-  if (isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch)) {
-    return new Err(new Error(WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE));
-  }
-  if (
-    currentKillSwitch !== undefined &&
-    !isWorkspaceConversationKillSwitchValue(currentKillSwitch)
-  ) {
-    return new Err(
-      new Error(
-        `${INVALID_WORKSPACE_KILL_SWITCH_METADATA_ERROR_PREFIX} ${JSON.stringify(currentKillSwitch)}`
-      )
-    );
-  }
-
-  const conversationIds = currentKillSwitch?.conversationIds ?? [];
-  const wasBlockedBefore = conversationIds.includes(conversationId);
-
-  let metadata: Record<string, string | number | boolean | object>;
-
-  switch (operation) {
-    case "block": {
-      if (wasBlockedBefore) {
-        return new Ok({
-          wasBlockedBefore,
-          wasUpdated: false,
-        });
-      }
-
-      metadata = {
-        ...(workspace.metadata ?? {}),
-        [KILL_SWITCH_METADATA_KEY]: {
-          conversationIds: [...conversationIds, conversationId],
-        },
-      };
-      break;
-    }
-
-    case "unblock": {
-      if (!wasBlockedBefore) {
-        return new Ok({
-          wasBlockedBefore,
-          wasUpdated: false,
-        });
-      }
-
-      const updatedConversationIds = conversationIds.filter(
-        (cId) => cId !== conversationId
-      );
-      metadata = { ...(workspace.metadata ?? {}) };
-      if (updatedConversationIds.length === 0) {
-        delete metadata[KILL_SWITCH_METADATA_KEY];
-      } else {
-        metadata[KILL_SWITCH_METADATA_KEY] = {
-          conversationIds: updatedConversationIds,
-        };
-      }
-      break;
-    }
-
-    default:
-      return assertNever(operation);
-  }
-
-  const updateResult = await WorkspaceResource.updateMetadata(
-    workspace.id,
-    metadata
-  );
-  if (updateResult.isErr()) {
-    return new Err(updateResult.error);
-  }
-
-  return new Ok({
-    wasBlockedBefore,
-    wasUpdated: true,
-  });
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -12,7 +12,10 @@ import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import type { SearchMembersPaginationParams } from "@app/lib/resources/user_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  type WorkspaceConversationKillSwitchValue as WorkspaceConversationKillSwitchValueResource,
+  WorkspaceResource,
+} from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -26,7 +29,7 @@ import type { SubscriptionType } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isStringArray, removeNulls } from "@app/types/shared/utils/general";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { md5 } from "@app/types/shared/utils/hashing";
 import type {
   LightWorkspaceType,
@@ -405,11 +408,12 @@ export async function deleteWorkspace(
   return new Ok(undefined);
 }
 
-export const KILL_SWITCH_METADATA_KEY = "killSwitched";
-export const FULL_WORKSPACE_KILL_SWITCH_VALUE = "full";
-export type WorkspaceConversationKillSwitchValue = {
-  conversationIds: string[];
-};
+export const KILL_SWITCH_METADATA_KEY =
+  WorkspaceResource.KILL_SWITCH_METADATA_KEY;
+export const FULL_WORKSPACE_KILL_SWITCH_VALUE =
+  WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE;
+export type WorkspaceConversationKillSwitchValue =
+  WorkspaceConversationKillSwitchValueResource;
 export type WorkspaceKillSwitchValue =
   | typeof FULL_WORKSPACE_KILL_SWITCH_VALUE
   | WorkspaceConversationKillSwitchValue;
@@ -426,32 +430,23 @@ export interface WorkspaceMetadata {
 export function isWorkspaceConversationKillSwitchValue(
   killSwitched: unknown
 ): killSwitched is WorkspaceConversationKillSwitchValue {
-  if (typeof killSwitched !== "object" || killSwitched === null) {
-    return false;
-  }
-
-  if (!("conversationIds" in killSwitched)) {
-    return false;
-  }
-
-  return isStringArray(killSwitched.conversationIds);
+  return WorkspaceResource.isWorkspaceConversationKillSwitchValue(killSwitched);
 }
 
 export function isWorkspaceKillSwitchedForAllAPIs(
   killSwitched: unknown
 ): boolean {
-  return killSwitched === FULL_WORKSPACE_KILL_SWITCH_VALUE;
+  return WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(killSwitched);
 }
 
 export function isWorkspaceConversationKillSwitched(
   killSwitched: unknown,
   conversationId: string
 ): boolean {
-  if (!isWorkspaceConversationKillSwitchValue(killSwitched)) {
-    return false;
-  }
-
-  return killSwitched.conversationIds.includes(conversationId);
+  return WorkspaceResource.isWorkspaceConversationKillSwitched(
+    killSwitched,
+    conversationId
+  );
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -13,7 +13,7 @@ import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/works
 import type { SearchMembersPaginationParams } from "@app/lib/resources/user_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import {
-  type WorkspaceConversationKillSwitchValue as WorkspaceConversationKillSwitchValueResource,
+  type WorkspaceConversationKillSwitchValue,
   WorkspaceResource,
 } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -408,14 +408,8 @@ export async function deleteWorkspace(
   return new Ok(undefined);
 }
 
-export const KILL_SWITCH_METADATA_KEY =
-  WorkspaceResource.KILL_SWITCH_METADATA_KEY;
-export const FULL_WORKSPACE_KILL_SWITCH_VALUE =
-  WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE;
-export type WorkspaceConversationKillSwitchValue =
-  WorkspaceConversationKillSwitchValueResource;
-export type WorkspaceKillSwitchValue =
-  | typeof FULL_WORKSPACE_KILL_SWITCH_VALUE
+type WorkspaceKillSwitchValue =
+  | typeof WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE
   | WorkspaceConversationKillSwitchValue;
 
 export interface WorkspaceMetadata {
@@ -425,28 +419,6 @@ export interface WorkspaceMetadata {
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;
-}
-
-export function isWorkspaceConversationKillSwitchValue(
-  killSwitched: unknown
-): killSwitched is WorkspaceConversationKillSwitchValue {
-  return WorkspaceResource.isWorkspaceConversationKillSwitchValue(killSwitched);
-}
-
-export function isWorkspaceKillSwitchedForAllAPIs(
-  killSwitched: unknown
-): boolean {
-  return WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(killSwitched);
-}
-
-export function isWorkspaceConversationKillSwitched(
-  killSwitched: unknown,
-  conversationId: string
-): boolean {
-  return WorkspaceResource.isWorkspaceConversationKillSwitched(
-    killSwitched,
-    conversationId
-  );
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -557,18 +557,15 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return this.updateByModelIdAndCheckExistence(id, { metadata });
   }
 
-  static async updateConversationKillSwitch(
-    workspace: Pick<WorkspaceResource, "id" | "metadata">,
-    {
-      conversationId,
-      operation,
-    }: {
-      conversationId: string;
-      operation: WorkspaceConversationKillSwitchOperation;
-    }
-  ): Promise<Result<UpdateWorkspaceConversationKillSwitchResult, Error>> {
+  async updateConversationKillSwitch({
+    conversationId,
+    operation,
+  }: {
+    conversationId: string;
+    operation: WorkspaceConversationKillSwitchOperation;
+  }): Promise<Result<UpdateWorkspaceConversationKillSwitchResult, Error>> {
     const currentKillSwitch =
-      workspace.metadata?.[WORKSPACE_KILL_SWITCH_METADATA_KEY];
+      this.metadata?.[WORKSPACE_KILL_SWITCH_METADATA_KEY];
     if (isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch)) {
       return new Err(new Error(WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE));
     }
@@ -598,7 +595,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         }
 
         metadata = {
-          ...(workspace.metadata ?? {}),
+          ...(this.metadata ?? {}),
           [WORKSPACE_KILL_SWITCH_METADATA_KEY]: {
             conversationIds: [...conversationIds, conversationId],
           },
@@ -617,7 +614,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         const updatedConversationIds = conversationIds.filter(
           (cId) => cId !== conversationId
         );
-        metadata = { ...(workspace.metadata ?? {}) };
+        metadata = { ...(this.metadata ?? {}) };
         if (updatedConversationIds.length === 0) {
           delete metadata[WORKSPACE_KILL_SWITCH_METADATA_KEY];
         } else {
@@ -629,7 +626,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       }
     }
 
-    const updateResult = await this.updateMetadata(workspace.id, metadata);
+    const updateResult = await WorkspaceResource.updateMetadata(
+      this.id,
+      metadata
+    );
     if (updateResult.isErr()) {
       return new Err(updateResult.error);
     }

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -19,6 +19,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isStringArray } from "@app/types/shared/utils/general";
 import type { WorkspaceSegmentationType } from "@app/types/user";
 import type { WorkspaceDomain } from "@app/types/workspace";
 import type {
@@ -30,6 +31,34 @@ import type {
 import { Op } from "sequelize";
 
 const WORKSPACE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const WORKSPACE_KILL_SWITCH_METADATA_KEY = "killSwitched";
+const WORKSPACE_FULL_KILL_SWITCH_VALUE = "full";
+const WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE =
+  "Workspace is fully blocked. Use `workspace unblock` before managing conversation blocks.";
+const INVALID_WORKSPACE_KILL_SWITCH_METADATA_ERROR_PREFIX =
+  "Invalid workspace kill switch metadata:";
+
+type WorkspaceConversationKillSwitchValue = {
+  conversationIds: string[];
+};
+
+function isWorkspaceConversationKillSwitchValue(
+  killSwitched: unknown
+): killSwitched is WorkspaceConversationKillSwitchValue {
+  if (typeof killSwitched !== "object" || killSwitched === null) {
+    return false;
+  }
+
+  if (!("conversationIds" in killSwitched)) {
+    return false;
+  }
+
+  return isStringArray(killSwitched.conversationIds);
+}
+
+function isWorkspaceKillSwitchedForAllAPIs(killSwitched: unknown): boolean {
+  return killSwitched === WORKSPACE_FULL_KILL_SWITCH_VALUE;
+}
 
 // We use this to avoid accidentaly inflating the cache footprint
 // Add new attributes with caution
@@ -54,6 +83,12 @@ type CachedWorkspaceData = {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WorkspaceResource
   extends ReadonlyAttributesType<WorkspaceModel> {}
+
+export type WorkspaceConversationKillSwitchOperation = "block" | "unblock";
+export type UpdateWorkspaceConversationKillSwitchResult = {
+  wasBlockedBefore: boolean;
+  wasUpdated: boolean;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class WorkspaceResource extends BaseResource<WorkspaceModel> {
@@ -520,6 +555,89 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     metadata: Record<string, string | number | boolean | object> | null
   ): Promise<Result<void, Error>> {
     return this.updateByModelIdAndCheckExistence(id, { metadata });
+  }
+
+  static async updateConversationKillSwitch(
+    workspace: Pick<WorkspaceResource, "id" | "metadata">,
+    {
+      conversationId,
+      operation,
+    }: {
+      conversationId: string;
+      operation: WorkspaceConversationKillSwitchOperation;
+    }
+  ): Promise<Result<UpdateWorkspaceConversationKillSwitchResult, Error>> {
+    const currentKillSwitch =
+      workspace.metadata?.[WORKSPACE_KILL_SWITCH_METADATA_KEY];
+    if (isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch)) {
+      return new Err(new Error(WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE));
+    }
+    if (
+      currentKillSwitch !== undefined &&
+      !isWorkspaceConversationKillSwitchValue(currentKillSwitch)
+    ) {
+      return new Err(
+        new Error(
+          `${INVALID_WORKSPACE_KILL_SWITCH_METADATA_ERROR_PREFIX} ${JSON.stringify(currentKillSwitch)}`
+        )
+      );
+    }
+
+    const conversationIds = currentKillSwitch?.conversationIds ?? [];
+    const wasBlockedBefore = conversationIds.includes(conversationId);
+
+    let metadata: Record<string, string | number | boolean | object>;
+
+    switch (operation) {
+      case "block": {
+        if (wasBlockedBefore) {
+          return new Ok({
+            wasBlockedBefore,
+            wasUpdated: false,
+          });
+        }
+
+        metadata = {
+          ...(workspace.metadata ?? {}),
+          [WORKSPACE_KILL_SWITCH_METADATA_KEY]: {
+            conversationIds: [...conversationIds, conversationId],
+          },
+        };
+        break;
+      }
+
+      case "unblock": {
+        if (!wasBlockedBefore) {
+          return new Ok({
+            wasBlockedBefore,
+            wasUpdated: false,
+          });
+        }
+
+        const updatedConversationIds = conversationIds.filter(
+          (cId) => cId !== conversationId
+        );
+        metadata = { ...(workspace.metadata ?? {}) };
+        if (updatedConversationIds.length === 0) {
+          delete metadata[WORKSPACE_KILL_SWITCH_METADATA_KEY];
+        } else {
+          metadata[WORKSPACE_KILL_SWITCH_METADATA_KEY] = {
+            conversationIds: updatedConversationIds,
+          };
+        }
+        break;
+      }
+    }
+
+    const updateResult = await this.updateMetadata(workspace.id, metadata);
+    if (updateResult.isErr()) {
+      return new Err(updateResult.error);
+    }
+
+    return new Ok({
+      wasBlockedBefore,
+      wasUpdated: true,
+    });
   }
 
   static async updateWorkOSOrganizationId(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -31,34 +31,14 @@ import type {
 import { Op } from "sequelize";
 
 const WORKSPACE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-const WORKSPACE_KILL_SWITCH_METADATA_KEY = "killSwitched";
-const WORKSPACE_FULL_KILL_SWITCH_VALUE = "full";
 const WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE =
   "Workspace is fully blocked. Use `workspace unblock` before managing conversation blocks.";
 const INVALID_WORKSPACE_KILL_SWITCH_METADATA_ERROR_PREFIX =
   "Invalid workspace kill switch metadata:";
 
-type WorkspaceConversationKillSwitchValue = {
+export type WorkspaceConversationKillSwitchValue = {
   conversationIds: string[];
 };
-
-function isWorkspaceConversationKillSwitchValue(
-  killSwitched: unknown
-): killSwitched is WorkspaceConversationKillSwitchValue {
-  if (typeof killSwitched !== "object" || killSwitched === null) {
-    return false;
-  }
-
-  if (!("conversationIds" in killSwitched)) {
-    return false;
-  }
-
-  return isStringArray(killSwitched.conversationIds);
-}
-
-function isWorkspaceKillSwitchedForAllAPIs(killSwitched: unknown): boolean {
-  return killSwitched === WORKSPACE_FULL_KILL_SWITCH_VALUE;
-}
 
 // We use this to avoid accidentaly inflating the cache footprint
 // Add new attributes with caution
@@ -95,6 +75,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static model: ModelStatic<WorkspaceModel> = WorkspaceModel;
   private static workspaceDomainModel: ModelStaticWorkspaceAware<WorkspaceHasDomainModel> =
     WorkspaceHasDomainModel;
+  static readonly KILL_SWITCH_METADATA_KEY = "killSwitched";
+  static readonly FULL_WORKSPACE_KILL_SWITCH_VALUE = "full";
 
   readonly blob: Attributes<WorkspaceModel>;
 
@@ -108,6 +90,37 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
   private static readonly workspaceCacheKeyResolver = (wId: string) =>
     `workspace:sid:${wId}`;
+
+  static isWorkspaceConversationKillSwitchValue(
+    killSwitched: unknown
+  ): killSwitched is WorkspaceConversationKillSwitchValue {
+    if (typeof killSwitched !== "object" || killSwitched === null) {
+      return false;
+    }
+
+    if (!("conversationIds" in killSwitched)) {
+      return false;
+    }
+
+    return isStringArray(killSwitched.conversationIds);
+  }
+
+  static isWorkspaceKillSwitchedForAllAPIs(killSwitched: unknown): boolean {
+    return killSwitched === WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE;
+  }
+
+  static isWorkspaceConversationKillSwitched(
+    killSwitched: unknown,
+    conversationId: string
+  ): boolean {
+    if (
+      !WorkspaceResource.isWorkspaceConversationKillSwitchValue(killSwitched)
+    ) {
+      return false;
+    }
+
+    return killSwitched.conversationIds.includes(conversationId);
+  }
 
   private static async _fetchByIdUncached(
     wId: string
@@ -565,13 +578,17 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     operation: WorkspaceConversationKillSwitchOperation;
   }): Promise<Result<UpdateWorkspaceConversationKillSwitchResult, Error>> {
     const currentKillSwitch =
-      this.metadata?.[WORKSPACE_KILL_SWITCH_METADATA_KEY];
-    if (isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch)) {
+      this.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+    if (
+      WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch)
+    ) {
       return new Err(new Error(WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE));
     }
     if (
       currentKillSwitch !== undefined &&
-      !isWorkspaceConversationKillSwitchValue(currentKillSwitch)
+      !WorkspaceResource.isWorkspaceConversationKillSwitchValue(
+        currentKillSwitch
+      )
     ) {
       return new Err(
         new Error(
@@ -596,7 +613,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
 
         metadata = {
           ...(this.metadata ?? {}),
-          [WORKSPACE_KILL_SWITCH_METADATA_KEY]: {
+          [WorkspaceResource.KILL_SWITCH_METADATA_KEY]: {
             conversationIds: [...conversationIds, conversationId],
           },
         };
@@ -616,9 +633,9 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         );
         metadata = { ...(this.metadata ?? {}) };
         if (updatedConversationIds.length === 0) {
-          delete metadata[WORKSPACE_KILL_SWITCH_METADATA_KEY];
+          delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
         } else {
-          metadata[WORKSPACE_KILL_SWITCH_METADATA_KEY] = {
+          metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY] = {
             conversationIds: updatedConversationIds,
           };
         }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/21972.

- Adds `conversation block` and `conversation unblock` commands to `front/admin/cli.ts`.
- `conversation block` validates workspace/conversation, then adds `cId` to `workspace.metadata.killSwitched.conversationIds` (idempotent).
- `conversation unblock` removes `cId` from `conversationIds` and clears `killSwitched` when the list becomes empty.
- Both commands fail fast when the workspace is currently full-blocked (`killSwitched = "full"`) to avoid ambiguous state transitions.

## Risks
Blast radius: front admin CLI only (`front/admin/cli.ts`) used for manual emergency operations.
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] `cd front && ./admin/cli.sh conversation block --wId DevWkSpace --cId FCWWa2fiZY`
- [x] `cd cli && npm run start -- chat -a gpt5-mini -c FCWWa2fiZY -m 'should be blocked by conversation kill switch'` (returns `503 service_unavailable`)
- [x] `cd front && ./admin/cli.sh conversation unblock --wId DevWkSpace --cId FCWWa2fiZY`
- [x] `cd cli && npm run start -- chat -a gpt5-mini -c FCWWa2fiZY -m 'should pass after conversation unblock'` (returns success JSON)
