### PR TITLE
[Connectors] fix(microsoft): import shared types in encode/decode scripts

### DIFF
--- a/connectors/scripts/microsoft_decode_internal_id.ts
+++ b/connectors/scripts/microsoft_decode_internal_id.ts
@@ -8,16 +8,7 @@
  *   npx ts-node scripts/decode_internal_id.ts microsoft-Zm9sZGVyLy9kcml2ZXMvYiFTblg3...
  */
 
-const MICROSOFT_NODE_TYPES = [
-  "sites-root",
-  "site",
-  "drive",
-  "folder",
-  "file",
-  "page",
-  "message",
-  "worksheet",
-] as const;
+import { isValidNodeType } from "@connectors/connectors/microsoft/lib/types";
 
 function decode(internalId: string) {
   if (!internalId.startsWith("microsoft-")) {
@@ -34,12 +25,7 @@ function decode(internalId: string) {
   }
 
   const [nodeType, ...rest] = decodedId.split("/");
-  if (
-    !nodeType ||
-    !MICROSOFT_NODE_TYPES.includes(
-      nodeType as (typeof MICROSOFT_NODE_TYPES)[number]
-    )
-  ) {
+  if (!nodeType || !isValidNodeType(nodeType)) {
     throw new Error(`Invalid nodeType: ${nodeType} (decoded: ${decodedId})`);
   }
 

--- a/connectors/scripts/microsoft_encode_internal_id.ts
+++ b/connectors/scripts/microsoft_encode_internal_id.ts
@@ -11,23 +11,13 @@
  *   npx ts-node scripts/encode_internal_id.ts file /drives/b!abc123/items/014EON
  */
 
-const MICROSOFT_NODE_TYPES = [
-  "sites-root",
-  "site",
-  "drive",
-  "folder",
-  "file",
-  "page",
-  "message",
-  "worksheet",
-] as const;
+import {
+  isValidNodeType,
+  MICROSOFT_NODE_TYPES,
+} from "@connectors/connectors/microsoft/lib/types";
 
 function encode(nodeType: string, itemAPIPath: string) {
-  if (
-    !MICROSOFT_NODE_TYPES.includes(
-      nodeType as (typeof MICROSOFT_NODE_TYPES)[number]
-    )
-  ) {
+  if (!isValidNodeType(nodeType)) {
     throw new Error(
       `Invalid nodeType: ${nodeType}. Valid types: ${MICROSOFT_NODE_TYPES.join(", ")}`
     );


### PR DESCRIPTION
## Description

Fix connectors build broken by #21997. The added scripts redeclare `MICROSOFT_NODE_TYPES` locally without imports, making them global-scoped and causing `tsgo` to fail on duplicate variable declarations.

Import `isValidNodeType` and `MICROSOFT_NODE_TYPES` from the existing source instead.