### PR TITLE
[front] - feat(workspace): download usage data

### DIFF
--- a/front/pages/api/w/[wId]/analytics/active-users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users-export.ts
@@ -1,0 +1,85 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const result = await fetchActiveUsersMetrics(owner.sId, q.data.days);
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve active users metrics: ${result.error.message}`,
+          },
+        });
+      }
+
+      const headers = ["date", "dau", "wau", "mau"];
+      const csvData = result.value.map((point) => [
+        point.date,
+        point.dau,
+        point.wau,
+        point.mau,
+      ]);
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_active_users_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/analytics/usage-metrics-export.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics-export.ts
@@ -1,0 +1,94 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { formatUTCDateFromMillis } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days: q.data.days,
+      });
+
+      const result = await fetchMessageMetrics(baseQuery, "day", [
+        "conversations",
+        "activeUsers",
+      ] as const);
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve usage metrics: ${result.error.message}`,
+          },
+        });
+      }
+
+      const headers = ["date", "messages", "conversations", "activeUsers"];
+      const csvData = result.value.map((point) => [
+        formatUTCDateFromMillis(point.timestamp),
+        point.count,
+        point.conversations,
+        point.activeUsers,
+      ]);
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_activity_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR adds CSV export functionality for workspace usage analytics charts. When the `analytics_csv_export` feature flag is enabled, workspace admins can download CSV files directly from the activity and active users charts using a new download button. The implementation includes two new API endpoints (`/api/w/[wId]/analytics/usage-metrics-export` and `/api/w/[wId]/analytics/active-users-export`) that export daily metrics for the selected time period

## Risk

Medium. The feature is behind the `analytics_csv_export` feature flag and does not modify existing functionality - but touches user data

## Tests

- [x] Locally
- [ ] front-edge

## Deploy Plan

Deploy front