### PR TITLE
Fix various copilot template issues

### DIFF
--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -80,7 +80,7 @@ function PanelHeader({
                   icon={BarChartIcon}
                   onClick={() => onTabChange("insights")}
                 />
-                {hasTemplate && (
+                {hasTemplate && !hasCopilot && (
                   <TabsTrigger
                     value="template"
                     label="Template"
@@ -143,7 +143,7 @@ function CollapsedTabs({
         tooltip="Insights"
         onClick={() => onTabSelect("insights")}
       />
-      {hasTemplate && (
+      {hasTemplate && !hasCopilot && (
         <Button
           icon={MagicIcon}
           variant="ghost"

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -58,7 +58,7 @@ export function CreateAgentPage() {
     const validTemplates = assistantTemplates.filter(
       (template) =>
         isTemplateTagCodeArray(template.tags) &&
-        (!hasCopilot || template.copilotInstructions !== null)
+        (!hasCopilot || template.hasCopilotInstructions)
     );
 
     const filtered = validTemplates.filter((template) => {

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -55,8 +55,10 @@ export function CreateAgentPage() {
   const { assistantTemplates } = useAssistantTemplates();
 
   const { filteredTemplates, availableTags } = useMemo(() => {
-    const validTemplates = assistantTemplates.filter((template) =>
-      isTemplateTagCodeArray(template.tags)
+    const validTemplates = assistantTemplates.filter(
+      (template) =>
+        isTemplateTagCodeArray(template.tags) &&
+        (!hasCopilot || template.copilotInstructions !== null)
     );
 
     const filtered = validTemplates.filter((template) => {
@@ -81,7 +83,7 @@ export function CreateAgentPage() {
     const tags = getUniqueTemplateTags(validTemplates);
 
     return { filteredTemplates: filtered, availableTags: tags };
-  }, [assistantTemplates, selectedTags, searchTerm]);
+  }, [assistantTemplates, selectedTags, searchTerm, hasCopilot]);
 
   const openTemplateModal = async (templateId: string) => {
     setSelectedTemplateId(templateId);

--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -21,6 +21,7 @@ import React, { useState } from "react";
 export interface TemplatesDisplayType {
   id: string;
   name: string;
+  hasCopilotInstructions: boolean;
   visibility: TemplateVisibility;
   tags: TemplateTagCodeType[];
   onClick?: () => void;
@@ -34,6 +35,7 @@ function prepareTemplatesForDisplay(
   return templates.map((t) => ({
     id: t.sId,
     name: t.handle,
+    hasCopilotInstructions: t.hasCopilotInstructions,
     visibility: t.visibility,
     tags: t.tags,
   }));
@@ -66,6 +68,15 @@ export function makeColumnsForTemplates() {
       cell: (info: Info) => (
         <DataTable.CellContent>
           {info.row.original.visibility}
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      header: "Copilot Instructions",
+      accessorKey: "hasCopilotInstructions",
+      cell: (info: Info) => (
+        <DataTable.CellContent>
+          {info.row.original.hasCopilotInstructions ? "Yes" : "No"}
         </DataTable.CellContent>
       ),
     },

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1955,6 +1955,7 @@ describe("agent_copilot_context tools", () => {
 
       // Create a template without copilotInstructions.
       const template = await TemplateFactory.published();
+      await template.updateAttributes({ copilotInstructions: null });
 
       const tool = getToolByName("get_agent_template");
       const result = await tool.handler(

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -1892,9 +1892,11 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
   },
 
   search_agent_templates: async ({ jobType, query }, { auth }) => {
-    const allTemplates = await TemplateResource.listAll({
-      visibility: "published",
-    });
+    const allTemplates = (
+      await TemplateResource.listAll({
+        visibility: "published",
+      })
+    ).filter((t) => t.copilotInstructions !== null);
 
     const matchingTags =
       jobType && isJobType(jobType) ? JOB_TYPE_TO_TEMPLATE_TAGS[jobType] : [];

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -172,7 +172,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       sId: this.sId,
       tags: this.tags,
       visibility: this.visibility,
-      copilotInstructions: this.copilotInstructions,
+      hasCopilotInstructions: this.copilotInstructions !== null,
     };
   }
 

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -172,6 +172,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       sId: this.sId,
       tags: this.tags,
       visibility: this.visibility,
+      copilotInstructions: this.copilotInstructions,
     };
   }
 

--- a/front/tests/utils/TemplateFactory.ts
+++ b/front/tests/utils/TemplateFactory.ts
@@ -20,6 +20,7 @@ export class TemplateFactory {
       presetInstructions: null,
       helpInstructions: null,
       helpActions: null,
+      copilotInstructions: faker.lorem.sentence(),
     };
   };
 


### PR DESCRIPTION
## Description

- Filter agent templates to only show copilot-compatible templates (those with non-null copilotInstructions) when the copilot flag is enabled
- Hide the "Template" tab in the agent builder right panel when copilot is enabled
- Filter search_agent_templates MCP tool to only return templates with copilotInstructions
- Add poke column that shows in the list if a template has copilot instructions

## Tests

Manual

## Risk

Should only affects copilot

## Deploy Plan

Front