### PR TITLE
fix: mcp completion time

### DIFF
--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -110,14 +110,13 @@ export async function* runToolWithStreaming(
     }
   );
 
-  const endDate = performance.now();
-
   // Err here means an exception ahead of calling the tool, like a connection error, an input
   // validation error, or any other kind of error from MCP, but not a tool error, which are returned
   // as content.
   if (toolCallResult.isError) {
     statsDClient.increment("mcp_actions_error.count", 1, tags);
 
+    const endDate = performance.now();
     yield await handleMCPActionError({
       action,
       agentConfiguration,
@@ -155,6 +154,7 @@ export async function* runToolWithStreaming(
   } else {
     statsDClient.increment("mcp_actions_success.count", 1, tags);
 
+    const endDate = performance.now();
     await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
 
     yield {

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -45,6 +45,9 @@ export const formatDurationString = (durationMs: number): string => {
     }
     return `${minutes} min ${seconds} sec`;
   }
+  if (totalSeconds === 0) {
+    return "< 1 sec";
+  }
   return `${seconds} sec`;
 };
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/6687

This PR does 2 things : 
- move completion time calculation closer to actual end for MCPs
- rephrase 0 seconds as less than a second

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front