### PR TITLE
Keep selected files when adding new site

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -237,7 +237,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           }
 
           // If there are any changes, trigger setPermissions to handle the sync
-          console.log("Permissions to update:", permissions);
           if (Object.keys(permissions).length > 0) {
             const setPermissionsRes = await this.setPermissions({
               permissions,

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -193,37 +193,51 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           });
 
           const newSelectedSites = mapResolvedSitesToMetadata(resolvedSites);
-
-          // Update the configuration with the new selected sites
-          await config.update({ selectedSites: newSelectedSites });
-
-          // Calculate which sites were added or removed
-          const currentRoots =
-            await MicrosoftRootResource.listRootsByConnectorId(connector.id);
-          const currentInternalIds = new Set(
-            currentRoots.map((r) => r.internalId)
-          );
           const newInternalIds = new Set(
             resolvedSites.map((s) => s.internalId)
           );
 
+          // Update the configuration with the new selected sites
+          await config.update({ selectedSites: newSelectedSites });
+
+          const currentRoots =
+            await MicrosoftRootResource.listRootsByConnectorId(connector.id);
+          const currentSiteRoots = currentRoots.filter(
+            (r) => r.nodeType === "site"
+          );
+          const currentSiteInternalIds = new Set(
+            currentSiteRoots.map((r) => r.internalId)
+          );
+
+          const removedSiteIds = [...currentSiteInternalIds].filter(
+            (id) => !newInternalIds.has(id)
+          );
+          const addedSiteIds = [...newInternalIds].filter(
+            (id) => !currentSiteInternalIds.has(id)
+          );
+
           const permissions: Record<string, ConnectorPermission> = {};
 
-          // Mark removed sites as "none"
-          for (const currentId of currentInternalIds) {
-            if (!newInternalIds.has(currentId)) {
-              permissions[currentId] = "none";
-            }
+          // Mark added sites as "read"
+          for (const id of addedSiteIds) {
+            permissions[id] = "read";
           }
 
-          // Mark added sites as "read"
-          for (const newId of newInternalIds) {
-            if (!currentInternalIds.has(newId)) {
-              permissions[newId] = "read";
+          // If any site was removed, also clear all non-site roots (drives/folders)
+          // since we cannot easily determine which site they belong to.
+          if (removedSiteIds.length > 0) {
+            for (const id of removedSiteIds) {
+              permissions[id] = "none";
+            }
+            for (const root of currentRoots.filter(
+              (r) => r.nodeType !== "site"
+            )) {
+              permissions[root.internalId] = "none";
             }
           }
 
           // If there are any changes, trigger setPermissions to handle the sync
+          console.log("Permissions to update:", permissions);
           if (Object.keys(permissions).length > 0) {
             const setPermissionsRes = await this.setPermissions({
               permissions,


### PR DESCRIPTION
## Description

Fixes a bug where file and folder selections were lost when adding new SharePoint sites to a Microsoft connector. Previously, when updating the selected sites list, all root resources (drives and folders) would be cleared, causing users to lose their existing file selections.

The change now marks newly added sites as "read", preserving existing selections when adding new sites.

A limitation is that all non-site roots (drives/folders) are cleared when a site is removed, even if these roots are not in the removed site. This limitation comes from the difficulty to easily know if a file/folder is in a site in `connectors`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
