### PR TITLE
feat: update notification preferences

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -2,15 +2,25 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
-import { PROJECT_NEW_CONVERSATION_TRIGGER_ID } from "@app/types/notification_preferences";
+import {
+  CONVERSATION_NOTIFICATION_METADATA_KEYS,
+  DEFAULT_PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION,
+  isProjectNewConversationNotificationConditionOptions,
+  PROJECT_NEW_CONVERSATION_TRIGGER_ID,
+  type ProjectNewConversationNotificationConditionOptions,
+} from "@app/types/notification_preferences";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import uniqBy from "lodash/uniqBy";
+import { Op } from "sequelize";
 import z from "zod";
 
 export const projectNewConversationPayloadSchema = z.object({
@@ -24,6 +34,45 @@ export type ProjectNewConversationPayloadType = z.infer<
 >;
 
 const NOTIFICATION_DELAY_MS = 15_000; // 15 seconds
+
+export const filterMembersByNotifyCondition = async (
+  members: UserResource[]
+): Promise<UserResource[]> => {
+  const userModelIds = members.map((p) => p.id);
+
+  // Bulk query for all preferences.
+  const preferences = await UserMetadataModel.findAll({
+    where: {
+      userId: { [Op.in]: userModelIds },
+      key: CONVERSATION_NOTIFICATION_METADATA_KEYS.projectNewConversationNotifyCondition,
+    },
+    attributes: ["userId", "value"],
+  });
+
+  const preferenceMap = new Map<
+    number,
+    ProjectNewConversationNotificationConditionOptions
+  >();
+  for (const pref of preferences) {
+    if (isProjectNewConversationNotificationConditionOptions(pref.value)) {
+      preferenceMap.set(pref.userId, pref.value);
+    }
+  }
+
+  return members.filter((member) => {
+    const notifyCondition =
+      preferenceMap.get(member.id) ??
+      DEFAULT_PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION;
+    switch (notifyCondition) {
+      case "all_projects":
+        return true;
+      case "never":
+        return false;
+      default:
+        assertNever(notifyCondition);
+    }
+  });
+};
 
 /**
  * Trigger notifications for users added to a project.
@@ -74,9 +123,16 @@ const triggerProjectNewConversationNotifications = async (
     "sId"
   );
 
-  const usersToNotify = projectMembers.filter(
+  const otherProjectMembers = projectMembers.filter(
     (member) => member.sId !== userThatCreatedConversation.sId
   );
+
+  const usersToNotify =
+    await filterMembersByNotifyCondition(otherProjectMembers);
+
+  if (usersToNotify.length === 0) {
+    return new Ok(undefined);
+  }
 
   try {
     const novuClient = await getNovuClient();

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -76,6 +76,17 @@ export const NOTIFICATION_CONDITION_OPTIONS = [
 export type NotificationCondition =
   (typeof NOTIFICATION_CONDITION_OPTIONS)[number];
 
+const PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_OPTIONS = [
+  "all_projects",
+  "never",
+] as const;
+
+export type ProjectNewConversationNotificationConditionOptions =
+  (typeof PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_OPTIONS)[number];
+
+export const DEFAULT_PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION: ProjectNewConversationNotificationConditionOptions =
+  "all_projects";
+
 export const isNotificationCondition = (
   value: unknown
 ): value is NotificationCondition => {
@@ -85,11 +96,24 @@ export const isNotificationCondition = (
   );
 };
 
+export const isProjectNewConversationNotificationConditionOptions = (
+  value: unknown
+): value is ProjectNewConversationNotificationConditionOptions => {
+  return (
+    typeof value === "string" &&
+    PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_OPTIONS.includes(
+      value as ProjectNewConversationNotificationConditionOptions
+    )
+  );
+};
+
 /**
  * User metadata keys for conversation notification preferences.
  */
 export const CONVERSATION_NOTIFICATION_METADATA_KEYS = {
   notifyCondition: "conversation_notify_condition",
+  projectNewConversationNotifyCondition:
+    "project_new_conversation_notify_condition",
 } as const;
 
 export const CONVERSATION_UNREAD_TRIGGER_ID = "conversation-unread" as const;


### PR DESCRIPTION




## Description

This PR refactors the notification preferences UI as per the new design

- Updated copy
- Added user metadata key `project_new_conversation_notify_condition` to store preferences
- Implemented function to filter project members based on their notification preferences before sending notifications

<img width="908" height="327" alt="Capture d’écran 2026-02-20 à 11 24 03" src="https://github.com/user-attachments/assets/78ad4717-9a09-4ad1-83b2-04d38fb198ef" />


## Tests

Manually tested the UI changes. Added unit tests in `project-new-conversation.test.ts`

## Risks

Low risk. The changes add a new preference option and filter logic for project new conversation notifications. Existing notification behavior remains unchanged, with the default set to "all_projects" to maintain current functionality.

## Deploy Plan

Standard deployment.
