### PR TITLE
Use context for fetcher

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,6 +1,8 @@
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { ErrorBoundary } from "@dust-tt/front/components/error_boundary/ErrorBoundary";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
+import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
+import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
 import Custom404 from "@dust-tt/front/pages/404";
 import { Spinner, safeLazy } from "@dust-tt/sparkle";
 import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
@@ -531,13 +533,15 @@ const router = createBrowserRouter(
 export default function App() {
   return (
     <AppReadyProvider>
-      <RegionProvider>
-        <RootLayout>
-          <ErrorBoundary fallback={<GlobalErrorFallback />}>
-            <RouterProvider router={router} />
-          </ErrorBoundary>
-        </RootLayout>
-      </RegionProvider>
+      <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
+        <RegionProvider>
+          <RootLayout>
+            <ErrorBoundary fallback={<GlobalErrorFallback />}>
+              <RouterProvider router={router} />
+            </ErrorBoundary>
+          </RootLayout>
+        </RegionProvider>
+      </FetcherProvider>
     </AppReadyProvider>
   );
 }

--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -31,6 +31,8 @@ import { TriggerDetailsPage } from "@dust-tt/front/components/poke/pages/Trigger
 import { WebhookSourceDetailsPage } from "@dust-tt/front/components/poke/pages/WebhookSourceDetailsPage";
 import { WorkspacePage } from "@dust-tt/front/components/poke/pages/WorkspacePage";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
+import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
+import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
 import Custom404 from "@dust-tt/front/pages/404";
 import { AppReadyProvider } from "@spa/app/contexts/AppReadyContext";
 import { PokePage } from "@spa/poke/layouts/PokePage";
@@ -130,11 +132,13 @@ const router = createBrowserRouter(
 export default function PokeApp() {
   return (
     <AppReadyProvider>
-      <RegionProvider>
-        <RootLayout>
-          <RouterProvider router={router} />
-        </RootLayout>
-      </RegionProvider>
+      <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
+        <RegionProvider>
+          <RootLayout>
+            <RouterProvider router={router} />
+          </RootLayout>
+        </RegionProvider>
+      </FetcherProvider>
     </AppReadyProvider>
   );
 }

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -51,7 +51,7 @@ import { useEditors } from "@app/lib/swr/agent_editors";
 import { useAgentTriggers } from "@app/lib/swr/agent_triggers";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr/assistants";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
-import { emptyArray } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -115,6 +115,7 @@ export default function AgentBuilder({
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { mcpServerViews } = useMCPServerViewsContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  const { fetcherWithBody } = useFetcher();
 
   const router = useAppRouter();
   const sendNotification = useSendNotification(true);
@@ -395,6 +396,7 @@ export default function AgentBuilder({
         areSlackChannelsChanged: form.getFieldState(
           "agentSettings.slackChannels"
         ).isDirty,
+        fetcherWithBody,
       });
 
       if (!result.isOk()) {

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -5,6 +5,7 @@ import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversati
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
+import { useFetcher } from "@app/lib/swr/swr";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -17,6 +18,7 @@ import { useFormContext } from "react-hook-form";
 
 export function useDraftAgent() {
   const { owner, user } = useAgentBuilderContext();
+  const { fetcherWithBody } = useFetcher();
   const sendNotification = useSendNotification();
   const { getValues } = useFormContext<AgentBuilderFormData>();
 
@@ -56,6 +58,7 @@ export function useDraftAgent() {
         owner,
         agentConfigurationId: null,
         isDraft: true,
+        fetcherWithBody,
       });
 
       if (!aRes.isOk()) {

--- a/front/components/agent_builder/shared/tables.ts
+++ b/front/components/agent_builder/shared/tables.ts
@@ -1,4 +1,4 @@
-import { fetcherWithBody } from "@app/lib/swr/swr";
+import type { FetcherWithBodyFn } from "@app/lib/swr/fetcher";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -55,7 +55,8 @@ export function getTableIdForContentNode(
 async function expandFolderToTables(
   owner: LightWorkspaceType,
   dataSourceView: DataSourceViewType,
-  folderNode: LightContentNode
+  folderNode: LightContentNode,
+  fetcherWithBody: FetcherWithBodyFn
 ): Promise<LightContentNode[]> {
   try {
     const url = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes`;
@@ -92,11 +93,13 @@ async function expandFolderToTables(
 export async function expandFoldersToTables(
   owner: LightWorkspaceType,
   dataSourceView: DataSourceViewType,
-  folderNodes: LightContentNode[]
+  folderNodes: LightContentNode[],
+  fetcherWithBody: FetcherWithBodyFn
 ): Promise<LightContentNode[]> {
   const tablesArrays = await concurrentExecutor(
     folderNodes,
-    (folderNode) => expandFolderToTables(owner, dataSourceView, folderNode),
+    (folderNode) =>
+      expandFolderToTables(owner, dataSourceView, folderNode, fetcherWithBody),
     { concurrency: 5 }
   );
 

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -8,7 +8,7 @@ import type { AdditionalConfigurationInBuilderType } from "@app/components/share
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { clientFetch } from "@app/lib/egress/client";
 import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
-import { fetcherWithBody } from "@app/lib/swr/swr";
+import type { FetcherWithBodyFn } from "@app/lib/swr/fetcher";
 import {
   TRACKING_ACTIONS,
   TRACKING_AREAS,
@@ -65,7 +65,8 @@ function processDataSourceConfigurations(
 
 async function processTableSelection(
   tablesConfigurations: DataSourceViewSelectionConfigurations | null,
-  owner: WorkspaceType
+  owner: WorkspaceType,
+  fetcherWithBody: FetcherWithBodyFn
 ): Promise<TableDataSourceConfiguration[] | null> {
   if (!tablesConfigurations || Object.keys(tablesConfigurations).length === 0) {
     return null;
@@ -139,7 +140,8 @@ async function processTableSelection(
         const expandedTables = await expandFoldersToTables(
           owner,
           dataSourceView,
-          folderResources
+          folderResources,
+          fetcherWithBody
         );
         for (const tableNode of expandedTables) {
           allTables.push({
@@ -383,6 +385,7 @@ export async function submitAgentBuilderForm({
   agentConfigurationId = null,
   isDraft = false,
   areSlackChannelsChanged,
+  fetcherWithBody,
 }: {
   user: UserType;
   formData: AgentBuilderFormData;
@@ -390,6 +393,7 @@ export async function submitAgentBuilderForm({
   agentConfigurationId?: string | null;
   isDraft?: boolean;
   areSlackChannelsChanged?: boolean;
+  fetcherWithBody: FetcherWithBodyFn;
 }): Promise<
   Result<LightAgentConfigurationType | AgentConfigurationType, Error>
 > {
@@ -427,7 +431,8 @@ export async function submitAgentBuilderForm({
             action.configuration.tablesConfigurations !== null
               ? await processTableSelection(
                   action.configuration.tablesConfigurations,
-                  owner
+                  owner,
+                  fetcherWithBody
                 )
               : null,
           childAgentId: action.configuration.childAgentId,

--- a/front/components/poke/pages/ConnectorRedirectPage.tsx
+++ b/front/components/poke/pages/ConnectorRedirectPage.tsx
@@ -1,6 +1,6 @@
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
-import { fetcher } from "@app/lib/swr/swr";
+import { useFetcher } from "@app/lib/swr/swr";
 import { Spinner } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 import useSWR from "swr";
@@ -10,6 +10,7 @@ export function ConnectorRedirectPage() {
 
   const connectorId = useRequiredPathParam("connectorId");
   const router = useAppRouter();
+  const { fetcher } = useFetcher();
 
   const { data, error } = useSWR<{ redirectUrl: string }>(
     `/api/poke/connectors/${connectorId}/redirect`,

--- a/front/hooks/conversations/useAgentMessageSkills.ts
+++ b/front/hooks/conversations/useAgentMessageSkills.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentMessageSkillsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/skills";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -17,6 +17,7 @@ export function useAgentMessageSkills({
     disabled: boolean;
   };
 }) {
+  const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetAgentMessageSkillsResponseBody> = fetcher;
 
   const { data, error, mutate, isLoading } = useSWRWithDefaults(

--- a/front/hooks/conversations/useConversation.ts
+++ b/front/hooks/conversations/useConversation.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
 import type {
   ConversationError,
@@ -22,6 +22,7 @@ export function useConversation({
     typeof useSWRWithDefaults<string, GetConversationResponseBody>
   >["mutate"];
 } {
+  const { fetcher } = useFetcher();
   const conversationFetcher: Fetcher<GetConversationResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/hooks/conversations/useConversationFeedbacks.ts
+++ b/front/hooks/conversations/useConversationFeedbacks.ts
@@ -1,5 +1,5 @@
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { Fetcher } from "swr";
 
 export function useConversationFeedbacks({
@@ -11,6 +11,7 @@ export function useConversationFeedbacks({
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const conversationFeedbacksFetcher: Fetcher<{
     feedbacks: AgentMessageFeedbackType[];
   }> = fetcher;

--- a/front/hooks/conversations/useConversationFiles.ts
+++ b/front/hooks/conversations/useConversationFiles.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationFilesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";
@@ -13,6 +13,7 @@ export function useConversationFiles({
   options?: { disabled?: boolean };
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const conversationFilesFetcher: Fetcher<GetConversationFilesResponseBody> =
     fetcher;
 

--- a/front/hooks/conversations/useConversationMessages.ts
+++ b/front/hooks/conversations/useConversationMessages.ts
@@ -1,5 +1,5 @@
 import {
-  fetcher,
+  useFetcher,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -18,6 +18,7 @@ export function useConversationMessages({
   limit: number;
   startAtRank?: number;
 }) {
+  const { fetcher } = useFetcher();
   const messagesFetcher: Fetcher<FetchConversationMessagesResponse> = fetcher;
 
   const { data, error, mutate, size, setSize, isLoading, isValidating } =
@@ -74,6 +75,7 @@ export function useConversationMessage({
     disabled: boolean;
   };
 }) {
+  const { fetcher } = useFetcher();
   const messageFetcher: Fetcher<FetchConversationMessageResponse> = fetcher;
 
   const { data, error, mutate, isLoading, isValidating } = useSWRWithDefaults(

--- a/front/hooks/conversations/useConversationParticipants.ts
+++ b/front/hooks/conversations/useConversationParticipants.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
@@ -16,6 +16,7 @@ export function useConversationParticipants({
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const conversationParticipantsFetcher: Fetcher<FetchConversationParticipantsResponse> =
     fetcher;
 

--- a/front/hooks/conversations/useConversationSkills.ts
+++ b/front/hooks/conversations/useConversationSkills.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
   ConversationSkillActionRequest,
@@ -19,6 +19,7 @@ export function useConversationSkills({
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const conversationSkillsFetcher: Fetcher<FetchConversationSkillsResponse> =
     fetcher;
 

--- a/front/hooks/conversations/useConversationTools.ts
+++ b/front/hooks/conversations/useConversationTools.ts
@@ -1,5 +1,5 @@
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
 import type {
   ConversationToolActionRequest,
@@ -17,6 +17,7 @@ export function useConversationTools({
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const conversationToolsFetcher: Fetcher<FetchConversationToolsResponse> =
     fetcher;
 

--- a/front/hooks/conversations/useConversations.ts
+++ b/front/hooks/conversations/useConversations.ts
@@ -1,6 +1,6 @@
 import {
   emptyArray,
-  fetcher,
+  useFetcher,
   useSWRInfiniteWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
@@ -26,6 +26,7 @@ export function useConversations({
   workspaceId: string;
   limit?: number;
 }) {
+  const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<GetConversationsResponseBody> = fetcher;
 
   const { data, error, mutate, size, setSize, isValidating } =

--- a/front/hooks/conversations/useSearchPrivateConversations.ts
+++ b/front/hooks/conversations/useSearchPrivateConversations.ts
@@ -1,6 +1,6 @@
 import {
   emptyArray,
-  fetcher,
+  useFetcher,
   useSWRInfiniteWithDefaults,
 } from "@app/lib/swr/swr";
 import type { SearchConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/search";
@@ -24,6 +24,7 @@ export function useSearchPrivateConversations({
   query = "",
   limit = 20,
 }: UseSearchPrivateConversationsParams) {
+  const { fetcher } = useFetcher();
   const [debouncedQuery, setDebouncedQuery] = useState(query);
 
   useEffect(() => {

--- a/front/hooks/conversations/useSearchProjectConversations.ts
+++ b/front/hooks/conversations/useSearchProjectConversations.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { SemanticSearchConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/semantic_search";
 import { useEffect, useMemo, useState } from "react";
 
@@ -18,6 +18,7 @@ export function useSearchProjectConversations({
   query = "",
   limit = 50,
 }: UseSearchProjectConversationsParams) {
+  const { fetcher } = useFetcher();
   const [debouncedQuery, setDebouncedQuery] = useState(query);
 
   useEffect(() => {

--- a/front/hooks/conversations/useSpaceConversations.ts
+++ b/front/hooks/conversations/useSpaceConversations.ts
@@ -1,6 +1,6 @@
 import {
   emptyArray,
-  fetcher,
+  useFetcher,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -18,6 +18,7 @@ export function useSpaceConversationsSummary({
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const summaryFetcher: Fetcher<GetBySpacesSummaryResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -45,6 +46,7 @@ export function useSpaceConversations({
   spaceId: string | null;
   limit?: number;
 }) {
+  const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<GetSpaceConversationsResponseBody> =
     fetcher;
 
@@ -111,6 +113,7 @@ export function useSpaceUnreadConversationIds({
   spaceId: string | null;
   options?: { disabled: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<GetSpaceUnreadConversationsResponseBody> =
     fetcher;
 

--- a/front/hooks/usePokeProductionChecks.ts
+++ b/front/hooks/usePokeProductionChecks.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { GetProductionChecksResponseBody } from "@app/pages/api/poke/production-checks";
 import type { GetCheckHistoryResponseBody } from "@app/pages/api/poke/production-checks/[checkName]/history";
 import { useState } from "react";
@@ -11,6 +11,7 @@ const REFRESH_INTERVAL_MS = 30000;
 const REFETCH_DELAY_MS = 2000;
 
 export function usePokeProductionChecks() {
+  const { fetcher } = useFetcher();
   const productionChecksFetcher: Fetcher<GetProductionChecksResponseBody> =
     fetcher;
 
@@ -29,6 +30,7 @@ export function usePokeProductionChecks() {
 }
 
 export function usePokeCheckHistory(checkName: string, enabled: boolean) {
+  const { fetcher } = useFetcher();
   const checkHistoryFetcher: Fetcher<GetCheckHistoryResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWR(

--- a/front/hooks/useSearchConversations.ts
+++ b/front/hooks/useSearchConversations.ts
@@ -1,5 +1,5 @@
 import { useDebounce } from "@app/hooks/useDebounce";
-import { emptyArray, fetcher } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { SearchConversationsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/search_conversations";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { useMemo } from "react";
@@ -21,6 +21,7 @@ export function useSearchConversations({
   enabled = true,
   initialSearchText = "",
 }: UseSearchConversationsParams) {
+  const { fetcher } = useFetcher();
   const {
     debouncedValue: debouncedQuery,
     isDebouncing,

--- a/front/hooks/useSearchProjects.ts
+++ b/front/hooks/useSearchProjects.ts
@@ -1,6 +1,6 @@
 import {
   emptyArray,
-  fetcher,
+  useFetcher,
   useSWRInfiniteWithDefaults,
 } from "@app/lib/swr/swr";
 import type { SearchProjectsResponseBody } from "@app/pages/api/w/[wId]/spaces/search_projects";
@@ -22,6 +22,7 @@ export function useSearchProjects({
   query = "",
   limit = 20,
 }: UseSearchProjectsParams) {
+  const { fetcher } = useFetcher();
   const [debouncedQuery, setDebouncedQuery] = useState(query);
 
   useEffect(() => {

--- a/front/lib/swr/FetcherContext.tsx
+++ b/front/lib/swr/FetcherContext.tsx
@@ -1,0 +1,35 @@
+import type { FetcherFn, FetcherWithBodyFn } from "@app/lib/swr/fetcher";
+import { createContext, useContext } from "react";
+
+interface FetcherContextType {
+  fetcher: FetcherFn;
+  fetcherWithBody: FetcherWithBodyFn;
+}
+
+const FetcherContext = createContext<FetcherContextType | null>(null);
+
+export function useFetcher(): FetcherContextType {
+  const ctx = useContext(FetcherContext);
+  if (!ctx) {
+    throw new Error("useFetcher must be used within a FetcherProvider");
+  }
+  return ctx;
+}
+
+interface FetcherProviderProps {
+  fetcher: FetcherFn;
+  fetcherWithBody: FetcherWithBodyFn;
+  children: React.ReactNode;
+}
+
+export function FetcherProvider({
+  fetcher,
+  fetcherWithBody,
+  children,
+}: FetcherProviderProps) {
+  return (
+    <FetcherContext.Provider value={{ fetcher, fetcherWithBody }}>
+      {children}
+    </FetcherContext.Provider>
+  );
+}

--- a/front/lib/swr/academy.ts
+++ b/front/lib/swr/academy.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { CourseProgressData } from "@app/pages/api/academy/progress/courses";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Fetcher } from "swr";
@@ -66,7 +66,10 @@ interface PostProgressResponse {
   isNewCompletion: boolean;
 }
 
-function makeBrowserIdFetcher<T>(browserId: string | null): Fetcher<T, string> {
+function makeBrowserIdFetcher<T>(
+  browserId: string | null,
+  fetcher: Fetcher<T, string>
+): Fetcher<T, string> {
   if (!browserId) {
     return fetcher;
   }
@@ -93,8 +96,9 @@ export function useAcademyContentProgress({
   disabled?: boolean;
   browserId?: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const progressFetcher: Fetcher<GetProgressResponse, string> =
-    makeBrowserIdFetcher(browserId ?? null);
+    makeBrowserIdFetcher(browserId ?? null, fetcher);
 
   // `_bid` is a cache-busting parameter so SWR refetches when the browserId
   // becomes available (it starts as null during SSR). The server ignores it;
@@ -122,8 +126,9 @@ export function useAcademyCourseProgress({
   disabled?: boolean;
   browserId?: string | null;
 } = {}) {
+  const { fetcher } = useFetcher();
   const courseProgressFetcher: Fetcher<GetCourseProgressResponse, string> =
-    makeBrowserIdFetcher(browserId ?? null);
+    makeBrowserIdFetcher(browserId ?? null, fetcher);
 
   // `_bid` is a cache-busting parameter so SWR refetches when the browserId
   // becomes available (it starts as null during SSR). The server ignores it;

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -1,5 +1,5 @@
 import type { AgentBuilderMCPConfigurationWithId } from "@app/components/agent_builder/types";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetActionsResponseBody } from "@app/pages/api/w/[wId]/builder/assistants/[aId]/actions";
 import uniqueId from "lodash/uniqueId";
 import { useMemo } from "react";
@@ -9,6 +9,7 @@ export function useAgentConfigurationActions(
   ownerId: string,
   agentConfigurationId: string | null
 ) {
+  const { fetcher } = useFetcher();
   const disabled = agentConfigurationId === null;
   const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/agent_editors.ts
+++ b/front/lib/swr/agent_editors.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetAgentEditorsResponseBody,
   PatchAgentEditorsRequestBody,
@@ -19,6 +19,7 @@ export function useEditors({
   agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const editorsFetcher: Fetcher<GetAgentEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/agent_memories.ts
+++ b/front/lib/swr/agent_memories.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentMemoriesResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories";
 import type { PatchAgentMemoryRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -17,6 +17,7 @@ export function useAgentMemoriesForUser({
   agentConfiguration: AgentConfigurationType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const memoriesFetcher: Fetcher<GetAgentMemoriesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/agent_suggestions.ts
+++ b/front/lib/swr/agent_suggestions.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
@@ -30,6 +30,7 @@ export function useAgentSuggestions({
   limit?: number;
   workspaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const suggestionsFetcher: Fetcher<GetSuggestionsResponseBody> = fetcher;
 
   const urlParams = new URLSearchParams();

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -3,8 +3,8 @@ import { clientFetch } from "@app/lib/egress/client";
 import { parseMatcherExpression } from "@app/lib/matcher";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetTriggersResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers";
@@ -35,6 +35,7 @@ export function useAgentTriggers({
   agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const triggersFetcher: Fetcher<GetTriggersResponseBody> = fetcher;
 
   const { data, error, mutate, isValidating } = useSWRWithDefaults(
@@ -61,6 +62,7 @@ export function useUserTriggers({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const userTriggersFetcher: Fetcher<GetUserTriggersResponseBody> = fetcher;
 
   const { data, error, mutate, isValidating } = useSWRWithDefaults(
@@ -128,6 +130,7 @@ export function useTextAsCronRule({
 }: {
   workspace: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const textAsCronRule = useCallback(
     async (naturalDescription: string, signal?: AbortSignal) => {
       let r: PostTextAsCronRuleResponseBody;
@@ -149,7 +152,7 @@ export function useTextAsCronRule({
 
       return new Ok({ cron: r.cronRule, timezone: r.timezone });
     },
-    [workspace]
+    [workspace, fetcher]
   );
 
   return textAsCronRule;
@@ -160,6 +163,7 @@ export function useWebhookFilterGenerator({
 }: {
   workspace: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const generateFilter = useCallback(
     async ({
       naturalDescription,
@@ -194,7 +198,7 @@ export function useWebhookFilterGenerator({
 
       return { filter: r.filter };
     },
-    [workspace]
+    [workspace, fetcher]
   );
 
   return generateFilter;
@@ -211,6 +215,7 @@ export function useTriggerSubscribers({
   triggerId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const subscribersFetcher: Fetcher<GetSubscribersResponseBody> = fetcher;
 
   const { data, error, mutate, isValidating } = useSWRWithDefaults(
@@ -385,6 +390,7 @@ export function useTriggerEstimation({
   filter?: string | null;
   selectedEvent?: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const key = webhookSourceId
     ? `/api/w/${workspaceId}/webhook_sources/${webhookSourceId}/trigger-estimation`
     : null;

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,5 +1,5 @@
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
@@ -26,6 +26,7 @@ export function useApps({
   owner: LightWorkspaceType;
   space: SpaceType;
 }) {
+  const { fetcher } = useFetcher();
   const appsFetcher: Fetcher<GetAppsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -55,6 +56,7 @@ export function useApp({
   appId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const appFetcher: Fetcher<GetOrPostAppResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -78,6 +80,7 @@ export function useSavedRunStatus(
   app: AppType | null,
   refresh: (data: GetRunStatusResponseBody | undefined) => number
 ) {
+  const { fetcher } = useFetcher();
   const runStatusFetcher: Fetcher<GetRunStatusResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
     app
@@ -104,6 +107,7 @@ export function useRunBlock(
   name: string,
   refresh: (data: GetRunBlockResponseBody | undefined) => number
 ) {
+  const { fetcher } = useFetcher();
   const runBlockFetcher: Fetcher<GetRunBlockResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
     `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs/${runId}/blocks/${type}/${name}`,
@@ -121,6 +125,7 @@ export function useRunBlock(
 }
 
 export function useDustAppSecrets(owner: LightWorkspaceType | null) {
+  const { fetcher } = useFetcher();
   const keysFetcher: Fetcher<GetDustAppSecretsResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
     owner ? `/api/w/${owner.sId}/dust_app_secrets` : null,
@@ -142,6 +147,7 @@ export function useRuns(
   runType: RunRunType,
   wIdTarget: string | null
 ) {
+  const { fetcher } = useFetcher();
   const runsFetcher: Fetcher<GetRunsResponseBody> = fetcher;
   const disabled = !app;
   let url: string | null = null;
@@ -168,6 +174,7 @@ export function useProviders({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const providersFetcher: Fetcher<GetProvidersResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
@@ -186,6 +193,7 @@ export function useProviders({
 }
 
 export function useKeys(owner: LightWorkspaceType) {
+  const { fetcher } = useFetcher();
   const keysFetcher: Fetcher<GetKeysResponseBody> = fetcher;
   const { data, error, isValidating } = useSWRWithDefaults(
     `/api/w/${owner.sId}/keys`,
@@ -255,6 +263,7 @@ export function useRunWithSpec({
   runId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const runFetcher: Fetcher<GetRunResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -11,8 +11,8 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -58,6 +58,7 @@ export function useAgentMcpConfigurations({
   agentConfigurationId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const mcpConfigurationsFetcher: Fetcher<GetAgentMcpConfigurationsResponseBody> =
     fetcher;
 
@@ -78,6 +79,7 @@ export function useAgentMcpConfigurations({
 }
 
 export function useAssistantTemplates() {
+  const { fetcher } = useFetcher();
   const assistantTemplatesFetcher: Fetcher<FetchAssistantTemplatesResponse> =
     fetcher;
 
@@ -99,6 +101,7 @@ export function useAssistantTemplate({
 }: {
   templateId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const assistantTemplateFetcher: Fetcher<FetchAgentTemplateResponse> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -135,6 +138,7 @@ export function useAgentConfigurations({
   disabled?: boolean;
   revalidate?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
 
@@ -204,6 +208,7 @@ export function useSuggestedAgentConfigurations({
   messageId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const agentConfigurationsFetcher: Fetcher<GetAgentConfigurationsResponseBody> =
     fetcher;
 
@@ -273,6 +278,7 @@ export function useAgentConfiguration({
   agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const agentConfigurationFetcher: Fetcher<{
     agentConfiguration: AgentConfigurationType;
   }> = fetcher;
@@ -311,6 +317,7 @@ export function useAgentConfigurationFeedbacksByDescVersion({
   version,
   days,
 }: AgentConfigurationFeedbacksByDescVersionProps) {
+  const { fetcher } = useFetcher();
   const agentConfigurationFeedbacksFetcher: Fetcher<{
     feedbacks: (
       | AgentMessageFeedbackType
@@ -393,6 +400,7 @@ export function useAgentConfigurationHistory({
   limit?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const agentConfigurationHistoryFetcher: Fetcher<{
     history: AgentConfigurationType[];
   }> = fetcher;
@@ -421,6 +429,7 @@ export function useAgentConfigurationLastAuthor({
   workspaceId: string;
   agentConfigurationId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const userFetcher: Fetcher<{
     user: UserType;
   }> = fetcher;
@@ -446,6 +455,7 @@ export function useAgentUsage({
   agentConfigurationId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const agentUsageFetcher: Fetcher<GetAgentUsageResponseBody> = fetcher;
   const fetchUrl = agentConfigurationId
     ? `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/usage`
@@ -477,6 +487,7 @@ export function useAgentAnalytics({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const agentAnalyticsFetcher: Fetcher<GetAgentOverviewResponseBody> = fetcher;
   const fetchUrl = agentConfigurationId
     ? (() => {
@@ -510,6 +521,7 @@ export function useAgentObservabilitySummary({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const summaryFetcher: Fetcher<GetAgentSummaryResponseBody> = fetcher;
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/summary?days=${days}`;
 
@@ -534,6 +546,7 @@ export function useSlackChannelsLinkedWithAgent({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const slackChannelsLinkedWithAgentFetcher: Fetcher<GetSlackChannelsLinkedWithAgentResponseBody> =
     fetcher;
 
@@ -877,6 +890,7 @@ export function useAgentUsageMetrics({
   interval?: "day" | "week";
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetUsageMetricsResponse> = fetcher;
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/usage-metrics?days=${days}&interval=${interval}`;
 
@@ -907,6 +921,7 @@ export function useAgentContextOrigin(params: {
     version,
     disabled,
   } = params;
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetContextOriginResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/source?days=${days}${versionParam}`;
@@ -937,6 +952,7 @@ export function useAgentLatency({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetLatencyResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/latency?days=${days}${versionParam}`;
@@ -967,6 +983,7 @@ export function useAgentErrorRate({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetErrorRateResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/error_rate?days=${days}${versionParam}`;
@@ -995,6 +1012,7 @@ export function useAgentFeedbackDistribution({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetFeedbackDistributionResponse> = fetcher;
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/feedback-distribution?days=${days}`;
 
@@ -1022,6 +1040,7 @@ export function useAgentVersionMarkers({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetVersionMarkersResponse> = fetcher;
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/version-markers?days=${days}`;
 
@@ -1051,6 +1070,7 @@ export function useAgentToolExecution({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetToolExecutionResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/tool-execution?days=${days}${versionParam}`;
@@ -1081,6 +1101,7 @@ export function useAgentSkillExecution({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetSkillExecutionResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/skill-execution?days=${days}${versionParam}`;
@@ -1123,6 +1144,7 @@ export function useAgentToolLatency({
   serverName?: string;
   disabled?: boolean;
 }): AgentToolLatencyResult {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetToolLatencyResponse> = fetcher;
   const params = new URLSearchParams({ days: days.toString(), view });
   if (version) {
@@ -1159,6 +1181,7 @@ export function useAgentToolStepIndex({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetToolStepIndexResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
   const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/tool-step-index?days=${days}${versionParam}`;
@@ -1189,6 +1212,7 @@ export function useAgentDatasourceRetrieval({
   version?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetDatasourceRetrievalResponse> = fetcher;
   const params = new URLSearchParams({ days: days.toString() });
   if (version) {
@@ -1232,6 +1256,7 @@ export function useAgentDatasourceRetrievalDocuments({
   limit?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetDatasourceRetrievalDocumentsResponse> = fetcher;
   const hasConfigIds = mcpServerConfigIds && mcpServerConfigIds.length > 0;
   // Allow query if we have either config IDs or server name.
@@ -1280,6 +1305,7 @@ export function useMemberDetails({
   workspaceId: string;
   userId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const userConfigurationFetcher: Fetcher<GetMemberResponseBody> = fetcher;
 
   const { data, error, mutate, isValidating } = useSWRWithDefaults(

--- a/front/lib/swr/bigquery.ts
+++ b/front/lib/swr/bigquery.ts
@@ -1,4 +1,4 @@
-import { fetcherWithBody, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PostCheckBigQueryLocationsResponseBody } from "@app/pages/api/w/[wId]/credentials/check_bigquery_locations";
 import type { CheckBigQueryCredentials } from "@app/types/oauth/lib";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -11,6 +11,7 @@ export function useBigQueryLocations({
   owner: LightWorkspaceType;
   credentials?: CheckBigQueryCredentials | null;
 }) {
+  const { fetcherWithBody } = useFetcher();
   const url = `/api/w/${owner.sId}/credentials/check_bigquery_locations`;
   const fetchKey = useMemo(() => {
     return JSON.stringify({

--- a/front/lib/swr/blocked_actions.ts
+++ b/front/lib/swr/blocked_actions.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetBlockedActionsResponseType } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked";
 import type { Fetcher } from "swr";
 
@@ -9,6 +9,7 @@ export function useBlockedActions({
   conversationId: string | null;
   workspaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const blockedActionsFetcher: Fetcher<GetBlockedActionsResponseType> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -1,8 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -43,6 +43,7 @@ export function useConnectorPermissions<T extends ConnectorPermission | null>({
   disabled?: boolean;
   viewType?: ContentNodesViewType;
 }): UseConnectorPermissionsReturn<T> {
+  const { fetcher } = useFetcher();
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
@@ -93,6 +94,7 @@ export function useConnectorConfig({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetOrPostManagedDataSourceConfigResponseBody> =
     fetcher;
 
@@ -120,6 +122,7 @@ export function useOAuthMetadata({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const metadataFetcher: Fetcher<{ metadata: Record<string, unknown> }> =
     fetcher;
 

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -1,5 +1,5 @@
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetCreditPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/credits/purchase";
 import type {
   GetCreditsResponseBody,
@@ -56,6 +56,7 @@ export function useCredits({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const creditsFetcher: Fetcher<GetCreditsResponseBody> = fetcher;
 
   const { data, error, mutate, isValidating } = useSWRWithDefaults(
@@ -167,6 +168,7 @@ export function useCreditPurchaseInfo({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const creditPurchaseInfoFetcher: Fetcher<GetCreditPurchaseInfoResponseBody> =
     fetcher;
 

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetDataSourceViewDocumentResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]";
@@ -28,6 +28,7 @@ export function useDataSourceViewDocument({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const dataSourceViewDocumentFetcher: Fetcher<GetDataSourceViewDocumentResponseBody> =
     fetcher;
   const url =

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -3,8 +3,8 @@ import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables";
@@ -27,6 +27,7 @@ export function useDataSourceViewTable({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const dataSourceViewTableFetcher: Fetcher<GetDataSourceViewTableResponseBody> =
     fetcher;
   const url =
@@ -63,6 +64,7 @@ export function useDataSourceViewTables({
   searchQuery?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const isDisabled = !dataSourceView || disabled;
   const params = new URLSearchParams();
 

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -4,8 +4,7 @@ import type {
 } from "@app/lib/api/pagination";
 import {
   emptyArray,
-  fetcher,
-  fetcherWithBody,
+  useFetcher,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -37,6 +36,7 @@ export function useDataSourceViews(
   owner: LightWorkspaceType,
   options = { disabled: false }
 ) {
+  const { fetcher } = useFetcher();
   const { disabled } = options;
   const dataSourceViewsFetcher: Fetcher<GetDataSourceViewsResponseBody> =
     fetcher;
@@ -75,6 +75,7 @@ export function useMultipleDataSourceViewsContentNodes({
   // We need to return an invalidation function to avoid stale data.
   invalidate: () => void;
 } {
+  const { fetcherWithBody } = useFetcher();
   const [dataSourceViewsAndNodes, setDataSourceViewsAndNodes] = useState<
     DataSourceViewsAndNodes[]
   >(emptyArray());
@@ -245,6 +246,7 @@ export function useDataSourceViewContentNodes({
   totalNodesCountIsAccurate: boolean;
   nextPageCursor: string | null;
 } {
+  const { fetcherWithBody } = useFetcher();
   const params = new URLSearchParams();
   if (pagination?.cursor) {
     params.append("cursor", pagination.cursor);
@@ -310,6 +312,7 @@ export function useInfiniteDataSourceViewContentNodes({
   sorting,
   swrOptions,
 }: FetchDataSourceViewContentNodesOptions) {
+  const { fetcherWithBody } = useFetcher();
   const { data, error, isLoading, size, setSize, mutate, isValidating } =
     useSWRInfiniteWithDefaults<
       [string, GetContentNodesOrChildrenRequestBodyType] | null,
@@ -384,6 +387,7 @@ export function useDataSourceViewConnectorConfiguration({
   dataSourceView: DataSourceViewType | null;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const dataSourceViewDocumentFetcher: Fetcher<GetDataSourceConfigurationResponseBody> =
     fetcher;
   const disabled = !dataSourceView;
@@ -414,6 +418,7 @@ export function useDataSourceViewSearchTags({
   owner: LightWorkspaceType;
   query: string;
 }) {
+  const { fetcherWithBody } = useFetcher();
   const url =
     query.length >= MIN_SEARCH_QUERY_SIZE
       ? `/api/w/${owner.sId}/data_source_views/tags/search`

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDataSourceUsageResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/usage";
 import type { GetBotDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources/bot-data-sources";
 import type { GetPostNotionSyncResponseBody } from "@app/types/api/internal/spaces";
@@ -13,6 +13,7 @@ export function useDataSourceUsage({
   owner: LightWorkspaceType;
   dataSource: DataSourceType;
 }) {
+  const { fetcher } = useFetcher();
   const usageFetcher: Fetcher<GetDataSourceUsageResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/data_sources/${dataSource.sId}/usage`,
@@ -39,6 +40,7 @@ export function useNotionLastSyncedUrls({
   isError: boolean;
   mutate: () => Promise<void>;
 } {
+  const { fetcher } = useFetcher();
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
     `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion_url_sync`,
     fetcher
@@ -59,6 +61,7 @@ export function useBotDataSources({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const botDataSourcesFetcher: Fetcher<GetBotDataSourcesResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets";
 import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]";
 import type { AppType } from "@app/types/app";
@@ -14,6 +14,7 @@ export function useDatasets({
   app: AppType | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const datasetsFetcher: Fetcher<GetDatasetsResponseBody> = fetcher;
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const isDisabled = disabled || !app;
@@ -41,6 +42,7 @@ export function useDataset(
   dataset: string | undefined,
   showData = false
 ) {
+  const { fetcher } = useFetcher();
   const datasetFetcher: Fetcher<GetDatasetResponseBody> = fetcher;
   const disabled = !dataset || !app;
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/fetcher.ts
+++ b/front/lib/swr/fetcher.ts
@@ -1,0 +1,102 @@
+import config from "@app/lib/api/config";
+import { BUILD_DATE, COMMIT_HASH } from "@app/lib/commit-hash";
+import { clientFetch } from "@app/lib/egress/client";
+import { isAPIErrorResponse } from "@app/types/error";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import {
+  FORCE_RELOAD_INTERVAL_MS,
+  FORCE_RELOAD_SESSION_KEY,
+} from "@dust-tt/sparkle";
+
+const addClientVersionHeaders = (headers: HeadersInit = {}): HeadersInit => ({
+  ...headers,
+  "X-Commit-Hash": COMMIT_HASH,
+  "X-Build-Date": BUILD_DATE,
+});
+
+const resHandler = async (res: Response) => {
+  if (res.headers.get("X-Reload-Required") === "true") {
+    const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
+    const nowMs = Date.now();
+    const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
+    const shouldReload =
+      !Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS;
+    if (shouldReload) {
+      sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
+      window.location.reload();
+      // Return a never-resolving promise to prevent SWR from processing.
+      return new Promise(() => {});
+    }
+  }
+
+  if (res.status >= 300) {
+    const errorText = await res.text();
+    console.error(
+      "Error returned by the front API: ",
+      res.status,
+      res.headers,
+      errorText
+    );
+
+    const parseRes = safeParseJSON(errorText);
+    if (parseRes.isOk()) {
+      if (isAPIErrorResponse(parseRes.value)) {
+        if (parseRes.value.error.type === "not_authenticated") {
+          const returnTo =
+            window.location.pathname !== "/"
+              ? `?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`
+              : "";
+          window.location.href = `${config.getApiBaseUrl()}/api/workos/login${returnTo}`;
+          // Return a never-resolving promise to prevent SWR from processing.
+          return new Promise(() => {});
+        }
+        throw parseRes.value;
+      }
+    }
+
+    throw new Error(errorText);
+  }
+  return res.json();
+};
+
+export type FetcherFn = (url: string, init?: RequestInit) => Promise<any>;
+
+export type FetcherWithBodyFn = (
+  args: [url: string, body: object, method: string],
+  init?: RequestInit
+) => Promise<any>;
+
+export const fetcher: FetcherFn = async (url, init) => {
+  const res = await clientFetch(url, {
+    ...init,
+    headers: addClientVersionHeaders(init?.headers),
+  });
+  return resHandler(res);
+};
+
+export const fetcherWithBody: FetcherWithBodyFn = async (
+  [url, body, method],
+  init
+) => {
+  const res = await clientFetch(url, {
+    ...init,
+    method,
+    headers: addClientVersionHeaders({
+      ...init?.headers,
+      "Content-Type": "application/json",
+    }),
+    body: JSON.stringify(body),
+  });
+
+  return resHandler(res);
+};
+
+type UrlsAndOptions = { url: string; options: RequestInit };
+
+export const fetcherMultiple = <T>(urlsAndOptions: UrlsAndOptions[]) => {
+  const f = async (url: string, options: RequestInit) => fetcher(url, options);
+
+  return Promise.all<T>(
+    urlsAndOptions.map(({ url, options }) => f(url, options))
+  );
+};

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -4,8 +4,8 @@ import config from "@app/lib/api/config";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
@@ -144,6 +144,7 @@ export function useFileMetadata({
   owner: LightWorkspaceType;
   cacheKey?: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const fileMetadataFetcher: Fetcher<FileTypeWithMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
@@ -212,6 +213,7 @@ export function useFileSignedUrl({
   owner: LightWorkspaceType;
   config?: SWRConfiguration & { disabled?: boolean };
 }) {
+  const { fetcher } = useFetcher();
   const signedUrlFetcher: Fetcher<{ signedUrl: string }> = fetcher;
   const isDisabled = config?.disabled ?? !fileId;
 
@@ -236,6 +238,7 @@ export function useShareInteractiveContentFile({
   fileId: string;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const sendNotification = useSendNotification();
 
   const fileShareFetcher: Fetcher<ShareFileResponseBody> = fetcher;

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -1,11 +1,12 @@
 // This hook uses a public API endpoint, so it's fine to use the client types.
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";
 import type { Fetcher } from "swr";
 
 export function usePublicFrame({ shareToken }: { shareToken: string | null }) {
+  const { fetcher } = useFetcher();
   const frameMetadataFetcher: Fetcher<PublicFrameResponseBodyType> = fetcher;
 
   const swrKey = shareToken ? `/api/v1/public/frames/${shareToken}` : null;

--- a/front/lib/swr/geo.ts
+++ b/front/lib/swr/geo.ts
@@ -2,7 +2,7 @@ import type { GeoLocationResponse } from "@app/pages/api/geo/location";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "./swr";
+import { useFetcher, useSWRWithDefaults } from "./swr";
 
 const GEO_CACHE_KEY = "dust-geo-location";
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
@@ -58,6 +58,7 @@ function setCachedGeoData(data: GeoLocationResponse): void {
 }
 
 export function useGeolocation({ disabled }: { disabled?: boolean } = {}) {
+  const { fetcher } = useFetcher();
   const cachedData = getCachedGeoData();
   const shouldFetch = !disabled && !cachedData;
 

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetGroupsResponseBody } from "@app/pages/api/w/[wId]/groups";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -16,6 +16,7 @@ export function useGroups({
   spaceId?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const url = useMemo(() => {
     const params = new URLSearchParams();
     if (kinds && kinds.length > 0) {

--- a/front/lib/swr/kill.ts
+++ b/front/lib/swr/kill.ts
@@ -1,10 +1,11 @@
 // LABS - CAN BE REMOVED ANYTIME
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetKillSwitchesResponseBody } from "@app/pages/api/kill";
 import type { Fetcher } from "swr";
 
 export function useKillSwitches() {
+  const { fetcher } = useFetcher();
   const killSwitchesFetcher: Fetcher<GetKillSwitchesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -3,7 +3,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import type { PatchTranscriptsConfiguration } from "@app/pages/api/w/[wId]/labs/transcripts/[tId]";
 import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
@@ -19,6 +19,7 @@ export function useLabsTranscriptsConfiguration({
 }: {
   workspaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const transcriptsConfigurationFetcher: Fetcher<GetLabsTranscriptsConfigurationResponseBody> =
     fetcher;
 
@@ -42,6 +43,7 @@ export function useLabsTranscriptsDefaultConfiguration({
   owner: LightWorkspaceType;
   provider: string;
 }) {
+  const { fetcher } = useFetcher();
   const defaultConfigurationFetcher: Fetcher<GetLabsTranscriptsConfigurationResponseBody> =
     fetcher;
 
@@ -65,6 +67,7 @@ export function useLabsTranscriptsIsConnectorConnected({
   owner: LightWorkspaceType;
   provider: string;
 }) {
+  const { fetcher } = useFetcher();
   const isConnectorConnectedFetcher: Fetcher<{
     isConnected: boolean;
     dataSource: DataSourceResource | null;

--- a/front/lib/swr/mcp_actions.ts
+++ b/front/lib/swr/mcp_actions.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
@@ -30,6 +30,7 @@ export function useMCPActions({
   agentId,
   pageSize = 25,
 }: UseMCPActionsProps): UseMCPActionsReturn {
+  const { fetcher } = useFetcher();
   const [currentPage, setCurrentPage] = useState(0);
   const [cursors, setCursors] = useState<(string | null)[]>([null]);
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -18,7 +18,7 @@ import type {
   MCPServerConnectionType,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import { useSpaceInfo, useSpacesAsAdmin } from "@app/lib/swr/spaces";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   CreateMCPServerResponseBody,
   GetMCPServersResponseBody,
@@ -105,6 +105,7 @@ export function useMCPServer({
   owner: LightWorkspaceType;
   serverId: string;
 }) {
+  const { fetcher } = useFetcher();
   const serverFetcher: Fetcher<GetMCPServerResponseBody> = fetcher;
 
   const url = serverId ? `/api/w/${owner.sId}/mcp/${serverId}` : null;
@@ -141,6 +142,7 @@ export function useAvailableMCPServers({
   space?: SpaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
 
   const url = space
@@ -176,6 +178,7 @@ export function useMCPServers({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
 
   const url = `/api/w/${owner.sId}/mcp`;
@@ -620,6 +623,7 @@ export function useMCPServerConnections({
   connectionType: MCPServerConnectionConnectionType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const connectionsFetcher: Fetcher<GetConnectionsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -950,6 +954,7 @@ export function useMCPServerViews({
   availability?: MCPServerAvailability | "all";
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServerViewsResponseBody> = fetcher;
   const url = getMCPServerViewsKey(owner, space, availability);
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
@@ -1043,6 +1048,7 @@ export function useMCPServersUsage({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServersUsageResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/mcp/usage`,
@@ -1068,6 +1074,7 @@ export function useMCPServerViewsNotActivated({
   space: SpaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServerViewsNotActivatedResponseBody> =
     fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
@@ -1213,6 +1220,7 @@ function useMCPServerViewsFromSpacesBase(
   availabilities: MCPServerAvailability[],
   swrOptions?: SWRConfiguration
 ) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServerViewsListResponseBody> = fetcher;
 
   const spaceIds = spaces.map((s) => s.sId).join(",");

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
@@ -39,6 +39,7 @@ export function useMembers({
   pagination?: PaginationParams;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const defaultUrl = useMemo(() => {
     const params = new URLSearchParams();
     appendPaginationParams(params, pagination);
@@ -73,6 +74,7 @@ export function useWorkspaceInvitations(
   owner: LightWorkspaceType,
   { includeExpired = false }: { includeExpired?: boolean } = {}
 ) {
+  const { fetcher } = useFetcher();
   const workspaceInvitationsFetcher: Fetcher<GetWorkspaceInvitationsResponseBody> =
     fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
@@ -105,6 +107,7 @@ export function useSearchMembers({
   buildersOnly?: boolean;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const searchMembersFetcher: Fetcher<SearchMembersResponseBody> = fetcher;
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
@@ -161,6 +164,7 @@ export function useMembersLookup({
   memberIds: number[];
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const membersLookupFetcher: Fetcher<MembersLookupResponseBody> = fetcher;
 
   const query =

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -1,8 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
@@ -39,6 +39,7 @@ export function useMentionSuggestions({
   disabled?: boolean;
   includeCurrentUser?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const suggestionsFetcher: Fetcher<MentionSuggestionsResponseBody> = fetcher;
 
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,9 +1,10 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAvailableModelsResponseType } from "@app/pages/api/w/[wId]/models";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 
 export function useModels({ owner }: { owner: LightWorkspaceType }) {
+  const { fetcher } = useFetcher();
   const modelsFetcher: Fetcher<GetAvailableModelsResponseType> = fetcher;
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,5 +1,5 @@
 import { clientFetch } from "@app/lib/egress/client";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSlackClientIdResponseBody } from "@app/pages/api/w/[wId]/credentials/slack_is_legacy";
 import type { GetOAuthSetupResponseBody } from "@app/pages/api/w/[wId]/oauth/[provider]/setup";
 import type { APIError, WithAPIErrorResponse } from "@app/types/error";
@@ -61,6 +61,7 @@ export function useSlackIsLegacy({
   credentialId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const slackIsLegacyFetcher: Fetcher<GetSlackClientIdResponseBody> = fetcher;
 
   const url = `/api/w/${workspaceId}/credentials/slack_is_legacy${
@@ -98,6 +99,7 @@ export function useOAuthSetup({
   openerOrigin?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const oauthSetupFetcher: Fetcher<GetOAuthSetupResponseBody> = fetcher;
 
   let url = `/api/w/${workspaceId}/oauth/${provider}/setup?useCase=${useCase}`;

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -1,5 +1,5 @@
 import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/pages/api/poke/auth-context";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
@@ -16,6 +16,7 @@ import { useEffect } from "react";
 import type { Fetcher } from "swr";
 
 export function usePokeRegion() {
+  const { fetcher } = useFetcher();
   const regionFetcher: Fetcher<GetRegionResponseType> = fetcher;
 
   const { data, error } = useSWRWithDefaults("/api/poke/region", regionFetcher);
@@ -40,6 +41,7 @@ export function usePokeConnectorPermissions({
   filterPermission: ConnectorPermission | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const permissionsFetcher: Fetcher<GetDataSourcePermissionsResponseBody> =
     fetcher;
 
@@ -73,6 +75,7 @@ export function usePokeWorkspaces({
   disabled?: boolean;
   limit?: number;
 } = {}) {
+  const { fetcher } = useFetcher();
   const workspacesFetcher: Fetcher<GetPokeWorkspacesResponseBody> = fetcher;
 
   const queryParams = [
@@ -102,6 +105,7 @@ export function usePokeWorkspaces({
 }
 
 export function usePokePlans() {
+  const { fetcher } = useFetcher();
   const plansFetcher: Fetcher<GetPokePlansResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults("/api/poke/plans", plansFetcher);
@@ -120,6 +124,7 @@ export function usePokeFeatureFlags({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const featureFlagsFetcher: Fetcher<GetPokeFeaturesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -143,6 +148,7 @@ export function usePokeWorkOSDSyncStatus({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/dsync`,
     fetcher,
@@ -178,6 +184,7 @@ export function usePokeAuthContext(options: {
 export function usePokeAuthContext(
   options: { workspaceId?: string; disabled?: boolean } = {}
 ) {
+  const { fetcher } = useFetcher();
   const { workspaceId, disabled } = options;
   const regionContext = useRegionContextSafe();
 

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -2,8 +2,8 @@ import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
@@ -29,6 +29,7 @@ export function useProjectFiles({
   projectId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const projectFilesFetcher: Fetcher<GetProjectFilesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -135,6 +136,7 @@ export function useCheckProjectName({
   owner: LightWorkspaceType;
   initialName?: string;
 }) {
+  const { fetcher } = useFetcher();
   const {
     debouncedValue: debouncedName,
     isDebouncing,

--- a/front/lib/swr/share.ts
+++ b/front/lib/swr/share.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetShareFrameMetadataResponseBody } from "@app/pages/api/share/frame/[token]";
 import type { Fetcher } from "swr";
 
@@ -7,6 +7,7 @@ export function useShareFrameMetadata({
 }: {
   shareToken: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const shareMetadataFetcher: Fetcher<GetShareFrameMetadataResponseBody> =
     fetcher;
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
@@ -66,6 +66,7 @@ export function useSkill({
   isSkillError: boolean;
   mutateSkill: () => void;
 } {
+  const { fetcher } = useFetcher();
   const skillFetcher: Fetcher<
     GetSkillResponseBody | GetSkillWithRelationsResponseBody
   > = fetcher;
@@ -99,6 +100,7 @@ export function useSkills({
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetSkillsResponseBody> = fetcher;
 
   const queryParams = new URLSearchParams();
@@ -133,6 +135,7 @@ export function useSkillsWithRelations({
   disabled?: boolean;
   status: SkillStatus;
 }) {
+  const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetSkillsWithRelationsResponseBody> = fetcher;
 
   const { data, isLoading, mutate } = useSWRWithDefaults(
@@ -149,6 +152,7 @@ export function useSkillsWithRelations({
 }
 
 export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
+  const { fetcher } = useFetcher();
   const getSimilarSkills = useCallback(
     async (
       naturalDescription: string,
@@ -306,6 +310,7 @@ export function useSkillHistory({
   limit?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const skillHistoryFetcher: Fetcher<GetSkillHistoryResponseBody> = fetcher;
 
   const queryParams = limit ? `?limit=${limit}` : "";
@@ -334,6 +339,7 @@ export function useSkillWithRelations(
     string
   >
 ) {
+  const { fetcher } = useFetcher();
   const { trigger, isMutating } = useSWRMutation(
     `/api/w/${owner.sId}/skills`,
     async (url: string, { arg }: { arg: string }) => {

--- a/front/lib/swr/skill_editors.ts
+++ b/front/lib/swr/skill_editors.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetSkillEditorsResponseBody,
   PatchSkillEditorsRequestBody,
@@ -19,6 +19,7 @@ export function useSkillEditors({
   skillId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const editorsFetcher: Fetcher<GetSkillEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/skills.ts
+++ b/front/lib/swr/skills.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentSkillsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -12,6 +12,7 @@ export function useAgentConfigurationSkills({
   agentConfigurationId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetAgentSkillsResponseBody> = fetcher;
 
   const { data, isLoading } = useSWRWithDefaults(

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -9,9 +9,8 @@ import { clientFetch } from "@app/lib/egress/client";
 import { getSpaceName } from "@app/lib/spaces";
 import {
   emptyArray,
-  fetcher,
-  fetcherWithBody,
   getErrorFromResponse,
+  useFetcher,
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -61,6 +60,7 @@ export function useSpaces({
   kinds: SpaceKind[] | "all";
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const spacesFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -96,6 +96,7 @@ export function useSpaceProjectsLookup({
   spaceIds: string[];
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const spacesLookupFetcher: Fetcher<SpacesLookupResponseBody> = fetcher;
 
   const query =
@@ -135,6 +136,7 @@ export function useSpacesAsAdmin({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const spacesFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -162,6 +164,7 @@ export function useSpaceInfo({
   disabled?: boolean;
   includeAllMembers?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const spacesCategoriesFetcher: Fetcher<GetSpaceResponseBody> = fetcher;
 
   const queryParams = includeAllMembers ? "?includeAllMembers=true" : "";
@@ -196,6 +199,7 @@ export function useSpaceDataSourceView({
   owner: LightWorkspaceType;
   spaceId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const dataSourceViewsFetcher: Fetcher<GetDataSourceViewResponseBody> =
     fetcher;
 
@@ -227,6 +231,7 @@ export function useSpaceDataSourceViews({
   spaceId: string;
   workspaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const spacesDataSourceViewsFetcher: Fetcher<
     GetSpaceDataSourceViewsResponseBody<false>
   > = fetcher;
@@ -263,6 +268,7 @@ export function useSpaceDataSourceViewsWithDetails({
   spaceId: string;
   workspaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const spacesDataSourceViewsFetcher: Fetcher<
     GetSpaceDataSourceViewsResponseBody<true>
   > = fetcher;
@@ -721,6 +727,7 @@ export function useSystemSpace({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const systemSpaceFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -794,6 +801,7 @@ export function useSpacesSearch({
   nextPageCursor: string | null;
   resultsCount: number | null;
 } {
+  const { fetcherWithBody } = useFetcher();
   const params = new URLSearchParams();
   if (pagination?.cursor) {
     params.append("cursor", pagination.cursor);
@@ -874,6 +882,7 @@ export function useSpacesSearchWithInfiniteScroll({
   nextPage: () => Promise<void>;
   hasMore: boolean;
 } {
+  const { fetcherWithBody } = useFetcher();
   const body = {
     query: search,
     viewType,
@@ -947,6 +956,7 @@ export function useProjectMetadata({
   spaceId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const projectMetadataFetcher: Fetcher<GetProjectMetadataResponseBody> =
     fetcher;
 
@@ -1022,6 +1032,7 @@ export function useUserProjectDigests({
   limit?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const digestsFetcher: Fetcher<GetUserProjectDigestsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -1048,6 +1059,7 @@ export function useDigestGenerationStatus({
   workspaceId: string;
   spaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const statusFetcher: Fetcher<GetDigestGenerationStatusResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -1,12 +1,6 @@
-import config from "@app/lib/api/config";
-import { BUILD_DATE, COMMIT_HASH } from "@app/lib/commit-hash";
-import { clientFetch } from "@app/lib/egress/client";
+export { FetcherProvider, useFetcher } from "@app/lib/swr/FetcherContext";
+
 import { isAPIErrorResponse } from "@app/types/error";
-import { safeParseJSON } from "@app/types/shared/utils/json_utils";
-import {
-  FORCE_RELOAD_INTERVAL_MS,
-  FORCE_RELOAD_SESSION_KEY,
-} from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
 import { useCallback } from "react";
 import type {
@@ -139,92 +133,6 @@ export function useSWRInfiniteWithDefaults<TKey extends Key, TData>(
   const mergedConfig = { ...DEFAULT_SWR_CONFIG, ...config };
   return useSWRInfinite<TData>(getKey, fetcher, mergedConfig);
 }
-
-const addClientVersionHeaders = (headers: HeadersInit = {}): HeadersInit => ({
-  ...headers,
-  "X-Commit-Hash": COMMIT_HASH,
-  "X-Build-Date": BUILD_DATE,
-});
-
-const resHandler = async (res: Response) => {
-  if (res.headers.get("X-Reload-Required") === "true") {
-    const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
-    const nowMs = Date.now();
-    const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
-    const shouldReload =
-      !Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS;
-    if (shouldReload) {
-      sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
-      window.location.reload();
-      // Return a never-resolving promise to prevent SWR from processing.
-      return new Promise(() => {});
-    }
-  }
-
-  if (res.status >= 300) {
-    const errorText = await res.text();
-    console.error(
-      "Error returned by the front API: ",
-      res.status,
-      res.headers,
-      errorText
-    );
-
-    const parseRes = safeParseJSON(errorText);
-    if (parseRes.isOk()) {
-      if (isAPIErrorResponse(parseRes.value)) {
-        if (parseRes.value.error.type === "not_authenticated") {
-          const returnTo =
-            window.location.pathname !== "/"
-              ? `?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`
-              : "";
-          window.location.href = `${config.getApiBaseUrl()}/api/workos/login${returnTo}`;
-          // Return a never-resolving promise to prevent SWR from processing.
-          return new Promise(() => {});
-        }
-        throw parseRes.value;
-      }
-    }
-
-    throw new Error(errorText);
-  }
-  return res.json();
-};
-
-export const fetcher = async (...args: Parameters<typeof fetch>) => {
-  const [url, config] = args;
-  const res = await clientFetch(url, {
-    ...config,
-    headers: addClientVersionHeaders(config?.headers),
-  });
-  return resHandler(res);
-};
-
-export const fetcherWithBody = async ([url, body, method]: [
-  string,
-  object,
-  string,
-]) => {
-  const res = await clientFetch(url, {
-    method,
-    headers: addClientVersionHeaders({
-      "Content-Type": "application/json",
-    }),
-    body: JSON.stringify(body),
-  });
-
-  return resHandler(res);
-};
-
-type UrlsAndOptions = { url: string; options: RequestInit };
-
-export const fetcherMultiple = <T>(urlsAndOptions: UrlsAndOptions[]) => {
-  const f = async (url: string, options: RequestInit) => fetcher(url, options);
-
-  return Promise.all<T>(
-    urlsAndOptions.map(({ url, options }) => f(url, options))
-  );
-};
 
 export const appendPaginationParams = (
   params: URLSearchParams,

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PatchAgentTagsRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
 import type { GetSuggestionsResponseBody } from "@app/pages/api/w/[wId]/tags/suggest_from_agents";
@@ -17,6 +17,7 @@ export function useTags({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const tagsFetcher: Fetcher<GetTagsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -42,6 +43,7 @@ export function useTagsUsage({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const tagsFetcher: Fetcher<GetTagsUsageResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -67,6 +69,7 @@ export function useTagsSuggestions({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const tagsFetcher: Fetcher<GetSuggestionsResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/swr/trial_message_usage.ts
+++ b/front/lib/swr/trial_message_usage.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTrialMessageUsageResponseType } from "@app/pages/api/w/[wId]/trial-message-usage";
 import type { Fetcher } from "swr";
 
@@ -9,6 +9,7 @@ export function useTrialMessageUsage({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const usageFetcher: Fetcher<GetTrialMessageUsageResponseType> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/useAppStatus.ts
+++ b/front/lib/swr/useAppStatus.ts
@@ -1,8 +1,9 @@
 import type { AppStatus } from "@app/lib/api/status";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { Fetcher } from "swr";
 
 export function useAppStatus() {
+  const { fetcher } = useFetcher();
   const appStatusFetcher: Fetcher<AppStatus> = fetcher;
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/swr/useWebhookServiceData.ts
+++ b/front/lib/swr/useWebhookServiceData.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetServiceDataResponseType } from "@app/pages/api/w/[wId]/webhook_sources/service-data";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -12,6 +12,7 @@ export function useWebhookServiceData<P extends WebhookProvider>({
   connectionId: string | null;
   provider: P;
 }) {
+  const { fetcher } = useFetcher();
   const { data, error, mutate } = useSWRWithDefaults<
     string,
     GetServiceDataResponseType<P>

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
@@ -23,6 +23,7 @@ export function useUser(
     disabled?: boolean;
   }
 ) {
+  const { fetcher } = useFetcher();
   const userFetcher: Fetcher<GetUserResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults("/api/user", userFetcher, {
     revalidateOnFocus: false,
@@ -46,6 +47,7 @@ export function useUserMetadata(
     workspaceId?: string;
   }
 ) {
+  const { fetcher } = useFetcher();
   const userMetadataFetcher: Fetcher<GetUserMetadataResponseBody> = fetcher;
 
   let url = `/api/user/metadata/${encodeURIComponent(key)}`;
@@ -69,6 +71,7 @@ export function useUserMetadata(
 }
 
 export function useUserApprovals(owner: LightWorkspaceType) {
+  const { fetcher } = useFetcher();
   const userApprovalsFetcher: Fetcher<GetUserApprovalsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -179,6 +182,7 @@ export function usePendingInvitations({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const pendingInvitationsFetcher: Fetcher<GetPendingInvitationsResponseBody> =
     fetcher;
 
@@ -202,6 +206,7 @@ export function useSlackNotifications(
     disabled?: boolean;
   }
 ) {
+  const { fetcher } = useFetcher();
   const slackNotificationsFetcher: Fetcher<GetSlackNotificationResponseBody> =
     fetcher;
 

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetWebhookRequestsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests";
@@ -34,6 +34,7 @@ export function useWebhookSourceViews({
   space?: SpaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetWebhookSourceViewsResponseBody> = fetcher;
   const url =
     space !== undefined
@@ -64,6 +65,7 @@ export function useWebhookSourceViewsFromSpaces(
   spaces: SpaceType[],
   disabled?: boolean
 ) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetWebhookSourceViewsListResponseBody> = fetcher;
 
   const spaceIds = spaces.map((s) => s.sId).join(",");
@@ -89,6 +91,7 @@ export function useWebhookSourcesWithViews({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetWebhookSourcesResponseBody> = fetcher;
 
   const url = `/api/w/${owner.sId}/webhook_sources`;
@@ -291,6 +294,7 @@ export function useWebhookSourceViewsByWebhookSource({
   webhookSourceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetSpecificWebhookSourceViewsResponseBody> =
     fetcher;
   const url = `/api/w/${owner.sId}/webhook_sources/${webhookSourceId}/views`;
@@ -457,6 +461,7 @@ export function useWebhookRequestTriggersForTrigger({
   triggerId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetWebhookRequestsResponseBody> = fetcher;
 
   const url =

--- a/front/lib/swr/website.ts
+++ b/front/lib/swr/website.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
 import type { Fetcher } from "swr";
 
@@ -7,6 +7,7 @@ export function useLandingAuthContext({
 }: {
   hasSessionCookie: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const authContextFetcher: Fetcher<GetNoWorkspaceAuthContextResponseType> =
     fetcher;
 

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
@@ -24,6 +24,7 @@ export function useWorkspaceDomains({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const { data, error, mutate } = useSWRWithDefaults<
     string,
     GetWorkspaceDomainsResponseBody
@@ -93,6 +94,7 @@ export function useWorkOSSSOStatus({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const { data, error, isLoading, mutate } = useSWRWithDefaults<
     string,
     WorkOSConnectionSyncStatus
@@ -158,6 +160,7 @@ export function useWorkOSDSyncStatus({
   disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const { data, error, isLoading, mutate } = useSWRWithDefaults<
     string,
     WorkOSConnectionSyncStatus
@@ -220,6 +223,7 @@ export function useProvisioningStatus({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const provisioningStatusFetcher: Fetcher<GetProvisioningStatusResponseBody> =
     fetcher;
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -4,7 +4,7 @@ import type {
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
 import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
 import type { GetPendingInvitationsLookupResponseBody } from "@app/pages/api/invitations";
 import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
@@ -54,6 +54,7 @@ export function useWorkspace({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const workspaceFetcher: Fetcher<GetWorkspaceResponseBody> = fetcher;
 
   const { data, error, mutate, isValidating } = useSWRWithDefaults(
@@ -76,6 +77,7 @@ export function useWorkspaceSubscriptions({
 }: {
   owner: LightWorkspaceType;
 }) {
+  const { fetcher } = useFetcher();
   const workspaceSubscrptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
     fetcher;
 
@@ -98,6 +100,7 @@ export function useWorkspaceAnalytics({
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const analyticsFetcher: Fetcher<GetWorkspaceAnalyticsResponse> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
@@ -127,6 +130,7 @@ export function useWorkspaceUsageMetrics({
   interval?: "day" | "week";
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceUsageMetricsResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/usage-metrics?days=${days}&interval=${interval}`;
 
@@ -152,6 +156,7 @@ export function useWorkspaceActiveUsersMetrics({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceActiveUsersResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/active-users?days=${days}`;
 
@@ -177,6 +182,7 @@ export function useWorkspaceContextOrigin({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceContextOriginResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/source?days=${days}`;
 
@@ -202,6 +208,7 @@ export function useWorkspaceTools({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceToolsResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/tools?days=${days}`;
 
@@ -229,6 +236,7 @@ export function useWorkspaceToolUsage({
   serverName?: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceToolUsageResponse> = fetcher;
   const params = new URLSearchParams({ days: String(days) });
   if (serverName) {
@@ -260,6 +268,7 @@ export function useWorkspaceTopUsers({
   limit?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceTopUsersResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/top-users?days=${days}&limit=${limit}`;
 
@@ -287,6 +296,7 @@ export function useWorkspaceTopAgents({
   limit?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceTopAgentsResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/top-agents?days=${days}&limit=${limit}`;
 
@@ -312,6 +322,7 @@ export function useWorkspaceAnalyticsOverview({
   days?: number;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceAnalyticsOverviewResponse> = fetcher;
   const key = `/api/w/${workspaceId}/analytics/overview?days=${days}`;
 
@@ -335,6 +346,7 @@ export function useWorkspaceActiveSubscription({
   owner: LightWorkspaceType | undefined;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const workspaceSubscriptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
     fetcher;
 
@@ -370,6 +382,7 @@ export function useFeatureFlags({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const featureFlagsFetcher: Fetcher<GetWorkspaceFeatureFlagsResponseType> =
     fetcher;
 
@@ -417,6 +430,7 @@ export function useWorkspaceProgrammaticCost({
   filter?: Partial<Record<GroupByType, string[]>>;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;
 
   const queryParams = new URLSearchParams();
@@ -456,6 +470,7 @@ export function useWorkspaceSeatAvailability({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const seatAvailabilityFetcher: Fetcher<GetSeatAvailabilityResponseBody> =
     fetcher;
 
@@ -480,6 +495,7 @@ export function usePerSeatPricing({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const pricingFetcher: Fetcher<GetSubscriptionPricingResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
@@ -502,6 +518,7 @@ export function useWorkspaceVerifiedDomains({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const verifiedDomainsFetcher: Fetcher<GetWorkspaceVerifiedDomainsResponseBody> =
     fetcher;
 
@@ -526,6 +543,7 @@ export function useSubscriptionTrialInfo({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const trialInfoFetcher: Fetcher<GetSubscriptionTrialInfoResponseBody> =
     fetcher;
 
@@ -549,6 +567,7 @@ export function useWorkspaceSeatsCount({
   workspaceId: string;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const seatsCountFetcher: Fetcher<GetWorkspaceSeatsCountResponseBody> =
     fetcher;
 
@@ -591,6 +610,7 @@ export function useAuthContext(
   options: { workspaceId?: string; disabled?: boolean } = {}
 ) {
   const { workspaceId, disabled } = options;
+  const { fetcher } = useFetcher();
   const regionContext = useRegionContextSafe();
 
   const url = workspaceId
@@ -637,6 +657,7 @@ export function useSubscriptionStatus({
 }: {
   workspaceId: string;
 }) {
+  const { fetcher } = useFetcher();
   const statusFetcher: Fetcher<GetSubscriptionStatusResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
@@ -653,6 +674,7 @@ export function useSubscriptionStatus({
 }
 
 export function useWelcomeData({ workspaceId }: { workspaceId: string }) {
+  const { fetcher } = useFetcher();
   const welcomeFetcher: Fetcher<GetWelcomeResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
@@ -670,6 +692,7 @@ export function useWelcomeData({ workspaceId }: { workspaceId: string }) {
 }
 
 export function useVerifyData({ workspaceId }: { workspaceId: string }) {
+  const { fetcher } = useFetcher();
   const verifyFetcher: Fetcher<GetVerifyResponseBody> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
@@ -695,6 +718,7 @@ export function useJoinData({
   token: string | null;
   conversationId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const regionContext = useRegionContextSafe();
   const joinFetcher: Fetcher<GetJoinResponseBody> = fetcher;
 
@@ -734,6 +758,7 @@ export function useJoinData({
 }
 
 export function usePendingInvitations() {
+  const { fetcher } = useFetcher();
   const pendingInvitationsFetcher: Fetcher<GetPendingInvitationsLookupResponseBody> =
     fetcher;
 
@@ -749,6 +774,7 @@ export function usePendingInvitations() {
 }
 
 export function useWorkspaceLookup({ flow }: { flow: string | null }) {
+  const { fetcher } = useFetcher();
   const workspaceLookupFetcher: Fetcher<GetWorkspaceLookupResponseBody> =
     fetcher;
 

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -22,6 +22,8 @@ const CONSOLE_MESSAGE_SHOWN_KEY = "dust_console_message_shown";
 
 import { PostHogTracker } from "@app/components/app/PostHogTracker";
 import RootLayout from "@app/components/app/RootLayout";
+import { FetcherProvider } from "@app/lib/swr/FetcherContext";
+import { fetcher, fetcherWithBody } from "@app/lib/swr/fetcher";
 
 if (DATADOG_CLIENT_TOKEN) {
   datadogLogs.init({
@@ -127,9 +129,11 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
   return (
     <PostHogTracker>
-      <RootLayout>
-        {getLayout(<Component {...pageProps} />, pageProps)}
-      </RootLayout>
+      <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
+        <RootLayout>
+          {getLayout(<Component {...pageProps} />, pageProps)}
+        </RootLayout>
+      </FetcherProvider>
     </PostHogTracker>
   );
 }

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetAgentConfigurationsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -16,6 +16,7 @@ export function usePokeAgentConfigurations({
   disabled,
   owner,
 }: PokeAgentConfigurationsProps) {
+  const { fetcher } = useFetcher();
   const agentConfigurationsFetcher: Fetcher<PokeGetAgentConfigurationsResponseBody> =
     fetcher;
 

--- a/front/poke/swr/agent_details.ts
+++ b/front/poke/swr/agent_details.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetAgentDetails } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details";
 import type { PokeGetDatasourceRetrievalResponse } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -16,6 +16,7 @@ export function usePokeAgentDetails({
   owner,
   aId,
 }: UsePokeAgentDetailsProps) {
+  const { fetcher } = useFetcher();
   const agentDetailsFetcher: Fetcher<PokeGetAgentDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/agent_configurations/${aId}/details`,
@@ -44,6 +45,7 @@ export function usePokeAgentDatasourceRetrieval({
   days = DEFAULT_PERIOD_DAYS,
   disabled,
 }: UsePokeAgentDatasourceRetrievalProps) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<PokeGetDatasourceRetrievalResponse> = fetcher;
   const params = new URLSearchParams({ days: days.toString() });
   const key = `/api/poke/workspaces/${workspaceId}/agent_configurations/${agentConfigurationId}/observability/datasource-retrieval?${params.toString()}`;

--- a/front/poke/swr/app_details.ts
+++ b/front/poke/swr/app_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetAppDetails } from "@app/pages/api/poke/workspaces/[wId]/apps/[aId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -16,6 +16,7 @@ export function usePokeAppDetails({
   appId,
   hash,
 }: UsePokeAppDetailsProps) {
+  const { fetcher } = useFetcher();
   const detailsFetcher: Fetcher<PokeGetAppDetails> = fetcher;
   const hashParam = hash ? `?hash=${hash}` : "";
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/poke/swr/apps.ts
+++ b/front/poke/swr/apps.ts
@@ -1,9 +1,10 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListApps } from "@app/pages/api/poke/workspaces/[wId]/apps";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 
 export function usePokeApps({ disabled, owner }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const dataSourceViewsFetcher: Fetcher<PokeListApps> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/apps`,

--- a/front/poke/swr/cache.ts
+++ b/front/poke/swr/cache.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeCacheResponseBody } from "@app/pages/api/poke/cache";
 import type { Fetcher } from "swr";
 
@@ -11,6 +11,7 @@ export function usePokeCacheLookup({
   rawKey,
   disabled,
 }: UsePokeCacheLookupParams) {
+  const { fetcher } = useFetcher();
   const cacheFetcher: Fetcher<GetPokeCacheResponseBody> = fetcher;
 
   const queryParams = new URLSearchParams();

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListConversations } from "@app/pages/api/poke/workspaces/[wId]/conversations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeConversations({
   agentId,
   triggerId,
 }: PokeConversationsFetchProps) {
+  const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
 
   let url: string | null = null;

--- a/front/poke/swr/conversation_config.ts
+++ b/front/poke/swr/conversation_config.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetConversationConfig } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/config";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeConversationConfig({
   owner,
   conversationId,
 }: UsePokeConversationConfigProps) {
+  const { fetcher } = useFetcher();
   const configFetcher: Fetcher<PokeGetConversationConfig> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/config`,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -2,7 +2,7 @@ import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListCreditsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -13,6 +13,7 @@ export type PokeCreditsData = {
 };
 
 export function usePokeCredits({ disabled, owner }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const creditsFetcher: Fetcher<PokeListCreditsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -49,6 +50,7 @@ export function usePokeProgrammaticCost({
   billingCycleStartDay: number;
   filter?: Partial<Record<GroupByType, string[]>>;
 }) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;
 
   const queryParams = new URLSearchParams();

--- a/front/poke/swr/data_retention.ts
+++ b/front/poke/swr/data_retention.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetDataRetentionResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_retention";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -7,6 +7,7 @@ export function usePokeDataRetention({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const dataRetentionFetcher: Fetcher<PokeGetDataRetentionResponseBody> =
     fetcher;
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/poke/swr/data_source_details.ts
+++ b/front/poke/swr/data_source_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetDataSourceDetails } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeDataSourceDetails({
   owner,
   dsId,
 }: UsePokeDataSourceDetailsProps) {
+  const { fetcher } = useFetcher();
   const dataSourceDetailsFetcher: Fetcher<PokeGetDataSourceDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/details`,

--- a/front/poke/swr/data_source_view_details.ts
+++ b/front/poke/swr/data_source_view_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetDataSourceViewDetails } from "@app/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeDataSourceViewDetails({
   owner,
   dataSourceViewId,
 }: UsePokeDataSourceViewDetailsProps) {
+  const { fetcher } = useFetcher();
   const detailsFetcher: Fetcher<PokeGetDataSourceViewDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/data_source_views/${dataSourceViewId}/details`,

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -1,10 +1,5 @@
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
-import {
-  emptyArray,
-  fetcher,
-  fetcherWithBody,
-  useSWRWithDefaults,
-} from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   DataSourceViewWithUsage,
   PokeListDataSourceViews,
@@ -21,6 +16,7 @@ export function usePokeDataSourceViews({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const dataSourceViewsFetcher: Fetcher<PokeListDataSourceViews> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/data_source_views`,
@@ -65,6 +61,7 @@ export function usePokeDataSourceViewContentNodes({
   totalNodesCountIsAccurate: boolean;
   nextPageCursor: string | null;
 } {
+  const { fetcherWithBody } = useFetcher();
   const params = new URLSearchParams();
   if (pagination && pagination.cursor) {
     params.set("cursor", pagination.cursor.toString());

--- a/front/poke/swr/data_sources.ts
+++ b/front/poke/swr/data_sources.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListDataSources } from "@app/pages/api/poke/workspaces/[wId]/data_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -7,6 +7,7 @@ export function usePokeDataSources({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const dataSourceViewsFetcher: Fetcher<PokeListDataSources> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/data_sources`,

--- a/front/poke/swr/document.ts
+++ b/front/poke/swr/document.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetDocument } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -16,6 +16,7 @@ export function usePokeDocument({
   dsId,
   documentId,
 }: UsePokeDocumentProps) {
+  const { fetcher } = useFetcher();
   const documentFetcher: Fetcher<PokeGetDocument> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     documentId

--- a/front/poke/swr/frame_details.ts
+++ b/front/poke/swr/frame_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeFileResponseBody } from "@app/pages/api/poke/workspaces/[wId]/files/[sId]";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -12,6 +12,7 @@ export function usePokeFileDetails({
   sId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const fileFetcher: Fetcher<GetPokeFileResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/poke/swr/group_details.ts
+++ b/front/poke/swr/group_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetGroupDetails } from "@app/pages/api/poke/workspaces/[wId]/groups/[groupId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeGroupDetails({
   owner,
   groupId,
 }: UsePokeGroupDetailsProps) {
+  const { fetcher } = useFetcher();
   const groupDetailsFetcher: Fetcher<PokeGetGroupDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/groups/${groupId}/details`,

--- a/front/poke/swr/groups.ts
+++ b/front/poke/swr/groups.ts
@@ -1,9 +1,10 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListGroups } from "@app/pages/api/poke/workspaces/[wId]/groups";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 
 export function usePokeGroups({ disabled, owner }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const groupsFetcher: Fetcher<PokeListGroups> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/groups`,

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -1,6 +1,6 @@
 import type { LLMTrace } from "@app/lib/api/llm/traces/types";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
 import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
@@ -49,6 +49,7 @@ export function usePokePullTemplates() {
 }
 
 export function usePokeAssistantTemplates() {
+  const { fetcher } = useFetcher();
   const assistantTemplatesFetcher: Fetcher<PokeAssistantTemplatesResponse> =
     fetcher;
 
@@ -72,6 +73,7 @@ export function usePokeAssistantTemplate({
 }: {
   templateId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const assistantTemplateFetcher: Fetcher<PokeFetchAssistantTemplateResponse> =
     fetcher;
 
@@ -96,6 +98,7 @@ export function usePokeConversation({
   workspaceId: string;
   conversationId: string | null;
 }) {
+  const { fetcher } = useFetcher();
   const conversationFetcher: Fetcher<{ conversation: ConversationType }> =
     fetcher;
 
@@ -123,6 +126,7 @@ export function usePokeLLMTrace({
   runId: string | null;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const llmTraceFetcher: Fetcher<{ trace: LLMTrace | null }> = fetcher;
 
   const { data, error, mutate } = useSWR(
@@ -146,6 +150,7 @@ export function usePokeDocuments(
   limit: number,
   offset: number
 ) {
+  const { fetcher } = useFetcher();
   const documentsFetcher: Fetcher<GetDocumentsResponseBody> = fetcher;
   const { data, error, mutate } = useSWR(
     `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/documents?limit=${limit}&offset=${offset}`,
@@ -167,6 +172,7 @@ export function usePokeTables(
   limit: number,
   offset: number
 ) {
+  const { fetcher } = useFetcher();
   const tablesFetcher: Fetcher<GetTablesResponseBody> = fetcher;
   const { data, error, mutate } = useSWR(
     `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/tables?limit=${limit}&offset=${offset}`,

--- a/front/poke/swr/kill.ts
+++ b/front/poke/swr/kill.ts
@@ -1,9 +1,10 @@
-import { emptyArray, fetcher } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { GetKillSwitchesResponseBody } from "@app/pages/api/poke/kill";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
 export function usePokeKillSwitches() {
+  const { fetcher } = useFetcher();
   const killSwitchesFetcher: Fetcher<GetKillSwitchesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWR("/api/poke/kill", killSwitchesFetcher);

--- a/front/poke/swr/mcp_server_view_details.ts
+++ b/front/poke/swr/mcp_server_view_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetMCPServerViewDetails } from "@app/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeMCPServerViewDetails({
   owner,
   mcpServerViewId,
 }: UsePokeMCPServerViewDetailsProps) {
+  const { fetcher } = useFetcher();
   const detailsFetcher: Fetcher<PokeGetMCPServerViewDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/mcp_server_views/${mcpServerViewId}/details`,

--- a/front/poke/swr/mcp_server_views.ts
+++ b/front/poke/swr/mcp_server_views.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListMCPServerViews } from "@app/pages/api/poke/workspaces/[wId]/mcp/views";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -15,6 +15,7 @@ export function usePokeMCPServerViews({
   owner,
   globalSpaceOnly,
 }: UsePokeMCPServerViewsProps) {
+  const { fetcher } = useFetcher();
   const mcpServerViewsFetcher: Fetcher<PokeListMCPServerViews> = fetcher;
 
   const params = new URLSearchParams();

--- a/front/poke/swr/memberships.ts
+++ b/front/poke/swr/memberships.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetMemberships } from "@app/pages/api/poke/workspaces/[wId]/memberships";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -7,6 +7,7 @@ export function usePokeMemberships({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const membershipsFetcher: Fetcher<PokeGetMemberships> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/memberships`,

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,8 +1,8 @@
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { PokeListPluginsForScopeResponseBody } from "@app/pages/api/poke/plugins/";
@@ -22,6 +22,7 @@ export function usePokeListPluginForResourceType({
   disabled?: boolean;
   pluginResourceTarget: PluginResourceTarget;
 }) {
+  const { fetcher } = useFetcher();
   const workspacesFetcher: Fetcher<PokeListPluginsForScopeResponseBody> =
     fetcher;
 
@@ -56,6 +57,7 @@ export function usePokePluginManifest({
   disabled?: boolean;
   pluginId: string;
 }) {
+  const { fetcher } = useFetcher();
   const pluginManifestFetcher: Fetcher<PokeGetPluginDetailsResponseBody> =
     fetcher;
 
@@ -83,6 +85,7 @@ export function usePokePluginAsyncArgs({
   pluginId: string;
   pluginResourceTarget: PluginResourceTarget;
 }) {
+  const { fetcher } = useFetcher();
   const pluginAsyncArgsFetcher: Fetcher<PokeGetPluginAsyncArgsResponseBody> =
     fetcher;
 
@@ -190,6 +193,7 @@ export function usePokePluginRuns({
   resourceType,
   resourceId,
 }: PokePluginRunsFetchProps) {
+  const { fetcher } = useFetcher();
   const pluginRunsFetcher: Fetcher<PokeListPluginRunsResponseBody> = fetcher;
 
   const urlParams = new URLSearchParams();

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,7 +1,7 @@
 import type { RegionType } from "@app/lib/api/regions/config";
 import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
 import type {
   GetPokeWorkspacesResponseBody,
@@ -18,6 +18,7 @@ export function usePokeSearch({
   disabled?: boolean;
   search?: string;
 } = {}) {
+  const { fetcher } = useFetcher();
   const workspacesFetcher: Fetcher<GetPokeSearchItemsResponseBody> = fetcher;
 
   const queryParams = new URLSearchParams({

--- a/front/poke/swr/skill_details.ts
+++ b/front/poke/swr/skill_details.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetSkillDetails } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/details";
 import type { PokeGetSkillVersions } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/versions";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -15,6 +15,7 @@ export function usePokeSkillDetails({
   owner,
   skillId,
 }: UsePokeSkillDetailsProps) {
+  const { fetcher } = useFetcher();
   const skillDetailsFetcher: Fetcher<PokeGetSkillDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/skills/${skillId}/details`,
@@ -41,6 +42,7 @@ export function usePokeSkillVersions({
   owner,
   skillId,
 }: UsePokeSkillVersionsProps) {
+  const { fetcher } = useFetcher();
   const skillVersionsFetcher: Fetcher<PokeGetSkillVersions> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/skills/${skillId}/versions`,

--- a/front/poke/swr/skills.ts
+++ b/front/poke/swr/skills.ts
@@ -2,8 +2,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
-  fetcher,
   getErrorFromResponse,
+  useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetPokeSkillsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/skills";
@@ -13,6 +13,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 
 export function usePokeSkills({ disabled, owner }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetPokeSkillsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/poke/swr/space_details.ts
+++ b/front/poke/swr/space_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetSpaceDetails } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeSpaceDetails({
   owner,
   spaceId,
 }: UsePokeSpaceDetailsProps) {
+  const { fetcher } = useFetcher();
   const spaceDetailsFetcher: Fetcher<PokeGetSpaceDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/spaces/${spaceId}/details`,

--- a/front/poke/swr/spaces.ts
+++ b/front/poke/swr/spaces.ts
@@ -1,9 +1,10 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListSpaces } from "@app/pages/api/poke/workspaces/[wId]/spaces";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 
 export function usePokeSpaces({ disabled, owner }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const spacesFetcher: Fetcher<PokeListSpaces> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/spaces`,

--- a/front/poke/swr/suggestions.ts
+++ b/front/poke/swr/suggestions.ts
@@ -1,4 +1,4 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListSuggestions } from "@app/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -12,6 +12,7 @@ export function usePokeSuggestions({
   owner,
   agentId,
 }: PokeSuggestionsFetchProps) {
+  const { fetcher } = useFetcher();
   const suggestionsFetcher: Fetcher<PokeListSuggestions> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/poke/swr/trigger_details.ts
+++ b/front/poke/swr/trigger_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetTriggerDetails } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeTriggerDetails({
   owner,
   triggerId,
 }: UsePokeTriggerDetailsProps) {
+  const { fetcher } = useFetcher();
   const triggerDetailsFetcher: Fetcher<PokeGetTriggerDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/triggers/${triggerId}/details`,

--- a/front/poke/swr/trigger_execution_stats.ts
+++ b/front/poke/swr/trigger_execution_stats.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetTriggerExecutionStats } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeTriggerExecutionStats({
   owner,
   triggerId,
 }: UsePokeTriggerStatsProps) {
+  const { fetcher } = useFetcher();
   const statsFetcher: Fetcher<PokeGetTriggerExecutionStats> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/triggers/${triggerId}/execution_stats`,

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListTriggers } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type { PokeGetWebhookRequestsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -10,6 +10,7 @@ export function usePokeTriggers({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const triggersFetcher: Fetcher<PokeListTriggers> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/triggers`,
@@ -38,6 +39,7 @@ export function usePokeWebhookRequests({
   status?: WebhookRequestTriggerStatus;
   disabled?: boolean;
 }) {
+  const { fetcher } = useFetcher();
   const requestsFetcher: Fetcher<PokeGetWebhookRequestsResponseBody> = fetcher;
   const params = new URLSearchParams();
   if (limit !== undefined) {

--- a/front/poke/swr/webhook_source_details.ts
+++ b/front/poke/swr/webhook_source_details.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetWebhookSourceDetails } from "@app/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -14,6 +14,7 @@ export function usePokeWebhookSourceDetails({
   owner,
   webhookSourceId,
 }: UsePokeWebhookSourceDetailsProps) {
+  const { fetcher } = useFetcher();
   const detailsFetcher: Fetcher<PokeGetWebhookSourceDetails> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/webhook_sources/${webhookSourceId}/details`,

--- a/front/poke/swr/webhook_sources.ts
+++ b/front/poke/swr/webhook_sources.ts
@@ -1,4 +1,4 @@
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListWebhookSources } from "@app/pages/api/poke/workspaces/[wId]/webhook_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
@@ -7,6 +7,7 @@ export function usePokeWebhookSources({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const webhookSourcesFetcher: Fetcher<PokeListWebhookSources> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/webhook_sources`,

--- a/front/poke/swr/workspace_info.ts
+++ b/front/poke/swr/workspace_info.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetWorkspaceDatasourceRetrievalResponse } from "@app/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval";
 import type { PokeGetWorkspaceInfo } from "@app/pages/api/poke/workspaces/[wId]/workspace-info";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -9,6 +9,7 @@ export function usePokeWorkspaceInfo({
   disabled,
   owner,
 }: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
   const workspaceInfoFetcher: Fetcher<PokeGetWorkspaceInfo> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/poke/workspaces/${owner.sId}/workspace-info`,
@@ -35,6 +36,7 @@ export function usePokeWorkspaceDatasourceRetrieval({
   days = DEFAULT_PERIOD_DAYS,
   disabled,
 }: UsePokeWorkspaceDatasourceRetrievalProps) {
+  const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<PokeGetWorkspaceDatasourceRetrievalResponse> =
     fetcher;
   const params = new URLSearchParams({ days: days.toString() });


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/6247

## Description

Refactor fetcher functions (`fetcher`, `fetcherWithBody`) to be provided via React context instead of direct module imports.

**What changed:**
- Created `FetcherContext.tsx` with a `FetcherProvider` and `useFetcher()` hook
- Moved fetcher implementations from `swr.ts` into a dedicated `fetcher.ts` file with proper named types (`FetcherFn`, `FetcherWithBodyFn`)
- `swr.ts` now only contains SWR wrappers (`useSWRWithDefaults`, `emptyArray`, `getErrorFromResponse`, etc.)
- Wired `FetcherProvider` into all three app entry points: `_app.tsx`, `App.tsx`, and `PokeApp.tsx`
- Updated ~100 SWR hook files to call `const { fetcher } = useFetcher()` instead of importing `fetcher` directly
- For non-hook utility functions (`submitAgentBuilderForm`, `expandFoldersToTables`), `fetcherWithBody` is now passed as a typed parameter (`FetcherWithBodyFn`)

This enables different apps (front, front-spa, extension) to provide different fetcher implementations via context.

## Tests

Type-checked with `npx tsgo --noEmit` — no new errors introduced.

## Risk

Low — purely a refactor of how fetcher functions are provided. No runtime behavior change; the same implementations are used, just delivered through React context instead of direct imports.

## Deploy Plan

Standard deploy, no special steps needed.