### PR TITLE
[front] fix: strip MIME type parameters in file content type resolution

### DIFF
--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -608,6 +608,12 @@ export function resolveFileContentType(
     }
   }
 
+  // Strip MIME parameters (e.g. "audio/webm;codecs=opus" -> "audio/webm").
+  const semicolonIndex = browserContentType.indexOf(";");
+  if (semicolonIndex !== -1) {
+    return browserContentType.slice(0, semicolonIndex).trim();
+  }
+
   return browserContentType;
 }
 


### PR DESCRIPTION
## Description

- This PR strips MIME type parameters in file content type resolution for uploads.
- Context [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1771590892224739).
- The voice recorder explicitly requests `audio/webm;codecs=opus` as the preferred MIME type via `PREFERRED_MIME_TYPES`.
- Having a param here incorrectly fails the check on `isSupportedFileContentType` in `useFileUploaderService`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
