### PR TITLE
[front] fix: strip MIME params in form stream handler when parsing upload requests

### DIFF
--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -5,6 +5,7 @@ import type {
   FileVersion,
 } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
+import { stripMimeParameters } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { File } from "formidable";
@@ -46,7 +47,8 @@ export const parseUploadRequest = async (
       filter: (part) =>
         !part.mimetype ||
         part.mimetype === "application/octet-stream" ||
-        part.mimetype === file.contentType,
+        // The mime params are already stripped from the file content type.
+        stripMimeParameters(part.mimetype) === file.contentType,
     });
 
     const [, files] = await form.parse(req);

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -594,6 +594,10 @@ const EXTENSION_CONTENT_TYPE_OVERRIDES: Record<
   ".tsv": "text/tsv",
 };
 
+export function stripMimeParameters(contentType: string): string {
+  return contentType.split(";")[0];
+}
+
 // This function overrides the browser-reported content type with a more accurate one based on the file extension, if applicable.
 export function resolveFileContentType(
   browserContentType: string,
@@ -608,13 +612,7 @@ export function resolveFileContentType(
     }
   }
 
-  // Strip MIME parameters (e.g. "audio/webm;codecs=opus" -> "audio/webm").
-  const semicolonIndex = browserContentType.indexOf(";");
-  if (semicolonIndex !== -1) {
-    return browserContentType.slice(0, semicolonIndex).trim();
-  }
-
-  return browserContentType;
+  return stripMimeParameters(browserContentType);
 }
 
 export function isPdfContentType(contentType: string): boolean {


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/22016.
- This PR adds the mime type stripping to the stream parser in `parseUploadRequest`
- As a follow up will see if we have a more reliable way of dealing with these.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
