### PR TITLE
fix: cli custom mcp transport

### DIFF
--- a/cli/src/mcp/servers/cliTransport.ts
+++ b/cli/src/mcp/servers/cliTransport.ts
@@ -1,0 +1,184 @@
+import type { DustAPI } from "@dust-tt/client";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+const HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000;
+const RECONNECT_DELAY_MS = 5_000;
+
+export class CLIMcpTransport implements Transport {
+  private running = false;
+  private serverId: string | null = null;
+  private lastEventId: string | null = null;
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private abortController: AbortController | null = null;
+
+  onmessage?: (message: JSONRPCMessage) => void;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  sessionId?: string;
+
+  constructor(
+    private readonly dustAPI: DustAPI,
+    private readonly onServerIdReceived: (serverId: string) => void,
+    private readonly serverName: string = "fs-cli"
+  ) {}
+
+  async start(): Promise<void> {
+    const registerRes = await this.dustAPI.registerMCPServer({
+      serverName: this.serverName,
+    });
+    if (registerRes.isErr()) {
+      throw new Error(
+        `Failed to register MCP server: ${registerRes.error.message}`
+      );
+    }
+    this.serverId = registerRes.value.serverId;
+    this.onServerIdReceived(this.serverId);
+
+    this.heartbeatTimer = setInterval(async () => {
+      if (!this.serverId) {
+        return;
+      }
+      const res = await this.dustAPI.heartbeatMCPServer({
+        serverId: this.serverId,
+      });
+      if (res.isErr() || !res.value.success) {
+        const reReg = await this.dustAPI.registerMCPServer({
+          serverName: this.serverName,
+        });
+        if (reReg.isOk()) {
+          this.serverId = reReg.value.serverId;
+          this.onServerIdReceived(this.serverId);
+        }
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    this.running = true;
+    void this.readLoop();
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.serverId) {
+      return;
+    }
+    const res = await this.dustAPI.postMCPResults({
+      serverId: this.serverId,
+      result: message,
+    });
+    if (res.isErr()) {
+      this.onerror?.(
+        new Error(`Failed to send MCP result: ${res.error.message}`)
+      );
+    }
+  }
+
+  async close(): Promise<void> {
+    this.running = false;
+    this.abortController?.abort();
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.onclose?.();
+  }
+
+  private async readLoop(): Promise<void> {
+    while (this.running) {
+      try {
+        const connRes = await this.dustAPI.getMCPRequestsConnectionDetails({
+          serverId: this.serverId!,
+          lastEventId: this.lastEventId,
+        });
+        if (connRes.isErr()) {
+          throw new Error(
+            `Failed to get connection details: ${connRes.error.message}`
+          );
+        }
+
+        const { url, headers } = connRes.value;
+        this.abortController = new AbortController();
+
+        const response = await fetch(url, {
+          headers,
+          signal: this.abortController.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`SSE request failed: ${response.status}`);
+        }
+        if (!response.body) {
+          throw new Error("No response body");
+        }
+
+        for await (const event of parseSSEStream(response.body)) {
+          if (!this.running) {
+            break;
+          }
+          if (event.data === "done") {
+            continue;
+          }
+
+          try {
+            const parsed = JSON.parse(event.data);
+            if (parsed.eventId) {
+              this.lastEventId = parsed.eventId;
+            }
+            if (parsed.data) {
+              this.onmessage?.(parsed.data);
+            }
+          } catch {}
+        }
+      } catch {
+        if (!this.running) {
+          break;
+        }
+        await sleep(RECONNECT_DELAY_MS);
+      }
+    }
+  }
+}
+
+async function* parseSSEStream(
+  body: ReadableStream<Uint8Array>
+): AsyncGenerator<{ data: string }> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      const events = buffer.split("\n\n");
+      buffer = events.pop() ?? "";
+
+      for (const event of events) {
+        if (!event.trim()) {
+          continue;
+        }
+
+        let data = "";
+        for (const line of event.split("\n")) {
+          if (line.startsWith("data: ")) {
+            data += (data ? "\n" : "") + line.slice(6);
+          }
+        }
+
+        if (data) {
+          yield { data };
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/cli/src/mcp/servers/fsServer.ts
+++ b/cli/src/mcp/servers/fsServer.ts
@@ -1,5 +1,5 @@
 import type { DustAPI, Result } from "@dust-tt/client";
-import { DustMcpServerTransport, Err, Ok } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { CLI_VERSION } from "../../utils/version.js";
@@ -8,6 +8,7 @@ import { ReadFileTool } from "../tools/readFile.js";
 import { RunCommandTool } from "../tools/runCommand.js";
 import { SearchContentTool } from "../tools/searchContent.js";
 import { SearchFilesTool } from "../tools/searchFiles.js";
+import { CLIMcpTransport } from "./cliTransport.js";
 
 // Add local development tools to the MCP server
 export const useFileSystemServer = async (
@@ -63,21 +64,7 @@ export const useFileSystemServer = async (
     );
   }
 
-  // Connect to Dust with enhanced error handling
-  const transport = new DustMcpServerTransport(
-    dustAPI,
-    (serverId) => {
-      onServerIdReceived(serverId);
-    },
-    "fs-cli",
-    false,
-    365 * 24 * 60 * 60 * 1000
-    // TODO: This is kind of a hack that is ok for now,
-    // the reason we need this is because we have yaffle's event source polyfill,
-    // which doesnt allow us to turn off timeouts, so we would need to continuously
-    // send keep alive messages from server, but there is currently an
-    // optimization to stop those messages from sever when mcp tools are not being used.
-  );
+  const transport = new CLIMcpTransport(dustAPI, onServerIdReceived, "fs-cli");
 
   try {
     await server.connect(transport);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR removes the dependency on the SDK's DustMCPServerTransport, and the fix on the custom 1y reconnection delay. 

Instead, it uses a custom based-fetch SSE transport for the local MCP server.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, no disconnection in 10 minutes of straight use of the MCP

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy CLI version