### PR TITLE
Switch getLargeWhitelistedModel to sonnet 4.6

### DIFF
--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1,7 +1,7 @@
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_4_6_SONNET_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
@@ -85,7 +85,7 @@ export function getLargeWhitelistedModel(
   owner: WorkspaceType
 ): ModelConfigurationType | null {
   if (isProviderWhitelisted(owner, "anthropic")) {
-    return CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG;
+    return CLAUDE_4_6_SONNET_DEFAULT_MODEL_CONFIG;
   }
   return getLargeNonAnthropicWhitelistedModel(owner);
 }

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1,7 +1,7 @@
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_4_6_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
@@ -85,7 +85,7 @@ export function getLargeWhitelistedModel(
   owner: WorkspaceType
 ): ModelConfigurationType | null {
   if (isProviderWhitelisted(owner, "anthropic")) {
-    return CLAUDE_4_6_SONNET_DEFAULT_MODEL_CONFIG;
+    return CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
   }
   return getLargeNonAnthropicWhitelistedModel(owner);
 }

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -118,30 +118,6 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
-export const CLAUDE_4_6_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
-  providerId: "anthropic",
-  modelId: CLAUDE_SONNET_4_6_MODEL_ID,
-  displayName: "Claude 4.6 Sonnet",
-  contextSize: 200_000,
-  recommendedTopK: 16,
-  recommendedExhaustiveTopK: 64,
-  largeModel: true,
-  description:
-    "Anthropic's Claude 4.6 Sonnet model with enhanced reasoning and tool use (200k context).",
-  shortDescription: "Anthropic's latest model.",
-  isLegacy: false,
-  isLatest: true,
-  generationTokensCount: 64_000,
-  supportsVision: true,
-  supportsResponseFormat: true,
-  minimumReasoningEffort: "light",
-  maximumReasoningEffort: "high",
-  defaultReasoningEffort: "light",
-  nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
-  tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
-  supportsPromptCaching: true,
-  tokenizer: { type: "tiktoken", base: "anthropic_base" },
-};
 export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_3_5_HAIKU_20241022_MODEL_ID,

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -118,6 +118,30 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
+export const CLAUDE_4_6_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "anthropic",
+  modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+  displayName: "Claude 4.6 Sonnet",
+  contextSize: 200_000,
+  recommendedTopK: 16,
+  recommendedExhaustiveTopK: 64,
+  largeModel: true,
+  description:
+    "Anthropic's Claude 4.6 Sonnet model with enhanced reasoning and tool use (200k context).",
+  shortDescription: "Anthropic's latest model.",
+  isLegacy: false,
+  isLatest: true,
+  generationTokensCount: 64_000,
+  supportsVision: true,
+  supportsResponseFormat: true,
+  minimumReasoningEffort: "light",
+  maximumReasoningEffort: "high",
+  defaultReasoningEffort: "light",
+  nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
+  tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  supportsPromptCaching: true,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
+};
 export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_3_5_HAIKU_20241022_MODEL_ID,


### PR DESCRIPTION
## Description

Comparison: https://www.anthropic.com/news/claude-sonnet-4-6

This affects the following scenarios that use it as a primary (not fallback) model:

  1. Icon suggestion (lib/api/skills/icon_suggestion.ts:112) — used directly as the model for generating agent icon suggestions.
  2. Description suggestion (lib/api/skills/description_suggestion.ts:74) — used directly as the model for generating agent description suggestions.
  3. Webhook filter (lib/api/assistant/configuration/triggers/webhook_filter.ts:289) — used directly as the model for evaluating webhook filters.
  4. Tag manager (lib/api/assistant/tag_manager.ts:121) — used directly as the model for agent tag management.
  5. Generic agents API (pages/api/v1/w/[wId]/assistant/generic_agents.ts:180) — used directly as the model for generic agent configurations.
  6. Copilot global agent (lib/api/assistant/global_agents/configurations/dust/copilot.ts:525) — used directly as the primary model (no conditional fallback logic).

## Tests

Manual with copilot

## Risk

Model degradation (unlikely)

## Deploy Plan

Front.