### PR TITLE
Fix thinking behavior

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -257,6 +257,7 @@ export function useAgentMessageStream({
                   ...updateMessageWithAction(m, action),
                   streaming: {
                     ...m.streaming,
+                    agentState: "thinking",
                     // Clean up progress for this specific action.
                     actionProgress: new Map(
                       Array.from(m.streaming.actionProgress.entries()).filter(


### PR DESCRIPTION
## Description

Reset agent state to thinking after action success.

- this prevents having the tool execution chip linger while the model is thinking or generating next action
- this fixes the thinking streaming post action execution

This may have an adversarial impact as we've had thinking tokens pretty much hidden from the conversation due to this.

Let's give it a try (as it's the intended behavior) and see how it feels in practice.

## Tests

Tested locally, pure UI.

## Risk

Very low

## Deploy Plan

- deploy `front`