### PR TITLE
[Front] refactor(skills): break circular dep skill_resource -> agent -> global_agents

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1679,31 +1679,7 @@ export async function updateAgentConfigurationScope(
   return new Ok(undefined);
 }
 
-export async function updateAgentRequirements(
-  auth: Authenticator,
-  {
-    agentModelId,
-    newSpaceIds,
-  }: { agentModelId: ModelId; newSpaceIds: ModelId[] },
-  { transaction }: { transaction?: Transaction }
-): Promise<Result<boolean, Error>> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const updated = await AgentConfigurationModel.update(
-    {
-      requestedSpaceIds: newSpaceIds,
-    },
-    {
-      where: {
-        workspaceId: owner.id,
-        id: agentModelId,
-      },
-      transaction,
-    }
-  );
-
-  return new Ok(updated[0] > 0);
-}
+export { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 
 export async function filterAgentsByRequestedSpaces(
   auth: Authenticator,

--- a/front/lib/api/assistant/configuration/agent_requirements.ts
+++ b/front/lib/api/assistant/configuration/agent_requirements.ts
@@ -1,0 +1,32 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Transaction } from "sequelize";
+
+export async function updateAgentRequirements(
+  auth: Authenticator,
+  {
+    agentModelId,
+    newSpaceIds,
+  }: { agentModelId: ModelId; newSpaceIds: ModelId[] },
+  { transaction }: { transaction?: Transaction }
+): Promise<Result<boolean, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const updated = await AgentConfigurationModel.update(
+    {
+      requestedSpaceIds: newSpaceIds,
+    },
+    {
+      where: {
+        workspaceId: owner.id,
+        id: agentModelId,
+      },
+      transaction,
+    }
+  );
+
+  return new Ok(updated[0] > 0);
+}

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -1,5 +1,5 @@
 import { hardDeleteApp } from "@app/lib/api/apps";
-import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent";
+import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects";
 import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";


### PR DESCRIPTION
## Description

Break the transitive dependency `skill_resource.ts -> configuration/agent.ts -> global_agents.ts` so that `global_agents.ts` can later import `skill_resource.ts`.

Removes `skill_resource.ts`'s two imports from `configuration/agent.ts` (`getAgentConfiguration` and `updateAgentRequirements`) by extracting/replacing them with narrower alternatives that don't pull in `global_agents.ts`.

Unlocks https://github.com/dust-tt/dust/pull/21986