### PR TITLE
Add FetcherProvider for extension

### DIFF
--- a/extension/platforms/chrome/main.tsx
+++ b/extension/platforms/chrome/main.tsx
@@ -21,6 +21,7 @@ import {
   PlatformProvider,
   usePlatform,
 } from "@extension/shared/context/PlatformContext";
+import { ExtensionFetcherProvider } from "@extension/shared/lib/FetcherProvider";
 import { AuthProvider } from "@extension/ui/components/auth/AuthProvider";
 import { routes } from "@extension/ui/pages/routes";
 import { compare } from "compare-versions";
@@ -112,9 +113,11 @@ const App = () => {
     <PlatformProvider platformService={platformService}>
       <PortProvider>
         <AuthProvider>
-          <Notification.Area>
-            <ChromeExtensionWrapper />
-          </Notification.Area>
+          <ExtensionFetcherProvider>
+            <Notification.Area>
+              <ChromeExtensionWrapper />
+            </Notification.Area>
+          </ExtensionFetcherProvider>
         </AuthProvider>
       </PortProvider>
     </PlatformProvider>

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -10,6 +10,7 @@ import "../../ui/css/custom.css";
 import { Notification } from "@dust-tt/sparkle";
 import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
 import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
+import { ExtensionFetcherProvider } from "@extension/shared/lib/FetcherProvider";
 import { AuthProvider } from "@extension/ui/components/auth/AuthProvider";
 import { routes } from "@extension/ui/pages/routes";
 import { useEffect, useState } from "react";
@@ -53,9 +54,11 @@ const AppWrapper = () => {
     <FrontContextProvider>
       <FrontPlatformProvider>
         <AuthProvider>
-          <Notification.Area>
-            <RouterProvider router={router} key="front-router" />
-          </Notification.Area>
+          <ExtensionFetcherProvider>
+            <Notification.Area>
+              <RouterProvider router={router} key="front-router" />
+            </Notification.Area>
+          </ExtensionFetcherProvider>
         </AuthProvider>
       </FrontPlatformProvider>
     </FrontContextProvider>

--- a/extension/shared/lib/FetcherProvider.tsx
+++ b/extension/shared/lib/FetcherProvider.tsx
@@ -1,0 +1,55 @@
+import type { FetcherFn, FetcherWithBodyFn } from "@app/lib/swr/fetcher";
+import { FetcherProvider } from "@app/lib/swr/FetcherContext";
+import { resHandler } from "@extension/shared/lib/swr";
+import { useAuth } from "@extension/ui/components/auth/AuthProvider";
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+
+interface ExtensionFetcherProviderProps {
+  children: ReactNode;
+}
+
+export function ExtensionFetcherProvider({
+  children,
+}: ExtensionFetcherProviderProps) {
+  const { token } = useAuth();
+
+  const { fetcher, fetcherWithBody } = useMemo(() => {
+    const addAuthHeaders = (headers: HeadersInit = {}): HeadersInit => ({
+      ...headers,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    });
+
+    const fetcher: FetcherFn = async (url, init) => {
+      const res = await fetch(url, {
+        ...init,
+        headers: addAuthHeaders(init?.headers),
+      });
+      return resHandler(res);
+    };
+
+    const fetcherWithBody: FetcherWithBodyFn = async (
+      [url, body, method],
+      init
+    ) => {
+      const res = await fetch(url, {
+        ...init,
+        method,
+        headers: addAuthHeaders({
+          ...init?.headers,
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify(body),
+      });
+      return resHandler(res);
+    };
+
+    return { fetcher, fetcherWithBody };
+  }, [token]);
+
+  return (
+    <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
+      {children}
+    </FetcherProvider>
+  );
+}


### PR DESCRIPTION
## Description

Add an `ExtensionFetcherProvider` for the extension that injects OAuth authorization headers into the shared `FetcherProvider` context from `front`.

This is the extension-side counterpart of #22015. The extension's fetcher functions:
- Get the OAuth token from `useAuth()` context
- Add `Authorization: Bearer <token>` headers to all requests
- Use the extension's `resHandler` for response handling
- Are memoized on token changes

The provider is added inside `AuthProvider` in both entry points (Chrome and Front plugin).

## Tests

Manual verification that the provider is correctly wired and types check.

## Risk

Low — additive change, wraps existing auth pattern.

## Deploy Plan

Standard deploy, no special steps.