### PR TITLE
feat: upgrade dd-trace for connectors

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -58,7 +58,7 @@
     "crawlee": "3.14.1",
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.5.0",
-    "dd-trace": "^5.52.0",
+    "dd-trace": "^5.87.0",
     "express": "^4.18.2",
     "file-type": "^20.5.0",
     "fp-ts": "^2.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -275,7 +275,7 @@
         "crawlee": "3.14.1",
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.5.0",
-        "dd-trace": "^5.52.0",
+        "dd-trace": "^5.87.0",
         "express": "^4.18.2",
         "file-type": "^20.5.0",
         "fp-ts": "^2.16.0",
@@ -339,6 +339,55 @@
         "node": "22.22.0"
       }
     },
+    "connectors/node_modules/@datadog/flagging-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-0.3.3.tgz",
+      "integrity": "sha512-LnkTXMVxaCDGCOF2I+CCACndpbi4E8CP8NIsb1IbMmmATzkQHmYiL1ntFcS4mt5kNGAWXNrKquM02jhoiVc+dA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "spark-md5": "^3.0.2"
+      }
+    },
+    "connectors/node_modules/@datadog/openfeature-node-server": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-0.3.3.tgz",
+      "integrity": "sha512-G3OdRxv3ZwFx+gTwot33nNcTmE8P7ObTLjviXv6zVMD4NB6R/yvCjJVe/Wh0WSTt/ZBjGYN2+SuZAPpf7gsR5g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@datadog/flagging-core": "0.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@openfeature/server-sdk": ">=1.15.0 <2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@openfeature/server-sdk": {
+          "optional": true
+        }
+      }
+    },
+    "connectors/node_modules/@datadog/pprof": {
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.13.3.tgz",
+      "integrity": "sha512-G25IicP7pc5CXmAfVz7nrIERsKK9hvPz6p7xsLTUwG4Qs+Zgd5KFedKCVsnvNasLc7l7OXQ6839ajowgQLWTyw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "delay": "^5.0.0",
+        "node-gyp-build": "<4.0",
+        "p-limit": "^3.1.0",
+        "pprof-format": "^2.2.1",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "connectors/node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
@@ -359,6 +408,37 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "connectors/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "connectors/node_modules/dd-trace": {
+      "version": "5.87.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.87.0.tgz",
+      "integrity": "sha512-wWY4ku7Ey0pIyhDjqJOk+h6piO04o5nyC0RPtspYWn/AoMLdHwZRKRI+mlt9isyJ2nuUZ/6rTBTB526T7BZWAw==",
+      "hasInstallScript": true,
+      "license": "(Apache-2.0 OR BSD-3-Clause)",
+      "dependencies": {
+        "dc-polyfill": "^0.1.10",
+        "import-in-the-middle": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=18 <26"
+      },
+      "optionalDependencies": {
+        "@datadog/libdatadog": "0.7.0",
+        "@datadog/native-appsec": "10.3.0",
+        "@datadog/native-iast-taint-tracking": "4.1.0",
+        "@datadog/native-metrics": "3.1.1",
+        "@datadog/openfeature-node-server": "^0.3.3",
+        "@datadog/pprof": "5.13.3",
+        "@datadog/wasm-js-rewriter": "5.0.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0"
       }
     },
     "connectors/node_modules/express": {
@@ -405,6 +485,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "connectors/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "connectors/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "eslint-plugin-dust": {


### PR DESCRIPTION
## Description

Upgrading dd-trace, because we are using a [version that doesn't work with express](https://docs.datadoghq.com/tracing/code_origin/?tab=nodejs#compatibility-requirements), and indeed I can't have source maps for connectors.

Note: I didn't read the changelog, it's too big. But I'm confident datadog doesn't break things.
Note2: I'm doing 1 PR per service, so I can deploy and monitor one by one (during multiple days

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
