### PR TITLE
Add better error message when agent response generation failed

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -384,14 +384,20 @@ export async function updateResourceAndPublishEvent(
 const DEFAULT_WORKFLOW_ERROR_MESSAGE =
   "An unexpected error occurred while generating the agent response. Please try again.";
 
-function toUserFriendlyMessage(message: string | undefined | null): string {
-  if (!message) {
+function toUserFriendlyMessage(error: {
+  message: string;
+  name: string;
+}): string {
+  if (!error.message) {
     return DEFAULT_WORKFLOW_ERROR_MESSAGE;
   }
-  if (message === "Activity task timed out") {
+  if (
+    error.message === "Activity task timed out" &&
+    error.name === "ActivityFailure"
+  ) {
     return "The agent took too long to respond. Please try again.";
   }
-  return message;
+  return error.message;
 }
 
 export async function notifyWorkflowError(
@@ -460,7 +466,7 @@ export async function notifyWorkflowError(
     messageId: agentMessageId,
     error: {
       code: "workflow_error",
-      message: toUserFriendlyMessage(error.message),
+      message: toUserFriendlyMessage(error),
       metadata: {
         category: "critical_failure",
         errorTitle: "Agent response generation failed",

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -49,7 +49,7 @@ export async function finalizeCancelledAgentLoopActivity(
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
-  error: Error
+  error: { message: string; name: string }
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -244,11 +244,13 @@ export async function agentLoopWorkflow({
       if (cancelRequested) {
         return finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
       }
-      await finalizeErroredAgentLoopActivity(
-        authType,
-        agentLoopArgs,
-        workflowError
-      );
+      // Error objects don't survive JSON serialization across the workflow→activity
+      // boundary (Error.message is not enumerable), so we extract the relevant
+      // fields into a plain object before passing to the activity.
+      await finalizeErroredAgentLoopActivity(authType, agentLoopArgs, {
+        message: workflowError.message,
+        name: workflowError.name,
+      });
       throw err;
     });
   }


### PR DESCRIPTION
## Description

According to Claude the Error is serialized when passed from activity to workflow and we lose the "message" field.
That's why it sometimes end up empty


The behavior can be reproduce with this JS code

```
class TemporalFailure extends Error {
  constructor(message) { super(message); }
}
class ActivityFailure extends TemporalFailure {
  constructor(message) { super(message); this.activityType = 'test'; }
}

const failure = new ActivityFailure('Activity task failed');
console.log('JSON:', JSON.stringify(failure));
```

```
JSON: {"activityType":"test"}
```

This PR avoid empty message by passing only the required field instead of the Error object.

New error message displayed like this:

<img width="1588" height="512" alt="image" src="https://github.com/user-attachments/assets/26948106-707c-400f-acad-80286efa783b" />


## Tests

no

## Risk

low

## Deploy Plan

deploy front
