### PR TITLE
Prevent reload when navigation is locked

### DIFF
--- a/front/hooks/useNavigationLock.tsx
+++ b/front/hooks/useNavigationLock.tsx
@@ -1,4 +1,8 @@
 import { ConfirmContext } from "@app/components/Confirm";
+import {
+  decrementNavigationLock,
+  incrementNavigationLock,
+} from "@app/lib/navigation-lock";
 import { useAppRouter, useNavigationBlocker } from "@app/lib/platform";
 import React, { useCallback, useContext, useEffect } from "react";
 
@@ -23,6 +27,14 @@ export function useNavigationLock(
   );
 
   useNavigationBlocker(isEnabled, onBlock);
+
+  // Prevent programmatic reloads (e.g. from SWR resHandler) while the lock is active.
+  useEffect(() => {
+    if (isEnabled) {
+      incrementNavigationLock();
+      return () => decrementNavigationLock();
+    }
+  }, [isEnabled]);
 
   // Next.js: use routeChangeStart events to intercept navigation.
   // This is a noop in the SPA since routeChangeStart is not emitted

--- a/front/lib/navigation-lock.ts
+++ b/front/lib/navigation-lock.ts
@@ -1,0 +1,13 @@
+let lockCount = 0;
+
+export function incrementNavigationLock(): void {
+  lockCount++;
+}
+
+export function decrementNavigationLock(): void {
+  lockCount--;
+}
+
+export function isNavigationLocked(): boolean {
+  return lockCount > 0;
+}

--- a/front/lib/swr/fetcher.ts
+++ b/front/lib/swr/fetcher.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { BUILD_DATE, COMMIT_HASH } from "@app/lib/commit-hash";
 import { clientFetch } from "@app/lib/egress/client";
+import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { isAPIErrorResponse } from "@app/types/error";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import {
@@ -20,7 +21,8 @@ const resHandler = async (res: Response) => {
     const nowMs = Date.now();
     const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
     const shouldReload =
-      !Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS;
+      (!Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS) &&
+      !isNavigationLocked();
     if (shouldReload) {
       sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
       window.location.reload();


### PR DESCRIPTION
## Description

The SWR `resHandler` in `front/lib/swr/fetcher.ts` forces a `window.location.reload()` when the server sends `X-Reload-Required: true`. However, pages that use `useNavigationLock` (e.g. AgentBuilder with unsaved form changes) had no way to prevent this programmatic reload, causing users to lose unsaved work.

This PR adds a simple module-level lock counter (`front/lib/navigation-lock.ts`) that `useNavigationLock` increments/decrements, and that `resHandler` checks before reloading. When the lock is active, the forced reload is skipped.

### Changes
- **`front/lib/navigation-lock.ts`** (new) — Lock counter with `incrementNavigationLock()`, `decrementNavigationLock()`, `isNavigationLocked()`
- **`front/hooks/useNavigationLock.tsx`** — `useEffect` that increments the lock when enabled and decrements on cleanup
- **`front/lib/swr/fetcher.ts`** — `shouldReload` now also checks `!isNavigationLocked()`

## Tests

- Manual: on a page with `useNavigationLock` active, SWR responses with `X-Reload-Required: true` no longer trigger a reload
- Manual: on pages without the lock, reload still works as expected
- Type-check: `npx tsgo --noEmit` passes

## Risk

Low. The lock counter is only incremented by components already using `useNavigationLock`, and the reload is only deferred, not permanently suppressed — users will get the reload on their next navigation.

## Deploy Plan

Standard deploy, no migration or special steps needed.