### PR TITLE
Add transpileConfig in extensions webpack config

### DIFF
--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -133,6 +133,7 @@ export const getConfig = async ({
             loader: "ts-loader",
             options: {
               configFile: resolvePath("../../tsconfig.json"),
+              transpileOnly: true,
             },
           },
           exclude: /node_modules/,

--- a/extension/platforms/front/webpack.config.ts
+++ b/extension/platforms/front/webpack.config.ts
@@ -24,6 +24,7 @@ export const getConfig = ({ env }: { env: Environment }) => {
             loader: "ts-loader",
             options: {
               configFile: path.resolve(__dirname, "../../tsconfig.json"),
+              transpileOnly: true,
             },
           },
           exclude: /node_modules/,


### PR DESCRIPTION
## Description

Adds `transpileOnly: true` to ts-loader configuration in both Chrome and Front extension webpack configs. This skips type checking during compilation, speeding up extension builds since type checking is already performed separately in CI.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

