### PR TITLE
Remove `agent_bound_loop_rendering` (and enable)

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -353,7 +353,6 @@ export function renderUserMessage(
 
 /**
  * Renders an agent message from a different agent as a user message with system tags.
- * This is used when the `agent_bound_loop_rendering` feature flag is enabled.
  * Only the final text output is rendered, not the full agentic loop (actions/tool calls).
  */
 export function renderOtherAgentMessageAsUserMessage(

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -16,7 +16,6 @@ import {
   isTextContent,
 } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -45,7 +44,6 @@ export async function renderConversationForModel(
     excludeImages,
     onMissingAction = "inject-placeholder",
     agentConfiguration,
-    featureFlags,
   }: {
     conversation: ConversationType;
     model: ModelConfigurationType;
@@ -57,7 +55,6 @@ export async function renderConversationForModel(
     onMissingAction?: "inject-placeholder" | "skip";
     enablePreviousInteractionsPruning?: boolean;
     agentConfiguration?: AgentConfigurationType;
-    featureFlags?: WhitelistableFeature[];
   }
 ): Promise<
   Result<
@@ -78,7 +75,6 @@ export async function renderConversationForModel(
     excludeImages,
     onMissingAction,
     agentConfiguration,
-    featureFlags,
   });
 
   // Tokenize messages and prompt/tools in parallel to reduce latency

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -28,7 +28,6 @@ import type {
 } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
@@ -128,9 +127,8 @@ export function renderAgentSteps(
 /**
  * Renders all conversation messages into model messages
  *
- * When `agentConfiguration` is provided and the `agent_bound_loop_rendering` feature flag
- * is enabled, agent messages from other agents are rendered as user messages with system tags,
- * showing only the final output (not the full agentic loop).
+ * When `agentConfiguration` is provided, agent messages from other agents are rendered as user
+ * messages with system tags, showing only the final output (not the full agentic loop).
  */
 export async function renderAllMessages(
   auth: Authenticator,
@@ -141,7 +139,6 @@ export async function renderAllMessages(
     excludeImages,
     onMissingAction,
     agentConfiguration,
-    featureFlags,
   }: {
     conversation: ConversationType;
     model: ModelConfigurationType;
@@ -149,13 +146,9 @@ export async function renderAllMessages(
     excludeImages?: boolean;
     onMissingAction: "inject-placeholder" | "skip";
     agentConfiguration?: AgentConfigurationType;
-    featureFlags?: WhitelistableFeature[];
   }
 ): Promise<ModelMessageTypeMultiActions[]> {
   const messages: ModelMessageTypeMultiActions[] = [];
-
-  const agentBoundLoopRendering =
-    featureFlags?.includes("agent_bound_loop_rendering") ?? false;
 
   // Render loop: render all messages and all actions.
   for (const versions of conversation.content) {
@@ -163,9 +156,8 @@ export async function renderAllMessages(
 
     if (isAgentMessageType(m)) {
       if (m.visibility === "visible") {
-        // When agent_bound_loop_rendering is enabled, check if this is the current agent's message.
+        // Check if this is the current agent's message.
         const isCurrentAgentMessage =
-          !agentBoundLoopRendering ||
           !agentConfiguration ||
           m.configuration.sId === agentConfiguration.sId;
 

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -158,8 +158,7 @@ export async function renderAllMessages(
       if (m.visibility === "visible") {
         // Check if this is the current agent's message.
         const isCurrentAgentMessage =
-          !agentConfiguration ||
-          m.configuration.sId === agentConfiguration.sId;
+          !agentConfiguration || m.configuration.sId === agentConfiguration.sId;
 
         if (isCurrentAgentMessage) {
           // Render the current agent's messages normally with full agentic loop.

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -11,7 +11,7 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -103,15 +103,13 @@ async function handler(
         });
       }
 
-      const [conversationRes, agentConfiguration, featureFlags] =
-        await Promise.all([
-          getConversation(auth, cId, true),
-          getAgentConfiguration(auth, {
-            agentId,
-            variant: "full",
-          }),
-          getFeatureFlags(auth.getNonNullableWorkspace()),
-        ]);
+      const [conversationRes, agentConfiguration] = await Promise.all([
+        getConversation(auth, cId, true),
+        getAgentConfiguration(auth, {
+          agentId,
+          variant: "full",
+        }),
+      ]);
 
       if (conversationRes.isErr()) {
         return apiError(req, res, {
@@ -298,7 +296,6 @@ async function handler(
         excludeImages,
         onMissingAction,
         agentConfiguration,
-        featureFlags,
       });
 
       if (convoRes.isErr()) {

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -229,7 +229,6 @@ async function _runModelAndCreateActionsActivity({
     runIds,
     step,
     functionCallStepContentIds,
-    featureFlags,
   });
 
   if (!modelResult) {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -63,7 +63,6 @@ import type { AgentActionsEvent } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { isTextContent } from "@app/types/assistant/generation";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -80,13 +79,11 @@ export async function runModel(
     runIds,
     step,
     functionCallStepContentIds,
-    featureFlags,
   }: {
     runAgentData: AgentLoopExecutionData;
     runIds: string[];
     step: number;
     functionCallStepContentIds: Record<string, ModelId>;
-    featureFlags: WhitelistableFeature[];
   }
 ): Promise<{
   actions: AgentActionsEvent["actions"];
@@ -381,7 +378,6 @@ export async function runModel(
           tools,
           allowedTokenCount: model.contextSize - model.generationTokensCount,
           agentConfiguration,
-          featureFlags,
         })
       )
   );

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -258,11 +258,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable slack notifications",
     stage: "dust_only",
   },
-  agent_bound_loop_rendering: {
-    description:
-      "When rendering conversations for agents, only show the current agent's agentic loop. Other agents' messages are shown as user messages with system tags.",
-    stage: "dust_only",
-  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -663,7 +663,6 @@ export type RetrievalDocumentPublicType = z.infer<
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
-  | "agent_bound_loop_rendering"
   | "agent_builder_copilot"
   | "agent_builder_shrink_wrap"
   | "agent_management_tool"


### PR DESCRIPTION
## Description

Remove `agent_bound_loop_rendering` which enables the feature for all workspaces.

## Tests

Run for 2 days on Dust workspace with no impact recorded

## Risk

Medium (hence using the weekend to warm the change). Easy to revert. Impact possible is slight change of behavior of agenst in multi-agent conversations

## Deploy Plan

- deploy `front`