### PR TITLE
Add new X-Dust-User-Id header to sending all the groups

### DIFF
--- a/core/src/api/runs.rs
+++ b/core/src/api/runs.rs
@@ -279,6 +279,16 @@ pub async fn runs_create(
         None => (),
     };
 
+    match headers.get("X-Dust-User-Id") {
+        Some(v) => match v.to_str() {
+            Ok(v) => {
+                credentials.insert("DUST_USER_ID".to_string(), v.to_string());
+            }
+            _ => (),
+        },
+        None => (),
+    };
+
     // If the run is made by a system key, it's a system run
     match headers.get("X-Dust-IsSystemRun") {
         Some(v) => match v.to_str() {
@@ -356,6 +366,16 @@ pub async fn runs_create_stream(
         Some(v) => match v.to_str() {
             Ok(v) => {
                 credentials.insert("DUST_GROUP_IDS".to_string(), v.to_string());
+            }
+            _ => (),
+        },
+        None => (),
+    };
+
+    match headers.get("X-Dust-User-Id") {
+        Some(v) => match v.to_str() {
+            Ok(v) => {
+                credentials.insert("DUST_USER_ID".to_string(), v.to_string());
             }
             _ => (),
         },

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -21,7 +21,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
     if (!user) {
       logger.warn(
         { workspaceId: owner },
-        "No user available in auth to call Front API from server 'agent_router/tools'"
+        "No user available in auth to call Front API from server 'agent_router/list_all_published_agents'"
       );
     }
     const requestedGroupIds = auth.groupIds();
@@ -72,6 +72,12 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
   suggest_agents_for_content: async ({ userMessage }, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
     const user = auth.user();
+    if (!user) {
+      logger.warn(
+        { workspaceId: owner },
+        "No user available in auth to call Front API from server 'agent_router/suggest_agents_for_content'"
+      );
+    }
     const requestedGroupIds = auth.groupIds();
 
     const prodCredentials = await prodAPICredentialsForOwner(owner);

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -86,9 +86,9 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...(user
-            ? getHeaderFromUserId(user.sId)
-            : getHeaderFromGroupIds(requestedGroupIds)),
+          // TODO(x-dust-group-ids): return only if user is null after transition.
+          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...(user ? getHeaderFromUserId(user.sId) : {}),
         },
       },
       logger

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -18,6 +18,12 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
   list_all_published_agents: async (_, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
     const user = auth.user();
+    if (!user) {
+      logger.warn(
+        { workspaceId: owner },
+        "No user available in auth to call Front API from server 'agent_router/tools'"
+      );
+    }
     const requestedGroupIds = auth.groupIds();
 
     const prodCredentials = await prodAPICredentialsForOwner(owner);
@@ -26,9 +32,9 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...(user
-            ? getHeaderFromUserId(user.sId)
-            : getHeaderFromGroupIds(requestedGroupIds)),
+          // TODO(x-dust-group-ids): return only if user is null after transition.
+          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...(user ? getHeaderFromUserId(user.sId) : {}),
         },
       },
       logger

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -8,7 +8,7 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { getHeaderFromGroupIds } from "@app/types/groups";
+import { getHeaderFromGroupIds, getHeaderFromUserId } from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
 import { DustAPI } from "@dust-tt/client";
 
@@ -17,6 +17,7 @@ const MAX_INSTRUCTIONS_LENGTH = 1000;
 const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
   list_all_published_agents: async (_, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
+    const user = auth.user();
     const requestedGroupIds = auth.groupIds();
 
     const prodCredentials = await prodAPICredentialsForOwner(owner);
@@ -25,7 +26,9 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...(user
+            ? getHeaderFromUserId(user.sId)
+            : getHeaderFromGroupIds(requestedGroupIds)),
         },
       },
       logger
@@ -62,6 +65,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
 
   suggest_agents_for_content: async ({ userMessage }, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
+    const user = auth.user();
     const requestedGroupIds = auth.groupIds();
 
     const prodCredentials = await prodAPICredentialsForOwner(owner);
@@ -70,7 +74,9 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...(user
+            ? getHeaderFromUserId(user.sId)
+            : getHeaderFromGroupIds(requestedGroupIds)),
         },
       },
       logger

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -143,6 +143,12 @@ export default async function createServer(
         );
 
         const user = auth.user();
+        if (!user) {
+          logger.warn(
+            { workspaceId: owner },
+            "No user available in auth to call Front API from server 'run_dust_app'"
+          );
+        }
         const requestedGroupIds = auth.groupIds();
 
         const prodCredentials = await prodAPICredentialsForOwner(owner);
@@ -152,9 +158,9 @@ export default async function createServer(
           {
             ...prodCredentials,
             extraHeaders: {
-              ...(user
-                ? getHeaderFromUserId(user.sId)
-                : getHeaderFromGroupIds(requestedGroupIds)),
+              // TODO(x-dust-group-ids): return only if user is null after transition.
+              ...getHeaderFromGroupIds(requestedGroupIds),
+              ...(user ? getHeaderFromUserId(user.sId) : {}),
               ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
             },
           },

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -23,7 +23,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { getHeaderFromGroupIds, getHeaderFromRole } from "@app/types/groups";
+import {
+  getHeaderFromGroupIds,
+  getHeaderFromRole,
+  getHeaderFromUserId,
+} from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -138,6 +142,7 @@ export default async function createServer(
           auth
         );
 
+        const user = auth.user();
         const requestedGroupIds = auth.groupIds();
 
         const prodCredentials = await prodAPICredentialsForOwner(owner);
@@ -147,7 +152,9 @@ export default async function createServer(
           {
             ...prodCredentials,
             extraHeaders: {
-              ...getHeaderFromGroupIds(requestedGroupIds),
+              ...(user
+                ? getHeaderFromUserId(user.sId)
+                : getHeaderFromGroupIds(requestedGroupIds)),
               ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
             },
           },

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -90,6 +90,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       return new Err(new MCPError("User not found", { tracked: false }));
     }
 
+    const requestedGroupIds = auth.groupIds();
     const prodCredentials = await prodAPICredentialsForOwner(owner, {
       useLocalInDev: true,
     });
@@ -100,6 +101,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
+          // TODO(x-dust-group-ids): remove groupIds header after transition.
+          ...getHeaderFromGroupIds(requestedGroupIds),
           ...getHeaderFromUserId(user.sId),
           ...getHeaderFromUserEmail(user.email),
         },

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -12,7 +12,11 @@ import apiConfig from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import { getHeaderFromGroupIds, getHeaderFromUserId } from "@app/types/groups";
+import {
+  getHeaderFromGroupIds,
+  getHeaderFromUserEmail,
+  getHeaderFromUserId,
+} from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -12,7 +12,7 @@ import apiConfig from "@app/lib/api/config";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import { getHeaderFromGroupIds } from "@app/types/groups";
+import { getHeaderFromGroupIds, getHeaderFromUserId } from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
@@ -24,6 +24,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
         .map((action) => action.mcpServerViewId) ?? [];
 
     const owner = auth.getNonNullableWorkspace();
+    const user = auth.user();
     const requestedGroupIds = auth.groupIds();
     const prodCredentials = await prodAPICredentialsForOwner(owner, {
       useLocalInDev: true,
@@ -34,7 +35,9 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...(user
+            ? getHeaderFromUserId(user.sId)
+            : getHeaderFromGroupIds(requestedGroupIds)),
         },
       },
       logger,
@@ -87,7 +90,6 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       return new Err(new MCPError("User not found", { tracked: false }));
     }
 
-    const requestedGroupIds = auth.groupIds();
     const prodCredentials = await prodAPICredentialsForOwner(owner, {
       useLocalInDev: true,
     });
@@ -98,8 +100,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
-          "x-api-user-email": user.email,
+          ...getHeaderFromUserId(user.sId),
+          ...getHeaderFromUserEmail(user.email),
         },
       },
       logger,

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -12,7 +12,11 @@ import type {
   APIErrorWithStatusCode,
   WithAPIErrorResponse,
 } from "@app/types/error";
-import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
+import {
+  getGroupIdsFromHeaders,
+  getRoleFromHeaders,
+  getUserIdFromHeaders,
+} from "@app/types/groups";
 import { isString } from "@app/types/shared/utils/general";
 import { getUserEmailFromHeaders } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -414,7 +418,8 @@ export function withPublicAPIAuthentication<T>(
         keyRes.value,
         wId,
         getGroupIdsFromHeaders(req.headers),
-        getRoleFromHeaders(req.headers)
+        getRoleFromHeaders(req.headers),
+        getUserIdFromHeaders(req.headers)
       );
       let { workspaceAuth } = keyAndWorkspaceAuth;
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -417,7 +417,8 @@ export class Authenticator {
     key: KeyResource,
     wId: string,
     requestedGroupIds?: string[],
-    requestedRole?: RoleType
+    requestedRole?: RoleType,
+    userId?: string
   ): Promise<{
     workspaceAuth: Authenticator;
     keyAuth: Authenticator;
@@ -445,6 +446,7 @@ export class Authenticator {
 
     let keyGroups: GroupResource[] = [];
     let requestedGroups: GroupResource[] = [];
+    let userGroupModelIds: ModelId[] | null = null;
     let workspaceSubscription: SubscriptionResource | null = null;
     let keySubscription: SubscriptionResource | null = null;
 
@@ -453,7 +455,25 @@ export class Authenticator {
       const lightKeyWorkspace = renderLightWorkspaceType({
         workspace: keyWorkspace,
       });
-      if (requestedGroupIds && key.isSystem) {
+
+      // If a userId is provided with a system key, resolve the user's groups
+      // from the database instead of relying on the (potentially large)
+      // groupIds list.
+      const user =
+        userId && key.isSystem ? await UserResource.fetchById(userId) : null;
+      if (user) {
+        const result = await Authenticator.fetchRoleGroupsAndSubscription({
+          user,
+          workspace,
+        });
+        userGroupModelIds = result.role === "none" ? [] : result.groupModelIds;
+        keySubscription = result.subscription;
+        workspaceSubscription = isKeyWorkspace
+          ? keySubscription
+          : await SubscriptionResource.fetchActiveByWorkspaceModelId(
+              lightWorkspace.id
+            );
+      } else if (requestedGroupIds && key.isSystem) {
         [requestedGroups, keySubscription, workspaceSubscription] =
           await Promise.all([
             GroupResource.listGroupsWithSystemKey(key, requestedGroupIds),
@@ -491,13 +511,15 @@ export class Authenticator {
         workspaceSubscription = keySubscription;
       }
     }
-    const allGroups = requestedGroupIds ? requestedGroups : keyGroups;
+    const allGroupModelIds =
+      userGroupModelIds ??
+      (requestedGroupIds ? requestedGroups : keyGroups).map((g) => g.id);
 
     return {
       workspaceAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
         // If the key is associated with the workspace, we associate the groups.
-        groupModelIds: isKeyWorkspace ? allGroups.map((g) => g.id) : [],
+        groupModelIds: isKeyWorkspace ? allGroupModelIds : [],
         key: key.toAuthJSON(),
         role,
         subscription: workspaceSubscription,
@@ -505,7 +527,7 @@ export class Authenticator {
       }),
       keyAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
-        groupModelIds: allGroups.map((g) => g.id),
+        groupModelIds: allGroupModelIds,
         key: key.toAuthJSON(),
         role: "builder",
         subscription: keySubscription,
@@ -522,10 +544,12 @@ export class Authenticator {
   // sensitive operations related to secret validation and workspace access.
   static async fromRegistrySecret({
     groupIds,
+    userId,
     secret,
     workspaceId,
   }: {
     groupIds: string[];
+    userId?: string;
     secret: string;
     workspaceId: string;
   }) {
@@ -538,22 +562,37 @@ export class Authenticator {
       throw new Error(`Could not find workspace with sId ${workspaceId}`);
     }
 
-    // We use the system key for the workspace to fetch the groups.
-    const systemKeyForWorkspaceRes = await getOrCreateSystemApiKey(
-      renderLightWorkspaceType({ workspace })
-    );
-    if (systemKeyForWorkspaceRes.isErr()) {
-      throw new Error(`Could not get system key for workspace ${workspaceId}`);
-    }
+    let groupModelIds: ModelId[];
 
-    const groups = await GroupResource.listGroupsWithSystemKey(
-      systemKeyForWorkspaceRes.value,
-      groupIds
-    );
+    // If a userId is provided, resolve the user's groups from the database
+    // instead of relying on the (potentially large) groupIds list.
+    const user = userId ? await UserResource.fetchById(userId) : null;
+    if (user) {
+      const result = await Authenticator.fetchRoleGroupsAndSubscription({
+        user,
+        workspace,
+      });
+      groupModelIds = result.role === "none" ? [] : result.groupModelIds;
+    } else {
+      const systemKeyForWorkspaceRes = await getOrCreateSystemApiKey(
+        renderLightWorkspaceType({ workspace })
+      );
+      if (systemKeyForWorkspaceRes.isErr()) {
+        throw new Error(
+          `Could not get system key for workspace ${workspaceId}`
+        );
+      }
+
+      const groups = await GroupResource.listGroupsWithSystemKey(
+        systemKeyForWorkspaceRes.value,
+        groupIds
+      );
+      groupModelIds = groups.map((g) => g.id);
+    }
 
     return new Authenticator({
       authMethod: "internal",
-      groupModelIds: groups.map((g) => g.id),
+      groupModelIds,
       role: "builder",
       subscription: null,
       workspace,

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -8,6 +8,7 @@ import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { CoreAPISearchFilter } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { getUserIdFromHeaders } from "@app/types/groups";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -75,6 +76,7 @@ async function handler(
   }
 
   const dustGroupIds = rawDustGroupIds.split(",");
+  const dustUserId = getUserIdFromHeaders(req.headers);
 
   // by default, data sources from the "conversations" space are not allowed
   // except for our packaged dust-apps called internally, see
@@ -106,6 +108,7 @@ async function handler(
 
           const auth = await Authenticator.fromRegistrySecret({
             groupIds: dustGroupIds,
+            userId: dustUserId,
             secret,
             workspaceId: userWorkspaceId,
           });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -339,7 +339,8 @@ async function handler(
           secrets,
           isSystemKey: auth.isSystemKey(),
           storeBlocksResults,
-        }
+        },
+        auth.user()?.sId
       );
 
       if (runRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -329,7 +329,6 @@ async function handler(
         owner,
         keyWorkspaceFlags,
         auth.groupIds(),
-        auth.user()?.sId,
         {
           projectId: app.dustAPIProjectId,
           runType: "deploy",
@@ -340,7 +339,8 @@ async function handler(
           secrets,
           isSystemKey: auth.isSystemKey(),
           storeBlocksResults,
-        }
+        },
+        auth.user()?.sId
       );
 
       if (runRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -329,6 +329,7 @@ async function handler(
         owner,
         keyWorkspaceFlags,
         auth.groupIds(),
+        auth.user()?.sId,
         {
           projectId: app.dustAPIProjectId,
           runType: "deploy",
@@ -339,8 +340,7 @@ async function handler(
           secrets,
           isSystemKey: auth.isSystemKey(),
           storeBlocksResults,
-        },
-        auth.user()?.sId
+        }
       );
 
       if (runRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -340,7 +340,7 @@ async function handler(
           isSystemKey: auth.isSystemKey(),
           storeBlocksResults,
         },
-        auth.user()?.sId
+        auth.user()?.toJSON()
       );
 
       if (runRes.isErr()) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -145,7 +145,8 @@ async function handler(
           credentials: credentialsFromProviders(providers),
           secrets,
           storeBlocksResults,
-        }
+        },
+        auth.user()?.sId
       );
 
       if (dustRun.isErr()) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -133,7 +133,7 @@ async function handler(
         owner,
         keyWorkspaceFlags,
         auth.groupIds(),
-        auth.user().sId,
+        user.sId,
         {
           projectId: app.dustAPIProjectId,
           runType: "local",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -133,7 +133,7 @@ async function handler(
         owner,
         keyWorkspaceFlags,
         auth.groupIds(),
-        user.sId,
+        user.toJSON(),
         {
           projectId: app.dustAPIProjectId,
           runType: "local",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -133,6 +133,7 @@ async function handler(
         owner,
         keyWorkspaceFlags,
         auth.groupIds(),
+        auth.user().sId,
         {
           projectId: app.dustAPIProjectId,
           runType: "local",
@@ -145,8 +146,7 @@ async function handler(
           credentials: credentialsFromProviders(providers),
           secrets,
           storeBlocksResults,
-        },
-        auth.user()?.sId
+        }
       );
 
       if (dustRun.isErr()) {

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -516,7 +516,8 @@ export class CoreAPI {
       secrets,
       isSystemKey,
       storeBlocksResults = true,
-    }: CoreAPICreateRunParams
+    }: CoreAPICreateRunParams,
+    userId?: string
   ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(projectId)}/runs`,
@@ -525,9 +526,11 @@ export class CoreAPI {
         headers: {
           "Content-Type": "application/json",
           "X-Dust-Feature-Flags": featureFlags.join(","),
+          // TODO(x-dust-group-ids): remove once all receivers use X-Dust-User-Id.
           "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
+          ...(userId ? { "X-Dust-User-Id": userId } : {}),
         },
         body: JSON.stringify({
           run_type: runType,
@@ -562,7 +565,8 @@ export class CoreAPI {
       secrets,
       isSystemKey,
       storeBlocksResults = true,
-    }: CoreAPICreateRunParams
+    }: CoreAPICreateRunParams,
+    userId?: string
   ): Promise<
     CoreAPIResponse<{
       chunkStream: AsyncGenerator<Uint8Array, void, unknown>;
@@ -576,9 +580,11 @@ export class CoreAPI {
         headers: {
           "Content-Type": "application/json",
           "X-Dust-Feature-Flags": featureFlags.join(","),
+          // TODO(x-dust-group-ids): remove once all receivers use X-Dust-User-Id.
           "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
+          ...(userId ? { "X-Dust-User-Id": userId } : {}),
         },
         body: JSON.stringify({
           run_type: runType,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -31,7 +31,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
 import type { TokenizerConfig } from "@app/types/tokenizer";
-import type { LightWorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { createParser } from "eventsource-parser";
 import * as t from "io-ts";
 import chunk from "lodash/chunk";
@@ -505,7 +505,7 @@ export class CoreAPI {
     featureFlags: WhitelistableFeature[],
     // TODO(x-dust-group-ids): remove groupIds once all receivers use X-Dust-User-Id.
     groupIds: string[],
-    userId: string,
+    user: UserType,
     {
       projectId,
       runType,
@@ -531,7 +531,7 @@ export class CoreAPI {
           "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
-          "X-Dust-User-Id": userId,
+          "X-Dust-User-Id": user.sId,
         },
         body: JSON.stringify({
           run_type: runType,
@@ -568,7 +568,7 @@ export class CoreAPI {
       isSystemKey,
       storeBlocksResults = true,
     }: CoreAPICreateRunParams,
-    userId?: string
+    user?: UserType
   ): Promise<
     CoreAPIResponse<{
       chunkStream: AsyncGenerator<Uint8Array, void, unknown>;
@@ -586,7 +586,7 @@ export class CoreAPI {
           "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
-          ...(userId ? { "X-Dust-User-Id": userId } : {}),
+          ...(user ? { "X-Dust-User-Id": user.sId } : {}),
         },
         body: JSON.stringify({
           run_type: runType,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -503,7 +503,9 @@ export class CoreAPI {
   async createRun(
     workspace: LightWorkspaceType,
     featureFlags: WhitelistableFeature[],
+    // TODO(x-dust-group-ids): remove groupIds once all receivers use X-Dust-User-Id.
     groupIds: string[],
+    userId: string,
     {
       projectId,
       runType,
@@ -516,8 +518,7 @@ export class CoreAPI {
       secrets,
       isSystemKey,
       storeBlocksResults = true,
-    }: CoreAPICreateRunParams,
-    userId?: string
+    }: CoreAPICreateRunParams
   ): Promise<CoreAPIResponse<{ run: CoreAPIRun }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(projectId)}/runs`,
@@ -552,7 +553,9 @@ export class CoreAPI {
   async createRunStream(
     workspace: LightWorkspaceType,
     featureFlags: WhitelistableFeature[],
+    // TODO(x-dust-group-ids): remove once all receivers use X-Dust-User-Id.
     groupIds: string[],
+    userId?: string,
     {
       projectId,
       runType,
@@ -565,8 +568,7 @@ export class CoreAPI {
       secrets,
       isSystemKey,
       storeBlocksResults = true,
-    }: CoreAPICreateRunParams,
-    userId?: string
+    }: CoreAPICreateRunParams
   ): Promise<
     CoreAPIResponse<{
       chunkStream: AsyncGenerator<Uint8Array, void, unknown>;

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -531,7 +531,7 @@ export class CoreAPI {
           "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
-          ...(userId ? { "X-Dust-User-Id": userId } : {}),
+          "X-Dust-User-Id": userId,
         },
         body: JSON.stringify({
           run_type: runType,
@@ -555,7 +555,6 @@ export class CoreAPI {
     featureFlags: WhitelistableFeature[],
     // TODO(x-dust-group-ids): remove once all receivers use X-Dust-User-Id.
     groupIds: string[],
-    userId?: string,
     {
       projectId,
       runType,
@@ -568,7 +567,8 @@ export class CoreAPI {
       secrets,
       isSystemKey,
       storeBlocksResults = true,
-    }: CoreAPICreateRunParams
+    }: CoreAPICreateRunParams,
+    userId?: string
   ): Promise<
     CoreAPIResponse<{
       chunkStream: AsyncGenerator<Uint8Array, void, unknown>;

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -162,6 +162,17 @@ export function getHeaderFromUserId(userId: string | undefined) {
   };
 }
 
+const DustUserEmailHeader = "X-Api-User-Email";
+
+export function getHeaderFromUserEmail(email: string | undefined) {
+  if (!email) {
+    return undefined;
+  }
+  return {
+    [DustUserEmailHeader]: email,
+  };
+}
+
 export const AGENT_GROUP_PREFIX = "Group for Agent";
 export const SKILL_GROUP_PREFIX = "Group for Skill";
 export const SPACE_GROUP_PREFIX = "Group for space";


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/6555

Using group ids is an issue because it can become too large

This PR uses the user id to recomput the group ids instead of passing them.

There is already a header existing with the email, but this behave differently as it create a user auth which is not possible to use when using auth fromRegistrySecret, so not possible for the FRONT -> CORE -> FRONT authentication

For MCP we can chose between using this new header and using the email one. I have used the new user id one to do minimal change compare to what was done before.

This PR must be followed by another one to stop sending the groupd ids in the front -> core -> front exchange when they all support user ids

## Tests

TODO: manual tests

## Risk

Large blast radius here, -we don't want to break the auth

## Deploy Plan

deploy core and deploy front: everything is backrd compatible
