### PR TITLE
[connectors] perf: speed up connector fetch

### DIFF
--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -2,7 +2,6 @@ import {
   GithubDiscussionModel,
   GithubIssueModel,
 } from "@connectors/lib/models/github";
-import { NotionPageModel } from "@connectors/lib/models/notion";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type {
@@ -39,7 +38,7 @@ const _getConnector = async (
     });
   }
 
-  let firstSyncProgress = connector.firstSyncProgress;
+  let { firstSyncProgress } = connector;
 
   if (!firstSyncProgress) {
     switch (connector.type) {
@@ -57,15 +56,6 @@ const _getConnector = async (
           }),
         ]);
         firstSyncProgress = `${issues} issues, ${discussions} discussions`;
-        break;
-      }
-      case "notion": {
-        const c = await NotionPageModel.count({
-          where: {
-            connectorId: connector.id,
-          },
-        });
-        firstSyncProgress = `${c} pages`;
         break;
       }
     }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6704.
- This PR improves the performances of the GET `/connectors/:cId` route, specifically for Notion connectors.
- This route is called when visiting Spaces > Connections via the `/api/w/[wId]/spaces/[spaceId]/data_source_views` endpoint.
- It sometimes takes over 15s ([example trace](https://app.datadoghq.eu/apm/traces?query=%40next.page%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Fspaces%2F%5BspaceId%5D%2Fdata_source_views%22%20%40service%3Afront&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=5511602993932219899&spanType=all&spanViewType=errors&storage=hot&target-span=a&timeHint=1771594971958&tq_query_translation_version=v0&trace=AwAAAZx7Sfs2ohKY0wAAABhBWng3U2dHZEFBQUNHZ2ltSS1NRjVDUkUAAAAkMTE5YzdiNGUtOGQ1MS00NzI0LTk1YjEtODY4MDRhNGJlYzMyAALreQ&traceID=699864c80000000044248273c5b0e82e&traceQuery=a&view=spans&viz=stream&start=1771600002090&end=1771614402090&paused=false)).
- It removes the query that counts all Notion pages for the connector, which was used to populate the chip in the `Last sync` column. New behavior is to see the date of the last sync (e.g. `<1min`). If we think we do need it we can have the connector report its status and fill the column on the `connectors` table (semi-heavy to do as it requires patching the workflow).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
