### PR TITLE
[front] - fix(analytics): active members computation

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -531,8 +531,65 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
+  /**
+   * Computes the number of active members at each given timestamp (end of day).
+   * Fetches all memberships overlapping the date range in a single query,
+   * then counts distinct users in-memory for each day.
+   */
+  static async countActiveMembersPerDay({
+    workspace,
+    timestampsMs,
+  }: {
+    workspace: LightWorkspaceType;
+    timestampsMs: readonly number[];
+  }): Promise<Map<number, number>> {
+    const result = new Map<number, number>();
+    if (timestampsMs.length === 0) {
+      return result;
+    }
+
+    const sorted = [...timestampsMs].sort((a, b) => a - b);
+    const rangeStartDate = new Date(sorted[0]);
+    // Use end of day for the last timestamp to capture the full day.
+    const rangeEndDate = new Date(sorted[sorted.length - 1]);
+    rangeEndDate.setUTCHours(23, 59, 59, 999);
+
+    // Fetch all memberships that overlap with [rangeStart, rangeEnd]:
+    // startAt <= rangeEnd AND (endAt IS NULL OR endAt >= rangeStart).
+    // Include userId to deduplicate users with multiple membership records.
+    const memberships = await MembershipModel.findAll({
+      attributes: ["userId", "startAt", "endAt"],
+      where: {
+        workspaceId: workspace.id,
+        startAt: { [Op.lte]: rangeEndDate },
+        endAt: {
+          [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: rangeStartDate }],
+        },
+      },
+    });
+
+    // O(timestamps x memberships) -- acceptable: timestamps is bounded by the
+    // analytics period (typically <= 90 days) and memberships by workspace size
+    // (typically < 5000). Use a Set to count distinct users per day.
+    for (const ts of timestampsMs) {
+      const dayEnd = new Date(ts);
+      dayEnd.setUTCHours(23, 59, 59, 999);
+      const dayStart = new Date(ts);
+      const activeUserIds = new Set<number>();
+      for (const m of memberships) {
+        if (m.startAt <= dayEnd && (!m.endAt || m.endAt >= dayStart)) {
+          activeUserIds.add(m.userId);
+        }
+      }
+      result.set(ts, activeUserIds.size);
+    }
+
+    return result;
+  }
+
   private static readonly SEATS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
+  // Seat counting with caching - used to track active seats in a workspace
   private static readonly seatsCacheKeyResolver = (workspaceId: string) =>
     `count-active-seats-in-workspace:${workspaceId}`;
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -575,6 +575,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       const dayEnd = new Date(ts);
       dayEnd.setUTCHours(23, 59, 59, 999);
       const dayStart = new Date(ts);
+      dayStart.setUTCHours(0, 0, 0, 0);
       const activeUserIds = new Set<number>();
       for (const m of memberships) {
         if (m.startAt <= dayEnd && (!m.endAt || m.endAt >= dayStart)) {

--- a/front/pages/api/w/[wId]/analytics/active-users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users-export.ts
@@ -43,7 +43,7 @@ async function handler(
 
       const owner = auth.getNonNullableWorkspace();
 
-      const result = await fetchActiveUsersMetrics(owner.sId, q.data.days);
+      const result = await fetchActiveUsersMetrics(owner, q.data.days);
 
       if (result.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/analytics/active-users.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users.ts
@@ -48,7 +48,7 @@ async function handler(
       const { days } = q.data;
       const owner = auth.getNonNullableWorkspace();
 
-      const result = await fetchActiveUsersMetrics(owner.sId, days);
+      const result = await fetchActiveUsersMetrics(owner, days);
 
       if (result.isErr()) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

This PR fixes the active users metrics computation by moving the member count directly into each data point rather than using a single static `totalMembers` value. Previously, the chart fetched `totalMembers` from the workspace analytics overview endpoint and applied it uniformly across all time periods. This caused inaccurate percentage calculations for historical data where the actual member count was different. The new implementation introduces `MembershipResource.countActiveMembersPerDay()` to compute the correct member count for each timestamp. DAU, WAU, and MAU percentages are now calculated against the actual member count for each day.

## Risk

Low. Modifies how member counts are fetched but doesn't change the chart structure or existing endpoints.

## Tests

- [x] Locally
- [ ] front-edge

## Deploy Plan

Deploy front