### PR TITLE
[connectors] enh(Gong): improve typing

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -120,7 +120,7 @@ const GongTranscriptMetadataWithoutTrackersCodec = t.intersection([
         title: t.string,
         media: t.union([t.literal("Video"), t.literal("Audio")]),
         language: t.string, // The language codes (as defined by ISO-639-2B): eng, fre, spa, ger, and ita.
-        isPrivate: t.union([t.boolean, t.undefined]), // Whether the call is marked as private in Gong.
+        isPrivate: t.boolean, // Whether the call is marked as private in Gong.
       }),
       CatchAllCodec,
     ]),


### PR DESCRIPTION
## Description

- This PR improves the typing to flag the `isPrivate` field of call transcript metadata as mandatory.
- True on our workspace, easy to revert if untrue on other workspaces.
- Also updates the script used to backfill existing connectors to allow running on all connectors + check for missing transcripts.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
