### PR TITLE
Simplified onCancel

### DIFF
--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -273,8 +273,6 @@ export function useAppRouter(): AppRouter {
   // In SPA mode, router is always ready (no SSR hydration needed)
   const isReady = true;
 
-  const beforePopState = useCallback(() => {}, []);
-
   return useMemo(
     () => ({
       push,
@@ -286,11 +284,8 @@ export function useAppRouter(): AppRouter {
       query,
       isReady,
       events: routerEvents,
-      // beforePopState is a noop in SPA mode (not supported in React Router)
-      // TODO: Check usage in AppContentLayout and remove it.
-      beforePopState,
     }),
-    [push, replace, back, reload, pathname, search, hash, query, beforePopState]
+    [push, replace, back, reload, pathname, search, hash, query]
   );
 }
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -39,7 +39,6 @@ import type {
   AdditionalConfigurationInBuilderType,
   BuilderAction,
 } from "@app/components/shared/tools_picker/types";
-import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -53,6 +52,7 @@ import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr/assistants";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -500,8 +500,12 @@ export default function AgentBuilder({
     void form.handleSubmit(handleSubmit, handleFormErrors)();
   };
 
-  const handleCancel = async () => {
-    await appLayoutBack(owner, router);
+  const handleCancel = () => {
+    if (window.history.state?.idx > 0) {
+      router.back();
+    } else {
+      void router.replace(getConversationRoute(owner.sId));
+    }
   };
 
   const { isDirty, isSubmitting } = form.formState;
@@ -566,7 +570,7 @@ interface AgentBuilderContentProps {
   agentConfiguration?: LightAgentConfigurationType;
   pendingAgentId: string | null;
   title: string;
-  handleCancel: () => Promise<void>;
+  handleCancel: () => void;
   saveLabel: string;
   handleSave: () => void;
   isSaveDisabled: boolean;

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -1,7 +1,6 @@
 import { AgentTemplateGrid } from "@app/components/agent_builder/AgentTemplateGrid";
 import { AgentTemplateModal } from "@app/components/agent_builder/AgentTemplateModal";
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
-import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import {
   useSetContentWidth,
   useSetHideSidebar,
@@ -13,7 +12,10 @@ import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { getAgentBuilderRoute } from "@app/lib/utils/router";
+import {
+  getAgentBuilderRoute,
+  getConversationRoute,
+} from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
 import {
@@ -111,12 +113,16 @@ export function CreateAgentPage() {
     () => (
       <AppLayoutSimpleCloseTitle
         title="Create an Agent"
-        onClose={async () => {
-          await appLayoutBack(owner, router);
+        onClose={() => {
+          if (window.history.state?.idx > 0) {
+            router.back();
+          } else {
+            void router.replace(getConversationRoute(owner.sId));
+          }
         }}
       />
     ),
-    [owner, router]
+    [owner.sId, router]
   );
 
   useSetContentWidth("centered");

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -15,12 +15,12 @@ import {
 } from "@app/components/skill_builder/skillFormData";
 import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkillBuilderForm";
 import { ExtendedSkillBadge } from "@app/components/skills/ExtendedSkillBadge";
-import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useAppRouter } from "@app/lib/platform";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
+import { getConversationRoute } from "@app/lib/utils/router";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
   BarFooter,
@@ -131,8 +131,12 @@ export default function SkillBuilder({
     setIsSaving(false);
   };
 
-  const handleCancel = async () => {
-    await appLayoutBack(owner, router);
+  const handleCancel = () => {
+    if (window.history.state?.idx > 0) {
+      router.back();
+    } else {
+      void router.replace(getConversationRoute(owner.sId));
+    }
   };
 
   const handleSave = () => {

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -5,45 +5,10 @@ import { useAppLayout } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import type { AppRouter } from "@app/lib/platform";
 import { Head } from "@app/lib/platform";
-import { getConversationRoute } from "@app/lib/utils/router";
-import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { cn } from "@dust-tt/sparkle";
 import React from "react";
-
-// This function is used to navigate back to the previous page (eg modal like page close) and
-// fallback to the landing if we linked directly to that modal.
-export const appLayoutBack = async (
-  owner: WorkspaceType,
-  router: AppRouter
-) => {
-  // TODO(2024-02-08 flav) Remove once internal router is in better shape. Opening a new tab/window
-  // counts the default page as an entry in the history stack, leading to a history length of 2.
-  // Directly opening a link without the "new tab" page results in a history length of 1.
-  if (window.history.length < 3) {
-    await router.push(getConversationRoute(owner.sId));
-  } else {
-    // Set up beforePopState to intercept the back navigation and clean query params.
-    router.beforePopState(({ as }) => {
-      // Parse the destination URL that router.back() would navigate to.
-      const urlObj = new URL(as, window.location.origin);
-      // Remove agentDetails query parameter from the destination URL.
-      urlObj.searchParams.delete("agentDetails");
-
-      // Reconstruct the cleaned URL.
-      const cleanedUrl = urlObj.pathname + urlObj.search;
-
-      // Navigate to the cleaned URL instead of the original back destination.
-      void router.push(cleanedUrl);
-      return false; // Prevent the default back navigation to allow our custom navigation.
-    });
-
-    // Trigger the back navigation, which will be intercepted by beforePopState.
-    router.back();
-  }
-};
 
 interface AppContentLayoutProps {
   children: React.ReactNode;

--- a/front/lib/platform/next.tsx
+++ b/front/lib/platform/next.tsx
@@ -29,7 +29,6 @@ export function useAppRouter(): AppRouter {
       query: router.query as Record<string, string | string[] | undefined>,
       isReady: router.isReady,
       events: router.events,
-      beforePopState: router.beforePopState,
     }),
     [router]
   );

--- a/front/lib/platform/types.ts
+++ b/front/lib/platform/types.ts
@@ -64,9 +64,6 @@ export interface AppRouter {
   query: Record<string, string | string[] | undefined>;
   isReady: boolean;
   events: RouterEvents;
-  beforePopState: (
-    cb: (state: { url: string; as: string; options: unknown }) => boolean
-  ) => void;
 }
 
 /**


### PR DESCRIPTION
## Description

Remove `appLayoutBack` — a Next.js-specific helper that relied on `beforePopState` (Pages Router API) and a fragile `window.history.length` heuristic to navigate back from builder pages.

Replace with a simpler approach using React Router's `window.history.state.idx` to reliably detect whether there's a page to go back to:
- If `idx > 0`: `router.back()` (go back in history)
- Otherwise: `router.replace(getConversationRoute(...))` (fallback to conversations without adding history)

Also removes `beforePopState` from the `AppRouter` interface and both platform implementations (Next.js and SPA).

## Tests

Manual — cancel/close on agent builder, skill builder, and create agent pages.

## Risk

Low — replaces unreliable heuristic with a reliable one. Fallback to conversations page if no history.

## Deploy Plan

Standard deploy, no special steps needed.