### PR TITLE
Handle multi region lookup for viz

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -47,6 +47,7 @@ import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import config from "@app/lib/api/config";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -894,6 +895,7 @@ function AgentMessageContent({
     VirtuosoMessageListContext
   >();
 
+  const { vizUrl } = useAuth();
   const { sId, configuration: agentConfiguration } = agentMessage;
 
   const { postFollowUp } = usePostOnboardingFollowUp({
@@ -968,7 +970,8 @@ function AgentMessageContent({
         owner,
         agentConfiguration.sId,
         conversationId,
-        sId
+        sId,
+        vizUrl
       ),
       sup: CiteBlock,
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
@@ -980,6 +983,7 @@ function AgentMessageContent({
       conversationId,
       sId,
       agentConfiguration.sId,
+      vizUrl,
       onQuickReplySend,
       isLastMessage,
       handleToolSetupComplete,

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,6 +1,5 @@
 import { useVisualizationRetry } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
-import config from "@app/lib/api/config";
 import { clientFetch } from "@app/lib/egress/client";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
@@ -238,6 +237,7 @@ interface VisualizationActionIframeProps {
   conversationId: string | null;
   isInDrawer?: boolean;
   visualization: Visualization;
+  vizUrl: string;
   workspaceId: string;
   isPublic?: boolean;
 }
@@ -347,8 +347,8 @@ export const VisualizationActionIframe = forwardRef<
       params.set("fullHeight", "true");
     }
 
-    return `${config.getClientFacingVizUrl()}/content?${params.toString()}`;
-  }, [visualization, isInDrawer]);
+    return `${props.vizUrl}/content?${params.toString()}`;
+  }, [visualization, isInDrawer, props.vizUrl]);
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -9,6 +9,7 @@ import { useVisualizationRevert } from "@app/hooks/conversations";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
@@ -192,6 +193,7 @@ export function FrameRenderer({
   lastEditedByAgentConfigurationId,
   contentHash,
 }: FrameRendererProps) {
+  const { vizUrl } = useAuth();
   const { isNavigationBarOpen, setIsNavigationBarOpen } =
     useDesktopNavigation();
   const [isLoading, setIsLoading] = useState(false);
@@ -363,6 +365,7 @@ export function FrameRenderer({
                   .lastEditedByAgentConfigurationId ?? ""
               }
               workspaceId={owner.sId}
+              vizUrl={vizUrl}
               visualization={{
                 code: fileContent ?? "",
                 complete: true,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -15,6 +15,7 @@ interface PublicFrameRendererProps {
   fileName?: string;
   shareToken: string;
   workspaceId: string;
+  vizUrl: string;
 }
 
 export function PublicFrameRenderer({
@@ -22,6 +23,7 @@ export function PublicFrameRenderer({
   fileName,
   shareToken,
   workspaceId,
+  vizUrl,
 }: PublicFrameRendererProps) {
   const { conversationUrl, isFrameLoading, error, accessToken } =
     usePublicFrame({
@@ -69,6 +71,7 @@ export function PublicFrameRenderer({
             agentConfigurationId={null}
             conversationId={null}
             workspaceId={workspaceId}
+            vizUrl={vizUrl}
             visualization={{
               accessToken,
               complete: true,

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@dust-tt/sparkle";
 interface PublicInteractiveContentContainerProps {
   shareToken: string;
   workspaceId: string;
+  vizUrl: string;
 }
 
 /**
@@ -18,6 +19,7 @@ interface PublicInteractiveContentContainerProps {
 export function PublicInteractiveContentContainer({
   shareToken,
   workspaceId,
+  vizUrl,
 }: PublicInteractiveContentContainerProps) {
   const { frameMetadata, isFrameLoading, error } = usePublicFrame({
     shareToken,
@@ -45,6 +47,7 @@ export function PublicInteractiveContentContainer({
             fileName={frameMetadata.fileName}
             shareToken={shareToken}
             workspaceId={workspaceId}
+            vizUrl={vizUrl}
           />
         );
 

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -54,13 +54,15 @@ export function getVisualizationPlugin(
   owner: LightWorkspaceType,
   agentConfigurationId: string,
   conversationId: string,
-  messageId: string
+  messageId: string,
+  vizUrl: string
 ) {
   const customRenderer = {
     visualization: (code: string, complete: boolean, lineStart: number) => {
       return (
         <VisualizationActionIframe
           workspaceId={owner.sId}
+          vizUrl={vizUrl}
           visualization={{
             code,
             complete,

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -88,6 +88,7 @@ export function SharedFramePage() {
         <PublicInteractiveContentContainer
           shareToken={token}
           workspaceId={shareMetadata.workspaceId}
+          vizUrl={shareMetadata.vizUrl}
         />
       </div>
     </>

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -23,16 +23,6 @@ const config = {
     return baseUrlResolver?.() || config.getClientFacingUrl();
   },
 
-  getClientFacingVizUrl: (): string | undefined => {
-    const baseUrl = getBaseUrlFromResolver();
-    if (baseUrl) {
-      // Derive viz URL from the resolver's base URL (e.g. https://eu.dust.tt -> https://eu.viz.dust.tt).
-      return baseUrl.replace("dust.tt", "viz.dust.tt");
-    }
-
-    return process.env.NEXT_PUBLIC_VIZ_URL;
-  },
-
   getClientFacingUrl: (): string => {
     // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the
     // uploadUrl returned by the file API points to the `http://front-internal-service` and not our
@@ -297,8 +287,8 @@ const config = {
     return EnvironmentConfig.getOptionalEnvVariable("DOCUMENT_RENDERER_URL");
   },
   // Public viz URL (used by Gotenberg which routes through egress proxy).
-  getVizPublicUrl: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("VIZ_PUBLIC_URL");
+  getVizPublicUrl: (): string => {
+    return EnvironmentConfig.getEnvVariable("VIZ_PUBLIC_URL");
   },
   // Status page.
   getStatusPageProvidersPageId: (): string => {

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -10,6 +10,8 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type {
   InvitationsLookupRequestBodyType,
   InvitationsLookupResponse,
+  ShareTokenLookupRequestBodyType,
+  ShareTokenLookupResponse,
   UserLookupRequestBodyType,
   UserLookupResponse,
   WorkspaceLookupRequestBodyType,
@@ -272,6 +274,34 @@ export async function fetchInvitationsFromOtherRegion(
     return new Ok(invitations);
   } catch (err) {
     return new Err(normalizeError(err));
+  }
+}
+
+export async function lookupShareToken(
+  token: string
+): Promise<Result<RegionType | null, Error>> {
+  const { url, name } = config.getOtherRegionInfo();
+  const body: ShareTokenLookupRequestBodyType = { token };
+
+  try {
+    // eslint-disable-next-line no-restricted-globals
+    const otherRegionResponse = await fetch(`${url}/api/lookup/share-token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.getLookupApiSecret()}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data: ShareTokenLookupResponse = await otherRegionResponse.json();
+    if (isAPIErrorResponse(data)) {
+      return new Err(new Error(data.error.message));
+    }
+
+    return new Ok(data.exists ? name : null);
+  } catch (error) {
+    return new Err(normalizeError(error));
   }
 }
 

--- a/front/lib/auth/AuthContext.tsx
+++ b/front/lib/auth/AuthContext.tsx
@@ -10,6 +10,7 @@ export interface AuthContextValue {
   subscription: SubscriptionType;
   isAdmin: boolean;
   isBuilder: boolean;
+  vizUrl: string;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/front/lib/auth/appServerSideProps.ts
+++ b/front/lib/auth/appServerSideProps.ts
@@ -56,6 +56,7 @@ export const appGetServerSideProps =
           user: auth.getNonNullableUser().toJSON(),
           isAdmin: auth.isAdmin(),
           isBuilder: auth.isBuilder(),
+          vizUrl: config.getVizPublicUrl(),
         },
       }
     );
@@ -79,6 +80,7 @@ export const appGetServerSidePropsForBuilders =
           user: auth.getNonNullableUser().toJSON(),
           isAdmin: auth.isAdmin(),
           isBuilder: auth.isBuilder(),
+          vizUrl: config.getVizPublicUrl(),
         },
       }
     );
@@ -102,6 +104,7 @@ export const appGetServerSidePropsForAdmin =
           user: auth.getNonNullableUser().toJSON(),
           isAdmin: auth.isAdmin(),
           isBuilder: auth.isBuilder(),
+          vizUrl: config.getVizPublicUrl(),
         },
       }
     );
@@ -126,6 +129,7 @@ export const appGetServerSidePropsPaywallWhitelisted =
             user: auth.getNonNullableUser().toJSON(),
             isAdmin: auth.isAdmin(),
             isBuilder: auth.isBuilder(),
+            vizUrl: config.getVizPublicUrl(),
           },
         }
       );
@@ -151,6 +155,7 @@ export const appGetServerSidePropsPaywallWhitelistedForAdmin =
             user: auth.getNonNullableUser().toJSON(),
             isAdmin: auth.isAdmin(),
             isBuilder: auth.isBuilder(),
+            vizUrl: config.getVizPublicUrl(),
           },
         }
       );

--- a/front/lib/auth/pokeServerSideProps.ts
+++ b/front/lib/auth/pokeServerSideProps.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import type {
   AuthContextNoWorkspaceValue,
   AuthContextValue,
@@ -35,6 +36,7 @@ export const pokeGetServerSideProps =
         user: auth.getNonNullableUser().toJSON(),
         isAdmin: auth.isAdmin(),
         isBuilder: auth.isBuilder(),
+        vizUrl: config.getVizPublicUrl(),
       },
     };
   });

--- a/front/lib/swr/share.ts
+++ b/front/lib/swr/share.ts
@@ -1,5 +1,8 @@
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetShareFrameMetadataResponseBody } from "@app/pages/api/share/frame/[token]";
+import { useEffect } from "react";
 import type { Fetcher } from "swr";
 
 export function useShareFrameMetadata({
@@ -10,10 +13,11 @@ export function useShareFrameMetadata({
   const { fetcher } = useFetcher();
   const shareMetadataFetcher: Fetcher<GetShareFrameMetadataResponseBody> =
     fetcher;
+  const regionContext = useRegionContextSafe();
 
   const swrKey = shareToken ? `/api/share/frame/${shareToken}` : null;
 
-  const { data, error, isLoading } = useSWRWithDefaults(
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
     swrKey,
     shareMetadataFetcher,
     {
@@ -22,9 +26,25 @@ export function useShareFrameMetadata({
     }
   );
 
+  const isRegionRedirectResponse = error && isRegionRedirect(error.error);
+  const regionRedirect = isRegionRedirectResponse
+    ? error.error.redirect
+    : undefined;
+
+  // Handle region redirect.
+  useEffect(() => {
+    if (regionRedirect && regionContext) {
+      regionContext.setRegionInfo({
+        name: regionRedirect.region,
+        url: regionRedirect.url,
+      });
+      void mutate();
+    }
+  }, [regionRedirect, mutate, regionContext]);
+
   return {
-    shareMetadata: data,
-    isShareMetadataLoading: isLoading,
-    shareMetadataError: error,
+    shareMetadata: isRegionRedirectResponse ? undefined : data,
+    isShareMetadataLoading: isLoading || !!isRegionRedirectResponse,
+    shareMetadataError: isRegionRedirectResponse ? undefined : error,
   };
 }

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -5,6 +5,7 @@ import {
   hasEmailLocalRegionAffinity,
 } from "@app/lib/api/regions/lookup";
 import { getBearerToken } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
@@ -28,6 +29,10 @@ export type InvitationsLookupResponse = {
   pendingInvitations: PendingInvitationOption[];
 };
 
+export type ShareTokenLookupResponse = {
+  exists: boolean;
+};
+
 const ExternalUserCodec = t.type({
   email: t.string,
   email_verified: t.boolean,
@@ -36,7 +41,8 @@ const ExternalUserCodec = t.type({
 type LookupResponseBody =
   | UserLookupResponse
   | WorkspaceLookupResponse
-  | InvitationsLookupResponse;
+  | InvitationsLookupResponse
+  | ShareTokenLookupResponse;
 
 const UserLookupSchema = t.type({
   user: ExternalUserCodec,
@@ -50,6 +56,10 @@ const InvitationsLookupSchema = t.type({
   email: t.string,
 });
 
+const ShareTokenLookupSchema = t.type({
+  token: t.string,
+});
+
 export type UserLookupRequestBodyType = t.TypeOf<typeof UserLookupSchema>;
 
 export type WorkspaceLookupRequestBodyType = t.TypeOf<
@@ -60,10 +70,15 @@ export type InvitationsLookupRequestBodyType = t.TypeOf<
   typeof InvitationsLookupSchema
 >;
 
+export type ShareTokenLookupRequestBodyType = t.TypeOf<
+  typeof ShareTokenLookupSchema
+>;
+
 const ResourceType = t.union([
   t.literal("user"),
   t.literal("workspace"),
   t.literal("invitations"),
+  t.literal("share-token"),
 ]);
 
 async function handler(
@@ -120,7 +135,7 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message:
-          "Invalid resource type. Must be 'user', 'workspace', or 'invitations'",
+          "Invalid resource type. Must be 'user', 'workspace', 'invitations', or 'share-token'",
       },
     });
   }
@@ -183,6 +198,28 @@ async function handler(
           });
         }
         response = await handleLookupInvitations(bodyValidation.right.email);
+      }
+      break;
+
+    case "share-token":
+      {
+        const bodyValidation = ShareTokenLookupSchema.decode(req.body);
+        if (isLeft(bodyValidation)) {
+          const pathError = reporter.formatValidationErrors(
+            bodyValidation.left
+          );
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid request body for share-token lookup: ${pathError}`,
+            },
+          });
+        }
+        const result = await FileResource.fetchByShareTokenWithContent(
+          bodyValidation.right.token
+        );
+        response = { exists: !!result };
       }
       break;
 

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -1,4 +1,6 @@
 import config from "@app/lib/api/config";
+import { config as regionConfig } from "@app/lib/api/regions/config";
+import { lookupShareToken } from "@app/lib/api/regions/lookup";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -11,6 +13,7 @@ export interface GetShareFrameMetadataResponseBody {
   title: string;
   workspaceName: string;
   workspaceId: string;
+  vizUrl: string;
 }
 
 async function handler(
@@ -40,6 +43,22 @@ async function handler(
 
   const result = await FileResource.fetchByShareTokenWithContent(token);
   if (!result) {
+    // Not found locally — check other region.
+    const lookupResult = await lookupShareToken(token);
+    if (lookupResult.isOk() && lookupResult.value) {
+      const region = lookupResult.value;
+      return res.status(400).json({
+        error: {
+          type: "workspace_in_different_region",
+          message: "File is located in a different region",
+          redirect: {
+            region,
+            url: regionConfig.getRegionUrl(region),
+          },
+        },
+      });
+    }
+
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -94,6 +113,7 @@ async function handler(
     title: file.fileName,
     workspaceName: workspace.name,
     workspaceId: workspace.sId,
+    vizUrl: config.getVizPublicUrl(),
   });
 }
 

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,4 +1,5 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
@@ -16,6 +17,7 @@ export type GetWorkspaceAuthContextResponseType = {
   isAdmin: boolean;
   isBuilder: boolean;
   isEligibleForTrial?: boolean;
+  vizUrl: string;
 };
 
 async function handler(
@@ -86,6 +88,7 @@ async function handler(
     isAdmin: auth.isAdmin(),
     isBuilder: auth.isBuilder(),
     ...(isEligibleForTrial !== undefined && { isEligibleForTrial }),
+    vizUrl: config.getVizPublicUrl(),
   });
 }
 


### PR DESCRIPTION
## Description

Cross-region support for shared frame URLs + server-provided viz URL.

**Problem:** The `/api/share/frame/[token]` endpoint only resolves files in the local region, returning 404 for tokens belonging to workspaces in another region. Also, the viz iframe URL was derived client-side via `getClientFacingVizUrl()` which relied on heuristics (base URL resolver, `NEXT_PUBLIC_VIZ_URL` env var).

**Solution:**
- Add cross-region share token lookup: when a token is not found locally, query the other region via a new `/api/lookup/share-token` resource, and return a `workspace_in_different_region` redirect so the SPA can switch regions
- Return `vizUrl` from the server (via `VIZ_PUBLIC_URL` env var) in both the share frame endpoint and the auth-context endpoint
- Remove the client-side `getClientFacingVizUrl()` — all viz iframe URLs now come from the server
- Thread `vizUrl` through the component tree: `AuthContext` → `AgentMessage`/`FrameRenderer` → `VisualizationActionIframe`

### Changes

| Area | Files | What |
|------|-------|------|
| Lookup API | `pages/api/lookup/[resource]`, `lib/api/regions/lookup.ts` | New `share-token` resource type + `lookupShareToken()` |
| Share frame | `pages/api/share/frame/[token].ts`, `lib/swr/share.ts` | Region redirect + vizUrl in response + SWR redirect handling |
| Auth context | `pages/api/w/[wId]/auth-context.ts`, `lib/auth/AuthContext.tsx`, `appServerSideProps.ts`, `pokeServerSideProps.ts` | `vizUrl` field in auth context |
| Components | `AgentMessage`, `VisualizationBlock`, `FrameRenderer`, `PublicFrameRenderer`, `PublicInteractiveContentContainer`, `SharedFramePage` | Thread `vizUrl` prop to `VisualizationActionIframe` |
| Cleanup | `lib/api/config.ts`, `VisualizationActionIframe.tsx` | Remove `getClientFacingVizUrl()`, `vizUrl` is now a required prop |

## Tests

Manual testing with local dev setup (front + front-spa + viz).

## Risk

Low. The region redirect follows the exact same pattern used by `auth-context` and `join` endpoints. The viz URL change is backwards-compatible since the server always had access to `VIZ_PUBLIC_URL`.

## Deploy Plan

Standard deploy. Ensure `VIZ_PUBLIC_URL` env var is set in all environments.