### PR TITLE
Add viz in hive

### DIFF
--- a/x/henry/dust-hive/src/forward-daemon.ts
+++ b/x/henry/dust-hive/src/forward-daemon.ts
@@ -7,6 +7,7 @@
 //   3001 → base + 1 (core)
 //   3002 → base + 2 (connectors)
 //   3006 → base + 6 (oauth)
+//   3007 → base + 7 (viz)
 
 import type { Socket } from "bun";
 import { FORWARDER_MAPPINGS } from "./lib/forwarderConfig";

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -64,6 +64,10 @@ export QDRANT_USE_SHARDING=false
 export ELASTICSEARCH_URL=http://localhost:${ports.elasticsearch}
 export TEXT_EXTRACTION_URL=http://localhost:${ports.apacheTika}
 
+# === Viz service ===
+export VIZ_PUBLIC_URL=http://localhost:${ports.viz}
+export ALLOWED_VISUALIZATION_ORIGIN=http://localhost:3000,http://localhost:3011,http://localhost:${ports.front},http://localhost:${ports.frontSpaApp}
+
 # === Region & auth overrides (used by front cross-region and Dust CLI) ===
 export DUST_US_URL=http://localhost:${ports.front}
 export DUST_EU_URL=http://localhost:${ports.front}

--- a/x/henry/dust-hive/src/lib/forwarderConfig.ts
+++ b/x/henry/dust-hive/src/lib/forwarderConfig.ts
@@ -5,6 +5,7 @@ export const FORWARDER_MAPPINGS = [
   { listenPort: 3001, targetOffset: PORT_OFFSETS.core, name: "core" },
   { listenPort: 3002, targetOffset: PORT_OFFSETS.connectors, name: "connectors" },
   { listenPort: 3006, targetOffset: PORT_OFFSETS.oauth, name: "oauth" },
+  { listenPort: 3007, targetOffset: PORT_OFFSETS.viz, name: "viz" },
   { listenPort: 3010, targetOffset: PORT_OFFSETS.frontSpaPoke, name: "front-spa-poke" },
   { listenPort: 3011, targetOffset: PORT_OFFSETS.frontSpaApp, name: "front-spa-app" },
 ] as const;

--- a/x/henry/dust-hive/src/lib/multiplexer/types.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/types.ts
@@ -229,4 +229,5 @@ export const TAB_NAMES: Record<ServiceName, string> = {
   "front-workers": "workers",
   "front-spa-poke": "spa-poke",
   "front-spa-app": "spa-app",
+  viz: "viz",
 };

--- a/x/henry/dust-hive/src/lib/ports.ts
+++ b/x/henry/dust-hive/src/lib/ports.ts
@@ -16,6 +16,7 @@ export const PORT_OFFSETS = {
   core: 1,
   connectors: 2,
   oauth: 6,
+  viz: 7,
   frontSpaPoke: 10,
   frontSpaApp: 11,
   postgres: 432,
@@ -39,6 +40,7 @@ const PortAllocationSchema = z
     core: z.number(),
     connectors: z.number(),
     oauth: z.number(),
+    viz: z.number().optional(),
     frontSpaPoke: z.number().optional(),
     frontSpaApp: z.number().optional(),
     postgres: z.number(),
@@ -50,6 +52,7 @@ const PortAllocationSchema = z
   })
   .transform((data) => ({
     ...data,
+    viz: data.viz ?? data.base + PORT_OFFSETS.viz,
     frontSpaPoke: data.frontSpaPoke ?? data.base + PORT_OFFSETS.frontSpaPoke,
     frontSpaApp: data.frontSpaApp ?? data.base + PORT_OFFSETS.frontSpaApp,
   }));
@@ -64,6 +67,7 @@ export function calculatePorts(base: number): PortAllocation {
     core: base + PORT_OFFSETS.core,
     connectors: base + PORT_OFFSETS.connectors,
     oauth: base + PORT_OFFSETS.oauth,
+    viz: base + PORT_OFFSETS.viz,
     frontSpaPoke: base + PORT_OFFSETS.frontSpaPoke,
     frontSpaApp: base + PORT_OFFSETS.frontSpaApp,
     postgres: base + PORT_OFFSETS.postgres,

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -121,6 +121,17 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     },
     portKey: "frontSpaApp",
   },
+  viz: {
+    cwd: "viz",
+    needsNvm: true,
+    needsEnvSh: true,
+    buildCommand: (env) => `npm run dev -- -p ${env.ports.viz}`,
+    readinessCheck: {
+      type: "http",
+      url: (ports) => `http://localhost:${ports.viz}/`,
+    },
+    portKey: "viz",
+  },
 };
 
 const registryKeys = Object.keys(SERVICE_REGISTRY) as ServiceName[];
@@ -134,9 +145,9 @@ if (missingKeys.length > 0 || extraKeys.length > 0) {
   );
 }
 
-// Services to start during warm (all services except sparkle and SDK, which start at spawn)
+// Services to start during warm (all services except sparkle, SDK, and viz which start at spawn/manually)
 export const WARM_SERVICES: ServiceName[] = ALL_SERVICES.filter(
-  (service) => service !== "sparkle" && service !== "sdk"
+  (service) => service !== "sparkle" && service !== "sdk" && service !== "viz"
 );
 
 // Build the full shell command for a service

--- a/x/henry/dust-hive/src/lib/services.ts
+++ b/x/henry/dust-hive/src/lib/services.ts
@@ -9,6 +9,7 @@ export const ALL_SERVICES = [
   "front-workers",
   "front-spa-poke",
   "front-spa-app",
+  "viz",
 ] as const;
 
 // Services that run in "cold" state (build watchers)

--- a/x/henry/dust-hive/tests/lib/envgen.test.ts
+++ b/x/henry/dust-hive/tests/lib/envgen.test.ts
@@ -110,6 +110,14 @@ describe("envgen", () => {
       expect(content2).toContain("TEMPORAL_NAMESPACE=dust-hive-env-b");
     });
 
+    it("exports viz service variables", () => {
+      const content = generateEnvSh("test", ports);
+      expect(content).toContain("export VIZ_PUBLIC_URL=http://localhost:10007");
+      expect(content).toContain(
+        "export ALLOWED_VISUALIZATION_ORIGIN=http://localhost:3000,http://localhost:3011,http://localhost:10000,http://localhost:10011"
+      );
+    });
+
     it("includes section comments for organization", () => {
       const content = generateEnvSh("test", ports);
       expect(content).toContain("# === Ports");
@@ -118,6 +126,7 @@ describe("envgen", () => {
       expect(content).toContain("# === Inter-service URLs");
       expect(content).toContain("# === Database URIs");
       expect(content).toContain("# === Service URIs");
+      expect(content).toContain("# === Viz service");
     });
 
     it("ends with newline", () => {

--- a/x/henry/dust-hive/tests/lib/ports.test.ts
+++ b/x/henry/dust-hive/tests/lib/ports.test.ts
@@ -11,6 +11,7 @@ describe("ports", () => {
       expect(ports.core).toBe(10001);
       expect(ports.connectors).toBe(10002);
       expect(ports.oauth).toBe(10006);
+      expect(ports.viz).toBe(10007);
       expect(ports.postgres).toBe(10432);
       expect(ports.redis).toBe(10379);
       expect(ports.qdrantHttp).toBe(10333);
@@ -39,6 +40,7 @@ describe("ports", () => {
       expect(ports.core).toBe(base + PORT_OFFSETS.core);
       expect(ports.connectors).toBe(base + PORT_OFFSETS.connectors);
       expect(ports.oauth).toBe(base + PORT_OFFSETS.oauth);
+      expect(ports.viz).toBe(base + PORT_OFFSETS.viz);
       expect(ports.postgres).toBe(base + PORT_OFFSETS.postgres);
       expect(ports.redis).toBe(base + PORT_OFFSETS.redis);
       expect(ports.qdrantHttp).toBe(base + PORT_OFFSETS.qdrantHttp);

--- a/x/henry/dust-hive/tests/lib/registry.test.ts
+++ b/x/henry/dust-hive/tests/lib/registry.test.ts
@@ -67,9 +67,10 @@ describe("registry", () => {
   });
 
   describe("WARM_SERVICES", () => {
-    it("excludes sparkle and sdk from warm services", () => {
+    it("excludes sparkle, sdk, and viz from warm services", () => {
       expect(WARM_SERVICES).not.toContain("sparkle");
       expect(WARM_SERVICES).not.toContain("sdk");
+      expect(WARM_SERVICES).not.toContain("viz");
     });
 
     it("includes all other services", () => {
@@ -82,13 +83,15 @@ describe("registry", () => {
       expect(WARM_SERVICES).toContain("front-spa-app");
     });
 
-    it("has 7 services (all except sparkle and sdk)", () => {
+    it("has 7 services (all except sparkle, sdk, and viz)", () => {
       expect(WARM_SERVICES).toHaveLength(7);
     });
 
     it("is derived from SERVICE_REGISTRY", () => {
       const registryServices = Object.keys(SERVICE_REGISTRY) as ServiceName[];
-      const expectedWarm = registryServices.filter((s) => s !== "sparkle" && s !== "sdk");
+      const expectedWarm = registryServices.filter(
+        (s) => s !== "sparkle" && s !== "sdk" && s !== "viz"
+      );
       expect(WARM_SERVICES.sort()).toEqual(expectedWarm.sort());
     });
   });

--- a/x/henry/dust-hive/tests/lib/services.test.ts
+++ b/x/henry/dust-hive/tests/lib/services.test.ts
@@ -13,18 +13,19 @@ describe("services", () => {
       expect(ALL_SERVICES).toContain("front-workers");
       expect(ALL_SERVICES).toContain("front-spa-poke");
       expect(ALL_SERVICES).toContain("front-spa-app");
+      expect(ALL_SERVICES).toContain("viz");
     });
 
-    it("has 9 services total", () => {
-      expect(ALL_SERVICES).toHaveLength(9);
+    it("has 10 services total", () => {
+      expect(ALL_SERVICES).toHaveLength(10);
     });
 
     it("has sdk as first service (start order)", () => {
       expect(ALL_SERVICES[0]).toBe("sdk");
     });
 
-    it("has front-spa-app as last service", () => {
-      expect(ALL_SERVICES[ALL_SERVICES.length - 1]).toBe("front-spa-app");
+    it("has viz as last service", () => {
+      expect(ALL_SERVICES[ALL_SERVICES.length - 1]).toBe("viz");
     });
 
     it("is immutable (readonly tuple)", () => {
@@ -61,6 +62,7 @@ describe("services", () => {
         "front-workers",
         "front-spa-poke",
         "front-spa-app",
+        "viz",
       ];
 
       // All should be valid ServiceName values


### PR DESCRIPTION
## Description

Add the viz (visualization) service to dust-hive so that visualizations work in hive environments.

Changes:
- Register `viz` as a new service in the service registry (port offset 7)
- Add port forwarding from `3007 → base + 7` for the viz service
- Generate `VIZ_PUBLIC_URL` and `ALLOWED_VISUALIZATION_ORIGIN` env vars in `env.sh`
- Exclude viz from warm services (started manually like sparkle/sdk)
- Update all related tests

## Tests

Updated existing unit tests for ports, registry, services, and envgen.

## Risk

Low — additive change, only affects dust-hive tooling.

## Deploy Plan

No deploy needed — dust-hive is a local dev tool.