### PR TITLE
[front] Expose table ID in data warehouse `list` and `find`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -652,6 +652,7 @@ export const isDataSourceNodeListType = (
 
 const RenderedWarehouseNodeSchema = z.object({
   nodeId: z.string(),
+  tableId: z.string().nullable(),
   title: z.string(),
   parentTitle: z.string().nullable(),
   mimeType: z.string(),

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -652,7 +652,9 @@ export const isDataSourceNodeListType = (
 
 const RenderedWarehouseNodeSchema = z.object({
   nodeId: z.string(),
-  tableId: z.string().nullable(),
+  // TODO(2026-02-22 aubin): remove optional after a few weeks.
+  // Having an optional here makes the type retro-compatible for the front-end schema check.
+  tableId: z.string().nullable().optional(),
   title: z.string(),
   parentTitle: z.string().nullable(),
   mimeType: z.string(),

--- a/front/lib/api/actions/servers/data_warehouses/helpers.ts
+++ b/front/lib/api/actions/servers/data_warehouses/helpers.ts
@@ -229,8 +229,14 @@ function renderNode(
       ? INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE
       : node.mime_type;
 
+  const tableId =
+    node.node_type === "table" && dataSourceId
+      ? `table-${dataSourceId}-${node.node_id}`
+      : null;
+
   return {
     nodeId,
+    tableId,
     title: node.title,
     parentTitle: node.parent_title,
     mimeType,


### PR DESCRIPTION
## Description

- Had examples where finding a table via a `list` or a `find` is not sufficient to execute a query on it. `execute_query` requires a table ID that contains the data source ID, which is not part of the output of `list`/`find`.
- This PR exposes the `tableId` in the output of `list` and `find` to allow chaining directly with a `describe_table`/`execute_query`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
