### PR TITLE
[front] perf: fix N+1 remote server queries in MCP server views listing

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -78,13 +78,20 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   private async init(
     auth: Authenticator,
-    systemSpace: SpaceResource
+    systemSpace: SpaceResource,
+    prefetchedRemoteServers?: Map<ModelId, RemoteMCPServerResource>
   ): Promise<Result<void, DustError>> {
     if (this.remoteMCPServerId) {
-      const remoteServer = await RemoteMCPServerResource.findByPk(
-        auth,
-        this.remoteMCPServerId
-      );
+      let remoteServer =
+        prefetchedRemoteServers?.get(this.remoteMCPServerId) ?? null;
+
+      if (!remoteServer) {
+        remoteServer = await RemoteMCPServerResource.findByPk(
+          auth,
+          this.remoteMCPServerId
+        );
+      }
+
       if (!remoteServer) {
         return new Err(
           new DustError(
@@ -267,10 +274,17 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       filteredViews.push(...views);
     } else {
       const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+
+      const remoteServers = await RemoteMCPServerResource.findByModelIds(
+        auth,
+        removeNulls(views.map((v) => v.remoteMCPServerId))
+      );
+      const remoteServerMap = new Map(remoteServers.map((s) => [s.id, s]));
+
       await concurrentExecutor(
         views,
         async (view) => {
-          const r = await view.init(auth, systemSpace);
+          const r = await view.init(auth, systemSpace, remoteServerMap);
           if (r.isOk()) {
             filteredViews.push(view);
           }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -83,14 +83,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   ): Promise<Result<void, DustError>> {
     if (this.remoteMCPServerId) {
       let remoteServer =
-        prefetchedRemoteServers?.get(this.remoteMCPServerId) ?? null;
-
-      if (!remoteServer) {
-        remoteServer = await RemoteMCPServerResource.findByPk(
-          auth,
-          this.remoteMCPServerId
-        );
-      }
+        prefetchedRemoteServers?.get(this.remoteMCPServerId);
 
       if (!remoteServer) {
         return new Err(
@@ -166,9 +159,25 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
     const resource = new this(MCPServerViewResource.model, server.get(), space);
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-    const r = await resource.init(auth, systemSpace);
-    if (r.isErr()) {
-      throw r.error;
+
+    const remoteServersByModelId = new Map<ModelId, RemoteMCPServerResource>();
+    if (blob.remoteMCPServerId) {
+      const remoteServer = await RemoteMCPServerResource.findByPk(
+        auth,
+        blob.remoteMCPServerId
+      );
+      if (remoteServer) {
+        remoteServersByModelId.set(remoteServer.id, remoteServer);
+      }
+    }
+
+    const initResult = await resource.init(
+      auth,
+      systemSpace,
+      remoteServersByModelId
+    );
+    if (initResult.isErr()) {
+      throw initResult.error;
     }
 
     return resource;

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -79,7 +79,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   private async init(
     auth: Authenticator,
     systemSpace: SpaceResource,
-    prefetchedRemoteServers?: Map<ModelId, RemoteMCPServerResource>
+    prefetchedRemoteServers: Map<ModelId, RemoteMCPServerResource>
   ): Promise<Result<void, DustError>> {
     if (this.remoteMCPServerId) {
       let remoteServer =

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -82,8 +82,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     prefetchedRemoteServers: Map<ModelId, RemoteMCPServerResource>
   ): Promise<Result<void, DustError>> {
     if (this.remoteMCPServerId) {
-      let remoteServer =
-        prefetchedRemoteServers?.get(this.remoteMCPServerId);
+      let remoteServer = prefetchedRemoteServers?.get(this.remoteMCPServerId);
 
       if (!remoteServer) {
         return new Err(

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -24,6 +24,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -166,6 +166,18 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return servers.length > 0 ? servers[0] : null;
   }
 
+  static async findByModelIds(
+    auth: Authenticator,
+    ids: ModelId[]
+  ): Promise<RemoteMCPServerResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    return this.baseFetch(auth, {
+      where: { id: { [Op.in]: ids } },
+    });
+  }
+
   static async listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth);
   }


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/6705
- This PR speeds the endpoints that fetches MCP servers (Spaces > Tools page, agent details, agent builder, skill builder, tools picker in input bar, ...), scaling with the number of remote MCP servers installed on the workspace.
- This PR batches a db fetch on remote MCP servers done in the `baseFetch` of the `MCPServerViewResource`.
- Example of trace [here](https://app.datadoghq.eu/apm/traces?query=%40next.page%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Fmcp%22%20%40service%3Afront%20%40http.method%3AGET&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=4515326854192896223&spanType=all&spanViewType=databases&storage=hot&target-span=a&timeHint=1771596361823&tq_query_translation_version=v0&trace=AwAAAZx7XzBfTueYuQAAABhBWng3WHo5RkFBRC0yY21YYzRsTC1pa0oAAAAkMDE5YzdiOGMtNjRiZC00OTY0LWEwMDUtMjRjZDM4NzA0NjRmAAI2YA&traceID=69986a48000000000929a140fc35ec49&traceQuery=a&view=spans&viz=stream&start=1771760011708&end=1771774411708&paused=false), where we run 82 SQL queries in the `/api/w/[wId]/mcp` route.
- A similar fix is planned for internal MCP servers.

## Tests

- Tested locally.
- Well covered by existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
