### PR TITLE
feat: agent builder space selection ui

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -285,7 +285,7 @@ export function AgentBuilderSpacesBlock({
               className="mt-4"
             />
           </SheetHeader>
-          <SheetContainer className="p-0">
+          <SheetContainer isListSelector>
             <SpaceSelectionPageContent
               alreadyRequestedSpaceIds={actionsAndSkillsRequestedSpaceIds}
               selectedSpaces={draftSelectedSpaces}

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -4,8 +4,14 @@ import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { ProjectType, SpaceType } from "@app/types/space";
 import { isProjectType } from "@app/types/space";
-import { Checkbox, cn, DataTable, Tooltip } from "@dust-tt/sparkle";
-import type { ColumnDef } from "@tanstack/react-table";
+import {
+  Checkbox,
+  cn,
+  ListGroup,
+  ListItem,
+  ListItemSection,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useMemo } from "react";
 
@@ -130,86 +136,114 @@ export function SpaceSelectionPageContent({
     handleSpaceToggle,
   ]);
 
-  const columns: ColumnDef<SpaceRowData>[] = useMemo(
-    () => [
-      {
-        id: "name",
-        cell: ({ row }) => {
-          const SpaceIcon = getSpaceIcon(row.original.space);
-          const cellContent = (
-            <DataTable.CellContent
-              onClick={
-                row.original.isAlreadyRequested
-                  ? undefined
-                  : row.original.onToggle
-              }
-              grow
-              className={cn(
-                "p-3 hover:bg-muted-background dark:hover:bg-muted-background-night active:bg-primary-100 dark:active:bg-primary-100-night",
-                row.original.isAlreadyRequested
-                  ? "cursor-not-allowed opacity-60"
-                  : "cursor-pointer"
-              )}
-            >
-              <div className="flex flex-row items-center justify-between gap-3">
-                <div className="flex flex-row items-center gap-3 min-w-0">
-                  <SpaceIcon className="h-5 w-5 min-h-5 min-w-5 text-muted-foreground dark:text-muted-foreground-night" />
-                  <div className="flex flex-col items-start min-w-0">
-                    <span className="text-sm font-medium text-foreground dark:text-foreground-night truncate">
-                      {row.original.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground dark:text-muted-foreground-night truncate">
-                      {row.original.description}
-                    </span>
-                  </div>
-                </div>
-                <Checkbox
-                  checked={row.original.isSelected}
-                  disabled={row.original.isAlreadyRequested}
-                  onCheckedChange={row.original.onToggle}
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                  size="sm"
-                />
-              </div>
-            </DataTable.CellContent>
-          );
-
-          if (row.original.isAlreadyRequested) {
-            return (
-              <div className="[&>button]:w-full">
-                <Tooltip
-                  label="Used by other resources"
-                  side="right"
-                  trigger={cellContent}
-                />
-              </div>
-            );
-          }
-
-          return cellContent;
-        },
-        meta: {
-          sizeRatio: 100,
-        },
-      },
-    ],
-    []
-  );
-
   return (
     <div className="flex flex-col gap-4">
       {selectableSpaces.length > 0 ? (
         <div className="flex flex-col">
-          <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
-            Spaces
-          </div>
-          <DataTable data={spacesTableData} columns={columns} />
+          <ListItemSection size="sm">Spaces</ListItemSection>
+          <ListGroup>
+            {spacesTableData.map((row) => {
+              const SpaceIcon = getSpaceIcon(row.space);
+              const rowContent = (
+                <ListItem
+                  key={row.sId}
+                  itemsAlignment="center"
+                  onClick={row.isAlreadyRequested ? undefined : row.onToggle}
+                  className={cn(
+                    row.isSelected
+                      ? "bg-primary-50 dark:bg-primary-50-night"
+                      : "",
+                    row.isAlreadyRequested
+                      ? "cursor-not-allowed opacity-60"
+                      : "cursor-pointer"
+                  )}
+                >
+                  <SpaceIcon className="w-5 h-5 min-w-5 min-h-5" />
+                  <div className="flex min-w-0 flex-1 flex-col items-start">
+                    <span className="heading-sm truncate max-w-full text-foreground">
+                      {row.name}
+                    </span>
+                    <span className="truncate max-w-full text-xs text-muted-foreground">
+                      {row.description}
+                    </span>
+                  </div>
+                  <Checkbox
+                    checked={row.isSelected}
+                    onCheckedChange={row.onToggle}
+                    disabled={row.isAlreadyRequested}
+                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  />
+                </ListItem>
+              );
+
+              if (row.isAlreadyRequested) {
+                return (
+                  <Tooltip
+                    key={row.sId}
+                    label="Used by other resources"
+                    side="right"
+                    trigger={rowContent}
+                  />
+                );
+              }
+
+              return rowContent;
+            })}
+          </ListGroup>
           {isProjectsEnabled && (
             <>
-              <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
-                Projects
-              </div>
-              <DataTable data={projectsTableData} columns={columns} />
+              <ListItemSection size="sm">Projects</ListItemSection>
+              <ListGroup>
+                {projectsTableData.map((row) => {
+                  const ProjectIcon = getSpaceIcon(row.space);
+                  const rowContent = (
+                    <ListItem
+                      key={row.sId}
+                      itemsAlignment="center"
+                      onClick={
+                        row.isAlreadyRequested ? undefined : row.onToggle
+                      }
+                      className={cn(
+                        row.isSelected
+                          ? "bg-primary-50 dark:bg-primary-50-night"
+                          : "",
+                        row.isAlreadyRequested
+                          ? "cursor-not-allowed opacity-60"
+                          : "cursor-pointer"
+                      )}
+                    >
+                      <ProjectIcon className="w-5 h-5 min-w-5 min-h-5" />
+                      <div className="flex min-w-0 flex-1 flex-col items-start">
+                        <span className="heading-sm max-w-full truncate text-foreground">
+                          {row.name}
+                        </span>
+                        <span className="truncate max-w-full text-xs text-muted-foreground">
+                          {row.description}
+                        </span>
+                      </div>
+                      <Checkbox
+                        checked={row.isSelected}
+                        onCheckedChange={row.onToggle}
+                        disabled={row.isAlreadyRequested}
+                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                      />
+                    </ListItem>
+                  );
+
+                  if (row.isAlreadyRequested) {
+                    return (
+                      <Tooltip
+                        key={row.sId}
+                        label="Used by other resources"
+                        side="right"
+                        trigger={rowContent}
+                      />
+                    );
+                  }
+
+                  return rowContent;
+                })}
+              </ListGroup>
             </>
           )}
         </div>


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6703
This PR refactors the space selection UI in the agent builder by replacing the DataTable component with a ListGroup/ListItem-based layout.

<img width="908" height="848" alt="Capture d’écran 2026-02-23 à 10 08 42" src="https://github.com/user-attachments/assets/d8042658-0d63-45fa-b10a-dba2ea1b449e" />


## Tests

Manually

## Risks

Low - This is a visual refactor that maintains the same functionality. 

## Deploy Plan

Standard deployment.
