### PR TITLE
Define SandboxModel + SandboxResource data model (T3)

### DIFF
--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -12,8 +12,7 @@ import { Ok } from "@app/types/shared/result";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SandboxResource
-  extends ReadonlyAttributesType<SandboxModel> {}
+export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
@@ -97,9 +96,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return this.update({ status }, transaction);
   }
 
-  async updateLastActivityAt(
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<[affectedCount: number]> {
+  async updateLastActivityAt({
+    transaction,
+  }: {
+    transaction?: Transaction;
+  } = {}): Promise<[affectedCount: number]> {
     return this.update({ lastActivityAt: new Date() }, transaction);
   }
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,0 +1,131 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
+import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SandboxResource
+  extends ReadonlyAttributesType<SandboxModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SandboxResource extends BaseResource<SandboxModel> {
+  static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
+
+  constructor(
+    _model: ModelStatic<SandboxModel>,
+    blob: Attributes<SandboxModel>
+  ) {
+    super(SandboxModel, blob);
+  }
+
+  get sId(): string {
+    return SandboxResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("sandbox", { id, workspaceId });
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    blob: {
+      conversationId: number;
+      providerId: string;
+      status: SandboxStatus;
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    const sandbox = await this.model.create(
+      {
+        ...blob,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        lastActivityAt: new Date(),
+      },
+      { transaction }
+    );
+
+    return new this(this.model, sandbox.get());
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<SandboxModel>
+  ) {
+    const { where, ...rest } = options ?? {};
+    const rows = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...rest,
+    });
+
+    return rows.map((r) => new this(this.model, r.get()));
+  }
+
+  static async fetchByConversationId(
+    auth: Authenticator,
+    conversationId: number
+  ): Promise<SandboxResource | null> {
+    const [row] = await this.baseFetch(auth, {
+      where: { conversationId },
+    });
+
+    return row ?? null;
+  }
+
+  async updateStatus(
+    status: SandboxStatus,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<[affectedCount: number]> {
+    return this.update({ status }, transaction);
+  }
+
+  async updateLastActivityAt(
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<[affectedCount: number]> {
+    return this.update({ lastActivityAt: new Date() }, transaction);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<number, Error>> {
+    const deletedCount = await SandboxModel.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(deletedCount);
+  }
+
+  toLogJSON() {
+    return {
+      id: this.sId,
+      workspaceId: this.workspaceId,
+      conversationId: this.conversationId,
+      providerId: this.providerId,
+      status: this.status,
+      lastActivityAt: this.lastActivityAt.toISOString(),
+    };
+  }
+}

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -1,0 +1,86 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export type SandboxStatus = "running" | "sleeping" | "deleted";
+
+export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]>;
+  declare providerId: string;
+  declare status: SandboxStatus;
+  declare lastActivityAt: Date;
+
+  // Associations.
+  declare conversation: NonAttribute<ConversationModel>;
+}
+
+SandboxModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: ConversationModel,
+        key: "id",
+      },
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "running",
+    },
+    lastActivityAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    modelName: "sandbox",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "conversationId"],
+        name: "sandboxes_workspace_conversation_idx",
+      },
+      {
+        fields: ["conversationId"],
+        name: "sandboxes_conversation_id_idx",
+        concurrently: true,
+      },
+      {
+        fields: ["status", "lastActivityAt"],
+        name: "sandboxes_status_last_activity_idx",
+      },
+    ],
+  }
+);
+
+ConversationModel.hasMany(SandboxModel, {
+  foreignKey: "conversationId",
+  onDelete: "RESTRICT",
+});
+
+SandboxModel.belongsTo(ConversationModel, {
+  foreignKey: "conversationId",
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -74,6 +74,9 @@ export const RESOURCES_PREFIX = {
   // Academy quiz attempts.
   academy_quiz_attempt: "aqz",
   academy_chapter_visit: "acv",
+
+  // Sandboxes.
+  sandbox: "sbx",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/migrations/db/migration_516.sql
+++ b/front/migrations/db/migration_516.sql
@@ -1,0 +1,20 @@
+-- Migration created on Feb 23, 2026
+CREATE TABLE IF NOT EXISTS "sandboxes" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "conversationId" BIGINT NOT NULL REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "providerId" VARCHAR(255) NOT NULL,
+  "status" VARCHAR(255) NOT NULL DEFAULT 'running',
+  "lastActivityAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "sandboxes_workspace_conversation_idx"
+  ON "sandboxes" ("workspaceId", "conversationId");
+
+CREATE INDEX CONCURRENTLY "sandboxes_conversation_id_idx"
+  ON "sandboxes" ("conversationId");
+
+CREATE INDEX CONCURRENTLY "sandboxes_status_last_activity_idx"
+  ON "sandboxes" ("status", "lastActivityAt");


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/6714

Add persistent data model for sandbox lifecycle tracking. Each conversation can have at most one sandbox, tracked via `SandboxModel` (extends `WorkspaceAwareModel`) with provider-side ID, status (`running`/`sleeping`/`deleted`), and last activity timestamp.

**Changes:**
- `SandboxModel` with conversationId FK, providerId, status, lastActivityAt columns
- Unique index on `[workspaceId, conversationId]`, FK index on `conversationId`, composite index on `[status, lastActivityAt]` for the reaper
- `SandboxResource` following the standard Resource pattern (makeNew, fetchByConversationId, updateStatus, updateLastActivityAt, delete, toLogJSON)
- Register `"sbx"` sId prefix in `string_ids.ts`
- Migration 516 for the `sandboxes` table

Builds on T2 (#22058). Consumed by `ensureSandboxActive` (T7), sandbox tools (T8), and the sandbox reaper (T9).

## Tests

- Typecheck passes (`nvm use && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` — no new errors)
- Biome lint/format passes clean on new files
- Functional tests will be added with T7/T8 when the resource is exercised through endpoints

## Risk

Low. This is a new model + resource with no changes to existing code paths (only addition to `RESOURCES_PREFIX`). The migration creates a new table with no data modifications. Safe to rollback by dropping the table.

## Deploy Plan

- This is an addition-only migration (new table, no modifications to existing tables)
- Step 1: Merge PR and run migration 516 to create the `sandboxes` table and its three indexes
- Step 2: Deploy the code — no feature flags needed since the model is not yet consumed by any endpoint (pending T7/T8)
- Rollback: drop the `sandboxes` table and its indexes, then redeploy without the sandbox model codex