### PR TITLE
[front] Expose child agent convo/events URL in public API

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -844,6 +844,8 @@ const NotificationRunAgentContentSchema = z.object({
   query: z.string(),
   userMessageId: z.string(),
   agentMessageId: z.string().nullable(),
+  childConversationUrl: z.string().nullable().optional(),
+  childConversationEventsUrl: z.string().nullable().optional(),
 });
 
 export type RunAgentQueryProgressOutput = z.infer<

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -844,8 +844,6 @@ const NotificationRunAgentContentSchema = z.object({
   query: z.string(),
   userMessageId: z.string(),
   agentMessageId: z.string().nullable(),
-  childConversationUrl: z.string().nullable().optional(),
-  childConversationEventsUrl: z.string().nullable().optional(),
 });
 
 export type RunAgentQueryProgressOutput = z.infer<

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,10 +1,12 @@
 // This endpoint is redirected (307) to /api/sse/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events
 // via middleware. The /api/sse/ prefix allows the ingress to route SSE traffic to front-sse pods.
 
+import { isRunAgentQueryProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getConversationMessageType } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -179,6 +181,24 @@ async function handler(
         let publicEvent: AgentMessageEventType | undefined;
 
         if (event.data.type === "tool_notification") {
+          let output;
+          const { label, output: originalOutput } =
+            event.data.notification._meta.data;
+
+          if (isRunAgentQueryProgressOutput(originalOutput)) {
+            const wId = auth.getNonNullableWorkspace().sId;
+            const { conversationId, agentMessageId } = originalOutput;
+            const childConversationUrl = `${config.getClientFacingUrl()}/api/v1/w/${wId}/assistant/conversations/${conversationId}`;
+            output = {
+              ...originalOutput,
+              childConversationUrl,
+              childConversationEventsUrl: agentMessageId
+                ? `${childConversationUrl}/messages/${agentMessageId}/events`
+                : null,
+            };
+          } else {
+            output = originalOutput;
+          }
           publicEvent = {
             eventId: event.eventId,
             data: {
@@ -187,8 +207,8 @@ async function handler(
                 ...event.data.notification,
                 // For backward compatibility, we need to move the _meta.data to the root level.
                 data: {
-                  label: event.data.notification._meta.data.label,
-                  output: event.data.notification._meta.data.output,
+                  label,
+                  output,
                 },
               },
             },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1226,6 +1226,8 @@ const NotificationRunAgentContentSchema = z.object({
   childAgentId: z.string(),
   conversationId: z.string(),
   query: z.string(),
+  childConversationUrl: z.string().nullable().optional(),
+  childConversationEventsUrl: z.string().nullable().optional(),
 });
 
 const NotificationRunAgentChainOfThoughtSchema = z.object({


### PR DESCRIPTION
## Description

- This PR exposes the URLs to use when dealing with sub agents to the public API consumers: `childConversationURL`, `childConversationEventsURL`.
- Extends the public type inferred from `NotificationRunAgentContentSchema` to include these two fields. Private API untouched.

## Tests

- Tested locally

## Risk

- Low.

## Deploy Plan

- Deploy front-sse.
