### PR TITLE
Share suggestion limit in MCP tool description

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/constants.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/constants.ts
@@ -1,0 +1,6 @@
+// Limits for pending suggestions by kind
+export const MAX_PENDING_INSTRUCTIONS_SUGGESTIONS = 10;
+export const MAX_PENDING_TOOLS_SUGGESTIONS = 3;
+export const MAX_PENDING_SUB_AGENT_SUGGESTIONS = 2;
+export const MAX_PENDING_SKILLS_SUGGESTIONS = 3;
+export const MAX_PENDING_KNOWLEDGE_SUGGESTIONS = 3;

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -1,5 +1,12 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  MAX_PENDING_INSTRUCTIONS_SUGGESTIONS,
+  MAX_PENDING_KNOWLEDGE_SUGGESTIONS,
+  MAX_PENDING_SKILLS_SUGGESTIONS,
+  MAX_PENDING_SUB_AGENT_SUGGESTIONS,
+  MAX_PENDING_TOOLS_SUGGESTIONS,
+} from "@app/lib/api/actions/servers/agent_copilot_context/constants";
 import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import {
@@ -210,6 +217,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       "Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. " +
       `Each block ID must appear at most once. For full rewrites, use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}'. ` +
       "Word-level diffs will be computed and displayed inline. " +
+      `There can't be more than ${MAX_PENDING_INSTRUCTIONS_SUGGESTIONS} pending prompt edits suggestions. ` +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {
       suggestions: z
@@ -229,6 +237,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       "Suggest adding or removing tools from the agent's configuration. " +
       "This tool does not support sub_agent suggestions - use `suggest_sub_agent` instead for that purpose. " +
       "If a pending suggestion for the same tool already exists, it will be automatically marked as outdated. " +
+      `There can't be more than ${MAX_PENDING_TOOLS_SUGGESTIONS} pending tools suggestions. ` +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {
       suggestions: z
@@ -254,6 +263,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
     description:
       "Suggest adding or removing a sub-agent from the agent's configuration. A sub-agent allows the main agent to delegate tasks to a child agent. " +
       "If a pending suggestion for the same sub-agent already exists, it will be automatically marked as outdated. " +
+      `There can't be more than ${MAX_PENDING_SUB_AGENT_SUGGESTIONS} pending sub-agents suggestions. ` +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
     schema: {
       action: z
@@ -279,6 +289,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
     description:
       "Suggest adding or removing skills from the agent's configuration. " +
       "If a pending suggestion for the same skill already exists, it will be automatically marked as outdated. " +
+      `There can't be more than ${MAX_PENDING_SKILLS_SUGGESTIONS} pending skills suggestions. ` +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {
       suggestions: z
@@ -351,6 +362,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       "Suggest adding or removing a knowledge source (data source) from the agent's configuration. " +
       "Use `search_knowledge` first to identify relevant data sources, then suggest them here. " +
       "If a pending suggestion for the same data source already exists, it will be automatically marked as outdated. " +
+      `There can't be more than ${MAX_PENDING_KNOWLEDGE_SUGGESTIONS} pending knowledge suggestions. ` +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
     schema: {
       suggestion: KnowledgeSuggestionSchema.describe(

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -2,6 +2,13 @@ import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp"
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  MAX_PENDING_INSTRUCTIONS_SUGGESTIONS,
+  MAX_PENDING_KNOWLEDGE_SUGGESTIONS,
+  MAX_PENDING_SKILLS_SUGGESTIONS,
+  MAX_PENDING_SUB_AGENT_SUGGESTIONS,
+  MAX_PENDING_TOOLS_SUGGESTIONS,
+} from "@app/lib/api/actions/servers/agent_copilot_context/constants";
 import { AGENT_COPILOT_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
 import { getAgentConfigurationIdFromContext } from "@app/lib/api/actions/servers/agent_copilot_helpers";
 import { pruneConflictingInstructionSuggestions } from "@app/lib/api/assistant/agent_suggestion_pruning";
@@ -85,13 +92,6 @@ const JOB_TYPE_TO_TEMPLATE_TAGS: Record<JobType, TemplateTagCodeType[]> = {
   customer_support: ["SUPPORT"],
   other: [],
 };
-
-// Limits for pending suggestions by kind
-const MAX_PENDING_INSTRUCTIONS_SUGGESTIONS = 10;
-const MAX_PENDING_TOOLS_SUGGESTIONS = 3;
-const MAX_PENDING_SUB_AGENT_SUGGESTIONS = 2;
-const MAX_PENDING_SKILLS_SUGGESTIONS = 3;
-const MAX_PENDING_KNOWLEDGE_SUGGESTIONS = 3;
 
 type LimitedSuggestionKind =
   | "instructions"


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6729

Add the suggestion limit in the description of the suggest_XXX tools for copilot.
This forces to put the constants in another file to avoid circular dependencies.

## Tests

no

## Risk

low

## Deploy Plan

deploy front
