### PR TITLE
[front] Remove run agent cot/generation events

### DIFF
--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -43,10 +43,7 @@ import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/glo
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  getApiKeyNameHeader,
-  prodAPICredentialsForOwner,
-} from "@app/lib/auth";
+import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getConversationRoute } from "@app/lib/utils/router";

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -45,7 +45,6 @@ import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import {
   getApiKeyNameHeader,
-  getFeatureFlags,
   prodAPICredentialsForOwner,
 } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -122,9 +122,6 @@ const runAgent = async (
     "agentLoopContext is required to run the run_agent tool"
   );
 
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  const useChildStream = featureFlags.includes("run_agent_child_stream");
-
   const abortSignal = signal ?? null;
   let childCancellationPromise: Promise<void> | null = null;
   const finalizeAndReturn = async <T>(
@@ -492,54 +489,8 @@ const runAgent = async (
         // Separate content based on classification.
         if (event.classification === "chain_of_thought") {
           chainOfThought += event.text;
-          // When the child stream FF is on, the frontend subscribes directly
-          // to the child agent's EventSource, so we don't need this event
-          if (!useChildStream && sendNotification) {
-            const notification: MCPProgressNotificationType = {
-              method: "notifications/progress",
-              params: {
-                progress: 0,
-                total: 1,
-                progressToken: 0,
-                _meta: {
-                  data: {
-                    label: "Agent thinking...",
-                    output: {
-                      type: "run_agent_chain_of_thought",
-                      childAgentId: parsedChildAgentId,
-                      conversationId: conversation.sId,
-                      chainOfThought: event.text,
-                    },
-                  },
-                },
-              },
-            };
-            await sendNotification(notification);
-          }
         } else if (event.classification === "tokens") {
           finalContent += event.text;
-          if (!useChildStream && sendNotification) {
-            const notification: MCPProgressNotificationType = {
-              method: "notifications/progress",
-              params: {
-                progress: 0,
-                total: 1,
-                progressToken: 0,
-                _meta: {
-                  data: {
-                    label: "Agent responding...",
-                    output: {
-                      type: "run_agent_generation_tokens",
-                      childAgentId: parsedChildAgentId,
-                      conversationId: conversation.sId,
-                      text: event.text,
-                    },
-                  },
-                },
-              },
-            };
-            await sendNotification(notification);
-          }
         } else if (
           event.classification === "closing_delimiter" &&
           event.delimiterClassification === "chain_of_thought" &&
@@ -547,28 +498,6 @@ const runAgent = async (
         ) {
           // For closing chain of thought delimiters, add a newline.
           chainOfThought += "\n";
-          if (!useChildStream && sendNotification) {
-            const notification: MCPProgressNotificationType = {
-              method: "notifications/progress",
-              params: {
-                progress: 0,
-                total: 1,
-                progressToken: 0,
-                _meta: {
-                  data: {
-                    label: "Agent thinking...",
-                    output: {
-                      type: "run_agent_chain_of_thought",
-                      childAgentId: parsedChildAgentId,
-                      conversationId: conversation.sId,
-                      chainOfThought: "\n",
-                    },
-                  },
-                },
-              },
-            };
-            await sendNotification(notification);
-          }
         }
       } else if (event.type === "agent_error") {
         const errorMessage = `Agent error: ${event.error.message}`;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -215,14 +215,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Sandbox MCP tool for executing code in isolated Linux containers",
     stage: "dust_only",
   },
-  dust_no_spa: {
-    description: "Disable redirect to Dust SPA",
-    stage: "on_demand",
-  },
-  dust_spa: {
-    description: "Redirect all pages to Dust SPA",
-    stage: "dust_only",
-  },
   run_tools_from_prompt: {
     description: "Enable /run command to directly call tools without LLM",
     stage: "dust_only",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -215,10 +215,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Sandbox MCP tool for executing code in isolated Linux containers",
     stage: "dust_only",
   },
-  run_agent_child_stream: {
-    description:
-      "Subscribe directly to child agent EventSource in run_agent action " +
-      "details (potential optimization undergoing tests)",
+  dust_no_spa: {
+    description: "Disable redirect to Dust SPA",
+    stage: "on_demand",
+  },
+  dust_spa: {
+    description: "Redirect all pages to Dust SPA",
     stage: "dust_only",
   },
   run_tools_from_prompt: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -719,7 +719,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_message_splitting"
   | "slideshow"
   | "snowflake_tool"
-  | "statuspage_tool"
   | "run_tools_from_prompt"
   | "usage_data_api"
   | "xai_feature"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -719,7 +719,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_message_splitting"
   | "slideshow"
   | "snowflake_tool"
-  | "run_agent_child_stream"
+  | "statuspage_tool"
   | "run_tools_from_prompt"
   | "usage_data_api"
   | "xai_feature"


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/22077.
- This PR removes the events that are used to stream the chain of thought/generation tokens.
- These are not used in the front-end anymore, which connects to the child conversation's stream instead.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
