### PR TITLE
Fix posthog tracker

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,3 +1,4 @@
+import { PostHogTracker } from "@dust-tt/front/components/app/PostHogTracker";
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { ErrorBoundary } from "@dust-tt/front/components/error_boundary/ErrorBoundary";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
@@ -535,11 +536,13 @@ export default function App() {
     <AppReadyProvider>
       <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
         <RegionProvider>
-          <RootLayout>
-            <ErrorBoundary fallback={<GlobalErrorFallback />}>
-              <RouterProvider router={router} />
-            </ErrorBoundary>
-          </RootLayout>
+          <PostHogTracker authenticated>
+            <RootLayout>
+              <ErrorBoundary fallback={<GlobalErrorFallback />}>
+                <RouterProvider router={router} />
+              </ErrorBoundary>
+            </RootLayout>
+          </PostHogTracker>
         </RegionProvider>
       </FetcherProvider>
     </AppReadyProvider>

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -29,18 +29,51 @@ const EXCLUDED_PATHS = [
 
 interface PostHogTrackerProps {
   children: React.ReactNode;
+  // When true, skip fetching user data and assume cookies are accepted.
+  // Use in authenticated contexts (e.g. SPA) where the user is always logged in.
+  authenticated?: boolean;
 }
 
-export function PostHogTracker({ children }: PostHogTrackerProps) {
+export function PostHogTracker({
+  children,
+  authenticated,
+}: PostHogTrackerProps) {
+  // Always render PostHogProvider to avoid unmounting/remounting the entire
+  // tree when tracking state changes. Tracking is controlled via
+  // posthog.opt_in_capturing() / posthog.opt_out_capturing() instead.
+  return (
+    <PostHogProvider client={posthog}>
+      <PostHogTrackerInner authenticated={authenticated} />
+      {children}
+    </PostHogProvider>
+  );
+}
+
+/**
+ * Inner component that handles all PostHog side-effects (initialization,
+ * identification, opt-in/opt-out, workspace grouping, pageview tracking).
+ * Separated from PostHogTracker so that user/subscription loading never
+ * affects the children tree structure.
+ */
+interface PostHogTrackerInnerProps {
+  authenticated?: boolean;
+}
+
+function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
   const router = useAppRouter();
   const [cookies] = useCookies([DUST_COOKIES_ACCEPTED, DUST_HAS_SESSION]);
   const hasSession = hasSessionIndicator(cookies[DUST_HAS_SESSION]);
 
-  // Only fetch user if session indicator is present to avoid 401 errors on public pages.
-  const { user } = useUser({ disabled: !hasSession });
+  // Skip useUser in authenticated contexts — user is always logged in so
+  // hasCookiesAccepted is always true and we don't need user data for consent.
+  const { user } = useUser({
+    disabled: !!authenticated || !hasSession,
+  });
 
   const cookieValue = cookies[DUST_COOKIES_ACCEPTED];
-  const hasAcceptedCookies = hasCookiesAccepted(cookieValue, user);
+  const hasAcceptedCookies = authenticated
+    ? true
+    : hasCookiesAccepted(cookieValue, user);
 
   const { wId } = router.query;
   const workspaceId = isString(wId) ? wId : undefined;
@@ -247,9 +280,5 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
     };
   }, [router.events, router.pathname, shouldTrack]);
 
-  if (isTrackablePage && hasAcceptedCookies) {
-    return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
-  }
-
-  return <>{children}</>;
+  return null;
 }


### PR DESCRIPTION
## Description

Fixes two issues with `PostHogTracker`:

1. **No more full app remount when tracking state changes.** Previously, `PostHogTracker` conditionally rendered either `<PostHogProvider>{children}</PostHogProvider>` or `<>{children}</>`, which caused React to unmount and remount the entire app tree when `hasAcceptedCookies` changed. Now `PostHogProvider` is always rendered, and all side-effects (init, identification, opt-in/opt-out, workspace grouping, pageviews) are handled in a separate `PostHogTrackerInner` component that returns `null`.

2. **Skip `useUser` in authenticated contexts (SPA).** In the SPA, `PostHogTracker` is rendered inside `RegionProvider`. The old code called `useUser` which depends on `setBaseUrlResolver` being set. Added an `authenticated` prop that skips `useUser` entirely and assumes cookies are accepted (logged-in users always have accepted cookies). The SPA passes `<PostHogTracker authenticated>`.

### Changes
- `PostHogTracker` always renders `<PostHogProvider>` + `<PostHogTrackerInner />` + `{children}` (stable tree)
- New `authenticated` prop: disables `useUser`, sets `hasAcceptedCookies = true`
- Added `PostHogTracker` to `front-spa/src/app/App.tsx` inside `RegionProvider`

## Tests

Manual — verified no full-page remount on tracking state change.

## Risk

Low — `PostHogProvider` is just a context wrapper, always rendering it has no side effects. Tracking opt-in/opt-out was already handled via PostHog's API.

## Deploy Plan

Standard deploy, no special steps needed.