### PR TITLE
[front] perf: fix N+1 internal server queries in MCP server views listing

### DIFF
--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -255,25 +255,9 @@ export class InternalMCPServerInMemoryResource {
     id: string,
     systemSpace: SpaceResource
   ) {
-    // Fast path: Do not check for default internal MCP servers as they are always available.
-    const availability = getAvailabilityOfInternalMCPServerById(id);
-    if (availability === "manual") {
-      const server = await MCPServerViewModel.findOne({
-        attributes: ["internalMCPServerId"],
-        where: {
-          serverType: "internal",
-          internalMCPServerId: id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          vaultId: systemSpace.id,
-        },
-      });
+    const results = await this.fetchByIds(auth, [id], systemSpace);
 
-      if (!server?.internalMCPServerId) {
-        return null;
-      }
-    }
-
-    return InternalMCPServerInMemoryResource.init(auth, id);
+    return results[0] ?? null;
   }
 
   static async fetchByIds(
@@ -285,6 +269,7 @@ export class InternalMCPServerInMemoryResource {
       return [];
     }
 
+    // Fast path: Do not check for default internal MCP servers as they are always available.
     const validIds = ids.filter(
       (id) => getAvailabilityOfInternalMCPServerById(id) !== "manual"
     );

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -62,7 +62,10 @@ export class InternalMCPServerInMemoryResource {
     readonly availability: MCPServerAvailability
   ) {}
 
-  private static async init(auth: Authenticator, id: string) {
+  private static async init(
+    auth: Authenticator,
+    id: string
+  ): Promise<InternalMCPServerInMemoryResource | null> {
     const r = getInternalMCPServerNameAndWorkspaceId(id);
     if (r.isErr()) {
       return null;
@@ -271,6 +274,43 @@ export class InternalMCPServerInMemoryResource {
     }
 
     return InternalMCPServerInMemoryResource.init(auth, id);
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[],
+    systemSpace: SpaceResource
+  ): Promise<InternalMCPServerInMemoryResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const validIds = ids.filter(
+      (id) => getAvailabilityOfInternalMCPServerById(id) !== "manual"
+    );
+
+    const manualIds = ids.filter(
+      (id) => getAvailabilityOfInternalMCPServerById(id) === "manual"
+    );
+
+    const servers = await MCPServerViewModel.findAll({
+      attributes: ["internalMCPServerId"],
+      where: {
+        serverType: "internal",
+        internalMCPServerId: { [Op.in]: manualIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+        vaultId: systemSpace.id,
+      },
+    });
+    validIds.push(...removeNulls(servers.map((s) => s.internalMCPServerId)));
+
+    const resources = await concurrentExecutor(
+      validIds,
+      (id) => InternalMCPServerInMemoryResource.init(auth, id),
+      { concurrency: 10 }
+    );
+
+    return removeNulls(resources);
   }
 
   static async listAvailableInternalMCPServers(auth: Authenticator) {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -118,7 +118,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       if (!remoteServer) {
         throw new DustError(
           "remote_server_not_found",
-          "Remote server not found, it should have been fetched by the base fetch."
+          "Remote server not found after creation."
         );
       }
       resource.remoteMCPServer = remoteServer;

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -254,9 +254,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           removeNulls(views.map((v) => v.internalMCPServerId)),
           systemSpace
         );
-      const internalServerMap = new Map(
-        internalServers.map((s) => [s.id, s])
-      );
+      const internalServerMap = new Map(internalServers.map((s) => [s.id, s]));
 
       for (const view of views) {
         if (view.remoteMCPServerId) {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -123,14 +123,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
       resource.remoteMCPServer = remoteServer;
     } else if (blob.internalMCPServerId) {
-      const systemSpace =
-        await SpaceResource.fetchWorkspaceSystemSpace(auth);
-      const internalServer =
-        await InternalMCPServerInMemoryResource.fetchById(
-          auth,
-          blob.internalMCPServerId,
-          systemSpace
-        );
+      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+      const internalServer = await InternalMCPServerInMemoryResource.fetchById(
+        auth,
+        blob.internalMCPServerId,
+        systemSpace
+      );
       if (!internalServer) {
         throw new DustError(
           "internal_server_not_found",

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -30,7 +30,6 @@ import type {
   ResourceFindOptions,
 } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { tracer } from "@app/logger/tracer";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -76,53 +75,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     this.remoteToolsMetadata = includes?.remoteToolsMetadata;
   }
 
-  private async init(
-    auth: Authenticator,
-    systemSpace: SpaceResource,
-    prefetchedRemoteServers: Map<ModelId, RemoteMCPServerResource>
-  ): Promise<Result<void, DustError>> {
-    if (this.remoteMCPServerId) {
-      let remoteServer = prefetchedRemoteServers?.get(this.remoteMCPServerId);
-
-      if (!remoteServer) {
-        return new Err(
-          new DustError(
-            "remote_server_not_found",
-            "Remote server not found, it should have been fetched by the base fetch."
-          )
-        );
-      }
-
-      this.remoteMCPServer = remoteServer;
-      return new Ok(undefined);
-    }
-
-    if (this.internalMCPServerId) {
-      const internalServer = await InternalMCPServerInMemoryResource.fetchById(
-        auth,
-        this.internalMCPServerId,
-        systemSpace
-      );
-      if (!internalServer) {
-        return new Err(
-          new DustError(
-            "internal_server_not_found",
-            "Internal server not found, it might have been deleted from the list of internal servers. Action: clear the mcp server views of orphan internal servers."
-          )
-        );
-      }
-      this.internalMCPServer = internalServer;
-      return new Ok(undefined);
-    }
-
-    return new Err(
-      new DustError(
-        "internal_error",
-        "We could not find the server because it was of an unknown type, this should never happen."
-      )
-    );
-  }
-
   private static async makeNew(
     auth: Authenticator,
     blob: Omit<
@@ -157,26 +109,35 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     );
 
     const resource = new this(MCPServerViewResource.model, server.get(), space);
-    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
-    const remoteServersByModelId = new Map<ModelId, RemoteMCPServerResource>();
     if (blob.remoteMCPServerId) {
       const remoteServer = await RemoteMCPServerResource.findByPk(
         auth,
         blob.remoteMCPServerId
       );
-      if (remoteServer) {
-        remoteServersByModelId.set(remoteServer.id, remoteServer);
+      if (!remoteServer) {
+        throw new DustError(
+          "remote_server_not_found",
+          "Remote server not found, it should have been fetched by the base fetch."
+        );
       }
-    }
-
-    const initResult = await resource.init(
-      auth,
-      systemSpace,
-      remoteServersByModelId
-    );
-    if (initResult.isErr()) {
-      throw initResult.error;
+      resource.remoteMCPServer = remoteServer;
+    } else if (blob.internalMCPServerId) {
+      const systemSpace =
+        await SpaceResource.fetchWorkspaceSystemSpace(auth);
+      const internalServer =
+        await InternalMCPServerInMemoryResource.fetchById(
+          auth,
+          blob.internalMCPServerId,
+          systemSpace
+        );
+      if (!internalServer) {
+        throw new DustError(
+          "internal_server_not_found",
+          "Internal server not found, it might have been deleted from the list of internal servers."
+        );
+      }
+      resource.internalMCPServer = internalServer;
     }
 
     return resource;
@@ -283,22 +244,40 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     } else {
       const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
-      const remoteServers = await RemoteMCPServerResource.findByModelIds(
+      const remoteServers = await RemoteMCPServerResource.fetchByModelIds(
         auth,
         removeNulls(views.map((v) => v.remoteMCPServerId))
       );
       const remoteServerMap = new Map(remoteServers.map((s) => [s.id, s]));
 
-      await concurrentExecutor(
-        views,
-        async (view) => {
-          const r = await view.init(auth, systemSpace, remoteServerMap);
-          if (r.isOk()) {
-            filteredViews.push(view);
-          }
-        },
-        { concurrency: 10 }
+      const internalServers =
+        await InternalMCPServerInMemoryResource.fetchByIds(
+          auth,
+          removeNulls(views.map((v) => v.internalMCPServerId)),
+          systemSpace
+        );
+      const internalServerMap = new Map(
+        internalServers.map((s) => [s.id, s])
       );
+
+      for (const view of views) {
+        if (view.remoteMCPServerId) {
+          const remote = remoteServerMap.get(view.remoteMCPServerId);
+          if (!remote) {
+            continue;
+          }
+          view.remoteMCPServer = remote;
+        } else if (view.internalMCPServerId) {
+          const internal = internalServerMap.get(view.internalMCPServerId);
+          if (!internal) {
+            continue;
+          }
+          view.internalMCPServer = internal;
+        } else {
+          continue;
+        }
+        filteredViews.push(view);
+      }
     }
 
     if (includeMetadata && filteredViews.length > 0) {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -167,7 +167,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return servers.length > 0 ? servers[0] : null;
   }
 
-  static async findByModelIds(
+  static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[]
   ): Promise<RemoteMCPServerResource[]> {


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/22074.
- This PR speeds the endpoints that fetches MCP servers (Spaces > Tools page, agent details, agent builder, skill builder, tools picker in input bar, ...), scaling with the number of remote MCP servers installed on the workspace.
- This PR batches a db fetch on internal MCP servers done in the baseFetch of the MCPServerViewResource.
- Example of trace [here](https://app.datadoghq.eu/apm/traces?query=%40next.page%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Fskills%22%20%40service%3Afront%20%40http.method%3AGET&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=6823531262213076640&spanType=all&spanViewType=databases&storage=hot&target-span=a&timeHint=1771847547932&tq_query_translation_version=v0&trace=AwAAAZyKV_wcE7WNNQAAABhBWnlLV0FnNUFBQms2UjdUYTR4a0h0cGsAAAAkMDE5YzhhNWMtOTNhZS00NWNjLWJmNmItMjk5MDgxZTY1ZWY2AACOnQ&traceID=699c3f7b0000000064dad9532e370700&traceQuery=a&view=spans&viz=stream&start=1771844995348&end=1771848595348&paused=false), where we do 97 SQL queries to fetch a skill.
- Removes the `async` method `init`, which creates an easy way to add N+1 queries.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
