### PR TITLE
feat: add E2B sandbox config

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -457,14 +457,19 @@ const config = {
     return EnvironmentConfig.getEnvVariable("GATED_ASSETS_TOKEN_SECRET");
   },
   // E2B Sandbox.
-  getE2BSandboxConfig: (): {
-    apiKey: string;
-    templateId: string;
-    domain: string | undefined;
-  } => {
+  getE2BSandboxConfig: ():
+    | { apiKey: string; templateId: string; domain: string | undefined }
+    | undefined => {
+    const apiKey =
+      EnvironmentConfig.getOptionalEnvVariable("E2B_API_KEY");
+    const templateId =
+      EnvironmentConfig.getOptionalEnvVariable("E2B_TEMPLATE_ID");
+    if (!apiKey || !templateId) {
+      return undefined;
+    }
     return {
-      apiKey: EnvironmentConfig.getEnvVariable("E2B_API_KEY"),
-      templateId: EnvironmentConfig.getEnvVariable("E2B_TEMPLATE_ID"),
+      apiKey,
+      templateId,
       domain: EnvironmentConfig.getOptionalEnvVariable("E2B_DOMAIN"),
     };
   },

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -460,8 +460,7 @@ const config = {
   getE2BSandboxConfig: ():
     | { apiKey: string; templateId: string; domain: string | undefined }
     | undefined => {
-    const apiKey =
-      EnvironmentConfig.getOptionalEnvVariable("E2B_API_KEY");
+    const apiKey = EnvironmentConfig.getOptionalEnvVariable("E2B_API_KEY");
     const templateId =
       EnvironmentConfig.getOptionalEnvVariable("E2B_TEMPLATE_ID");
     if (!apiKey || !templateId) {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -456,6 +456,18 @@ const config = {
   getGatedAssetsTokenSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("GATED_ASSETS_TOKEN_SECRET");
   },
+  // E2B Sandbox.
+  getE2BSandboxConfig: (): {
+    apiKey: string;
+    templateId: string;
+    domain: string | undefined;
+  } => {
+    return {
+      apiKey: EnvironmentConfig.getEnvVariable("E2B_API_KEY"),
+      templateId: EnvironmentConfig.getEnvVariable("E2B_TEMPLATE_ID"),
+      domain: EnvironmentConfig.getOptionalEnvVariable("E2B_DOMAIN"),
+    };
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6715

Add `getE2BSandboxConfig()` to `front/lib/api/config.ts` for E2B BYOC cluster integration.

The config exposes three env vars:
- `E2B_API_KEY` (required) — API key for the BYOC cluster
- `E2B_TEMPLATE_ID` (required) — template ID for sandbox creation
- `E2B_DOMAIN` (optional) — custom domain for BYOC cluster

Follows existing config patterns (`getCoreAPIConfig`, `getOAuthAPIConfig`).

## Tests

- Typecheck passes (`tsc --noEmit`)
- Biome lint/format passes

## Risk

Low — additive change only, no existing behavior modified. Env vars are not yet consumed.

## Deploy Plan

No special deploy steps. Env vars should be set before downstream consumers are deployed.