### PR TITLE
[front] Wire SandboxProvider singleton into sandbox MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -449,10 +449,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_actions": "never_ask",
   },
   "sandbox": {
-    "execute": "low",
-    "list_files": "never_ask",
-    "read_file": "never_ask",
-    "write_file": "low",
+    "bash": "never_ask",
   },
   "schedules_management": {
     "create_schedule": "high",

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SANDBOX_TOOL_NAME = "sandbox" as const;
 
 export const SANDBOX_TOOLS_METADATA = createToolsRecord({
-  execute: {
+  bash: {
     description:
       "Execute a shell command in an isolated sandbox environment. " +
       "The sandbox is a Linux container with common tools pre-installed. " +
@@ -31,67 +31,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
           "Timeout in milliseconds for command execution. Defaults to 60000, max 120000."
         ),
     },
-    stake: "low",
+    stake: "never_ask",
     displayLabels: {
       running: "Executing command in sandbox",
       done: "Execute command in sandbox",
-    },
-  },
-  write_file: {
-    description:
-      "Write content to a file in the sandbox. " +
-      "Creates parent directories if they don't exist. " +
-      "Overwrites the file if it already exists.",
-    schema: {
-      path: z
-        .string()
-        .describe(
-          "Absolute path where the file should be written in the sandbox."
-        ),
-      content: z.string().describe("The content to write to the file."),
-    },
-    stake: "low",
-    displayLabels: {
-      running: "Writing file to sandbox",
-      done: "Write file to sandbox",
-    },
-  },
-  read_file: {
-    description:
-      "Read a file from the sandbox and make it available as a Dust file. " +
-      "Use this to retrieve results of computations, generated content, or any file " +
-      "that should be shared with the user in the conversation.",
-    schema: {
-      path: z.string().describe("Absolute path to the file to read."),
-      title: z
-        .string()
-        .optional()
-        .describe("Title for the file in Dust. Defaults to the filename."),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Reading file from sandbox",
-      done: "Read file from sandbox",
-    },
-  },
-  list_files: {
-    description:
-      "List files and directories in the sandbox. " +
-      "Returns file names, sizes, and types (file/directory).",
-    schema: {
-      path: z
-        .string()
-        .optional()
-        .describe("Directory path to list. Defaults to /tmp."),
-      recursive: z
-        .boolean()
-        .optional()
-        .describe("Whether to list files recursively. Defaults to false."),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Listing files in sandbox",
-      done: "List files in sandbox",
     },
   },
 });
@@ -111,8 +54,7 @@ export const SANDBOX_SERVER = {
     instructions:
       // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
       "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
-      "Use `execute` to run commands, `write_file`/`read_file` for file operations. " +
-      "Use `read_file` to retrieve generated files and make them available in the conversation. " +
+      "Use `bash` to run commands and scripts. " +
       "The sandbox persists for the conversation duration. " +
       "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
   },

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -6,6 +6,7 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
+import { getSandboxProvider } from "@app/lib/api/sandbox";
 import type { Authenticator } from "@app/lib/auth";
 import { Err } from "@app/types/shared/result";
 
@@ -14,28 +15,14 @@ export function createSandboxTools(
   _agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
-    execute: async (_args) => {
-      return new Err(
-        new MCPError("Sandbox execute tool is not implemented yet.")
-      );
-    },
+    bash: async (_args) => {
+      const provider = getSandboxProvider();
+      if (!provider) {
+        return new Err(new MCPError("Sandbox provider not configured."));
+      }
 
-    write_file: async (_args) => {
-      return new Err(
-        new MCPError("Sandbox write_file tool is not implemented yet.")
-      );
-    },
-
-    read_file: async (_args) => {
-      return new Err(
-        new MCPError("Sandbox read_file tool is not implemented yet.")
-      );
-    },
-
-    list_files: async (_args) => {
-      return new Err(
-        new MCPError("Sandbox list_files tool is not implemented yet.")
-      );
+      // TODO(SANDBOX-S1-T6): call provider.exec() once the E2B adapter is implemented.
+      return new Err(new MCPError("Sandbox bash tool is not implemented yet."));
     },
   };
 

--- a/front/lib/api/sandbox/index.ts
+++ b/front/lib/api/sandbox/index.ts
@@ -1,0 +1,6 @@
+import type { SandboxProvider } from "@app/lib/api/sandbox/provider";
+
+// TODO(SANDBOX-S1-T6): instantiate E2B adapter here once it's implemented.
+export function getSandboxProvider(): SandboxProvider | undefined {
+  return undefined;
+}


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/6716

Wire the `SandboxProvider` interface into the sandbox MCP server tool handlers via a lazy singleton getter, following the same pattern as `elasticsearch.ts` and `persona/client.ts`.

- Add `getE2BSandboxConfig()` to `config.ts` reading the optional `E2B_API_KEY` env var
- Create `getSandboxProvider()` singleton in `lib/api/sandbox/index.ts` — returns `undefined` until the E2B adapter is implemented (T6)
- Slim sandbox server down to a single `bash` tool (removed premature `write_file`, `read_file`, `list_files`)
- Each handler checks for a configured provider and returns a clear `"Sandbox provider not configured."` error when missing

## Tests

- `tsc --noEmit` passes (no new type errors)
- `biome check` passes on all changed files
- No functional tests needed: handlers are stubs returning errors, no runtime behavior to test yet

## Risk

Low. All tool handlers still return errors — no behavioral change for end users. The provider getter returns `undefined` until T6 lands.

## Deploy Plan

Standard deploy, no migrations or env vars required for this change. `E2B_API_KEY` is optional and only needed once the E2B adapter is implemented.