### PR TITLE
[front] Perf: optimize blocked actions query with index-aligned filter and lighter fetches

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -169,6 +169,57 @@ describe("listBlockedActionsForConversation", () => {
     expect(result[0].metadata.agentName).toBe("Test Agent");
   });
 
+  it("should only return blocked actions, not succeeded ones", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    // Create user message at rank 0.
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+
+    // Create agent message at rank 1.
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+
+    // Create one blocked action and one succeeded action on the same agent message.
+    await createBlockedAction({
+      agentMessageId: agentMessageRow.agentMessageId!,
+    });
+    await createBlockedAction({
+      agentMessageId: agentMessageRow.agentMessageId!,
+      status: "succeeded",
+    });
+
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+
+    const result =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource!
+      );
+
+    // Only the blocked action should be returned, not the succeeded one.
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("blocked_validation_required");
+  });
+
   it("should only return blocked actions from the latest agent message version at a given rank", async () => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -1,0 +1,240 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("listBlockedActionsForConversation", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  let stepContentIndex = 0;
+
+  beforeEach(async () => {
+    stepContentIndex = 0;
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  });
+
+  async function createBlockedAction({
+    agentMessageId,
+    status = "blocked_validation_required",
+  }: {
+    agentMessageId: number;
+    status?: ToolExecutionStatus;
+  }) {
+    const functionCallId = generateRandomModelSId();
+    const currentIndex = stepContentIndex++;
+
+    const stepContent = await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      step: 1,
+      index: currentIndex,
+      version: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          id: functionCallId,
+          name: "test_tool",
+          arguments: "{}",
+        },
+      },
+    });
+
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "test_tool",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission: "low",
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+    };
+
+    const action = await AgentMCPActionModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      stepContentId: stepContent.id,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      version: 0,
+      status,
+      citationsAllocated: 0,
+      augmentedInputs: {},
+      toolConfiguration,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+
+    return { action, stepContent };
+  }
+
+  it("should return empty array for conversation with no agent messages", async () => {
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+
+    const result =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource!
+      );
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return blocked actions for conversation", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    // Create user message at rank 0.
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+
+    // Create agent message at rank 1.
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+
+    await createBlockedAction({
+      agentMessageId: agentMessageRow.agentMessageId!,
+    });
+
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+
+    const result =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource!
+      );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("blocked_validation_required");
+    expect(result[0].metadata.agentName).toBe("Test Agent");
+  });
+
+  it("should only return blocked actions from the latest agent message version at a given rank", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    // Create user message at rank 0.
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+
+    // Create agent message v0 at rank 1 with a blocked action.
+    const agentMessageV0Row =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+        version: 0,
+      });
+
+    await createBlockedAction({
+      agentMessageId: agentMessageV0Row.agentMessageId!,
+    });
+
+    // Create agent message v1 at the same rank (simulating a retry) with its own blocked action.
+    const agentMessageV1Row =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+        version: 1,
+      });
+
+    const { action: v1Action } = await createBlockedAction({
+      agentMessageId: agentMessageV1Row.agentMessageId!,
+    });
+
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+
+    const result =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource!
+      );
+
+    // Only the v1 blocked action should be returned, not v0's.
+    expect(result).toHaveLength(1);
+
+    // Verify the returned action belongs to the v1 agent message (not v0).
+    const expectedActionSId = AgentMCPActionResource.modelIdToSId({
+      id: v1Action.id,
+      workspaceId: workspace.id,
+    });
+    expect(result[0].actionId).toBe(expectedActionSId);
+  });
+});

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -16,13 +16,14 @@ import {
 import type { StepContext } from "@app/lib/actions/types";
 import { isFileAuthorizationInfo } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
+import { filterAgentsByRequestedSpaces } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
   AgentMessageModel,
   MessageModel,
@@ -230,39 +231,49 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   ): Promise<BlockedToolExecution[]> {
     const owner = auth.getNonNullableWorkspace();
 
-    const [latestAgentMessages, blockedActions] = await Promise.all([
-      conversation.getLatestAgentMessageIdByRank(auth),
-      AgentMCPActionModel.findAll({
-        include: [
-          {
-            model: AgentMessageModel,
-            as: "agentMessage",
-            required: true,
-            include: [
-              {
-                model: MessageModel,
-                as: "message",
-                required: true,
-                where: {
-                  conversationId: conversation.id,
-                },
-              },
-            ],
-          },
-        ],
-        where: {
-          workspaceId: owner.id,
-          status: {
-            [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES,
-          },
-        },
-        order: [["createdAt", "ASC"]],
-      }),
-    ]);
+    const latestAgentMessages =
+      await conversation.getLatestAgentMessageIdByRank(auth);
 
-    const latestAgentMessageIds = new Set(
-      latestAgentMessages.map((m) => m.agentMessageId)
+    const latestAgentMessageIds = latestAgentMessages.map(
+      (m) => m.agentMessageId
     );
+
+    if (latestAgentMessageIds.length === 0) {
+      return [];
+    }
+
+    // Scope by agentMessageId to fully use the (workspaceId, agentMessageId, status) index,
+    // avoiding a broad scan + join through messages to filter by conversationId.
+    const blockedActions = await AgentMCPActionModel.findAll({
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          attributes: [
+            "id",
+            "agentConfigurationId",
+            "agentConfigurationVersion",
+          ],
+          include: [
+            {
+              model: MessageModel,
+              as: "message",
+              required: true,
+              attributes: ["id", "sId", "parentId"],
+            },
+          ],
+        },
+      ],
+      where: {
+        workspaceId: owner.id,
+        agentMessageId: { [Op.in]: latestAgentMessageIds },
+        status: {
+          [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES,
+        },
+      },
+      order: [["createdAt", "ASC"]],
+    });
 
     const parentUserMessageIds = removeNulls(
       blockedActions.map((a) => a.agentMessage!.message!.parentId)
@@ -274,15 +285,18 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         conversationId: conversation.id,
         id: { [Op.in]: parentUserMessageIds },
       },
+      attributes: ["id"],
       include: [
         {
           model: UserMessageModel,
           as: "userMessage",
           required: true,
+          attributes: ["id"],
           include: [
             {
               model: UserModel,
               as: "user",
+              attributes: ["sId"],
             },
           ],
         },
@@ -319,12 +333,26 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       ),
     ];
 
-    const [agentConfigurations, mcpServerViews] = await Promise.all([
-      getAgentConfigurationsWithVersion(auth, agentConfigVersionPairs, {
-        variant: "extra_light",
-      }),
+    const [allAgentConfigurations, mcpServerViews] = await Promise.all([
+      agentConfigVersionPairs.length > 0
+        ? AgentConfigurationModel.findAll({
+            where: {
+              workspaceId: owner.id,
+              [Op.or]: agentConfigVersionPairs.map((pair) => ({
+                sId: pair.agentId,
+                version: pair.agentVersion,
+              })),
+            },
+            attributes: ["sId", "version", "name", "requestedSpaceIds"],
+          })
+        : Promise.resolve([]),
       MCPServerViewResource.fetchByIds(auth, mcpServerViewIds),
     ]);
+
+    const agentConfigurations = await filterAgentsByRequestedSpaces(
+      auth,
+      allAgentConfigurations
+    );
 
     const agentConfigurationMap = new Map(
       agentConfigurations.map((a) => [`${a.sId}:${a.version}`, a])
@@ -337,11 +365,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     for (const action of blockedActions) {
       const agentMessage = action.agentMessage;
       assert(agentMessage?.message, "No message for agent message.");
-
-      // Ignore actions that are not the latest version of the agent message.
-      if (!latestAgentMessageIds.has(agentMessage.id)) {
-        continue;
-      }
 
       const agentConfiguration = agentConfigurationMap.get(
         `${agentMessage.agentConfigurationId}:${agentMessage.agentConfigurationVersion}`

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -16,14 +16,13 @@ import {
 import type { StepContext } from "@app/lib/actions/types";
 import { isFileAuthorizationInfo } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import { filterAgentsByRequestedSpaces } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
   AgentMessageModel,
   MessageModel,
@@ -333,26 +332,12 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       ),
     ];
 
-    const [allAgentConfigurations, mcpServerViews] = await Promise.all([
-      agentConfigVersionPairs.length > 0
-        ? AgentConfigurationModel.findAll({
-            where: {
-              workspaceId: owner.id,
-              [Op.or]: agentConfigVersionPairs.map((pair) => ({
-                sId: pair.agentId,
-                version: pair.agentVersion,
-              })),
-            },
-            attributes: ["sId", "version", "name", "requestedSpaceIds"],
-          })
-        : Promise.resolve([]),
+    const [agentConfigurations, mcpServerViews] = await Promise.all([
+      getAgentConfigurationsWithVersion(auth, agentConfigVersionPairs, {
+        variant: "extra_light",
+      }),
       MCPServerViewResource.fetchByIds(auth, mcpServerViewIds),
     ]);
-
-    const agentConfigurations = await filterAgentsByRequestedSpaces(
-      auth,
-      allAgentConfigurations
-    );
 
     const agentConfigurationMap = new Map(
       agentConfigurations.map((a) => [`${a.sId}:${a.version}`, a])

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -217,16 +217,22 @@ export class ConversationFactory {
     conversationId,
     rank,
     agentConfigurationId,
+    agentConfigurationVersion = 0,
+    parentId = null,
+    version = 0,
   }: {
     workspace: WorkspaceType;
     conversationId: ModelId;
     rank: number;
     agentConfigurationId: string;
+    agentConfigurationVersion?: number;
+    parentId?: ModelId | null;
+    version?: number;
   }): Promise<MessageModel> {
     const agentMessageRow = await AgentMessageModel.create({
       status: "created",
       agentConfigurationId,
-      agentConfigurationVersion: 0,
+      agentConfigurationVersion,
       workspaceId: workspace.id,
       skipToolsValidation: false,
     });
@@ -234,8 +240,9 @@ export class ConversationFactory {
     return MessageModel.create({
       sId: generateRandomModelSId(),
       rank,
+      version,
       conversationId,
-      parentId: null,
+      parentId,
       agentMessageId: agentMessageRow.id,
       workspaceId: workspace.id,
     });


### PR DESCRIPTION
## Description

## Summary
- Replace the JOIN-based `conversationId` filter with a direct `agentMessageId IN (...)` filter that leverages the `(workspaceId, agentMessageId, status)` index, avoiding a broad scan.
- Replace `getAgentConfigurationsWithVersion` (~4 DB queries + permission filtering) with a single .`AgentConfigurationModel.findAll` fetching only `sId`, `version`, `name`.
- Add `attributes` to all Sequelize includes to skip heavy unused columns (`runIds`, `errorMessage`, `errorMetadata`, `content`, user context fields).
- Add regression tests for `listBlockedActionsForConversation`, including version filtering.


## Tests

Tests passes but I should test locally also -> not sure exactly how, will ask and do before merging 👍🏻 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 