### PR TITLE
Fix staging preview URL in Slack notifications

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -169,7 +169,7 @@ jobs:
           echo "### SPA Deployed :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **App**: ${{ inputs.app }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **URL**: ${{ github.ref_name == 'main' && format('https://staging-{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: ${{ github.ref_name == 'main' && format('https://staging-{0}--{1}.preview.dust.tt', github.sha, inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Region**: ${{ inputs.region }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
 
@@ -182,7 +182,7 @@ jobs:
           component: spa-${{ inputs.app }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          preview_url: ${{ github.ref_name == 'main' && format('https://staging-{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}
+          preview_url: ${{ github.ref_name == 'main' && format('https://staging-{0}--{1}.preview.dust.tt', github.sha, inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}
 
       - name: Notify Failure
         if: failure()


### PR DESCRIPTION
## Description

Fix the staging preview URL displayed in Slack notifications and GitHub step summary when deploying from `main`.

The URL was using `github.ref_name` (`main`) instead of `github.sha`, producing `https://staging-main--app.preview.dust.tt` instead of the correct `https://staging-<sha>--app.preview.dust.tt` (matching the `--branch` flag passed to `wrangler pages deploy`).

## Tests

Manual — deploy from main and verify the Slack notification contains the correct staging URL with the commit SHA.

## Risk

Low — CI-only change, no application code affected.

## Deploy Plan

Merge to main.