### PR TITLE
Handle multi region lookup for viz

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -47,6 +47,7 @@ import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import config from "@app/lib/api/config";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -894,6 +895,7 @@ function AgentMessageContent({
     VirtuosoMessageListContext
   >();
 
+  const { vizUrl } = useAuth();
   const { sId, configuration: agentConfiguration } = agentMessage;
 
   const { postFollowUp } = usePostOnboardingFollowUp({
@@ -968,7 +970,8 @@ function AgentMessageContent({
         owner,
         agentConfiguration.sId,
         conversationId,
-        sId
+        sId,
+        vizUrl
       ),
       sup: CiteBlock,
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
@@ -980,6 +983,7 @@ function AgentMessageContent({
       conversationId,
       sId,
       agentConfiguration.sId,
+      vizUrl,
       onQuickReplySend,
       isLastMessage,
       handleToolSetupComplete,

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,6 +1,5 @@
 import { useVisualizationRetry } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
-import config from "@app/lib/api/config";
 import { clientFetch } from "@app/lib/egress/client";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
@@ -238,6 +237,7 @@ interface VisualizationActionIframeProps {
   conversationId: string | null;
   isInDrawer?: boolean;
   visualization: Visualization;
+  vizUrl: string;
   workspaceId: string;
   isPublic?: boolean;
 }
@@ -347,8 +347,8 @@ export const VisualizationActionIframe = forwardRef<
       params.set("fullHeight", "true");
     }
 
-    return `${config.getClientFacingVizUrl()}/content?${params.toString()}`;
-  }, [visualization, isInDrawer]);
+    return `${props.vizUrl}/content?${params.toString()}`;
+  }, [visualization, isInDrawer, props.vizUrl]);
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -9,6 +9,7 @@ import { useVisualizationRevert } from "@app/hooks/conversations";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
@@ -191,6 +192,7 @@ export function FrameRenderer({
   lastEditedByAgentConfigurationId,
   contentHash,
 }: FrameRendererProps) {
+  const { vizUrl } = useAuth();
   const { isNavigationBarOpen, setIsNavigationBarOpen } =
     useDesktopNavigation();
   const [isLoading, setIsLoading] = useState(false);
@@ -363,6 +365,7 @@ export function FrameRenderer({
                   .lastEditedByAgentConfigurationId ?? ""
               }
               workspaceId={owner.sId}
+              vizUrl={vizUrl}
               visualization={{
                 code: fileContent ?? "",
                 complete: true,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -15,6 +15,7 @@ interface PublicFrameRendererProps {
   fileName?: string;
   shareToken: string;
   workspaceId: string;
+  vizUrl: string;
 }
 
 export function PublicFrameRenderer({
@@ -22,6 +23,7 @@ export function PublicFrameRenderer({
   fileName,
   shareToken,
   workspaceId,
+  vizUrl,
 }: PublicFrameRendererProps) {
   const { conversationUrl, isFrameLoading, error, accessToken } =
     usePublicFrame({
@@ -69,6 +71,7 @@ export function PublicFrameRenderer({
             agentConfigurationId={null}
             conversationId={null}
             workspaceId={workspaceId}
+            vizUrl={vizUrl}
             visualization={{
               accessToken,
               complete: true,

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@dust-tt/sparkle";
 interface PublicInteractiveContentContainerProps {
   shareToken: string;
   workspaceId: string;
+  vizUrl: string;
 }
 
 /**
@@ -18,6 +19,7 @@ interface PublicInteractiveContentContainerProps {
 export function PublicInteractiveContentContainer({
   shareToken,
   workspaceId,
+  vizUrl,
 }: PublicInteractiveContentContainerProps) {
   const { frameMetadata, isFrameLoading, error } = usePublicFrame({
     shareToken,
@@ -46,6 +48,7 @@ export function PublicInteractiveContentContainer({
             fileName={frameMetadata.fileName}
             shareToken={shareToken}
             workspaceId={workspaceId}
+            vizUrl={vizUrl}
           />
         );
 

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -54,13 +54,15 @@ export function getVisualizationPlugin(
   owner: LightWorkspaceType,
   agentConfigurationId: string,
   conversationId: string,
-  messageId: string
+  messageId: string,
+  vizUrl: string
 ) {
   const customRenderer = {
     visualization: (code: string, complete: boolean, lineStart: number) => {
       return (
         <VisualizationActionIframe
           workspaceId={owner.sId}
+          vizUrl={vizUrl}
           visualization={{
             code,
             complete,

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -88,6 +88,7 @@ export function SharedFramePage() {
         <PublicInteractiveContentContainer
           shareToken={token}
           workspaceId={shareMetadata.workspaceId}
+          vizUrl={shareMetadata.vizUrl}
         />
       </div>
     </>

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -23,16 +23,6 @@ const config = {
     return baseUrlResolver?.() || config.getClientFacingUrl();
   },
 
-  getClientFacingVizUrl: (): string | undefined => {
-    const baseUrl = getBaseUrlFromResolver();
-    if (baseUrl && baseUrl.includes("dust.tt")) {
-      // Derive viz URL from the resolver's base URL (e.g. https://eu.dust.tt -> https://eu.viz.dust.tt).
-      return baseUrl.replace("dust.tt", "viz.dust.tt");
-    }
-
-    return process.env.NEXT_PUBLIC_VIZ_URL;
-  },
-
   getClientFacingUrl: (): string => {
     // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the
     // uploadUrl returned by the file API points to the `http://front-internal-service` and not our

--- a/front/lib/swr/share.ts
+++ b/front/lib/swr/share.ts
@@ -1,5 +1,8 @@
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetShareFrameMetadataResponseBody } from "@app/pages/api/share/frame/[token]";
+import { useEffect } from "react";
 import type { Fetcher } from "swr";
 
 export function useShareFrameMetadata({
@@ -10,10 +13,11 @@ export function useShareFrameMetadata({
   const { fetcher } = useFetcher();
   const shareMetadataFetcher: Fetcher<GetShareFrameMetadataResponseBody> =
     fetcher;
+  const regionContext = useRegionContextSafe();
 
   const swrKey = shareToken ? `/api/share/frame/${shareToken}` : null;
 
-  const { data, error, isLoading } = useSWRWithDefaults(
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
     swrKey,
     shareMetadataFetcher,
     {
@@ -22,9 +26,25 @@ export function useShareFrameMetadata({
     }
   );
 
+  const isRegionRedirectResponse = error && isRegionRedirect(error.error);
+  const regionRedirect = isRegionRedirectResponse
+    ? error.error.redirect
+    : undefined;
+
+  // Handle region redirect.
+  useEffect(() => {
+    if (regionRedirect && regionContext) {
+      regionContext.setRegionInfo({
+        name: regionRedirect.region,
+        url: regionRedirect.url,
+      });
+      void mutate();
+    }
+  }, [regionRedirect, mutate, regionContext]);
+
   return {
-    shareMetadata: data,
-    isShareMetadataLoading: isLoading,
-    shareMetadataError: error,
+    shareMetadata: isRegionRedirectResponse ? undefined : data,
+    isShareMetadataLoading: isLoading || !!isRegionRedirectResponse,
+    shareMetadataError: isRegionRedirectResponse ? undefined : error,
   };
 }


### PR DESCRIPTION
## Summary
- Wire `vizUrl` from auth context through to all visualization iframe renderers, replacing the previous client-side `config.getClientFacingVizUrl()` approach
- Remove `getClientFacingVizUrl()` from config (was deriving viz URL client-side from RegionContext or `NEXT_PUBLIC_VIZ_URL`)
- Add region redirect handling in share frame metadata hook
- Stacked on #22103

## Test plan
- [ ] Verify visualizations render correctly in conversations (US + EU)
- [ ] Verify shared frames render correctly
- [ ] Verify cross-region shared frames redirect and render correctly
- [ ] No `localStorage` SecurityError in browser console

## Risk
Previous attempt (reverted in #22085) caused `SecurityError: Failed to read 'localStorage'` in production. Root cause: if `vizUrl` was empty/falsy, the iframe `src` resolved to a relative URL loading the front app (with RegionContext) inside the sandboxed iframe. This is mitigated by `VIZ_PUBLIC_URL` now being a required env var (#22103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)