### PR TITLE
dh fix(seed): set firstUsedAt on membership in dust-hive seed

### DIFF
--- a/front/lib/dev/dust_hive_seed.sql
+++ b/front/lib/dev/dust_hive_seed.sql
@@ -142,8 +142,8 @@ link_conversations AS (
 
 -- Step 6: Create membership
 inserted_membership AS (
-  INSERT INTO memberships ("workspaceId", "userId", role, origin, "startAt", "endAt", "createdAt", "updatedAt")
-  SELECT w.id, u.id, 'admin', 'invited', NOW(), NULL, NOW(), NOW()
+  INSERT INTO memberships ("workspaceId", "userId", role, origin, "startAt", "endAt", "firstUsedAt", "createdAt", "updatedAt")
+  SELECT w.id, u.id, 'admin', 'invited', NOW(), NULL, NOW(), NOW(), NOW()
   FROM inserted_workspace w
   CROSS JOIN inserted_user u
   RETURNING id


### PR DESCRIPTION
## Description

- Set `firstUsedAt = NOW()` on the seeded membership in `dust_hive_seed.sql`
- Without this, the membership has `firstUsedAt = NULL`, which causes `getMembersCountForWorkspace(activeOnly: true)` to return 0, blocking message sending in  dev environments

## Tests

/

## Risk

/

## Deploy Plan

Merge. 