### PR TITLE
Add slideshow frame content type for multi-page presentation export

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -61,7 +61,7 @@ import type {
 } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
-  isInteractiveContentFileContentType,
+  isInteractiveContentType,
   isSupportedImageContentType,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
@@ -1097,7 +1097,7 @@ function AgentMessageContent({
     .filter(
       (file) =>
         !isSupportedImageContentType(file.contentType) &&
-        !isInteractiveContentFileContentType(file.contentType)
+        !isInteractiveContentType(file.contentType)
     );
 
   return (

--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -1,7 +1,10 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { formatCalendarDate } from "@app/lib/utils/timestamps";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
-import { frameContentType } from "@app/types/files";
+import {
+  frameSlideshowContentType,
+  isFrameContentType,
+} from "@app/types/files";
 import { getTime } from "@app/types/shared/utils/date_utils";
 import {
   ActionFrameIcon,
@@ -15,7 +18,11 @@ import {
 function getDescriptionForContentType(
   file: LightAgentMessageType["generatedFiles"][number]
 ) {
-  if (file.contentType === frameContentType) {
+  if (file.contentType === frameSlideshowContentType) {
+    return "Presentation";
+  }
+
+  if (isFrameContentType(file.contentType)) {
     return "Frames";
   }
 

--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -3,7 +3,7 @@ import { formatCalendarDate } from "@app/lib/utils/timestamps";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 import {
   frameSlideshowContentType,
-  isFrameContentType,
+  isInteractiveContentType,
 } from "@app/types/files";
 import { getTime } from "@app/types/shared/utils/date_utils";
 import {
@@ -22,7 +22,7 @@ function getDescriptionForContentType(
     return "Presentation";
   }
 
-  if (isFrameContentType(file.contentType)) {
+  if (isInteractiveContentType(file.contentType)) {
     return "Frames";
   }
 

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -7,6 +7,7 @@ import config from "@app/lib/api/config";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import {
   frameContentType,
+  frameSlideshowContentType,
   isInteractiveContentContentType,
 } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -33,6 +34,7 @@ interface FileGroup {
 // Configuration for content types that get their own groups.
 const GROUPED_CONTENT_TYPES = {
   [frameContentType]: "Frames",
+  [frameSlideshowContentType]: "Presentations",
   "application/json": "JSON",
   "text/csv": "Tables",
   "text/plain": "Text",

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -8,7 +8,7 @@ import type { AllSupportedFileContentType } from "@app/types/files";
 import {
   frameContentType,
   frameSlideshowContentType,
-  isInteractiveContentContentType,
+  isInteractiveContentType,
 } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -134,9 +134,7 @@ const FileGroupSection = ({
   onFileClick,
   owner,
 }: FileGroupSectionProps) => {
-  const isInteractiveContent = isInteractiveContentContentType(
-    group.contentType
-  );
+  const isInteractiveContent = isInteractiveContentType(group.contentType);
 
   return (
     <div className="space-y-2">

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -43,6 +43,7 @@ interface ExportContentDropdownProps {
   owner: LightWorkspaceType;
   fileId: string;
   fileContent: string | null;
+  fileName?: string;
 }
 
 function ExportContentDropdown({
@@ -50,6 +51,7 @@ function ExportContentDropdown({
   owner,
   fileId,
   fileContent,
+  fileName,
 }: ExportContentDropdownProps) {
   const sendNotification = useSendNotification();
   const [isExportingPdf, setIsExportingPdf] = useState(false);
@@ -106,10 +108,7 @@ function ExportContentDropdown({
       const link = document.createElement("a");
       link.href = url;
 
-      // Get filename from Content-Disposition header or use default.
-      const contentDisposition = response.headers.get("Content-Disposition");
-      const filenameMatch = contentDisposition?.match(/filename="([^"]+)"/);
-      link.download = filenameMatch?.[1] ?? "frame.pdf";
+      link.download = fileName?.replace(/\.[^.]+$/, ".pdf") ?? "frame.pdf";
 
       link.click();
       URL.revokeObjectURL(url);
@@ -336,6 +335,7 @@ export function FrameRenderer({
               owner={owner}
               fileId={fileId}
               fileContent={fileContent ?? null}
+              fileName={fileMetadata?.fileName}
             />
             <ShareFramePopover
               fileId={fileId}

--- a/front/components/assistant/conversation/interactive_content/InteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/InteractiveContentContainer.tsx
@@ -4,7 +4,7 @@ import { FrameRenderer } from "@app/components/assistant/conversation/interactiv
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/interactive_content/UnsupportedContentRenderer";
 import { useFileMetadata } from "@app/lib/swr/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
 import { useMemo } from "react";
@@ -69,6 +69,7 @@ export function InteractiveContentContainer({
     // Render appropriate content based on content type.
     switch (fileMetadata.contentType) {
       case frameContentType:
+      case frameSlideshowContentType:
         return (
           <FrameRenderer
             conversation={conversation}

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -3,7 +3,7 @@ import { PublicFrameRenderer } from "@app/components/assistant/conversation/inte
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/interactive_content/UnsupportedContentRenderer";
 import { usePublicFrame } from "@app/lib/swr/frames";
 import Custom404 from "@app/pages/404";
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import { Spinner } from "@dust-tt/sparkle";
 
 interface PublicInteractiveContentContainerProps {
@@ -39,6 +39,7 @@ export function PublicInteractiveContentContainer({
 
     switch (frameMetadata.contentType) {
       case frameContentType:
+      case frameSlideshowContentType:
         return (
           <PublicFrameRenderer
             fileId={frameMetadata.sId}

--- a/front/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent.ts
+++ b/front/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent.ts
@@ -1,7 +1,7 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type { MessageTemporaryState } from "@app/components/assistant/conversation/types";
 import { isInteractiveContentFileContentOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { isInteractiveContentFileContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import { removeNulls } from "@app/types/shared/utils/general";
 import React from "react";
 
@@ -60,7 +60,7 @@ export function useAutoOpenInteractiveContent({
   const completedInteractiveFiles = React.useMemo(
     () =>
       agentMessage.generatedFiles.filter((file) =>
-        isInteractiveContentFileContentType(file.contentType)
+        isInteractiveContentType(file.contentType)
       ),
     [agentMessage.generatedFiles]
   );

--- a/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
@@ -1,4 +1,4 @@
-import { frameContentType } from "@app/types/files";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 
 export const VIZ_REACT_COMPONENT_GUIDELINES = `
 ### React Component Guidelines:
@@ -357,3 +357,4 @@ const CHART_COLORS = [
 `;
 
 export const VIZ_MIME_TYPE = frameContentType;
+export const VIZ_SLIDESHOW_MIME_TYPE = frameSlideshowContentType;

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -159,8 +159,77 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
 - When to Create Files:
   - Create files for data visualizations such as graphs, charts, and plots
   - Create files for complex visualizations that require user interaction
+  - Create files for slideshow presentations (use the Slideshow component)
   - Do not create files for simple text-based content that can be rendered in Markdown
   - Do not create files for content that does not require user interaction
+
+### Slideshows
+
+When the user asks for a presentation, slideshow, deck, or multi-slide content, create an interactive
+content file using the \`Slideshow\` and \`Slide\` components.
+
+**Import:** \`import { Slideshow, Slide } from "@dust/slideshow/v2";\`
+
+**Components:**
+- \`<Slideshow>\` wraps all slides. It handles navigation (prev/next arrows, dot indicators, keyboard
+  arrow keys) and PDF export automatically. Accepts an optional \`className\` prop.
+- \`<Slide>\` represents one slide. Each slide takes the full viewport height, centers its children,
+  and accepts a \`className\` prop (commonly used for background colors like \`bg-slate-50\`).
+  Inside a \`<Slide>\`, use any React and Tailwind — standard HTML elements, Recharts charts,
+  grid layouts, etc.
+
+**Content guidelines:**
+- One main idea per slide. Avoid overcrowding.
+- Use a consistent background color across slides for cohesion (e.g. all \`bg-white\` or all \`bg-slate-50\`).
+  Use 1-2 accent colors for emphasis elements.
+- Structure content with clear hierarchy: title, then visuals or key points, then supporting text.
+- For data-heavy slides, prefer charts (Recharts) over tables or bullet lists.
+
+**Do not:**
+- Do not build navigation controls (buttons, arrows, dots, keyboard handlers). They are built in.
+- Do not import from \`@dust/slideshow/v1\`. Always use \`@dust/slideshow/v2\`.
+- Do not set explicit heights on \`<Slide>\` — it fills the viewport automatically.
+- Do not use gradients unless the user explicitly requests them.
+
+\`\`\`tsx
+import { Slideshow, Slide } from "@dust/slideshow/v2";
+
+export default function Deck() {
+  return (
+    <Slideshow>
+      <Slide className="bg-slate-50">
+        <h1 className="text-6xl font-bold text-slate-900 mb-4">Q4 Revenue Analysis</h1>
+        <p className="text-xl text-slate-500">Annual review & key insights</p>
+      </Slide>
+      <Slide className="bg-white">
+        <h2 className="text-4xl font-semibold mb-8">Key Metrics</h2>
+        <div className="grid grid-cols-3 gap-8">
+          <div className="text-center">
+            <p className="text-5xl font-bold text-blue-600">+25%</p>
+            <p className="text-lg text-slate-500 mt-2">YoY Growth</p>
+          </div>
+          <div className="text-center">
+            <p className="text-5xl font-bold text-green-600">92%</p>
+            <p className="text-lg text-slate-500 mt-2">Retention</p>
+          </div>
+          <div className="text-center">
+            <p className="text-5xl font-bold text-purple-600">1.2k</p>
+            <p className="text-lg text-slate-500 mt-2">New Customers</p>
+          </div>
+        </div>
+      </Slide>
+      <Slide className="bg-slate-50">
+        <h2 className="text-4xl font-semibold mb-6">Next Steps</h2>
+        <ul className="space-y-4 text-xl text-slate-700">
+          <li>Expand into EU markets</li>
+          <li>Launch premium tier</li>
+          <li>Revamp onboarding flow</li>
+        </ul>
+      </Slide>
+    </Slideshow>
+  );
+}
+\`\`\`
 
 ${VIZ_USE_FILE_EXAMPLES}
 

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -5,6 +5,7 @@ import {
   VIZ_MIME_TYPE,
   VIZ_MISCELLANEOUS_GUIDELINES,
   VIZ_REACT_COMPONENT_GUIDELINES,
+  VIZ_SLIDESHOW_MIME_TYPE,
   VIZ_STYLING_GUIDELINES,
   VIZ_USE_FILE_EXAMPLES,
 } from "@app/lib/actions/mcp_internal_actions/servers/common/viz/instructions";
@@ -25,9 +26,10 @@ This toolset is called Frame in the product, users may refer to it as such.
 ### Creating Files
 
 Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files:
-- Use MIME type \`${VIZ_MIME_TYPE}\`
+- Use MIME type \`${VIZ_MIME_TYPE}\` for visualizations/dashboards or \`${VIZ_SLIDESHOW_MIME_TYPE}\` for slideshows
 - Supported file extensions: .js, .jsx, .ts, .tsx
 - Files are automatically made available to the user for execution
+- The MIME type is set at creation and cannot be changed afterward. To switch content type, create a new file.
 
 The tool supports two creation modes via the \`mode\` parameter. The mode determines where the
 React component code comes from:
@@ -167,6 +169,8 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
 
 When the user asks for a presentation, slideshow, deck, or multi-slide content, create an interactive
 content file using the \`Slideshow\` and \`Slide\` components.
+
+**MIME type:** Always set \`mime_type\` to \`${VIZ_SLIDESHOW_MIME_TYPE}\` when creating a slideshow.
 
 **Import:** \`import { Slideshow, Slide } from "@dust/slideshow/v2";\`
 

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -3,6 +3,7 @@ import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_de
 import type { InteractiveContentFileContentType } from "@app/types/files";
 import {
   frameContentType,
+  frameSlideshowContentType,
   INTERACTIVE_CONTENT_FILE_FORMATS,
 } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -49,7 +50,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
         )
         .describe(
           "The MIME type for the Interactive Content file. Use " +
-            `'${frameContentType}' for Frame components (React/JSX).`
+            `'${frameContentType}' for visualizations and dashboards. Use ` +
+            `'${frameSlideshowContentType}' for presentations and slideshows.`
         ),
       mode: z
         .enum(["template", "inline"])

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -25,7 +25,7 @@ const config = {
 
   getClientFacingVizUrl: (): string | undefined => {
     const baseUrl = getBaseUrlFromResolver();
-    if (baseUrl) {
+    if (baseUrl && baseUrl.includes("dust.tt")) {
       // Derive viz URL from the resolver's base URL (e.g. https://eu.dust.tt -> https://eu.viz.dust.tt).
       return baseUrl.replace("dust.tt", "viz.dust.tt");
     }

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -15,7 +15,7 @@ import logger from "@app/logger/logger";
 import type { InteractiveContentFileContentType } from "@app/types/files";
 import {
   INTERACTIVE_CONTENT_FILE_FORMATS,
-  isInteractiveContentFileContentType,
+  isInteractiveContentType,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -96,7 +96,7 @@ export async function createClientExecutableFile(
     const workspace = auth.getNonNullableWorkspace();
 
     // Validate that the MIME type is supported.
-    if (!isInteractiveContentFileContentType(mimeType)) {
+    if (!isInteractiveContentType(mimeType)) {
       const supportedTypes = Object.keys(INTERACTIVE_CONTENT_FILE_FORMATS).join(
         ", "
       );
@@ -272,7 +272,7 @@ export async function renameClientExecutableFile(
     return new Err({ message: `File not found: ${fileId}`, tracked: false });
   }
 
-  if (!isInteractiveContentFileContentType(fileResource.contentType)) {
+  if (!isInteractiveContentType(fileResource.contentType)) {
     return new Err({
       message: `File '${fileId}' is not an interactive content file (content type: ${fileResource.contentType})`,
       tracked: false,
@@ -336,7 +336,7 @@ export async function getClientExecutableFileContent(
     }
 
     // Check if it's an Interactive Content file.
-    if (!isInteractiveContentFileContentType(fileResource.contentType)) {
+    if (!isInteractiveContentType(fileResource.contentType)) {
       return new Err({
         message:
           `File '${fileId}' is not an Interactive Content file ` +

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -13,7 +13,7 @@ import type {
 } from "@app/types/files";
 import {
   extensionsForContentType,
-  isInteractiveContentFileContentType,
+  isInteractiveContentType,
   isSupportedAudioContentType,
   isSupportedDelimitedTextContentType,
   isSupportedImageContentType,
@@ -427,7 +427,7 @@ const getProcessingFunction = ({
   useCase: FileUseCase;
 }): ProcessingFunction | undefined => {
   // Interactive Content file types are not processed.
-  if (isInteractiveContentFileContentType(contentType)) {
+  if (isInteractiveContentType(contentType)) {
     return undefined;
   }
 

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -25,7 +25,7 @@ import type {
   FileUseCase,
 } from "@app/types/files";
 import {
-  isInteractiveContentFileContentType,
+  isInteractiveContentType,
   isSupportedAudioContentType,
   isSupportedImageContentType,
   TABLE_PREFIX,
@@ -428,7 +428,7 @@ const getProcessingFunction = ({
   }
 
   // Interactive Content files should not be processed.
-  if (isInteractiveContentFileContentType(contentType)) {
+  if (isInteractiveContentType(contentType)) {
     return undefined;
   }
 

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -16,7 +16,7 @@ import {
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import { isInteractiveContentFileContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import { isArrayOf } from "@app/types/shared/typescipt_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
@@ -89,7 +89,7 @@ export function filterOutInteractiveContentFileContentTypes(
 ): ContentFragmentPublicType[] {
   const result: ContentFragmentPublicType[] = [];
   for (const m of c) {
-    if (isInteractiveContentFileContentType(m.contentType)) {
+    if (isInteractiveContentType(m.contentType)) {
       continue;
     }
     result.push({

--- a/front/lib/api/viz/access_tokens.ts
+++ b/front/lib/api/viz/access_tokens.ts
@@ -1,13 +1,18 @@
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
-import { fileShareScopeSchema, frameContentType } from "@app/types/files";
+import type { FrameContentType } from "@app/types/files";
+import {
+  fileShareScopeSchema,
+  frameContentType,
+  frameSlideshowContentType,
+} from "@app/types/files";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import jwt from "jsonwebtoken";
 import { z } from "zod";
 
 // Zod schema for VizAccessTokenPayload.
 const VizAccessTokenPayloadSchema = z.object({
-  contentType: z.literal(frameContentType),
+  contentType: z.enum([frameContentType, frameSlideshowContentType]),
   fileToken: z.string(),
   shareScope: fileShareScopeSchema,
   userId: z.string().optional(),
@@ -17,18 +22,20 @@ const VizAccessTokenPayloadSchema = z.object({
 export type VizAccessTokenPayload = z.infer<typeof VizAccessTokenPayloadSchema>;
 
 export function generateVizAccessToken({
+  contentType,
   fileToken,
   userId,
   shareScope,
   workspaceId,
 }: {
+  contentType: FrameContentType;
   fileToken: string;
   userId?: string;
   shareScope: "public" | "workspace";
   workspaceId: string;
 }): string {
   const payload: VizAccessTokenPayload = {
-    contentType: frameContentType,
+    contentType,
     fileToken,
     shareScope,
     userId,

--- a/front/lib/api/viz/access_tokens.ts
+++ b/front/lib/api/viz/access_tokens.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
-import type { FrameContentType } from "@app/types/files";
+import type { InteractiveContentFileContentType } from "@app/types/files";
 import {
   fileShareScopeSchema,
   frameContentType,
@@ -28,7 +28,7 @@ export function generateVizAccessToken({
   shareScope,
   workspaceId,
 }: {
-  contentType: FrameContentType;
+  contentType: InteractiveContentFileContentType;
   fileToken: string;
   userId?: string;
   shareScope: "public" | "workspace";

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -28,11 +28,7 @@ import type {
   FileUseCase,
   FileUseCaseMetadata,
 } from "@app/types/files";
-import {
-  ALL_FILE_FORMATS,
-  isFrameContentType,
-  isInteractiveContentFileContentType,
-} from "@app/types/files";
+import { ALL_FILE_FORMATS, isInteractiveContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -419,7 +415,7 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   get isInteractiveContent(): boolean {
-    return isInteractiveContentFileContentType(this.contentType);
+    return isInteractiveContentType(this.contentType);
   }
 
   // Cloud storage logic.
@@ -754,7 +750,7 @@ export class FileResource extends BaseResource<FileModel> {
       "getShareUrlForShareableFile called on non-interactive content file"
     );
 
-    if (isFrameContentType(this.contentType)) {
+    if (isInteractiveContentType(this.contentType)) {
       return `${config.getAppUrl()}/share/frame/${shareableFileToken}`;
     }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -30,7 +30,7 @@ import type {
 } from "@app/types/files";
 import {
   ALL_FILE_FORMATS,
-  frameContentType,
+  isFrameContentType,
   isInteractiveContentFileContentType,
 } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -754,7 +754,7 @@ export class FileResource extends BaseResource<FileModel> {
       "getShareUrlForShareableFile called on non-interactive content file"
     );
 
-    if (this.contentType === frameContentType) {
+    if (isFrameContentType(this.contentType)) {
       return `${config.getAppUrl()}/share/frame/${shareableFileToken}`;
     }
 

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -24,7 +24,7 @@ const CONTENT_SECURITY_POLICIES = [
   `object-src 'none';`,
   `form-action 'self' *.hsforms.com;`,
   `base-uri 'self';`,
-  `frame-ancestors 'self' https://dust.tt https://*.dust.tt https://app.contentful.com;`,
+  `frame-ancestors 'self' https://dust.tt https://*.dust.tt https://app.contentful.com${isDev ? " http://localhost:3000 http://localhost:3007" : ""};`,
   `manifest-src 'self';`,
   `worker-src 'self' blob:;`,
   // Only upgrade insecure requests in production - in development we use HTTP

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -3,7 +3,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { frameContentType } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface GetShareFrameMetadataResponseBody {
@@ -52,7 +52,7 @@ async function handler(
   const { file, shareScope } = result;
 
   // Only allow Frame files.
-  if (file.contentType !== frameContentType) {
+  if (!isFrameContentType(file.contentType)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -3,7 +3,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isFrameContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface GetShareFrameMetadataResponseBody {
@@ -52,7 +52,7 @@ async function handler(
   const { file, shareScope } = result;
 
   // Only allow Frame files.
-  if (!isFrameContentType(file.contentType)) {
+  if (!isInteractiveContentType(file.contentType)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -7,7 +7,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isFrameContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -68,7 +68,10 @@ async function handler(
   const { file, shareScope } = result;
 
   // Only allow conversation Frame files.
-  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
+  if (
+    !file.isInteractiveContent ||
+    !isInteractiveContentType(file.contentType)
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -7,7 +7,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { frameContentType } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -68,7 +68,7 @@ async function handler(
   const { file, shareScope } = result;
 
   // Only allow conversation Frame files.
-  if (!file.isInteractiveContent || file.contentType !== frameContentType) {
+  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -139,6 +139,7 @@ async function handler(
 
   // Generate access token for viz rendering.
   const accessToken = generateVizAccessToken({
+    contentType: file.contentType,
     fileToken: token,
     userId: user?.sId,
     shareScope,

--- a/front/pages/api/v1/viz/content.test.ts
+++ b/front/pages/api/v1/viz/content.test.ts
@@ -40,6 +40,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
     }
 
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -163,6 +164,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
 
     // Generate token with current time.
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -208,6 +210,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
     }
 
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -252,6 +255,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
     }
 
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "workspace",

--- a/front/pages/api/v1/viz/content.ts
+++ b/front/pages/api/v1/viz/content.ts
@@ -3,7 +3,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isFrameContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import type { PublicVizContentResponseBodyType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -110,7 +110,10 @@ async function handler(
   }
 
   // Only allow conversation interactive files.
-  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
+  if (
+    !file.isInteractiveContent ||
+    !isInteractiveContentType(file.contentType)
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/v1/viz/content.ts
+++ b/front/pages/api/v1/viz/content.ts
@@ -3,7 +3,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { frameContentType } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import type { PublicVizContentResponseBodyType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -110,7 +110,7 @@ async function handler(
   }
 
   // Only allow conversation interactive files.
-  if (!file.isInteractiveContent || file.contentType !== frameContentType) {
+  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -159,7 +159,7 @@ async function handler(
 
   return res.status(200).json({
     content: result.content,
-    contentType: frameContentType,
+    contentType: file.contentType,
     metadata: {
       conversationId: result.file.useCaseMetadata?.conversationId,
     },

--- a/front/pages/api/v1/viz/files/[fileId].ts
+++ b/front/pages/api/v1/viz/files/[fileId].ts
@@ -8,7 +8,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { frameContentType } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -131,7 +131,7 @@ async function handler(
   // Only allow conversation Frame files.
   if (
     !frameFile.isInteractiveContent ||
-    frameFile.contentType !== frameContentType
+    !isFrameContentType(frameFile.contentType)
   ) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/v1/viz/files/[fileId].ts
+++ b/front/pages/api/v1/viz/files/[fileId].ts
@@ -8,7 +8,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isFrameContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -131,7 +131,7 @@ async function handler(
   // Only allow conversation Frame files.
   if (
     !frameFile.isInteractiveContent ||
-    !isFrameContentType(frameFile.contentType)
+    !isInteractiveContentType(frameFile.contentType)
   ) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -82,6 +82,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
     // Generate JWT access token.
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -150,6 +151,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
     // Generate JWT access token.
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -218,6 +220,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
     // Generate JWT access token.
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       // Generating token with 'public' scope.
@@ -293,6 +296,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
     // Generate JWT access token for frame from conversation A
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -361,6 +365,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
     // Generate JWT access token
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -423,6 +428,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
     // Generate JWT access token
     const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
       fileToken,
       workspaceId: workspace.sId,
       shareScope: "public",
@@ -692,6 +698,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       }
 
       const accessToken = generateVizAccessToken({
+        contentType: frameContentType,
         fileToken,
         workspaceId: workspace.sId,
         shareScope: "public",
@@ -829,6 +836,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       }
 
       const accessToken = generateVizAccessToken({
+        contentType: frameContentType,
         fileToken,
         workspaceId: workspace.sId,
         shareScope: "public",

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -10,7 +10,7 @@ import {
   isContentFragmentInputWithInlinedContent,
 } from "@app/types/api/internal/assistant";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isInteractiveContentFileContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import type { PostContentFragmentResponseType } from "@dust-tt/client";
 import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -171,9 +171,7 @@ async function handler(
 
       const publicContentFragment =
         !contentFragmentRes.value ||
-        isInteractiveContentFileContentType(
-          contentFragmentRes.value.contentType
-        )
+        isInteractiveContentType(contentFragmentRes.value.contentType)
           ? undefined
           : {
               ...contentFragmentRes.value,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -43,7 +43,7 @@ import type {
 import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isInteractiveContentFileContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import type {
   GetConversationsResponseType,
@@ -503,7 +503,7 @@ async function handler(
         message: newMessage ?? undefined,
         contentFragment:
           !newContentFragment ||
-          isInteractiveContentFileContentType(newContentFragment.contentType)
+          isInteractiveContentType(newContentFragment.contentType)
             ? undefined
             : {
                 ...newContentFragment,

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -12,7 +12,10 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { frameContentType } from "@app/types/files";
+import {
+  frameSlideshowContentType,
+  isFrameContentType,
+} from "@app/types/files";
 import type { PdfOptions } from "@app/types/shared/document_renderer";
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import { isString } from "@app/types/shared/utils/general";
@@ -20,7 +23,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
 const PostPdfExportBodySchema = z.object({
-  orientation: z.enum(["portrait", "landscape"]).optional().default("portrait"),
+  orientation: z.enum(["portrait", "landscape"]).optional(),
 });
 
 async function handler(
@@ -84,7 +87,7 @@ async function handler(
   }
 
   // Only allow Frame files.
-  if (!file.isInteractiveContent || file.contentType !== frameContentType) {
+  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -131,6 +134,7 @@ async function handler(
   const owner = auth.getNonNullableWorkspace();
   const user = auth.user();
   const accessToken = generateVizAccessToken({
+    contentType: file.contentType,
     fileToken: shareToken,
     userId: user?.sId,
     shareScope: shareInfo.scope,
@@ -157,7 +161,12 @@ async function handler(
   });
   const targetUrl = `${vizUrl}/content?${params.toString()}`;
 
-  const { orientation } = bodyResult.data;
+  // Default to landscape for slideshow content, portrait for regular frames.
+  const orientation =
+    bodyResult.data.orientation ??
+    (file.contentType === frameSlideshowContentType ? "landscape" : "portrait");
+
+  const isSlideshow = file.contentType === frameSlideshowContentType;
 
   // Only show footer for non-Enterprise plans and non-FriendsAndFamily plans.
   const plan = auth.plan();
@@ -168,10 +177,11 @@ async function handler(
 
   const renderer = new DocumentRenderer(documentRendererUrl, logger);
 
+  // Slideshows use zero margins (full-bleed slides).
   const options: PdfOptions = showFooter
     ? {
         footerHtml: PDF_FOOTER_HTML,
-        marginBottom: "1cm", // Space for footer.
+        marginBottom: isSlideshow ? "0" : "1cm",
       }
     : {};
 

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -14,7 +14,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import {
   frameSlideshowContentType,
-  isFrameContentType,
+  isInteractiveContentType,
 } from "@app/types/files";
 import type { PdfOptions } from "@app/types/shared/document_renderer";
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
@@ -87,7 +87,10 @@ async function handler(
   }
 
   // Only allow Frame files.
-  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
+  if (
+    !file.isInteractiveContent ||
+    !isInteractiveContentType(file.contentType)
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -7,8 +7,8 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { FileShareScope } from "@app/types/files";
 import {
   fileShareScopeSchema,
-  frameContentType,
   isConversationFileUseCase,
+  isFrameContentType,
 } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -71,7 +71,7 @@ async function handler(
   }
 
   // Only allow sharing Frame files.
-  if (!file.isInteractiveContent || file.contentType !== frameContentType) {
+  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -8,7 +8,7 @@ import type { FileShareScope } from "@app/types/files";
 import {
   fileShareScopeSchema,
   isConversationFileUseCase,
-  isFrameContentType,
+  isInteractiveContentType,
 } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -71,7 +71,10 @@ async function handler(
   }
 
   // Only allow sharing Frame files.
-  if (!file.isInteractiveContent || !isFrameContentType(file.contentType)) {
+  if (
+    !file.isInteractiveContent ||
+    !isInteractiveContentType(file.contentType)
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -363,6 +363,20 @@ export const FILE_FORMATS = {
 export type SupportedFileContentType = keyof typeof FILE_FORMATS;
 
 export const frameContentType = "application/vnd.dust.frame";
+export const frameSlideshowContentType = "application/vnd.dust.frame.slideshow";
+
+export type FrameContentType =
+  | typeof frameContentType
+  | typeof frameSlideshowContentType;
+
+export function isFrameContentType(
+  contentType: string
+): contentType is FrameContentType {
+  return (
+    contentType === frameContentType ||
+    contentType === frameSlideshowContentType
+  );
+}
 
 // Interactive Content MIME types for specialized use cases (not exposed via APIs).
 export const INTERACTIVE_CONTENT_FILE_FORMATS = {
@@ -370,6 +384,11 @@ export const INTERACTIVE_CONTENT_FILE_FORMATS = {
   // These files are internal-only and should not be exposed via APIs.
   // Limited to JavaScript/TypeScript files that can run in the browser.
   [frameContentType]: {
+    cat: "code",
+    exts: [".js", ".jsx", ".ts", ".tsx"],
+    isSafeToDisplay: true,
+  },
+  [frameSlideshowContentType]: {
     cat: "code",
     exts: [".js", ".jsx", ".ts", ".tsx"],
     isSafeToDisplay: true,

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -365,19 +365,6 @@ export type SupportedFileContentType = keyof typeof FILE_FORMATS;
 export const frameContentType = "application/vnd.dust.frame";
 export const frameSlideshowContentType = "application/vnd.dust.frame.slideshow";
 
-export type FrameContentType =
-  | typeof frameContentType
-  | typeof frameSlideshowContentType;
-
-export function isFrameContentType(
-  contentType: string
-): contentType is FrameContentType {
-  return (
-    contentType === frameContentType ||
-    contentType === frameSlideshowContentType
-  );
-}
-
 // Interactive Content MIME types for specialized use cases (not exposed via APIs).
 export const INTERACTIVE_CONTENT_FILE_FORMATS = {
   // Custom for frame code files managed by interactive_content MCP server.
@@ -394,10 +381,6 @@ export const INTERACTIVE_CONTENT_FILE_FORMATS = {
     isSafeToDisplay: true,
   },
 } as const satisfies Record<string, FileFormat>;
-
-export function isInteractiveContentContentType(contentType: string): boolean {
-  return Object.keys(INTERACTIVE_CONTENT_FILE_FORMATS).includes(contentType);
-}
 
 // Define a type for Interactive Content file content types.
 export type InteractiveContentFileContentType =
@@ -462,7 +445,7 @@ export function isSupportedFileContentType(
   return !!FILE_FORMATS[contentType as SupportedFileContentType];
 }
 
-export function isInteractiveContentFileContentType(
+export function isInteractiveContentType(
   contentType: string
 ): contentType is InteractiveContentFileContentType {
   return !!INTERACTIVE_CONTENT_FILE_FORMATS[
@@ -474,7 +457,7 @@ export function isAllSupportedFileContentType(
   contentType: string
 ): contentType is AllSupportedFileContentType {
   return (
-    isInteractiveContentFileContentType(contentType) ||
+    isInteractiveContentType(contentType) ||
     isSupportedFileContentType(contentType)
   );
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -279,10 +279,14 @@ const SupportedFileContentFragmentTypeSchema = FlexibleEnumSchema<
 >();
 
 const FrameContentTypeSchema = z.literal("application/vnd.dust.frame");
+const FrameSlideshowContentTypeSchema = z.literal(
+  "application/vnd.dust.frame.slideshow"
+);
 
 const ActionGeneratedFileContentTypeSchema = z.union([
   SupportedFileContentFragmentTypeSchema,
   FrameContentTypeSchema,
+  FrameSlideshowContentTypeSchema,
 ]);
 
 export function isSupportedFileContentType(

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { Spinner } from "@viz/app/components/Components";
 import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
+import { VizContext } from "@viz/app/components/VizContext";
 import type {
   VisualizationAPI,
   VisualizationConfig,
@@ -20,6 +21,7 @@ import {
   validateMessage,
 } from "@viz/app/types/messages";
 import * as dustSlideshowV1 from "@viz/components/dust/slideshow/v1";
+import * as dustSlideshowV2 from "@viz/components/dust/slideshow/v2";
 import * as shadcnAll from "@viz/components/ui";
 import * as utilsAll from "@viz/lib/utils";
 import { toBlob, toSvg } from "html-to-image";
@@ -322,6 +324,7 @@ export function VisualizationWrapper({
               utils: utilsAll,
               "lucide-react": lucideAll,
               "@dust/slideshow/v1": dustSlideshowV1,
+              "@dust/slideshow/v2": dustSlideshowV2,
               "@dust/generated-code": importCode(codeToUse, {
                 import: {
                   papaparse: papaparseAll,
@@ -334,6 +337,7 @@ export function VisualizationWrapper({
                   "@viz/lib/utils": utilsAll,
                   "lucide-react": lucideAll,
                   "@dust/slideshow/v1": dustSlideshowV1,
+                  "@dust/slideshow/v2": dustSlideshowV2,
                   "@dust/react-hooks": {
                     captureScreenshot: handleScreenshotDownload,
                     triggerUserFileDownload: memoizedDownloadFile,
@@ -449,20 +453,22 @@ export function VisualizationWrapper({
         </div>
       )}
       <div ref={ref}>
-        <Runner
-          code={runnerParams.code}
-          scope={runnerParams.scope}
-          onRendered={(error) => {
-            if (error) {
-              setErrorMessage(error);
-            } else {
-              // Set data-viz-ready attribute once fully rendered to enable screen capture.
-              // In PDF mode, delay to let Recharts animations complete (react-smooth is JS-based).
-              const delayMs = isPdfMode ? 5000 : 0;
-              setTimeout(() => setVizReady(true), delayMs);
-            }
-          }}
-        />
+        <VizContext.Provider value={{ isPdfMode }}>
+          <Runner
+            code={runnerParams.code}
+            scope={runnerParams.scope}
+            onRendered={(error) => {
+              if (error) {
+                setErrorMessage(error);
+              } else {
+                // Set data-viz-ready attribute once fully rendered to enable screen capture.
+                // In PDF mode, delay to let Recharts animations complete (react-smooth is JS-based).
+                const delayMs = isPdfMode ? 5000 : 0;
+                setTimeout(() => setVizReady(true), delayMs);
+              }
+            }}
+          />
+        </VizContext.Provider>
       </div>
     </div>
   );

--- a/viz/app/components/VizContext.tsx
+++ b/viz/app/components/VizContext.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface VizContextValue {
+  isPdfMode: boolean;
+}
+
+export const VizContext = createContext<VizContextValue>({
+  isPdfMode: false,
+});
+
+export function useVizContext(): VizContextValue {
+  return useContext(VizContext);
+}

--- a/viz/app/styles/globals.css
+++ b/viz/app/styles/globals.css
@@ -380,7 +380,7 @@
 
 /* Print styles for PDF export */
 @page {
-  margin: 2rem;
+  margin: 0;
 }
 
 @media print {

--- a/viz/components/dust/slideshow/v2/index.tsx
+++ b/viz/components/dust/slideshow/v2/index.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useVizContext } from "@viz/app/components/VizContext";
+import { cn } from "@viz/lib/utils";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+// -- Slide --
+
+interface SlideProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Slide({ children, className }: SlideProps) {
+  return (
+    <div
+      className={cn(
+        "w-full h-full min-h-screen flex flex-col items-center justify-center overflow-hidden p-12",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+// -- Navigation --
+
+const NAVIGATION_HIDE_DELAY_MS = 3000;
+
+interface NavigationProps {
+  activeIndex: number;
+  onNext: () => void;
+  onPrev: () => void;
+  total: number;
+}
+
+function Navigation({ activeIndex, onNext, onPrev, total }: NavigationProps) {
+  const [isVisible, setIsVisible] = useState(true);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const resetHideTimer = useCallback(() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+    setIsVisible(true);
+    hideTimeoutRef.current = setTimeout(() => {
+      setIsVisible(false);
+    }, NAVIGATION_HIDE_DELAY_MS);
+  }, []);
+
+  useEffect(() => {
+    resetHideTimer();
+    return () => {
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+      }
+    };
+  }, [resetHideTimer]);
+
+  useEffect(() => {
+    resetHideTimer();
+  }, [activeIndex, resetHideTimer]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        onPrev();
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        onNext();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onPrev, onNext]);
+
+  return (
+    <>
+      {/* Prev / Next arrow buttons */}
+      <button
+        onClick={onPrev}
+        disabled={activeIndex === 0}
+        className={cn(
+          "absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/80 shadow border border-gray-200 transition-opacity duration-300",
+          "disabled:opacity-0",
+          isVisible
+            ? "opacity-70 hover:opacity-100"
+            : "opacity-0 pointer-events-none"
+        )}
+        aria-label="Previous slide"
+      >
+        <ChevronLeftIcon className="h-6 w-6" />
+      </button>
+      <button
+        onClick={onNext}
+        disabled={activeIndex === total - 1}
+        className={cn(
+          "absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/80 shadow border border-gray-200 transition-opacity duration-300",
+          "disabled:opacity-0",
+          isVisible
+            ? "opacity-70 hover:opacity-100"
+            : "opacity-0 pointer-events-none"
+        )}
+        aria-label="Next slide"
+      >
+        <ChevronRightIcon className="h-6 w-6" />
+      </button>
+
+      {/* Dot indicators */}
+      <div
+        className={cn(
+          "absolute bottom-6 left-1/2 -translate-x-1/2 flex gap-2 transition-opacity duration-300",
+          isVisible ? "opacity-100" : "opacity-0 pointer-events-none"
+        )}
+      >
+        {Array.from({ length: total }, (_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "w-2.5 h-2.5 rounded-full transition-colors",
+              i === activeIndex ? "bg-gray-800" : "bg-gray-300"
+            )}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+// -- Slideshow --
+
+interface SlideshowProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Slideshow({ children, className }: SlideshowProps) {
+  const { isPdfMode } = useVizContext();
+  const slides = React.Children.toArray(children);
+
+  if (isPdfMode) {
+    return <PdfSlideshow className={className}>{slides}</PdfSlideshow>;
+  }
+
+  return (
+    <InteractiveSlideshow className={className}>{slides}</InteractiveSlideshow>
+  );
+}
+
+// -- PDF mode: all slides stacked with page breaks --
+
+interface PdfSlideshowProps {
+  children: React.ReactNode[];
+  className?: string;
+}
+
+function PdfSlideshow({ children, className }: PdfSlideshowProps) {
+  return (
+    <div className={cn("w-full", className)}>
+      {children.map((slide, i) => (
+        <div
+          key={i}
+          style={{ breakAfter: i < children.length - 1 ? "page" : "auto" }}
+        >
+          {slide}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// -- Interactive mode: one slide at a time with navigation --
+
+interface InteractiveSlideshowProps {
+  children: React.ReactNode[];
+  className?: string;
+}
+
+function InteractiveSlideshow({
+  children,
+  className,
+}: InteractiveSlideshowProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const onPrev = useCallback(() => {
+    setActiveIndex((i) => Math.max(i - 1, 0));
+  }, []);
+
+  const onNext = useCallback(() => {
+    setActiveIndex((i) => Math.min(i + 1, children.length - 1));
+  }, [children.length]);
+
+  if (children.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("relative h-screen w-full overflow-hidden", className)}
+      role="region"
+      aria-label="Slideshow"
+    >
+      {children[activeIndex]}
+      {children.length > 1 && (
+        <Navigation
+          activeIndex={activeIndex}
+          onNext={onNext}
+          onPrev={onPrev}
+          total={children.length}
+        />
+      )}
+    </div>
+  );
+}

--- a/viz/components/dust/slideshow/v2/index.tsx
+++ b/viz/components/dust/slideshow/v2/index.tsx
@@ -13,13 +13,10 @@ interface SlideProps {
 }
 
 export function Slide({ children, className }: SlideProps) {
-  const { isPdfMode } = useVizContext();
-
   return (
     <div
       className={cn(
-        "w-full h-full min-h-screen flex flex-col items-center justify-center overflow-hidden",
-        isPdfMode ? "p-0" : "p-12",
+        "w-full h-full min-h-screen flex flex-col items-center justify-center overflow-hidden p-12",
         className
       )}
     >

--- a/viz/components/dust/slideshow/v2/index.tsx
+++ b/viz/components/dust/slideshow/v2/index.tsx
@@ -13,10 +13,13 @@ interface SlideProps {
 }
 
 export function Slide({ children, className }: SlideProps) {
+  const { isPdfMode } = useVizContext();
+
   return (
     <div
       className={cn(
-        "w-full h-full min-h-screen flex flex-col items-center justify-center overflow-hidden p-12",
+        "w-full h-full min-h-screen flex flex-col items-center justify-center overflow-hidden",
+        isPdfMode ? "p-0" : "p-12",
         className
       )}
     >

--- a/viz/components/dust/slideshow/v2/index.tsx
+++ b/viz/components/dust/slideshow/v2/index.tsx
@@ -193,7 +193,6 @@ function InteractiveSlideshow({
   return (
     <div
       className={cn("relative h-screen w-full overflow-hidden", className)}
-      role="region"
       aria-label="Slideshow"
     >
       {children[activeIndex]}

--- a/viz/components/dust/slideshow/v2/index.tsx
+++ b/viz/components/dust/slideshow/v2/index.tsx
@@ -5,8 +5,6 @@ import { cn } from "@viz/lib/utils";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
-// -- Slide --
-
 interface SlideProps {
   children: React.ReactNode;
   className?: string;
@@ -25,9 +23,7 @@ export function Slide({ children, className }: SlideProps) {
   );
 }
 
-// -- Navigation --
-
-const NAVIGATION_HIDE_DELAY_MS = 3000;
+const NAVIGATION_HIDE_DELAY_MS = 3_000;
 
 interface NavigationProps {
   activeIndex: number;
@@ -40,6 +36,7 @@ function Navigation({ activeIndex, onNext, onPrev, total }: NavigationProps) {
   const [isVisible, setIsVisible] = useState(true);
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
+  // Resets the hide timer, making navigation controls visible for a few seconds.
   const resetHideTimer = useCallback(() => {
     if (hideTimeoutRef.current) {
       clearTimeout(hideTimeoutRef.current);
@@ -128,8 +125,6 @@ function Navigation({ activeIndex, onNext, onPrev, total }: NavigationProps) {
   );
 }
 
-// -- Slideshow --
-
 interface SlideshowProps {
   children: React.ReactNode;
   className?: string;
@@ -148,7 +143,7 @@ export function Slideshow({ children, className }: SlideshowProps) {
   );
 }
 
-// -- PDF mode: all slides stacked with page breaks --
+// PDF mode: all slides stacked with page breaks
 
 interface PdfSlideshowProps {
   children: React.ReactNode[];
@@ -170,7 +165,7 @@ function PdfSlideshow({ children, className }: PdfSlideshowProps) {
   );
 }
 
-// -- Interactive mode: one slide at a time with navigation --
+// Interactive mode: one slide at a time with navigation
 
 interface InteractiveSlideshowProps {
   children: React.ReactNode[];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When users ask agents to create presentations, the output is a regular frame. A single-page interactive content file.
This works for viewing, but PDF export produces a single long page instead of individual slides. There's no way to
get a proper multi-page PDF deck with page breaks.

To fix this, we built a `Slideshow/Slide` component (`@dust/slideshow/v2`) that lives in the viz sandbox. It handles
navigation (arrows, keyboard, dots) in interactive mode, and automatically stacks slides with CSS page breaks in PDF
mode. But for the PDF export to work well, slideshows need different defaults than regular frames.

### What this PR does

Introduces a dedicated MIME type `application/vnd.dust.frame.slideshow` to distinguish slideshows from regular frames.
This lets us:
- Default to landscape PDF export with full-bleed pages (no margins) for slideshows, while regular frames keep
portrait with 2rem padding
- Show a "Presentation" snippet label in conversations instead of "Frames"
- Give the model targeted instructions on when to use the slideshow content type, which components to import, and
design guardrails (one idea per slide, consistent backgrounds, no custom navigation)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
