### PR TITLE
fix(gmail): improve attachment error handling

### DIFF
--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -394,14 +394,25 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         base64Data = result.data;
       } else {
         const attachmentErrorText = await getErrorText(response);
-        return new Err(
-          new MCPError(
-            `Failed to fetch attachment via API: ${attachmentErrorText}`
-          )
-        );
+        const lowerError = attachmentErrorText.toLowerCase();
+
+        // Gmail sometimes returns attachmentIds that look valid but fail with
+        // "invalid attachment token". Fall back to fetching from the MIME body.
+        if (!lowerError.includes("invalid") && !lowerError.includes("token")) {
+          return new Err(
+            new MCPError(
+              `Failed to fetch attachment via Gmail API (messageId: ${messageId}, ` +
+                `filename: "${filename}"): ${attachmentErrorText}`
+            )
+          );
+        }
       }
-    } else {
-      // For inline content (no real attachmentId), fetch from message body
+    }
+
+    // Fallback: fetch attachment data from the message MIME body.
+    // Used when hasRealAttachmentId is false (inline content) or when the
+    // attachments API returned an invalid token error.
+    if (!base64Data) {
       const messageResponse = await fetchFromGmail(
         `/gmail/v1/users/me/messages/${encodedMessageId}?format=full`,
         accessToken,
@@ -411,7 +422,9 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       if (!messageResponse.ok) {
         const messageErrorText = await getErrorText(messageResponse);
         return new Err(
-          new MCPError(`Failed to fetch message: ${messageErrorText}`)
+          new MCPError(
+            `Failed to fetch message for attachment fallback (messageId: ${messageId}): ${messageErrorText}`
+          )
         );
       }
 
@@ -421,14 +434,13 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       if (!base64Data) {
         return new Err(
           new MCPError(
-            `Inline attachment data not found in message body. This attachment may not be retrievable.`
+            `Attachment data not found in message body (messageId: ${messageId}, ` +
+              `filename: "${filename}", partId: ${partId}, mimeType: ${mimeType}). ` +
+              `This can happen when Gmail returns an invalid attachment token and ` +
+              `the attachment is too large to be included inline in the message payload.`
           )
         );
       }
-    }
-
-    if (!base64Data) {
-      return new Err(new MCPError("Failed to retrieve attachment data"));
     }
 
     // Gmail returns URL-safe base64, convert to standard base64

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -402,7 +402,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
           return new Err(
             new MCPError(
               `Failed to fetch attachment via Gmail API (messageId: ${messageId}, ` +
-                `filename: "${filename}"): ${attachmentErrorText}`
+                `filename: "${filename}"): ${attachmentErrorText}`,
+              { tracked: false }
             )
           );
         }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  Summary

  - When the Gmail attachments API fails with "invalid attachment token", fall back to fetching attachment data from the message body (format=full) instead of immediately erroring
  - Improve all error messages to include diagnostic context (messageId, filename, partId, mimeType) for easier debugging
  - Add a human-readable explanation when the fallback also fails (known Gmail bug where attachment tokens become invalid and large attachments aren't included inline)

  Context

  Gmail's API sometimes returns attachmentId values that look valid but fail with "invalid attachment token" when calling messages.attachments.get.
   Previously the code would return an error immediately on any API failure. Now it detects the invalid token case and falls through to the format=full fallback path (which was previously only used for inline content).

Contributes to https://github.com/dust-tt/tasks/issues/6188

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front