### PR TITLE
Allow calls from *.preview on production viz

### DIFF
--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -119,7 +119,7 @@ export function useVisualizationAPI(
       handler: (data: SupportedMessage) => void
     ): (() => void) => {
       const messageHandler = (event: MessageEvent) => {
-        if (!allowedOrigins.includes(event.origin)) {
+        if (!isOriginAllowed(event.origin, allowedOrigins)) {
           console.log(
             `Ignored message from unauthorized origin: ${
               event.origin
@@ -468,6 +468,20 @@ export function VisualizationWrapper({
   );
 }
 
+/**
+ * Check if an origin matches any of the allowed origins.
+ * Supports wildcard patterns like "*.preview.dust.tt" which match any subdomain.
+ */
+function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
+  return allowedOrigins.some((allowed) => {
+    if (allowed.startsWith("https://*.")) {
+      const suffix = allowed.slice("https://*".length); // e.g. ".preview.dust.tt"
+      return origin.startsWith("https://") && origin.endsWith(suffix);
+    }
+    return origin === allowed;
+  });
+}
+
 export function makeSendCrossDocumentMessage({
   identifier,
   allowedOrigins,
@@ -483,7 +497,7 @@ export function makeSendCrossDocumentMessage({
       const messageUniqueId = Math.random().toString();
 
       const listener = (event: MessageEvent) => {
-        if (!allowedOrigins.includes(event.origin)) {
+        if (!isOriginAllowed(event.origin, allowedOrigins)) {
           console.log(
             `Ignored message from unauthorized origin: ${event.origin}`
           );

--- a/viz/next.config.mjs
+++ b/viz/next.config.mjs
@@ -2,7 +2,7 @@
 const isDev = process.env.NODE_ENV === "development";
 
 const CONTENT_SECURITY_POLICIES = `connect-src 'self'; media-src 'self'; frame-ancestors 'self' ${
-  isDev ? "http://localhost:3000 http://localhost:3011" : "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt"
+  isDev ? "http://localhost:3000 http://localhost:3011" : "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt https://*.preview.dust.tt"
 };`;
 
 const nextConfig = {


### PR DESCRIPTION
## Summary
- Add wildcard origin matching support in viz iframe message handlers, so origins like `https://*.preview.dust.tt` can be allowed
- Add `https://*.preview.dust.tt` to CSP `frame-ancestors` in viz's Next.js config
- This allows preview deployments to embed and communicate with the production viz server

## Test plan
- [ ] Verify existing visualizations still work on dust.tt and eu.dust.tt
- [ ] Verify a preview deployment can embed and interact with viz iframes

## Risk
Low — additive change only. The wildcard matching is restricted to `https://` origins with a suffix check, so it can't accidentally match unrelated origins.

## Deploy

Update `ALLOWED_VISUALIZATION_ORIGIN` with `https://dust.tt,https://front-edge.dust.tt,https://app.dust.tt,https://*.preview.dust.tt`

