### PR TITLE
[Conversation Guardrails] Mitigation 1: add existing-conversation submit locks

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -188,6 +188,7 @@ export const ConversationViewer = ({
     user,
     conversationId,
   });
+  const submitInFlightRef = useRef(false);
 
   const [initialListData, setInitialListData] = useState<
     VirtuosoMessage[] | undefined
@@ -501,126 +502,142 @@ export const ConversationViewer = ({
           message: "No ref",
         });
       }
-      const messageData = {
-        input,
-        mentions: mentions.map(toMentionType),
-        contentFragments,
-        clientSideMCPServerIds: agentBuilderContext?.clientSideMCPServerIds,
-        skipToolsValidation: agentBuilderContext?.skipToolsValidation,
-      };
 
-      const lastMessageRank = Math.max(
-        ...ref.current.data.get().map((m) => m.rank)
-      );
-
-      let rank =
-        lastMessageRank +
-        // Content fragments are prepended as "message" in the conversation, before the user message.
-        // We need to account for their ranks as well.
-        contentFragments.contentNodes.length +
-        contentFragments.uploaded.length +
-        // +1 for the user message
-        1;
-
-      const placeholderUserMsg: VirtuosoMessage = createPlaceholderUserMessage({
-        input,
-        mentions,
-        user,
-        rank,
-        contentFragments,
-      });
-
-      const placeholderAgentMessages: VirtuosoMessage[] = [];
-      for (const mention of mentions) {
-        if (isRichAgentMention(mention)) {
-          // +1 per agent message mentioned
-          rank += 1;
-          placeholderAgentMessages.push(
-            createPlaceholderAgentMessage({
-              userMessage: placeholderUserMsg,
-              mention,
-              rank,
-            })
-          );
-        }
-      }
-
-      // An agent will answer immediately only if it is explicitely mentioned.
-      // In that case, we want to scroll to put the user message at the top.
-      const isMentioningAgent = mentions.some(isRichAgentMention);
-
-      const nbMessages = ref.current.data.get().length;
-      ref.current.data.append(
-        [placeholderUserMsg, ...placeholderAgentMessages],
-        isMentioningAgent
-          ? () => {
-              return {
-                index: nbMessages, // Avoid jumping around when the agent message is generated.
-                align: "start",
-                behavior: customSmoothScroll,
-              };
-            }
-          : (params) => {
-              if (params.scrollLocation.bottomOffset >= 0) {
-                return {
-                  index: "LAST",
-                  align: "end",
-                  behavior: customSmoothScroll,
-                };
-              } else {
-                return false;
-              }
-            }
-      );
-
-      const result = await submitMessage(messageData);
-
-      if (result.isErr()) {
-        if (result.error.type === "plan_limit_reached_error") {
-          setPlanLimitReached?.(true);
-        } else {
-          sendNotification({
-            title: result.error.title,
-            description: result.error.message,
-            type: "error",
-          });
-        }
-
-        // If the API errors, the original data will be rolled back by SWR automatically.
-        console.error("Failed to post message:", result.error);
+      if (submitInFlightRef.current) {
         return new Err({
           code: "internal_error",
-          name: "FailedToPostMessage",
-          message: `Failed to post message ${result.error}`,
+          name: "AlreadySubmitting",
+          message: "Already submitting",
         });
       }
 
-      const {
-        message: messageFromBackend,
-        contentFragments: contentFragmentsFromBackend,
-      } = result.value;
+      submitInFlightRef.current = true;
 
-      // map() is how we update the state of virtuoso messages.
-      ref.current.data.map((m) =>
-        m.rank === placeholderUserMsg.rank
-          ? {
-              ...messageFromBackend,
-              contentFragments: contentFragmentsFromBackend,
-            }
-          : m
-      );
+      try {
+        const messageData = {
+          input,
+          mentions: mentions.map(toMentionType),
+          contentFragments,
+          clientSideMCPServerIds: agentBuilderContext?.clientSideMCPServerIds,
+          skipToolsValidation: agentBuilderContext?.skipToolsValidation,
+        };
 
-      void mutateConversations(
-        (currentData: ConversationWithoutContentType[] | undefined) =>
-          currentData?.map((c) =>
-            c.sId === conversationId
-              ? { ...c, updated: new Date().getTime() }
-              : c
-          ),
-        { revalidate: false }
-      );
+        const lastMessageRank = Math.max(
+          ...ref.current.data.get().map((m) => m.rank)
+        );
 
-      return new Ok(undefined);
+        let rank =
+          lastMessageRank +
+          // Content fragments are prepended as "message" in the conversation, before the user message.
+          // We need to account for their ranks as well.
+          contentFragments.contentNodes.length +
+          contentFragments.uploaded.length +
+          // +1 for the user message
+          1;
+
+        const placeholderUserMsg: VirtuosoMessage =
+          createPlaceholderUserMessage({
+            input,
+            mentions,
+            user,
+            rank,
+            contentFragments,
+          });
+
+        const placeholderAgentMessages: VirtuosoMessage[] = [];
+        for (const mention of mentions) {
+          if (isRichAgentMention(mention)) {
+            // +1 per agent message mentioned
+            rank += 1;
+            placeholderAgentMessages.push(
+              createPlaceholderAgentMessage({
+                userMessage: placeholderUserMsg,
+                mention,
+                rank,
+              })
+            );
+          }
+        }
+
+        // An agent will answer immediately only if it is explicitely mentioned.
+        // In that case, we want to scroll to put the user message at the top.
+        const isMentioningAgent = mentions.some(isRichAgentMention);
+
+        const nbMessages = ref.current.data.get().length;
+        ref.current.data.append(
+          [placeholderUserMsg, ...placeholderAgentMessages],
+          isMentioningAgent
+            ? () => {
+                return {
+                  index: nbMessages, // Avoid jumping around when the agent message is generated.
+                  align: "start",
+                  behavior: customSmoothScroll,
+                };
+              }
+            : (params) => {
+                if (params.scrollLocation.bottomOffset >= 0) {
+                  return {
+                    index: "LAST",
+                    align: "end",
+                    behavior: customSmoothScroll,
+                  };
+                } else {
+                  return false;
+                }
+              }
+        );
+
+        const result = await submitMessage(messageData);
+
+        if (result.isErr()) {
+          if (result.error.type === "plan_limit_reached_error") {
+            setPlanLimitReached?.(true);
+          } else {
+            sendNotification({
+              title: result.error.title,
+              description: result.error.message,
+              type: "error",
+            });
+          }
+
+          // If the API errors, the original data will be rolled back by SWR automatically.
+          console.error("Failed to post message:", result.error);
+          return new Err({
+            code: "internal_error",
+            name: "FailedToPostMessage",
+            message: `Failed to post message ${result.error}`,
+          });
+        }
+
+        const {
+          message: messageFromBackend,
+          contentFragments: contentFragmentsFromBackend,
+        } = result.value;
+
+        // map() is how we update the state of virtuoso messages.
+        ref.current.data.map((m) =>
+          m.rank === placeholderUserMsg.rank
+            ? {
+                ...messageFromBackend,
+                contentFragments: contentFragmentsFromBackend,
+              }
+            : m
+        );
+
+        void mutateConversations(
+          (currentData: ConversationWithoutContentType[] | undefined) =>
+            currentData?.map((c) =>
+              c.sId === conversationId
+                ? { ...c, updated: new Date().getTime() }
+                : c
+            ),
+          { revalidate: false }
+        );
+
+        return new Ok(undefined);
+      } finally {
+        submitInFlightRef.current = false;
+      }
     },
     [
       agentBuilderContext?.clientSideMCPServerIds,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -30,10 +30,10 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import type { DustError } from "@app/lib/error";
-import logger from "@app/logger/logger";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
+import logger from "@app/logger/logger";
 import type {
   AgentGenerationCancelledEvent,
   AgentMessageDoneEvent,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -30,6 +30,7 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import type { DustError } from "@app/lib/error";
+import logger from "@app/logger/logger";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
@@ -465,7 +466,7 @@ export const ConversationViewer = ({
             break;
           default:
             ((t: never) => {
-              console.error("Unknown event type", t);
+              logger.error({ event: t }, "Unknown event type");
             })(event);
         }
       }
@@ -601,7 +602,7 @@ export const ConversationViewer = ({
           }
 
           // If the API errors, the original data will be rolled back by SWR automatically.
-          console.error("Failed to post message:", result.error);
+          logger.error({ err: result.error }, "Failed to post message");
           return new Err({
             code: "internal_error",
             name: "FailedToPostMessage",

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -225,7 +225,7 @@ export const InputBar = React.memo(function InputBar({
     resetEditorText,
     setLoading
   ) => {
-    if (isEmpty || fileUploaderService.isProcessingFiles) {
+    if (isLocalSubmitting || isEmpty || fileUploaderService.isProcessingFiles) {
       return;
     }
 
@@ -264,10 +264,42 @@ export const InputBar = React.memo(function InputBar({
       setLoading(true);
       setIsLocalSubmitting(true);
 
-      const r = await onSubmit(
-        markdown,
-        mentions,
-        {
+      try {
+        const r = await onSubmit(
+          markdown,
+          mentions,
+          {
+            uploaded: fileUploaderService.getFileBlobs().map((cf) => {
+              return {
+                title: cf.filename,
+                fileId: cf.fileId,
+                contentType: cf.contentType,
+                url: cf.sourceUrl,
+              };
+            }),
+            contentNodes: attachedNodes,
+          },
+          // Only send the selectedMCPServerViewIds if we are creating a new conversation.
+          // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
+          selectedMCPServerViews.map((sv) => sv.sId),
+          // JIT skills for new conversations
+          selectedSkills.map((s) => s.sId)
+        );
+
+        if (r.isOk()) {
+          clearDraft();
+          resetEditorText();
+          fileUploaderService.resetUpload();
+        }
+      } finally {
+        setLoading(false);
+        setIsLocalSubmitting(false);
+      }
+    } else {
+      setIsLocalSubmitting(true);
+
+      try {
+        await onSubmit(markdown, mentions, {
           uploaded: fileUploaderService.getFileBlobs().map((cf) => {
             return {
               title: cf.filename,
@@ -277,38 +309,15 @@ export const InputBar = React.memo(function InputBar({
             };
           }),
           contentNodes: attachedNodes,
-        },
-        // Only send the selectedMCPServerViewIds if we are creating a new conversation.
-        // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
-        selectedMCPServerViews.map((sv) => sv.sId),
-        // JIT skills for new conversations
-        selectedSkills.map((s) => s.sId)
-      );
+        });
 
-      setLoading(false);
-      setIsLocalSubmitting(false);
-      if (r.isOk()) {
-        clearDraft();
         resetEditorText();
+        clearDraft();
         fileUploaderService.resetUpload();
+        setAttachedNodes([]);
+      } finally {
+        setIsLocalSubmitting(false);
       }
-    } else {
-      void onSubmit(markdown, mentions, {
-        uploaded: fileUploaderService.getFileBlobs().map((cf) => {
-          return {
-            title: cf.filename,
-            fileId: cf.fileId,
-            contentType: cf.contentType,
-            url: cf.sourceUrl,
-          };
-        }),
-        contentNodes: attachedNodes,
-      });
-
-      resetEditorText();
-      clearDraft();
-      fileUploaderService.resetUpload();
-      setAttachedNodes([]);
     }
   };
 

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -25,10 +25,9 @@ import { Markdown } from "@tiptap/markdown";
 import type { Editor } from "@tiptap/react";
 import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
-const SUBMIT_COOLDOWN_MS = 400;
 
 function isLongTextPaste(text: string, maxCharThreshold?: number) {
   const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;
@@ -352,7 +351,6 @@ const useCustomEditor = ({
   );
 
   const editorService = useEditorService(editor);
-  const lastSubmitTimestampMsRef = useRef(0);
 
   // Set keydown handler after editor is initialized to avoid synchronous updates during render.
   useEffect(() => {
@@ -395,18 +393,6 @@ const useCustomEditor = ({
             if (isMobile(navigator)) {
               return false;
             }
-
-            if (event.repeat) {
-              event.preventDefault();
-              return true;
-            }
-
-            const nowMs = Date.now();
-            if (nowMs - lastSubmitTimestampMsRef.current < SUBMIT_COOLDOWN_MS) {
-              event.preventDefault();
-              return true;
-            }
-            lastSubmitTimestampMsRef.current = nowMs;
 
             // Prevent the default Enter key behavior
             event.preventDefault();

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -25,9 +25,10 @@ import { Markdown } from "@tiptap/markdown";
 import type { Editor } from "@tiptap/react";
 import { useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
+const SUBMIT_COOLDOWN_MS = 400;
 
 function isLongTextPaste(text: string, maxCharThreshold?: number) {
   const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;
@@ -351,6 +352,7 @@ const useCustomEditor = ({
   );
 
   const editorService = useEditorService(editor);
+  const lastSubmitTimestampMsRef = useRef(0);
 
   // Set keydown handler after editor is initialized to avoid synchronous updates during render.
   useEffect(() => {
@@ -393,6 +395,18 @@ const useCustomEditor = ({
             if (isMobile(navigator)) {
               return false;
             }
+
+            if (event.repeat) {
+              event.preventDefault();
+              return true;
+            }
+
+            const nowMs = Date.now();
+            if (nowMs - lastSubmitTimestampMsRef.current < SUBMIT_COOLDOWN_MS) {
+              event.preventDefault();
+              return true;
+            }
+            lastSubmitTimestampMsRef.current = nowMs;
 
             // Prevent the default Enter key behavior
             event.preventDefault();


### PR DESCRIPTION
## Description
Fixes partly https://github.com/dust-tt/tasks/issues/6648

Follows https://github.com/dust-tt/dust/pull/21440.
Implements mitigation 1 only:
- Add an in-flight submit lock for existing conversations in `InputBar`.
- Add a second in-flight guard in `ConversationViewer.handleSubmit`.

## Risks
Blast radius: assistant conversation message submission from the web input bar for existing conversations.
Risk: low

## Deploy Plan
- deploy front
