### PR TITLE
[Conversation] Add message POST idempotency dedupe (mitigation 3)

### DIFF
--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -108,12 +108,14 @@ export function useSubmitMessage({
       }
 
       // Create a new user message.
+      const messageIdempotencyKey = crypto.randomUUID();
       const mRes = await clientFetch(
         `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages`,
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            "X-Idempotency-Key": messageIdempotencyKey,
           },
           body: JSON.stringify({
             content: input,

--- a/front/lib/api/assistant/messages_idempotency.ts
+++ b/front/lib/api/assistant/messages_idempotency.ts
@@ -4,6 +4,7 @@ import logger from "@app/logger/logger";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 
 const MESSAGE_IDEMPOTENCY_WINDOW_SECONDS = 30;
 const MESSAGE_IDEMPOTENCY_KEY_HEADER = "x-idempotency-key";
@@ -32,7 +33,7 @@ export function getMessageIdempotencyKey(
   }
 
   if (
-    typeof idempotencyKey !== "string" ||
+    !isString(idempotencyKey) ||
     idempotencyKey.length === 0 ||
     idempotencyKey.length > MAX_MESSAGE_IDEMPOTENCY_KEY_LENGTH
   ) {

--- a/front/lib/api/assistant/messages_idempotency.ts
+++ b/front/lib/api/assistant/messages_idempotency.ts
@@ -1,0 +1,107 @@
+import { getRedisStreamClient } from "@app/lib/api/redis";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const MESSAGE_IDEMPOTENCY_WINDOW_SECONDS = 30;
+const MESSAGE_IDEMPOTENCY_KEY_HEADER = "x-idempotency-key";
+const MAX_MESSAGE_IDEMPOTENCY_KEY_LENGTH = 255;
+
+type MessagePostRequestLike = {
+  headers: Record<string, string | string[] | undefined>;
+};
+
+const getMessageIdempotencyRedisKey = (
+  workspaceId: string,
+  userId: string,
+  conversationId: string,
+  idempotencyKey: string
+) => {
+  return `message-idempotency:${workspaceId}:${userId}:${conversationId}:${idempotencyKey}`;
+};
+
+export function getMessageIdempotencyKey(
+  req: MessagePostRequestLike
+): Result<string | null, APIErrorWithStatusCode> {
+  const idempotencyKey = req.headers[MESSAGE_IDEMPOTENCY_KEY_HEADER];
+
+  if (idempotencyKey === undefined) {
+    return new Ok(null);
+  }
+
+  if (
+    typeof idempotencyKey !== "string" ||
+    idempotencyKey.length === 0 ||
+    idempotencyKey.length > MAX_MESSAGE_IDEMPOTENCY_KEY_LENGTH
+  ) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid X-Idempotency-Key header. It must be a non-empty string " +
+          `up to ${MAX_MESSAGE_IDEMPOTENCY_KEY_LENGTH} characters.`,
+      },
+    });
+  }
+
+  return new Ok(idempotencyKey);
+}
+
+export async function ensureMessageIdempotency(
+  auth: Authenticator,
+  {
+    conversationId,
+    idempotencyKey,
+  }: {
+    conversationId: string;
+    idempotencyKey: string | null;
+  }
+): Promise<Result<void, APIErrorWithStatusCode>> {
+  if (!idempotencyKey) {
+    return new Ok(undefined);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "user_message_events" });
+    const redisKey = getMessageIdempotencyRedisKey(
+      workspace.sId,
+      user.sId,
+      conversationId,
+      idempotencyKey
+    );
+
+    const setResult = await redis.set(redisKey, "1", {
+      NX: true,
+      EX: MESSAGE_IDEMPOTENCY_WINDOW_SECONDS,
+    });
+
+    if (setResult === "OK") {
+      return new Ok(undefined);
+    }
+
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Duplicate message request detected.",
+      },
+    });
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        conversationId,
+        err,
+      },
+      "Failed to enforce message idempotency; allowing request."
+    );
+    return new Ok(undefined);
+  }
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,5 +1,9 @@
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { isCopilotConversation } from "@app/lib/api/actions/servers/helpers";
+import {
+  ensureMessageIdempotency,
+  getMessageIdempotencyKey,
+} from "@app/lib/api/assistant/messages_idempotency";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -125,6 +129,11 @@ async function handler(
       break;
 
     case "POST":
+      const messageIdempotencyKeyRes = getMessageIdempotencyKey(req);
+      if (messageIdempotencyKeyRes.isErr()) {
+        return apiError(req, res, messageIdempotencyKeyRes.error);
+      }
+
       const bodyValidation = InternalPostMessagesRequestBodySchema.decode(
         req.body
       );
@@ -200,6 +209,15 @@ async function handler(
       const origin = isCopilotConversation(conversation.metadata)
         ? "agent_copilot"
         : "web";
+
+      const messageIdempotencyRes = await ensureMessageIdempotency(auth, {
+        conversationId,
+        idempotencyKey: messageIdempotencyKeyRes.value,
+      });
+
+      if (messageIdempotencyRes.isErr()) {
+        return apiError(req, res, messageIdempotencyRes.error);
+      }
 
       const messageRes = await postUserMessage(auth, {
         conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,13 +1,13 @@
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { isCopilotConversation } from "@app/lib/api/actions/servers/helpers";
-import {
-  ensureMessageIdempotency,
-  getMessageIdempotencyKey,
-} from "@app/lib/api/assistant/messages_idempotency";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
+import {
+  ensureMessageIdempotency,
+  getMessageIdempotencyKey,
+} from "@app/lib/api/assistant/messages_idempotency";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6648

Implements mitigation 3 for assistant web message submits by:
- adding a client `X-Idempotency-Key` on `/api/w/.../assistant/conversations/.../messages` POSTs;
- rejecting duplicate keys for the same workspace/user/conversation within a short Redis window;
- allowing requests to proceed if Redis is unavailable (log + fail-open).

## Risks
Blast radius: Assistant web conversation message creation endpoint (`/api/w/{wId}/assistant/conversations/{cId}/messages`).
Risk: low

## Deploy Plan
- deploy front
