### PR TITLE
feat: lower langfuse logging level

### DIFF
--- a/front/lib/api/instrumentation/init.ts
+++ b/front/lib/api/instrumentation/init.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { FilteredLangfuseSpanProcessor } from "@app/lib/api/instrumentation/processor";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { configureGlobalLogger, LogLevel } from "@langfuse/core";
 import type { Resource } from "@opentelemetry/resources";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { NodeSDK } from "@opentelemetry/sdk-node";
@@ -23,6 +24,9 @@ export function initializeOpenTelemetryInstrumentation({
   }
 
   try {
+    // Suppress noisy "[Langfuse SDK] [WARN] No active OTEL span in context" warnings.
+    configureGlobalLogger({ level: LogLevel.ERROR });
+
     resource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: serviceName,
     });


### PR DESCRIPTION
## Description

Lower langfuse log level to error, so we only get useful logs.

In the last week we had 1.5M logs like [this one](https://app.datadoghq.eu/logs?query=%22%5BLangfuse%20SDK%5D%20%5BWARN%5D%20No%20active%20OTEL%20span%20in%20context.%20Skipping%20span%20update.%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1771254780078&to_ts=1771859580078&live=true).

Unfortunately, it seems to be a bug with next => https://github.com/orgs/langfuse/discussions/11613

Note: I didn't dig more than a few minutes on it, I'm not sure it's worth it

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
