### PR TITLE
Keep track of the source conversation when create a file in the project context.

### DIFF
--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -80,10 +80,19 @@ export function createProjectManagerTools(
             return sourceFileRes;
           }
 
+          const sourceFile = sourceFileRes.value;
+          const sourceConversationId = sourceFile.useCaseMetadata
+            ?.conversationId
+            ? sourceFile.useCaseMetadata.sourceConversationId
+            : undefined;
+
           const copyResult = await FileResource.copy(auth, {
             sourceId: sourceFileId,
             useCase: "project_context",
-            useCaseMetadata: { spaceId: space.sId },
+            useCaseMetadata: {
+              spaceId: space.sId,
+              sourceConversationId,
+            },
           });
 
           if (copyResult.isErr()) {
@@ -131,7 +140,11 @@ export function createProjectManagerTools(
             fileName,
             fileSize: Buffer.byteLength(content, "utf-8"),
             useCase: "project_context",
-            useCaseMetadata: { spaceId: space.sId },
+            useCaseMetadata: {
+              spaceId: space.sId,
+              sourceConversationId:
+                agentLoopContext?.runContext?.conversation?.sId,
+            },
           });
 
           // Upload content to GCS.

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -30,6 +30,7 @@ export type FileUseCase =
 export type FileUseCaseMetadata = {
   conversationId?: string;
   spaceId?: string;
+  sourceConversationId?: string;
   generatedTables?: string[];
   lastEditedByAgentConfigurationId?: string;
   sourceProvider?: string;


### PR DESCRIPTION
## Description

Add an optional sourceConversationId when storing conversation file in project.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front