### PR TITLE
Reverse the seen/unseen tooltip when marking a comment

### DIFF
--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -296,7 +296,7 @@ function FeedbackCard({
             icon={feedback.dismissed ? EyeIcon : EyeSlashIcon}
             onClick={() => toggleDismiss(!feedback.dismissed)}
             disabled={isDismissing}
-            tooltip={`Mark feedback as ${feedback.dismissed ? "seen" : "unseen"}`}
+            tooltip={`Mark feedback as ${feedback.dismissed ? "unseen" : "seen"}`}
           />
           {conversationUrl && (
             <CardActionButton


### PR DESCRIPTION
## Description

At the moment it does not make sense: in the unseen tab you see "mark as unseen".
I think dismissed == seen so if feedback.dismissed is true the feedback is already seen so we want to mark it as unseen.

Current situation without the fix:

<img width="694" height="434" alt="Screenshot 2026-02-23 at 16 09 36" src="https://github.com/user-attachments/assets/64e9d9b1-a251-4115-8a5a-3f5f08f680a4" />



## Tests

manuallly checked

## Risk

low

## Deploy Plan

deploy front
