### PR TITLE
Prevent multi-MB tool outputs from bloating the database

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -13,7 +13,7 @@ export const MAX_RESOURCE_CONTENT_SIZE = 20 * 1024 * 1024; // 20MB.
 export const MAXED_OUTPUT_FILE_SNIPPET_LENGTH = 64_000; // Approximately 16K tokens.
 
 export function computeTextByteSize(text: string): number {
-  return text.length * 2; // UTF-8 approximate
+  return Buffer.byteLength(text, "utf-8");
 }
 
 export function computeBase64ByteSize(base64: string): number {

--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -13,7 +13,7 @@ export const MAX_RESOURCE_CONTENT_SIZE = 20 * 1024 * 1024; // 20MB.
 export const MAXED_OUTPUT_FILE_SNIPPET_LENGTH = 64_000; // Approximately 16K tokens.
 
 export function computeTextByteSize(text: string): number {
-  return Buffer.byteLength(text, "utf-8");
+  return text.length * 2; // UTF-8 approximate
 }
 
 export function computeBase64ByteSize(base64: string): number {

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -103,7 +103,7 @@ describe("processToolResults", () => {
 
     // The large text block should be converted to a resource with a truncated snippet.
     expect(stored.type).toBe("resource");
-    if (stored.type === "resource") {
+    if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text.length).toBeLessThanOrEqual(
         MAXED_OUTPUT_FILE_SNIPPET_LENGTH + 50
       );
@@ -135,7 +135,7 @@ describe("processToolResults", () => {
     const stored = outputItems[0].content;
 
     expect(stored.type).toBe("resource");
-    if (stored.type === "resource") {
+    if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text.length).toBeLessThanOrEqual(
         MAXED_OUTPUT_FILE_SNIPPET_LENGTH + 50
       );
@@ -187,7 +187,7 @@ describe("processToolResults", () => {
     const stored = outputItems[0].content;
 
     expect(stored.type).toBe("resource");
-    if (stored.type === "resource") {
+    if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text).toBe(smallText);
     }
   });

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -1,0 +1,193 @@
+import {
+  MAX_RESOURCE_CONTENT_SIZE,
+  MAX_TEXT_CONTENT_SIZE,
+  MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
+} from "@app/lib/actions/action_output_limits";
+import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { processToolResults } from "@app/lib/actions/mcp_execution";
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import logger from "@app/logger/logger";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { assert, describe, expect, it, vi } from "vitest";
+
+// Mock file storage to avoid cloud storage interactions.
+vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/files/processing")>();
+  return {
+    ...actual,
+    processAndStoreFile: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+async function setupTest() {
+  const user = await UserFactory.basic();
+  const workspace = await WorkspaceFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "admin" });
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  await SpaceResource.makeDefaultsForWorkspace(auth, {
+    globalGroup,
+    systemGroup,
+  });
+
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfig.sId,
+    messagesCreatedAt: [],
+  });
+
+  const toolConfiguration: LightServerSideMCPToolConfigurationType = {
+    id: -1 as any,
+    sId: generateRandomModelSId(),
+    type: "mcp_configuration",
+    name: "test_tool",
+    originalName: "test_tool",
+    mcpServerName: "test_server",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: generateRandomModelSId(),
+    dustAppConfiguration: null,
+    internalMCPServerId: null,
+    secretName: null,
+    dustProject: null,
+    availability: "auto",
+    permission: "never_ask",
+    toolServerId: generateRandomModelSId(),
+    retryPolicy: "no_retry",
+  };
+
+  const { action } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig,
+    mcpAction: { toolConfiguration },
+  });
+  assert(action, "MCP action should be created");
+
+  return { auth, conversation, action, toolConfiguration };
+}
+
+describe("processToolResults", () => {
+  it("should store snippet in DB when text exceeds MAX_TEXT_CONTENT_SIZE", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    // Generate text that exceeds MAX_TEXT_CONTENT_SIZE (400KB).
+    // With Buffer.byteLength on ASCII, 1 char = 1 byte.
+    const largeText = "x".repeat(MAX_TEXT_CONTENT_SIZE + 1);
+
+    const { outputItems } = await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [{ type: "text", text: largeText }],
+      toolConfiguration,
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+
+    // The large text block should be converted to a resource with a truncated snippet.
+    expect(stored.type).toBe("resource");
+    if (stored.type === "resource") {
+      expect(stored.resource.text.length).toBeLessThanOrEqual(
+        MAXED_OUTPUT_FILE_SNIPPET_LENGTH + 50
+      );
+      expect(stored.resource.text).toContain("... (truncated)");
+    }
+  });
+
+  it("should store snippet for large resource text", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    // Generate resource text that exceeds MAX_RESOURCE_CONTENT_SIZE (20MB).
+    const largeResourceText = "y".repeat(MAX_RESOURCE_CONTENT_SIZE + 1);
+
+    const { outputItems } = await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [
+        {
+          type: "resource",
+          resource: { uri: "file://test.txt", text: largeResourceText },
+        },
+      ],
+      toolConfiguration,
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+
+    expect(stored.type).toBe("resource");
+    if (stored.type === "resource") {
+      expect(stored.resource.text.length).toBeLessThanOrEqual(
+        MAXED_OUTPUT_FILE_SNIPPET_LENGTH + 50
+      );
+      expect(stored.resource.text).toContain("... (truncated)");
+    }
+  });
+
+  it("should keep small text content as-is", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    const smallText = "hello world";
+
+    const { outputItems } = await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [{ type: "text", text: smallText }],
+      toolConfiguration,
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+
+    expect(stored.type).toBe("text");
+    if (stored.type === "text") {
+      expect(stored.text).toBe(smallText);
+    }
+  });
+
+  it("should keep small resource text as-is", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    const smallText = "small resource text";
+
+    const { outputItems } = await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [
+        {
+          type: "resource",
+          resource: { uri: "file://small.txt", text: smallText },
+        },
+      ],
+      toolConfiguration,
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+
+    expect(stored.type).toBe("resource");
+    if (stored.type === "resource") {
+      expect(stored.resource.text).toBe(smallText);
+    }
+  });
+});

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -48,7 +48,7 @@ async function setupTest() {
   });
 
   const toolConfiguration: LightServerSideMCPToolConfigurationType = {
-    id: -1 as any,
+    id: -1,
     sId: generateRandomModelSId(),
     type: "mcp_configuration",
     name: "test_tool",

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -87,8 +87,8 @@ describe("processToolResults", () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
     // Generate text that exceeds MAX_TEXT_CONTENT_SIZE (400KB).
-    // With Buffer.byteLength on ASCII, 1 char = 1 byte.
-    const largeText = "x".repeat(MAX_TEXT_CONTENT_SIZE + 1);
+    // computeTextByteSize uses text.length * 2, so length > MAX_TEXT_CONTENT_SIZE / 2 triggers it.
+    const largeText = "x".repeat(MAX_TEXT_CONTENT_SIZE / 2 + 1);
 
     const { outputItems } = await processToolResults(auth, {
       action,
@@ -115,7 +115,8 @@ describe("processToolResults", () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
     // Generate resource text that exceeds MAX_RESOURCE_CONTENT_SIZE (20MB).
-    const largeResourceText = "y".repeat(MAX_RESOURCE_CONTENT_SIZE + 1);
+    // computeTextByteSize uses text.length * 2, so length > MAX_RESOURCE_CONTENT_SIZE / 2 triggers it.
+    const largeResourceText = "y".repeat(MAX_RESOURCE_CONTENT_SIZE / 2 + 1);
 
     const { outputItems } = await processToolResults(auth, {
       action,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -189,7 +189,7 @@ export async function processToolResults(
                 resource: {
                   uri: file.getPublicUrl(auth),
                   mimeType: "text/plain",
-                  text: block.text,
+                  text: snippet,
                 },
               },
               file,
@@ -332,7 +332,7 @@ export async function processToolResults(
                   type: block.type,
                   resource: {
                     ...sanitizedResource,
-                    text: text,
+                    text: snippet,
                   },
                 },
                 file,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1884,11 +1884,14 @@ describe("createUserMentions", () => {
         { name: "Test Agent" }
       );
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -1925,11 +1928,14 @@ describe("createUserMentions", () => {
         { name: "Test Agent" }
       );
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -2029,11 +2035,14 @@ describe("createUserMentions", () => {
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).toContain(mentionedUser.sId);
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: updatedConversation,
-        agentConfig: updatedAgentConfig!,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: updatedConversation,
+          agentConfig: updatedAgentConfig!,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -2132,11 +2141,14 @@ describe("createUserMentions", () => {
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).not.toContain(mentionedUser.sId);
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: updatedConversation,
-        agentConfig: updatedAgentConfig!,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: updatedConversation,
+          agentConfig: updatedAgentConfig!,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -2235,11 +2247,14 @@ describe("createUserMentions", () => {
       expect(updatedAgentConfig).not.toBeNull();
       expect(updatedAgentConfig?.instructions).toBeNull();
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: updatedConversation,
-        agentConfig: updatedAgentConfig!,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: updatedConversation,
+          agentConfig: updatedAgentConfig!,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -2507,11 +2522,14 @@ describe("createUserMentions", () => {
         { name: "Test Agent" }
       );
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: restrictedConversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: restrictedConversation,
+          agentConfig,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -2589,11 +2607,14 @@ describe("createUserMentions", () => {
         }
       );
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: projectConversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: projectConversation,
+          agentConfig,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -2663,11 +2684,14 @@ describe("createUserMentions", () => {
         }
       );
 
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: projectConversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: projectConversation,
+          agentConfig,
+        }
+      );
 
       const mentions: MentionType[] = [
         {
@@ -3066,11 +3090,14 @@ describe("createUserMentions", () => {
       expect(updatedAgentConfig?.instructions).toContain(mentionedUser.sId);
 
       // Create an agent message
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation: updatedConversation,
-        agentConfig: updatedAgentConfig!,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation: updatedConversation,
+          agentConfig: updatedAgentConfig!,
+        }
+      );
 
       const mentionedUserResource = await getUserForWorkspace(auth, {
         userId: mentionedUser.sId,

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -44,11 +44,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       const initialMessage = await AgentMessageModel.findOne({
@@ -99,11 +102,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial duration
       await AgentMessageModel.update(
@@ -151,11 +157,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Act: Process event with non-integer duration
       const event: AgentMessageSuccessEvent = {
@@ -197,11 +206,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial duration
       await AgentMessageModel.update(
@@ -250,11 +262,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       const initialMessage = await AgentMessageModel.findOne({
@@ -305,11 +320,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial runIds
       await AgentMessageModel.update(
@@ -360,11 +378,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial runIds
       await AgentMessageModel.update(
@@ -411,11 +432,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial runIds
       await AgentMessageModel.update(
@@ -465,11 +489,14 @@ describe("processEventForDatabase", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Act: Process event with both modelInteractionDurationMs and runIds
       const baseEvent: AgentMessageSuccessEvent = {
@@ -526,11 +553,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       expect(agentMessage.status).toBe("created");
@@ -585,11 +615,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       expect(agentMessage.status).toBe("created");
@@ -631,11 +664,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Act: Update status to cancelled
       await updateAgentMessageDBAndMemory(auth, {
@@ -675,11 +711,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       expect(agentMessage.modelInteractionDurationMs).toBeNull();
@@ -718,11 +757,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial duration in DB and memory
       await AgentMessageModel.update(
@@ -765,11 +807,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Act: Update with non-integer duration
       await updateAgentMessageDBAndMemory(auth, {
@@ -807,11 +852,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       const initialMessage = await AgentMessageModel.findOne({
@@ -856,11 +904,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Set initial runIds
       await AgentMessageModel.update(
@@ -904,11 +955,14 @@ describe("updateAgentMessageDBAndMemory", () => {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],
       });
-      const { agentMessage } = await ConversationFactory.createAgentMessage({
-        workspace,
-        conversation,
-        agentConfig,
-      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
 
       // Verify initial state
       expect(agentMessage.prunedContext).toBeUndefined();

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -1,3 +1,4 @@
+import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -6,6 +7,8 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -249,19 +252,28 @@ export class ConversationFactory {
   }
 
   /**
-   * Creates a test agent message with full type information
+   * Creates a test agent message with full type information.
+   * Optionally creates an MCP action (with its step content) when `mcpAction` is provided.
    */
-  static async createAgentMessage({
-    workspace,
-    conversation,
-    agentConfig,
-  }: {
-    workspace: WorkspaceType;
-    conversation: ConversationType | ConversationWithoutContentType;
-    agentConfig: LightAgentConfigurationType;
-  }): Promise<{
+  static async createAgentMessage(
+    auth: Authenticator,
+    {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction,
+    }: {
+      workspace: WorkspaceType;
+      conversation: ConversationType | ConversationWithoutContentType;
+      agentConfig: LightAgentConfigurationType;
+      mcpAction?: {
+        toolConfiguration: LightServerSideMCPToolConfigurationType;
+      };
+    }
+  ): Promise<{
     messageRow: MessageModel;
     agentMessage: AgentMessageType;
+    action?: AgentMCPActionResource;
   }> {
     const agentMessageRow = await AgentMessageModel.create({
       status: "created",
@@ -306,7 +318,47 @@ export class ConversationFactory {
       richMentions: [],
     };
 
-    return { messageRow, agentMessage };
+    if (!mcpAction) {
+      return { messageRow, agentMessage };
+    }
+
+    const { toolConfiguration } = mcpAction;
+
+    const stepContent = await AgentStepContentResource.createNewVersion({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: 0,
+      index: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          name: toolConfiguration.name,
+          arguments: "{}",
+          id: generateRandomModelSId(),
+        },
+      },
+    });
+
+    const action = await AgentMCPActionResource.makeNew(auth, {
+      agentMessageId: agentMessage.agentMessageId,
+      augmentedInputs: {},
+      citationsAllocated: 0,
+      mcpServerConfigurationId: toolConfiguration.sId,
+      status: "running",
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 0,
+        websearchResultCount: 0,
+      },
+      toolConfiguration,
+      version: 0,
+    });
+
+    return { messageRow, agentMessage, action };
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While investigating large rows in the `agent_mcp_action_output_items` table, we discovered that MCP tool output content was being stored in full in the `JSONB` content column. Even when a `FileResource` had already been created with the same data.

**The flow worked like this:**
A tool returns a large text block (e.g., a multi-MB document from a data source cat). `processToolResults` detects it exceeds `MAX_TEXT_CONTENT_SIZE` (~400KB) and creates a `FileResource` with the full content + a 64K-char snippet.
But the full text was still stored verbatim in the DB row's `content.resource.text` field. Defeating the purpose of the file upload.
This meant every large tool output was paying the cost three times: stored in Postgres (multi-MB TOAST'd JSONB), fetched in bulk during batchRenderAgentMessages, and sent to the model as-is (potentially hundreds of thousands of tokens).

**The fix**
- store the snippet in the DB row instead of the full text, for both the text-to-resource conversion path and the large resource text path. The `FileResource` already holds the complete content and is accessible to the agent via conversation attachments.

> [!WARNING]
> Known limitation: `conversation_files server`

The `conversation_files` MCP server is currently excluded from this logic. When the agent cats a large attached file, the entire content is stored as-is in the output item. No file upload, no snippet, no truncation.

Fixing this properly requires improving the `conversation_files` MCP server to support pagination on the cat tool (offset/limit), so that large file reads are bounded at the source. Once that's in place, we can remove the exclusion and apply the same truncation to `conversation_files` outputs. Tracked as a follow-up.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
There is some risks, as until today, the model was always getting the full context without interacting with the underlying file. Safe to rollback. Actions created while this code was out will be inaccurate.  

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
