### PR TITLE
Context separation for copilot suggestion cards to fix flickering & re-renders

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -56,6 +56,10 @@ export interface CopilotSuggestionsContextType {
   // Get frozen snapshot of instructions HTML for a suggestion (captured once, never changes)
   getFrozenInstructionsHtml: (sId: string) => string;
 
+  // DiffBlock expansion state (persists across remounts)
+  getDiffBlockExpanded: (sId: string) => boolean;
+  setDiffBlockExpanded: (sId: string, expanded: boolean) => void;
+
   // Actions on suggestions. Returns true on success, false on failure.
   acceptSuggestion: (sId: string) => Promise<boolean>;
   rejectSuggestion: (sId: string) => Promise<boolean>;
@@ -135,6 +139,8 @@ function CopilotSuggestionsProviderContent({
   const refetchAttemptedRef = useRef<Set<string>>(new Set());
   // Frozen HTML cache - captures instructions HTML once per suggestion, never changes
   const frozenHtmlCacheRef = useRef<Map<string, string>>(new Map());
+  // DiffBlock expansion state - persists across component remounts
+  const diffBlockExpansionRef = useRef<Map<string, boolean>>(new Map());
 
   // Local state for processed (accepted/rejected/outdated) suggestions - prevents card "blink"
   const [processedSuggestions, setProcessedSuggestions] = useState<
@@ -219,72 +225,89 @@ function CopilotSuggestionsProviderContent({
     [suggestions, processedSuggestions]
   );
 
-  // Resolve a suggestion with its relations from context.
-  const getSuggestionWithRelations = useCallback(
-    (sId: string): AgentSuggestionWithRelationsType | null => {
-      const suggestion = getSuggestion(sId);
+  // Pre-compute enriched suggestions map for stable object references
+  // This prevents unnecessary re-renders from object reference changes
+  // Includes both API suggestions and locally processed (accepted/rejected) suggestions
+  const enrichedSuggestionsMap = useMemo(() => {
+    const map = new Map<string, AgentSuggestionWithRelationsType>();
 
-      if (!suggestion) {
-        return null;
-      }
+    // Combine API suggestions and locally processed suggestions
+    const allSuggestions = [
+      ...suggestions,
+      ...Array.from(processedSuggestions.values()),
+    ];
+
+    for (const suggestion of allSuggestions) {
+      let enriched: AgentSuggestionWithRelationsType | null = null;
 
       switch (suggestion.kind) {
         case "tools":
         case "sub_agent": {
           const tool = mcpServerViewsMap.get(suggestion.suggestion.toolId);
-          if (!tool) {
-            return null;
+          if (tool) {
+            enriched = { ...suggestion, relations: { tool } };
           }
-
-          return { ...suggestion, relations: { tool } };
+          break;
         }
 
         case "skills": {
           const skill = skillsMap.get(suggestion.suggestion.skillId);
-          if (!skill) {
-            return null;
+          if (skill) {
+            enriched = { ...suggestion, relations: { skill } };
           }
-
-          return { ...suggestion, relations: { skill } };
+          break;
         }
 
         case "model": {
           const model = getModelConfigByModelId(suggestion.suggestion.modelId);
-          if (!model) {
-            return null;
+          if (model) {
+            enriched = { ...suggestion, relations: { model } };
           }
-
-          return { ...suggestion, relations: { model } };
+          break;
         }
 
         case "knowledge": {
           const dataSourceView = dataSourceViewsMap.get(
             suggestion.suggestion.dataSourceViewId
           );
-          if (!dataSourceView || !searchServerView) {
-            return null;
+          if (dataSourceView && searchServerView) {
+            enriched = {
+              ...suggestion,
+              relations: { dataSourceView, searchServerView },
+            };
           }
-
-          return {
-            ...suggestion,
-            relations: { dataSourceView, searchServerView },
-          };
+          break;
         }
 
         case "instructions":
-          return { ...suggestion, relations: null };
+          enriched = { ...suggestion, relations: null };
+          break;
 
         default:
           assertNever(suggestion);
       }
+
+      if (enriched) {
+        map.set(suggestion.sId, enriched);
+      }
+    }
+
+    return map;
+  }, [
+    suggestions,
+    processedSuggestions,
+    skillsMap,
+    mcpServerViewsMap,
+    dataSourceViewsMap,
+    searchServerView,
+  ]);
+
+  // Resolve a suggestion with its relations - simple lookup from memoized map
+  const getSuggestionWithRelations = useCallback(
+    (sId: string): AgentSuggestionWithRelationsType | null => {
+      return enrichedSuggestionsMap.get(sId) ?? null;
     },
-    [
-      getSuggestion,
-      skillsMap,
-      mcpServerViewsMap,
-      dataSourceViewsMap,
-      searchServerView,
-    ]
+    [enrichedSuggestionsMap]
   );
 
   // Debounced refetch to batch multiple directive renders into one SWR call.
@@ -713,12 +736,23 @@ function CopilotSuggestionsProviderContent({
     return html;
   }, []);
 
+  // Get DiffBlock expansion state (persists across remounts)
+  const getDiffBlockExpanded = useCallback((sId: string): boolean => {
+    return diffBlockExpansionRef.current.get(sId) ?? false;
+  }, []);
+
+  // Set DiffBlock expansion state (persists across remounts)
+  const setDiffBlockExpanded = useCallback((sId: string, expanded: boolean) => {
+    diffBlockExpansionRef.current.set(sId, expanded);
+  }, []);
+
   const value: CopilotSuggestionsContextType = useMemo(
     () => ({
       acceptAllInstructionSuggestions,
       acceptSuggestion,
       focusOnSuggestion,
       getCommittedInstructionsHtml,
+      getDiffBlockExpanded,
       getFrozenInstructionsHtml,
       getPendingSuggestions,
       getSuggestionWithRelations,
@@ -729,6 +763,7 @@ function CopilotSuggestionsProviderContent({
       rejectAllInstructionSuggestions,
       rejectSuggestion,
       scrollToNextSuggestion,
+      setDiffBlockExpanded,
       triggerRefetch,
     }),
     [
@@ -736,6 +771,7 @@ function CopilotSuggestionsProviderContent({
       acceptSuggestion,
       focusOnSuggestion,
       getCommittedInstructionsHtml,
+      getDiffBlockExpanded,
       getFrozenInstructionsHtml,
       getPendingSuggestions,
       getSuggestionWithRelations,
@@ -746,6 +782,7 @@ function CopilotSuggestionsProviderContent({
       rejectAllInstructionSuggestions,
       rejectSuggestion,
       scrollToNextSuggestion,
+      setDiffBlockExpanded,
       triggerRefetch,
     ]
   );

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -43,8 +43,6 @@ export interface CopilotSuggestionsContextType {
   ) => AgentSuggestionWithRelationsType | null;
   getPendingSuggestions: () => AgentSuggestionType[];
   triggerRefetch: (sId: string) => void;
-  isSuggestionsLoading: boolean;
-  isSuggestionsValidating: boolean;
 
   // Refetch tracking (persists across component remounts).
   hasAttemptedRefetch: (sId: string) => boolean;
@@ -81,6 +79,25 @@ export const useCopilotSuggestions = () => {
   if (!context) {
     throw new Error(
       "useCopilotSuggestions must be used within a CopilotSuggestionsProvider"
+    );
+  }
+  return context;
+};
+
+export interface CopilotSuggestionsLoadingContextType {
+  isSuggestionsLoading: boolean;
+  isSuggestionsValidating: boolean;
+}
+
+const CopilotSuggestionsLoadingContext = createContext<
+  CopilotSuggestionsLoadingContextType | undefined
+>(undefined);
+
+export const useCopilotSuggestionsLoading = () => {
+  const context = useContext(CopilotSuggestionsLoadingContext);
+  if (!context) {
+    throw new Error(
+      "useCopilotSuggestionsLoading must be used within a CopilotSuggestionsProvider"
     );
   }
   return context;
@@ -208,21 +225,43 @@ function CopilotSuggestionsProviderContent({
   const isSuggestionsLoading = isPendingLoading || isOutdatedLoading;
   const isSuggestionsValidating = isPendingValidating;
 
+  // Store SWR mutate functions in refs for stable function references
+  const mutatePendingRef = useRef(mutatePending);
+  mutatePendingRef.current = mutatePending;
+
+  const mutateOutdatedRef = useRef(mutateOutdated);
+  mutateOutdatedRef.current = mutateOutdated;
+
+  // Stable wrapper
   const mutateSuggestions = useCallback(async () => {
-    await Promise.all([mutatePending(), mutateOutdated()]);
-  }, [mutatePending, mutateOutdated]);
+    await Promise.all([
+      mutatePendingRef.current(),
+      mutateOutdatedRef.current(),
+    ]);
+  }, []);
+
+  // Store suggestions state in refs for stable function references
+  const suggestionsRef = useRef(suggestions);
+  suggestionsRef.current = suggestions;
+
+  const processedSuggestionsRef = useRef(processedSuggestions);
+  processedSuggestionsRef.current = processedSuggestions;
 
   // Get suggestion: check local state first, then backend (n is small, .find is fine)
   const getSuggestion = useCallback(
     (sId: string) =>
-      processedSuggestions.get(sId) ?? suggestions.find((s) => s.sId === sId),
-    [processedSuggestions, suggestions]
+      processedSuggestionsRef.current.get(sId) ??
+      suggestionsRef.current.find((s) => s.sId === sId),
+    []
   );
 
-  // Get pending suggestions: backend suggestions not yet processed locally
+  // Stable wrapper - get pending suggestions
   const getPendingSuggestions = useCallback(
-    () => suggestions.filter((s) => !processedSuggestions.has(s.sId)),
-    [suggestions, processedSuggestions]
+    () =>
+      suggestionsRef.current.filter(
+        (s) => !processedSuggestionsRef.current.has(s.sId)
+      ),
+    []
   );
 
   // Pre-compute enriched suggestions map for stable object references
@@ -302,12 +341,16 @@ function CopilotSuggestionsProviderContent({
     searchServerView,
   ]);
 
-  // Resolve a suggestion with its relations - simple lookup from memoized map
+  // Store enrichedSuggestionsMap in ref for stable function reference
+  const enrichedSuggestionsMapRef = useRef(enrichedSuggestionsMap);
+  enrichedSuggestionsMapRef.current = enrichedSuggestionsMap;
+
+  // Stable wrapper - resolve a suggestion with its relations
   const getSuggestionWithRelations = useCallback(
     (sId: string): AgentSuggestionWithRelationsType | null => {
-      return enrichedSuggestionsMap.get(sId) ?? null;
+      return enrichedSuggestionsMapRef.current.get(sId) ?? null;
     },
-    [enrichedSuggestionsMap]
+    []
   );
 
   // Debounced refetch to batch multiple directive renders into one SWR call.
@@ -315,24 +358,25 @@ function CopilotSuggestionsProviderContent({
   const debounceTimerRef = useRef<NodeJS.Timeout>();
   const attemptedRefetchRef = useRef<Set<string>>(new Set());
 
-  const triggerRefetch = useCallback(
-    (sId: string) => {
-      attemptedRefetchRef.current.add(sId);
+  const mutateSuggestionsRef = useRef(mutateSuggestions);
+  mutateSuggestionsRef.current = mutateSuggestions;
 
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
+  // Stable wrapper
+  const triggerRefetch = useCallback((sId: string) => {
+    attemptedRefetchRef.current.add(sId);
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(async () => {
+      await mutateSuggestionsRef.current();
+      for (const id of attemptedRefetchRef.current) {
+        refetchAttemptedRef.current.add(id);
       }
-
-      debounceTimerRef.current = setTimeout(async () => {
-        await mutateSuggestions();
-        for (const id of attemptedRefetchRef.current) {
-          refetchAttemptedRef.current.add(id);
-        }
-        attemptedRefetchRef.current.clear();
-      }, 100);
-    },
-    [mutateSuggestions]
-  );
+      attemptedRefetchRef.current.clear();
+    }, 100);
+  }, []);
 
   const { patchSuggestions } = usePatchAgentSuggestions({
     agentConfigurationId,
@@ -483,65 +527,84 @@ function CopilotSuggestionsProviderContent({
     });
   }, []);
 
-  const focusOnSuggestion = useCallback(
-    (suggestionId: string) => {
-      const editor = editorRef.current;
-      if (!editor) {
-        return;
-      }
-      const suggestion = getSuggestion(suggestionId);
-      if (!suggestion || suggestion.kind !== "instructions") {
-        return;
-      }
-      const position = getSuggestionPosition(editor, suggestionId);
+  // Store latest implementations in refs to avoid breaking function reference stability
+  const getSuggestionRef = useRef(getSuggestion);
+  getSuggestionRef.current = getSuggestion;
 
-      if (position !== null) {
-        editor
-          .chain()
-          .focus()
-          .setTextSelection(position)
-          .scrollIntoView()
-          .run();
+  const highlightSuggestionRef = useRef(highlightSuggestion);
+  highlightSuggestionRef.current = highlightSuggestion;
 
-        highlightSuggestion(suggestionId, true);
-      }
-    },
-    [getSuggestion, highlightSuggestion]
-  );
+  // Stable wrapper - never changes reference, calls latest implementation
+  const focusOnSuggestion = useCallback((suggestionId: string) => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    const suggestion = getSuggestionRef.current(suggestionId);
+    if (!suggestion || suggestion.kind !== "instructions") {
+      return;
+    }
+    const position = getSuggestionPosition(editor, suggestionId);
 
-  const scrollToNextSuggestion = useCallback(
-    (acceptedSuggestionId: string) => {
-      const editor = editorRef.current;
-      const pendingInstructions = getPendingSuggestions().filter(
+    if (position !== null) {
+      editor.chain().focus().setTextSelection(position).scrollIntoView().run();
+
+      highlightSuggestionRef.current(suggestionId, true);
+    }
+  }, []); // Empty deps - truly stable
+
+  const getPendingSuggestionsRef = useRef(getPendingSuggestions);
+  getPendingSuggestionsRef.current = getPendingSuggestions;
+
+  const scrollCopilotToSuggestionRef = useRef(scrollCopilotToSuggestion);
+  scrollCopilotToSuggestionRef.current = scrollCopilotToSuggestion;
+
+  const focusOnSuggestionRef = useRef(focusOnSuggestion);
+  focusOnSuggestionRef.current = focusOnSuggestion;
+
+  // Stable wrapper
+  const scrollToNextSuggestion = useCallback((acceptedSuggestionId: string) => {
+    const editor = editorRef.current;
+    const pendingInstructions = getPendingSuggestionsRef
+      .current()
+      .filter(
         (s) => s.kind === "instructions" && s.sId !== acceptedSuggestionId
       );
-      if (pendingInstructions.length === 0) {
-        return;
-      }
+    if (pendingInstructions.length === 0) {
+      return;
+    }
 
-      // Order by document position (top to bottom in the instruction form)
-      const sorted =
-        editor && !editor.isDestroyed
-          ? [...pendingInstructions].sort((a, b) => {
-              const posA = getSuggestionPosition(editor, a.sId);
-              const posB = getSuggestionPosition(editor, b.sId);
-              if (posA === null) {
-                return 1;
-              }
-              if (posB === null) {
-                return -1;
-              }
-              return posA - posB;
-            })
-          : pendingInstructions;
+    // Order by document position (top to bottom in the instruction form)
+    const sorted =
+      editor && !editor.isDestroyed
+        ? [...pendingInstructions].sort((a, b) => {
+            const posA = getSuggestionPosition(editor, a.sId);
+            const posB = getSuggestionPosition(editor, b.sId);
+            if (posA === null) {
+              return 1;
+            }
+            if (posB === null) {
+              return -1;
+            }
+            return posA - posB;
+          })
+        : pendingInstructions;
 
-      const next = sorted[0];
-      focusOnSuggestion(next.sId);
-      scrollCopilotToSuggestion(next.sId);
-    },
-    [getPendingSuggestions, focusOnSuggestion, scrollCopilotToSuggestion]
-  );
+    const next = sorted[0];
+    focusOnSuggestionRef.current(next.sId);
+    scrollCopilotToSuggestionRef.current(next.sId);
+  }, []);
 
+  const patchSuggestionsRef = useRef(patchSuggestions);
+  patchSuggestionsRef.current = patchSuggestions;
+
+  const dispatchDelayedBlurRef = useRef(dispatchDelayedBlur);
+  dispatchDelayedBlurRef.current = dispatchDelayedBlur;
+
+  const scrollToNextSuggestionRef = useRef(scrollToNextSuggestion);
+  scrollToNextSuggestionRef.current = scrollToNextSuggestion;
+
+  // Stable wrapper
   const acceptSuggestion = useCallback(
     async (sId: string): Promise<boolean> => {
       const editor = editorRef.current;
@@ -549,7 +612,7 @@ function CopilotSuggestionsProviderContent({
         return false;
       }
 
-      const suggestion = getSuggestion(sId);
+      const suggestion = getSuggestionRef.current(sId);
       if (!suggestion) {
         return false;
       }
@@ -559,7 +622,7 @@ function CopilotSuggestionsProviderContent({
         new Map(prev).set(sId, { ...suggestion, state: "approved" })
       );
 
-      const result = await patchSuggestions([sId], "approved");
+      const result = await patchSuggestionsRef.current([sId], "approved");
       if (!result || result.suggestions.length === 0) {
         setProcessedSuggestions((prev) => new Map(prev).set(sId, suggestion));
         return false;
@@ -568,20 +631,17 @@ function CopilotSuggestionsProviderContent({
       if (suggestion.kind === "instructions") {
         editor.commands.acceptSuggestion(sId);
         appliedSuggestionsRef.current.delete(sId);
-        dispatchDelayedBlur();
-        scrollToNextSuggestion(sId);
+        dispatchDelayedBlurRef.current();
+        // Don't auto-scroll to next suggestion - let user stay at current position
+        // scrollToNextSuggestionRef.current(sId);
       }
 
       return true;
     },
-    [
-      patchSuggestions,
-      getSuggestion,
-      dispatchDelayedBlur,
-      scrollToNextSuggestion,
-    ]
+    []
   );
 
+  // Stable wrapper
   const rejectSuggestion = useCallback(
     async (sId: string): Promise<boolean> => {
       const editor = editorRef.current;
@@ -589,7 +649,7 @@ function CopilotSuggestionsProviderContent({
         return false;
       }
 
-      const suggestion = getSuggestion(sId);
+      const suggestion = getSuggestionRef.current(sId);
       if (!suggestion) {
         return false;
       }
@@ -599,7 +659,7 @@ function CopilotSuggestionsProviderContent({
         new Map(prev).set(sId, { ...suggestion, state: "rejected" })
       );
 
-      const result = await patchSuggestions([sId], "rejected");
+      const result = await patchSuggestionsRef.current([sId], "rejected");
       if (!result || result.suggestions.length === 0) {
         setProcessedSuggestions((prev) => new Map(prev).set(sId, suggestion));
         return false;
@@ -613,9 +673,10 @@ function CopilotSuggestionsProviderContent({
 
       return true;
     },
-    [patchSuggestions, getSuggestion]
+    []
   );
 
+  // Stable wrapper
   const acceptAllInstructionSuggestions =
     useCallback(async (): Promise<boolean> => {
       const editor = editorRef.current;
@@ -623,16 +684,16 @@ function CopilotSuggestionsProviderContent({
         return false;
       }
 
-      const instructionSuggestions = getPendingSuggestions().filter(
-        (s) => s.kind === "instructions"
-      );
+      const instructionSuggestions = getPendingSuggestionsRef
+        .current()
+        .filter((s) => s.kind === "instructions");
 
       if (instructionSuggestions.length === 0) {
         return true;
       }
 
       const instructionSuggestionIds = instructionSuggestions.map((s) => s.sId);
-      const result = await patchSuggestions(
+      const result = await patchSuggestionsRef.current(
         instructionSuggestionIds,
         "approved"
       );
@@ -652,17 +713,13 @@ function CopilotSuggestionsProviderContent({
         appliedSuggestionsRef.current.delete(sId);
       }
 
-      highlightSuggestion(null);
-      dispatchDelayedBlur();
+      highlightSuggestionRef.current(null);
+      dispatchDelayedBlurRef.current();
 
       return true;
-    }, [
-      patchSuggestions,
-      getPendingSuggestions,
-      dispatchDelayedBlur,
-      highlightSuggestion,
-    ]);
+    }, []);
 
+  // Stable wrapper
   const rejectAllInstructionSuggestions =
     useCallback(async (): Promise<boolean> => {
       const editor = editorRef.current;
@@ -670,16 +727,16 @@ function CopilotSuggestionsProviderContent({
         return false;
       }
 
-      const instructionSuggestions = getPendingSuggestions().filter(
-        (s) => s.kind === "instructions"
-      );
+      const instructionSuggestions = getPendingSuggestionsRef
+        .current()
+        .filter((s) => s.kind === "instructions");
 
       if (instructionSuggestions.length === 0) {
         return true;
       }
 
       const instructionSuggestionIds = instructionSuggestions.map((s) => s.sId);
-      const result = await patchSuggestions(
+      const result = await patchSuggestionsRef.current(
         instructionSuggestionIds,
         "rejected"
       );
@@ -699,10 +756,10 @@ function CopilotSuggestionsProviderContent({
         appliedSuggestionsRef.current.delete(sId);
       }
 
-      highlightSuggestion(null);
+      highlightSuggestionRef.current(null);
 
       return true;
-    }, [patchSuggestions, getPendingSuggestions, highlightSuggestion]);
+    }, []);
 
   const getCommittedInstructionsHtml = useCallback(() => {
     const editor = editorRef.current;
@@ -746,6 +803,14 @@ function CopilotSuggestionsProviderContent({
     diffBlockExpansionRef.current.set(sId, expanded);
   }, []);
 
+  const loadingValue: CopilotSuggestionsLoadingContextType = useMemo(
+    () => ({
+      isSuggestionsLoading,
+      isSuggestionsValidating,
+    }),
+    [isSuggestionsLoading, isSuggestionsValidating]
+  );
+
   const value: CopilotSuggestionsContextType = useMemo(
     () => ({
       acceptAllInstructionSuggestions,
@@ -757,8 +822,6 @@ function CopilotSuggestionsProviderContent({
       getPendingSuggestions,
       getSuggestionWithRelations,
       hasAttemptedRefetch,
-      isSuggestionsLoading,
-      isSuggestionsValidating,
       registerEditor,
       rejectAllInstructionSuggestions,
       rejectSuggestion,
@@ -776,8 +839,6 @@ function CopilotSuggestionsProviderContent({
       getPendingSuggestions,
       getSuggestionWithRelations,
       hasAttemptedRefetch,
-      isSuggestionsLoading,
-      isSuggestionsValidating,
       registerEditor,
       rejectAllInstructionSuggestions,
       rejectSuggestion,
@@ -788,10 +849,12 @@ function CopilotSuggestionsProviderContent({
   );
 
   return (
-    <CopilotSuggestionsContext.Provider value={value}>
-      <EditorHighlightSync editorRef={editorRef} />
-      {children}
-    </CopilotSuggestionsContext.Provider>
+    <CopilotSuggestionsLoadingContext.Provider value={loadingValue}>
+      <CopilotSuggestionsContext.Provider value={value}>
+        <EditorHighlightSync editorRef={editorRef} />
+        {children}
+      </CopilotSuggestionsContext.Provider>
+    </CopilotSuggestionsLoadingContext.Provider>
   );
 }
 

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -264,8 +264,7 @@ function CopilotSuggestionsProviderContent({
     []
   );
 
-  // Pre-compute enriched suggestions map for stable object references
-  // This prevents unnecessary re-renders from object reference changes
+  // Pre-compute enriched suggestions map with stable object references
   // Includes both API suggestions and locally processed (accepted/rejected) suggestions
   const enrichedSuggestionsMap = useMemo(() => {
     const map = new Map<string, AgentSuggestionWithRelationsType>();
@@ -632,8 +631,7 @@ function CopilotSuggestionsProviderContent({
         editor.commands.acceptSuggestion(sId);
         appliedSuggestionsRef.current.delete(sId);
         dispatchDelayedBlurRef.current();
-        // Don't auto-scroll to next suggestion - let user stay at current position
-        // scrollToNextSuggestionRef.current(sId);
+        scrollToNextSuggestionRef.current(sId);
       }
 
       return true;

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -84,19 +84,14 @@ const InstructionsSuggestionCard = memo(
       getDiffBlockExpanded(sId)
     );
 
-    // Persist to context when state changes
+    // Update local state (triggers re-render) and persist to context (survives remount)
     const handleExpandedChange = useCallback(
       (expanded: boolean) => {
-        setIsExpanded(expanded); // ← Local state update triggers re-render!
-        setDiffBlockExpanded(sId, expanded); // Persist to context for remount
+        setIsExpanded(expanded);
+        setDiffBlockExpanded(sId, expanded);
       },
       [sId, setDiffBlockExpanded]
     );
-
-    // Note: We don't need useEffect to restore from context because:
-    // 1. useState initializes from context on mount
-    // 2. State persists across re-renders automatically
-    // 3. If component unmounts/remounts, useState will re-initialize from context
 
     const blockHtml = useMemo(() => {
       if (!frozenInstructionsHtml) {
@@ -584,23 +579,19 @@ function KnowledgeSuggestionCard({
 
 interface SuggestionCardProps {
   agentSuggestion: AgentSuggestionWithRelationsType;
-  // Context functions passed as props to avoid context subscription
-  focusOnSuggestion: (id: string) => void;
-  getFrozenInstructionsHtml: (sId: string) => string;
-  getDiffBlockExpanded: (sId: string) => boolean;
-  setDiffBlockExpanded: (sId: string, expanded: boolean) => void;
 }
 
 export const CopilotSuggestionCard = memo(
-  function CopilotSuggestionCard({
-    agentSuggestion,
-    focusOnSuggestion,
-    getFrozenInstructionsHtml,
-    getDiffBlockExpanded,
-    setDiffBlockExpanded,
-  }: SuggestionCardProps) {
-    // Call directly each render - caching happens inside getFrozenInstructionsHtml
-    // This allows it to capture HTML once editor is ready, even if not ready on first render
+  function CopilotSuggestionCard({ agentSuggestion }: SuggestionCardProps) {
+    // Subscribe to main context directly (no loading state, so won't re-render on SWR changes)
+    const {
+      focusOnSuggestion,
+      getFrozenInstructionsHtml,
+      getDiffBlockExpanded,
+      setDiffBlockExpanded,
+    } = useCopilotSuggestions();
+
+    // getFrozenInstructionsHtml caches internally after first capture
     const frozenInstructionsHtml =
       agentSuggestion.kind === "instructions"
         ? getFrozenInstructionsHtml(agentSuggestion.sId)
@@ -631,20 +622,9 @@ export const CopilotSuggestionCard = memo(
         assertNever(agentSuggestion);
     }
   },
-  (prev, next) => {
-    // Only compare suggestion content, not function references
-    // Functions from context get new references even when behavior hasn't changed
-    // This causes unnecessary re-renders, so we skip function comparison
-    if (prev.agentSuggestion.sId !== next.agentSuggestion.sId) {
-      return false;
-    }
-    if (prev.agentSuggestion.state !== next.agentSuggestion.state) {
-      return false;
-    }
-
-    // Skip re-render - only sId and state matter for rendering
-    return true;
-  }
+  (prev, next) =>
+    prev.agentSuggestion.sId === next.agentSuggestion.sId &&
+    prev.agentSuggestion.state === next.agentSuggestion.state
 );
 
 interface SuggestionCardSkeletonProps {

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -38,7 +38,7 @@ import {
   LoadingBlock,
 } from "@dust-tt/sparkle";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 function mapSuggestionStateToCardState(
@@ -62,6 +62,8 @@ interface InstructionsSuggestionCardProps {
   agentSuggestion: AgentInstructionsSuggestionType;
   focusOnSuggestion: (id: string) => void;
   frozenInstructionsHtml: string;
+  getDiffBlockExpanded: (sId: string) => boolean;
+  setDiffBlockExpanded: (sId: string, expanded: boolean) => void;
 }
 
 // Re-render only when suggestion identity/state or callbacks change.
@@ -71,9 +73,30 @@ const InstructionsSuggestionCard = memo(
     agentSuggestion,
     focusOnSuggestion,
     frozenInstructionsHtml,
+    getDiffBlockExpanded,
+    setDiffBlockExpanded,
   }: InstructionsSuggestionCardProps) {
     const { content, targetBlockId } = agentSuggestion.suggestion;
     const { state, sId } = agentSuggestion;
+
+    // Initialize from context, then manage locally (triggers re-renders on change)
+    const [isExpanded, setIsExpanded] = useState(() =>
+      getDiffBlockExpanded(sId)
+    );
+
+    // Persist to context when state changes
+    const handleExpandedChange = useCallback(
+      (expanded: boolean) => {
+        setIsExpanded(expanded); // ← Local state update triggers re-render!
+        setDiffBlockExpanded(sId, expanded); // Persist to context for remount
+      },
+      [sId, setDiffBlockExpanded]
+    );
+
+    // Restore from context on mount (handles remount from state change)
+    useEffect(() => {
+      setIsExpanded(getDiffBlockExpanded(sId));
+    }, [sId, getDiffBlockExpanded]);
 
     const blockHtml = useMemo(() => {
       if (!frozenInstructionsHtml) {
@@ -114,6 +137,8 @@ const InstructionsSuggestionCard = memo(
     return (
       <div className="mb-2">
         <DiffBlock
+          expanded={isExpanded}
+          onExpandedChange={handleExpandedChange}
           actions={
             isPending ? (
               <Button
@@ -564,8 +589,12 @@ interface SuggestionCardProps {
 export function CopilotSuggestionCard({
   agentSuggestion,
 }: SuggestionCardProps) {
-  const { focusOnSuggestion, getFrozenInstructionsHtml } =
-    useCopilotSuggestions();
+  const {
+    focusOnSuggestion,
+    getFrozenInstructionsHtml,
+    getDiffBlockExpanded,
+    setDiffBlockExpanded,
+  } = useCopilotSuggestions();
 
   // Call directly each render - caching happens inside getFrozenInstructionsHtml
   // This allows it to capture HTML once editor is ready, even if not ready on first render
@@ -581,6 +610,8 @@ export function CopilotSuggestionCard({
           agentSuggestion={agentSuggestion}
           focusOnSuggestion={focusOnSuggestion}
           frozenInstructionsHtml={frozenInstructionsHtml}
+          getDiffBlockExpanded={getDiffBlockExpanded}
+          setDiffBlockExpanded={setDiffBlockExpanded}
         />
       );
     case "tools":

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -38,7 +38,7 @@ import {
   LoadingBlock,
 } from "@dust-tt/sparkle";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 function mapSuggestionStateToCardState(
@@ -93,10 +93,10 @@ const InstructionsSuggestionCard = memo(
       [sId, setDiffBlockExpanded]
     );
 
-    // Restore from context on mount (handles remount from state change)
-    useEffect(() => {
-      setIsExpanded(getDiffBlockExpanded(sId));
-    }, [sId, getDiffBlockExpanded]);
+    // Note: We don't need useEffect to restore from context because:
+    // 1. useState initializes from context on mount
+    // 2. State persists across re-renders automatically
+    // 3. If component unmounts/remounts, useState will re-initialize from context
 
     const blockHtml = useMemo(() => {
       if (!frozenInstructionsHtml) {
@@ -584,50 +584,68 @@ function KnowledgeSuggestionCard({
 
 interface SuggestionCardProps {
   agentSuggestion: AgentSuggestionWithRelationsType;
+  // Context functions passed as props to avoid context subscription
+  focusOnSuggestion: (id: string) => void;
+  getFrozenInstructionsHtml: (sId: string) => string;
+  getDiffBlockExpanded: (sId: string) => boolean;
+  setDiffBlockExpanded: (sId: string, expanded: boolean) => void;
 }
 
-export function CopilotSuggestionCard({
-  agentSuggestion,
-}: SuggestionCardProps) {
-  const {
+export const CopilotSuggestionCard = memo(
+  function CopilotSuggestionCard({
+    agentSuggestion,
     focusOnSuggestion,
     getFrozenInstructionsHtml,
     getDiffBlockExpanded,
     setDiffBlockExpanded,
-  } = useCopilotSuggestions();
+  }: SuggestionCardProps) {
+    // Call directly each render - caching happens inside getFrozenInstructionsHtml
+    // This allows it to capture HTML once editor is ready, even if not ready on first render
+    const frozenInstructionsHtml =
+      agentSuggestion.kind === "instructions"
+        ? getFrozenInstructionsHtml(agentSuggestion.sId)
+        : "";
 
-  // Call directly each render - caching happens inside getFrozenInstructionsHtml
-  // This allows it to capture HTML once editor is ready, even if not ready on first render
-  const frozenInstructionsHtml =
-    agentSuggestion.kind === "instructions"
-      ? getFrozenInstructionsHtml(agentSuggestion.sId)
-      : "";
+    switch (agentSuggestion.kind) {
+      case "instructions":
+        return (
+          <InstructionsSuggestionCard
+            agentSuggestion={agentSuggestion}
+            focusOnSuggestion={focusOnSuggestion}
+            frozenInstructionsHtml={frozenInstructionsHtml}
+            getDiffBlockExpanded={getDiffBlockExpanded}
+            setDiffBlockExpanded={setDiffBlockExpanded}
+          />
+        );
+      case "tools":
+        return <ToolSuggestionCard agentSuggestion={agentSuggestion} />;
+      case "sub_agent":
+        return <SubAgentSuggestionCard agentSuggestion={agentSuggestion} />;
+      case "skills":
+        return <SkillSuggestionCard agentSuggestion={agentSuggestion} />;
+      case "model":
+        return <ModelSuggestionCard agentSuggestion={agentSuggestion} />;
+      case "knowledge":
+        return <KnowledgeSuggestionCard agentSuggestion={agentSuggestion} />;
+      default:
+        assertNever(agentSuggestion);
+    }
+  },
+  (prev, next) => {
+    // Only compare suggestion content, not function references
+    // Functions from context get new references even when behavior hasn't changed
+    // This causes unnecessary re-renders, so we skip function comparison
+    if (prev.agentSuggestion.sId !== next.agentSuggestion.sId) {
+      return false;
+    }
+    if (prev.agentSuggestion.state !== next.agentSuggestion.state) {
+      return false;
+    }
 
-  switch (agentSuggestion.kind) {
-    case "instructions":
-      return (
-        <InstructionsSuggestionCard
-          agentSuggestion={agentSuggestion}
-          focusOnSuggestion={focusOnSuggestion}
-          frozenInstructionsHtml={frozenInstructionsHtml}
-          getDiffBlockExpanded={getDiffBlockExpanded}
-          setDiffBlockExpanded={setDiffBlockExpanded}
-        />
-      );
-    case "tools":
-      return <ToolSuggestionCard agentSuggestion={agentSuggestion} />;
-    case "sub_agent":
-      return <SubAgentSuggestionCard agentSuggestion={agentSuggestion} />;
-    case "skills":
-      return <SkillSuggestionCard agentSuggestion={agentSuggestion} />;
-    case "model":
-      return <ModelSuggestionCard agentSuggestion={agentSuggestion} />;
-    case "knowledge":
-      return <KnowledgeSuggestionCard agentSuggestion={agentSuggestion} />;
-    default:
-      assertNever(agentSuggestion);
+    // Skip re-render - only sId and state matter for rendering
+    return true;
   }
-}
+);
 
 interface SuggestionCardSkeletonProps {
   kind?: AgentSuggestionKind;

--- a/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
@@ -56,16 +56,8 @@ export function getCopilotSuggestionPlugin() {
     sId,
     kind,
   }: CopilotSuggestionPluginProps) => {
-    const {
-      getSuggestionWithRelations,
-      triggerRefetch,
-      hasAttemptedRefetch,
-      // Extract context functions to pass as props to CopilotSuggestionCard
-      focusOnSuggestion,
-      getFrozenInstructionsHtml,
-      getDiffBlockExpanded,
-      setDiffBlockExpanded,
-    } = useCopilotSuggestions();
+    const { getSuggestionWithRelations, triggerRefetch, hasAttemptedRefetch } =
+      useCopilotSuggestions();
 
     // Separate subscription for loading state
     const { isSuggestionsValidating } = useCopilotSuggestionsLoading();
@@ -106,13 +98,7 @@ export function getCopilotSuggestionPlugin() {
 
     return (
       <div data-suggestion-s-id={sId}>
-        <CopilotSuggestionCard
-          agentSuggestion={suggestion}
-          focusOnSuggestion={focusOnSuggestion}
-          getFrozenInstructionsHtml={getFrozenInstructionsHtml}
-          getDiffBlockExpanded={getDiffBlockExpanded}
-          setDiffBlockExpanded={setDiffBlockExpanded}
-        />
+        <CopilotSuggestionCard agentSuggestion={suggestion} />
       </div>
     );
   };

--- a/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
@@ -5,7 +5,10 @@
  * suggestion directives in markdown content, enabling the :agent_suggestion[]{sId=xxx kind=yyy} syntax.
  */
 
-import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
+import {
+  useCopilotSuggestions,
+  useCopilotSuggestionsLoading,
+} from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import {
   CopilotSuggestionCard,
   SuggestionCardSkeleton,
@@ -56,9 +59,16 @@ export function getCopilotSuggestionPlugin() {
     const {
       getSuggestionWithRelations,
       triggerRefetch,
-      isSuggestionsValidating,
       hasAttemptedRefetch,
+      // Extract context functions to pass as props to CopilotSuggestionCard
+      focusOnSuggestion,
+      getFrozenInstructionsHtml,
+      getDiffBlockExpanded,
+      setDiffBlockExpanded,
     } = useCopilotSuggestions();
+
+    // Separate subscription for loading state
+    const { isSuggestionsValidating } = useCopilotSuggestionsLoading();
 
     const suggestion = sId ? getSuggestionWithRelations(sId) : null;
 
@@ -96,7 +106,13 @@ export function getCopilotSuggestionPlugin() {
 
     return (
       <div data-suggestion-s-id={sId}>
-        <CopilotSuggestionCard agentSuggestion={suggestion} />
+        <CopilotSuggestionCard
+          agentSuggestion={suggestion}
+          focusOnSuggestion={focusOnSuggestion}
+          getFrozenInstructionsHtml={getFrozenInstructionsHtml}
+          getDiffBlockExpanded={getDiffBlockExpanded}
+          setDiffBlockExpanded={setDiffBlockExpanded}
+        />
       </div>
     );
   };

--- a/front/lib/swr/agent_suggestions.ts
+++ b/front/lib/swr/agent_suggestions.ts
@@ -51,7 +51,10 @@ export function useAgentSuggestions({
       ? `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/suggestions?${queryString}`
       : null,
     suggestionsFetcher,
-    { disabled }
+    {
+      disabled,
+      revalidateOnFocus: false,
+    }
   );
 
   return {

--- a/sparkle/playground/src/components/AgentBuilderView.tsx
+++ b/sparkle/playground/src/components/AgentBuilderView.tsx
@@ -186,6 +186,7 @@ export function AgentBuilderView({
   const [agentDescription, setAgentDescription] = useState(
     template ? "" : agent?.description || ""
   );
+  const [diffBlockExpanded, setDiffBlockExpanded] = useState(false);
   const actionCardComponents: Components = useMemo(
     () =>
       ({
@@ -1115,6 +1116,8 @@ export function AgentBuilderView({
                               ) : null}
                               <DiffBlock
                                 changes={parseDiffString(diffContent)}
+                                expanded={diffBlockExpanded}
+                                onExpandedChange={setDiffBlockExpanded}
                                 actions={
                                   <Button
                                     variant="outline"

--- a/sparkle/src/components/DiffBlock.tsx
+++ b/sparkle/src/components/DiffBlock.tsx
@@ -29,9 +29,8 @@ export type DiffBlockProps = {
   collapsedLines?: number;
   changes?: DiffChange[];
   children?: React.ReactNode;
-  // Controlled expansion state (optional - falls back to internal state if not provided)
-  expanded?: boolean;
-  onExpandedChange?: (expanded: boolean) => void;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
 };
 
 const DEFAULT_COLLAPSED_LINES = 6;
@@ -47,7 +46,7 @@ export function DiffBlock({
   actions,
   className,
   collapsedLines = DEFAULT_COLLAPSED_LINES,
-  expanded: controlledExpanded,
+  expanded,
   onExpandedChange,
 }: DiffBlockProps) {
   const hasContent = changes !== undefined || children !== undefined;
@@ -58,16 +57,10 @@ export function DiffBlock({
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // Use controlled state if provided, otherwise use internal state
-  const isControlled = controlledExpanded !== undefined;
-  const [internalExpanded, setInternalExpanded] = useState(false);
-  const isExpanded = isControlled ? controlledExpanded : internalExpanded;
-
   const [isCollapsible, setIsCollapsible] = useState(false);
   const [isMeasured, setIsMeasured] = useState(false);
   const [collapsedHeight, setCollapsedHeight] = useState<number>();
   const [expandedHeight, setExpandedHeight] = useState<number>();
-  const userInteractedRef = useRef(false);
 
   useLayoutEffect(() => {
     const element = contentRef.current;
@@ -97,8 +90,6 @@ export function DiffBlock({
 
       const isOverflowing = fullHeight > nextCollapsedHeight + 1;
       setIsCollapsible(isOverflowing);
-      // Never auto-collapse - user must manually click "Show less"
-      // (Prevents unwanted collapse during editor re-renders)
       setIsMeasured(true);
     };
 
@@ -114,7 +105,7 @@ export function DiffBlock({
     };
   }, [changes, children, collapsedLines]);
 
-  const shouldClamp = isCollapsible && !isExpanded;
+  const shouldClamp = isCollapsible && !expanded;
 
   return (
     <ContentBlockWrapper
@@ -180,21 +171,9 @@ export function DiffBlock({
             <Button
               size="xs"
               variant="outline"
-              label={isExpanded ? "Show less" : "Show more"}
-              onClick={() => {
-                // Mark that user has interacted - prevent future auto-collapse
-                userInteractedRef.current = true;
-                const newValue = !isExpanded;
-
-                if (isControlled && onExpandedChange) {
-                  // Controlled mode - notify parent
-                  onExpandedChange(newValue);
-                } else {
-                  // Uncontrolled mode - update internal state
-                  setInternalExpanded(newValue);
-                }
-              }}
-              aria-expanded={isExpanded}
+              label={expanded ? "Show less" : "Show more"}
+              onClick={() => onExpandedChange(!expanded)}
+              aria-expanded={expanded}
             />
           </div>
         )}

--- a/sparkle/src/components/DiffBlock.tsx
+++ b/sparkle/src/components/DiffBlock.tsx
@@ -29,6 +29,9 @@ export type DiffBlockProps = {
   collapsedLines?: number;
   changes?: DiffChange[];
   children?: React.ReactNode;
+  // Controlled expansion state (optional - falls back to internal state if not provided)
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
 };
 
 const DEFAULT_COLLAPSED_LINES = 6;
@@ -44,6 +47,8 @@ export function DiffBlock({
   actions,
   className,
   collapsedLines = DEFAULT_COLLAPSED_LINES,
+  expanded: controlledExpanded,
+  onExpandedChange,
 }: DiffBlockProps) {
   const hasContent = changes !== undefined || children !== undefined;
   if (!hasContent) {
@@ -52,11 +57,17 @@ export function DiffBlock({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Use controlled state if provided, otherwise use internal state
+  const isControlled = controlledExpanded !== undefined;
+  const [internalExpanded, setInternalExpanded] = useState(false);
+  const isExpanded = isControlled ? controlledExpanded : internalExpanded;
+
   const [isCollapsible, setIsCollapsible] = useState(false);
   const [isMeasured, setIsMeasured] = useState(false);
   const [collapsedHeight, setCollapsedHeight] = useState<number>();
   const [expandedHeight, setExpandedHeight] = useState<number>();
+  const userInteractedRef = useRef(false);
 
   useLayoutEffect(() => {
     const element = contentRef.current;
@@ -86,9 +97,8 @@ export function DiffBlock({
 
       const isOverflowing = fullHeight > nextCollapsedHeight + 1;
       setIsCollapsible(isOverflowing);
-      if (!isOverflowing) {
-        setIsExpanded(false);
-      }
+      // Never auto-collapse - user must manually click "Show less"
+      // (Prevents unwanted collapse during editor re-renders)
       setIsMeasured(true);
     };
 
@@ -171,7 +181,19 @@ export function DiffBlock({
               size="xs"
               variant="outline"
               label={isExpanded ? "Show less" : "Show more"}
-              onClick={() => setIsExpanded((value) => !value)}
+              onClick={() => {
+                // Mark that user has interacted - prevent future auto-collapse
+                userInteractedRef.current = true;
+                const newValue = !isExpanded;
+
+                if (isControlled && onExpandedChange) {
+                  // Controlled mode - notify parent
+                  onExpandedChange(newValue);
+                } else {
+                  // Uncontrolled mode - update internal state
+                  setInternalExpanded(newValue);
+                }
+              }}
               aria-expanded={isExpanded}
             />
           </div>

--- a/sparkle/src/stories/ActionBlock.stories.tsx
+++ b/sparkle/src/stories/ActionBlock.stories.tsx
@@ -6,6 +6,7 @@ import {
   type ActionCardBlockSize,
   Avatar,
   Button,
+  DiffBlock,
   EyeIcon,
   GmailLogo,
   Markdown,

--- a/sparkle/src/stories/ActionBlock.stories.tsx
+++ b/sparkle/src/stories/ActionBlock.stories.tsx
@@ -6,7 +6,6 @@ import {
   type ActionCardBlockSize,
   Avatar,
   Button,
-  DiffBlock,
   EyeIcon,
   GmailLogo,
   Markdown,

--- a/sparkle/src/stories/DiffBlock.stories.tsx
+++ b/sparkle/src/stories/DiffBlock.stories.tsx
@@ -76,6 +76,8 @@ export const Default: Story = {
         onClick={() => {}}
       />
     ),
+    expanded: false,
+    onExpandedChange: () => {},
   },
 };
 
@@ -88,5 +90,7 @@ export const CollapsedPreview: Story = {
   },
   args: {
     changes: longDiffExample,
+    expanded: false,
+    onExpandedChange: () => {},
   },
 };

--- a/sparkle/src/stories/DiffBlock.stories.tsx
+++ b/sparkle/src/stories/DiffBlock.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
+import React, { useState } from "react";
 
 import { Button, DiffBlock, EyeIcon } from "../index_with_tw_base";
 
@@ -59,6 +59,12 @@ const longDiffExample = [
 ];
 
 export const Default: Story = {
+  render: (args) => {
+    const [expanded, setExpanded] = useState(false);
+    return (
+      <DiffBlock {...args} expanded={expanded} onExpandedChange={setExpanded} />
+    );
+  },
   args: {
     changes: diffExample,
     actions: (
@@ -74,6 +80,12 @@ export const Default: Story = {
 };
 
 export const CollapsedPreview: Story = {
+  render: (args) => {
+    const [expanded, setExpanded] = useState(false);
+    return (
+      <DiffBlock {...args} expanded={expanded} onExpandedChange={setExpanded} />
+    );
+  },
   args: {
     changes: longDiffExample,
   },


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/6724
## Description
There was a ton of flickering, auto-collapsing, and re-render/remounting of the right panel copilot agent instruction card. The instruction card on the right was also updating with the accepted/rejected state instead of maintaining the suggestion diff. Two main fixes required:
1. Captures instruction HTML on first render into a ref-based cache (max ~10 entries, ~100KB, session-scoped), combined with always-controlled DiffBlock pattern using local useState + context useRef persistence, ensuring right panel shows frozen snapshot and expansion state survives re-renders/remounts.
2. Split context into two providers: stable functions (CopilotSuggestionsContext) and volatile loading flags (CopilotSuggestionsLoadingContext), preventing cascading re-renders during SWR revalidation since cards only subscribe to stable context while directive plugin subscribes to both.
 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tons of manual testing, now seeing that:
1. Instruction card diff block on right side maintains initial suggestion diff after accept/reject as expected
3. Show more/show less state persists without flickering, no auto-collapse on accept/reject
4. No flickering on accept/reject or scrolling

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Relatively low, contained change with this component only and I've tested thoroughly
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
