### PR TITLE
[front] Separate SEO articles from regular articles in blog index

### DIFF
--- a/front/components/blog/BlogComponents.tsx
+++ b/front/components/blog/BlogComponents.tsx
@@ -7,6 +7,7 @@ import { Button, Chip, LinkWrapper } from "@dust-tt/sparkle";
 import Image from "next/image";
 
 export const BLOG_PAGE_SIZE = 12;
+export const SEO_PAGE_SIZE = 10;
 
 export function BlogHeader() {
   return (

--- a/front/components/blog/BlogComponents.tsx
+++ b/front/components/blog/BlogComponents.tsx
@@ -198,3 +198,41 @@ interface BlogLayoutProps {
 export function BlogLayout({ children }: BlogLayoutProps) {
   return <Grid>{children}</Grid>;
 }
+
+interface SeoArticleListProps {
+  posts: BlogPostSummary[];
+}
+
+export function SeoArticleList({ posts }: SeoArticleListProps) {
+  if (posts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="col-span-12 mt-12 border-t border-gray-200 pt-8">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">
+        Further reading
+      </h2>
+      <ul className="divide-y divide-gray-100">
+        {posts.map((post) => (
+          <li key={post.id}>
+            <LinkWrapper
+              href={`/blog/${post.slug}`}
+              className="flex items-baseline justify-between gap-4 py-3 hover:text-highlight"
+            >
+              <span className="text-base font-medium text-foreground">
+                {post.title}
+              </span>
+              <span className="shrink-0 text-sm text-muted-foreground">
+                {formatTimestampToFriendlyDate(
+                  new Date(post.createdAt).getTime(),
+                  "short"
+                )}
+              </span>
+            </LinkWrapper>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/front/pages/blog/index.tsx
+++ b/front/pages/blog/index.tsx
@@ -6,6 +6,7 @@ import {
   BlogPostGrid,
   BlogTagFilter,
   FeaturedPost,
+  SeoArticleList,
 } from "@app/components/blog/BlogComponents";
 import { BlogPagination } from "@app/components/blog/BlogPagination";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
@@ -80,21 +81,31 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
     return posts.filter((post) => post.tags.includes(selectedTag));
   }, [posts, selectedTag]);
 
-  // Featured post is the first non-SEO post.
+  // Split into regular and SEO articles.
+  const regularPosts = useMemo(
+    () => filteredPosts.filter((p) => !p.isSeoArticle),
+    [filteredPosts]
+  );
+  const seoPosts = useMemo(
+    () => filteredPosts.filter((p) => p.isSeoArticle),
+    [filteredPosts]
+  );
+
+  // Featured post is the first regular post (only on unfiltered view).
   const featuredPost = useMemo(() => {
     if (selectedTag) {
       return null;
     }
-    return filteredPosts.find((post) => !post.isSeoArticle) ?? null;
-  }, [filteredPosts, selectedTag]);
+    return regularPosts[0] ?? null;
+  }, [regularPosts, selectedTag]);
 
   // Remaining pool excludes the featured post.
   const remainingPool = useMemo(() => {
     if (!featuredPost) {
-      return filteredPosts;
+      return regularPosts;
     }
-    return filteredPosts.filter((post) => post.id !== featuredPost.id);
-  }, [filteredPosts, featuredPost]);
+    return regularPosts.filter((post) => post.id !== featuredPost.id);
+  }, [regularPosts, featuredPost]);
 
   const totalPages = Math.max(
     1,
@@ -104,16 +115,15 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
   const startIndex = (currentPage - 1) * BLOG_PAGE_SIZE;
   const endIndex = startIndex + BLOG_PAGE_SIZE;
 
-  // Sort within each page: regular articles first, SEO articles at the bottom.
-  const paginatedPosts = useMemo(() => {
-    const pageSlice = remainingPool.slice(startIndex, endIndex);
-    return [...pageSlice].sort((a, b) => {
-      if (a.isSeoArticle !== b.isSeoArticle) {
-        return a.isSeoArticle ? 1 : -1;
-      }
-      return 0;
-    });
-  }, [remainingPool, startIndex, endIndex]);
+  const paginatedPosts = useMemo(
+    () => remainingPool.slice(startIndex, endIndex),
+    [remainingPool, startIndex, endIndex]
+  );
+
+  const paginatedSeoPosts = useMemo(
+    () => seoPosts.slice(startIndex, endIndex),
+    [seoPosts, startIndex, endIndex]
+  );
 
   const showFeatured = featuredPost && currentPage === 1;
 
@@ -165,6 +175,8 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
             />
           </div>
         )}
+
+        <SeoArticleList posts={paginatedSeoPosts} />
       </BlogLayout>
     </>
   );

--- a/front/pages/blog/index.tsx
+++ b/front/pages/blog/index.tsx
@@ -6,6 +6,7 @@ import {
   BlogPostGrid,
   BlogTagFilter,
   FeaturedPost,
+  SEO_PAGE_SIZE,
   SeoArticleList,
 } from "@app/components/blog/BlogComponents";
 import { BlogPagination } from "@app/components/blog/BlogPagination";
@@ -120,9 +121,10 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
     [remainingPool, startIndex, endIndex]
   );
 
+  const seoStartIndex = (currentPage - 1) * SEO_PAGE_SIZE;
   const paginatedSeoPosts = useMemo(
-    () => seoPosts.slice(startIndex, endIndex),
-    [seoPosts, startIndex, endIndex]
+    () => seoPosts.slice(seoStartIndex, seoStartIndex + SEO_PAGE_SIZE),
+    [seoPosts, seoStartIndex]
   );
 
   const showFeatured = featuredPost && currentPage === 1;

--- a/front/pages/blog/page/[page].tsx
+++ b/front/pages/blog/page/[page].tsx
@@ -5,6 +5,7 @@ import {
   BlogLayout,
   BlogPostGrid,
   BlogTagFilter,
+  SeoArticleList,
 } from "@app/components/blog/BlogComponents";
 import { BlogPagination } from "@app/components/blog/BlogPagination";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
@@ -22,6 +23,7 @@ import type { ReactElement } from "react";
 
 interface BlogPageProps {
   posts: BlogPostSummary[];
+  seoPosts: BlogPostSummary[];
   currentPage: number;
   totalPages: number;
   totalPosts: number;
@@ -71,39 +73,40 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
 
   const allPosts = result.value;
 
-  // Extract all tags
+  // Split into regular and SEO articles.
+  const regularPosts = allPosts.filter((post) => !post.isSeoArticle);
+  const seoPosts = allPosts.filter((post) => post.isSeoArticle);
+
+  // Extract all tags.
   const tagSet = new Set<string>();
   allPosts.forEach((post) => post.tags.forEach((tag) => tagSet.add(tag)));
   const allTags = Array.from(tagSet).sort();
 
-  // Featured post is the first non-SEO post (shown on page 1 at /blog).
-  const featuredPost = allPosts.find((post) => !post.isSeoArticle);
+  // Featured post is the first regular post (shown on page 1 at /blog).
+  const featuredPost = regularPosts[0];
 
-  // Remaining posts exclude the featured post.
+  // Remaining regular posts exclude the featured post.
   const remainingPosts = featuredPost
-    ? allPosts.filter((post) => post.id !== featuredPost.id)
-    : allPosts;
+    ? regularPosts.filter((post) => post.id !== featuredPost.id)
+    : regularPosts;
   const totalPages = Math.ceil(remainingPosts.length / BLOG_PAGE_SIZE);
 
-  // If page is beyond available pages, 404
+  // If page is beyond available pages, 404.
   if (page > totalPages) {
     return { notFound: true };
   }
 
   const startIndex = (page - 1) * BLOG_PAGE_SIZE;
-  // Sort within each page: regular articles first, SEO articles at the bottom.
-  const posts = remainingPosts
-    .slice(startIndex, startIndex + BLOG_PAGE_SIZE)
-    .sort((a, b) => {
-      if (a.isSeoArticle !== b.isSeoArticle) {
-        return a.isSeoArticle ? 1 : -1;
-      }
-      return 0;
-    });
+  const posts = remainingPosts.slice(startIndex, startIndex + BLOG_PAGE_SIZE);
+  const paginatedSeoPosts = seoPosts.slice(
+    startIndex,
+    startIndex + BLOG_PAGE_SIZE
+  );
 
   return {
     props: {
       posts,
+      seoPosts: paginatedSeoPosts,
       currentPage: page,
       totalPages,
       totalPosts: remainingPosts.length,
@@ -117,6 +120,7 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default function BlogPage({
   posts,
+  seoPosts,
   currentPage,
   totalPages,
   totalPosts,
@@ -185,6 +189,8 @@ export default function BlogPage({
             />
           </div>
         )}
+
+        <SeoArticleList posts={seoPosts} />
       </BlogLayout>
     </>
   );

--- a/front/pages/blog/page/[page].tsx
+++ b/front/pages/blog/page/[page].tsx
@@ -5,6 +5,7 @@ import {
   BlogLayout,
   BlogPostGrid,
   BlogTagFilter,
+  SEO_PAGE_SIZE,
   SeoArticleList,
 } from "@app/components/blog/BlogComponents";
 import { BlogPagination } from "@app/components/blog/BlogPagination";
@@ -98,9 +99,10 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
 
   const startIndex = (page - 1) * BLOG_PAGE_SIZE;
   const posts = remainingPosts.slice(startIndex, startIndex + BLOG_PAGE_SIZE);
+  const seoStartIndex = (page - 1) * SEO_PAGE_SIZE;
   const paginatedSeoPosts = seoPosts.slice(
-    startIndex,
-    startIndex + BLOG_PAGE_SIZE
+    seoStartIndex,
+    seoStartIndex + SEO_PAGE_SIZE
   );
 
   return {


### PR DESCRIPTION


## Description

SEO articles are removed from the main card grid and shown in a compact "Further reading" list below pagination, paginated in sync with the main grid.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
