### PR TITLE
fix(mcp): re-trigger oauth on external revocation

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -52,6 +52,7 @@ import {
   isConnectViaClientSideMCPServer,
   isConnectViaMCPServerId,
 } from "@app/lib/actions/mcp_metadata";
+import { MCPOAuthProviderError } from "@app/lib/actions/mcp_oauth_provider";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type {
   AgentLoopListToolsContextType,
@@ -77,6 +78,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
@@ -606,6 +608,35 @@ export async function* tryCallMCPTool(
             `The tool execution timed out, error: ${error.message}`,
             { cause: error }
           );
+        }
+      }
+    }
+
+    // When the MCP SDK receives a 401/403 from the remote server during a
+    // tool call (e.g., StreamableHTTP where each call is a separate HTTP
+    // request), it calls unimplemented methods on MCPOAuthProvider which
+    // throw MCPOAuthProviderError. Trigger re-authentication.
+    if (
+      error instanceof MCPOAuthProviderError &&
+      isServerSideMCPToolConfiguration(toolConfiguration)
+    ) {
+      const mcpServerView = await MCPServerViewResource.fetchById(
+        auth,
+        toolConfiguration.mcpServerViewId
+      );
+      if (mcpServerView) {
+        const remoteMCPServer = await RemoteMCPServerResource.fetchById(
+          auth,
+          mcpServerView.mcpServerId
+        );
+        if (remoteMCPServer?.authorization) {
+          return {
+            isError: false,
+            content: makePersonalAuthenticationError(
+              remoteMCPServer.authorization.provider,
+              remoteMCPServer.authorization.scope
+            ).content,
+          };
         }
       }
     }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -75,6 +75,7 @@ import {
   DEFAULT_MCP_TOOL_RETRY_POLICY,
   getRetryPolicyFromToolConfiguration,
 } from "@app/lib/api/mcp";
+import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -83,7 +84,6 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
-import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -76,13 +76,14 @@ import {
   getRetryPolicyFromToolConfiguration,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
-import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
+import { invalidateOAuthConnectionAccessTokenCache } from "@app/types/oauth/client/access_token";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -625,16 +626,33 @@ export async function* tryCallMCPTool(
         toolConfiguration.mcpServerViewId
       );
       if (mcpServerView) {
-        const remoteMCPServer = await RemoteMCPServerResource.fetchById(
-          auth,
-          mcpServerView.mcpServerId
-        );
-        if (remoteMCPServer?.authorization) {
+        const authorization = mcpServerView.toJSON().server.authorization;
+        if (authorization) {
+          // Invalidate the cached access token so the next connection attempt
+          // fetches a fresh token after the user re-authenticates.
+          const connectionType =
+            mcpServerView.oAuthUseCase === "personal_actions"
+              ? "personal"
+              : "workspace";
+          const connection = await MCPServerConnectionResource.findByMCPServer(
+            auth,
+            {
+              mcpServerId: mcpServerView.mcpServerId,
+              connectionType,
+            }
+          );
+          if (connection.isOk() && connection.value.connectionId) {
+            invalidateOAuthConnectionAccessTokenCache(
+              connection.value.connectionId
+            );
+          }
+
           return {
+            // Complex code path, but errors returned here are processed in getExitOrPauseEvents.
             isError: false,
             content: makePersonalAuthenticationError(
-              remoteMCPServer.authorization.provider,
-              remoteMCPServer.authorization.scope
+              authorization.provider,
+              authorization.scope
             ).content,
           };
         }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -83,7 +83,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
-import { invalidateOAuthConnectionAccessTokenCache } from "@app/types/oauth/client/access_token";
+import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -1,10 +1,10 @@
 import apiConfig from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { OAuthConnectionType, OAuthProvider } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -4,7 +4,7 @@ import { DustError } from "@app/lib/error";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { OAuthConnectionType, OAuthProvider } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -38,7 +38,7 @@ import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
-import { invalidateOAuthConnectionAccessTokenCache } from "@app/types/oauth/client/access_token";
+import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -27,6 +27,7 @@ import {
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
+import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import { isHostUnderVerifiedDomain } from "@app/lib/api/workspace_has_domains";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -38,7 +39,6 @@ import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
-import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -20,7 +20,10 @@ import {
   getInternalMCPServerNameFromSId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
-import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
+import {
+  MCPOAuthProvider,
+  MCPOAuthProviderError,
+} from "@app/lib/actions/mcp_oauth_provider";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
@@ -35,6 +38,7 @@ import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
+import { invalidateOAuthConnectionAccessTokenCache } from "@app/types/oauth/client/access_token";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -332,6 +336,8 @@ export async function connectToMCPServer(
           const url = new URL(remoteMCPServer.url);
 
           let token: OAuthTokens | undefined;
+          let oauthConnectionType: "personal" | "workspace" | undefined;
+          let oauthConnectionId: string | undefined;
 
           // If the server has a shared secret, we use it to authenticate.
           if (remoteMCPServer.sharedSecret) {
@@ -346,7 +352,7 @@ export async function connectToMCPServer(
           else if (remoteMCPServer.authorization) {
             // We only fetch the personal token if we are running a tool.
             // Otherwise, for listing tools etc.., we use the workspace token.
-            const connectionType =
+            oauthConnectionType =
               params.oAuthUseCase === "personal_actions" &&
               agentLoopContext?.runContext
                 ? "personal"
@@ -354,9 +360,10 @@ export async function connectToMCPServer(
 
             const c = await getConnectionForMCPServer(auth, {
               mcpServerId: params.mcpServerId,
-              connectionType: connectionType,
+              connectionType: oauthConnectionType,
             });
             if (c.isOk()) {
+              oauthConnectionId = c.value.connection.connection_id;
               token = {
                 access_token: c.value.access_token,
                 token_type: "bearer",
@@ -366,7 +373,7 @@ export async function connectToMCPServer(
             } else {
               const scope = remoteMCPServer.authorization.scope;
 
-              if (connectionType === "personal") {
+              if (oauthConnectionType === "personal") {
                 // Check if admin connection exists for the server.
                 // We only check if the connection resource exists (not if the token is valid)
                 // because for personal_actions we just need to know if admin setup is done.
@@ -394,7 +401,7 @@ export async function connectToMCPServer(
                     scope
                   )
                 );
-              } else if (connectionType === "workspace") {
+              } else if (oauthConnectionType === "workspace") {
                 // Workspace connection required — admin must set up or reconnect.
                 return new Err(
                   new MCPServerRequiresAdminAuthenticationError(
@@ -404,7 +411,7 @@ export async function connectToMCPServer(
                   )
                 );
               } else {
-                assertNever(connectionType);
+                assertNever(oauthConnectionType);
               }
             }
           }
@@ -421,9 +428,39 @@ export async function connectToMCPServer(
 
             await connectToRemoteMCPServer(mcpClient, url, req);
           } catch (e: unknown) {
+            // When the MCP SDK receives a 401/403 from the remote server, it
+            // calls unimplemented methods on MCPOAuthProvider which throw
+            // MCPOAuthProviderError. This reliably indicates token rejection.
+            if (
+              e instanceof MCPOAuthProviderError &&
+              remoteMCPServer.authorization &&
+              oauthConnectionType
+            ) {
+              if (oauthConnectionId) {
+                invalidateOAuthConnectionAccessTokenCache(oauthConnectionId);
+              }
+              const scope = remoteMCPServer.authorization.scope;
+              if (oauthConnectionType === "personal") {
+                return new Err(
+                  new MCPServerPersonalAuthenticationRequiredError(
+                    params.mcpServerId,
+                    remoteMCPServer.authorization.provider,
+                    scope
+                  )
+                );
+              }
+              return new Err(
+                new MCPServerRequiresAdminAuthenticationError(
+                  params.mcpServerId,
+                  remoteMCPServer.authorization.provider,
+                  scope
+                )
+              );
+            }
+
             logger.error(
               {
-                connectionType,
+                oauthConnectionType,
                 serverType,
                 workspaceId: auth.getNonNullableWorkspace().sId,
                 error: e,

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -7,6 +7,13 @@ import type {
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 
+export class MCPOAuthProviderError extends Error {
+  constructor(method: string) {
+    super(`MCPOAuthProvider: ${method} not implemented`);
+    this.name = "MCPOAuthProviderError";
+  }
+}
+
 export class MCPOAuthProvider implements OAuthClientProvider {
   private token: OAuthTokens | undefined;
 
@@ -14,9 +21,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     this.token = tokens;
   }
   get redirectUrl(): string {
-    throw new Error(
-      "Method redirectUrl not implemented. We should never reach this point."
-    );
+    throw new MCPOAuthProviderError("redirectUrl");
   }
 
   get clientMetadata(): OAuthClientMetadata {
@@ -44,26 +49,18 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   saveTokens() {
-    throw new Error(
-      "Method saveTokens not implemented. We should never reach this point."
-    );
+    throw new MCPOAuthProviderError("saveTokens");
   }
 
   redirectToAuthorization() {
-    throw new Error(
-      "Method redirectToAuthorization not implemented. We should never reach this point."
-    );
+    throw new MCPOAuthProviderError("redirectToAuthorization");
   }
 
   saveCodeVerifier() {
-    throw new Error(
-      "Method saveCodeVerifier not implemented. We should never reach this point."
-    );
+    throw new MCPOAuthProviderError("saveCodeVerifier");
   }
 
   codeVerifier(): string | Promise<string> {
-    throw new Error(
-      "Method codeVerifier not implemented. We should never reach this point."
-    );
+    throw new MCPOAuthProviderError("codeVerifier");
   }
 }

--- a/front/lib/api/oauth_access_token.ts
+++ b/front/lib/api/oauth_access_token.ts
@@ -1,11 +1,11 @@
-import type { OAuthConnectionType } from "../../oauth/lib";
-import type { OAuthAPIError } from "../../oauth/oauth_api";
-import { OAuthAPI } from "../../oauth/oauth_api";
-import type { LoggerInterface } from "../../shared/logger";
-import type { Result } from "../../shared/result";
-import { Ok } from "../../shared/result";
+import type { OAuthConnectionType } from "@app/types/oauth/lib";
+import type { OAuthAPIError } from "@app/types/oauth/oauth_api";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import type { LoggerInterface } from "@app/types/shared/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 
-const OAUTH_ACCESS_TOKEN_CACHE_TTL = 1000 * 60 * 5;
+const OAUTH_ACCESS_TOKEN_CACHE_TTL_MS = 1000 * 60 * 5;
 
 const CACHE = new Map<
   string,
@@ -14,7 +14,7 @@ const CACHE = new Map<
     access_token: string;
     access_token_expiry: number | null;
     scrubbed_raw_json: unknown;
-    local_expiry: number;
+    localExpiryMs: number;
   }
 >();
 
@@ -45,7 +45,7 @@ export async function getOAuthConnectionAccessToken({
 > {
   const cached = CACHE.get(connectionId);
 
-  if (cached && cached.local_expiry > Date.now()) {
+  if (cached && cached.localExpiryMs > Date.now()) {
     return new Ok(cached);
   }
 
@@ -58,7 +58,7 @@ export async function getOAuthConnectionAccessToken({
   }
 
   CACHE.set(connectionId, {
-    local_expiry: Date.now() + OAUTH_ACCESS_TOKEN_CACHE_TTL,
+    localExpiryMs: Date.now() + OAUTH_ACCESS_TOKEN_CACHE_TTL_MS,
     ...res.value,
   });
 

--- a/front/lib/api/poke/plugins/data_sources/get_access_token.ts
+++ b/front/lib/api/poke/plugins/data_sources/get_access_token.ts
@@ -2,7 +2,7 @@ import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const getAccessTokenPlugin = createPlugin({

--- a/front/lib/api/poke/plugins/data_sources/get_access_token.ts
+++ b/front/lib/api/poke/plugins/data_sources/get_access_token.ts
@@ -1,8 +1,8 @@
 import config from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { createPlugin } from "@app/lib/api/poke/types";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const getAccessTokenPlugin = createPlugin({

--- a/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-access-token.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-access-token.ts
@@ -2,7 +2,7 @@ import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const getMcpServerViewAccessTokenPlugin = createPlugin({

--- a/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-access-token.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-access-token.ts
@@ -1,8 +1,8 @@
 import config from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const getMcpServerViewAccessTokenPlugin = createPlugin({

--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -1,9 +1,9 @@
 import apiConfig from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import logger from "@app/logger/logger";
 import { stopRetrieveTranscriptsWorkflow } from "@app/temporal/labs/transcripts/client";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import { google } from "googleapis";

--- a/front/lib/labs/transcripts/utils/helpers.ts
+++ b/front/lib/labs/transcripts/utils/helpers.ts
@@ -3,7 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import logger from "@app/logger/logger";
 import { stopRetrieveTranscriptsWorkflow } from "@app/temporal/labs/transcripts/client";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import { google } from "googleapis";

--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -1,11 +1,11 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 

--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -5,7 +5,7 @@ import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_conne
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -17,6 +17,7 @@ import type {
   MCPServerTypeWithViews,
   MCPServerViewType,
 } from "@app/lib/api/mcp";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -27,7 +28,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import { isLeft } from "fp-ts/lib/Either";

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -27,7 +27,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import { isLeft } from "fp-ts/lib/Either";

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -1,11 +1,11 @@
 import config from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import type { Logger } from "@app/logger/logger";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 
 const getGongAccessToken = async (connectionId: string, logger: Logger) => {
   const tokRes = await getOAuthConnectionAccessToken({

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -5,7 +5,7 @@ import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/la
 import type { Logger } from "@app/logger/logger";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 
 const getGongAccessToken = async (connectionId: string, logger: Logger) => {
   const tokRes = await getOAuthConnectionAccessToken({

--- a/front/types/oauth/client/access_token.ts
+++ b/front/types/oauth/client/access_token.ts
@@ -18,6 +18,12 @@ const CACHE = new Map<
   }
 >();
 
+export function invalidateOAuthConnectionAccessTokenCache(
+  connectionId: string
+): void {
+  CACHE.delete(connectionId);
+}
+
 export async function getOAuthConnectionAccessToken({
   config,
   logger,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/6667

  Problem

  Remote MCP servers with personal OAuth (e.g., Miro) fail when tokens are externally revoked. Providers like Miro enforce 1:1 token validity — when a new OAuth flow completes from another client, previous tokens are silently invalidated. Dust is not notified.

  Currently the stored token is rejected by the remote server → the MCP SDK tries to re-authenticate via MCPOAuthProvider which throws (methods not implemented) → a generic "Error establishing connection" is returned → user sees a generic failure with no way to re-authenticate.

  Solution

  Leverage the fact that the MCP SDK's built-in auth retry (on 401/403) calls unimplemented methods on MCPOAuthProvider that throw. We:

  1. Create a dedicated MCPOAuthProviderError class and use it in all unimplemented MCPOAuthProvider method throws — this lets us instanceof-detect token rejection.
  2. In connectToMCPServer() (connection phase): catch MCPOAuthProviderError, invalidate the cached token, and return MCPServerPersonalAuthenticationRequiredError / MCPServerRequiresAdminAuthenticationError to trigger the existing "Connect" button flow.
  3. In tryCallMCPTool() (tool call phase): catch MCPOAuthProviderError and return a makePersonalAuthenticationError() result to trigger re-auth in conversation.
  4. Add invalidateOAuthConnectionAccessTokenCache() to clear the 5-minute token cache so the next attempt fetches a fresh token.



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

 Low — the new error class is only thrown in the same code paths that previously threw generic Error. The instanceof checks are additive (existing fallback behavior is preserved when they don't match).

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front