### PR TITLE
Cap `conversation_files` cat output and enable pagination

### DIFF
--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -40,7 +40,8 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
         .number()
         .optional()
         .describe(
-          "The maximum number of characters to read. If not provided, reads all characters."
+          "The maximum number of characters to read. Capped to ~200K characters per call. " +
+            "If the file is larger, use offset to paginate."
         ),
       grep: z
         .string()

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -1,4 +1,7 @@
-import { computeTextByteSize } from "@app/lib/actions/action_output_limits";
+import {
+  computeTextByteSize,
+  MAX_TEXT_CONTENT_SIZE,
+} from "@app/lib/actions/action_output_limits";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -147,10 +150,11 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
       );
     }
 
-    let text = content.text;
+    const fullText = content.text;
+    const totalLength = fullText.length;
 
     // Returning early with a custom message if the text is empty.
-    if (text.length === 0) {
+    if (totalLength === 0) {
       return new Ok([
         {
           type: "text",
@@ -160,27 +164,35 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     }
 
     // Apply offset and limit.
-    if (offset !== undefined || limit !== undefined) {
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      const start = offset || 0;
-      const end = limit !== undefined ? start + limit : undefined;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const start = offset || 0;
 
-      if (start > text.length) {
-        return new Err(
-          new MCPError(`Offset ${start} is out of bounds for file ${title}.`, {
+    if (start > totalLength) {
+      return new Err(
+        new MCPError(
+          `Offset ${start} is out of bounds for file ${title} (total length: ${totalLength}).`,
+          {
             tracked: false,
-          })
-        );
-      }
-      if (limit === 0) {
-        return new Err(
-          new MCPError(`Limit cannot be equal to 0.`, {
-            tracked: false,
-          })
-        );
-      }
-      text = text.slice(start, end);
+          }
+        )
+      );
     }
+    if (limit === 0) {
+      return new Err(
+        new MCPError(`Limit cannot be equal to 0.`, {
+          tracked: false,
+        })
+      );
+    }
+
+    // Cap to MAX_TEXT_CONTENT_SIZE to avoid storing oversized content in the DB.
+    // computeTextByteSize uses length * 2, so the character cap is MAX_TEXT_CONTENT_SIZE / 2.
+    const maxCharacters = MAX_TEXT_CONTENT_SIZE / 2;
+    const effectiveLimit =
+      limit !== undefined ? Math.min(limit, maxCharacters) : maxCharacters;
+    const end = start + effectiveLimit;
+
+    let text = fullText.slice(start, end);
 
     // Apply grep filter if provided.
     if (grep) {
@@ -221,10 +233,14 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
       }
     }
 
+    const hasMore = end < totalLength;
+
     return new Ok([
       {
         type: "text",
-        text,
+        text: hasMore
+          ? `${text}\n\n[Showing characters ${start}-${end} of ${totalLength} total. Use offset=${end} to read more.]`
+          : text,
       },
     ]);
   },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/22119.

The `cat_conversation_file` tool had no upper bound on the text it returned. When the agent catted a large attached file (e.g., a multi-MB CSV), the entire content was returned as a single text block. Because the `conversation_files` server is excluded from the large-text file-upload path in `processToolResults`, this content was stored verbatim in the `agent_mcp_action_output_items` JSONB column. Producing multi-MB database rows, and sent in full to the model, wasting context window.

This PR enforces a per-call output cap in the cat tool itself, at the source:
- Output is now capped to `MAX_TEXT_CONTENT_SIZE / 2` characters (~200K chars) regardless of whether the caller provides a limit. This ensures the returned text stays within the size threshold that `processToolResults` considers safe for DB storage.
- When the file has more content beyond what was returned, a pagination hint is appended: `[Showing characters {start}-{end} of {total} total. Use offset={end} to read more.]`. Guiding the model to paginate naturally.

### Why this matters

This is the companion fix to the snippet-storage PR. Together they close both sides of the problem:
- Other MCP servers → `processToolResults` now stores the snippet instead of the full text in the DB row.
- `conversation_files` -> the tool itself now caps output at the source, so oversized content never reaches `processToolResults` in the first place.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
