### PR TITLE
fix(hubspot): fix invisible note creation

### DIFF
--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -778,9 +778,9 @@ export const createNote = async ({
     propertiesForApi.hs_timestamp = Date.now().toString();
   } else {
     // Convert ISO 8601 strings to Unix milliseconds.
-    const parsed = Date.parse(propertiesForApi.hs_timestamp);
-    if (!isNaN(parsed)) {
-      propertiesForApi.hs_timestamp = parsed.toString();
+    const parsedMs = Date.parse(propertiesForApi.hs_timestamp);
+    if (!isNaN(parsedMs)) {
+      propertiesForApi.hs_timestamp = parsedMs.toString();
     }
   }
 

--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -752,6 +752,7 @@ export const createNote = async ({
   properties: {
     hs_note_body: string;
     hs_timestamp?: string;
+    hubspot_owner_id?: string;
     [key: string]: any;
   };
   associations?: {
@@ -771,9 +772,16 @@ export const createNote = async ({
     );
   }
 
+  // Use Unix milliseconds for hs_timestamp to ensure proper timeline placement.
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!propertiesForApi.hs_timestamp) {
-    propertiesForApi.hs_timestamp = new Date().toISOString();
+    propertiesForApi.hs_timestamp = Date.now().toString();
+  } else {
+    // Convert ISO 8601 strings to Unix milliseconds.
+    const parsed = Date.parse(propertiesForApi.hs_timestamp);
+    if (!isNaN(parsed)) {
+      propertiesForApi.hs_timestamp = parsed.toString();
+    }
   }
 
   const builtAssociations: SimplePublicObjectInputForCreate["associations"] =

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -485,6 +485,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
             .describe(
               "The timestamp of the note (ISO 8601 format). Defaults to current time if not provided."
             ),
+          hubspot_owner_id: z
+            .string()
+            .optional()
+            .describe("The ID of the note's owner/creator."),
         })
         .describe("Properties for the note."),
       associations: noteAssociationsSchema


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Tentatively adresses https://github.com/dust-tt/tasks/issues/6741

  - Fix HubSpot create_note tool producing notes that exist in the API but don't render in HubSpot's UI
  - Convert hs_timestamp to Unix milliseconds format for reliable timeline placement
  - Add hubspot_owner_id to the note schema, remove invalid ownerIds association

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Will ask nic to try and see if his usecase work 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front