### PR TITLE
[front] enh: Make TTL optional on caching

### DIFF
--- a/front/lib/utils/cache.test.ts
+++ b/front/lib/utils/cache.test.ts
@@ -1,10 +1,28 @@
 import logger from "@app/logger/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockRedisClient = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+const mockDistributedLock = vi.hoisted(() => vi.fn());
+const mockDistributedUnlock = vi.hoisted(() => vi.fn());
+
 vi.mock("@app/logger/logger", () => ({
   default: {
     error: vi.fn(),
   },
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisCacheClient: vi.fn().mockResolvedValue(mockRedisClient),
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  distributedLock: mockDistributedLock,
+  distributedUnlock: mockDistributedUnlock,
 }));
 
 // Import actual cache module to bypass the global mock in vite.setup.ts
@@ -13,7 +31,12 @@ vi.mock("@app/lib/utils/cache", async (importOriginal) => {
   return actual;
 });
 
-import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+import {
+  batchInvalidateCacheWithRedis,
+  cacheWithRedis,
+  invalidateCacheAfterCommit,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 
 describe("invalidateCacheAfterCommit", () => {
   beforeEach(() => {
@@ -104,5 +127,410 @@ describe("invalidateCacheAfterCommit", () => {
       { panic: true, err: testError },
       "Failed to invalidate cache after transaction commit"
     );
+  });
+});
+
+describe("cacheWithRedis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedisClient.get.mockReset();
+    mockRedisClient.set.mockReset();
+    mockRedisClient.del.mockReset();
+    mockDistributedLock.mockReset();
+    mockDistributedUnlock.mockReset();
+  });
+
+  describe("basic caching behavior", () => {
+    it("returns cached value on cache hit", async () => {
+      const mockFn = vi.fn().mockResolvedValue({ data: "fresh" });
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(JSON.stringify({ data: "cached" }));
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {});
+      const result = await cachedFn("key1");
+
+      expect(result).toEqual({ data: "cached" });
+      expect(mockFn).not.toHaveBeenCalled();
+      expect(mockRedisClient.get).toHaveBeenCalledWith(
+        "cacheWithRedis-testFn-key1"
+      );
+    });
+
+    it("calls function and caches result on cache miss", async () => {
+      const mockFn = vi.fn().mockResolvedValue({ data: "fresh" });
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {});
+      const result = await cachedFn("key1");
+
+      expect(result).toEqual({ data: "fresh" });
+      expect(mockFn).toHaveBeenCalledWith("key1");
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        "cacheWithRedis-testFn-key1",
+        JSON.stringify({ data: "fresh" })
+      );
+    });
+
+    it("generates correct cache key using resolver", async () => {
+      const mockFn = vi.fn().mockResolvedValue("result");
+      Object.defineProperty(mockFn, "name", { value: "myFunc" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(
+        mockFn,
+        (a: string, b: number) => `${a}-${b}`,
+        {}
+      );
+      await cachedFn("foo", 123);
+
+      expect(mockRedisClient.get).toHaveBeenCalledWith(
+        "cacheWithRedis-myFunc-foo-123"
+      );
+    });
+  });
+
+  describe("TTL handling", () => {
+    it("sets TTL (PX) when ttlMs is provided", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {
+        ttlMs: 60000,
+      });
+      await cachedFn("key1");
+
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        "cacheWithRedis-testFn-key1",
+        JSON.stringify("data"),
+        { PX: 60000 }
+      );
+    });
+
+    it("does not set TTL when ttlMs is undefined", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {});
+      await cachedFn("key1");
+
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        "cacheWithRedis-testFn-key1",
+        JSON.stringify("data")
+      );
+    });
+
+    it("throws error when ttlMs > 24 hours", () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+
+      expect(() =>
+        cacheWithRedis(mockFn, (arg: string) => arg, {
+          ttlMs: 25 * 60 * 60 * 1000,
+        })
+      ).toThrow("ttlMs should be less than 24 hours");
+    });
+  });
+
+  describe("null value handling (cacheNullValues option)", () => {
+    it("caches null when cacheNullValues is true (default)", async () => {
+      const mockFn = vi.fn().mockResolvedValue(null);
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {});
+      const result = await cachedFn("key1");
+
+      expect(result).toBeNull();
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        "cacheWithRedis-testFn-key1",
+        "null"
+      );
+    });
+
+    it("does not cache null when cacheNullValues is false", async () => {
+      const mockFn = vi.fn().mockResolvedValue(null);
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {
+        cacheNullValues: false,
+      });
+      const result = await cachedFn("key1");
+
+      expect(result).toBeNull();
+      expect(mockRedisClient.set).not.toHaveBeenCalled();
+    });
+
+    it("does not cache undefined when cacheNullValues is false", async () => {
+      const mockFn = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {
+        cacheNullValues: false,
+      });
+      await cachedFn("key1");
+
+      expect(mockRedisClient.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("distributed lock behavior (useDistributedLock: true)", () => {
+    it("acquires and releases distributed lock", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+      mockDistributedLock.mockResolvedValue("lock-value-123");
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {
+        useDistributedLock: true,
+      });
+      await cachedFn("key1");
+
+      expect(mockDistributedLock).toHaveBeenCalledWith(
+        mockRedisClient,
+        "cacheWithRedis-testFn-key1"
+      );
+      expect(mockDistributedUnlock).toHaveBeenCalledWith(
+        mockRedisClient,
+        "cacheWithRedis-testFn-key1",
+        "lock-value-123"
+      );
+    });
+
+    it("returns null immediately when skipIfLocked is true and lock is taken", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockDistributedLock.mockResolvedValue(undefined);
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {
+        useDistributedLock: true,
+        skipIfLocked: true,
+      });
+      const result = await cachedFn("key1");
+
+      expect(result).toBeNull();
+      expect(mockFn).not.toHaveBeenCalled();
+      expect(mockDistributedUnlock).not.toHaveBeenCalled();
+    });
+
+    it("spin-waits when lock is taken, then returns cached value", async () => {
+      const mockFn = vi.fn().mockResolvedValue("data");
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      let lockCallCount = 0;
+      let getCallCount = 0;
+
+      mockRedisClient.get.mockImplementation(async () => {
+        getCallCount++;
+        if (getCallCount === 1) {
+          return null;
+        }
+        if (getCallCount === 2) {
+          return null;
+        }
+        return JSON.stringify("cached-by-another");
+      });
+
+      mockDistributedLock.mockImplementation(async () => {
+        lockCallCount++;
+        if (lockCallCount <= 2) {
+          return undefined;
+        }
+        return "lock-value";
+      });
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {
+        useDistributedLock: true,
+      });
+
+      const result = await cachedFn("key1");
+
+      expect(result).toBe("cached-by-another");
+      expect(mockFn).not.toHaveBeenCalled();
+      expect(lockCallCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("in-memory lock behavior (useDistributedLock: false)", () => {
+    it("uses in-memory lock to prevent concurrent calls", async () => {
+      const callOrder: string[] = [];
+      const resolveContainer: { resolve?: () => void } = {};
+      const firstPromise = new Promise<void>((resolve) => {
+        resolveContainer.resolve = resolve;
+      });
+
+      const mockFn = vi.fn().mockImplementation(async (arg: string) => {
+        callOrder.push(`start-${arg}`);
+        if (arg === "key1") {
+          await firstPromise;
+        }
+        callOrder.push(`end-${arg}`);
+        return `result-${arg}`;
+      });
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      // Track cached values so get returns what was set
+      const cache = new Map<string, string>();
+      mockRedisClient.get.mockImplementation(
+        async (key: string) => cache.get(key) ?? null
+      );
+      mockRedisClient.set.mockImplementation(
+        async (key: string, value: string) => {
+          cache.set(key, value);
+          return "OK";
+        }
+      );
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {});
+
+      const promise1 = cachedFn("key1");
+      const promise2 = cachedFn("key1");
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      if (resolveContainer.resolve) {
+        resolveContainer.resolve();
+      }
+
+      await Promise.all([promise1, promise2]);
+
+      expect(callOrder).toEqual(["start-key1", "end-key1"]);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows parallel calls for different keys", async () => {
+      const mockFn = vi.fn().mockImplementation(async (arg: string) => {
+        return `result-${arg}`;
+      });
+      Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+      mockRedisClient.get.mockResolvedValue(null);
+      mockRedisClient.set.mockResolvedValue("OK");
+
+      const cachedFn = cacheWithRedis(mockFn, (arg: string) => arg, {});
+
+      await Promise.all([cachedFn("key1"), cachedFn("key2")]);
+
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("invalidateCacheWithRedis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedisClient.del.mockReset();
+  });
+
+  it("deletes the correct cache key from Redis", async () => {
+    const mockFn = vi.fn();
+    Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+    mockRedisClient.del.mockResolvedValue(1);
+
+    const invalidateFn = invalidateCacheWithRedis(mockFn, (arg: string) => arg);
+    await invalidateFn("key1");
+
+    expect(mockRedisClient.del).toHaveBeenCalledWith(
+      "cacheWithRedis-testFn-key1"
+    );
+  });
+
+  it("uses correct key format with multi-arg resolver", async () => {
+    const mockFn = vi.fn();
+    Object.defineProperty(mockFn, "name", { value: "myFunc" });
+
+    mockRedisClient.del.mockResolvedValue(1);
+
+    const invalidateFn = invalidateCacheWithRedis(
+      mockFn,
+      (a: string, b: number) => `${a}-${b}`
+    );
+    await invalidateFn("foo", 42);
+
+    expect(mockRedisClient.del).toHaveBeenCalledWith(
+      "cacheWithRedis-myFunc-foo-42"
+    );
+  });
+});
+
+describe("batchInvalidateCacheWithRedis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedisClient.del.mockReset();
+  });
+
+  it("deletes multiple cache keys in single Redis call", async () => {
+    const mockFn = vi.fn();
+    Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+    mockRedisClient.del.mockResolvedValue(3);
+
+    const batchInvalidateFn = batchInvalidateCacheWithRedis(
+      mockFn,
+      (arg: string) => arg
+    );
+    await batchInvalidateFn([["key1"], ["key2"], ["key3"]]);
+
+    expect(mockRedisClient.del).toHaveBeenCalledWith([
+      "cacheWithRedis-testFn-key1",
+      "cacheWithRedis-testFn-key2",
+      "cacheWithRedis-testFn-key3",
+    ]);
+    expect(mockRedisClient.del).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when argsList is empty", async () => {
+    const mockFn = vi.fn();
+    Object.defineProperty(mockFn, "name", { value: "testFn" });
+
+    const batchInvalidateFn = batchInvalidateCacheWithRedis(
+      mockFn,
+      (arg: string) => arg
+    );
+    await batchInvalidateFn([]);
+
+    expect(mockRedisClient.del).not.toHaveBeenCalled();
+  });
+
+  it("uses correct key format for all keys", async () => {
+    const mockFn = vi.fn();
+    Object.defineProperty(mockFn, "name", { value: "myFunc" });
+
+    mockRedisClient.del.mockResolvedValue(2);
+
+    const batchInvalidateFn = batchInvalidateCacheWithRedis(
+      mockFn,
+      (a: string, b: number) => `${a}-${b}`
+    );
+    await batchInvalidateFn([
+      ["foo", 1],
+      ["bar", 2],
+    ]);
+
+    expect(mockRedisClient.del).toHaveBeenCalledWith([
+      "cacheWithRedis-myFunc-foo-1",
+      "cacheWithRedis-myFunc-bar-2",
+    ]);
   });
 });

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -51,7 +51,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,
   options: {
-    ttlMs: number;
+    ttlMs?: number;
     redisUri?: string;
     useDistributedLock?: boolean;
     skipIfLocked?: false;
@@ -63,7 +63,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,
   options: {
-    ttlMs: number;
+    ttlMs?: number;
     redisUri?: string;
     useDistributedLock: true;
     // When true and the distributed lock is taken, return null immediately.
@@ -83,7 +83,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     skipIfLocked = false,
     cacheNullValues = true,
   }: {
-    ttlMs: number;
+    ttlMs?: number;
     // Kept for backwards compatibility, no longer used.
     redisUri?: string;
     useDistributedLock?: boolean;
@@ -93,7 +93,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     cacheNullValues?: boolean;
   }
 ): (...args: Args) => Promise<JsonSerializable<T> | null> {
-  if (ttlMs > 60 * 60 * 24 * 1000) {
+  if (ttlMs !== undefined && ttlMs > 60 * 60 * 24 * 1000) {
     throw new Error("ttlMs should be less than 24 hours");
   }
 
@@ -142,9 +142,13 @@ export function cacheWithRedis<T, Args extends unknown[]>(
 
       const result = await fn(...args);
       if (cacheNullValues || result != null) {
-        await redisCli.set(key, JSON.stringify(result), {
-          PX: ttlMs,
-        });
+        if (ttlMs !== undefined) {
+          await redisCli.set(key, JSON.stringify(result), {
+            PX: ttlMs,
+          });
+        } else {
+          await redisCli.set(key, JSON.stringify(result));
+        }
       }
       return result;
     } finally {


### PR DESCRIPTION
## Description

Currently we cache the most used queries with a TTL of 30 minutes.
This PR makes the param optional

current Redis params are maxmemory ~ 75% of physical RAM and eviction policy allkeys-lfu

## Tests

None

## Risk

Low, number of keys is vastly within the capacity of our cache instance, and memory is well under our monitors threshold.

## Deploy Plan

- [ ] Deploy front