### PR TITLE
[LLM-ROUTER] Virtually decrease sonnet 4.6 context window

### DIFF
--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -243,7 +243,9 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_SONNET_4_6_MODEL_ID,
   displayName: "Claude Sonnet 4.6",
-  contextSize: 200_000,
+  // 200k, reducing it temporarily to avoid "prompt too long" errors on dust agent
+  // due to reasoning tokens not being counted when estimating prompt size in countTokensForMessages
+  contextSize: 190_000,
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 64,
   largeModel: true,


### PR DESCRIPTION
## Description

Dust is powered by sonnet 4.6 with medium adaptive thinking.
Problem is that Anthropic does not return token reasoning details, and reasoning tokens are thus not counted when assessing prompt size before requesting a model, which can lead to `prompt too long` errors.

This is a temporary solution before implementing reasoning token count with anthripic `token count` api

## Tests

no

## Risk

low

## Deploy Plan

front
