### PR TITLE
Do not duplicate tags when copy pasting content with tag

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -1,6 +1,10 @@
 import { InstructionBlockExtension } from "@app/components/editor/extensions/agent_builder/InstructionBlockExtension";
+import { InstructionsDocumentExtension } from "@app/components/editor/extensions/agent_builder/InstructionsDocumentExtension";
+import { InstructionsRootExtension } from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
 import type { Editor } from "@tiptap/core";
+import type { Slice } from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("InstructionBlockExtension", () => {
@@ -407,5 +411,123 @@ Toto:
 </prompt>
 
 &nbsp;`);
+  });
+});
+
+describe("InstructionBlockExtension transformCopied", () => {
+  let editor: Editor;
+
+  // Helper: creates an editor with the instructionsRoot wrapper (like the
+  // real agent-builder editor) so that the document structure is:
+  // doc > instructionsRoot > block+
+  const createInstructionsEditor = () =>
+    EditorFactory(
+      [
+        InstructionsDocumentExtension,
+        InstructionsRootExtension,
+        InstructionBlockExtension,
+      ],
+      { starterKit: { document: false } }
+    );
+
+  afterEach(() => {
+    editor?.destroy();
+  });
+
+  /**
+   * Extract the transformCopied prop from the instructionBlockCopyContext
+   * plugin registered by InstructionBlockExtension.
+   */
+  function getTransformCopied(ed: Editor) {
+    const plugins = ed.state.plugins;
+    const plugin = plugins.find((p) =>
+      (p as any).key?.includes("instructionBlockCopyContext")
+    );
+    expect(plugin).toBeDefined();
+    return (plugin as any).props.transformCopied as (slice: Slice) => Slice;
+  }
+
+  it("should strip instructionBlock/instructionsRoot context when copying inner text", () => {
+    editor = createInstructionsEditor();
+    editor.commands.setContent("<example>test</example>", {
+      contentType: "markdown",
+    });
+
+    // Select the text "test" inside the instruction block.
+    // doc structure: doc > instructionsRoot > instructionBlock > paragraph("test")
+    // We need to find the text position inside the paragraph.
+    const doc = editor.state.doc;
+    let textFrom = -1;
+    let textTo = -1;
+    doc.descendants((node, pos) => {
+      if (node.isText && node.text === "test") {
+        textFrom = pos;
+        textTo = pos + node.nodeSize;
+      }
+    });
+    expect(textFrom).toBeGreaterThan(0);
+
+    // Create a text selection and get the slice (simulates what ProseMirror
+    // does on Cmd+C).
+    const selection = TextSelection.create(doc, textFrom, textTo);
+    const slice = selection.content();
+
+    // Before transformCopied: the slice should contain instructionsRoot and
+    // instructionBlock wrappers in its open context.
+    expect(slice.openStart).toBeGreaterThanOrEqual(2);
+
+    // Apply transformCopied.
+    const transformCopied = getTransformCopied(editor);
+    const result = transformCopied(slice);
+
+    // After: instructionsRoot and instructionBlock should be stripped.
+    // The result should just be paragraph-level content.
+    expect(result.openStart).toBeLessThan(slice.openStart);
+
+    // Verify no instructionBlock or instructionsRoot in the result's content tree.
+    let hasBlockWrapper = false;
+    result.content.descendants((node) => {
+      if (
+        node.type.name === "instructionBlock" ||
+        node.type.name === "instructionsRoot"
+      ) {
+        hasBlockWrapper = true;
+      }
+    });
+    expect(hasBlockWrapper).toBe(false);
+  });
+
+  it("should preserve full block when copying the whole instruction block", () => {
+    editor = createInstructionsEditor();
+    editor.commands.setContent("before\n\n<example>test</example>\n\nafter", {
+      contentType: "markdown",
+    });
+
+    // Select everything — this includes the instruction block and surrounding
+    // paragraphs, so the instructionsRoot will have multiple children.
+    editor.commands.selectAll();
+    const slice = editor.state.selection.content();
+
+    const transformCopied = getTransformCopied(editor);
+    const result = transformCopied(slice);
+
+    // The slice should be unchanged — the full block structure is preserved.
+    expect(result).toBe(slice);
+  });
+
+  it("should not modify slices that don't contain instruction blocks", () => {
+    editor = createInstructionsEditor();
+    editor.commands.setContent("just plain text", {
+      contentType: "markdown",
+    });
+
+    editor.commands.selectAll();
+    const slice = editor.state.selection.content();
+
+    const transformCopied = getTransformCopied(editor);
+    const result = transformCopied(slice);
+
+    // No instruction block in the content — slice should be unchanged.
+    expect(result).toBe(slice);
   });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -9,7 +9,8 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { ChevronDownIcon, ChevronRightIcon, Chip, cn } from "@dust-tt/sparkle";
 import type { MarkdownLexerConfiguration, MarkdownToken } from "@tiptap/core";
 import { InputRule, mergeAttributes, Node } from "@tiptap/core";
-import { TextSelection } from "@tiptap/pm/state";
+import { Slice } from "@tiptap/pm/model";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import type { NodeViewProps } from "@tiptap/react";
 import {
   NodeViewContent,
@@ -277,6 +278,73 @@ export const InstructionBlockExtension =
 
     addNodeView() {
       return ReactNodeViewRenderer(InstructionBlockComponent);
+    },
+
+    addProseMirrorPlugins() {
+      const instructionBlockName = this.name;
+
+      return [
+        new Plugin({
+          key: new PluginKey("instructionBlockCopyContext"),
+          props: {
+            // When copying text from inside an instruction block, ProseMirror
+            // builds a Slice that includes the surrounding nodes as context
+            // (stored in data-pm-slice). On paste, this context causes a new
+            // instruction block to be re-created, duplicating the XML tags.
+            //
+            // Copying just "test" from inside <example>test</example> produces:
+            //
+            //   instructionsRoot        (context — childCount: 1)
+            //     └── instructionBlock  (context — childCount: 1)
+            //           └── paragraph("test")  ← actual selection
+            //
+            // We strip the single-child instructionsRoot/instructionBlock
+            // wrappers so the clipboard only contains: paragraph("test").
+            //
+            // Copying the whole block (including the XML tag) produces:
+            //
+            //   instructionsRoot                (childCount: 3)
+            //     ├── paragraph()               ← before the block
+            //     ├── instructionBlock
+            //     │     └── paragraph("test")
+            //     └── paragraph()               ← after the block
+            //
+            // Here instructionsRoot has 3 children, so childCount !== 1 and
+            // the slice is left unchanged — the full block is preserved.
+            transformCopied(slice) {
+              let { content, openStart, openEnd } = slice;
+
+              // Peel off wrapper nodes that are instructionsRoot or
+              // instructionBlock when they are part of the open (context) portion
+              // of the slice — i.e. not explicitly selected.
+              while (openStart > 0 && openEnd > 0 && content.childCount === 1) {
+                if (!content.firstChild) {
+                  break;
+                }
+                const firstChild = content.firstChild;
+                const name = firstChild.type.name;
+
+                if (
+                  name !== instructionBlockName &&
+                  name !== "instructionsRoot"
+                ) {
+                  break;
+                }
+
+                content = firstChild.content;
+                openStart--;
+                openEnd--;
+              }
+
+              if (content !== slice.content) {
+                return new Slice(content, openStart, openEnd);
+              }
+
+              return slice;
+            },
+          },
+        }),
+      ];
     },
 
     addInputRules() {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6468

I tried to be self explainatory in the comment of the plugin but here is a detailed explanation of the issue and fix:

When copying text from inside an instruction block (e.g. selecting just "test" inside `<example>test</example>`) and pasting it, the XML tags get duplicated:

```html
<example>
  <example>
    test
  </example>
</example>
```

When you copy text from inside an instruction block, ProseMirror stores the surrounding node structure as context metadata in a data-pm-slice HTML attribute on the clipboard. This context tells ProseMirror how to reconstruct the wrapping nodes when pasting elsewhere.

**Copying just "test" inside `<example>`**
clipboard HTML:

```html
<p data-pm-slice="1 1 [&quot;instructionsRoot&quot;,null,&quot;instructionBlock&quot;,{&quot;type&quot;:&quot;example&quot;,&quot;isCollapsed&quot;:false}]">test</p>
```

The actual HTML content is just `<p>test</p>`, but the data-pm-slice context array `["instructionsRoot", null, "instructionBlock", {"type":"example",...}]` tells ProseMirror to re-wrap the content in an instructionsRoot > instructionBlock on paste. Combined with the `defining: true` and `isolating: true` properties on instructionBlock, ProseMirror creates a new instruction block instead of fitting the content into the existing one.

**Copying the whole block (including the XML tags)**
clipboard HTML:

```html
<div data-type="instructions-root" data-pm-slice="2 2 []">
  <p></p>
  <div data-type="instruction-block" data-instruction-type="example">
    <p>test</p>
  </div>
  <p></p>
</div>
```
Here the instruction block is part of the HTML itself, and the context is empty []. This works correctly.

**Fix**
Added a `transformCopied` ProseMirror plugin to `InstructionBlockExtension` that strips the instructionBlock and instructionsRoot wrappers from the copied slice's context when the user only selected inner content (not the whole block).

After the fix, copying "test" produces:

```html
<p data-pm-slice="1 1 []">test</p>
```

No instruction block context: pasting just inserts the text content. Copying the whole block (node selection with multiple children) is unchanged since the `childCount === 1` guard prevents stripping in that case.

## Tests

Manual test:
 - copying only the inner text and pasting just paste the inner text
 - copying the whole block and pasting actually paste the whole block

## Risk

May break other things as the fix is a bit "indirect" and feel brittle but I don't really have better idea.

## Deploy Plan

deploy front