### PR TITLE
[Conversation] Add hourly cap to actor message rate limit

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -16,12 +16,15 @@ import {
 } from "@app/lib/api/assistant/conversation/mentions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import {
+  MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
+  MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS,
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE,
   MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
   makeAgentMentionsRateLimitKeyForWorkspace,
   makeKeyCapRateLimitKey,
   makeMessageRateLimitKeyForWorkspace,
   makeMessageRateLimitKeyForWorkspaceActor,
+  makeMessageRateLimitKeyForWorkspaceActorPerHour,
   makeProgrammaticUsageRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
 import {
@@ -1861,6 +1864,20 @@ async function isMessagesLimitReached(
   });
 
   if (actorRemainingMessages <= 0) {
+    return {
+      isLimitReached: true,
+      limitType: "rate_limit_error",
+    };
+  }
+
+  const actorHourlyRemainingMessages = await rateLimiter({
+    key: makeMessageRateLimitKeyForWorkspaceActorPerHour(owner, actor),
+    maxPerTimeframe: MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
+    timeframeSeconds: MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS,
+    logger,
+  });
+
+  if (actorHourlyRemainingMessages <= 0) {
     return {
       isLimitReached: true,
       limitType: "rate_limit_error",

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -11,6 +11,8 @@ import type { LightWorkspaceType } from "@app/types/user";
 
 export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE = 100;
 export const MESSAGE_RATE_LIMIT_WINDOW_SECONDS = 60;
+export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR = 3_000;
+export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS = 60 * 60;
 
 type MessageRateLimitActor =
   | {
@@ -38,6 +40,13 @@ export const makeMessageRateLimitKeyForWorkspaceActor = (
     case "user":
       return `workspace:${owner.sId}:user:${actor.id}:post_user_message`;
   }
+};
+
+export const makeMessageRateLimitKeyForWorkspaceActorPerHour = (
+  owner: LightWorkspaceType,
+  actor: MessageRateLimitActor
+) => {
+  return `${makeMessageRateLimitKeyForWorkspaceActor(owner, actor)}:hourly`;
 };
 
 export const makeAgentMentionsRateLimitKeyForWorkspace = (


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6648

Adds an additional per-actor hourly guardrail to assistant message posting by reusing the existing Redis rate limiter path:
- keep the current per-actor cap at 100/min;
- add a per-actor cap at 3,000/hour.

## Risks
Blast radius: Assistant message posting rate limiting for `postUserMessage` call paths (web and API origins).
Risk: standard

## Deploy Plan
- deploy front
