### PR TITLE
feat(poke): search workspace by phone number in Poké

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -291,6 +291,10 @@ function PokeSearchCommandUI({
                     a1b2c3d4-e5f6-7890-abcd-ef1234567890
                   </span>
                 </div>
+                <div>
+                  <span className="font-medium">Phone number:</span>{" "}
+                  <span className="font-mono">+33612345678</span>
+                </div>
               </div>
             </div>
           )}

--- a/front/lib/plans/trial/phone.ts
+++ b/front/lib/plans/trial/phone.ts
@@ -1,4 +1,6 @@
-import parsePhoneNumber from "libphonenumber-js";
+import parsePhoneNumber, {
+  parsePhoneNumberFromString,
+} from "libphonenumber-js";
 import { isValidPhoneNumber as libIsValidPhoneNumber } from "react-phone-number-input";
 
 export const CODE_LENGTH = 6;
@@ -16,6 +18,31 @@ export function isValidPhoneNumber(phone: string): boolean {
   }
 
   return libIsValidPhoneNumber(phone);
+}
+
+/**
+ * Try to parse a string as a phone number and return the E.164 format.
+ * Handles: "+33612345678", "+33 6 12 34 56 78", "33612345678" (missing +).
+ * @returns E.164 string (e.g., "+33612345678") or null if not a valid phone number
+ */
+export function tryParsePhoneNumber(input: string): string | null {
+  const cleaned = input.replace(/[\s\-()]/g, "");
+
+  // Try parsing as-is (works for E.164 like "+33612345678").
+  const parsed = parsePhoneNumberFromString(cleaned);
+  if (parsed && isValidPhoneNumber(parsed.number)) {
+    return parsed.number;
+  }
+
+  // If the input is all digits, try adding a "+" prefix (handles "33612345678").
+  if (/^\d{7,15}$/.test(cleaned)) {
+    const withPlus = parsePhoneNumberFromString(`+${cleaned}`);
+    if (withPlus && isValidPhoneNumber(withPlus.number)) {
+      return withPlus.number;
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -5,6 +5,7 @@ import {
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
 import {
   dataSourceToPokeJSON,
   dataSourceViewToPokeJSON,
@@ -15,6 +16,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";
@@ -185,6 +187,38 @@ async function searchPokeFrames(searchTerm: string): Promise<PokeItemBase[]> {
   ];
 }
 
+async function searchByPhoneNumber(
+  searchTerm: string
+): Promise<PokeItemBase[]> {
+  const e164 = tryParsePhoneNumber(searchTerm);
+  if (!e164) {
+    return [];
+  }
+
+  const workspaceModelId =
+    await WorkspaceVerificationAttemptResource.findWorkspaceModelIdFromPhoneNumber(
+      e164
+    );
+  if (!workspaceModelId) {
+    return [];
+  }
+
+  const workspaces = await unsafeGetWorkspacesByModelId([workspaceModelId]);
+  if (workspaces.length === 0) {
+    return [];
+  }
+
+  const workspace = workspaces[0];
+  return [
+    {
+      id: workspace.id,
+      name: `${workspace.name} (phone trial)`,
+      link: `${config.getPokeAppUrl()}/${workspace.sId}`,
+      type: "Workspace",
+    },
+  ];
+}
+
 export async function searchPokeResources(
   auth: Authenticator,
   searchTerm: string
@@ -200,6 +234,7 @@ export async function searchPokeResources(
       searchPokeConnectors(searchTerm),
       searchPokeFrames(searchTerm),
       searchByStripeSubscriptionId(searchTerm),
+      searchByPhoneNumber(searchTerm),
     ])
   ).flat();
 }

--- a/front/lib/resources/workspace_verification_attempt_resource.ts
+++ b/front/lib/resources/workspace_verification_attempt_resource.ts
@@ -55,6 +55,19 @@ export class WorkspaceVerificationAttemptResource extends BaseResource<Workspace
     return existing !== null;
   }
 
+  static async findWorkspaceModelIdFromPhoneNumber(
+    phoneNumber: string
+  ): Promise<number | null> {
+    const phoneNumberHash = this.hashPhoneNumber(phoneNumber);
+    const existing = await this.model.findOne({
+      where: { phoneNumberHash, verifiedAt: { [Op.ne]: null } },
+      // WORKSPACE_ISOLATION_BYPASS: Poke search needs to find workspace across all workspaces by phone hash.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+    return existing?.workspaceId ?? null;
+  }
+
   static async makeNew(
     auth: Authenticator,
     {

--- a/front/pages/api/poke/search.test.ts
+++ b/front/pages/api/poke/search.test.ts
@@ -1,0 +1,159 @@
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it, vi } from "vitest";
+
+import handler from "./search";
+
+// The poke search also queries the Connectors API (for connector ID lookups).
+// Mock it to return a dummy URL so it doesn't throw on missing env var.
+vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      getConnectorsAPIConfig: vi.fn().mockReturnValue({
+        url: "http://localhost:0",
+        secret: "test",
+        webhookSecret: "test",
+      }),
+      getPokeAppUrl: vi.fn().mockReturnValue("http://localhost:3000/poke"),
+    },
+  };
+});
+
+describe("GET /api/poke/search - phone number", () => {
+  it("returns workspace when searching by phone number in E.164 format", async () => {
+    const { req, res, authenticator } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const phoneNumber = "+33612345678";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    await WorkspaceVerificationAttemptResource.makeVerified(authenticator, {
+      phoneNumberHash: phoneHash,
+    });
+
+    req.query.search = phoneNumber;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.stringContaining("(phone trial)"),
+          type: "Workspace",
+        }),
+      ])
+    );
+  });
+
+  it("returns workspace when searching by phone number without +", async () => {
+    const { req, res, authenticator } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const phoneNumber = "+33612345678";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    await WorkspaceVerificationAttemptResource.makeVerified(authenticator, {
+      phoneNumberHash: phoneHash,
+    });
+
+    // Search with digits only (no "+").
+    req.query.search = "33612345678";
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.stringContaining("(phone trial)"),
+          type: "Workspace",
+        }),
+      ])
+    );
+  });
+
+  it("returns no results for unverified phone numbers", async () => {
+    const { req, res, authenticator } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const phoneNumber = "+33611111111";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    // Create an unverified attempt.
+    await WorkspaceVerificationAttemptResource.makeNew(authenticator, {
+      phoneNumberHash: phoneHash,
+      twilioVerificationSid: "VEtest123",
+    });
+
+    req.query.search = phoneNumber;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    const phoneResults = data.results.filter(
+      (r: { name: string }) =>
+        typeof r.name === "string" && r.name.includes("(phone trial)")
+    );
+    expect(phoneResults).toHaveLength(0);
+  });
+
+  it("returns both workspace and phone trial when digits match both", async () => {
+    const { req, res, workspace, authenticator } =
+      await createPrivateApiMockRequest({
+        isSuperUser: true,
+        role: "admin",
+      });
+
+    // Use a phone number whose digits (without +) equal the workspace model ID.
+    // Both the workspace-by-ID and the phone-trial search should return results.
+    const phoneNumber = "+33612345678";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    await WorkspaceVerificationAttemptResource.makeVerified(authenticator, {
+      phoneNumberHash: phoneHash,
+    });
+
+    // Search with the workspace's own model ID — should still return the workspace.
+    req.query.search = String(workspace.id);
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    // The workspace should appear via the workspace-by-ID search.
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "Workspace",
+          id: workspace.id,
+        }),
+      ])
+    );
+  });
+
+  it("returns no results for random non-phone strings", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
+
+    req.query.search = "hello world";
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.results).toEqual([]);
+  });
+});

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -11,12 +11,14 @@ import {
   isProPlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
+import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { isDomain, isEmailValid } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
@@ -207,10 +209,26 @@ async function handler(
           }
         }
 
+        let isSearchByPhone = false;
+        const e164 = tryParsePhoneNumber(searchTerm);
+        if (e164) {
+          const workspaceModelId =
+            await WorkspaceVerificationAttemptResource.findWorkspaceModelIdFromPhoneNumber(
+              e164
+            );
+          if (workspaceModelId) {
+            isSearchByPhone = true;
+            conditions.push({
+              id: workspaceModelId,
+            });
+          }
+        }
+
         if (
           !isSearchByEmail &&
           !isSearchByDomain &&
-          !isSearchByStripeSubscription
+          !isSearchByStripeSubscription &&
+          !isSearchByPhone
         ) {
           conditions.push({
             [Op.or]: [


### PR DESCRIPTION
## Description

- Add phone number search to both Poké search surfaces (CMD+K palette and homepage "Search in Workspaces")
- When a phone number is pasted, it's normalized to E.164 format, hashed with SHA256, and matched against verified workspace verification attempts to find the associated trial workspace
- Supports `+15551234567` (E.164) and `15551234567` (digits without +). National formats like `0612345678` won't work since the country can't be inferred.

## Tests

Locally made a signup trial with my phone and then I would find my workspace when searching with the phone number. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 