### PR TITLE
Apply suggestion styling to nested structures

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -218,6 +218,16 @@ function buildBlockDecorations({
             const serializer = DOMSerializer.fromSchema(schema);
             serializer.serializeFragment(insertedSlice, {}, span);
 
+            // Apply styling to all child elements to ensure visibility in nested structures (e.g., list items)
+            const className = isHighlighted ? CLASSES.add : CLASSES.addDimmed;
+            span.querySelectorAll("*").forEach((el) => {
+              if (el instanceof HTMLElement) {
+                el.className = el.className
+                  ? `${el.className} ${className}`
+                  : className;
+              }
+            });
+
             return span;
           },
           { side: -1 }
@@ -297,6 +307,16 @@ function buildRootDecorations({
 
             const serializer = DOMSerializer.fromSchema(schema);
             serializer.serializeFragment(Fragment.from(newChild), {}, div);
+
+            // Apply styling to all child elements to ensure visibility in nested structures (e.g., list items)
+            const className = isHighlighted ? CLASSES.add : CLASSES.addDimmed;
+            div.querySelectorAll("*").forEach((el) => {
+              if (el instanceof HTMLElement) {
+                el.className = el.className
+                  ? `${el.className} ${className}`
+                  : className;
+              }
+            });
 
             return div;
           },


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/6722
## Description
Previously, when suggestions included changes to list items the blue highlight would be missing. This change applies the styling to nested elements:
<img width="1135" height="685" alt="Screenshot 2026-02-23 at 1 43 58 PM" src="https://github.com/user-attachments/assets/6a68c773-9b04-4f70-96fa-3f0260b1de9a" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
