### PR TITLE
[Kill Switch] Add workspace kill switch poke plugin

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -195,18 +195,15 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      const metadata = {
-        ...(w.metadata ?? {}),
-        [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
-          WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
-      };
-
-      const updateResult = await WorkspaceResource.updateMetadata(
-        w.id,
-        metadata
-      );
+      const updateResult = await w.updateWorkspaceKillSwitch({
+        operation: "block",
+      });
       if (updateResult.isErr()) {
         throw new Error(updateResult.error.message);
+      }
+      if (!updateResult.value.wasUpdated) {
+        logger.info({ wId: w.sId }, "Workspace was already blocked");
+        return;
       }
 
       logger.info({ wId: w.sId }, "Workspace blocked");
@@ -223,15 +220,15 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
         throw new Error(`Workspace not found: wId='${args.wId}'`);
       }
 
-      const metadata = { ...(w.metadata ?? {}) };
-      delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
-
-      const updateResult = await WorkspaceResource.updateMetadata(
-        w.id,
-        metadata
-      );
+      const updateResult = await w.updateWorkspaceKillSwitch({
+        operation: "unblock",
+      });
       if (updateResult.isErr()) {
         throw new Error(updateResult.error.message);
+      }
+      if (!updateResult.value.wasUpdated) {
+        logger.info({ wId: w.sId }, "Workspace was not blocked");
+        return;
       }
 
       logger.info({ wId: w.sId }, "Workspace unblocked");

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -17,6 +17,7 @@ export * from "./invite_user";
 export * from "./manage_authorized_domains";
 export * from "./manage_conversation_kill_switch";
 export * from "./manage_programmatic_usage_configuration";
+export * from "./manage_workspace_kill_switch";
 export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";
 export * from "./reset_provisioned_members_not_in_directory";

--- a/front/lib/api/poke/plugins/workspaces/manage_workspace_kill_switch.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_workspace_kill_switch.ts
@@ -1,12 +1,12 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  WORKSPACE_KILL_SWITCH_OPERATIONS,
+  type WorkspaceKillSwitchOperation,
+  WorkspaceResource,
+} from "@app/lib/resources/workspace_resource";
 import { mapToEnumValues } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-
-const WORKSPACE_KILL_SWITCH_OPERATIONS = ["block", "unblock"] as const;
-type WorkspaceKillSwitchOperation =
-  (typeof WORKSPACE_KILL_SWITCH_OPERATIONS)[number];
 
 function isWorkspaceKillSwitchOperation(
   operation: string
@@ -54,57 +54,31 @@ export const workspaceKillSwitchPlugin = createPlugin({
       return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
     }
 
-    const currentKillSwitch =
-      workspaceResource.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
-    const isFullyBlocked =
-      WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch);
-    let metadata: Record<string, string | number | boolean | object> | null =
-      null;
-
-    switch (operationArg) {
-      case "block":
-        if (isFullyBlocked) {
-          return new Ok({
-            display: "text",
-            value: `Workspace "${workspace.name}" was already fully blocked for emergency maintenance.`,
-          });
-        }
-
-        metadata = {
-          ...(workspaceResource.metadata ?? {}),
-          [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
-            WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
-        };
-        break;
-      case "unblock":
-        if (!isFullyBlocked) {
-          return new Ok({
-            display: "text",
-            value: `Workspace "${workspace.name}" was not fully blocked.`,
-          });
-        }
-
-        metadata = { ...(workspaceResource.metadata ?? {}) };
-        delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
-        break;
-      default:
-        return assertNever(operationArg);
-    }
-
-    const updateResult = await WorkspaceResource.updateMetadata(
-      workspaceResource.id,
-      metadata
-    );
+    const updateResult = await workspaceResource.updateWorkspaceKillSwitch({
+      operation: operationArg,
+    });
     if (updateResult.isErr()) {
       return new Err(updateResult.error);
     }
+    const { wasUpdated } = updateResult.value;
 
-    return new Ok({
-      display: "text",
-      value:
-        operationArg === "block"
-          ? `Workspace "${workspace.name}" is now fully blocked for emergency maintenance.`
-          : `Workspace "${workspace.name}" is now unblocked.`,
-    });
+    switch (operationArg) {
+      case "block":
+        return new Ok({
+          display: "text",
+          value: wasUpdated
+            ? `Workspace "${workspace.name}" is now fully blocked for emergency maintenance.`
+            : `Workspace "${workspace.name}" was already fully blocked for emergency maintenance.`,
+        });
+      case "unblock":
+        return new Ok({
+          display: "text",
+          value: wasUpdated
+            ? `Workspace "${workspace.name}" is now unblocked.`
+            : `Workspace "${workspace.name}" was not fully blocked.`,
+        });
+      default:
+        return assertNever(operationArg);
+    }
   },
 });

--- a/front/lib/api/poke/plugins/workspaces/manage_workspace_kill_switch.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_workspace_kill_switch.ts
@@ -1,0 +1,110 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { mapToEnumValues } from "@app/types/poke/plugins";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+const WORKSPACE_KILL_SWITCH_OPERATIONS = ["block", "unblock"] as const;
+type WorkspaceKillSwitchOperation =
+  (typeof WORKSPACE_KILL_SWITCH_OPERATIONS)[number];
+
+function isWorkspaceKillSwitchOperation(
+  operation: string
+): operation is WorkspaceKillSwitchOperation {
+  return WORKSPACE_KILL_SWITCH_OPERATIONS.some(
+    (allowedOperation) => allowedOperation === operation
+  );
+}
+
+export const workspaceKillSwitchPlugin = createPlugin({
+  manifest: {
+    id: "workspace-kill-switch",
+    name: "Workspace Kill Switch",
+    description:
+      "Block or unblock access to all workspace APIs for emergency maintenance.",
+    resourceTypes: ["workspaces"],
+    args: {
+      operation: {
+        type: "enum",
+        label: "Operation",
+        description: "Select whether to block or unblock the workspace",
+        values: mapToEnumValues(WORKSPACE_KILL_SWITCH_OPERATIONS, (value) => ({
+          label: value,
+          value,
+        })),
+        multiple: false,
+      },
+    },
+  },
+  execute: async (_auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const operationArg = args.operation[0];
+    if (!operationArg) {
+      return new Err(new Error("Please select an operation."));
+    }
+    if (!isWorkspaceKillSwitchOperation(operationArg)) {
+      return new Err(new Error(`Invalid operation: ${operationArg}`));
+    }
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource) {
+      return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
+    }
+
+    const currentKillSwitch =
+      workspaceResource.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+    const isFullyBlocked =
+      WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch);
+    let metadata: Record<string, string | number | boolean | object> | null =
+      null;
+
+    switch (operationArg) {
+      case "block":
+        if (isFullyBlocked) {
+          return new Ok({
+            display: "text",
+            value: `Workspace "${workspace.name}" was already fully blocked for emergency maintenance.`,
+          });
+        }
+
+        metadata = {
+          ...(workspaceResource.metadata ?? {}),
+          [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
+            WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
+        };
+        break;
+      case "unblock":
+        if (!isFullyBlocked) {
+          return new Ok({
+            display: "text",
+            value: `Workspace "${workspace.name}" was not fully blocked.`,
+          });
+        }
+
+        metadata = { ...(workspaceResource.metadata ?? {}) };
+        delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+        break;
+      default:
+        return assertNever(operationArg);
+    }
+
+    const updateResult = await WorkspaceResource.updateMetadata(
+      workspaceResource.id,
+      metadata
+    );
+    if (updateResult.isErr()) {
+      return new Err(updateResult.error);
+    }
+
+    return new Ok({
+      display: "text",
+      value:
+        operationArg === "block"
+          ? `Workspace "${workspace.name}" is now fully blocked for emergency maintenance.`
+          : `Workspace "${workspace.name}" is now unblocked.`,
+    });
+  },
+});

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -70,6 +70,12 @@ export const WORKSPACE_CONVERSATION_KILL_SWITCH_OPERATIONS = [
 ] as const;
 export type WorkspaceConversationKillSwitchOperation =
   (typeof WORKSPACE_CONVERSATION_KILL_SWITCH_OPERATIONS)[number];
+export const WORKSPACE_KILL_SWITCH_OPERATIONS = ["block", "unblock"] as const;
+export type WorkspaceKillSwitchOperation =
+  (typeof WORKSPACE_KILL_SWITCH_OPERATIONS)[number];
+export type UpdateWorkspaceKillSwitchResult = {
+  wasUpdated: boolean;
+};
 export type UpdateWorkspaceConversationKillSwitchResult = {
   wasUpdated: boolean;
 };
@@ -643,6 +649,56 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         }
         break;
       }
+    }
+
+    const updateResult = await WorkspaceResource.updateMetadata(
+      this.id,
+      metadata
+    );
+    if (updateResult.isErr()) {
+      return new Err(updateResult.error);
+    }
+
+    return new Ok({
+      wasUpdated: true,
+    });
+  }
+
+  async updateWorkspaceKillSwitch({
+    operation,
+  }: {
+    operation: WorkspaceKillSwitchOperation;
+  }): Promise<Result<UpdateWorkspaceKillSwitchResult, Error>> {
+    const currentKillSwitch =
+      this.metadata?.[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+    const isFullyBlocked =
+      WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(currentKillSwitch);
+    let metadata: Record<string, string | number | boolean | object>;
+
+    switch (operation) {
+      case "block":
+        if (isFullyBlocked) {
+          return new Ok({
+            wasUpdated: false,
+          });
+        }
+
+        metadata = {
+          ...(this.metadata ?? {}),
+          [WorkspaceResource.KILL_SWITCH_METADATA_KEY]:
+            WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE,
+        };
+        break;
+      case "unblock":
+        if (!isFullyBlocked) {
+          return new Ok({
+            wasUpdated: false,
+          });
+        }
+
+        metadata = { ...(this.metadata ?? {}) };
+        delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
+        break;
     }
 
     const updateResult = await WorkspaceResource.updateMetadata(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -18,6 +18,7 @@ import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types"
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isStringArray } from "@app/types/shared/utils/general";
 import type { WorkspaceSegmentationType } from "@app/types/user";
@@ -699,6 +700,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         metadata = { ...(this.metadata ?? {}) };
         delete metadata[WorkspaceResource.KILL_SWITCH_METADATA_KEY];
         break;
+      default:
+        return assertNever(operation);
     }
 
     const updateResult = await WorkspaceResource.updateMetadata(


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/22051 to split workspace and conversation kill switch poke plugins into separate PRs.

- Adds a new `workspace-kill-switch` poke plugin to block/unblock a workspace globally.
- Adds `WorkspaceResource.updateWorkspaceKillSwitch` and uses it from the plugin (so metadata mutation logic lives on the resource).
<img width="937" height="494" alt="image" src="https://github.com/user-attachments/assets/46ee186f-ea9b-4274-afb2-65a0d7ed92ee" />

<img width="937" height="494" alt="image" src="https://github.com/user-attachments/assets/01848e0c-5964-4145-a579-954db2be2fad" />


## Risks
Blast radius: Poke workspace plugin execution and workspace kill switch metadata updates.
Risk: low

## Deploy Plan
- deploy front