### PR TITLE
[connectors] feat(Gong): add permission profile to `gong_configurations`

### DIFF
--- a/connectors/migrations/db/migration_118.sql
+++ b/connectors/migrations/db/migration_118.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 23, 2026
+ALTER TABLE "public"."gong_configurations" ADD COLUMN "permissionProfileId" VARCHAR(255);

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -13,6 +13,7 @@ export class GongConfigurationModel extends ConnectorBaseModel<GongConfiguration
   declare retentionPeriodDays: number | null;
   declare trackersEnabled: boolean;
   declare accountsEnabled: boolean;
+  declare permissionProfileId: string | null;
 }
 
 GongConfigurationModel.init(
@@ -52,6 +53,10 @@ GongConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    permissionProfileId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -86,6 +86,7 @@ export class GongConfigurationResource extends BaseResource<GongConfigurationMod
       baseUrl: this.baseUrl,
       retentionPeriodDays: this.retentionPeriodDays,
       lastGarbageCollectionTimestamp: this.lastGarbageCollectionTimestamp,
+      permissionProfileId: this.permissionProfileId,
     };
   }
 


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C07Q0576XSP/p1771611894284519).
- This PR adds a column `permissionProfileId` to the table `gong_configurations`.
- Goal is to allow choosing a permission profile from the connectors permission modal.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy connectors.
