### PR TITLE
Fix router events emitting

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -13,6 +13,7 @@ import { AppContentRouterLayout } from "@spa/app/layouts/AppContentRouterLayout"
 import { AuthenticatedPage } from "@spa/app/layouts/AuthenticatedPage";
 import { ConversationRouterLayout } from "@spa/app/layouts/ConversationRouterLayout";
 import { DustAppRouterLayout } from "@spa/app/layouts/DustAppRouterLayout";
+import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { SpaceRouterLayout } from "@spa/app/layouts/SpaceRouterLayout";
 import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
 import { WorkspacePage } from "@spa/app/layouts/WorkspacePage";
@@ -332,197 +333,219 @@ const SsoEnforcedPage = withSuspense(
 
 const router = createBrowserRouter(
   [
-    { path: "/", element: <IndexPage /> },
     {
-      path: "/w/:wId",
-      element: <WorkspacePage />,
+      element: <RootRouterLayout />,
       children: [
-        // Routes WITH shared AppContentLayout (navigation, sidebar, title bar)
+        { path: "/", element: <IndexPage /> },
         {
-          element: <AppContentRouterLayout />,
+          path: "/w/:wId",
+          element: <WorkspacePage />,
           children: [
-            // Index - redirect to conversation/new
+            // Routes WITH shared AppContentLayout (navigation, sidebar, title bar)
             {
-              index: true,
-              element: <RedirectWithSearchParams to="conversation/new" />,
-            },
-
-            // Profile
-            { path: "me", element: <ProfilePage /> },
-
-            // Conversation (wrapped with ConversationLayout)
-            {
-              path: "conversation",
-              element: <ConversationRouterLayout />,
+              element: <AppContentRouterLayout />,
               children: [
-                { path: ":cId", element: <ConversationPage /> },
+                // Index - redirect to conversation/new
                 {
-                  path: "space/:spaceId",
-                  element: <SpaceConversationsPage />,
+                  index: true,
+                  element: <RedirectWithSearchParams to="conversation/new" />,
                 },
+
+                // Profile
+                { path: "me", element: <ProfilePage /> },
+
+                // Conversation (wrapped with ConversationLayout)
+                {
+                  path: "conversation",
+                  element: <ConversationRouterLayout />,
+                  children: [
+                    { path: ":cId", element: <ConversationPage /> },
+                    {
+                      path: "space/:spaceId",
+                      element: <SpaceConversationsPage />,
+                    },
+                  ],
+                },
+
+                {
+                  element: <AdminRouterLayout />,
+                  children: [
+                    { path: "members", element: <MembersPage /> },
+                    { path: "workspace", element: <WorkspaceSettingsPage /> },
+                    { path: "analytics", element: <AnalyticsPage /> },
+                    { path: "subscription", element: <SubscriptionPage /> },
+                    {
+                      path: "subscription/manage",
+                      element: <ManageSubscriptionPage />,
+                    },
+                    {
+                      path: "subscription/payment_processing",
+                      element: <PaymentProcessingPage />,
+                    },
+                    { path: "developers/api-keys", element: <APIKeysPage /> },
+                    {
+                      path: "developers/credits-usage",
+                      element: <CreditsUsagePage />,
+                    },
+                    {
+                      path: "developers/providers",
+                      element: <ProvidersPage />,
+                    },
+                    {
+                      path: "developers/dev-secrets",
+                      element: <SecretsPage />,
+                    },
+                  ],
+                },
+
+                // Labs
+                { path: "labs", element: <LabsPage /> },
+                { path: "labs/transcripts", element: <TranscriptsPage /> },
+                {
+                  path: "labs/mcp_actions",
+                  element: <MCPActionsDashboardPage />,
+                },
+                {
+                  path: "labs/mcp_actions/:agentId",
+                  element: <AgentMCPActionsPage />,
+                },
+
+                // Spaces
+                {
+                  path: "spaces/:spaceId",
+                  element: <SpaceRouterLayout />,
+                  children: [
+                    { index: true, element: <SpacePage /> },
+                    {
+                      path: "categories/actions",
+                      element: <SpaceActionsPage />,
+                    },
+                    { path: "categories/apps", element: <SpaceAppsListPage /> },
+                    {
+                      path: "categories/triggers",
+                      element: <SpaceTriggersPage />,
+                    },
+                    {
+                      path: "categories/:category",
+                      element: <SpaceCategoryPage />,
+                    },
+                    {
+                      path: "categories/:category/data_source_views/:dataSourceViewId",
+                      element: <DataSourceViewPage />,
+                    },
+                  ],
+                },
+
+                // Apps
+                {
+                  path: "spaces/:spaceId/apps/:aId",
+                  element: <DustAppRouterLayout />,
+                  children: [
+                    { index: true, element: <AppViewPage /> },
+                    { path: "settings", element: <AppSettingsPage /> },
+                    {
+                      path: "specification",
+                      element: <AppSpecificationPage />,
+                    },
+                    { path: "datasets", element: <DatasetsPage /> },
+                    { path: "datasets/new", element: <NewDatasetPage /> },
+                    { path: "datasets/:name", element: <DatasetPage /> },
+                    { path: "runs", element: <RunsPage /> },
+                    { path: "runs/:runId", element: <RunPage /> },
+                  ],
+                },
+
+                // Builder (pages with sidebar layout)
+                { path: "builder/agents", element: <ManageAgentsPage /> },
+                { path: "builder/agents/create", element: <CreateAgentPage /> },
+                { path: "builder/skills", element: <ManageSkillsPage /> },
+
+                // Spaces redirect (inside layout to preserve sidebar)
+                { path: "spaces", element: <SpacesRedirectPage /> },
               ],
             },
 
+            // Routes WITHOUT AppContentLayout (no sidebar/navigation chrome)
+
+            // Builder (full-page editors without sidebar)
+            { path: "builder/agents/new", element: <NewAgentPage /> },
+            { path: "builder/agents/:aId", element: <EditAgentPage /> },
+            { path: "builder/skills/new", element: <CreateSkillPage /> },
+            { path: "builder/skills/:sId", element: <EditSkillPage /> },
+
+            // Legacy assistants -> agents redirects
             {
-              element: <AdminRouterLayout />,
-              children: [
-                { path: "members", element: <MembersPage /> },
-                { path: "workspace", element: <WorkspaceSettingsPage /> },
-                { path: "analytics", element: <AnalyticsPage /> },
-                { path: "subscription", element: <SubscriptionPage /> },
-                {
-                  path: "subscription/manage",
-                  element: <ManageSubscriptionPage />,
-                },
-                {
-                  path: "subscription/payment_processing",
-                  element: <PaymentProcessingPage />,
-                },
-                { path: "developers/api-keys", element: <APIKeysPage /> },
-                {
-                  path: "developers/credits-usage",
-                  element: <CreditsUsagePage />,
-                },
-                { path: "developers/providers", element: <ProvidersPage /> },
-                { path: "developers/dev-secrets", element: <SecretsPage /> },
-              ],
+              path: "builder/assistants",
+              element: <RedirectWithSearchParams to="../builder/agents" />,
+            },
+            {
+              path: "builder/assistants/create",
+              element: (
+                <RedirectWithSearchParams to="../builder/agents/create" />
+              ),
+            },
+            {
+              path: "builder/assistants/new",
+              element: <RedirectWithSearchParams to="../builder/agents/new" />,
+            },
+            {
+              path: "builder/assistants/dust",
+              element: (
+                <RedirectWithSearchParams to="../builder/agents#?selectedTab=global" />
+              ),
+            },
+            {
+              path: "builder/assistants/:aId",
+              element: <AssistantAgentRedirect />,
             },
 
-            // Labs
-            { path: "labs", element: <LabsPage /> },
-            { path: "labs/transcripts", element: <TranscriptsPage /> },
-            { path: "labs/mcp_actions", element: <MCPActionsDashboardPage /> },
+            // Onboarding (paywall-whitelisted: accessible even when canUseProduct is false)
             {
-              path: "labs/mcp_actions/:agentId",
-              element: <AgentMCPActionsPage />,
+              path: "welcome",
+              element: <WelcomePage />,
+              handle: { requireCanUseProduct: false },
             },
-
-            // Spaces
             {
-              path: "spaces/:spaceId",
-              element: <SpaceRouterLayout />,
-              children: [
-                { index: true, element: <SpacePage /> },
-                { path: "categories/actions", element: <SpaceActionsPage /> },
-                { path: "categories/apps", element: <SpaceAppsListPage /> },
-                {
-                  path: "categories/triggers",
-                  element: <SpaceTriggersPage />,
-                },
-                {
-                  path: "categories/:category",
-                  element: <SpaceCategoryPage />,
-                },
-                {
-                  path: "categories/:category/data_source_views/:dataSourceViewId",
-                  element: <DataSourceViewPage />,
-                },
-              ],
+              path: "subscribe",
+              element: <SubscribePage />,
+              handle: { requireCanUseProduct: false },
             },
-
-            // Apps
             {
-              path: "spaces/:spaceId/apps/:aId",
-              element: <DustAppRouterLayout />,
-              children: [
-                { index: true, element: <AppViewPage /> },
-                { path: "settings", element: <AppSettingsPage /> },
-                { path: "specification", element: <AppSpecificationPage /> },
-                { path: "datasets", element: <DatasetsPage /> },
-                { path: "datasets/new", element: <NewDatasetPage /> },
-                { path: "datasets/:name", element: <DatasetPage /> },
-                { path: "runs", element: <RunsPage /> },
-                { path: "runs/:runId", element: <RunPage /> },
-              ],
+              path: "trial",
+              element: <TrialPage />,
+              handle: { requireCanUseProduct: false },
             },
-
-            // Builder (pages with sidebar layout)
-            { path: "builder/agents", element: <ManageAgentsPage /> },
-            { path: "builder/agents/create", element: <CreateAgentPage /> },
-            { path: "builder/skills", element: <ManageSkillsPage /> },
-
-            // Spaces redirect (inside layout to preserve sidebar)
-            { path: "spaces", element: <SpacesRedirectPage /> },
+            {
+              path: "trial-ended",
+              element: <TrialEndedPage />,
+              handle: { requireCanUseProduct: false },
+            },
+            {
+              path: "verify",
+              element: <VerifyPage />,
+              handle: { requireCanUseProduct: false },
+            },
           ],
         },
-
-        // Routes WITHOUT AppContentLayout (no sidebar/navigation chrome)
-
-        // Builder (full-page editors without sidebar)
-        { path: "builder/agents/new", element: <NewAgentPage /> },
-        { path: "builder/agents/:aId", element: <EditAgentPage /> },
-        { path: "builder/skills/new", element: <CreateSkillPage /> },
-        { path: "builder/skills/:sId", element: <EditSkillPage /> },
-
-        // Legacy assistants -> agents redirects
         {
-          path: "builder/assistants",
-          element: <RedirectWithSearchParams to="../builder/agents" />,
+          element: <AuthenticatedPage />,
+          children: [
+            { path: "/invite-choose", element: <InviteChoosePage /> },
+            { path: "/no-workspace", element: <NoWorkspacePage /> },
+            { path: "/sso-enforced", element: <SsoEnforcedPage /> },
+          ],
         },
+        // Redirect /poke/* to the poke app (e.g., poke.dust.tt)
+        { path: "/poke/*", element: <PokeRedirect /> },
         {
-          path: "builder/assistants/create",
-          element: <RedirectWithSearchParams to="../builder/agents/create" />,
+          element: <UnauthenticatedPage />,
+          children: [
+            { path: "/w/:wId/join", element: <JoinPage /> },
+            { path: "/login-error", element: <LoginErrorPage /> },
+            { path: "/maintenance", element: <MaintenancePage /> },
+            { path: "*", element: <Custom404 /> },
+          ],
         },
-        {
-          path: "builder/assistants/new",
-          element: <RedirectWithSearchParams to="../builder/agents/new" />,
-        },
-        {
-          path: "builder/assistants/dust",
-          element: (
-            <RedirectWithSearchParams to="../builder/agents#?selectedTab=global" />
-          ),
-        },
-        {
-          path: "builder/assistants/:aId",
-          element: <AssistantAgentRedirect />,
-        },
-
-        // Onboarding (paywall-whitelisted: accessible even when canUseProduct is false)
-        {
-          path: "welcome",
-          element: <WelcomePage />,
-          handle: { requireCanUseProduct: false },
-        },
-        {
-          path: "subscribe",
-          element: <SubscribePage />,
-          handle: { requireCanUseProduct: false },
-        },
-        {
-          path: "trial",
-          element: <TrialPage />,
-          handle: { requireCanUseProduct: false },
-        },
-        {
-          path: "trial-ended",
-          element: <TrialEndedPage />,
-          handle: { requireCanUseProduct: false },
-        },
-        {
-          path: "verify",
-          element: <VerifyPage />,
-          handle: { requireCanUseProduct: false },
-        },
-      ],
-    },
-    {
-      element: <AuthenticatedPage />,
-      children: [
-        { path: "/invite-choose", element: <InviteChoosePage /> },
-        { path: "/no-workspace", element: <NoWorkspacePage /> },
-        { path: "/sso-enforced", element: <SsoEnforcedPage /> },
-      ],
-    },
-    // Redirect /poke/* to the poke app (e.g., poke.dust.tt)
-    { path: "/poke/*", element: <PokeRedirect /> },
-    {
-      element: <UnauthenticatedPage />,
-      children: [
-        { path: "/w/:wId/join", element: <JoinPage /> },
-        { path: "/login-error", element: <LoginErrorPage /> },
-        { path: "/maintenance", element: <MaintenancePage /> },
-        { path: "*", element: <Custom404 /> },
       ],
     },
   ],

--- a/front-spa/src/app/layouts/RootRouterLayout.tsx
+++ b/front-spa/src/app/layouts/RootRouterLayout.tsx
@@ -1,0 +1,58 @@
+import { routerEvents } from "@spa/lib/platform";
+import { useEffect, useRef } from "react";
+import { Outlet, useLocation } from "react-router-dom";
+
+/**
+ * Root layout for all routes.
+ * Emits router events (routeChangeComplete, hashChangeComplete) exactly once
+ * per navigation, rather than once per component using useAppRouter.
+ */
+export function RootRouterLayout() {
+  const location = useLocation();
+
+  const previousLocationRef = useRef<{
+    pathname: string;
+    search: string;
+    hash: string;
+  } | null>(null);
+
+  // Emit routeChangeComplete when pathname or search changes
+  useEffect(() => {
+    const currentLocation = {
+      pathname: location.pathname,
+      search: location.search,
+      hash: window.location.hash,
+    };
+
+    const previousLocation = previousLocationRef.current;
+
+    // Skip initial mount - don't emit event on first render
+    if (previousLocation !== null) {
+      // Only emit if pathname or search changed (not hash - that's handled by hashchange listener)
+      if (
+        previousLocation.pathname !== currentLocation.pathname ||
+        previousLocation.search !== currentLocation.search
+      ) {
+        const fullUrl = `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
+        queueMicrotask(() => {
+          routerEvents.emit("routeChangeComplete", fullUrl);
+        });
+      }
+    }
+
+    previousLocationRef.current = currentLocation;
+  }, [location]);
+
+  // Listen for hash changes (React Router doesn't track these)
+  useEffect(() => {
+    const handleHashChange = () => {
+      const fullUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      routerEvents.emit("hashChangeComplete", fullUrl);
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  return <Outlet />;
+}

--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -126,7 +126,7 @@ function createRouterEvents(): RouterEvents {
 }
 
 // Singleton events object so all useAppRouter calls share the same listeners
-const routerEvents = createRouterEvents();
+export const routerEvents = createRouterEvents();
 
 export function useAppRouter(): AppRouter {
   const navigate = useSafeNavigate();
@@ -143,54 +143,6 @@ export function useAppRouter(): AppRouter {
       return () => window.removeEventListener("popstate", handlePopState);
     }
   }, [location]);
-
-  // Emit router events when location changes
-  // Track previous location to detect hash-only changes and skip initial mount
-  const previousLocationRef = useRef<{
-    pathname: string;
-    search: string;
-    hash: string;
-  } | null>(null);
-
-  // Track location for route change events
-  useEffect(() => {
-    if (location) {
-      const currentLocation = {
-        pathname: location.pathname,
-        search: location.search,
-        hash: window.location.hash,
-      };
-
-      const previousLocation = previousLocationRef.current;
-
-      // Skip initial mount - don't emit event on first render
-      if (previousLocation !== null) {
-        // Only emit if pathname or search changed (not hash - that's handled by hashchange listener)
-        if (
-          previousLocation.pathname !== currentLocation.pathname ||
-          previousLocation.search !== currentLocation.search
-        ) {
-          const fullUrl = `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
-          queueMicrotask(() => {
-            routerEvents.emit("routeChangeComplete", fullUrl);
-          });
-        }
-      }
-
-      previousLocationRef.current = currentLocation;
-    }
-  }, [location]);
-
-  // Listen for hash changes (React Router doesn't track these)
-  useEffect(() => {
-    const handleHashChange = () => {
-      const fullUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-      routerEvents.emit("hashChangeComplete", fullUrl);
-    };
-
-    window.addEventListener("hashchange", handleHashChange);
-    return () => window.removeEventListener("hashchange", handleHashChange);
-  }, []);
 
   const push = useCallback(
     async (

--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -35,6 +35,7 @@ import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
 import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
 import Custom404 from "@dust-tt/front/pages/404";
 import { AppReadyProvider } from "@spa/app/contexts/AppReadyContext";
+import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { PokePage } from "@spa/poke/layouts/PokePage";
 import { PokeWorkspacePage } from "@spa/poke/layouts/PokeWorkspacePage";
 import {
@@ -56,73 +57,87 @@ function PokeRedirect() {
 const router = createBrowserRouter(
   [
     {
-      path: "/",
-      element: <PokePage />,
+      element: <RootRouterLayout />,
       children: [
-        { index: true, element: <DashboardPage /> },
-        { path: "kill", element: <KillPage /> },
-        { path: "plans", element: <PlansPage /> },
-        { path: "pokefy", element: <PokefyPage /> },
-        { path: "production-checks", element: <ProductionChecksPage /> },
-        { path: "email-templates", element: <EmailTemplatesPage /> },
-        { path: "templates", element: <TemplatesListPage /> },
-        { path: "templates/:tId", element: <TemplateDetailPage /> },
-        { path: "plugins", element: <PluginsPage /> },
-        { path: "cache", element: <CacheLookupPage /> },
-        { path: "connectors/:connectorId", element: <ConnectorRedirectPage /> },
+        {
+          path: "/",
+          element: <PokePage />,
+          children: [
+            { index: true, element: <DashboardPage /> },
+            { path: "kill", element: <KillPage /> },
+            { path: "plans", element: <PlansPage /> },
+            { path: "pokefy", element: <PokefyPage /> },
+            { path: "production-checks", element: <ProductionChecksPage /> },
+            { path: "email-templates", element: <EmailTemplatesPage /> },
+            { path: "templates", element: <TemplatesListPage /> },
+            { path: "templates/:tId", element: <TemplateDetailPage /> },
+            { path: "plugins", element: <PluginsPage /> },
+            { path: "cache", element: <CacheLookupPage /> },
+            {
+              path: "connectors/:connectorId",
+              element: <ConnectorRedirectPage />,
+            },
+          ],
+        },
+        { path: "/404", element: <Custom404 /> },
+        {
+          path: "/:wId",
+          element: <PokeWorkspacePage />,
+          children: [
+            { index: true, element: <WorkspacePage /> },
+            { path: "memberships", element: <MembershipsPage /> },
+            { path: "llm-traces/:runId", element: <LLMTracePage /> },
+            {
+              path: "assistants/:aId/instructions",
+              element: <AssistantInstructionsPage />,
+            },
+            { path: "assistants/:aId", element: <AssistantDetailsPage /> },
+            {
+              path: "assistants/:aId/triggers/:triggerId",
+              element: <TriggerDetailsPage />,
+            },
+            { path: "conversation/:cId", element: <ConversationPage /> },
+            { path: "data_sources/:dsId", element: <DataSourcePage /> },
+            {
+              path: "data_sources/:dsId/notion-requests",
+              element: <NotionRequestsPage />,
+            },
+            {
+              path: "data_sources/:dsId/query",
+              element: <DataSourceQueryPage />,
+            },
+            {
+              path: "data_sources/:dsId/search",
+              element: <DataSourceSearchPage />,
+            },
+            {
+              path: "data_sources/:dsId/view",
+              element: <DataSourceViewPage />,
+            },
+            { path: "groups/:groupId", element: <GroupPage /> },
+            { path: "files/:sId", element: <FramePage /> },
+            { path: "skills/:sId", element: <SkillDetailsPage /> },
+            { path: "spaces/:spaceId", element: <SpacePage /> },
+            { path: "spaces/:spaceId/apps/:appId", element: <AppPage /> },
+            {
+              path: "spaces/:spaceId/data_source_views/:dsvId",
+              element: <SpaceDataSourceViewPage />,
+            },
+            {
+              path: "spaces/:spaceId/mcp_server_views/:svId",
+              element: <MCPServerViewPage />,
+            },
+            {
+              path: "webhook-sources/:wsId",
+              element: <WebhookSourceDetailsPage />,
+            },
+          ],
+        },
+        // Redirect /poke/* to /* (strip /poke prefix)
+        { path: "poke/*", element: <PokeRedirect /> },
+        { path: "*", element: <Custom404 /> },
       ],
     },
-    { path: "/404", element: <Custom404 /> },
-    {
-      path: "/:wId",
-      element: <PokeWorkspacePage />,
-      children: [
-        { index: true, element: <WorkspacePage /> },
-        { path: "memberships", element: <MembershipsPage /> },
-        { path: "llm-traces/:runId", element: <LLMTracePage /> },
-        {
-          path: "assistants/:aId/instructions",
-          element: <AssistantInstructionsPage />,
-        },
-        { path: "assistants/:aId", element: <AssistantDetailsPage /> },
-        {
-          path: "assistants/:aId/triggers/:triggerId",
-          element: <TriggerDetailsPage />,
-        },
-        { path: "conversation/:cId", element: <ConversationPage /> },
-        { path: "data_sources/:dsId", element: <DataSourcePage /> },
-        {
-          path: "data_sources/:dsId/notion-requests",
-          element: <NotionRequestsPage />,
-        },
-        { path: "data_sources/:dsId/query", element: <DataSourceQueryPage /> },
-        {
-          path: "data_sources/:dsId/search",
-          element: <DataSourceSearchPage />,
-        },
-        { path: "data_sources/:dsId/view", element: <DataSourceViewPage /> },
-        { path: "groups/:groupId", element: <GroupPage /> },
-        { path: "files/:sId", element: <FramePage /> },
-        { path: "skills/:sId", element: <SkillDetailsPage /> },
-        { path: "spaces/:spaceId", element: <SpacePage /> },
-        { path: "spaces/:spaceId/apps/:appId", element: <AppPage /> },
-        {
-          path: "spaces/:spaceId/data_source_views/:dsvId",
-          element: <SpaceDataSourceViewPage />,
-        },
-        {
-          path: "spaces/:spaceId/mcp_server_views/:svId",
-          element: <MCPServerViewPage />,
-        },
-        {
-          path: "webhook-sources/:wsId",
-          element: <WebhookSourceDetailsPage />,
-        },
-      ],
-    },
-    // Redirect /poke/* to /* (strip /poke prefix)
-    { path: "poke/*", element: <PokeRedirect /> },
-    { path: "*", element: <Custom404 /> },
   ],
   {
     basename: import.meta.env.VITE_BASE_PATH ?? "",

--- a/front-spa/src/share/ShareApp.tsx
+++ b/front-spa/src/share/ShareApp.tsx
@@ -5,19 +5,25 @@ import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
 import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
 import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
+import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 const router = createBrowserRouter(
   [
-    // Frame: /share/frame/:token
     {
-      path: "/share/frame/:token",
-      element: <SharedFramePage />,
-    },
-    // File: /share/file/:token (redirects to frame)
-    {
-      path: "/share/file/:token",
-      element: <SharedFilePage />,
+      element: <RootRouterLayout />,
+      children: [
+        // Frame: /share/frame/:token
+        {
+          path: "/share/frame/:token",
+          element: <SharedFramePage />,
+        },
+        // File: /share/file/:token (redirects to frame)
+        {
+          path: "/share/file/:token",
+          element: <SharedFilePage />,
+        },
+      ],
     },
   ],
   {


### PR DESCRIPTION
## Summary

- **Fix duplicate `routeChangeComplete` events in the SPA**: The event-emitting `useEffect` was inside `useAppRouter()`, which meant every component calling the hook (~111 components) would emit its own `routeChangeComplete` event on each navigation. A single page change was firing the event ~111 times.
- **Extract event emission into a single `RootRouterLayout`**: Moved the route change and hash change listeners into a dedicated layout component mounted once at the root of each router tree (App, Poke, Share). This ensures exactly one event per navigation.

## Test plan

- [ ] Navigate between pages in the SPA and verify `routeChangeComplete` fires exactly once per navigation (check PostHog events / console)
- [ ] Verify hash changes still emit `hashChangeComplete`
- [ ] Verify PostHog pageview tracking still works correctly
- [ ] Test browser back/forward navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)