### PR TITLE
[connectors] feat(Gong): allow setting/displaying permission profiles

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -3,6 +3,7 @@ import { baseUrlFromConnectionId } from "@connectors/connectors/gong/lib/oauth";
 import {
   fetchGongConfiguration,
   fetchGongConnector,
+  getGongClient,
 } from "@connectors/connectors/gong/lib/utils";
 import {
   QUEUE_NAME,
@@ -46,6 +47,10 @@ const TRACKERS_CONFIG_KEY = "gongTrackersEnabled";
 
 const ACCOUNTS_CONFIG_KEY = "gongAccountsEnabled";
 
+const PERMISSION_PROFILE_ID_CONFIG_KEY = "gongPermissionProfileId";
+
+const PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
+
 // This function generates a connector-wise unique schedule ID for the Gong sync.
 // The IDs of the workflows spawned by this schedule will follow the pattern:
 //   gong-sync-${connectorId}-workflow-${isoFormatDate}
@@ -86,6 +91,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
         baseUrl: baseUrlRes.value,
         trackersEnabled: false,
         accountsEnabled: false,
+        permissionProfileId: null,
       }
     );
 
@@ -333,6 +339,21 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
         return new Ok(configuration.trackersEnabled.toString());
       case ACCOUNTS_CONFIG_KEY:
         return new Ok(configuration.accountsEnabled.toString());
+      case PERMISSION_PROFILE_ID_CONFIG_KEY:
+        return new Ok(configuration.permissionProfileId ?? null);
+      case PERMISSION_PROFILES_CONFIG_KEY: {
+        // Consider adding caching here.
+        const gongClient = await getGongClient(connector);
+        const workspaces = await gongClient.getWorkspaces();
+        const firstWorkspace = workspaces[0];
+        if (!firstWorkspace) {
+          return new Ok(JSON.stringify([]));
+        }
+        const profiles = await gongClient.getPermissionProfiles({
+          workspaceId: firstWorkspace.id,
+        });
+        return new Ok(JSON.stringify(profiles));
+      }
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
@@ -389,6 +410,19 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       }
       case ACCOUNTS_CONFIG_KEY: {
         await configuration.setAccountsEnabled(configValue === "true");
+
+        return new Ok(undefined);
+      }
+      case PERMISSION_PROFILE_ID_CONFIG_KEY: {
+        const profileId = configValue || null;
+        logger.info(
+          {
+            connectorId: connector.id,
+            permissionProfileId: profileId,
+          },
+          "[Gong] Update permission profile."
+        );
+        await configuration.setPermissionProfileId(profileId);
 
         return new Ok(undefined);
       }

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -127,6 +127,14 @@ export class GongConfigurationResource extends BaseResource<GongConfigurationMod
     });
   }
 
+  async setPermissionProfileId(
+    permissionProfileId: string | null
+  ): Promise<void> {
+    await this.update({
+      permissionProfileId,
+    });
+  }
+
   async setRetentionPeriodDays(
     retentionPeriodDays: number | null
   ): Promise<void> {


### PR DESCRIPTION
## Description

- This PR allows setting a permission profile for a Gong connector via `setConfigurationKey`.
- Also allows retrieving both the list of available configs and the currently selected configuration via `getConfigurationKey`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
