### PR TITLE
[front] feat(Gong): add front end to set/get permission profiles

### DIFF
--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -219,15 +219,15 @@ export function GongOptionComponent({
                   size="sm"
                   label={
                     selectedProfile
-                      ? selectedProfile.name.length > 20
-                        ? selectedProfile.name.slice(0, 20) + "..."
+                      ? selectedProfile.name.length > 15
+                        ? selectedProfile.name.slice(0, 15) + "..."
                         : selectedProfile.name
                       : "All calls"
                   }
                   isSelect
                   disabled={readOnly || !isAdmin || loading}
                   tooltip={selectedProfile?.name}
-                  className="w-36 overflow-hidden px-4"
+                  className="w-40 overflow-hidden px-4"
                 />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -249,11 +249,9 @@ export function GongOptionComponent({
         >
           <ContextItem.Description>
             <div className="text-muted-foreground dark:text-muted-foreground-night">
-              Select a Gong Permission Profile to restrict which calls are
-              synced. Only calls with at least one participant from the
-              profile&apos;s user list will be synced.
-              <br />
-              Changing the profile only affects future syncs.
+              Only calls with at least one participant from the profile&apos;s
+              user list will be synced. Changing the profile only affects future
+              syncs.
             </div>
           </ContextItem.Description>
         </ContextItem>

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -8,16 +8,35 @@ import {
   Button,
   ContentMessage,
   ContextItem,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   GongLogo,
   Input,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 // TODO(2025-03-17): share these variables between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 const GONG_TRACKERS_CONFIG_KEY = "gongTrackersEnabled";
 const GONG_ACCOUNTS_CONFIG_KEY = "gongAccountsEnabled";
+const GONG_PERMISSION_PROFILE_ID_CONFIG_KEY = "gongPermissionProfileId";
+const GONG_PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
+
+interface GongPermissionProfile {
+  id: string;
+  name: string;
+}
+
+function isGongPermissionProfile(value: unknown): value is GongPermissionProfile {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return typeof obj.id === "string" && typeof obj.name === "string";
+}
 
 function checkIsNonNegativeInteger(value: string) {
   return /^[0-9]+$/.test(value);
@@ -65,6 +84,46 @@ export function GongOptionComponent({
   });
   const accountsEnabled = accountsConfigValue === "true";
 
+  const {
+    configValue: permissionProfileIdConfigValue,
+    mutateConfig: mutatePermissionProfileIdConfig,
+  } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
+  });
+
+  const { configValue: permissionProfilesConfigValue } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: GONG_PERMISSION_PROFILES_CONFIG_KEY,
+  });
+
+  const permissionProfiles = useMemo<GongPermissionProfile[]>(() => {
+    if (!permissionProfilesConfigValue) {
+      return [];
+    }
+    try {
+      const parsed: unknown = JSON.parse(permissionProfilesConfigValue);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.filter(isGongPermissionProfile);
+    } catch {
+      return [];
+    }
+  }, [permissionProfilesConfigValue]);
+
+  const selectedProfile = useMemo(() => {
+    if (!permissionProfileIdConfigValue) {
+      return null;
+    }
+    return (
+      permissionProfiles.find((p) => p.id === permissionProfileIdConfigValue) ??
+      null
+    );
+  }, [permissionProfileIdConfigValue, permissionProfiles]);
+
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     retentionPeriodConfigValue || ""
@@ -73,6 +132,7 @@ export function GongOptionComponent({
   const [loading, setLoading] = useState(false);
   const sendNotification = useSendNotification();
 
+  // TODO: fix the auto-save pattern here and replace with an actual save on the sheet.
   const handleConfigUpdate = async (configKey: string, newValue: string) => {
     // Validate that the value is either empty or a positive integer
     if (
@@ -99,23 +159,32 @@ export function GongOptionComponent({
       }
     );
     if (res.ok) {
-      if (configKey === GONG_RETENTION_PERIOD_CONFIG_KEY) {
-        await mutateRetentionPeriodConfig();
-      } else if (configKey === GONG_TRACKERS_CONFIG_KEY) {
-        await mutateTrackersConfig();
-      } else if (configKey === GONG_ACCOUNTS_CONFIG_KEY) {
-        await mutateAccountsConfig();
+      let description: string;
+      switch (configKey) {
+        case GONG_RETENTION_PERIOD_CONFIG_KEY:
+          await mutateRetentionPeriodConfig();
+          description = "Retention period successfully updated.";
+          break;
+        case GONG_TRACKERS_CONFIG_KEY:
+          await mutateTrackersConfig();
+          description = "Trackers synchronization successfully updated.";
+          break;
+        case GONG_ACCOUNTS_CONFIG_KEY:
+          await mutateAccountsConfig();
+          description = "Accounts synchronization successfully updated.";
+          break;
+        case GONG_PERMISSION_PROFILE_ID_CONFIG_KEY:
+          await mutatePermissionProfileIdConfig();
+          description = "Permission profile successfully updated.";
+          break;
+        default:
+          description = "Configuration successfully updated.";
       }
       setLoading(false);
       sendNotification({
         type: "success",
         title: "Gong configuration updated",
-        description:
-          configKey === GONG_RETENTION_PERIOD_CONFIG_KEY
-            ? "Retention period successfully updated."
-            : (configKey === GONG_TRACKERS_CONFIG_KEY
-                ? "Trackers"
-                : "Accounts") + " synchronization successfully updated.",
+        description,
       });
     } else {
       setLoading(false);
@@ -137,6 +206,58 @@ export function GongOptionComponent({
       </ContentMessage>
 
       <ContextItem.List>
+        <ContextItem
+          title="Permission Profile"
+          visual={<ContextItem.Visual visual={GongLogo} />}
+          action={
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  label={selectedProfile?.name ?? "All calls"}
+                  isSelect
+                  disabled={readOnly || !isAdmin || loading}
+                  className="w-48 truncate"
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuItem
+                  label="All calls"
+                  onClick={() =>
+                    handleConfigUpdate(
+                      GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
+                      ""
+                    )
+                  }
+                />
+                {permissionProfiles.map((profile) => (
+                  <DropdownMenuItem
+                    key={profile.id}
+                    label={profile.name}
+                    onClick={() =>
+                      handleConfigUpdate(
+                        GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
+                        profile.id
+                      )
+                    }
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          }
+        >
+          <ContextItem.Description>
+            <div className="text-muted-foreground dark:text-muted-foreground-night">
+              Select a Gong Permission Profile to restrict which calls are
+              synced. Only calls with at least one participant from the
+              profile&apos;s user list will be synced.
+              <br />
+              Changing the profile only affects future syncs.
+            </div>
+          </ContextItem.Description>
+        </ContextItem>
+
         <ContextItem
           title="Retention Period"
           visual={<ContextItem.Visual visual={GongLogo} />}

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -227,7 +227,7 @@ export function GongOptionComponent({
                   isSelect
                   disabled={readOnly || !isAdmin || loading}
                   tooltip={selectedProfile?.name}
-                  className="w-48 overflow-hidden px-4"
+                  className="w-36 overflow-hidden px-4"
                 />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -227,6 +227,7 @@ export function GongOptionComponent({
                   isSelect
                   disabled={readOnly || !isAdmin || loading}
                   tooltip={selectedProfile?.name}
+                  className="w-48 overflow-hidden px-4"
                 />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -30,7 +30,9 @@ interface GongPermissionProfile {
   name: string;
 }
 
-function isGongPermissionProfile(value: unknown): value is GongPermissionProfile {
+function isGongPermissionProfile(
+  value: unknown
+): value is GongPermissionProfile {
   if (typeof value !== "object" || value === null) {
     return false;
   }
@@ -215,10 +217,16 @@ export function GongOptionComponent({
                 <Button
                   variant="outline"
                   size="sm"
-                  label={selectedProfile?.name ?? "All calls"}
+                  label={
+                    selectedProfile
+                      ? selectedProfile.name.length > 20
+                        ? selectedProfile.name.slice(0, 20) + "..."
+                        : selectedProfile.name
+                      : "All calls"
+                  }
                   isSelect
                   disabled={readOnly || !isAdmin || loading}
-                  className="w-48 truncate"
+                  tooltip={selectedProfile?.name}
                 />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start">

--- a/front/lib/connector_providers_ui.ts
+++ b/front/lib/connector_providers_ui.ts
@@ -422,7 +422,9 @@ export const CONNECTOR_UI_CONFIGURATIONS: Record<
       unselected: "none",
     },
     limitations:
-      "OAuth requires Gong administrator access. All transcripts from the workspace will be synchronized with Dust, except those marked as private in Gong.",
+      "OAuth requires Gong administrator access. All transcripts from the workspace will be synchronized with Dust, " +
+      "except those marked as private in Gong. A Permission Profile can be selected to restrict synced calls to " +
+      "participants from that profile.",
     mismatchError: `You cannot change the Gong account. Please add a new Gong connection instead.`,
   },
   dust_project: {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -93,6 +93,8 @@ async function handler(
       "gongRetentionPeriodDays",
       "gongTrackersEnabled",
       "gongAccountsEnabled",
+      "gongPermissionProfileId",
+      "gongPermissionProfiles",
       "privateIntegrationCredentialId",
     ].includes(configKey)
   ) {


### PR DESCRIPTION
## Description

- This PR adds a way to select and check out the currently selected permission profiles in connectors permission modal.
- Currently takes the form of a dropdown with only the name of the profile.
- We'll be able to add the permission level, the description for a richer UI (see [documentation](https://gong.app.gong.io/settings/api/documentation#get-/v2/permission-profile)).

<img width="686" height="761" alt="Screenshot 2026-02-24 at 12 32 30 AM" src="https://github.com/user-attachments/assets/74b12acf-ec5a-4410-bef2-ef455f9e1205" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
