### PR TITLE
Block editing within suggestion range

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -426,6 +426,62 @@ function createPlugin(getHighlightedId: () => string | null) {
         );
       },
     },
+
+    filterTransaction(tr, state) {
+      // Allow transactions that don't modify the document (e.g., selection changes, metadata)
+      if (!tr.docChanged) {
+        return true;
+      }
+
+      // Allow transactions with our plugin's metadata (accepting/rejecting suggestions)
+      if (tr.getMeta(pluginKey)) {
+        return true;
+      }
+
+      const pluginState = pluginKey.getState(state);
+      if (!pluginState || pluginState.suggestions.size === 0) {
+        return true;
+      }
+
+      // For each suggestion, find the block range and check if the transaction modifies it
+      for (const suggestion of pluginState.suggestions.values()) {
+        for (const op of suggestion.operations) {
+          const found = findBlockByBlockId(state.doc, op.targetBlockId);
+          if (!found) {
+            continue;
+          }
+
+          // Check content range (excluding block boundaries)
+          const contentStart = found.pos + 1;
+          const contentEnd = found.pos + found.node.nodeSize - 1;
+
+          // Check if any step in the transaction affects this block's content
+          for (let i = 0; i < tr.steps.length; i++) {
+            const map = tr.mapping.slice(0, i);
+            const mappedStart = map.map(contentStart);
+            const mappedEnd = map.map(contentEnd);
+
+            let affectsBlock = false;
+            tr.mapping.maps[i].forEach((oldStart, oldEnd) => {
+              // Check if the modification overlaps with the suggestion block content
+              if (
+                (oldStart >= mappedStart && oldStart < mappedEnd) ||
+                (oldEnd > mappedStart && oldEnd <= mappedEnd) ||
+                (oldStart <= mappedStart && oldEnd >= mappedEnd)
+              ) {
+                affectsBlock = true;
+              }
+            });
+
+            if (affectsBlock) {
+              return false;
+            }
+          }
+        }
+      }
+
+      return true;
+    },
   });
 }
 

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -46,12 +46,12 @@ export const SUGGESTION_ID_ATTRIBUTE = "data-suggestion-id";
 
 const CLASSES = {
   remove:
-    "suggestion-deletion rounded line-through bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200",
+    "suggestion-deletion rounded line-through bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200 cursor-default",
   removeDimmed:
-    "suggestion-deletion rounded line-through bg-red-50 dark:bg-red-900/20 text-gray-400",
-  add: "suggestion-addition rounded bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200",
+    "suggestion-deletion rounded line-through bg-red-50 dark:bg-red-900/20 text-gray-400 cursor-default",
+  add: "suggestion-addition rounded bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 cursor-default",
   addDimmed:
-    "suggestion-addition rounded bg-blue-50 dark:bg-blue-900/20 text-gray-400",
+    "suggestion-addition rounded bg-blue-50 dark:bg-blue-900/20 text-gray-400 cursor-default",
 };
 
 export function diffBlockContent(
@@ -367,6 +367,22 @@ function buildDecorations(
   return DecorationSet.create(state.doc, decorations);
 }
 
+// Check if a transaction step modifies a specific range
+function stepModifiesRange(
+  step: { forEach: (f: (oldStart: number, oldEnd: number) => void) => void },
+  rangeStart: number,
+  rangeEnd: number
+): boolean {
+  let modifies = false;
+  step.forEach((oldStart, oldEnd) => {
+    // Ranges overlap if they don't end before or start after each other
+    if (oldEnd > rangeStart && oldStart < rangeEnd) {
+      modifies = true;
+    }
+  });
+  return modifies;
+}
+
 function createPlugin(getHighlightedId: () => string | null) {
   return new Plugin<PluginState>({
     key: pluginKey,
@@ -428,13 +444,7 @@ function createPlugin(getHighlightedId: () => string | null) {
     },
 
     filterTransaction(tr, state) {
-      // Allow transactions that don't modify the document (e.g., selection changes, metadata)
-      if (!tr.docChanged) {
-        return true;
-      }
-
-      // Allow transactions with our plugin's metadata (accepting/rejecting suggestions)
-      if (tr.getMeta(pluginKey)) {
+      if (!tr.docChanged || tr.getMeta(pluginKey)) {
         return true;
       }
 
@@ -443,7 +453,7 @@ function createPlugin(getHighlightedId: () => string | null) {
         return true;
       }
 
-      // For each suggestion, find the block range and check if the transaction modifies it
+      // Block modifications to any suggestion block content
       for (const suggestion of pluginState.suggestions.values()) {
         for (const op of suggestion.operations) {
           const found = findBlockByBlockId(state.doc, op.targetBlockId);
@@ -451,29 +461,14 @@ function createPlugin(getHighlightedId: () => string | null) {
             continue;
           }
 
-          // Check content range (excluding block boundaries)
           const contentStart = found.pos + 1;
           const contentEnd = found.pos + found.node.nodeSize - 1;
 
-          // Check if any step in the transaction affects this block's content
           for (let i = 0; i < tr.steps.length; i++) {
-            const map = tr.mapping.slice(0, i);
-            const mappedStart = map.map(contentStart);
-            const mappedEnd = map.map(contentEnd);
+            const mappedStart = tr.mapping.slice(0, i).map(contentStart);
+            const mappedEnd = tr.mapping.slice(0, i).map(contentEnd);
 
-            let affectsBlock = false;
-            tr.mapping.maps[i].forEach((oldStart, oldEnd) => {
-              // Check if the modification overlaps with the suggestion block content
-              if (
-                (oldStart >= mappedStart && oldStart < mappedEnd) ||
-                (oldEnd > mappedStart && oldEnd <= mappedEnd) ||
-                (oldStart <= mappedStart && oldEnd >= mappedEnd)
-              ) {
-                affectsBlock = true;
-              }
-            });
-
-            if (affectsBlock) {
+            if (stepModifiesRange(tr.mapping.maps[i], mappedStart, mappedEnd)) {
               return false;
             }
           }

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -453,24 +453,33 @@ function createPlugin(getHighlightedId: () => string | null) {
         return true;
       }
 
-      // Block modifications to any suggestion block content
+      // Collect all suggestion block content ranges upfront to avoid redundant lookups.
+      // Typical case: 1-5 suggestions with 1-2 operations each = ~10 ranges max.
+      // Even with 20 suggestions × 5 operations × 5 steps = 500 iterations, this is negligible.
+      const suggestionRanges: Array<{ start: number; end: number }> = [];
       for (const suggestion of pluginState.suggestions.values()) {
         for (const op of suggestion.operations) {
           const found = findBlockByBlockId(state.doc, op.targetBlockId);
-          if (!found) {
-            continue;
+          if (found) {
+            suggestionRanges.push({
+              start: found.pos + 1,
+              end: found.pos + found.node.nodeSize - 1,
+            });
           }
+        }
+      }
 
-          const contentStart = found.pos + 1;
-          const contentEnd = found.pos + found.node.nodeSize - 1;
+      // Check each transaction step against all suggestion ranges.
+      // This is O(steps × ranges) but typically O(1-5 × 1-10) = ~50 operations max.
+      for (let i = 0; i < tr.steps.length; i++) {
+        const map = tr.mapping.slice(0, i);
 
-          for (let i = 0; i < tr.steps.length; i++) {
-            const mappedStart = tr.mapping.slice(0, i).map(contentStart);
-            const mappedEnd = tr.mapping.slice(0, i).map(contentEnd);
+        for (const range of suggestionRanges) {
+          const mappedStart = map.map(range.start);
+          const mappedEnd = map.map(range.end);
 
-            if (stepModifiesRange(tr.mapping.maps[i], mappedStart, mappedEnd)) {
-              return false;
-            }
+          if (stepModifiesRange(tr.mapping.maps[i], mappedStart, mappedEnd)) {
+            return false;
           }
         }
       }


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/6324
## Description
We were correctly blocking edits within a suggested addition, but if you typed near one it would get formatted as a suggested deletion, deletions were editable, and pressing enter/delete near suggestions caused super weird behavior because we lost track of start/end indeces and our formatting would shift entirely.
This fix completely blocks edits within entire suggestion blocks, and changes the cursor to default from the text cursor so it is more clear to users they can't type within blocks.
this does not prevent users from typing in the text box in sections that do not have a pending suggestion
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
