### PR TITLE
[connectors] feat(Gong): filter transcripts based on permission profile

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -223,7 +223,7 @@ export type GongPermissionProfile = t.TypeOf<typeof GongPermissionProfileCodec>;
 const GongPermissionProfileResponseCodec = t.intersection([
   t.type({
     requestId: t.string,
-    permissionProfile: GongPermissionProfileCodec,
+    profile: GongPermissionProfileCodec,
   }),
   CatchAllCodec,
 ]);
@@ -570,6 +570,6 @@ export class GongClient {
       { profileId },
       GongPermissionProfileResponseCodec
     );
-    return response.permissionProfile;
+    return response.profile;
   }
 }

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -65,17 +65,23 @@ async function resolvePermissionProfile(
 }
 
 /**
- * A call should be synced if any of its participants (host, invitee, attendee)
- * belongs to the permission profile's user list. When no profile is configured
- * all calls pass.
+ * Returns true if the transcript should be synced.
+ * Excludes private calls. When a permission profile is configured, only syncs
+ * calls where at least one participant belongs to the profile's user list.
  */
 function shouldSyncTranscript(
-  filter: PermissionProfileFilter,
-  parties: { userId: string | undefined }[]
+  metadata: GongTranscriptMetadata,
+  filter: PermissionProfileFilter
 ): boolean {
+  if (metadata.metaData.isPrivate) {
+    return false;
+  }
+
   if (filter.type === "unrestricted") {
     return true;
   }
+
+  const { parties = [] } = metadata;
   return parties.some((p) => p.userId && filter.userIds.has(p.userId));
 }
 
@@ -264,25 +270,15 @@ export async function gongSyncTranscriptsActivity({
         return;
       }
 
-      // Always filter out private transcripts.
-      if (transcriptMetadata.metaData.isPrivate === true) {
+      if (!shouldSyncTranscript(transcriptMetadata, permissionFilter)) {
         logger.info(
           { ...loggerArgs, callId: transcript.callId },
-          "[Gong] Skipping private transcript."
+          "[Gong] Skipping transcript (private or filtered by permission profile)."
         );
         return;
       }
 
       const { parties = [] } = transcriptMetadata;
-
-      // Filter by permission profile: skip if no party belongs to the profile.
-      if (!shouldSyncTranscript(permissionFilter, parties)) {
-        logger.info(
-          { ...loggerArgs, callId: transcript.callId },
-          "[Gong] Skipping transcript: not allowed by permission profile."
-        );
-        return;
-      }
 
       const participants = await getGongUsers(connector, {
         gongUserIds: parties

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -34,6 +34,51 @@ import { removeNulls } from "@connectors/types/shared/utils/general";
 
 const GARBAGE_COLLECT_BATCH_SIZE = 100;
 
+type PermissionProfileFilter =
+  | { type: "unrestricted" }
+  | { type: "restricted"; userIds: Set<string> };
+
+async function resolvePermissionProfile(
+  connector: ConnectorResource,
+  configuration: GongConfigurationResource
+): Promise<PermissionProfileFilter> {
+  const { permissionProfileId } = configuration;
+  if (!permissionProfileId) {
+    return { type: "unrestricted" };
+  }
+
+  const gongClient = await getGongClient(connector);
+  const profile = await gongClient.getPermissionProfile({
+    profileId: permissionProfileId,
+  });
+
+  if (profile.callsAccess.permissionLevel === "all") {
+    return { type: "unrestricted" };
+  }
+
+  const { teamLeadIds } = profile.callsAccess;
+  if (!teamLeadIds || teamLeadIds.length === 0) {
+    return { type: "unrestricted" };
+  }
+
+  return { type: "restricted", userIds: new Set(teamLeadIds) };
+}
+
+/**
+ * A call should be synced if any of its participants (host, invitee, attendee)
+ * belongs to the permission profile's user list. When no profile is configured
+ * all calls pass.
+ */
+function shouldSyncTranscript(
+  filter: PermissionProfileFilter,
+  parties: { userId: string | undefined }[]
+): boolean {
+  if (filter.type === "unrestricted") {
+    return true;
+  }
+  return parties.some((p) => p.userId && filter.userIds.has(p.userId));
+}
+
 export async function gongSaveStartSyncActivity({
   connectorId,
 }: {
@@ -201,6 +246,12 @@ export async function gongSyncTranscriptsActivity({
     callsMetadata.map((c) => [c.metaData.id, c])
   );
 
+  // Consider moving this in a dedicated activity that will be shared across pages.
+  const permissionFilter = await resolvePermissionProfile(
+    connector,
+    configuration
+  );
+
   await concurrentExecutor(
     transcriptsToSync,
     async (transcript) => {
@@ -223,6 +274,15 @@ export async function gongSyncTranscriptsActivity({
       }
 
       const { parties = [] } = transcriptMetadata;
+
+      // Filter by permission profile: skip if no party belongs to the profile.
+      if (!shouldSyncTranscript(permissionFilter, parties)) {
+        logger.info(
+          { ...loggerArgs, callId: transcript.callId },
+          "[Gong] Skipping transcript: not allowed by permission profile."
+        );
+        return;
+      }
 
       const participants = await getGongUsers(connector, {
         gongUserIds: parties

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -72,18 +72,18 @@ async function resolvePermissionProfile(
 function shouldSyncTranscript(
   metadata: GongTranscriptMetadata,
   filter: PermissionProfileFilter
-): { shouldSync: boolean; reason: string } {
+): { shouldSync: false; reason: string } | { shouldSync: true; reason: null } {
   if (metadata.metaData.isPrivate) {
     return { shouldSync: false, reason: "transcript is private" };
   }
 
   if (filter.type === "unrestricted") {
-    return { shouldSync: true, reason: "no permission profile restriction" };
+    return { shouldSync: true, reason: null };
   }
 
   const { parties = [] } = metadata;
   if (parties.some((p) => p.userId && filter.userIds.has(p.userId))) {
-    return { shouldSync: true, reason: "allowed by permission profile" };
+    return { shouldSync: true, reason: null };
   }
 
   return {

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -65,24 +65,31 @@ async function resolvePermissionProfile(
 }
 
 /**
- * Returns true if the transcript should be synced.
+ * Determines whether a transcript should be synced.
  * Excludes private calls. When a permission profile is configured, only syncs
  * calls where at least one participant belongs to the profile's user list.
  */
 function shouldSyncTranscript(
   metadata: GongTranscriptMetadata,
   filter: PermissionProfileFilter
-): boolean {
+): { shouldSync: boolean; reason: string } {
   if (metadata.metaData.isPrivate) {
-    return false;
+    return { shouldSync: false, reason: "transcript is private" };
   }
 
   if (filter.type === "unrestricted") {
-    return true;
+    return { shouldSync: true, reason: "no permission profile restriction" };
   }
 
   const { parties = [] } = metadata;
-  return parties.some((p) => p.userId && filter.userIds.has(p.userId));
+  if (parties.some((p) => p.userId && filter.userIds.has(p.userId))) {
+    return { shouldSync: true, reason: "allowed by permission profile" };
+  }
+
+  return {
+    shouldSync: false,
+    reason: "no participant matches the permission profile",
+  };
 }
 
 export async function gongSaveStartSyncActivity({
@@ -270,10 +277,14 @@ export async function gongSyncTranscriptsActivity({
         return;
       }
 
-      if (!shouldSyncTranscript(transcriptMetadata, permissionFilter)) {
+      const { shouldSync, reason } = shouldSyncTranscript(
+        transcriptMetadata,
+        permissionFilter
+      );
+      if (!shouldSync) {
         logger.info(
-          { ...loggerArgs, callId: transcript.callId },
-          "[Gong] Skipping transcript (private or filtered by permission profile)."
+          { ...loggerArgs, callId: transcript.callId, reason },
+          `[Gong] Skipping transcript.`
         );
         return;
       }


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C07Q0576XSP/p1771611894284519).
- This PR allows filtering transcripts to sync based on the selected permission profile if any.
- Note: only modes supported are the `"SPECIFIC TEAMS"` and the `"ALL"` ones where they specify specific team members.
- The `"THEIR OWN"` mode is not supported as the API does not allow checking which user is authenticated.
- On initial investigation, the other modes would rely on a relatively risky mapping of the org so out of scope for now.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.