### PR TITLE
[connectors,front] feat(Gong): flag unsupported permission profile rendering

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -1,9 +1,9 @@
 import { makeGongTranscriptFolderInternalId } from "@connectors/connectors/gong/lib/internal_ids";
 import { baseUrlFromConnectionId } from "@connectors/connectors/gong/lib/oauth";
+import { fetchPermissionProfileViews } from "@connectors/connectors/gong/lib/permission_profiles";
 import {
   fetchGongConfiguration,
   fetchGongConnector,
-  getGongClient,
 } from "@connectors/connectors/gong/lib/utils";
 import {
   QUEUE_NAME,
@@ -342,17 +342,8 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       case PERMISSION_PROFILE_ID_CONFIG_KEY:
         return new Ok(configuration.permissionProfileId ?? null);
       case PERMISSION_PROFILES_CONFIG_KEY: {
-        // Consider adding caching here.
-        const gongClient = await getGongClient(connector);
-        const workspaces = await gongClient.getWorkspaces();
-        const firstWorkspace = workspaces[0];
-        if (!firstWorkspace) {
-          return new Ok(JSON.stringify([]));
-        }
-        const profiles = await gongClient.getPermissionProfiles({
-          workspaceId: firstWorkspace.id,
-        });
-        return new Ok(JSON.stringify(profiles));
+        const views = await fetchPermissionProfileViews(connector);
+        return new Ok(JSON.stringify(views));
       }
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));

--- a/connectors/src/connectors/gong/lib/permission_profiles.ts
+++ b/connectors/src/connectors/gong/lib/permission_profiles.ts
@@ -2,11 +2,11 @@ import type { GongPermissionProfile } from "@connectors/connectors/gong/lib/gong
 import { getGongClient } from "@connectors/connectors/gong/lib/utils";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-const SUPPORTED_PERMISSION_LEVELS: readonly string[] = ["all", "none"];
+type PermissionLevel = GongPermissionProfile["callsAccess"]["permissionLevel"];
 
-function isSupportedPermissionLevel(
-  permissionLevel: GongPermissionProfile["callsAccess"]["permissionLevel"]
-): boolean {
+const SUPPORTED_PERMISSION_LEVELS: readonly PermissionLevel[] = ["all", "none"];
+
+function isSupportedPermissionLevel(permissionLevel: PermissionLevel): boolean {
   return SUPPORTED_PERMISSION_LEVELS.includes(permissionLevel);
 }
 

--- a/connectors/src/connectors/gong/lib/permission_profiles.ts
+++ b/connectors/src/connectors/gong/lib/permission_profiles.ts
@@ -4,7 +4,9 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 
 const SUPPORTED_PERMISSION_LEVELS: readonly string[] = ["all", "none"];
 
-function isSupportedPermissionLevel(permissionLevel: string): boolean {
+function isSupportedPermissionLevel(
+  permissionLevel: GongPermissionProfile["callsAccess"]["permissionLevel"]
+): boolean {
   return SUPPORTED_PERMISSION_LEVELS.includes(permissionLevel);
 }
 

--- a/connectors/src/connectors/gong/lib/permission_profiles.ts
+++ b/connectors/src/connectors/gong/lib/permission_profiles.ts
@@ -1,0 +1,52 @@
+import type { GongPermissionProfile } from "@connectors/connectors/gong/lib/gong_api";
+import { getGongClient } from "@connectors/connectors/gong/lib/utils";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+
+const SUPPORTED_PERMISSION_LEVELS: readonly string[] = ["all", "none"];
+
+function isSupportedPermissionLevel(permissionLevel: string): boolean {
+  return SUPPORTED_PERMISSION_LEVELS.includes(permissionLevel);
+}
+
+export interface GongPermissionProfileView {
+  id: string;
+  name: string;
+  permissionLevel: string;
+  supported: boolean;
+  reason: string | null;
+}
+
+export function renderPermissionProfiles(
+  profiles: GongPermissionProfile[]
+): GongPermissionProfileView[] {
+  return profiles.map((p) => {
+    const { permissionLevel } = p.callsAccess;
+    const supported = isSupportedPermissionLevel(permissionLevel);
+
+    return {
+      id: p.id,
+      name: p.name,
+      permissionLevel,
+      supported,
+      reason: supported
+        ? null
+        : `Permission level "${permissionLevel}" is not supported. ` +
+          `Only "all" and "specific teams" profiles can be used.`,
+    };
+  });
+}
+
+export async function fetchPermissionProfileViews(
+  connector: ConnectorResource
+): Promise<GongPermissionProfileView[]> {
+  const gongClient = await getGongClient(connector);
+  const workspaces = await gongClient.getWorkspaces();
+  const firstWorkspace = workspaces[0];
+  if (!firstWorkspace) {
+    return [];
+  }
+  const profiles = await gongClient.getPermissionProfiles({
+    workspaceId: firstWorkspace.id,
+  });
+  return renderPermissionProfiles(profiles);
+}

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -175,11 +175,7 @@ function PermissionProfileSelector({
               const item = (
                 <DropdownMenuItem
                   key={profile.id}
-                  label={
-                    profile.supported
-                      ? profile.name
-                      : `${profile.name} (unsupported)`
-                  }
+                  label={profile.name}
                   disabled={!profile.supported}
                   onClick={() => handleSelect(profile.id)}
                 />

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -3,6 +3,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType } from "@app/types/data_source";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -28,6 +29,9 @@ const GONG_PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
 interface GongPermissionProfile {
   id: string;
   name: string;
+  permissionLevel: string;
+  supported: boolean;
+  reason: string | null;
 }
 
 function isGongPermissionProfile(
@@ -36,12 +40,161 @@ function isGongPermissionProfile(
   if (typeof value !== "object" || value === null) {
     return false;
   }
-  const obj = value as Record<string, unknown>;
-  return typeof obj.id === "string" && typeof obj.name === "string";
+  return (
+    "id" in value &&
+    isString(value.id) &&
+    "name" in value &&
+    isString(value.name) &&
+    "permissionLevel" in value &&
+    isString(value.permissionLevel) &&
+    "supported" in value &&
+    typeof value.supported === "boolean" &&
+    "reason" in value &&
+    (value.reason === null || isString(value.reason))
+  );
 }
 
 function checkIsNonNegativeInteger(value: string) {
   return /^[0-9]+$/.test(value);
+}
+
+interface PermissionProfileSelectorProps {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+  disabled: boolean;
+}
+
+function PermissionProfileSelector({
+  owner,
+  dataSource,
+  disabled,
+}: PermissionProfileSelectorProps) {
+  const sendNotification = useSendNotification();
+  const [loading, setLoading] = useState(false);
+
+  const {
+    configValue: permissionProfileIdConfigValue,
+    mutateConfig: mutatePermissionProfileIdConfig,
+  } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
+  });
+
+  const { configValue: permissionProfilesConfigValue } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: GONG_PERMISSION_PROFILES_CONFIG_KEY,
+  });
+
+  const permissionProfiles = useMemo<GongPermissionProfile[]>(() => {
+    if (!permissionProfilesConfigValue) {
+      return [];
+    }
+    try {
+      const parsed: unknown = JSON.parse(permissionProfilesConfigValue);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.filter(isGongPermissionProfile);
+    } catch {
+      return [];
+    }
+  }, [permissionProfilesConfigValue]);
+
+  const selectedProfile = useMemo(() => {
+    if (!permissionProfileIdConfigValue) {
+      return null;
+    }
+    return (
+      permissionProfiles.find((p) => p.id === permissionProfileIdConfigValue) ??
+      null
+    );
+  }, [permissionProfileIdConfigValue, permissionProfiles]);
+
+  const handleSelect = async (profileId: string) => {
+    setLoading(true);
+    // The config API only accepts strings, so "" means "no filter" (normalized
+    // to null on the connector side).
+    const res = await clientFetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${GONG_PERMISSION_PROFILE_ID_CONFIG_KEY}`,
+      {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        body: JSON.stringify({ configValue: profileId }),
+      }
+    );
+    if (res.ok) {
+      await mutatePermissionProfileIdConfig();
+      sendNotification({
+        type: "success",
+        title: "Gong configuration updated",
+        description: "Permission profile successfully updated.",
+      });
+    } else {
+      const err = await res.json();
+      sendNotification({
+        type: "error",
+        title: "Failed to update Gong configuration",
+        description: normalizeError(err).message || "An unknown error occurred",
+      });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <ContextItem
+      title="Permission Profile"
+      visual={<ContextItem.Visual visual={GongLogo} />}
+      action={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              label={
+                selectedProfile
+                  ? selectedProfile.name.length > 15
+                    ? selectedProfile.name.slice(0, 15) + "..."
+                    : selectedProfile.name
+                  : "All calls"
+              }
+              isSelect
+              disabled={disabled || loading}
+              tooltip={selectedProfile?.name}
+              className="w-40 overflow-hidden px-4"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem
+              label="All calls"
+              onClick={() => handleSelect("")}
+            />
+            {permissionProfiles.map((profile) => (
+              <DropdownMenuItem
+                key={profile.id}
+                label={
+                  profile.supported
+                    ? profile.name
+                    : `${profile.name} (unsupported)`
+                }
+                disabled={!profile.supported}
+                description={profile.reason ?? undefined}
+                onClick={() => handleSelect(profile.id)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    >
+      <ContextItem.Description>
+        <div className="text-muted-foreground dark:text-muted-foreground-night">
+          Only calls with at least one participant from the profile&apos;s user
+          list will be synced. Changing the profile only affects future syncs.
+        </div>
+      </ContextItem.Description>
+    </ContextItem>
+  );
 }
 
 interface GongOptionComponentProps {
@@ -85,46 +238,6 @@ export function GongOptionComponent({
     configKey: GONG_ACCOUNTS_CONFIG_KEY,
   });
   const accountsEnabled = accountsConfigValue === "true";
-
-  const {
-    configValue: permissionProfileIdConfigValue,
-    mutateConfig: mutatePermissionProfileIdConfig,
-  } = useConnectorConfig({
-    owner,
-    dataSource,
-    configKey: GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
-  });
-
-  const { configValue: permissionProfilesConfigValue } = useConnectorConfig({
-    owner,
-    dataSource,
-    configKey: GONG_PERMISSION_PROFILES_CONFIG_KEY,
-  });
-
-  const permissionProfiles = useMemo<GongPermissionProfile[]>(() => {
-    if (!permissionProfilesConfigValue) {
-      return [];
-    }
-    try {
-      const parsed: unknown = JSON.parse(permissionProfilesConfigValue);
-      if (!Array.isArray(parsed)) {
-        return [];
-      }
-      return parsed.filter(isGongPermissionProfile);
-    } catch {
-      return [];
-    }
-  }, [permissionProfilesConfigValue]);
-
-  const selectedProfile = useMemo(() => {
-    if (!permissionProfileIdConfigValue) {
-      return null;
-    }
-    return (
-      permissionProfiles.find((p) => p.id === permissionProfileIdConfigValue) ??
-      null
-    );
-  }, [permissionProfileIdConfigValue, permissionProfiles]);
 
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -175,10 +288,6 @@ export function GongOptionComponent({
           await mutateAccountsConfig();
           description = "Accounts synchronization successfully updated.";
           break;
-        case GONG_PERMISSION_PROFILE_ID_CONFIG_KEY:
-          await mutatePermissionProfileIdConfig();
-          description = "Permission profile successfully updated.";
-          break;
         default:
           description = "Configuration successfully updated.";
       }
@@ -208,62 +317,11 @@ export function GongOptionComponent({
       </ContentMessage>
 
       <ContextItem.List>
-        <ContextItem
-          title="Permission Profile"
-          visual={<ContextItem.Visual visual={GongLogo} />}
-          action={
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  label={
-                    selectedProfile
-                      ? selectedProfile.name.length > 15
-                        ? selectedProfile.name.slice(0, 15) + "..."
-                        : selectedProfile.name
-                      : "All calls"
-                  }
-                  isSelect
-                  disabled={readOnly || !isAdmin || loading}
-                  tooltip={selectedProfile?.name}
-                  className="w-40 overflow-hidden px-4"
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                <DropdownMenuItem
-                  label="All calls"
-                  onClick={() =>
-                    handleConfigUpdate(
-                      GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
-                      ""
-                    )
-                  }
-                />
-                {permissionProfiles.map((profile) => (
-                  <DropdownMenuItem
-                    key={profile.id}
-                    label={profile.name}
-                    onClick={() =>
-                      handleConfigUpdate(
-                        GONG_PERMISSION_PROFILE_ID_CONFIG_KEY,
-                        profile.id
-                      )
-                    }
-                  />
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          }
-        >
-          <ContextItem.Description>
-            <div className="text-muted-foreground dark:text-muted-foreground-night">
-              Only calls with at least one participant from the profile&apos;s
-              user list will be synced. Changing the profile only affects future
-              syncs.
-            </div>
-          </ContextItem.Description>
-        </ContextItem>
+        <PermissionProfileSelector
+          owner={owner}
+          dataSource={dataSource}
+          disabled={readOnly || !isAdmin || loading}
+        />
 
         <ContextItem
           title="Retention Period"

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownTooltipTrigger,
   GongLogo,
   Input,
   SliderToggle,
@@ -170,19 +171,31 @@ function PermissionProfileSelector({
               label="All calls"
               onClick={() => handleSelect("")}
             />
-            {permissionProfiles.map((profile) => (
-              <DropdownMenuItem
-                key={profile.id}
-                label={
-                  profile.supported
-                    ? profile.name
-                    : `${profile.name} (unsupported)`
-                }
-                disabled={!profile.supported}
-                description={profile.reason ?? undefined}
-                onClick={() => handleSelect(profile.id)}
-              />
-            ))}
+            {permissionProfiles.map((profile) => {
+              const item = (
+                <DropdownMenuItem
+                  key={profile.id}
+                  label={
+                    profile.supported
+                      ? profile.name
+                      : `${profile.name} (unsupported)`
+                  }
+                  disabled={!profile.supported}
+                  onClick={() => handleSelect(profile.id)}
+                />
+              );
+              if (profile.reason) {
+                return (
+                  <DropdownTooltipTrigger
+                    key={profile.id}
+                    description={profile.reason}
+                  >
+                    {item}
+                  </DropdownTooltipTrigger>
+                );
+              }
+              return item;
+            })}
           </DropdownMenuContent>
         </DropdownMenu>
       }

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -158,7 +158,8 @@ function PermissionProfileSelector({
               label={
                 selectedProfile
                   ? selectedProfile.name.length > PROFILE_NAME_MAX_LENGTH
-                    ? selectedProfile.name.slice(0, PROFILE_NAME_MAX_LENGTH) + "..."
+                    ? selectedProfile.name.slice(0, PROFILE_NAME_MAX_LENGTH) +
+                      "..."
                     : selectedProfile.name
                   : "All calls"
               }

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -27,6 +27,8 @@ const GONG_ACCOUNTS_CONFIG_KEY = "gongAccountsEnabled";
 const GONG_PERMISSION_PROFILE_ID_CONFIG_KEY = "gongPermissionProfileId";
 const GONG_PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
 
+const PROFILE_NAME_MAX_LENGTH = 15;
+
 interface GongPermissionProfile {
   id: string;
   name: string;
@@ -155,8 +157,8 @@ function PermissionProfileSelector({
               size="sm"
               label={
                 selectedProfile
-                  ? selectedProfile.name.length > 15
-                    ? selectedProfile.name.slice(0, 15) + "..."
+                  ? selectedProfile.name.length > PROFILE_NAME_MAX_LENGTH
+                    ? selectedProfile.name.slice(0, PROFILE_NAME_MAX_LENGTH) + "..."
                     : selectedProfile.name
                   : "All calls"
               }


### PR DESCRIPTION
## Description

- This PR improves how permission profiles are rendered in the UI by flagging those that are actually not supported.

<img width="486" alt="Screenshot 2026-02-24 at 1 40 00 AM" src="https://github.com/user-attachments/assets/99713001-c87f-420e-97e2-780c51519e88" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Deploy front.
