### PR TITLE
Posthog cookieless tracking

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -16,7 +16,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { useCookies } from "react-cookie";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const POSTHOG_INITIALIZED_KEY = "dust-ph-init";
 
 const EXCLUDED_PATHS = [
   "/poke",
@@ -120,15 +119,22 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
     return pathname.startsWith(path) || pathname.endsWith(path);
   });
 
-  const shouldTrack = isTrackablePage && hasAcceptedCookies;
-
   const lastIdentifiedWorkspaceId = useRef<string | null>(null);
   const lastPlanPropertiesString = useRef<string | null>(null);
   const hasInitialized = useRef(false);
+  const hasUpgradedPersistence = useRef(false);
+  const lastIdentifiedUserId = useRef<string | null>(null);
 
-  // Initialize PostHog once
+  // Phase 1: Initialize PostHog with memory-only persistence (no cookies).
+  // This captures events for all visitors including anonymous ad traffic,
+  // without setting any cookies or using localStorage (GDPR-compliant).
   useEffect(() => {
-    if (!POSTHOG_KEY || posthog.__loaded || hasInitialized.current) {
+    if (
+      !POSTHOG_KEY ||
+      !isTrackablePage ||
+      posthog.__loaded ||
+      hasInitialized.current
+    ) {
       return;
     }
 
@@ -136,17 +142,21 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
       api_host: `${config.getApiBaseUrl()}/subtle1`,
       person_profiles: "identified_only",
       defaults: "2025-05-24",
-      opt_out_capturing_by_default: !shouldTrack,
+      persistence: "memory",
       capture_pageview: true,
       capture_pageleave: false,
       autocapture: false,
+      disable_session_recording: true,
       property_denylist: ["$ip"],
       before_send: (event) => {
         if (!event) {
           return null;
         }
 
-        // Read marketing parameters from sessionStorage (populated by useStripUtmParams).
+        // Inject marketing parameters from sessionStorage/cookies into every
+        // event. This is needed because memory persistence can't auto-capture
+        // UTM params across page loads, and URLs may have been stripped by
+        // useStripUtmParams.
         const storedParams = getStoredUTMParams();
         for (const param of MARKETING_PARAMS) {
           const storedValue = storedParams[param];
@@ -155,14 +165,6 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
           }
         }
 
-        // Strip query parameters from URLs for privacy.
-        if (event.properties.$current_url) {
-          event.properties.$current_url =
-            event.properties.$current_url.split("?")[0];
-        }
-        if (event.properties.$pathname) {
-          event.properties.$pathname = event.properties.$pathname.split("?")[0];
-        }
         return event;
       },
       session_recording: {
@@ -173,54 +175,50 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
     });
 
     hasInitialized.current = true;
-  }, [shouldTrack]);
+  }, [isTrackablePage]);
 
-  // Handle opt-in and user identification (once per user via localStorage)
-  const prevShouldTrack = useRef(shouldTrack);
+  // Phase 2: Upgrade to full cookie persistence and enable session recording
+  // once the user has accepted cookies (consent banner or login).
   useEffect(() => {
-    if (!posthog.__loaded || !hasInitialized.current) {
+    if (
+      !posthog.__loaded ||
+      !hasInitialized.current ||
+      !hasAcceptedCookies ||
+      hasUpgradedPersistence.current
+    ) {
       return;
     }
 
-    const trackingStateChanged = prevShouldTrack.current !== shouldTrack;
-    if (!trackingStateChanged) {
+    posthog.set_config({
+      persistence: "localStorage+cookie",
+      disable_session_recording: false,
+    });
+    posthog.startSessionRecording();
+    hasUpgradedPersistence.current = true;
+  }, [hasAcceptedCookies]);
+
+  // Identify user after consent is given. Handles both cases:
+  // consent-then-login and login-then-consent.
+  useEffect(() => {
+    if (
+      !posthog.__loaded ||
+      !hasInitialized.current ||
+      !hasAcceptedCookies ||
+      !user
+    ) {
       return;
     }
 
-    if (shouldTrack) {
-      const initializedUserId =
-        typeof window !== "undefined"
-          ? localStorage.getItem(POSTHOG_INITIALIZED_KEY)
-          : null;
-      const needsInitialization = user
-        ? initializedUserId !== user.sId
-        : !initializedUserId;
-
-      if (needsInitialization) {
-        posthog.opt_in_capturing();
-
-        if (user) {
-          posthog.identify(user.sId);
-        }
-
-        if (typeof window !== "undefined") {
-          localStorage.setItem(
-            POSTHOG_INITIALIZED_KEY,
-            user?.sId ?? "anonymous"
-          );
-        }
-      }
-    } else {
-      posthog.opt_out_capturing();
+    if (lastIdentifiedUserId.current !== user.sId) {
+      posthog.identify(user.sId);
+      lastIdentifiedUserId.current = user.sId;
     }
+  }, [hasAcceptedCookies, user]);
 
-    prevShouldTrack.current = shouldTrack;
-  }, [shouldTrack, user]);
-
-  // Group users by workspace and set workspace properties (admin only)
+  // Group users by workspace and set workspace properties (admin only).
   const lastUserRole = useRef<string | null>(null);
   useEffect(() => {
-    if (!posthog.__loaded || !workspaceId || !shouldTrack) {
+    if (!posthog.__loaded || !workspaceId || !hasAcceptedCookies) {
       return;
     }
 
@@ -249,14 +247,14 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
   }, [
     workspaceId,
     planProperties,
-    shouldTrack,
+    hasAcceptedCookies,
     isAdmin,
     currentWorkspace?.role,
   ]);
 
   // Track pageviews on route changes.
   useEffect(() => {
-    if (!posthog.__loaded || !shouldTrack) {
+    if (!posthog.__loaded || !isTrackablePage) {
       return;
     }
 
@@ -278,7 +276,7 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
     return () => {
       router.events.off("routeChangeComplete", handleRouteChange);
     };
-  }, [router.events, router.pathname, shouldTrack]);
+  }, [router.events, router.pathname, isTrackablePage]);
 
   return null;
 }

--- a/front/hooks/useStripUtmParams.ts
+++ b/front/hooks/useStripUtmParams.ts
@@ -3,6 +3,7 @@ import {
   extractUTMParams,
   MARKETING_PARAMS,
   persistClickIdCookies,
+  persistUTMCookies,
 } from "@app/lib/utils/utm";
 import { useEffect } from "react";
 
@@ -26,6 +27,7 @@ export function useStripUtmParams() {
       if (Object.keys(utmData).length > 0) {
         sessionStorage.setItem("utm_data", JSON.stringify(utmData));
         persistClickIdCookies(utmData);
+        persistUTMCookies(utmData);
 
         const url = new URL(window.location.href);
         let hasMarketingParam = false;

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -117,6 +117,9 @@ const config = {
   getServiceAccount: (): string => {
     return EnvironmentConfig.getEnvVariable("SERVICE_ACCOUNT");
   },
+  getPostHogApiKey: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("NEXT_PUBLIC_POSTHOG_KEY");
+  },
   getCustomerIoSiteId: (): string => {
     return EnvironmentConfig.getEnvVariable("CUSTOMERIO_SITE_ID");
   },

--- a/front/lib/tracking/posthog/server.ts
+++ b/front/lib/tracking/posthog/server.ts
@@ -1,0 +1,79 @@
+import config from "@app/lib/api/config";
+import type { UTMParams } from "@app/lib/utils/utm";
+import logger from "@app/logger/logger";
+import type { UserType } from "@app/types/user";
+import { PostHog } from "posthog-node";
+
+const POSTHOG_HOST = "https://eu.i.posthog.com";
+
+let posthogClient: PostHog | null = null;
+
+function getClient(): PostHog | null {
+  if (posthogClient) {
+    return posthogClient;
+  }
+
+  const apiKey = config.getPostHogApiKey();
+  if (!apiKey) {
+    return null;
+  }
+
+  posthogClient = new PostHog(apiKey, { host: POSTHOG_HOST });
+  return posthogClient;
+}
+
+export class PostHogServerSideTracking {
+  static trackSignup({
+    user,
+    utmParams,
+    userCreated,
+  }: {
+    user: UserType;
+    utmParams?: UTMParams;
+    userCreated?: boolean;
+  }): void {
+    const client = getClient();
+    if (!client) {
+      return;
+    }
+
+    try {
+      const utmProperties: Record<string, string> = {};
+      if (utmParams) {
+        for (const [key, value] of Object.entries(utmParams)) {
+          if (value) {
+            utmProperties[key] = value;
+          }
+        }
+      }
+
+      client.identify({
+        distinctId: user.sId,
+        properties: {
+          email: user.email,
+          first_name: user.firstName,
+          last_name: user.lastName,
+          name: user.fullName,
+          provider: user.provider,
+          ...utmProperties,
+        },
+      });
+
+      if (userCreated) {
+        client.capture({
+          distinctId: user.sId,
+          event: "signup",
+          properties: {
+            provider: user.provider,
+            ...utmProperties,
+          },
+        });
+      }
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, err },
+        "Failed to track signup on PostHog"
+      );
+    }
+  }
+}

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -2,6 +2,8 @@ import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
+import { PostHogServerSideTracking } from "@app/lib/tracking/posthog/server";
+import type { UTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -23,8 +25,32 @@ import * as _ from "lodash";
 import type { UserResource } from "../resources/user_resource";
 
 export class ServerSideTracking {
-  static trackSignup(_: { user: UserType }) {
-    // Do nothing for now
+  static trackSignup({
+    user,
+    utmParams,
+    userCreated,
+  }: {
+    user: UserType;
+    utmParams?: UTMParams;
+    userCreated?: boolean;
+  }) {
+    try {
+      CustomerioServerSideTracking.trackSignup({ user });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, err },
+        "Failed to track signup on Customer.io"
+      );
+    }
+
+    try {
+      PostHogServerSideTracking.trackSignup({ user, utmParams, userCreated });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, err },
+        "Failed to track signup on PostHog"
+      );
+    }
   }
 
   static async trackGetUser({ user }: { user: UserTypeWithWorkspaces }) {

--- a/front/lib/utils/utm.ts
+++ b/front/lib/utils/utm.ts
@@ -15,6 +15,18 @@ export type UTMParams = Partial<
   Record<(typeof MARKETING_PARAMS)[number], string>
 >;
 
+// UTM parameter keys (separate from click IDs).
+const UTM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+] as const;
+
+// Standard attribution window for UTM cookies.
+const UTM_COOKIE_EXPIRY_DAYS = 30;
+
 // Click ID keys that should be persisted as first-party cookies.
 const CLICK_ID_KEYS = ["gclid", "fbclid", "msclkid", "li_fat_id"] as const;
 
@@ -63,6 +75,43 @@ export function persistClickIdCookies(params: UTMParams): void {
   }
 }
 
+// Write UTM parameter values as first-party cookies.
+export function persistUTMCookies(params: UTMParams): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  for (const key of UTM_KEYS) {
+    const value = params[key];
+    if (value) {
+      const expires = new Date(
+        Date.now() + UTM_COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+      ).toUTCString();
+      document.cookie = `_dust_${key}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
+    }
+  }
+}
+
+// Read UTM cookies back as UTMParams.
+function getUTMCookies(): UTMParams {
+  if (typeof document === "undefined") {
+    return {};
+  }
+
+  const params: UTMParams = {};
+  const cookies = document.cookie.split("; ");
+
+  for (const key of UTM_KEYS) {
+    const prefix = `_dust_${key}=`;
+    const cookie = cookies.find((c) => c.startsWith(prefix));
+    if (cookie) {
+      params[key] = decodeURIComponent(cookie.slice(prefix.length));
+    }
+  }
+
+  return params;
+}
+
 // Read click ID cookies back as UTMParams.
 function getClickIdCookies(): UTMParams {
   if (typeof document === "undefined") {
@@ -83,19 +132,20 @@ function getClickIdCookies(): UTMParams {
   return params;
 }
 
-// Get stored UTM parameters from sessionStorage, with cookie fallback for click IDs.
+// Get stored UTM parameters from sessionStorage, with cookie fallback for click IDs and UTM params.
 export const getStoredUTMParams = (): UTMParams => {
   if (typeof window === "undefined") {
     return {};
   }
 
   try {
-    const cookieParams = getClickIdCookies();
+    const clickIdCookieParams = getClickIdCookies();
+    const utmCookieParams = getUTMCookies();
     const storedData = sessionStorage.getItem("utm_data");
     const sessionParams: UTMParams = storedData ? JSON.parse(storedData) : {};
 
-    // sessionStorage wins when both present.
-    return { ...cookieParams, ...sessionParams };
+    // Cookies provide the base, sessionStorage wins when both present.
+    return { ...clickIdCookieParams, ...utmCookieParams, ...sessionParams };
   } catch {
     return {};
   }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -96,6 +96,8 @@ async function handler(
       fullName: user.name,
       lastLoginAt: user.lastLoginAt?.getTime() ?? null,
     },
+    utmParams,
+    userCreated,
   });
 
   const isInviteOnOtherWorkspace =


### PR DESCRIPTION



## Description

PostHog was previously gated behind cookie consent, missing first-time visitors from paid ads entirely. This switches to a two-phase initialization: Phase 1 initializes PostHog with memory-only persistence (no cookies or localStorage, GDPR-safe) to capture all visits including anonymous ad traffic. Phase 2 upgrades to cookie persistence and enables session recording after consent. Additionally, UTM parameters are now persisted as first-party cookies with a 30-day expiry window (extending the existing click-ID cookie pattern), fixing attribution loss across tabs. Finally, wires up posthog-node server-side to identify users and capture signup events with UTM properties attached at signup, closing the gap where attribution data was stored in workspace metadata but never sent to PostHog.

## Risk

PostHog now initializes for all visitors (using memory-only storage before consent), which is a behavioral change from the previous cookie-gated approach. The memory persistence is GDPR-compliant as it doesn't persist data across sessions.

