### PR TITLE
Fix mention

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -299,7 +299,7 @@ export const InputBar = React.memo(function InputBar({
       setIsLocalSubmitting(true);
 
       try {
-        await onSubmit(markdown, mentions, {
+        const submitPromise = onSubmit(markdown, mentions, {
           uploaded: fileUploaderService.getFileBlobs().map((cf) => {
             return {
               title: cf.filename,
@@ -311,10 +311,13 @@ export const InputBar = React.memo(function InputBar({
           contentNodes: attachedNodes,
         });
 
+        // Execute these operations in parallel with the submission.
         resetEditorText();
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
+
+        await submitPromise;
       } finally {
         setIsLocalSubmitting(false);
       }


### PR DESCRIPTION
## Description

Fix a race condition in the InputBar where the input state (draft, files, attached nodes) was only cleared after `onSubmit` resolved. This caused mentions and other input state to persist briefly after submission, leading to stale mention data.

The fix separates the `onSubmit` call from the state cleanup: the submit promise is started, the input state is cleared immediately, and then the promise is awaited. This ensures the UI resets right away without waiting for the submission to complete.

## Tests

Manual — verify that mentions, file uploads, and attached nodes are cleared immediately on submit.

## Risk

Low — the change only reorders when state cleanup happens relative to the async submit. Rollback is safe.

## Deploy Plan

Standard front deploy.