### PR TITLE
Display model and total time in poke

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -190,7 +190,8 @@ const AgentMessageView = ({
           )}
           {message.modelInteractionDurationMs != null && (
             <>
-              {" • "}LLM: {(message.modelInteractionDurationMs / 1000).toFixed(1)}s
+              {" • "}LLM:{" "}
+              {(message.modelInteractionDurationMs / 1000).toFixed(1)}s
             </>
           )}
           {message.completionDurationMs != null && (

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -188,6 +188,16 @@ const AgentMessageView = ({
               ))}
             </>
           )}
+          {message.modelInteractionDurationMs != null && (
+            <>
+              {" • "}LLM: {(message.modelInteractionDurationMs / 1000).toFixed(1)}s
+            </>
+          )}
+          {message.completionDurationMs != null && (
+            <>
+              {" • "}total: {(message.completionDurationMs / 1000).toFixed(1)}s
+            </>
+          )}
         </div>
         {message.actions.map((a, i) => {
           const isExpanded = expandedActions.has(i);


### PR DESCRIPTION
## Description

Helps local debugging without langfuse.

Look at the end of the line:
<img width="874" height="47" alt="Screenshot 2026-02-24 at 10 57 44" src="https://github.com/user-attachments/assets/07b00c2d-14f8-448c-8fe6-4be1fd76cb8b" />


## Tests


## Risk

Poke only

## Deploy Plan

Front