### PR TITLE
Optimize frame lookup

### DIFF
--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -33,7 +33,10 @@ function setStoredRegionInfo({ name, url }: RegionInfo): void {
 
 export interface RegionContextValue {
   regionInfo: RegionInfo | null;
-  setRegionInfo: (regionInfo: RegionInfo) => void;
+  setRegionInfo: (
+    regionInfo: RegionInfo,
+    options?: { keepInStorage?: boolean }
+  ) => void;
   isReady: boolean;
 }
 
@@ -72,12 +75,14 @@ export function RegionProvider({ children }: { children: React.ReactNode }) {
 
   // Manual region switch.
   const setRegionInfo = useCallback(
-    (regionInfo: RegionInfo) => {
+    (regionInfo: RegionInfo, options?: { keepInStorage?: boolean }) => {
       // Update ref synchronously before anything else.
       currentUrlRef.current = regionInfo.url;
 
       // Update state and storage.
-      setStoredRegionInfo(regionInfo);
+      if (options?.keepInStorage) {
+        setStoredRegionInfo(regionInfo);
+      }
       setCurrentRegionInfo(regionInfo);
 
       // Invalidate all SWR cache to refetch with new region.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -3,6 +3,7 @@
 
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import {
   getPrivateUploadBucket,
   getPublicUploadBucket,
@@ -148,8 +149,36 @@ export class FileResource extends BaseResource<FileModel> {
     content: string;
     shareScope: FileShareScope;
   } | null> {
-    if (!validate(token)) {
+    const r = await this.fetchByShareToken(token);
+    if (r.isErr()) {
       return null;
+    }
+
+    const { file, shareScope, workspace } = r.value;
+    const content = await file.getFileContent(workspace, "original");
+    if (!content) {
+      return null;
+    }
+
+    return {
+      file,
+      content,
+      shareScope,
+    };
+  }
+
+  static async fetchByShareToken(token: string): Promise<
+    Result<
+      {
+        file: FileResource;
+        shareScope: FileShareScope;
+        workspace: LightWorkspaceType;
+      },
+      DustError
+    >
+  > {
+    if (!validate(token)) {
+      return new Err(new DustError("invalid_id", "Invalid share token"));
     }
 
     const shareableFile = await this.shareableFileModel.findOne({
@@ -160,14 +189,14 @@ export class FileResource extends BaseResource<FileModel> {
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
     if (!shareableFile) {
-      return null;
+      return new Err(new DustError("file_not_found", "Share not found"));
     }
 
     const [workspace] = await WorkspaceResource.fetchByModelIds([
       shareableFile.workspaceId,
     ]);
     if (!workspace) {
-      return null;
+      return new Err(new DustError("internal_error", "Workspace not found"));
     }
 
     const file = await this.model.findOne({
@@ -179,7 +208,7 @@ export class FileResource extends BaseResource<FileModel> {
 
     const fileRes = file ? new this(this.model, file.get()) : null;
     if (!fileRes) {
-      return null;
+      return new Err(new DustError("file_not_found", "File not found"));
     }
 
     // Check if associated conversation still exist (not soft-deleted).
@@ -203,24 +232,17 @@ export class FileResource extends BaseResource<FileModel> {
         { dangerouslySkipPermissionFiltering: true }
       );
       if (!conversation) {
-        return null;
+        return new Err(
+          new DustError("conversation_not_found", "Conversation not found")
+        );
       }
     }
 
-    const content = await fileRes.getFileContent(
-      renderLightWorkspaceType({ workspace }),
-      "original"
-    );
-
-    if (!content) {
-      return null;
-    }
-
-    return {
+    return new Ok({
       file: fileRes,
-      content,
+      workspace: renderLightWorkspaceType({ workspace }),
       shareScope: shareableFile.shareScope,
-    };
+    });
   }
 
   static async unsafeFetchByIdInWorkspace(

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -595,10 +595,13 @@ export function useAuthContext(
   // Handle region redirect.
   useEffect(() => {
     if (regionRedirect && regionContext) {
-      regionContext.setRegionInfo({
-        name: regionRedirect.region,
-        url: regionRedirect.url,
-      });
+      regionContext.setRegionInfo(
+        {
+          name: regionRedirect.region,
+          url: regionRedirect.url,
+        },
+        { keepInStorage: true }
+      );
       void mutate();
     }
   }, [regionRedirect, mutate, regionContext]);
@@ -702,10 +705,13 @@ export function useJoinData({
   // Handle region redirect.
   useEffect(() => {
     if (regionRedirect && regionContext) {
-      regionContext.setRegionInfo({
-        name: regionRedirect.region,
-        url: regionRedirect.url,
-      });
+      regionContext.setRegionInfo(
+        {
+          name: regionRedirect.region,
+          url: regionRedirect.url,
+        },
+        { keepInStorage: true }
+      );
       void mutate();
     }
   }, [regionRedirect, mutate, regionContext]);

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -216,10 +216,10 @@ async function handler(
             },
           });
         }
-        const result = await FileResource.fetchByShareTokenWithContent(
+        const result = await FileResource.fetchByShareToken(
           bodyValidation.right.token
         );
-        response = { exists: !!result };
+        response = { exists: result.isOk() };
       }
       break;
 

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -3,6 +3,7 @@ import { config as regionConfig } from "@app/lib/api/regions/config";
 import { lookupShareToken } from "@app/lib/api/regions/lookup";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isInteractiveContentType } from "@app/types/files";
@@ -41,22 +42,30 @@ async function handler(
     });
   }
 
-  const result = await FileResource.fetchByShareTokenWithContent(token);
-  if (!result) {
-    // Not found locally — check other region.
-    const lookupResult = await lookupShareToken(token);
-    if (lookupResult.isOk() && lookupResult.value) {
-      const region = lookupResult.value;
-      return res.status(400).json({
-        error: {
-          type: "workspace_in_different_region",
-          message: "File is located in a different region",
-          redirect: {
-            region,
-            url: regionConfig.getRegionUrl(region),
+  const result = await FileResource.fetchByShareToken(token);
+  if (result.isErr()) {
+    if (result.error.code === "file_not_found") {
+      // Not found locally — check other region.
+      const lookupResult = await lookupShareToken(token);
+      if (lookupResult.isErr()) {
+        logger.error(
+          { err: lookupResult.error },
+          "Failed to lookup share token in other region"
+        );
+      }
+      if (lookupResult.isOk() && lookupResult.value) {
+        const region = lookupResult.value;
+        return res.status(400).json({
+          error: {
+            type: "workspace_in_different_region",
+            message: "File is located in a different region",
+            redirect: {
+              region,
+              url: regionConfig.getRegionUrl(region),
+            },
           },
-        },
-      });
+        });
+      }
     }
 
     return apiError(req, res, {
@@ -68,7 +77,7 @@ async function handler(
     });
   }
 
-  const { file, shareScope } = result;
+  const { file, shareScope } = result.value;
 
   // Only allow Frame files.
   if (!isInteractiveContentType(file.contentType)) {


### PR DESCRIPTION
## Summary
- Extract `FileResource.fetchByShareToken()` from `fetchByShareTokenWithContent()` to avoid fetching file content when only checking existence (lookup endpoint)
- Return typed `Result<..., DustError>` instead of `null` from `fetchByShareToken()`, with specific error codes (`file_not_found`, `conversation_not_found`, `internal_error`)
- Only trigger cross-region lookup when the error is `file_not_found` (not for other failures like missing conversation)
- Add `keepInStorage` option to `setRegionInfo()` — defaults to **not persisting** to localStorage, so callers must explicitly opt-in. This prevents automatic region redirects (share, poke) from creating stale region overrides

## Test plan
- [ ] Verify shared frames still load correctly (same region)
- [ ] Verify cross-region share token lookup triggers redirect when file not found locally
- [ ] Verify no cross-region lookup for other error types (e.g. deleted conversation)
- [ ] Verify region redirect from share/poke pages doesn't persist in localStorage
- [ ] Verify explicit region switches (e.g. poke dropdown) still persist when passing `keepInStorage: true`

## Risk
Low — refactors existing lookup to be more precise about when to trigger cross-region calls and avoids unnecessary file content fetching. The `keepInStorage` default change is safe since automatic redirects should not override user's stored region preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)