### PR TITLE
Improve client-side MCP server SSE resilience

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -16,7 +16,7 @@ interface GetMCPEventsForServerOptions {
   lastEventId?: string;
 }
 
-const MCP_EVENTS_TIMEOUT = 1 * 60 * 1000; // 1 minute.
+const MCP_EVENTS_TIMEOUT = 5 * 60 * 1000; // 5 minutes.
 
 export async function* getMCPEventsForServer(
   auth: Authenticator,

--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -16,7 +16,7 @@ interface GetMCPEventsForServerOptions {
   lastEventId?: string;
 }
 
-const MCP_EVENTS_TIMEOUT = 5 * 60 * 1000; // 5 minutes.
+const MCP_EVENTS_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes.
 
 export async function* getMCPEventsForServer(
   auth: Authenticator,
@@ -52,7 +52,7 @@ export async function* getMCPEventsForServer(
       }
       const rawEvent = await Promise.race([
         callbackReader.next(),
-        setTimeoutAsync(MCP_EVENTS_TIMEOUT),
+        setTimeoutAsync(MCP_EVENTS_TIMEOUT_MS),
       ]);
 
       // Determine if we timeouted.

--- a/front/lib/api/sse_redirect.ts
+++ b/front/lib/api/sse_redirect.ts
@@ -8,6 +8,7 @@
 const SSE_REDIRECT_PATTERNS = [
   /^\/api\/(v1\/)?w\/[^/]+\/assistant\/conversations\/[^/]+\/events$/,
   /^\/api\/(v1\/)?w\/[^/]+\/assistant\/conversations\/[^/]+\/messages\/[^/]+\/events$/,
+  /^\/api\/(v1\/)?w\/[^/]+\/mcp\/requests$/,
 ];
 
 /**

--- a/front/pages/api/sse/v1/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/sse/v1/w/[wId]/mcp/requests.ts
@@ -1,0 +1,1 @@
+export { default } from "@app/pages/api/v1/w/[wId]/mcp/requests";

--- a/front/pages/api/sse/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/sse/w/[wId]/mcp/requests.ts
@@ -1,0 +1,1 @@
+export { default } from "@app/pages/api/w/[wId]/mcp/requests";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at improving the resilience of the client-side MCP server. While steady time is acceptable, we have very slow spikes making the copilot experience pretty slow.

This PR increases the SSE idle timeout from 1 minute to 5 minutes, reducing unnecessary reconnections that cause latency spikes and routes MCP SSE connections to dedicated `front-sse` pods so they don't compete with regular API traffic

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] First deploy `front-sse`
- [ ] Deploy `front`