### PR TITLE
[LLM-ROUTER] Count Anthropic reasoning tokens

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -29,7 +29,9 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { dustManagedCredentials } from "@app/types/api/credentials";
+import type { WorkspaceType } from "@app/types/user";
 
 /**
  * Maps prompt sections to Anthropic system blocks.
@@ -66,6 +68,7 @@ function buildSystemBlocks(
 
 export class AnthropicLLM extends LLM {
   private client: Anthropic;
+  private workspace: WorkspaceType;
 
   constructor(
     auth: Authenticator,
@@ -83,6 +86,8 @@ export class AnthropicLLM extends LLM {
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
     });
+
+    this.workspace = auth.getNonNullableWorkspace();
   }
 
   async *internalStream({
@@ -134,13 +139,22 @@ export class AnthropicLLM extends LLM {
         output_format: toOutputFormatParam(this.responseFormat),
       } as Parameters<typeof this.client.beta.messages.stream>[0]);
 
-      const countTokens =
-        this.reasoningEffort === "none" ||
-        (this.reasoningEffort === "light" &&
-          this.modelConfig.useNativeLightReasoning)
-          ? undefined
-          : (body: MessageCountTokensParams) =>
-              this.client.messages.countTokens(body);
+      const isCountReasoningTokenEnabled =
+        await FeatureFlagResource.isEnabledForWorkspace(
+          this.workspace,
+          "anthropic_reasoning_token_count"
+        );
+
+      const shouldCountReasoningTokens =
+        isCountReasoningTokenEnabled &&
+        this.reasoningEffort !== "none" &&
+        (this.reasoningEffort !== "light" ||
+          !!this.modelConfig.useNativeLightReasoning);
+
+      const countTokens = shouldCountReasoningTokens
+        ? (body: MessageCountTokensParams) =>
+            this.client.messages.countTokens(body)
+        : undefined;
 
       yield* streamLLMEvents(events, this.metadata, countTokens);
     } catch (err) {

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -1,4 +1,5 @@
 import Anthropic, { APIError } from "@anthropic-ai/sdk";
+import type { MessageCountTokensParams } from "@anthropic-ai/sdk/resources";
 
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
@@ -133,7 +134,15 @@ export class AnthropicLLM extends LLM {
         output_format: toOutputFormatParam(this.responseFormat),
       } as Parameters<typeof this.client.beta.messages.stream>[0]);
 
-      yield* streamLLMEvents(events, this.metadata);
+      const countTokens =
+        this.reasoningEffort === "none" ||
+        (this.reasoningEffort === "light" &&
+          this.modelConfig.useNativeLightReasoning)
+          ? undefined
+          : (body: MessageCountTokensParams) =>
+              this.client.messages.countTokens(body);
+
+      yield* streamLLMEvents(events, this.metadata, countTokens);
     } catch (err) {
       if (err instanceof APIError) {
         yield handleError(err, this.metadata);

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert";
-
+import type { APIPromise } from "@anthropic-ai/sdk";
 import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
 import type {
-  MessageDeltaUsage,
+  MessageCountTokensParams,
+  MessageParam,
   MessageStreamEvent,
+  MessageTokensCount,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import { validateContentBlockIndex } from "@app/lib/api/llm/clients/anthropic/utils/predicates";
 import type { StreamState } from "@app/lib/api/llm/clients/anthropic/utils/types";
@@ -14,22 +16,37 @@ import type {
   ReasoningGeneratedEvent,
   TextDeltaEvent,
   TextGeneratedEvent,
+  TokenUsage,
   TokenUsageEvent,
   ToolCallEvent,
 } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
+import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import cloneDeep from "lodash/cloneDeep";
 
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
+  countTokensCallback?: (
+    body: MessageCountTokensParams
+  ) => APIPromise<MessageTokensCount>
 ): AsyncGenerator<LLMEvent> {
   const stateContainer = { state: null };
   // Aggregate output items to build a SuccessCompletionEvent at the end of a turn.
   const aggregate = new SuccessAggregate();
+  // Accumulate token usage to return later
+  const tokenUsageAccumulator: Required<TokenUsage> = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedTokens: 0,
+    cacheCreationTokens: 0,
+    uncachedInputTokens: 0,
+    totalTokens: 0,
+    reasoningTokens: 0,
+  };
 
   // There is an issue in Anthropic SDK showcasing that stream events get mutated after they are yielded.
   // https://github.com/anthropics/anthropic-sdk-typescript/issues/777
@@ -41,12 +58,55 @@ export async function* streamLLMEvents(
     for (const ev of handleMessageStreamEvent(
       messageStreamEvent,
       stateContainer,
-      metadata
+      metadata,
+      tokenUsageAccumulator
     )) {
       aggregate.add(ev);
       yield ev;
     }
   }
+
+  const outputTokensWithoutReasoning: MessageParam[] = [];
+
+  if (aggregate.textGenerated) {
+    outputTokensWithoutReasoning.push({
+      content: aggregate.textGenerated.content.text,
+      role: "user" as const,
+    });
+  }
+  if (aggregate.toolCalls) {
+    outputTokensWithoutReasoning.push(
+      ...aggregate.toolCalls.map((call) => ({
+        content: `${call.content.name} ${JSON.stringify(call.content.arguments)}`,
+        role: "user" as const,
+      }))
+    );
+  }
+
+  try {
+    // Anthropic does not send the output token coutn details
+    // This allows a rough estimation of the reasoning tokens
+    const tokenCount = (await countTokensCallback?.({
+      model: metadata.modelId,
+      messages: outputTokensWithoutReasoning,
+    })) ?? {
+      input_tokens: tokenUsageAccumulator.outputTokens,
+    };
+    const reasoningTokens = Math.max(
+      0,
+      tokenUsageAccumulator.outputTokens - tokenCount.input_tokens
+    );
+    tokenUsageAccumulator.reasoningTokens = reasoningTokens;
+    tokenUsageAccumulator.outputTokens =
+      tokenUsageAccumulator.outputTokens - reasoningTokens;
+  } catch (err) {
+    logger.error("✅✅✅✅✅✅ Failed getting token details from Anthropic", {
+      error: err,
+      metadata,
+    });
+  }
+
+  yield tokenUsage(tokenUsageAccumulator, metadata);
 
   yield {
     type: "success",
@@ -61,7 +121,8 @@ export async function* streamLLMEvents(
 function* handleMessageStreamEvent(
   messageStreamEvent: BetaRawMessageStreamEvent,
   stateContainer: { state: StreamState },
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
+  tokenUsageAccumulator: Required<TokenUsage>
 ): Generator<LLMEvent> {
   switch (messageStreamEvent.type) {
     case "message_start":
@@ -100,7 +161,11 @@ function* handleMessageStreamEvent(
       );
       break;
     case "message_delta":
-      yield* handleMessageDelta(messageStreamEvent, metadata);
+      yield* handleMessageDelta(
+        messageStreamEvent,
+        metadata,
+        tokenUsageAccumulator
+      );
       break;
     default:
       assertNever(messageStreamEvent);
@@ -221,9 +286,22 @@ function* handleContentBlockStop(
 
 function* handleMessageDelta(
   event: Extract<BetaRawMessageStreamEvent, { type: "message_delta" }>,
-  metadata: LLMClientMetadata
+  metadata: LLMClientMetadata,
+  tokenUsageAccumulator: Required<TokenUsage>
 ): Generator<LLMEvent> {
-  yield tokenUsage(event.usage, metadata);
+  // Accumulate token usage instead of yielding it
+  const cachedTokens = event.usage.cache_read_input_tokens ?? 0;
+  const cacheCreationTokens = event.usage.cache_creation_input_tokens ?? 0;
+  const uncachedInputTokens = event.usage.input_tokens ?? 0;
+  const inputTokens = uncachedInputTokens + cachedTokens + cacheCreationTokens;
+  const outputTokens = event.usage.output_tokens;
+
+  tokenUsageAccumulator.inputTokens = inputTokens;
+  tokenUsageAccumulator.outputTokens = outputTokens;
+  tokenUsageAccumulator.cachedTokens = cachedTokens;
+  tokenUsageAccumulator.cacheCreationTokens = cacheCreationTokens;
+  tokenUsageAccumulator.uncachedInputTokens = uncachedInputTokens;
+  tokenUsageAccumulator.totalTokens = inputTokens + outputTokens;
 
   if (event.delta.stop_reason) {
     yield* handleStopReason(event.delta.stop_reason, metadata);
@@ -322,25 +400,12 @@ function reasoningGenerated(
 }
 
 function tokenUsage(
-  usage: MessageDeltaUsage,
+  tokenUsageAccumulator: Required<TokenUsage>,
   metadata: LLMClientMetadata
 ): TokenUsageEvent {
-  const cachedTokens = usage.cache_read_input_tokens ?? 0;
-  const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
-  const uncachedInputTokens = usage.input_tokens ?? 0;
-  // Include all input tokens to keep consistency with core implementation
-  const inputTokens = uncachedInputTokens + cachedTokens + cacheCreationTokens;
-
   return {
     type: "token_usage",
-    content: {
-      inputTokens,
-      outputTokens: usage.output_tokens,
-      cachedTokens,
-      cacheCreationTokens,
-      uncachedInputTokens,
-      totalTokens: inputTokens + usage.output_tokens,
-    },
+    content: tokenUsageAccumulator,
     metadata,
   };
 }

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -100,7 +100,7 @@ export async function* streamLLMEvents(
     tokenUsageAccumulator.outputTokens =
       tokenUsageAccumulator.outputTokens - reasoningTokens;
   } catch (err) {
-    logger.error("✅✅✅✅✅✅ Failed getting token details from Anthropic", {
+    logger.error("Failed getting token details from Anthropic", {
       error: err,
       metadata,
     });

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -34,6 +34,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     content: {
       inputTokens: 100,
       outputTokens: 20,
+      reasoningTokens: 0,
       cachedTokens: 0,
       cacheCreationTokens: 0,
       totalTokens: 120,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
@@ -77,6 +77,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       inputTokens: 2500,
       outputTokens: 180,
       cachedTokens: 0,
+      reasoningTokens: 0,
       cacheCreationTokens: 0,
       totalTokens: 2680,
       uncachedInputTokens: 2500,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -65,6 +65,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
       inputTokens: 1766,
       outputTokens: 128,
       cachedTokens: 0,
+      reasoningTokens: 0,
       cacheCreationTokens: 0,
       uncachedInputTokens: 1766,
       totalTokens: 1894,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -229,6 +229,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable slack notifications",
     stage: "dust_only",
   },
+  anthropic_reasoning_token_count: {
+    description:
+      "After a response from Anthropic, make an additional API call to get the reasoning token count for better usage tracking",
+    // Not really on_demand but we want to be able to enable it for customers
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -723,6 +723,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "usage_data_api"
   | "xai_feature"
   | "conversations_slack_notifications"
+  | "anthropic_reasoning_token_count"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Anthropic does not return the details of output tokens
This is a workaround (suggested by Anthropic) to hav an idea of reasoning tokens to be able to estimate a prompt before sending the request
Hoping soling "prompt too long" errors

❌ Drawbacks 
One additional api request per agent loop step

## Tests

local

## Risk

low

## Deploy Plan

front
