### PR TITLE
Tool activity: avoid calling Authenticator.fromJSON twice when calling tool

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -13,7 +13,7 @@ import type {
   AgentLoopExecutionData,
 } from "@app/types/assistant/agent_run";
 import {
-  getAgentLoopData,
+  getAgentLoopDataWithAuth,
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -50,16 +50,23 @@ export async function runToolActivity(
   const auth = authResult.value;
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
-  // Cache conversation fetches to reduce DB load when multiple tool activities run in parallel
-  // during the same step. Each tool would otherwise fetch the same conversation independently.
-  const runAgentDataRes = await getAgentLoopData(authType, {
-    ...runAgentArgs,
-    caching: {
-      useCachedGetConversation: true,
-      unicitySuffix: `${runAgentArgs.agentMessageId}:${runAgentArgs.agentMessageVersion}:${step}`,
-      ttlMs: CONVERSATION_CACHE_TTL_MS,
-    },
-  });
+  const [runAgentDataRes, action] = await startActiveObservation(
+    "get-agent-loop-data",
+    () =>
+      Promise.all([
+        // Cache conversation fetches to reduce DB load when multiple tool activities run in parallel
+        // during the same step. Each tool would otherwise fetch the same conversation independently.
+        getAgentLoopDataWithAuth(auth, {
+          ...runAgentArgs,
+          caching: {
+            useCachedGetConversation: true,
+            unicitySuffix: `${runAgentArgs.agentMessageId}:${runAgentArgs.agentMessageVersion}:${step}`,
+            ttlMs: CONVERSATION_CACHE_TTL_MS,
+          },
+        }),
+        AgentMCPActionResource.fetchByModelIdWithAuth(auth, actionId),
+      ])
+  );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
@@ -73,6 +80,7 @@ export async function runToolActivity(
     }
     throw runAgentDataRes.error;
   }
+  assert(action, "Action not found");
 
   // Heartbeating here as retrieving the agent loop data takes some time.
   heartbeat();
@@ -95,12 +103,6 @@ export async function runToolActivity(
       // sliceConversationForAgentMessage)
       step: step + 1,
     });
-
-  const action = await AgentMCPActionResource.fetchByModelIdWithAuth(
-    auth,
-    actionId
-  );
-  assert(action, "Action not found");
 
   return startActiveObservation(
     `${action.toolConfiguration.mcpServerName}/${action.toolConfiguration.name}`,

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -152,8 +152,23 @@ export async function getAgentLoopData(
       new Error(`Failed to deserialize authenticator: ${authResult.error.code}`)
     );
   }
-  const auth = authResult.value;
 
+  return getAgentLoopDataWithAuth(authResult.value, agentLoopArgs);
+}
+
+/**
+ * Same as getAgentLoopData but accepts a pre-built Authenticator, avoiding redundant
+ * Authenticator.fromJSON calls when the caller already has a valid auth.
+ */
+export async function getAgentLoopDataWithAuth(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs
+): Promise<
+  Result<
+    AgentLoopExecutionData & { auth: Authenticator },
+    AgentLoopDataError | Error
+  >
+> {
   const {
     agentMessageId,
     agentMessageVersion,


### PR DESCRIPTION
## Description

We see a lot of latency before calling the tool in copilot, for instance

<img width="350" height="160" alt="image" src="https://github.com/user-attachments/assets/6a8da623-2b33-47f5-b99f-d9bc43fe4896" />

This PR does 2 things:
 - avoids calling `Authenticator.fromJSON` twice in a row (`getAgentLoopData` does it) so it avoids 3 DB calls:
   - WorkspaceResource.fetchById
   - UserResource.fetchById
   - SubscriptionResource.fetchActiveByWorkspaceModelId
 - call getAgentLoopDataWithAuth and AgentMCPActionResource.fetchByModelIdWithAuth in parallel as they are independant
 - Add active observation to monitor how long it takes to get agent loop data (similar to what is done in runModelAndCreateActionsActivity:  https://github.com/dust-tt/dust/blob/e48eb726ba89477f77ad37b310d8f14eb6597764/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts#L87-L90

Nothing world changing here, but still a win.

## Tests

Tested manually, tool calls are still working

## Risk

low

## Deploy Plan

 - [ ] deploy front
