### PR TITLE
[front] fix: Fix cache invalidation on makeNew

### DIFF
--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { default as cls } from "cls-hooked";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
@@ -15,58 +16,63 @@ vi.mock("@app/lib/api/redis", () => ({
   ),
 }));
 
-vi.mock("@app/lib/utils/cache", () => ({
-  cacheWithRedis: vi
-    .fn()
-    .mockImplementation(
-      <T, Args extends unknown[]>(
-        fn: CacheableFunction<JsonSerializable<T>, Args>,
-        resolver: (...args: Args) => string
-      ) => {
-        return async (...args: Args): Promise<JsonSerializable<T>> => {
-          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
-          const cached = inMemoryCache.get(key);
-          if (cached) {
-            return JSON.parse(cached) as JsonSerializable<T>;
-          }
-          const result = await fn(...args);
-          inMemoryCache.set(key, JSON.stringify(result));
-          return result;
-        };
-      }
-    ),
-  invalidateCacheWithRedis: vi
-    .fn()
-    .mockImplementation(
-      <T, Args extends unknown[]>(
-        fn: CacheableFunction<JsonSerializable<T>, Args>,
-        resolver: (...args: Args) => string
-      ) => {
-        return async (...args: Args): Promise<void> => {
-          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
-          inMemoryCache.delete(key);
-        };
-      }
-    ),
-  batchInvalidateCacheWithRedis: vi
-    .fn()
-    .mockImplementation(
-      <T, Args extends unknown[]>(
-        fn: CacheableFunction<JsonSerializable<T>, Args>,
-        resolver: (...args: Args) => string
-      ) => {
-        return async (argsList: Args[]): Promise<void> => {
-          for (const args of argsList) {
+vi.mock("@app/lib/utils/cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/utils/cache")>();
+  return {
+    ...actual,
+    cacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(
+          fn: CacheableFunction<JsonSerializable<T>, Args>,
+          resolver: (...args: Args) => string
+        ) => {
+          return async (...args: Args): Promise<JsonSerializable<T>> => {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            const cached = inMemoryCache.get(key);
+            if (cached) {
+              return JSON.parse(cached) as JsonSerializable<T>;
+            }
+            const result = await fn(...args);
+            inMemoryCache.set(key, JSON.stringify(result));
+            return result;
+          };
+        }
+      ),
+    invalidateCacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(
+          fn: CacheableFunction<JsonSerializable<T>, Args>,
+          resolver: (...args: Args) => string
+        ) => {
+          return async (...args: Args): Promise<void> => {
             const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
             inMemoryCache.delete(key);
-          }
-        };
-      }
-    ),
-}));
+          };
+        }
+      ),
+    batchInvalidateCacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(
+          fn: CacheableFunction<JsonSerializable<T>, Args>,
+          resolver: (...args: Args) => string
+        ) => {
+          return async (argsList: Args[]): Promise<void> => {
+            for (const args of argsList) {
+              const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+              inMemoryCache.delete(key);
+            }
+          };
+        }
+      ),
+  };
+});
 
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -512,6 +518,47 @@ describe("GroupResource", () => {
 
       // Cache should be invalidated for the initial member
       expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+
+    it("defers cache invalidation until after transaction commits", async () => {
+      // Populate cache first
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      // Get the test's transaction from CLS namespace to create a nested transaction
+      const namespace = cls.getNamespace("test-namespace");
+      const parentTransaction = namespace?.get("transaction");
+      expect(parentTransaction).toBeDefined();
+
+      // Create a nested transaction (savepoint) within the test's transaction
+      const transaction = await frontSequelize.transaction({
+        transaction: parentTransaction,
+      });
+
+      try {
+        // Create group with member inside transaction
+        await GroupResource.makeNew(
+          {
+            name: "Transaction Cache Test",
+            workspaceId: workspace.id,
+            kind: "regular",
+          },
+          { memberIds: [user.id], transaction }
+        );
+
+        // Cache should NOT be invalidated yet (transaction not committed)
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        // Commit the nested transaction (releases savepoint and triggers afterCommit)
+        await transaction.commit();
+
+        // NOW cache should be invalidated
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      } catch (err) {
+        await transaction.rollback();
+        throw err;
+      }
     });
   });
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -17,6 +17,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import {
   batchInvalidateCacheWithRedis,
   cacheWithRedis,
+  invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
 } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
@@ -231,12 +232,13 @@ export class GroupResource extends BaseResource<GroupModel> {
         { transaction }
       );
 
-      // Always invalidate cache - safe even if transaction rolls back
-      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-        memberIds.map((userModelId) => [
-          { user: { id: userModelId }, workspace: { id: workspaceModelId } },
-        ])
-      );
+      invalidateCacheAfterCommit(transaction, async () => {
+        await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+          memberIds.map((userModelId) => [
+            { user: { id: userModelId }, workspace: { id: workspaceModelId } },
+          ])
+        );
+      });
     }
 
     return new this(GroupModel, group.get());
@@ -1342,10 +1344,15 @@ export class GroupResource extends BaseResource<GroupModel> {
       { transaction }
     );
 
-    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
-    await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-      users.map((u) => [{ user: { id: u.id }, workspace: { id: owner.id } }])
-    );
+    const workspaceModelId = owner.id;
+    const userModelIds = users.map((u) => u.id);
+    invalidateCacheAfterCommit(transaction, async () => {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        userModelIds.map((userModelId) => [
+          { user: { id: userModelId }, workspace: { id: workspaceModelId } },
+        ])
+      );
+    });
 
     return new Ok(undefined);
   }
@@ -1497,10 +1504,15 @@ export class GroupResource extends BaseResource<GroupModel> {
       }
     );
 
-    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
-    await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-      users.map((u) => [{ user: { id: u.id }, workspace: { id: owner.id } }])
-    );
+    const workspaceModelId = owner.id;
+    const userModelIds = users.map((u) => u.id);
+    invalidateCacheAfterCommit(transaction, async () => {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        userModelIds.map((userModelId) => [
+          { user: { id: userModelId }, workspace: { id: workspaceModelId } },
+        ])
+      );
+    });
 
     return new Ok(undefined);
   }
@@ -1586,10 +1598,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
-    await GroupResource.invalidateGroupIdsCacheForUser({
-      user: { id: user.id },
-      workspace: { id: workspace.id },
+    const userId = user.id;
+    const workspaceId = workspace.id;
+    invalidateCacheAfterCommit(transaction, async () => {
+      await GroupResource.invalidateGroupIdsCacheForUser({
+        user: { id: userId },
+        workspace: { id: workspaceId },
+      });
     });
 
     return new Ok(undefined);
@@ -1695,11 +1710,13 @@ export class GroupResource extends BaseResource<GroupModel> {
     );
 
     if (affectedUserIds.length > 0) {
-      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-        affectedUserIds.map((userId) => [
-          { user: { id: userId }, workspace: { id: workspaceId } },
-        ])
-      );
+      invalidateCacheAfterCommit(transaction, async () => {
+        await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+          affectedUserIds.map((userId) => [
+            { user: { id: userId }, workspace: { id: workspaceId } },
+          ])
+        );
+      });
     }
 
     return affectedUserIds;
@@ -1745,11 +1762,13 @@ export class GroupResource extends BaseResource<GroupModel> {
     );
 
     if (affectedUserIds.length > 0) {
-      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-        affectedUserIds.map((userId) => [
-          { user: { id: userId }, workspace: { id: workspaceId } },
-        ])
-      );
+      invalidateCacheAfterCommit(transaction, async () => {
+        await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+          affectedUserIds.map((userId) => [
+            { user: { id: userId }, workspace: { id: workspaceId } },
+          ])
+        );
+      });
     }
 
     return affectedUserIds;
@@ -1831,13 +1850,15 @@ export class GroupResource extends BaseResource<GroupModel> {
         transaction,
       });
 
-      // Always invalidate cache for all former members - safe even if transaction rolls back (just causes cache miss)
       if (memberUserIds.length > 0) {
-        await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-          memberUserIds.map((userId) => [
-            { user: { id: userId }, workspace: { id: owner.id } },
-          ])
-        );
+        const workspaceId = owner.id;
+        invalidateCacheAfterCommit(transaction, async () => {
+          await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+            memberUserIds.map((userId) => [
+              { user: { id: userId }, workspace: { id: workspaceId } },
+            ])
+          );
+        });
       }
 
       return new Ok(undefined);

--- a/front/lib/utils/cache.test.ts
+++ b/front/lib/utils/cache.test.ts
@@ -1,0 +1,108 @@
+import logger from "@app/logger/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+// Import actual cache module to bypass the global mock in vite.setup.ts
+vi.mock("@app/lib/utils/cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/utils/cache")>();
+  return actual;
+});
+
+import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+
+describe("invalidateCacheAfterCommit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls invalidateFn immediately when no transaction provided", async () => {
+    const invalidateFn = vi.fn().mockResolvedValue(undefined);
+
+    invalidateCacheAfterCommit(undefined, invalidateFn);
+
+    // Wait for the promise to resolve
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(invalidateFn).toHaveBeenCalledOnce();
+  });
+
+  it("defers invalidateFn until transaction commits", async () => {
+    const invalidateFn = vi.fn().mockResolvedValue(undefined);
+    const afterCommitCallbacks: (() => void)[] = [];
+
+    const mockTransaction = {
+      afterCommit: vi.fn((cb: () => void) => {
+        afterCommitCallbacks.push(cb);
+      }),
+    };
+
+    invalidateCacheAfterCommit(
+      mockTransaction as unknown as Parameters<
+        typeof invalidateCacheAfterCommit
+      >[0],
+      invalidateFn
+    );
+
+    // invalidateFn should not be called yet
+    expect(invalidateFn).not.toHaveBeenCalled();
+    expect(mockTransaction.afterCommit).toHaveBeenCalledOnce();
+
+    // Simulate transaction commit
+    afterCommitCallbacks.forEach((cb) => cb());
+
+    // Wait for the promise to resolve
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(invalidateFn).toHaveBeenCalledOnce();
+  });
+
+  it("logs error with panic: true when invalidateFn fails without transaction", async () => {
+    const testError = new Error("Cache invalidation failed");
+    const invalidateFn = vi.fn().mockRejectedValue(testError);
+
+    invalidateCacheAfterCommit(undefined, invalidateFn);
+
+    // Wait for the promise to reject and be caught
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logger.error).toHaveBeenCalledWith(
+      { panic: true, err: testError },
+      "Failed to invalidate cache after transaction commit"
+    );
+  });
+
+  it("logs error with panic: true when invalidateFn fails after transaction commit", async () => {
+    const testError = new Error("Cache invalidation failed");
+    const invalidateFn = vi.fn().mockRejectedValue(testError);
+    const afterCommitCallbacks: (() => void)[] = [];
+
+    const mockTransaction = {
+      afterCommit: vi.fn((cb: () => void) => {
+        afterCommitCallbacks.push(cb);
+      }),
+    };
+
+    invalidateCacheAfterCommit(
+      mockTransaction as unknown as Parameters<
+        typeof invalidateCacheAfterCommit
+      >[0],
+      invalidateFn
+    );
+
+    // Simulate transaction commit
+    afterCommitCallbacks.forEach((cb) => cb());
+
+    // Wait for the promise to reject and be caught
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logger.error).toHaveBeenCalledWith(
+      { panic: true, err: testError },
+      "Failed to invalidate cache after transaction commit"
+    );
+  });
+});

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -1,5 +1,7 @@
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
+import logger from "@app/logger/logger";
+import type { Transaction } from "sequelize";
 
 const SPIN_WAIT_INTERVAL_MS = 100;
 
@@ -223,4 +225,36 @@ function unlock(key: string) {
     throw new Error("Unreachable: unlock called without lock");
   }
   unlockFn();
+}
+
+/**
+ * Defers cache invalidation until after a transaction commits.
+ * This prevents a race condition where:
+ * 1. Cache is invalidated inside the transaction
+ * 2. Another request reads the DB (can't see uncommitted data)
+ * 3. Cache repopulated with stale data
+ * 4. Transaction commits
+ * 5. Cache now has stale data for TTL duration
+ */
+export function invalidateCacheAfterCommit(
+  transaction: Transaction | undefined,
+  invalidateFn: () => Promise<void>
+): void {
+  if (transaction) {
+    transaction.afterCommit(() =>
+      invalidateFn().catch((err) => {
+        logger.error(
+          { panic: true, err },
+          "Failed to invalidate cache after transaction commit"
+        );
+      })
+    );
+  } else {
+    invalidateFn().catch((err) => {
+      logger.error(
+        { panic: true, err },
+        "Failed to invalidate cache after transaction commit"
+      );
+    });
+  }
 }

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -66,6 +66,13 @@ vi.mock("@app/lib/utils/cache", () => ({
   batchInvalidateCacheWithRedis: vi.fn().mockImplementation(() => {
     return async () => {};
   }),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>) => {
+        invalidateFn();
+      }
+    ),
 }));
 
 // Mock Temporal - must be at module level


### PR DESCRIPTION
## Description

- currently we cache group memberships of users, and invalidate on makeNew
- but if the makeNew (or any other method for that matter) is inside a transaction, invalidating the caching needs to happen after the commit, otherwise a concurrent read will repopulate the cache with a "dirty" (from transact's perspective) value


## Tests

- Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front