### PR TITLE
Add logout shortcut

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { PostHogTracker } from "@dust-tt/front/components/app/PostHogTracker";
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { ErrorBoundary } from "@dust-tt/front/components/error_boundary/ErrorBoundary";
+import config from "@dust-tt/front/lib/api/config";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
 import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
@@ -43,6 +44,12 @@ function AssistantAgentRedirect() {
       replace
     />
   );
+}
+
+// Redirect /logout to the API server's WorkOS logout endpoint
+function LogoutRedirect() {
+  window.location.replace(`${config.getApiBaseUrl()}/api/workos/logout`);
+  return null;
 }
 
 // Redirect /poke/* to the poke app (poke.dust.tt)
@@ -535,6 +542,8 @@ const router = createBrowserRouter(
             { path: "/sso-enforced", element: <SsoEnforcedPage /> },
           ],
         },
+        // Redirect /logout to the API server's WorkOS logout endpoint
+        { path: "/logout", element: <LogoutRedirect /> },
         // Redirect /poke/* to the poke app (e.g., poke.dust.tt)
         { path: "/poke/*", element: <PokeRedirect /> },
         {


### PR DESCRIPTION
## Description

Add a `/logout` route to the front-spa that redirects to the API server's WorkOS logout endpoint (`/api/workos/logout`). This provides a simple, direct URL that can be used to trigger logout (e.g. from external links or bookmarks) without needing to navigate through the user menu.

## Tests

Manual — navigate to `/logout` and verify redirect to the WorkOS logout endpoint.

## Risk

Low — adds a new route with no impact on existing functionality. Safe to rollback.

## Deploy Plan

Standard deploy, no special steps required.