### PR TITLE
Add confirm dialog

### DIFF
--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -1,6 +1,17 @@
 import { useFrameSharingToggle } from "@app/hooks/useFrameSharingToggle";
 import type { WorkspaceType } from "@app/types/user";
-import { ActionFrameIcon, ContextItem, SliderToggle } from "@dust-tt/sparkle";
+import {
+  ActionFrameIcon,
+  ContextItem,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  SliderToggle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
 
 export function InteractiveContentSharingToggle({
   owner,
@@ -9,20 +20,65 @@ export function InteractiveContentSharingToggle({
 }) {
   const { isEnabled, isChanging, doToggleInteractiveContentSharing } =
     useFrameSharingToggle({ owner });
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const handleToggleClick = () => {
+    if (isEnabled) {
+      setIsConfirmOpen(true);
+    } else {
+      void doToggleInteractiveContentSharing();
+    }
+  };
 
   return (
-    <ContextItem
-      title="Public Frame sharing"
-      subElement="Allow Frames to be shared publicly via links"
-      visual={<ActionFrameIcon className="h-6 w-6" />}
-      hasSeparatorIfLast={true}
-      action={
-        <SliderToggle
-          selected={isEnabled}
-          disabled={isChanging}
-          onClick={doToggleInteractiveContentSharing}
-        />
-      }
-    />
+    <>
+      <ContextItem
+        title="Public Frame sharing"
+        subElement="Allow Frames to be shared publicly via links"
+        visual={<ActionFrameIcon className="h-6 w-6" />}
+        hasSeparatorIfLast={true}
+        action={
+          <SliderToggle
+            selected={isEnabled}
+            disabled={isChanging}
+            onClick={handleToggleClick}
+          />
+        }
+      />
+      <Dialog
+        open={isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsConfirmOpen(false);
+          }
+        }}
+      >
+        <DialogContent size="md" isAlertDialog>
+          <DialogHeader hideButton>
+            <DialogTitle>Disable public Frame sharing</DialogTitle>
+            <DialogDescription>
+              This will revoke public access to all currently shared Frames in
+              this workspace. Existing public links will stop working.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              disabled: isChanging,
+              variant: "outline",
+            }}
+            rightButtonProps={{
+              label: "Disable public sharing",
+              disabled: isChanging,
+              variant: "warning",
+              onClick: async () => {
+                await doToggleInteractiveContentSharing();
+                setIsConfirmOpen(false);
+              },
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
## Description

Add a confirmation modal when disabling "Public Frame sharing" in workspace settings. Previously, toggling the setting off would immediately revoke public access to all shared Frames without warning. Now a dialog warns the user that existing public links will stop working before proceeding.

## Tests

Manual: toggled the setting off and verified the confirmation dialog appears. Verified enabling the setting still works immediately without a modal.

## Risk

Low — UI-only change, no backend modifications. Safe to rollback.

## Deploy Plan

Standard front deploy.