### PR TITLE
Fix branch name in deploy workflow

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -7,8 +7,8 @@ on:
         description: "SPA to deploy"
         type: choice
         options:
-          - poke
           - app
+          - poke
         required: true
       env:
         description: "The environment to use for API endpoints (prod or edge)"
@@ -118,9 +118,12 @@ jobs:
         run: |
           set -a
           source ../.github/configs/${{ inputs.region == 'eu' && 'europe-west1' || 'us-central1' }}/.env.${{ inputs.env }}
-          # Override NEXT_PUBLIC_DUST_APP_URL: use branch preview URL for non-main branches
+          # Override NEXT_PUBLIC_DUST_APP_URL: use branch preview URL for non-main branches.
+          # Apply the same sanitization Cloudflare Pages uses for branch aliases:
+          # lowercase, replace non-alphanumeric with '-', collapse multiple '-', trim '-', truncate to 28 chars.
           if [ "${{ github.ref_name }}" != "main" ]; then
-            export NEXT_PUBLIC_DUST_APP_URL=https://${{ github.ref_name }}--app.preview.dust.tt
+            CF_BRANCH=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-28 | sed 's/-$//')
+            export NEXT_PUBLIC_DUST_APP_URL=https://${CF_BRANCH}--app.preview.dust.tt
           fi
           export NEXT_PUBLIC_BUILD_DATE=$(date +%s)
           # Map all NEXT_PUBLIC_* to VITE_* for SPA
@@ -149,6 +152,7 @@ jobs:
             --service=${{ inputs.app }}-spa-browser
 
       - name: Deploy to preview branch
+        id: cf_deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -156,6 +160,17 @@ jobs:
           workingDirectory: front-spa
           command: pages deploy dist/${{ inputs.app }} --project-name=${{ inputs.app }}-dust-tt --branch=${{ github.ref_name == 'main' && format('staging-{0}', github.sha) || github.ref_name }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive preview URL from Cloudflare deployment URL
+        id: preview_url
+        run: |
+          # Cloudflare deployment URL looks like: https://<branch-alias>.<project>.pages.dev
+          # We extract the branch alias and transform to our proxy: https://<branch-alias>--<app>.preview.dust.tt
+          CF_URL="${{ steps.cf_deploy.outputs.deployment-url }}"
+          # Extract the branch alias (everything before .<project>.pages.dev)
+          BRANCH_ALIAS=$(echo "$CF_URL" | sed -E 's|https://([^.]+)\..+\.pages\.dev|\1|')
+          PREVIEW_URL="https://${BRANCH_ALIAS}--${{ inputs.app }}.preview.dust.tt"
+          echo "url=${PREVIEW_URL}" >> $GITHUB_OUTPUT
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4
@@ -169,7 +184,7 @@ jobs:
           echo "### SPA Deployed :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **App**: ${{ inputs.app }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **URL**: ${{ github.ref_name == 'main' && format('https://staging-{0}--{1}.preview.dust.tt', github.sha, inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: ${{ steps.preview_url.outputs.url }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Region**: ${{ inputs.region }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
 
@@ -182,7 +197,7 @@ jobs:
           component: spa-${{ inputs.app }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          preview_url: ${{ github.ref_name == 'main' && format('https://staging-{0}--{1}.preview.dust.tt', github.sha, inputs.app) || format('https://{0}--{1}.preview.dust.tt', github.ref_name, inputs.app) }}
+          preview_url: ${{ steps.preview_url.outputs.url }}
 
       - name: Notify Failure
         if: failure()


### PR DESCRIPTION
## Description

Fix preview URLs in the `deploy-spa` workflow to match what Cloudflare Pages actually generates.

**Problem:** Preview URLs were constructed directly from `github.ref_name`, but Cloudflare Pages sanitizes branch names (replaces `/` with `-`, lowercases, truncates to 28 chars, etc.). This meant the URLs shown in GitHub summaries, Slack notifications, and `NEXT_PUBLIC_DUST_APP_URL` could be wrong — e.g. a branch `feat/my-feature` would generate a URL with `feat/my-feature` but CF actually serves it at `feat-my-feature`.

**Fix:**
- **Summary & Slack URLs**: Capture the `deployment-url` output from the `cloudflare/wrangler-action`, extract the branch alias CF actually assigned, and transform it to our proxy format (`<alias>--<app>.preview.dust.tt`).
- **`NEXT_PUBLIC_DUST_APP_URL`** (set at build time, before deploy): Apply the same sanitization rules CF uses — lowercase, replace non-alphanumeric with `-`, collapse consecutive dashes, trim, and truncate to 28 chars.

## Tests

- No automated tests — this is a CI workflow change.
- Can be validated by deploying from a branch with `/` in the name and checking that the preview URL in the GitHub summary and Slack notification is correct and reachable.

## Risk

Low. Only affects how preview URLs are displayed/used — no change to the actual deploy logic. Worst case, if wrangler action stops emitting `deployment-url`, the URL derivation step would produce a broken link (same as today's behavior).

## Deploy Plan

Merging to main is sufficient — changes only affect the GitHub Actions workflow.