### PR TITLE
fix: conversation title in projects on mobile

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -9,6 +9,7 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getProjectRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types/user";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
@@ -29,6 +30,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     spaceId: conversation?.spaceId ?? null,
   });
   const router = useAppRouter();
+  const isMobile = useIsMobile();
 
   const [showRenameDialog, setShowRenameDialog] = useState(false);
 
@@ -79,8 +81,8 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         <Breadcrumbs
           items={breadcrumbItems}
           className="dd-privacy-mask"
-          truncateLengthMiddle={35}
-          truncateLengthEnd={120}
+          truncateLengthMiddle={isMobile ? undefined : 35}
+          truncateLengthEnd={isMobile ? undefined : 120}
         />
         <EditConversationTitleDialog
           isOpen={showRenameDialog}


### PR DESCRIPTION
## Description

Fixes: https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=158308094&issue=dust-tt%7Ctasks%7C6621
## Tests

### Now

<img width="497" height="148" alt="image" src="https://github.com/user-attachments/assets/8b32010c-0a6e-4fbc-8ae2-b9672bebe793" />

### Before

<img width="494" height="154" alt="image" src="https://github.com/user-attachments/assets/eb32f45e-1397-462c-88a4-54a7bf3b5bdb" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
