### PR TITLE
copilot: Allow filtering by agent name prefix in get_available_agents

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -517,6 +517,48 @@ describe("agent_copilot_context tools", () => {
     });
   });
 
+  describe("get_available_agents with agentPrefix", () => {
+    it("filters agents by name prefix", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      // Create agents with distinct name prefixes.
+      const alphaAgent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "AlphaBot" }
+      );
+      await AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "BetaBot",
+      });
+
+      const tool = getToolByName("get_available_agents");
+      const result = await tool.handler(
+        { agentPrefix: "Alpha" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          // Should find AlphaBot.
+          const foundAlpha = parsed.agents.find(
+            (a: { sId: string }) => a.sId === alphaAgent.sId
+          );
+          expect(foundAlpha).toBeDefined();
+          expect(foundAlpha.name).toBe("AlphaBot");
+
+          // Should not find BetaBot.
+          const foundBeta = parsed.agents.find(
+            (a: { name: string }) => a.name === "BetaBot"
+          );
+          expect(foundBeta).toBeUndefined();
+        }
+      }
+    });
+  });
+
   describe("inspect_available_agent", () => {
     it("returns detailed agent information including tools and skills", async () => {
       const { authenticator, workspace, globalSpace } =

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -151,6 +151,12 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .optional()
         .default(100)
         .describe("Maximum number of agents to return (default: 100)"),
+      agentPrefix: z
+        .string()
+        .optional()
+        .describe(
+          "Optional prefix to filter agents by name (case-insensitive, matches start of name)"
+        ),
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -372,12 +372,13 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_agents: async ({ limit }, { auth }) => {
+  get_available_agents: async ({ limit, agentPrefix }, { auth }) => {
     const agents = await getAgentConfigurationsForView({
       auth,
       agentsGetView: "list",
       variant: "light",
       limit: limit ?? 100,
+      agentPrefix,
     });
 
     const agentList = agents.map((agent) => ({


### PR DESCRIPTION
## Description

This should solve the issue where there are hundreds of agents in a workspace and someone ask to create an agent "similar to XXX".

<img width="391" height="39" alt="Screenshot 2026-02-24 at 14 15 39" src="https://github.com/user-attachments/assets/ffdf2b70-7b35-4dcd-b51d-ee200ccccb4c" />

<img width="850" height="485" alt="Screenshot 2026-02-24 at 14 17 01" src="https://github.com/user-attachments/assets/40a8e755-8a6e-472c-baef-e819d78f167b" />


<img width="850" height="193" alt="Screenshot 2026-02-24 at 14 15 29" src="https://github.com/user-attachments/assets/d10cc68c-110e-40b8-9afb-d030b15a167c" />



## Tests

Unit tests + manual test

## Risk

low

## Deploy Plan

deploy front
