### PR TITLE
[front] enh: remove hardcoded triggered conversation title, add `Triggered - ` prefix 

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -85,7 +85,7 @@ export async function ensureConversationTitle(
     return null;
   }
 
-  const title = titleRes.value;
+  const title = (conversation.triggerId ? "Triggered - " : "") + titleRes.value;
   await ConversationResource.updateTitle(auth, conversation.sId, title);
 
   // Enqueue the conversation_title event in Redis.
@@ -135,9 +135,13 @@ async function generateConversationTitle(
     );
   }
 
-  const prompt =
+  let prompt =
     "Generate a concise conversation title (3-8 words) based on the user's message and context. " +
     "The title should capture the main topic or request without being too generic.";
+  if (conversation.triggerId) {
+    prompt +=
+      " The conversation was triggered either on a schedule or programmatically.";
+  }
 
   // Turn the conversation into a digest that can be presented to the model.
   const modelConversationRes = await renderConversationForModel(auth, {

--- a/front/temporal/triggers/common/activities.ts
+++ b/front/temporal/triggers/common/activities.ts
@@ -92,25 +92,8 @@ async function createConversationForAgentConfiguration({
   lastRunAt: Date | null;
   contentFragment?: ContentFragmentInputWithFileIdType;
 }): Promise<Result<ConversationType, APIErrorWithStatusCode>> {
-  let conversationTitle = `@${agentConfiguration.name} triggered (${trigger.kind})`;
-  switch (trigger.kind) {
-    case "schedule":
-      conversationTitle += ` - ${new Intl.DateTimeFormat(undefined, {
-        timeZone: trigger.configuration.timezone,
-        month: "short",
-        day: "numeric",
-        hour: "numeric",
-        minute: "2-digit",
-      }).format(new Date())}`;
-      break;
-    case "webhook":
-      break;
-    default:
-      assertNever(trigger);
-  }
-
   const newConversation = await createConversation(auth, {
-    title: conversationTitle,
+    title: null,
     visibility: "unlisted",
     triggerId: trigger.id,
     spaceId: null,


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C066R3PMUAU/p1771878104443539).
- This PR removes the hardcoded titles for triggered conversations, and adds a prefix to the model-generated one.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
