### PR TITLE
[front] Add max length on skill agent facing description

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -12,7 +12,6 @@ import { useCallback, useState } from "react";
 const AGENT_FACING_DESCRIPTION_FIELD_NAME = "agentFacingDescription";
 const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
-const MAX_DESCRIPTION_LENGTH = 500;
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();
@@ -77,7 +76,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       title="What will this skill be used for?"
       titleClassName="heading-lg"
       fieldName={AGENT_FACING_DESCRIPTION_FIELD_NAME}
-      triggerValidationOnChange={false}
+      triggerValidationOnChange
     >
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
         <div className="space-y-3">
@@ -86,7 +85,6 @@ export function SkillBuilderAgentFacingDescriptionSection() {
             placeholder="When should this skill be used? What is this skill good for?"
             className="h-40 text-base placeholder:italic placeholder:text-gray-400"
             resize="vertical"
-            maxLength={MAX_DESCRIPTION_LENGTH}
             onChange={(e) => handleDescriptionChange(e, onChange)}
             error={hasError ? errorMessage : undefined}
             showErrorLabel={hasError}

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -12,6 +12,7 @@ import { useCallback, useState } from "react";
 const AGENT_FACING_DESCRIPTION_FIELD_NAME = "agentFacingDescription";
 const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
+const MAX_DESCRIPTION_LENGTH = 500;
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();
@@ -85,6 +86,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
             placeholder="When should this skill be used? What is this skill good for?"
             className="h-40 text-base placeholder:italic placeholder:text-gray-400"
             resize="vertical"
+            maxLength={MAX_DESCRIPTION_LENGTH}
             onChange={(e) => handleDescriptionChange(e, onChange)}
             error={hasError ? errorMessage : undefined}
             showErrorLabel={hasError}

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -18,7 +18,8 @@ export const skillBuilderFormSchema = z.object({
     .pipe(z.string().min(1, "Skill name is required")),
   agentFacingDescription: z
     .string()
-    .min(1, "Description of when to use the skill is required"),
+    .min(1, "Description of when to use the skill is required")
+    .max(500, "Description must be 500 characters or less"),
   userFacingDescription: z.string().min(1, "Skill description is required"),
   instructions: z.string().min(1, "Skill instructions are required"),
   editors: z.array(editorUserSchema),

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -4,6 +4,8 @@ import { createContext } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 
+const AGENT_FACING_DESCRIPTION_MAX_LENGTH = 750;
+
 export const attachedKnowledgeSchema = z.object({
   dataSourceViewId: z.string(),
   nodeId: z.string(),
@@ -19,7 +21,10 @@ export const skillBuilderFormSchema = z.object({
   agentFacingDescription: z
     .string()
     .min(1, "Description of when to use the skill is required")
-    .max(750, "Description must be 750 characters or less"),
+    .max(
+      AGENT_FACING_DESCRIPTION_MAX_LENGTH,
+      `Description must be ${AGENT_FACING_DESCRIPTION_MAX_LENGTH} characters or less`
+    ),
   userFacingDescription: z.string().min(1, "Skill description is required"),
   instructions: z.string().min(1, "Skill instructions are required"),
   editors: z.array(editorUserSchema),

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -18,8 +18,7 @@ export const skillBuilderFormSchema = z.object({
     .pipe(z.string().min(1, "Skill name is required")),
   agentFacingDescription: z
     .string()
-    .min(1, "Description of when to use the skill is required")
-    .max(500, "Description must be 500 characters or less"),
+    .min(1, "Description of when to use the skill is required"),
   userFacingDescription: z.string().min(1, "Skill description is required"),
   instructions: z.string().min(1, "Skill instructions are required"),
   editors: z.array(editorUserSchema),

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -19,7 +19,7 @@ export const skillBuilderFormSchema = z.object({
   agentFacingDescription: z
     .string()
     .min(1, "Description of when to use the skill is required")
-    .max(500, "Description must be 500 characters or less"),
+    .max(750, "Description must be 750 characters or less"),
   userFacingDescription: z.string().min(1, "Skill description is required"),
   instructions: z.string().min(1, "Skill instructions are required"),
   editors: z.array(editorUserSchema),


### PR DESCRIPTION
## Description

- This PR adds a limit on the length of the agent-facing description for a skill.
- The limit is front-end only.
- Goal is to add some form of sane limit to indicate to users that this field is meant to remain somewhat small. There's no particular reason to have this very long.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
