### PR TITLE
feat: extension authentication with private api

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -12,7 +12,6 @@ import type { PendingUpdate } from "@extension/platforms/chrome/services/core_pl
 import { ChromeCorePlatformService } from "@extension/platforms/chrome/services/core_platform";
 import { DUST_US_URL } from "@extension/shared/lib/config";
 import { extractPage } from "@extension/shared/lib/extraction";
-import { generatePKCE } from "@extension/shared/lib/utils";
 import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
 import { jwtDecode } from "jwt-decode";
 
@@ -480,20 +479,20 @@ const authenticate = async (
 ) => {
   // First we call /authorize endpoint to get the authorization code (PKCE flow).
   const redirectUrl = chrome.identity.getRedirectURL();
-  const { codeVerifier, codeChallenge } = await generatePKCE();
+
+  const workspaceId =
+    connection && connection.startsWith("workspace-")
+      ? connection.split("workspace-")[1]
+      : "";
 
   const options: Record<string, string> = {
-    response_type: "code",
     redirect_uri: redirectUrl,
-    code_challenge_method: "S256",
-    code_challenge: codeChallenge,
-    organization_id: connection ?? "",
-    provider: "authkit",
+    workspaceId: workspaceId,
   };
 
   const queryString = new URLSearchParams(options).toString();
 
-  const authUrl = `${DUST_US_URL}/api/v1/auth/authorize?${queryString}`;
+  const authUrl = `${DUST_US_URL}/api/workos/login?${queryString}`;
 
   chrome.identity.launchWebAuthFlow(
     { url: authUrl, interactive: true },
@@ -531,10 +530,7 @@ const authenticate = async (
       }
 
       if (authorizationCode) {
-        const data = await exchangeCodeForTokens(
-          authorizationCode,
-          codeVerifier
-        );
+        const data = await exchangeCodeForTokens(authorizationCode);
         sendResponse(data);
       } else {
         log(`Missing authorization code: ${redirectUrl}`);
@@ -580,7 +576,7 @@ const refreshToken = async (
       }
 
       const response = await fetch(
-        `${user.dustDomain}/api/v1/auth/authenticate`,
+        `${user.dustDomain}/api/workos/authenticate`,
         {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -602,10 +598,10 @@ const refreshToken = async (
       handlers.forEach((sendResponse) => {
         sendResponse({
           success: true,
-          accessToken: data.access_token,
-          refreshToken: data.refresh_token || refreshToken,
-          expiresIn: data.expires_in ?? DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
-          authentication_method: data.authentication_method,
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken || refreshToken,
+          expiresIn: DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
+          authentication_method: data.authenticationMethod,
         });
       });
     } catch (error) {
@@ -628,18 +624,14 @@ const refreshToken = async (
  *  Exchange authorization code for tokens
  */
 const exchangeCodeForTokens = async (
-  code: string,
-  codeVerifier: string
+  code: string
 ): Promise<OAuthAuthorizeResponse | AuthBackgroundResponseError> => {
   try {
     const tokenParams: Record<string, string> = {
-      grant_type: "authorization_code",
-      code_verifier: codeVerifier,
       code,
-      redirect_uri: chrome.identity.getRedirectURL(),
     };
 
-    const response = await fetch(`${DUST_US_URL}/api/v1/auth/authenticate`, {
+    const response = await fetch(`${DUST_US_URL}/api/workos/authenticate`, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams(tokenParams),
@@ -656,11 +648,10 @@ const exchangeCodeForTokens = async (
 
     return {
       success: true,
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      expiresIn: data.expires_in ?? DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
-      ...(data.id_token && { idToken: data.id_token }),
-      authentication_method: data.authentication_method,
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      expiresIn: DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
+      authentication_method: data.authenticationMethod,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error.";
@@ -699,7 +690,7 @@ const logout = async (
     return true;
   }
 
-  const logoutUrl = `${user.dustDomain}/api/v1/auth/logout?${new URLSearchParams(
+  const logoutUrl = `${DUST_US_URL}/api/workos/logout-url?${new URLSearchParams(
     queryParams
   )}`;
 

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -11,6 +11,7 @@ import type { SessionCookie } from "@app/lib/api/workos/user";
 import { getSession } from "@app/lib/auth";
 import { DUST_HAS_SESSION } from "@app/lib/cookies";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
@@ -40,8 +41,12 @@ export default async function handler(
       return handleLogin(req, res);
     case "callback":
       return handleCallback(req, res);
+    case "authenticate":
+      return handleAuthenticate(req, res);
     case "logout":
       return handleLogout(req, res);
+    case "logout-url":
+      return handleLogoutUrl(req, res);
     default:
       return res.status(400).json({ error: "Invalid action" });
   }
@@ -49,9 +54,35 @@ export default async function handler(
 
 async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { organizationId, screenHint, loginHint, returnTo } = req.query;
+    const {
+      organizationId,
+      screenHint,
+      loginHint,
+      returnTo,
+      redirect_uri,
+      workspaceId,
+    } = req.query;
+
+    const redirectUri =
+      redirect_uri && isString(redirect_uri)
+        ? redirect_uri
+        : `${config.getAuthRedirectBaseUrl()}/api/workos/callback`;
 
     let organizationIdToUse;
+
+    if (workspaceId && typeof workspaceId === "string") {
+      const workspace = workspaceId
+        ? await WorkspaceResource.fetchById(workspaceId)
+        : null;
+
+      if (!workspace?.workOSOrganizationId) {
+        res.status(400).json({
+          error: "Workspace does not have a WorkOS organization ID",
+        });
+        return;
+      }
+      organizationIdToUse = workspace.workOSOrganizationId;
+    }
 
     if (organizationId && typeof organizationId === "string") {
       organizationIdToUse = organizationId;
@@ -98,7 +129,7 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       // Specify that we'd like AuthKit to handle the authentication flow
       provider: "authkit",
       // Use auth redirect base URL for WorkOS callbacks
-      redirectUri: `${config.getAuthRedirectBaseUrl()}/api/workos/callback`,
+      redirectUri,
       clientId: config.getWorkOSClientId(),
       ...enterpriseParams,
       state:
@@ -114,6 +145,38 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
     logger.error({ error }, "Error during WorkOS login");
     statsDClient.increment("login.error", 1);
     res.redirect("/login-error?type=workos-login");
+  }
+}
+
+async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
+  const { code, grant_type, refresh_token } = req.body;
+
+  if (grant_type === "refresh_token") {
+    if (!refresh_token || !isString(refresh_token)) {
+      return res.status(400).json({ error: "Invalid refresh token" });
+    }
+    try {
+      const result =
+        await getWorkOS().userManagement.authenticateWithRefreshToken({
+          refreshToken: refresh_token,
+          clientId: config.getWorkOSClientId(),
+        });
+      return res.status(200).json(result);
+    } catch (error) {
+      logger.error({ error }, "Error during WorkOS token refresh");
+      return res.status(500).json({ error: "Authentication failed" });
+    }
+  }
+
+  if (!code || !isString(code)) {
+    return res.status(400).json({ error: "Invalid code" });
+  }
+  try {
+    const authResult = await authenticate(code);
+    return res.status(200).json(authResult);
+  } catch (error) {
+    logger.error({ error }, "Error during WorkOS authentication");
+    return res.status(500).json({ error: "Authentication failed" });
   }
 }
 
@@ -385,6 +448,20 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
     : config.getClientFacingUrl();
 
   redirectTo(res, sanitizedReturnTo);
+}
+
+async function handleLogoutUrl(req: NextApiRequest, res: NextApiResponse) {
+  const { session_id, returnTo } = req.query;
+
+  if (!session_id || !isString(session_id)) {
+    return res.status(400).json({ error: "Invalid session_id" });
+  }
+  const logoutUrl = getWorkOS().userManagement.getLogoutUrl({
+    sessionId: session_id,
+    returnTo: isString(returnTo) ? returnTo : undefined,
+  });
+
+  return res.redirect(logoutUrl);
 }
 
 function redirectTo(res: NextApiResponse, sanitizedReturnTo: string) {

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -70,7 +70,7 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
 
     let organizationIdToUse;
 
-    if (workspaceId && typeof workspaceId === "string") {
+    if (workspaceId && isString(workspaceId)) {
       const workspace = workspaceId
         ? await WorkspaceResource.fetchById(workspaceId)
         : null;
@@ -150,6 +150,10 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
 
 async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
   const { code, grant_type, refresh_token } = req.body;
+
+  if (grant_type && !isString(grant_type)) {
+    return res.status(400).json({ error: "Invalid grant_type" });
+  }
 
   if (grant_type === "refresh_token") {
     if (!refresh_token || !isString(refresh_token)) {


### PR DESCRIPTION



## Description

This PR makes sure the Chrome extension uses the private api for authentication 
- Added new `authenticate` endpoint in `/api/workos/[action].ts` to handle both authorization code exchange and refresh token flows
- Added new `logout-url` endpoint to generate WorkOS logout URLs from session IDs


## Tests

Manually

## Risks

This changes the Chrome extension authentication flow

## Deploy Plan
