### PR TITLE
fix: add distributed lock around sandbox ensureActive

### DIFF
--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,7 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import type { ExecOptions, ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
+import { executeWithLock } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
@@ -151,78 +152,85 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       "Cannot ensure sandbox without a workspace"
     );
 
-    const provider = getSandboxProvider();
-    if (!provider) {
-      return new Err(new Error("Sandbox provider not configured."));
-    }
+    const lockName = `sandbox:ensureActive:${conversation.sId}`;
 
-    const conversationId = conversation.id;
-
-    const existing = await SandboxResource.fetchByConversationId(
-      auth,
-      conversationId
-    );
-
-    if (!existing) {
-      const createResult = await provider.create({});
-      if (createResult.isErr()) {
-        return createResult;
+    return executeWithLock(lockName, async () => {
+      const provider = getSandboxProvider();
+      if (!provider) {
+        return new Err(new Error("Sandbox provider not configured."));
       }
 
-      const sandbox = await SandboxResource.makeNew(auth, {
-        conversationId,
-        providerId: createResult.value.providerId,
-        status: "running",
-      });
+      const conversationId = conversation.id;
 
-      logger.info(
-        { sandbox: sandbox.toLogJSON() },
-        "Created new sandbox for conversation"
+      const existing = await SandboxResource.fetchByConversationId(
+        auth,
+        conversationId
       );
 
-      return new Ok({ sandbox, freshlyCreated: true });
-    }
-
-    const { status } = existing;
-    let freshlyCreated = false;
-
-    switch (status) {
-      case "running":
-        break;
-
-      case "sleeping": {
-        const wakeResult = await provider.wake(existing.providerId);
-        if (wakeResult.isErr()) {
-          return wakeResult;
-        }
-        logger.info({ sandbox: existing.toLogJSON() }, "Woke sleeping sandbox");
-        break;
-      }
-
-      case "deleted": {
+      if (!existing) {
         const createResult = await provider.create({});
         if (createResult.isErr()) {
           return createResult;
         }
-        await existing.update({ providerId: createResult.value.providerId });
-        freshlyCreated = true;
+
+        const sandbox = await SandboxResource.makeNew(auth, {
+          conversationId,
+          providerId: createResult.value.providerId,
+          status: "running",
+        });
+
         logger.info(
-          {
-            sandbox: existing.toLogJSON(),
-            newProviderId: createResult.value.providerId,
-          },
-          "Recreated sandbox from deleted state"
+          { sandbox: sandbox.toLogJSON() },
+          "Created new sandbox for conversation"
         );
-        break;
+
+        return new Ok({ sandbox, freshlyCreated: true });
       }
 
-      default:
-        assertNever(status);
-    }
+      const { status } = existing;
+      let freshlyCreated = false;
 
-    await existing.updateStatus("running");
-    await existing.updateLastActivityAt();
-    return new Ok({ sandbox: existing, freshlyCreated });
+      switch (status) {
+        case "running":
+          break;
+
+        case "sleeping": {
+          const wakeResult = await provider.wake(existing.providerId);
+          if (wakeResult.isErr()) {
+            return wakeResult;
+          }
+          logger.info(
+            { sandbox: existing.toLogJSON() },
+            "Woke sleeping sandbox"
+          );
+          break;
+        }
+
+        case "deleted": {
+          const createResult = await provider.create({});
+          if (createResult.isErr()) {
+            return createResult;
+          }
+          await existing.update({ providerId: createResult.value.providerId });
+          freshlyCreated = true;
+          logger.info(
+            {
+              sandbox: existing.toLogJSON(),
+              newProviderId: createResult.value.providerId,
+            },
+            "Recreated sandbox from deleted state"
+          );
+          break;
+        }
+
+        default:
+          assertNever(status);
+      }
+
+      await existing.updateStatus("running");
+      await existing.updateLastActivityAt();
+      return new Ok({ sandbox: existing, freshlyCreated });
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

Concurrent `ensureActive` calls for the same conversation (e.g. two bash tools fired in parallel) can race: both see no existing sandbox, both call `provider.create()`, and one sandbox gets orphaned.

Wraps the body of `ensureActive` in `executeWithLock` keyed on `conversation.sId` to serialize per-conversation. Uses the default 30s timeout which matches other locks in the codebase and covers sandbox creation time.

## Tests

- Type-checked with `tsc --noEmit` — passes
- Format-checked with `biome check` — passes

## Risk

Low. `executeWithLock` is already used extensively in the codebase. On timeout (30s), it throws which surfaces as a 500 — acceptable since it means something is seriously wrong. The lock is scoped per conversation so there's no global contention.

## Deploy Plan

Standard deploy — no migrations, no config changes.