### PR TITLE
Chrome extension mcp service

### DIFF
--- a/extension/platforms/chrome/services/core_platform.ts
+++ b/extension/platforms/chrome/services/core_platform.ts
@@ -1,6 +1,7 @@
 import { ChromeAuthService } from "@extension/platforms/chrome/services/auth";
 import { ChromeBrowserMessagingService } from "@extension/platforms/chrome/services/browser_messaging";
 import { ChromeCaptureService } from "@extension/platforms/chrome/services/capture";
+import { ChromeMcpService } from "@extension/platforms/chrome/services/mcp";
 import { ChromeStorageService } from "@extension/platforms/chrome/services/storage";
 import { CorePlatformService } from "@extension/shared/services/platform";
 
@@ -10,15 +11,19 @@ export interface PendingUpdate {
 }
 
 export class ChromeCorePlatformService extends CorePlatformService {
-  readonly supportsMCP = false;
+  readonly supportsMCP = true;
 
   constructor() {
+    const messaging = new ChromeBrowserMessagingService();
+    const mcpService = new ChromeMcpService(messaging);
+
     super(
       "chrome",
       ChromeAuthService,
       new ChromeStorageService(),
       new ChromeCaptureService(),
-      new ChromeBrowserMessagingService()
+      messaging,
+      mcpService
     );
   }
 

--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -1,0 +1,101 @@
+import type { DustAPI } from "@dust-tt/client";
+import { DustMcpServerTransport } from "@dust-tt/client";
+import { registerAllTools } from "@extension/platforms/chrome/tools";
+import { McpService } from "@extension/shared/services/mcp";
+import type { BrowserMessagingService } from "@extension/shared/services/platform";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Chrome-specific implementation of the MCP service.
+ * Tools use the browser messaging service to communicate with the background script.
+ */
+export class ChromeMcpService extends McpService {
+  private messaging: BrowserMessagingService | null;
+  private server: McpServer | null = null;
+  private transport: DustMcpServerTransport | null = null;
+  private serverId: string | undefined = undefined;
+
+  constructor(messaging?: BrowserMessagingService) {
+    super();
+    this.messaging = messaging ?? null;
+  }
+
+  createServerForWorkspace(): McpServer | null {
+    try {
+      const server = new McpServer({
+        name: "chrome-mcp-server",
+        version: "1.0.0",
+      });
+
+      registerAllTools(server, this.messaging);
+
+      this.server = server;
+      return server;
+    } catch (error) {
+      console.error("Error creating MCP server:", error);
+      return null;
+    }
+  }
+
+  async connectServer(
+    server: McpServer,
+    dustAPI: DustAPI,
+    onServerIdReceived: (serverId: string) => void
+  ): Promise<void> {
+    if (!server) {
+      throw new Error("Cannot connect null server");
+    }
+
+    try {
+      if (this.transport) {
+        return;
+      }
+
+      const transport = new DustMcpServerTransport(dustAPI, (serverId) => {
+        this.serverId = serverId;
+        onServerIdReceived(serverId);
+      });
+
+      await server.connect(transport);
+
+      this.transport = transport;
+    } catch (error) {
+      console.error("Failed to connect MCP server:", error);
+      throw error;
+    }
+  }
+
+  async getOrCreateServer(
+    dustAPI: DustAPI,
+    onServerIdReceived: (serverId: string) => void
+  ): Promise<{ server: McpServer | null; serverId: string | undefined }> {
+    try {
+      if (this.server) {
+        await this.connectServer(this.server, dustAPI, onServerIdReceived);
+        return { server: this.server, serverId: this.serverId };
+      }
+
+      const server = this.createServerForWorkspace();
+      if (!server) {
+        return { server: null, serverId: undefined };
+      }
+
+      await this.connectServer(server, dustAPI, onServerIdReceived);
+      return { server, serverId: this.serverId };
+    } catch (error) {
+      console.error("Error getting or creating MCP server:", error);
+      return { server: null, serverId: undefined };
+    }
+  }
+
+  getServerId(): string | undefined {
+    return this.serverId;
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.transport) {
+      await this.transport.close();
+      this.transport = null;
+    }
+  }
+}

--- a/extension/platforms/chrome/tools/getCurrentPageTool.ts
+++ b/extension/platforms/chrome/tools/getCurrentPageTool.ts
@@ -1,0 +1,75 @@
+import type {
+  GetActiveTabBackgroundMessage,
+  GetActiveTabBackgroundResponse,
+} from "@extension/platforms/chrome/messages";
+import type { BrowserMessagingService } from "@extension/shared/services/platform";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Registers the get-current-page tool with the MCP server.
+ * Retrieves the title, URL, and text content of the active browser tab.
+ */
+export function registerGetCurrentPageTool(
+  server: McpServer,
+  messaging: BrowserMessagingService | null
+): void {
+  server.tool(
+    "get-current-page",
+    "Retrieves the title, URL, and text content of the active browser tab. " +
+      "Use this to understand what page the user is currently viewing.",
+    {},
+    async () => {
+      if (!messaging) {
+        return {
+          content: [{ type: "text", text: "Messaging service not available." }],
+        };
+      }
+
+      try {
+        const response = await messaging.sendMessage<
+          GetActiveTabBackgroundMessage,
+          GetActiveTabBackgroundResponse
+        >({
+          type: "GET_ACTIVE_TAB",
+          includeContent: true,
+          includeCapture: false,
+        });
+
+        if (!response) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No response received from background script.",
+              },
+            ],
+          };
+        }
+
+        if (response.error) {
+          return {
+            content: [{ type: "text", text: `Error: ${response.error}` }],
+          };
+        }
+
+        const parts = [`Title: ${response.title}`, `URL: ${response.url}`];
+        if (response.content) {
+          parts.push(`Content:\n${response.content}`);
+        }
+
+        return {
+          content: [{ type: "text", text: parts.join("\n") }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get current page: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -1,0 +1,14 @@
+import type { BrowserMessagingService } from "@extension/shared/services/platform";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Registers all Chrome MCP tools with the server
+ * @param server The MCP server to register tools with
+ * @param messaging The browser messaging service for communicating with the background script
+ */
+export function registerAllTools(
+  server: McpServer,
+  messaging: BrowserMessagingService | null
+): void {
+  // Register Chrome-specific tools here.
+}

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -1,3 +1,4 @@
+import { registerGetCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
 import type { BrowserMessagingService } from "@extension/shared/services/platform";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -10,5 +11,5 @@ export function registerAllTools(
   server: McpServer,
   messaging: BrowserMessagingService | null
 ): void {
-  // Register Chrome-specific tools here.
+  registerGetCurrentPageTool(server, messaging);
 }

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,0 +1,112 @@
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { normalizeError } from "@extension/shared/lib/utils";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * React hook for using MCP servers in components
+ * This hook provides access to workspace-scoped MCP servers
+ *
+ * @returns An object with the MCP server, serverId for message payloads, and connection state
+ */
+export function useMcpServer() {
+  const platform = usePlatform();
+  const [isSupported, setIsSupported] = useState(false);
+  const [server, setServer] = useState<any>(null);
+  const [serverId, setServerId] = useState<string | undefined>(undefined);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const serverRef = useRef<any>(null);
+
+  const dustAPI = useDustAPI();
+
+  // Function to disconnect the server.
+  const disconnectServer = useCallback(async () => {
+    if (serverRef.current) {
+      try {
+        // If the server has a disconnect method, call it.
+        if (typeof serverRef.current.disconnect === "function") {
+          await serverRef.current.disconnect();
+        }
+        setIsConnected(false);
+      } catch (err) {
+        console.error("Error disconnecting MCP server:", err);
+      }
+    }
+  }, []);
+
+  // Create and connect to the MCP server.
+  useEffect(() => {
+    // Check if the platform supports MCP.
+    if (!platform.mcp) {
+      setIsSupported(false);
+      return;
+    }
+
+    setIsSupported(true);
+
+    let isMounted = true;
+
+    const setupServer = async () => {
+      try {
+        if (!platform.mcp) {
+          if (isMounted) {
+            setIsSupported(false);
+            return;
+          }
+
+          return;
+        }
+
+        const result = await platform.mcp.getOrCreateServer(
+          dustAPI,
+          (serverId) => {
+            setServerId(serverId);
+          }
+        );
+        if (!result.server) {
+          console.log("MCP server creation returned null");
+          if (isMounted) {
+            setIsSupported(false);
+            return;
+          }
+        }
+
+        if (isMounted) {
+          serverRef.current = result.server;
+          setServer(result.server);
+          setServerId(result.serverId);
+          setIsConnected(true);
+          setError(null);
+        }
+      } catch (err) {
+        console.error("Error setting up MCP server:", err);
+        if (isMounted) {
+          setError(normalizeError(err));
+          setIsConnected(false);
+        }
+      }
+    };
+
+    // Start the setup process.
+    void setupServer();
+
+    // Cleanup function.
+    return () => {
+      isMounted = false;
+      if (serverRef.current && isConnected) {
+        // Disconnect server if connected.
+        void disconnectServer();
+      }
+    };
+  }, [platform.mcp, isConnected, disconnectServer]);
+
+  return {
+    server,
+    serverId,
+    isConnected,
+    isSupported,
+    error,
+    disconnect: disconnectServer,
+  };
+}

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -21,6 +21,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@dust-tt/sparkle";
+import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
 import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
 import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
 import { DropzoneContainer } from "@extension/ui/components/DropzoneContainer";
@@ -30,6 +31,7 @@ import { useParams } from "react-router-dom";
 
 export const MainPage = () => {
   const { user, workspace, subscription } = useAuth();
+  const { serverId } = useMcpServer();
   const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
   const shortcut = isMac ? "⇧⌘E" : "⇧+Ctrl+E";
 
@@ -156,6 +158,7 @@ export const MainPage = () => {
                       user={user}
                       subscription={subscription}
                       conversationId={conversationId}
+                      clientSideMCPServerIds={serverId ? [serverId] : undefined}
                     />
                   </InputBarProvider>
                 </GenerationContextProvider>

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -141,6 +141,7 @@ export function ConversationContainerVirtuoso({
       router,
       sendNotification,
       createConversationWithMessage,
+      clientSideMCPServerIds,
     ]
   );
 

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -34,6 +34,7 @@ interface ConversationContainerProps {
   subscription: SubscriptionType;
   user: UserType;
   conversationId?: string | null;
+  clientSideMCPServerIds?: string[];
 }
 
 export function ConversationContainerVirtuoso({
@@ -41,6 +42,7 @@ export function ConversationContainerVirtuoso({
   subscription,
   user,
   conversationId: conversationIdProp,
+  clientSideMCPServerIds,
 }: ConversationContainerProps) {
   const conversationIdFromRouter = useActiveConversationId();
   const activeConversationId =
@@ -88,6 +90,7 @@ export function ConversationContainerVirtuoso({
           input,
           mentions: mentions.map(toMentionType),
           contentFragments,
+          clientSideMCPServerIds,
           selectedMCPServerViewIds,
           selectedSkillIds,
         },
@@ -160,6 +163,7 @@ export function ConversationContainerVirtuoso({
           conversationId={activeConversationId}
           setPlanLimitReached={setPlanLimitReached}
           key={activeConversationId}
+          clientSideMCPServerIds={clientSideMCPServerIds}
         />
       ) : (
         <>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -646,6 +646,7 @@ export const ConversationViewer = ({
     },
     [
       agentBuilderContext?.clientSideMCPServerIds,
+      clientSideMCPServerIds,
       agentBuilderContext?.skipToolsValidation,
       conversationId,
       mutateConversations,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -90,6 +90,7 @@ interface ConversationViewerProps {
   setPlanLimitReached?: (planLimitReached: boolean) => void;
   owner: WorkspaceType;
   user: UserType;
+  clientSideMCPServerIds?: string[];
 }
 
 function easeOutQuint(x: number): number {
@@ -115,6 +116,7 @@ export const ConversationViewer = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   setPlanLimitReached,
+  clientSideMCPServerIds,
 }: ConversationViewerProps) => {
   const ref =
     useRef<
@@ -519,7 +521,9 @@ export const ConversationViewer = ({
           input,
           mentions: mentions.map(toMentionType),
           contentFragments,
-          clientSideMCPServerIds: agentBuilderContext?.clientSideMCPServerIds,
+          clientSideMCPServerIds:
+            clientSideMCPServerIds ??
+            agentBuilderContext?.clientSideMCPServerIds,
           skipToolsValidation: agentBuilderContext?.skipToolsValidation,
         };
 


### PR DESCRIPTION
## Description

Implements MCP service support for the Chrome extension, enabling client-side tools to interact with browser content. This follows the same architecture pattern as the existing Front extension implementation. 

The Chrome platform service now instantiates a `ChromeMcpService` that registers tools using the browser messaging service to communicate with the background script. 

Adds a first tool, get-current-page, that retrieves the title, URL, and text content of the active browser tab.

## Tests

Ask an agent information about the current browser tab.

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
