### PR TITLE
Cache getAgentConfiguration for copilot

### DIFF
--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -22,8 +22,13 @@ import {
 
 import type { Result } from "../shared/result";
 import { Err, Ok } from "../shared/result";
-import { isGlobalAgentId } from "./assistant";
+import { normalizeError } from "../shared/utils/error_utils";
+import { GLOBAL_AGENTS_SID, isGlobalAgentId } from "./assistant";
 import { ConversationError } from "./conversation";
+
+// Copilot agent config is expensive to fetch (MCP server queries) so we cache it.
+// This can be increased when we have versions for copilot: we can then cache indefinitly.
+const COPILOT_AGENT_CONFIGURATION_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Error types for getAgentLoopData that indicate soft-deleted resources.
@@ -87,6 +92,33 @@ function getCachedGetConversation(ttlMs: number) {
     }
   );
 }
+
+async function getCopilotAgentConfigurationForCache(
+  auth: Authenticator,
+  // Only used for cache key uniqueness.
+  _workspaceId: string,
+  _userId: string
+): Promise<AgentConfigurationType> {
+  const config = await getAgentConfiguration(auth, {
+    agentId: GLOBAL_AGENTS_SID.COPILOT,
+    variant: "full",
+  });
+  if (!config) {
+    // Throws on error because cacheWithRedis expects functions that throw (not nullable returns).
+    throw new Error("Copilot agent configuration not found");
+  }
+  return config;
+}
+
+const getCachedCopilotAgentConfiguration = cacheWithRedis(
+  getCopilotAgentConfigurationForCache,
+  // cache is done per user as the prompt (available tools, skills...) may differ per users.
+  (_auth, workspaceId, userId) => `${workspaceId}:copilot:${userId}`,
+  {
+    ttlMs: COPILOT_AGENT_CONFIGURATION_CACHE_TTL_MS,
+    useDistributedLock: true,
+  }
+);
 
 export type AgentLoopArgs = {
   agentMessageId: string;
@@ -275,17 +307,35 @@ export async function getAgentLoopDataWithAuth(
     return new Err(new AgentLoopDataError("user_message_deleted"));
   }
 
-  // Fetch the agent configuration as we need the full version of the agent configuration.
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: agentMessage.configuration.sId,
-    // We do define agentMessage.configuration.version for global agent, ignoring this value here.
-    agentVersion: isGlobalAgentId(agentMessage.configuration.sId)
-      ? undefined
-      : agentMessage.configuration.version,
-    variant: "full",
-  });
-  if (!agentConfiguration) {
-    return new Err(new Error("Agent configuration not found"));
+  // Fetch the agent configuration.
+  // Copilot is cached per userId (expensive MCP server queries).
+  // Other agents are fetched directly for now.
+  let agentConfiguration: AgentConfigurationType;
+  const agentId = agentMessage.configuration.sId;
+  const user = auth.user();
+  if (agentId === GLOBAL_AGENTS_SID.COPILOT && user) {
+    try {
+      agentConfiguration = await getCachedCopilotAgentConfiguration(
+        auth,
+        auth.getNonNullableWorkspace().sId,
+        user.sId
+      );
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  } else {
+    const config = await getAgentConfiguration(auth, {
+      agentId,
+      // We do define agentMessage.configuration.version for global agent, ignoring this value here.
+      agentVersion: isGlobalAgentId(agentMessage.configuration.sId)
+        ? undefined
+        : agentMessage.configuration.version,
+      variant: "full" as const,
+    });
+    if (!config) {
+      return new Err(new Error("Agent configuration not found"));
+    }
+    agentConfiguration = config;
   }
 
   return new Ok({

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -26,9 +26,9 @@ import { normalizeError } from "../shared/utils/error_utils";
 import { GLOBAL_AGENTS_SID, isGlobalAgentId } from "./assistant";
 import { ConversationError } from "./conversation";
 
-// Copilot agent config is expensive to fetch (MCP server queries) so we cache it.
-// This can be increased when we have versions for copilot: we can then cache indefinitly.
-const COPILOT_AGENT_CONFIGURATION_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// Global agent config is expensive to fetch (MCP server queries) so we cache it.
+// This TTL can be increased when we have versions for global agents: we can then cache indefinitly.
+const GLOBAL_AGENT_CONFIGURATION_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Error types for getAgentLoopData that indicate soft-deleted resources.
@@ -39,6 +39,10 @@ export const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
   "agent_message_deleted",
   "user_message_deleted",
 ] as const;
+
+function isCachedGlobalAgent(agentId: string): boolean {
+  return agentId === GLOBAL_AGENTS_SID.COPILOT;
+}
 
 export type AgentLoopDataSoftDeleteErrorType =
   (typeof AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES)[number];
@@ -93,29 +97,31 @@ function getCachedGetConversation(ttlMs: number) {
   );
 }
 
-async function getCopilotAgentConfigurationForCache(
+async function getGlobalAgentConfigurationForCache(
   auth: Authenticator,
+  agentId: string,
   // Only used for cache key uniqueness.
   _workspaceId: string,
   _userId: string
 ): Promise<AgentConfigurationType> {
   const config = await getAgentConfiguration(auth, {
-    agentId: GLOBAL_AGENTS_SID.COPILOT,
+    agentId: agentId,
     variant: "full",
   });
   if (!config) {
     // Throws on error because cacheWithRedis expects functions that throw (not nullable returns).
-    throw new Error("Copilot agent configuration not found");
+    throw new Error(`Global agent configuration not found for id ${agentId}.`);
   }
   return config;
 }
 
-const getCachedCopilotAgentConfiguration = cacheWithRedis(
-  getCopilotAgentConfigurationForCache,
+const getCachedGlobalAgentConfiguration = cacheWithRedis(
+  getGlobalAgentConfigurationForCache,
   // cache is done per user as the prompt (available tools, skills...) may differ per users.
-  (_auth, workspaceId, userId) => `${workspaceId}:copilot:${userId}`,
+  (_auth, agentId, workspaceId, userId) =>
+    `${workspaceId}:${agentId}:${userId}`,
   {
-    ttlMs: COPILOT_AGENT_CONFIGURATION_CACHE_TTL_MS,
+    ttlMs: GLOBAL_AGENT_CONFIGURATION_CACHE_TTL_MS,
     useDistributedLock: true,
   }
 );
@@ -307,16 +313,14 @@ export async function getAgentLoopDataWithAuth(
     return new Err(new AgentLoopDataError("user_message_deleted"));
   }
 
-  // Fetch the agent configuration.
-  // Copilot is cached per userId (expensive MCP server queries).
-  // Other agents are fetched directly for now.
   let agentConfiguration: AgentConfigurationType;
   const agentId = agentMessage.configuration.sId;
   const user = auth.user();
-  if (agentId === GLOBAL_AGENTS_SID.COPILOT && user) {
+  if (isCachedGlobalAgent(agentId) && user) {
     try {
-      agentConfiguration = await getCachedCopilotAgentConfiguration(
+      agentConfiguration = await getCachedGlobalAgentConfiguration(
         auth,
+        agentId,
         auth.getNonNullableWorkspace().sId,
         user.sId
       );


### PR DESCRIPTION
## Description

Copilot is cached per user as the prompt may differ per user on which tool/skill is available for a global agent.
The cache TTL is low at the moment as we don't have versioning.
As soon as we have it we can cache per version and increase the cache TTL a lot.

This should make 

## Tests

manual tests

## Risk

low, may have previous version of copilot for 5 minutes
will be fixed when we have versions 

## Deploy Plan

deploy front
