### PR TITLE
fix: html entities in messages in projects

### DIFF
--- a/front/types/shared/utils/string_utils.test.ts
+++ b/front/types/shared/utils/string_utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { stripMarkdown } from "./string_utils";
+
+describe("stripMarkdown", () => {
+  it("strips basic markdown formatting", () => {
+    expect(stripMarkdown("**bold** and *italic*")).toBe("bold and italic");
+  });
+
+  it("strips headings", () => {
+    expect(stripMarkdown("# Heading 1")).toBe("Heading 1");
+    expect(stripMarkdown("## Heading 2")).toBe("Heading 2");
+  });
+
+  it("strips links", () => {
+    expect(stripMarkdown("[click here](https://example.com)")).toBe(
+      "click here"
+    );
+  });
+
+  it("strips inline code", () => {
+    expect(stripMarkdown("use `console.log`")).toBe("use console.log");
+  });
+
+  it("replaces agent mentions with @name", () => {
+    expect(stripMarkdown(":mention[Dust]{sId=abc123}")).toBe("@Dust");
+  });
+
+  it("replaces user mentions with @name", () => {
+    expect(stripMarkdown(":mention_user[Alice]{sId=user42}")).toBe("@Alice");
+  });
+
+  it("replaces content node mentions with quoted title", () => {
+    expect(
+      stripMarkdown(":content_node_mention[My Doc]{url=https://example.com}")
+    ).toBe('"My Doc"');
+  });
+
+  it("handles a mix of mentions and markdown", () => {
+    const input =
+      "Hey :mention[Bot]{sId=b1}, check **this** :content_node_mention[Report]{url=https://x.com}";
+    const result = stripMarkdown(input);
+    expect(result).toBe('Hey @Bot, check this "Report"');
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripMarkdown("just plain text")).toBe("just plain text");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMarkdown("")).toBe("");
+  });
+
+  it("handles &nbsp;", () => {
+    expect(stripMarkdown("hello&nbsp;darkness&nbsp;my&nbsp;old friend")).toBe(
+      "hello darkness my old friend"
+    );
+  });
+});

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -48,9 +48,32 @@ export function pluralize(count: number) {
   return count !== 1 ? "s" : "";
 }
 
+const HTML_ENTITIES: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};
+
+const HTML_ENTITY_PATTERN = new RegExp(
+  Object.keys(HTML_ENTITIES).join("|"),
+  "g"
+);
+
+function decodeHtmlEntities(text: string): string {
+  return text.replace(
+    HTML_ENTITY_PATTERN,
+    (match) => HTML_ENTITIES[match] ?? match
+  );
+}
+
 export function stripMarkdown(text: string): string {
-  return removeMarkdown(
-    replaceMentionsWithAt(replaceContentNodeMarkdownWithQuotedTitle(text))
+  return decodeHtmlEntities(
+    removeMarkdown(
+      replaceMentionsWithAt(replaceContentNodeMarkdownWithQuotedTitle(text))
+    )
   );
 }
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=159390020&issue=dust-tt%7Ctasks%7C6759
## Tests

### After

<img width="551" height="165" alt="image" src="https://github.com/user-attachments/assets/d18df0c5-b64c-4b49-a123-1e2706756319" />


### Before

<img width="612" height="136" alt="image" src="https://github.com/user-attachments/assets/1cad59dc-efb6-418b-b564-2434f4306c07" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
