### PR TITLE
[ON-CALL] Log get agent config error

### DIFF
--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -85,6 +85,10 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       view: "all",
     });
     if (getAgentsRes.isErr()) {
+      logger.error(
+        { err: getAgentsRes.error },
+        "suggest_agents_for_content: error fetching agent configurations"
+      );
       return new Err(new MCPError("Error fetching agent configurations"));
     }
     const agents = getAgentsRes.value as LightAgentConfigurationType[];


### PR DESCRIPTION
## Description

Got alerting in slack-monitor channels but error is too Generic
`Error fetching agent configurations` 
This PR logs the actual error from the api call

## Tests

no

## Risk

no - logs

## Deploy Plan

front
