### PR TITLE
Gong connector copy change

### DIFF
--- a/connectors/src/connectors/gong/lib/permission_profiles.ts
+++ b/connectors/src/connectors/gong/lib/permission_profiles.ts
@@ -33,7 +33,7 @@ export function renderPermissionProfiles(
       reason: supported
         ? null
         : `Permission level "${permissionLevel}" is not supported. ` +
-          `Only "all" and "specific teams" profiles can be used.`,
+          `Only profiles with "all" or "specific teams" access can be used as participant filters.`,
     };
   });
 }

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -132,7 +132,7 @@ function PermissionProfileSelector({
       sendNotification({
         type: "success",
         title: "Gong configuration updated",
-        description: "Permission profile successfully updated.",
+        description: "Participant filter successfully updated.",
       });
     } else {
       const err = await res.json();
@@ -147,7 +147,7 @@ function PermissionProfileSelector({
 
   return (
     <ContextItem
-      title="Permission Profile"
+      title="Participant Filter"
       visual={<ContextItem.Visual visual={GongLogo} />}
       action={
         <DropdownMenu>
@@ -161,7 +161,7 @@ function PermissionProfileSelector({
                     ? selectedProfile.name.slice(0, PROFILE_NAME_MAX_LENGTH) +
                       "..."
                     : selectedProfile.name
-                  : "All calls"
+                  : "All participants"
               }
               isSelect
               disabled={disabled || loading}
@@ -171,7 +171,7 @@ function PermissionProfileSelector({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
             <DropdownMenuItem
-              label="All calls"
+              label="All participants"
               onClick={() => handleSelect("")}
             />
             {permissionProfiles.map((profile) => {
@@ -201,8 +201,9 @@ function PermissionProfileSelector({
     >
       <ContextItem.Description>
         <div className="text-muted-foreground dark:text-muted-foreground-night">
-          Only calls with at least one participant from the profile&apos;s user
-          list will be synced. Changing the profile only affects future syncs.
+          Filter calls by participant group. Only calls where at least one
+          participant is assigned to the selected profile will be synced.
+          Changing the filter only affects future syncs.
         </div>
       </ContextItem.Description>
     </ContextItem>


### PR DESCRIPTION
## Description
Updating the copy for the Gong connector for user clarity. The field in Gong is called "permission profile" but we don't want to give the impression we are mimicking the permissions assigned to this profile. Instead, we'll be importing calls for the members of this profile.
@aubin-tchoi can you verify whether this new description aligns with our intent?

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
tested manually:
<img width="743" height="579" alt="Screenshot 2026-02-24 at 3 39 50 PM" src="https://github.com/user-attachments/assets/a2ea8123-d5a4-4d97-bc67-658f342de9c9" />

## Risk
Low, copy only
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front
- [ ] deploy connectors

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
