### PR TITLE
[ON-CALL] Silence noisy Langfuse no OTEL span

### DIFF
--- a/front/lib/api/instrumentation/init.ts
+++ b/front/lib/api/instrumentation/init.ts
@@ -19,14 +19,15 @@ export function initializeOpenTelemetryInstrumentation({
 }: {
   serviceName: "dust-agent-loop" | "dust-front";
 }): void {
+  // Suppress noisy "[Langfuse SDK] [WARN] No active OTEL span in context" warnings.
+  // This must be called even when Langfuse is disabled, otherwise the warnings will appear.
+  configureGlobalLogger({ level: LogLevel.ERROR });
+
   if (!config.isLangfuseEnabled() || sdk) {
     return;
   }
 
   try {
-    // Suppress noisy "[Langfuse SDK] [WARN] No active OTEL span in context" warnings.
-    configureGlobalLogger({ level: LogLevel.ERROR });
-
     resource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: serviceName,
     });


### PR DESCRIPTION
## Description

move logging config to avoid noisy
`[Langfuse SDK] [WARN] No active OTEL span in context. Skipping span update.`

## Tests

local

## Risk

low

## Deploy Plan

front
