### PR TITLE
Add new line to agent instruction start

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -977,7 +977,10 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: `\n:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
+          text: [
+            "",
+            `:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
+          ].join("\n\n"),
         },
       ]);
     } catch (error) {
@@ -1166,7 +1169,10 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: `\n:agent_suggestion[]{sId=${suggestion.sId} kind=${suggestion.kind}}`,
+          text: [
+            "",
+            `:agent_suggestion[]{sId=${suggestion.sId} kind=${suggestion.kind}}`,
+          ].join("\n\n"),
         },
       ]);
     } catch (error) {
@@ -1345,7 +1351,10 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: `\n:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
+          text: [
+            "",
+            `:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
+          ].join("\n\n"),
         },
       ]);
     } catch (error) {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -742,7 +742,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: directives.join("\n\n"),
+        text: ["", ...directives].join("\n\n"),
       },
     ]);
   },
@@ -863,7 +863,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: directives.join("\n\n"),
+        text: ["", ...directives].join("\n\n"),
       },
     ]);
   },
@@ -977,7 +977,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: `:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
+          text: `\n:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
         },
       ]);
     } catch (error) {
@@ -1105,7 +1105,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: directives.join("\n\n"),
+        text: ["", ...directives].join("\n\n"),
       },
     ]);
   },
@@ -1166,7 +1166,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: `:agent_suggestion[]{sId=${suggestion.sId} kind=${suggestion.kind}}`,
+          text: `\n:agent_suggestion[]{sId=${suggestion.sId} kind=${suggestion.kind}}`,
         },
       ]);
     } catch (error) {
@@ -1345,7 +1345,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: `:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
+          text: `\n:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`,
         },
       ]);
     } catch (error) {


### PR DESCRIPTION
close https://github.com/dust-tt/tasks/issues/6784
## Description
Markdown parsing library `remark-directive` isn't able to pull out an :agent_suggestion node if it's prefaced with another `:` - so we occasionally see something like:
<img width="420" height="162" alt="Screenshot 2026-02-24 at 2 12 45 PM" src="https://github.com/user-attachments/assets/39ffdb86-f785-4478-a2e8-c51bb408035e" />
We're already joining each directive with `\n\n` but `join` doesn't add one before the first element. We can fix the issue by adding an empty string to the beginning of each directive array so that when we `join`, we also capture the `\n\n` before the first suggestion
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Hard to test but manually confirmed this doesn't break currently functional behavior
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
