### PR TITLE
Fix sandbox lifetime and add resilience to unexpected E2B state

### DIFF
--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -61,6 +61,21 @@ export interface FileEntry {
 }
 
 // ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown (or returned) when the provider no longer knows about a sandbox.
+ * E.g. E2B killed it after its lifetime expired.
+ */
+export class SandboxNotFoundError extends Error {
+  constructor(providerId: string) {
+    super(`Sandbox ${providerId} not found at provider.`);
+    this.name = "SandboxNotFoundError";
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Provider interface
 // ---------------------------------------------------------------------------
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -6,13 +6,18 @@ import type {
   SandboxHandle,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
+import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { CommandExitError, Sandbox } from "e2b";
+import { CommandExitError, NotFoundError, Sandbox } from "e2b";
 
-const SANDBOX_CREATION_TIMEOUT_MS = 30_000;
+/** How long E2B keeps the sandbox alive (renewed on every connect). */
+const SANDBOX_LIFETIME_MS = 3_600_000; // 1 hour
+
+/** Timeout for individual API calls to E2B (create, connect, etc.). */
+const REQUEST_TIMEOUT_MS = 30_000;
 
 interface E2BConfig {
   apiKey: string;
@@ -56,7 +61,8 @@ export class E2BSandboxProvider implements SandboxProvider {
       sandbox = await Sandbox.create(templateId, {
         ...this.connectionOpts(),
         envs: config.envVars,
-        timeoutMs: SANDBOX_CREATION_TIMEOUT_MS,
+        timeoutMs: SANDBOX_LIFETIME_MS,
+        requestTimeoutMs: REQUEST_TIMEOUT_MS,
       });
     } catch (err) {
       return new Err(normalizeError(err));
@@ -75,8 +81,14 @@ export class E2BSandboxProvider implements SandboxProvider {
 
     // Sandbox.connect auto-resumes paused sandboxes.
     try {
-      await Sandbox.connect(providerId, this.connectionOpts());
+      await Sandbox.connect(providerId, {
+        ...this.connectionOpts(),
+        timeoutMs: SANDBOX_LIFETIME_MS,
+      });
     } catch (err) {
+      if (err instanceof NotFoundError) {
+        return new Err(new SandboxNotFoundError(providerId));
+      }
       return new Err(normalizeError(err));
     }
 
@@ -127,8 +139,14 @@ export class E2BSandboxProvider implements SandboxProvider {
   ): Promise<Result<ExecResult, Error>> {
     let sandbox: Sandbox;
     try {
-      sandbox = await Sandbox.connect(providerId, this.connectionOpts());
+      sandbox = await Sandbox.connect(providerId, {
+        ...this.connectionOpts(),
+        timeoutMs: SANDBOX_LIFETIME_MS,
+      });
     } catch (err) {
+      if (err instanceof NotFoundError) {
+        return new Err(new SandboxNotFoundError(providerId));
+      }
       return new Err(normalizeError(err));
     }
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -13,7 +13,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { CommandExitError, NotFoundError, Sandbox } from "e2b";
 
-/** How long E2B keeps the sandbox alive (renewed on every connect). */
+// TODO(SANDBOX-S1): Replace fixed lifetime with reaper-based cleanup.
+// https://github.com/dust-tt/tasks/issues/6720
 const SANDBOX_LIFETIME_MS = 3_600_000; // 1 hour
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,5 +1,6 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import type { ExecOptions, ExecResult } from "@app/lib/api/sandbox/provider";
+import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -197,14 +198,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         case "sleeping": {
           const wakeResult = await provider.wake(existing.providerId);
           if (wakeResult.isErr()) {
-            return wakeResult;
+            // The sandbox may have been killed by the provider (e.g. lifetime
+            // expired). Fall through to recreation instead of propagating the
+            // error.
+            logger.error(
+              {
+                sandbox: existing.toLogJSON(),
+                error: wakeResult.error.message,
+              },
+              "Failed to wake sandbox — will recreate"
+            );
+          } else {
+            logger.info(
+              { sandbox: existing.toLogJSON() },
+              "Woke sleeping sandbox"
+            );
+            break;
           }
-          logger.info(
-            { sandbox: existing.toLogJSON() },
-            "Woke sleeping sandbox"
-          );
-          break;
         }
+        // Falls through to recreation when wake fails.
 
         case "deleted": {
           const createResult = await provider.create({});
@@ -246,7 +258,17 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       return new Err(new Error("Sandbox provider not configured."));
     }
 
-    return provider.exec(this.providerId, command, opts);
+    const result = await provider.exec(this.providerId, command, opts);
+
+    if (result.isErr() && result.error instanceof SandboxNotFoundError) {
+      logger.error(
+        { sandbox: this.toLogJSON() },
+        "Sandbox not found at provider during exec — marking as deleted"
+      );
+      await this.updateStatus("deleted");
+    }
+
+    return result;
   }
 
   toLogJSON() {


### PR DESCRIPTION
## Description

`SANDBOX_CREATION_TIMEOUT_MS = 30_000` was passed as `timeoutMs` to `Sandbox.create()`, but in the E2B SDK `timeoutMs` controls the **sandbox lifetime** (not the API call timeout). Sandboxes auto-killed after 30 seconds and only survived longer because each `Sandbox.connect()` in `exec()` reset the timeout to the default 5 minutes. Once idle for >5 minutes, E2B killed the sandbox while our DB still said `"running"`, causing a `NotFoundError` loop.

**Changes:**
- Set sandbox lifetime to 1 hour (`SANDBOX_LIFETIME_MS = 3_600_000`) and use `requestTimeoutMs` for the 30s API call timeout
- Pass `timeoutMs` on every `Sandbox.connect()` (wake, exec) so the sandbox gets a full hour each time
- Add `SandboxNotFoundError` to the provider interface
- Detect E2B `NotFoundError` in `wake()` and `exec()`, wrap as `SandboxNotFoundError`
- In `ensureActive`: if waking a sleeping sandbox fails, fall through to recreation instead of propagating the error
- In `exec`: if sandbox is not found at provider, mark it as `"deleted"` so the next `ensureActive` call recreates it

## Tests

- Type-checked with `npx tsc --noEmit`
- Biome format check passed
- Manual verification of E2B SDK types (`SandboxOpts.timeoutMs`, `ConnectionOpts.requestTimeoutMs`, `NotFoundError`)

## Risk

Low — the sandbox lifetime change (30s → 1h) is purely beneficial. The resilience logic adds fallback paths that only trigger when the sandbox is already broken, so no impact on the happy path.

## Deploy Plan

Standard deploy. No migration needed — changes only affect runtime behavior.