### PR TITLE
Add exclude keywords for gong connector

### DIFF
--- a/connectors/migrations/db/migration_119.sql
+++ b/connectors/migrations/db/migration_119.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 24, 2026
+ALTER TABLE "public"."gong_configurations" ADD COLUMN "excludeTitleKeywords" VARCHAR(255)[] DEFAULT NULL;

--- a/connectors/migrations/db/migration_119.sql
+++ b/connectors/migrations/db/migration_119.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 24, 2026
+ALTER TABLE "public"."gong_configurations" ADD COLUMN "excludeTitleKeywords" VARCHAR(255)[];

--- a/connectors/migrations/db/migration_119.sql
+++ b/connectors/migrations/db/migration_119.sql
@@ -1,2 +1,0 @@
--- Migration created on Feb 24, 2026
-ALTER TABLE "public"."gong_configurations" ADD COLUMN "excludeTitleKeywords" VARCHAR(255)[] DEFAULT NULL;

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -14,6 +14,7 @@ export class GongConfigurationModel extends ConnectorBaseModel<GongConfiguration
   declare trackersEnabled: boolean;
   declare accountsEnabled: boolean;
   declare permissionProfileId: string | null;
+  declare excludeTitleKeywords: string[] | null;
 }
 
 GongConfigurationModel.init(
@@ -57,6 +58,11 @@ GongConfigurationModel.init(
     permissionProfileId: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    excludeTitleKeywords: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -62,7 +62,6 @@ GongConfigurationModel.init(
     excludeTitleKeywords: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
-      defaultValue: null,
     },
   },
   {


### PR DESCRIPTION
## Description
Context [here](https://dust4ai.slack.com/archives/C07Q0576XSP/p1771611894284519).
This PR adds a column excludeTitleKeywords to the table gong_configurations.
Goal is to allow filtering out of certain keywords (like interview) which was mentioned as the highest value filtration pattern for gong transcripts

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Run migration
- [ ] Deploy connectors

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
