### PR TITLE
Make suggestion directive robust

### DIFF
--- a/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
@@ -11,9 +11,8 @@ import {
   SuggestionCardSkeleton,
 } from "@app/components/markdown/suggestion/CopilotSuggestionCard";
 import type { AgentSuggestionKind } from "@app/types/suggestions/agent_suggestion";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useEffect } from "react";
-import { visit } from "unist-util-visit";
+import { useEffect } from "react";
+import { SKIP, visit } from "unist-util-visit";
 
 /**
  * Remark directive plugin for parsing copilot suggestion directives.
@@ -23,7 +22,7 @@ import { visit } from "unist-util-visit";
  */
 export function copilotSuggestionDirective() {
   return (tree: any) => {
-    visit(tree, ["textDirective"], (node) => {
+    visit(tree, ["textDirective", "leafDirective"], (node) => {
       if (node.name === "agent_suggestion") {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const data = node.data || (node.data = {});
@@ -33,6 +32,36 @@ export function copilotSuggestionDirective() {
           kind: node.attributes.kind,
         };
       }
+    });
+
+    // Models may not output a newline before the directive
+    // (e.g. "issues::agent_suggestion[]{sId=xxx kind=yyy}" — the prefix
+    // prevents remarkDirective from parsing it). We drop the prefix and render the directive.
+    visit(tree, "text", (node, index, parent) => {
+      if (!parent || index === null) {
+        return;
+      }
+      const match = /::agent_suggestion\[\]\{([^}]*)\}/.exec(node.value);
+      if (!match) {
+        return;
+      }
+      const attrs = Object.fromEntries(
+        [...match[1].matchAll(/(\w+)=([^\s}]+)/g)].map((m) => [m[1], m[2]])
+      );
+      // Replace the entire text node (incl. leaked prefix) with a leafDirective node.
+      parent.children = [
+        ...parent.children.slice(0, index),
+        {
+          type: "leafDirective",
+          name: "agent_suggestion",
+          attributes: attrs,
+          children: [],
+          data: { hName: "agent_suggestion", hProperties: attrs },
+        },
+        ...parent.children.slice(index + 1),
+      ];
+
+      return [SKIP, index];
     });
   };
 }


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/6763
* Problem is that model was rendering directive without a space, which caused it not to match. Instead of prompting our way out of this, added a fallback visit for this use case

## Tests

Created a mock example for testing:

<img width="654" height="437" alt="Screenshot 2026-02-24 at 6 37 23 PM" src="https://github.com/user-attachments/assets/2bedcb7c-1132-46bf-bca1-3e819b980e12" />

## Risk

* Low

## Deploy Plan

* Deploy front