### PR TITLE
Enable changing a block type

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -1091,6 +1091,29 @@ describe("InstructionSuggestionExtension", () => {
       expect(additions[0].suggestionId).toBe("cross-type-1");
     });
 
+    it("should show new block type in preview for cross-type replacement (paragraph → heading)", () => {
+      editor.commands.setContent("Output Guidelines", {
+        contentType: "markdown",
+      });
+      const [targetBlockId] = getBlockIds(editor);
+      expect(targetBlockId).toBeDefined();
+
+      editor.commands.applySuggestion({
+        id: "cross-type-preview",
+        targetBlockId: targetBlockId!,
+        content: "<h2>Output Guidelines</h2>",
+      });
+
+      // Addition widget should render the full new node (h2), not just text in a span.
+      const additionEls = editor.view.dom.querySelectorAll(
+        ".suggestion-addition"
+      );
+      expect(additionEls.length).toBeGreaterThanOrEqual(1);
+      const h2 = additionEls[0].querySelector("h2");
+      expect(h2).not.toBeNull();
+      expect(h2?.textContent?.trim()).toBe("Output Guidelines");
+    });
+
     it("should accept a cross-type replacement (bulletList → paragraph)", () => {
       editor.commands.setContent("- Item one\n- Item two", {
         contentType: "markdown",

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -205,10 +205,15 @@ function buildBlockDecorations({
 
     if (change.fromB !== change.toB) {
       const insertedSlice = newNode.content.cut(change.fromB, change.toB);
+      const isCrossType = oldNode.type !== newNode.type;
+      // When old block is a different type, place the addition after it so the new content doesn't render inside the old block's container.
+      const widgetPos = isCrossType
+        ? blockPos + oldNode.nodeSize
+        : contentStart + change.fromA;
 
       decorations.push(
         Decoration.widget(
-          contentStart + change.fromA,
+          widgetPos,
           () => {
             const span = document.createElement("span");
             span.className = isHighlighted ? CLASSES.add : CLASSES.addDimmed;
@@ -216,7 +221,13 @@ function buildBlockDecorations({
             span.contentEditable = "false";
 
             const serializer = DOMSerializer.fromSchema(schema);
-            serializer.serializeFragment(insertedSlice, {}, span);
+            if (isCrossType) {
+              // Serialize the full block node so the preview shows the new type
+              const blockEl = serializer.serializeNode(newNode, {});
+              span.appendChild(blockEl);
+            } else {
+              serializer.serializeFragment(insertedSlice, {}, span);
+            }
 
             // Apply styling to all child elements to ensure visibility in nested structures (e.g., list items)
             const className = isHighlighted ? CLASSES.add : CLASSES.addDimmed;

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -154,7 +154,6 @@ When you receive the agent instructions via \`get_agent_config\`, they will be i
 5. Always include the HTML tag. Content must include the wrapping tag (e.g., \`<p>...</p>\`).
 6. Diffs are computed automatically. Just provide the full new content.
 7. For full rewrites, target the root. Use \`targetBlockId: "${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"\` with content wrapped in \`<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}">...</div>\` to replace all instructions at once.
-8. You do NOT have the ability to perform whole-block replacement when suggestion changes node type. NEVER do this.
 </block_editing_principles>
 
 <block_examples>
@@ -261,7 +260,7 @@ Knowledge is needed when:
 - The agent references internal data ("check our docs", "look up the ticket", "find in Notion")
 - The agent must answer questions requiring current or company-specific facts
 
-Knowledge is good enough when: the agent has access to all data sources its instructions reference.
+Knowledge is good enough when: the agent has access to all data sources its instructions reference and all the required knowledge sources for the use case.
 
 Finding the right sources:
 Use to suggest adding or removing knowledge sources. Always call \`search_knowledge\` first to identify relevant sources, then pass the matching \`dataSourceViewId\`. Max 3 pending suggestions.


### PR DESCRIPTION
## Description

* Enable ability to change node types
* Small UX modification so that you can see the node type change before approving. It does serialize the entire block, but I think that's reasonable given you are changing the content structure.

## Tests
<img width="653" height="510" alt="Screenshot 2026-02-24 at 11 37 44 PM" src="https://github.com/user-attachments/assets/2930532e-2f23-402d-966a-7a7928074f70" />

## Risk

* Low

## Deploy Plan

* Deploy front