### PR TITLE
Add parallel copilot-haiku agent for testing

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -7,6 +7,7 @@ import { useSearchParam } from "@app/lib/platform";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { TemplateInfo } from "@app/types/assistant/templates";
+import { isString } from "@app/types/shared/utils/general";
 import type { ReactNode } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, {
@@ -66,7 +67,7 @@ export const CopilotPanelProvider = ({
   const sendNotification = useSendNotification();
   const model = useSearchParam("model");
   const copilotAgentId =
-    model === "haiku"
+    isString(model) && model === "haiku"
       ? GLOBAL_AGENTS_SID.COPILOT_HAIKU
       : GLOBAL_AGENTS_SID.COPILOT;
 

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -3,6 +3,7 @@ import { useCopilotFirstMessage } from "@app/hooks/useCopilotFirstMessage";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { useSearchParam } from "@app/lib/platform";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { TemplateInfo } from "@app/types/assistant/templates";
@@ -63,6 +64,11 @@ export const CopilotPanelProvider = ({
   const { owner } = useAgentBuilderContext();
   const { user } = useAuth();
   const sendNotification = useSendNotification();
+  const model = useSearchParam("model");
+  const copilotAgentId =
+    model === "haiku"
+      ? GLOBAL_AGENTS_SID.COPILOT_HAIKU
+      : GLOBAL_AGENTS_SID.COPILOT;
 
   const [conversation, setConversation] = useState<ConversationType | null>(
     null
@@ -104,7 +110,7 @@ export const CopilotPanelProvider = ({
     const result = await createConversationWithMessage({
       messageData: {
         input: firstMessagePrompt,
-        mentions: [{ configurationId: GLOBAL_AGENTS_SID.COPILOT }],
+        mentions: [{ configurationId: copilotAgentId }],
         contentFragments: { uploaded: [], contentNodes: [] },
         origin: "agent_copilot",
         clientSideMCPServerIds,
@@ -134,6 +140,7 @@ export const CopilotPanelProvider = ({
     setIsCreatingConversation(false);
   }, [
     clientSideMCPServerIds,
+    copilotAgentId,
     createConversationWithMessage,
     getFirstMessage,
     useCase,

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -489,7 +489,7 @@ function formatAvailableTools(tools: AvailableTool[]): string {
   return `## AVAILABLE TOOLS\n${tools.length} tools available.\n\n${toolLines}`;
 }
 
-function buildCopilotInstructions(
+export function buildCopilotInstructions(
   copilotContext: CopilotContext | null
 ): string {
   const parts: string[] = [

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot_haiku.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot_haiku.ts
@@ -1,0 +1,63 @@
+import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
+// Re-use the same instruction builder from the main copilot module.
+import { buildCopilotInstructions } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
+import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
+import type { CopilotContext } from "@app/lib/api/assistant/global_agents/global_agents";
+import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+
+export function _getCopilotHaikuGlobalAgent(
+  auth: Authenticator,
+  copilotContext: CopilotContext | null
+): AgentConfigurationType {
+  const actions = copilotContext?.mcpServerViews?.context
+    ? [
+        buildServerSideMCPServerConfiguration({
+          mcpServerView: copilotContext.mcpServerViews.context,
+        }),
+      ]
+    : [];
+
+  const modelConfiguration = CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
+  const model = modelConfiguration
+    ? {
+        providerId: modelConfiguration.providerId,
+        modelId: modelConfiguration.modelId,
+        temperature: 0.7,
+        reasoningEffort: modelConfiguration.maximumReasoningEffort,
+      }
+    : dummyModelConfiguration;
+
+  const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT_HAIKU);
+
+  const instructions = buildCopilotInstructions(copilotContext);
+
+  return {
+    id: -1,
+    sId: metadata.sId,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: metadata.name,
+    description: metadata.description,
+    instructions,
+    instructionsHtml: null,
+    pictureUrl: metadata.pictureUrl,
+    status: "active",
+    scope: "global",
+    userFavorite: false,
+    model,
+    actions,
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -457,6 +457,13 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "An agent that suggests improvements for another agent.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.COPILOT_HAIKU:
+      return {
+        sId: GLOBAL_AGENTS_SID.COPILOT_HAIKU,
+        name: "Sidekick (Haiku)",
+        description: "An agent that suggests improvements for another agent.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.NOOP:
       return {
         sId: GLOBAL_AGENTS_SID.NOOP,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/api/assistant/global_agents/configurations/anthropic";
 import { _getDeepSeekR1GlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/deepseek";
 import { _getCopilotGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
+import { _getCopilotHaikuGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot_haiku";
 import {
   _getBrowserSummaryAgent,
   _getDeepDiveGlobalAgent,
@@ -207,6 +208,10 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsToolsets: false,
   },
   [GLOBAL_AGENTS_SID.COPILOT]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.COPILOT_HAIKU]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
   [GLOBAL_AGENTS_SID.SLACK]: { injectsMemory: false, injectsToolsets: false },
   [GLOBAL_AGENTS_SID.GOOGLE_DRIVE]: {
     injectsMemory: false,
@@ -775,6 +780,9 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.COPILOT:
       agentConfiguration = _getCopilotGlobalAgent(auth, copilotContext);
       break;
+    case GLOBAL_AGENTS_SID.COPILOT_HAIKU:
+      agentConfiguration = _getCopilotHaikuGlobalAgent(auth, copilotContext);
+      break;
     case GLOBAL_AGENTS_SID.NOOP:
       // we want only to have it in development
       if (isDevelopment()) {
@@ -858,8 +866,12 @@ export async function getGlobalAgents(
     agentIds ??
     Object.values(GLOBAL_AGENTS_SID)
       .filter((sId) => !RETIRED_GLOBAL_AGENTS_SID.includes(sId))
-      // We only want to fetch copilot global agent if explicitely requested.
-      .filter((sId) => sId !== GLOBAL_AGENTS_SID.COPILOT);
+      // We only want to fetch copilot global agents if explicitly requested.
+      .filter(
+        (sId) =>
+          sId !== GLOBAL_AGENTS_SID.COPILOT &&
+          sId !== GLOBAL_AGENTS_SID.COPILOT_HAIKU
+      );
 
   const flags = await getFeatureFlags(owner);
 
@@ -921,14 +933,17 @@ export async function getGlobalAgents(
   }
   if (!flags.includes("agent_builder_copilot")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.COPILOT
+      (sId) =>
+        sId !== GLOBAL_AGENTS_SID.COPILOT &&
+        sId !== GLOBAL_AGENTS_SID.COPILOT_HAIKU
     );
   }
 
   let copilotContext: CopilotContext | null = null;
   if (
     variant === "full" &&
-    agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT)
+    (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_HAIKU))
   ) {
     const [context, userMetadata, models, skills, tools] = await Promise.all([
       MCPServerViewResource.getMCPServerViewForAutoInternalTool(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -146,6 +146,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
   DUST_PLANNING = "dust-planning",
   COPILOT = "copilot",
+  COPILOT_HAIKU = "copilot-haiku",
   SLACK = "slack",
   GOOGLE_DRIVE = "google_drive",
   NOTION = "notion",
@@ -187,6 +188,7 @@ export function isGlobalAgentId(sId: string): sId is GLOBAL_AGENTS_SID {
 
 const AGENT_IDS_RESTRICTED_TO_BUILDER = new Set<string>([
   GLOBAL_AGENTS_SID.COPILOT,
+  GLOBAL_AGENTS_SID.COPILOT_HAIKU,
 ]);
 
 export function canShowAgentConversationActions(agentId: string): boolean {


### PR DESCRIPTION
## Description

This is an experimentation that exposes a parallel haiku copilot agent for testing. To use it, pass model=haiku on the agent build URL.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Under copilot flag

## Deploy Plan

Front