### PR TITLE
[Front] feat(copilot): add Langfuse prompt fetching for copilot variants

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -1,11 +1,7 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
+import type { CopilotContext } from "@app/lib/api/assistant/global_agents/copilot_context";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
-import type { CopilotContext } from "@app/lib/api/assistant/global_agents/global_agents";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import type {
-  AvailableSkill,
-  AvailableTool,
-} from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
@@ -13,8 +9,6 @@ import {
   GLOBAL_AGENTS_SID,
   getLargeWhitelistedModel,
 } from "@app/types/assistant/assistant";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
-import { JOB_TYPE_LABELS } from "@app/types/job_type";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 
 const COPILOT_INSTRUCTION_SECTIONS = {
@@ -422,72 +416,19 @@ You CANNOT configure triggers or schedules for the agent. When users ask about s
 Do NOT attempt to handle scheduling through instructions or tools — triggers are a separate configuration outside of what you can suggest.
 </triggers_and_schedules>`,
 
-  workspaceContext: ({
-    models,
-    skills,
-    tools,
-  }: {
-    models: string;
-    skills: string;
-    tools: string;
-  }) => `<workspace_context>
+  workspaceContext: (formatted: string) => `<workspace_context>
 The following capabilities are available in this workspace and can be suggested when building agents:
 
-${models}
-
-${skills}
-
-${tools}
+${formatted}
 </workspace_context>`,
 
-  userContext: (jobTypeLabel: string, platforms: string) => `<user_context>
+  userContext: (formatted: string) => `<user_context>
 The user building this agent has the following profile:
-- Job function: ${jobTypeLabel}
-- Preferred platforms: ${platforms}
+${formatted}
 
 Consider their role and platform preferences when suggesting tools and improvements.
 </user_context>`,
 };
-
-function formatAvailableModels(models: ModelConfigurationType[]): string {
-  const byProvider = new Map<string, ModelConfigurationType[]>();
-  for (const m of models) {
-    const list = byProvider.get(m.providerId) ?? [];
-    list.push(m);
-    byProvider.set(m.providerId, list);
-  }
-
-  const sections = Array.from(byProvider.entries()).map(
-    ([provider, models]) => {
-      const modelLines = models
-        .map(
-          (m) =>
-            `- **${m.displayName}** (modelId: ${m.modelId}): ${m.description}${m.supportsVision ? " (vision)" : " (no vision)"}`
-        )
-        .join("\n");
-      return `### ${provider}\n${modelLines}`;
-    }
-  );
-
-  return `## AVAILABLE MODELS\n${models.length} models available.\n\n${sections.join("\n\n")}`;
-}
-
-function formatAvailableSkills(skills: AvailableSkill[]): string {
-  const skillLines = skills
-    .map(
-      (s) =>
-        `- **${s.name}** (ID: ${s.sId}): ${s.agentFacingDescription ?? "No description"}`
-    )
-    .join("\n");
-  return `## AVAILABLE SKILLS\n${skills.length} skills available.\n\n${skillLines}`;
-}
-
-function formatAvailableTools(tools: AvailableTool[]): string {
-  const toolLines = tools
-    .map((t) => `- **${t.name}** (ID: ${t.sId}): ${t.description}`)
-    .join("\n");
-  return `## AVAILABLE TOOLS\n${tools.length} tools available.\n\n${toolLines}`;
-}
 
 export function buildCopilotInstructions(
   copilotContext: CopilotContext | null
@@ -512,31 +453,19 @@ export function buildCopilotInstructions(
     return parts.join("\n\n");
   }
 
-  const { userMetadata, workspaceCapabilities } = copilotContext;
-
-  if (
-    userMetadata &&
-    (userMetadata.jobType || userMetadata.favoritePlatforms.length > 0)
-  ) {
-    const jobTypeLabel = userMetadata.jobType
-      ? JOB_TYPE_LABELS[userMetadata.jobType]
-      : "Not specified";
-    const platforms =
-      userMetadata.favoritePlatforms.join(", ") || "None specified";
-
+  if (copilotContext.formattedUserContext) {
     parts.push(
-      COPILOT_INSTRUCTION_SECTIONS.userContext(jobTypeLabel, platforms)
+      COPILOT_INSTRUCTION_SECTIONS.userContext(
+        copilotContext.formattedUserContext
+      )
     );
   }
 
-  if (workspaceCapabilities) {
-    const { models, skills, tools } = workspaceCapabilities;
+  if (copilotContext.formattedWorkspaceContext) {
     parts.push(
-      COPILOT_INSTRUCTION_SECTIONS.workspaceContext({
-        models: formatAvailableModels(models),
-        skills: formatAvailableSkills(skills),
-        tools: formatAvailableTools(tools),
-      })
+      COPILOT_INSTRUCTION_SECTIONS.workspaceContext(
+        copilotContext.formattedWorkspaceContext
+      )
     );
   }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot_haiku.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot_haiku.ts
@@ -1,8 +1,8 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
 // Re-use the same instruction builder from the main copilot module.
 import { buildCopilotInstructions } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
+import type { CopilotContext } from "@app/lib/api/assistant/global_agents/copilot_context";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
-import type { CopilotContext } from "@app/lib/api/assistant/global_agents/global_agents";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -34,7 +34,9 @@ export function _getCopilotHaikuGlobalAgent(
 
   const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT_HAIKU);
 
-  const instructions = buildCopilotInstructions(copilotContext);
+  const instructions =
+    copilotContext?.langfuseInstructions ??
+    buildCopilotInstructions(copilotContext);
 
   return {
     id: -1,

--- a/front/lib/api/assistant/global_agents/copilot_context.ts
+++ b/front/lib/api/assistant/global_agents/copilot_context.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import logger from "@app/logger/logger";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
@@ -170,14 +171,20 @@ export async function buildCopilotContext(
 
   let langfuseInstructions: string | null = null;
   if (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_HAIKU)) {
-    const result = await fetchAndCompileLangfusePrompt(
-      GLOBAL_AGENTS_SID.COPILOT_HAIKU,
-      {
-        userContext: formattedUserContext ?? "",
-        workspaceContext: formattedWorkspaceContext,
-      }
-    );
-    if (result.isOk()) {
+    const promptName = GLOBAL_AGENTS_SID.COPILOT_HAIKU;
+    const result = await fetchAndCompileLangfusePrompt(promptName, {
+      userContext: formattedUserContext ?? "",
+      workspaceContext: formattedWorkspaceContext,
+    });
+    if (result.isErr()) {
+      logger.error(
+        {
+          promptName,
+          error: result.error,
+        },
+        "[Langfuse] Failed to fetch prompt"
+      );
+    } else {
       langfuseInstructions = result.value;
     }
   }

--- a/front/lib/api/assistant/global_agents/copilot_context.ts
+++ b/front/lib/api/assistant/global_agents/copilot_context.ts
@@ -1,0 +1,191 @@
+import { AGENT_COPILOT_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
+import { fetchAndCompileLangfusePrompt } from "@app/lib/api/assistant/global_agents/langfuse_prompts";
+import type {
+  AvailableSkill,
+  AvailableTool,
+} from "@app/lib/api/assistant/workspace_capabilities";
+import {
+  getAvailableModelsForWorkspace,
+  listAvailableSkills,
+  listAvailableTools,
+} from "@app/lib/api/assistant/workspace_capabilities";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { FavoritePlatform } from "@app/types/favorite_platforms";
+import { isFavoritePlatform } from "@app/types/favorite_platforms";
+import type { JobType } from "@app/types/job_type";
+import { isJobType, JOB_TYPE_LABELS } from "@app/types/job_type";
+import { isStringArray } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+interface CopilotUserMetadata {
+  jobType: JobType | null;
+  favoritePlatforms: FavoritePlatform[];
+}
+
+export interface CopilotContext {
+  mcpServerViews: {
+    context: MCPServerViewResource;
+  } | null;
+  formattedUserContext: string | null;
+  formattedWorkspaceContext: string | null;
+  langfuseInstructions: string | null;
+}
+
+export function formatAvailableModels(
+  models: ModelConfigurationType[]
+): string {
+  const byProvider = new Map<string, ModelConfigurationType[]>();
+  for (const m of models) {
+    const list = byProvider.get(m.providerId) ?? [];
+    list.push(m);
+    byProvider.set(m.providerId, list);
+  }
+
+  const sections = Array.from(byProvider.entries()).map(
+    ([provider, models]) => {
+      const modelLines = models
+        .map(
+          (m) =>
+            `- **${m.displayName}** (modelId: ${m.modelId}): ${m.description}${m.supportsVision ? " (vision)" : " (no vision)"}`
+        )
+        .join("\n");
+      return `### ${provider}\n${modelLines}`;
+    }
+  );
+
+  return `## AVAILABLE MODELS\n${models.length} models available.\n\n${sections.join("\n\n")}`;
+}
+
+export function formatAvailableSkills(skills: AvailableSkill[]): string {
+  const skillLines = skills
+    .map(
+      (s) =>
+        `- **${s.name}** (ID: ${s.sId}): ${s.agentFacingDescription ?? "No description"}`
+    )
+    .join("\n");
+  return `## AVAILABLE SKILLS\n${skills.length} skills available.\n\n${skillLines}`;
+}
+
+export function formatAvailableTools(tools: AvailableTool[]): string {
+  const toolLines = tools
+    .map((t) => `- **${t.name}** (ID: ${t.sId}): ${t.description}`)
+    .join("\n");
+  return `## AVAILABLE TOOLS\n${tools.length} tools available.\n\n${toolLines}`;
+}
+
+async function fetchCopilotUserMetadata(
+  auth: Authenticator
+): Promise<CopilotUserMetadata | null> {
+  const user = auth.user();
+  if (!user) {
+    return null;
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const [jobTypeMeta, platformsMeta] = await Promise.all([
+    user.getMetadata("job_type"),
+    user.getMetadata("favorite_platforms", owner.id),
+  ]);
+
+  let favoritePlatforms: FavoritePlatform[] = [];
+  if (platformsMeta?.value) {
+    const parsed = safeParseJSON(platformsMeta.value);
+    if (
+      parsed.isOk() &&
+      isStringArray(parsed.value) &&
+      parsed.value.every(isFavoritePlatform)
+    ) {
+      favoritePlatforms = parsed.value;
+    }
+  }
+
+  const jobType = isJobType(jobTypeMeta?.value) ? jobTypeMeta.value : null;
+
+  return { jobType, favoritePlatforms };
+}
+
+function formatUserContext(
+  userMetadata: CopilotUserMetadata | null
+): string | null {
+  if (
+    !userMetadata ||
+    (!userMetadata.jobType && userMetadata.favoritePlatforms.length === 0)
+  ) {
+    return null;
+  }
+
+  const jobTypeLabel = userMetadata.jobType
+    ? JOB_TYPE_LABELS[userMetadata.jobType]
+    : "Not specified";
+  const platforms =
+    userMetadata.favoritePlatforms.join(", ") || "None specified";
+
+  return `- Job function: ${jobTypeLabel}\n- Preferred platforms: ${platforms}`;
+}
+
+function formatWorkspaceContext(
+  models: ModelConfigurationType[],
+  skills: AvailableSkill[],
+  tools: AvailableTool[]
+): string {
+  return [
+    formatAvailableModels(models),
+    formatAvailableSkills(skills),
+    formatAvailableTools(tools),
+  ].join("\n\n");
+}
+
+export async function buildCopilotContext(
+  auth: Authenticator,
+  agentsIdsToFetch: string[]
+): Promise<CopilotContext | null> {
+  if (
+    !agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT) &&
+    !agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_HAIKU)
+  ) {
+    return null;
+  }
+
+  const [context, userMetadata, models, skills, tools] = await Promise.all([
+    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      AGENT_COPILOT_CONTEXT_TOOL_NAME
+    ),
+    fetchCopilotUserMetadata(auth),
+    getAvailableModelsForWorkspace(auth),
+    listAvailableSkills(auth),
+    listAvailableTools(auth),
+  ]);
+
+  const formattedUserContext = formatUserContext(userMetadata);
+  const formattedWorkspaceContext = formatWorkspaceContext(
+    models,
+    skills,
+    tools
+  );
+
+  let langfuseInstructions: string | null = null;
+  if (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_HAIKU)) {
+    const result = await fetchAndCompileLangfusePrompt(
+      GLOBAL_AGENTS_SID.COPILOT_HAIKU,
+      {
+        userContext: formattedUserContext ?? "",
+        workspaceContext: formattedWorkspaceContext,
+      }
+    );
+    if (result.isOk()) {
+      langfuseInstructions = result.value;
+    }
+  }
+
+  return {
+    mcpServerViews: context ? { context } : null,
+    formattedUserContext,
+    formattedWorkspaceContext,
+    langfuseInstructions,
+  };
+}

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1,4 +1,3 @@
-import { AGENT_COPILOT_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import {
   _getClaude3_7GlobalAgent,
@@ -71,6 +70,10 @@ import {
   _getNotionGlobalAgent,
   _getSlackGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/retired_managed";
+import {
+  buildCopilotContext,
+  type CopilotContext,
+} from "@app/lib/api/assistant/global_agents/copilot_context";
 import type {
   MCPServerViewsForGlobalAgentsMap,
   PrefetchedDataSourcesType,
@@ -79,19 +82,9 @@ import {
   getDataSourcesAndWorkspaceIdForGlobalAgents,
   getMCPServerViewsForGlobalAgents,
 } from "@app/lib/api/assistant/global_agents/tools";
-import type {
-  AvailableSkill,
-  AvailableTool,
-} from "@app/lib/api/assistant/workspace_capabilities";
-import {
-  getAvailableModelsForWorkspace,
-  listAvailableSkills,
-  listAvailableTools,
-} from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
   AgentFetchVariant,
@@ -103,14 +96,7 @@ import {
 } from "@app/types/assistant/assistant";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
-import type { FavoritePlatform } from "@app/types/favorite_platforms";
-import { isFavoritePlatform } from "@app/types/favorite_platforms";
-import type { JobType } from "@app/types/job_type";
-import { isJobType } from "@app/types/job_type";
 import { isDevelopment } from "@app/types/shared/env";
-import { isStringArray } from "@app/types/shared/utils/general";
-import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 
 // Exhaustive map of flags for each global agent. This is used to control which agents inject
 // per-user dynamic content (like memories) into the prompt context. This approach is not ideal but
@@ -314,56 +300,6 @@ export function isDustLikeAgent(sId: string): boolean {
     GLOBAL_AGENT_FLAGS[sId].injectsMemory &&
     GLOBAL_AGENT_FLAGS[sId].injectsToolsets
   );
-}
-
-export interface CopilotUserMetadata {
-  jobType: JobType | null;
-  favoritePlatforms: FavoritePlatform[];
-}
-
-export interface CopilotContext {
-  mcpServerViews: {
-    context: MCPServerViewResource;
-  } | null;
-  userMetadata: CopilotUserMetadata | null;
-  workspaceCapabilities: {
-    models: ModelConfigurationType[];
-    skills: AvailableSkill[];
-    tools: AvailableTool[];
-  } | null;
-}
-
-async function fetchCopilotUserMetadata(
-  auth: Authenticator
-): Promise<CopilotUserMetadata | null> {
-  const user = auth.user();
-  if (!user) {
-    return null;
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-
-  const [jobTypeMeta, platformsMeta] = await Promise.all([
-    // Job type is user-scoped (not workspace-specific).
-    user.getMetadata("job_type"),
-    user.getMetadata("favorite_platforms", owner.id),
-  ]);
-
-  let favoritePlatforms: FavoritePlatform[] = [];
-  if (platformsMeta?.value) {
-    const parsed = safeParseJSON(platformsMeta.value);
-    if (
-      parsed.isOk() &&
-      isStringArray(parsed.value) &&
-      parsed.value.every(isFavoritePlatform)
-    ) {
-      favoritePlatforms = parsed.value;
-    }
-  }
-
-  const jobType = isJobType(jobTypeMeta?.value) ? jobTypeMeta.value : null;
-
-  return { jobType, favoritePlatforms };
 }
 
 function getGlobalAgent({
@@ -939,28 +875,10 @@ export async function getGlobalAgents(
     );
   }
 
-  let copilotContext: CopilotContext | null = null;
-  if (
-    variant === "full" &&
-    (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_HAIKU))
-  ) {
-    const [context, userMetadata, models, skills, tools] = await Promise.all([
-      MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-        auth,
-        AGENT_COPILOT_CONTEXT_TOOL_NAME
-      ),
-      fetchCopilotUserMetadata(auth),
-      getAvailableModelsForWorkspace(auth),
-      listAvailableSkills(auth),
-      listAvailableTools(auth),
-    ]);
-    copilotContext = {
-      mcpServerViews: context ? { context } : null,
-      userMetadata,
-      workspaceCapabilities: { models, skills, tools },
-    };
-  }
+  const copilotContext =
+    variant === "full"
+      ? await buildCopilotContext(auth, agentsIdsToFetch)
+      : null;
 
   // For now we retrieve them all
   // We will store them in the database later to allow admin enable them or not

--- a/front/lib/api/assistant/global_agents/langfuse_prompts.ts
+++ b/front/lib/api/assistant/global_agents/langfuse_prompts.ts
@@ -1,0 +1,27 @@
+import { getLangfuseClient } from "@app/lib/api/langfuse_client";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export async function fetchAndCompileLangfusePrompt(
+  promptName: string,
+  variables: Record<string, string>
+): Promise<Result<string, Error>> {
+  const client = getLangfuseClient();
+  if (!client) {
+    return new Err(new Error("Langfuse is not enabled"));
+  }
+
+  try {
+    const prompt = await client.prompt.get(promptName);
+
+    return new Ok(prompt.compile(variables));
+  } catch (error) {
+    logger.error(
+      { promptName, error: normalizeError(error) },
+      "[Langfuse] Failed to fetch prompt"
+    );
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/lib/api/assistant/global_agents/langfuse_prompts.ts
+++ b/front/lib/api/assistant/global_agents/langfuse_prompts.ts
@@ -1,5 +1,4 @@
 import { getLangfuseClient } from "@app/lib/api/langfuse_client";
-import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -15,13 +14,10 @@ export async function fetchAndCompileLangfusePrompt(
 
   try {
     const prompt = await client.prompt.get(promptName);
+    const compiledPrompt = prompt.compile(variables);
 
-    return new Ok(prompt.compile(variables));
+    return new Ok(compiledPrompt);
   } catch (error) {
-    logger.error(
-      { promptName, error: normalizeError(error) },
-      "[Langfuse] Failed to fetch prompt"
-    );
     return new Err(normalizeError(error));
   }
 }

--- a/front/lib/api/instrumentation/langfuse_datasets.ts
+++ b/front/lib/api/instrumentation/langfuse_datasets.ts
@@ -1,21 +1,9 @@
-import config from "@app/lib/api/config";
+import { getLangfuseClient } from "@app/lib/api/langfuse_client";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { LangfuseClient } from "@langfuse/client";
-
-let langfuseClient: LangfuseClient | null = null;
-
-function getLangfuseClient(): LangfuseClient | null {
-  if (!config.isLangfuseEnabled()) {
-    return null;
-  }
-
-  langfuseClient ??= new LangfuseClient(config.getLangfuseClientConfig());
-
-  return langfuseClient;
-}
+import type { LangfuseClient } from "@langfuse/client";
 
 function hasProperty<K extends string>(
   value: unknown,

--- a/front/lib/api/langfuse_client.ts
+++ b/front/lib/api/langfuse_client.ts
@@ -1,0 +1,14 @@
+import config from "@app/lib/api/config";
+import { LangfuseClient } from "@langfuse/client";
+
+let langfuseClient: LangfuseClient | null = null;
+
+export function getLangfuseClient(): LangfuseClient | null {
+  if (!config.isLangfuseEnabled()) {
+    return null;
+  }
+
+  langfuseClient ??= new LangfuseClient(config.getLangfuseClientConfig());
+
+  return langfuseClient;
+}


### PR DESCRIPTION
## Description

> [!WARNING]  
> ### This change is transient and only meant to iterate efficiently on copilot prompt, not for production use.

Add Langfuse prompt integration for copilot variants so alternative copilots (e.g. copilot-haiku) can pull their instructions from Langfuse instead of using the static prompt, with automatic fallback.

### Approach

- **Shared Langfuse client** (`langfuse_client.ts`): singleton extracted from `langfuse_datasets.ts` so both dataset and prompt modules share one instance
- **Prompt fetcher** (`langfuse_prompts.ts`): `fetchAndCompileLangfusePrompt` fetches by name, compiles `{{variables}}`, returns `Result`
- **Copilot context** (`copilot_context.ts`): all copilot-specific context building (user metadata, workspace capabilities, formatting, Langfuse fetch) extracted from `global_agents.ts` into a dedicated module
- **copilot-haiku** uses Langfuse instructions when available, falls back to `buildCopilotInstructions`

Langfuse prompts use `{{userContext}}` and `{{workspaceContext}}` variables, pre-formatted once in `buildCopilotContext` and shared by both the static copilot and the Langfuse template.

Builds on #22233

Next steps are :
- better management of prompt caching
- add model configuration in langfuse (we can test other models than haiku!)