### PR TITLE
Fix replacements for branch name

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -163,9 +163,12 @@ runs:
         fi
 
         # Override NEXT_PUBLIC_DUST_APP_URL for front-edge
+        # Apply the same sanitization Cloudflare Pages uses for branch aliases:
+        # lowercase, replace non-alphanumeric with '-', collapse multiple '-', trim '-', truncate to 28 chars.
         if [[ "$COMPONENT" == "front-edge" ]]; then
-          echo "🏗️ Setting build arg NEXT_PUBLIC_DUST_APP_URL=https://${{ github.ref_name }}--app.preview.dust.tt"
-          build_args+=("--build-arg NEXT_PUBLIC_DUST_APP_URL=https://${{ github.ref_name }}--app.preview.dust.tt")
+          CF_BRANCH=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-28 | sed 's/-$//')
+          echo "🏗️ Setting build arg NEXT_PUBLIC_DUST_APP_URL=https://${CF_BRANCH}--app.preview.dust.tt"
+          build_args+=("--build-arg NEXT_PUBLIC_DUST_APP_URL=https://${CF_BRANCH}--app.preview.dust.tt")
         fi
 
         # Special handling for front component, build both front and workers targets


### PR DESCRIPTION
## Description

Fix `NEXT_PUBLIC_DUST_APP_URL` for `front-edge` in the `build-image` action.

The `deploy-spa` workflow sanitizes branch names the same way Cloudflare Pages does (lowercase, replace non-alphanumeric with `-`, collapse, trim, truncate to 28 chars) before constructing the preview URL. The `build-image` action was using the raw branch name instead, causing a mismatch (e.g. `feature/MY-THING` vs `feature-my-thing`).

This applies the same `CF_BRANCH` sanitization in `build-image` so both produce identical URLs.

## Tests

Verified the sed/tr transformation logic matches the existing `deploy-spa.yaml` implementation.

## Risk

Low — only affects `front-edge` preview builds. No change to production (`front`) builds.

## Deploy Plan

Merge to main. Takes effect on next `front-edge` build.