### PR TITLE
feat: conversation menu in extension

### DIFF
--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -1,5 +1,9 @@
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
+import {
+  ConversationMenu,
+  useConversationMenu,
+} from "@app/components/assistant/conversation/ConversationMenu";
 import { NoOpConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
@@ -10,8 +14,8 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import {
   BarHeader,
   Button,
-  ExternalLinkIcon,
   MenuIcon,
+  MoreIcon,
   Sheet,
   SheetContent,
   SheetHeader,
@@ -55,6 +59,9 @@ export const MainPage = ({
       conversationId: conversationId,
       workspaceId: workspace.sId,
     });
+
+  const { isMenuOpen, menuTriggerPosition, handleMenuOpenChange } =
+    useConversationMenu();
 
   const headerTitle = useMemo(() => {
     if (!conversationId) {
@@ -106,16 +113,25 @@ export const MainPage = ({
             }
             rightActions={
               conversationId ? (
-                <div className="items-right flex flex-row">
-                  <Button
-                    icon={ExternalLinkIcon}
-                    variant="ghost"
-                    href={`${user.dustDomain}/w/${workspace.sId}/agent/${conversationId}`}
-                    target="_blank"
-                    size="sm"
-                    tooltip="Open in Dust"
-                  />
-                </div>
+                <ConversationMenu
+                  activeConversationId={conversationId}
+                  conversation={conversation}
+                  owner={workspace}
+                  trigger={
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      icon={MoreIcon}
+                      aria-label="Conversation menu"
+                    />
+                  }
+                  isConversationDisplayed={true}
+                  isOpen={isMenuOpen}
+                  onOpenChange={handleMenuOpenChange}
+                  triggerPosition={menuTriggerPosition}
+                  displayOpenInBrowser
+                  openDetailsInNewTab
+                />
               ) : (
                 <div className="items-right flex flex-row space-x-1">
                   <UserDropdownMenu user={user} handleLogout={handleLogout} />

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  ExternalLinkIcon,
   LinkIcon,
   PencilSquareIcon,
   PlusCircleIcon,
@@ -113,6 +114,19 @@ export function useConversationMenu() {
   };
 }
 
+interface ConversationMenuProps {
+  activeConversationId: string | null;
+  conversation?: ConversationWithoutContentType;
+  owner: WorkspaceType;
+  trigger: ReactElement;
+  isConversationDisplayed: boolean;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerPosition?: { x: number; y: number };
+  displayOpenInBrowser?: boolean;
+  openDetailsInNewTab?: boolean;
+}
+
 export function ConversationMenu({
   activeConversationId,
   conversation,
@@ -122,16 +136,9 @@ export function ConversationMenu({
   isOpen,
   onOpenChange,
   triggerPosition,
-}: {
-  activeConversationId: string | null;
-  conversation?: ConversationWithoutContentType;
-  owner: WorkspaceType;
-  trigger: ReactElement;
-  isConversationDisplayed: boolean;
-  isOpen: boolean;
-  onOpenChange: (open: boolean) => void;
-  triggerPosition?: { x: number; y: number };
-}) {
+  displayOpenInBrowser,
+  openDetailsInNewTab,
+}: ConversationMenuProps) {
   const { user } = useAuth();
   const { hasFeature } = useFeatureFlags();
 
@@ -142,11 +149,31 @@ export function ConversationMenu({
   const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
 
   const handleSeeAgentDetails = (agentId: string) => {
+    if (openDetailsInNewTab) {
+      const agentDetailsUrl = getConversationRoute(
+        owner.sId,
+        activeConversationId,
+        `agentDetails=${agentId}`,
+        config.getApiBaseUrl()
+      );
+      window.open(agentDetailsUrl, "_blank");
+      return;
+    }
     onOpenChangeAgentModal(true);
     setQueryParam(router, "agentDetails", agentId);
   };
 
   const handleSeeUserDetails = (userId: string) => {
+    if (openDetailsInNewTab) {
+      const userDetailsUrl = getConversationRoute(
+        owner.sId,
+        activeConversationId,
+        `userDetails=${userId}`,
+        config.getApiBaseUrl()
+      );
+      window.open(userDetailsUrl, "_blank");
+      return;
+    }
     onOpenChangeUserModal(true);
     setQueryParam(router, "userDetails", userId);
   };
@@ -182,7 +209,7 @@ export function ConversationMenu({
   const [showLeaveDialog, setShowLeaveDialog] = useState<boolean>(false);
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
 
-  const shareLink = getConversationRoute(
+  const conversationLink = getConversationRoute(
     owner.sId,
     activeConversationId,
     undefined,
@@ -205,9 +232,13 @@ export function ConversationMenu({
   );
 
   const copyConversationLink = useCallback(async () => {
-    await navigator.clipboard.writeText(shareLink ?? "");
+    await navigator.clipboard.writeText(conversationLink ?? "");
     sendNotification({ type: "success", title: "Link copied !" });
-  }, [shareLink, sendNotification]);
+  }, [conversationLink, sendNotification]);
+
+  const openConversationInBrowser = () => {
+    window.open(conversationLink, "_blank");
+  };
 
   if (!activeConversationId) {
     return null;
@@ -345,7 +376,14 @@ export function ConversationMenu({
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>
-          {shareLink && (
+          {displayOpenInBrowser && conversationLink && (
+            <DropdownMenuItem
+              label="Open in a browser tab"
+              onClick={openConversationInBrowser}
+              icon={ExternalLinkIcon}
+            />
+          )}
+          {conversationLink && (
             <DropdownMenuItem
               label="Copy the link"
               onClick={copyConversationLink}


### PR DESCRIPTION






## Description

This PR adds the conversation menu to the browser extension.

- agent/user details are opened in new tabs instead of modals


<img width="709" height="875" alt="Capture d’écran 2026-02-25 à 11 06 45" src="https://github.com/user-attachments/assets/2ac3356c-6fe6-4659-a270-65c6afa378aa" />
## Tests

Manually.

## Risks

## Deploy Plan
