### PR TITLE
feat(cli): add copilot as a target in skill:init

### DIFF
--- a/cli/src/ui/commands/SkillInit.tsx
+++ b/cli/src/ui/commands/SkillInit.tsx
@@ -34,6 +34,11 @@ const CLI_TARGETS = [
     label: "Codex (OpenAI)",
     dir: path.join(os.homedir(), ".agents", "skills", SKILL_NAME),
   },
+  {
+    id: "copilot",
+    label: "Copilot (GitHub)",
+    dir: path.join(os.homedir(), ".copilot", "skills", SKILL_NAME),
+  },
 ];
 
 const ITEMS = CLI_TARGETS.map((t) => ({


### PR DESCRIPTION
## Description

Enhancement to CLI skill targets:

* Added a new entry for Copilot (GitHub): https://docs.github.com/en/copilot/concepts/agents/about-agent-skills