### PR TITLE
[front] refactor hashing to allow new "MCP server credentials" use case

### DIFF
--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -64,7 +64,11 @@ export async function getAshbyClient({
   });
 
   const apiKey = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
   if (!apiKey) {
     return new Err(

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -140,7 +140,11 @@ export async function getFrontAPIToken(
   });
 
   const apiToken = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
 
   if (!apiToken) {

--- a/front/lib/api/actions/servers/http_client/tools/index.ts
+++ b/front/lib/api/actions/servers/http_client/tools/index.ts
@@ -52,7 +52,11 @@ async function getBearerToken(
   });
 
   const bearerToken = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
 
   return bearerToken;

--- a/front/lib/api/actions/servers/openai_usage/client.ts
+++ b/front/lib/api/actions/servers/openai_usage/client.ts
@@ -37,7 +37,11 @@ export async function getOpenAIUsageClient(
   });
 
   const adminApiKey = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
   if (!adminApiKey) {
     return new Err(

--- a/front/lib/api/actions/servers/salesloft/helpers.ts
+++ b/front/lib/api/actions/servers/salesloft/helpers.ts
@@ -44,7 +44,11 @@ export async function getBearerToken(
   });
 
   const bearerToken = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
 
   return bearerToken;

--- a/front/lib/api/actions/servers/statuspage/client.ts
+++ b/front/lib/api/actions/servers/statuspage/client.ts
@@ -54,7 +54,11 @@ export async function getStatuspageClient(
   });
 
   const apiKey = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
   if (!apiKey) {
     return new Err(

--- a/front/lib/api/actions/servers/val_town/helpers.ts
+++ b/front/lib/api/actions/servers/val_town/helpers.ts
@@ -39,7 +39,11 @@ export async function getValTownClient(
   });
 
   const apiKey = secret
-    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    ? decrypt({
+        encrypted: secret.hash,
+        key: auth.getNonNullableWorkspace().sId,
+        useCase: "developer_secret",
+      })
     : null;
 
   if (!apiKey) {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -449,7 +449,7 @@ const config = {
   getDeveloperSecretsSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_DEVELOPERS_SECRETS_SECRET");
   },
-  getMcpServerCredentialsSecret: (): string => {
+  getMCPServerCredentialsSecret: (): string => {
     return EnvironmentConfig.getEnvVariable(
       "DUST_MCP_SERVER_CREDENTIALS_SECRET"
     );

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -445,6 +445,15 @@ const config = {
   getGatedAssetsTokenSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("GATED_ASSETS_TOKEN_SECRET");
   },
+  // Secrets for secure storage of keys and bearer tokens.
+  getDeveloperSecretsSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_DEVELOPERS_SECRETS_SECRET");
+  },
+  getMcpServerCredentialsSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "DUST_MCP_SERVER_CREDENTIALS_SECRET"
+    );
+  },
   // E2B Sandbox.
   getE2BSandboxConfig: ():
     | { apiKey: string; templateId: string; domain: string | undefined }

--- a/front/lib/api/dust_app_secrets.ts
+++ b/front/lib/api/dust_app_secrets.ts
@@ -21,7 +21,11 @@ export async function getDustAppSecrets(
   });
 
   return secrets.map((s) => {
-    const clearSecret = decrypt(s.hash, owner.sId);
+    const clearSecret = decrypt({
+      encrypted: s.hash,
+      key: owner.sId,
+      useCase: "developer_secret",
+    });
     return {
       name: s.name,
       value: clear ? clearSecret : redactString(clearSecret, 1),

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -95,7 +95,12 @@ async function handler(
       // Sanitize the secret name to be alphanumeric and underscores only
       const sanitizedSecretName = postSecretName.replace(/[^a-zA-Z0-9_]/g, "_");
 
-      const encryptedValue = encrypt(secretValue, owner.sId); // We feed the workspace sid as key that will be added to the salt.
+      // We feed the workspace sid as key that will be added to the salt.
+      const encryptedValue = encrypt({
+        text: secretValue,
+        key: owner.sId,
+        useCase: "developer_secret",
+      });
 
       let postSecret = await getDustAppSecret(auth, sanitizedSecretName);
 

--- a/front/types/shared/utils/hashing.ts
+++ b/front/types/shared/utils/hashing.ts
@@ -1,4 +1,8 @@
+import config from "@app/lib/api/config";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import crypto from "crypto";
+
+type EncryptionUseCase = "developer_secret" | "mcp_server_credentials";
 
 export function md5(str: string): string {
   return crypto.createHash("md5").update(str).digest("hex");
@@ -8,26 +12,60 @@ export function sha256(str: string): string {
   return crypto.createHash("sha256").update(str).digest("base64");
 }
 
-function saltedKey(key: string, size = 32): string {
-  const { DUST_DEVELOPERS_SECRETS_SECRET } = process.env;
+function getSecretForUseCase(useCase: EncryptionUseCase): string {
+  switch (useCase) {
+    case "developer_secret":
+      return config.getDeveloperSecretsSecret();
+    case "mcp_server_credentials":
+      return config.getMcpServerCredentialsSecret();
+    default:
+      assertNever(useCase);
+  }
+}
+
+function saltedKey(key: string, useCase: EncryptionUseCase, size = 32): string {
   return crypto
     .createHash("sha256")
-    .update(DUST_DEVELOPERS_SECRETS_SECRET + key)
+    .update(getSecretForUseCase(useCase) + key)
     .digest("base64")
     .substring(0, size);
 }
 
-export function encrypt(text: string, key: string): string {
+export function encrypt({
+  text,
+  key,
+  useCase,
+}: {
+  text: string;
+  key: string;
+  useCase: EncryptionUseCase;
+}): string {
   const iv = md5(key).substring(0, 16);
-  const cipher = crypto.createCipheriv("aes-256-cbc", saltedKey(key), iv);
+  const cipher = crypto.createCipheriv(
+    "aes-256-cbc",
+    saltedKey(key, useCase),
+    iv
+  );
   let encrypted = cipher.update(text, "utf8", "hex");
   encrypted += cipher.final("hex");
   return encrypted;
 }
 
-export function decrypt(encrypted: string, key: string): string {
+export function decrypt({
+  encrypted,
+  key,
+  useCase,
+}: {
+  encrypted: string;
+  key: string;
+  useCase: EncryptionUseCase;
+}): string {
   const iv = md5(key).substring(0, 16);
-  const decipher = crypto.createDecipheriv("aes-256-cbc", saltedKey(key), iv);
+  const decipher = crypto.createDecipheriv(
+    "aes-256-cbc",
+    saltedKey(key, useCase),
+    iv
+  );
   let decrypted = decipher.update(encrypted, "hex", "utf8");
   decrypted += decipher.final("utf8");
   return decrypted;

--- a/front/types/shared/utils/hashing.ts
+++ b/front/types/shared/utils/hashing.ts
@@ -17,7 +17,7 @@ function getSecretForUseCase(useCase: EncryptionUseCase): string {
     case "developer_secret":
       return config.getDeveloperSecretsSecret();
     case "mcp_server_credentials":
-      return config.getMcpServerCredentialsSecret();
+      return config.getMCPServerCredentialsSecret();
     default:
       assertNever(useCase);
   }


### PR DESCRIPTION
## Description

- This PR refactors the `encrypt` and `decrypt` methods to allow passing a use case that is either `developer_secrets` (legacy Dust apps) or `mcp_server_credentials` (new secure way of storing api keys we are adding).
- No runtime changes expected.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
