### PR TITLE
Redirect oauth to SPA

### DIFF
--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -145,12 +145,15 @@ function serveHtmlPlugin(
     name: "serve-html",
     configureServer(server) {
       server.middlewares.use((req, _res, next) => {
+        // Strip query string to check only the path portion.
+        const urlPath = req.url?.split("?")[0] ?? "";
+
         // Skip requests for actual files (assets, HMR, source files, etc.)
         if (
-          req.url?.startsWith("/@") ||
-          req.url?.startsWith("/node_modules") ||
-          req.url?.startsWith("/src") ||
-          req.url?.match(/\.\w+(\?|$)/)
+          urlPath.startsWith("/@") ||
+          urlPath.startsWith("/node_modules") ||
+          urlPath.startsWith("/src") ||
+          urlPath.match(/\.\w+$/)
         ) {
           return next();
         }

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import {
   useCreateMCPServerConnection,
   useDiscoverOAuthMetadata,
@@ -56,6 +57,7 @@ export function ConnectMCPServerDialog({
   setIsOpen,
 }: ConnectMCPServerDialogProps) {
   const sendNotification = useSendNotification();
+  const regionContext = useRegionContextSafe();
 
   const defaultValues = getConnectMCPServerDialogDefaultValues();
   const form = useForm<MCPServerOAuthFormValues>({
@@ -189,6 +191,7 @@ export function ConnectMCPServerDialog({
       createMCPServerConnection,
       updateServerView,
       onBeforeAssociateConnection: () => setExternalIsLoading(true),
+      regionInfo: regionContext?.regionInfo ?? null,
     });
 
     if (submitRes.isErr()) {

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -23,6 +23,7 @@ import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerType } from "@app/lib/api/mcp";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import {
   useCreateInternalMCPServer,
   useCreateRemoteMCPServer,
@@ -79,6 +80,7 @@ export function CreateMCPServerDialog({
   defaultServerConfig,
 }: CreateMCPServerDialogProps) {
   const sendNotification = useSendNotification();
+  const regionContext = useRegionContextSafe();
 
   const defaultValues = useMemo<CreateMCPServerDialogFormValues>(() => {
     return getCreateMCPServerDialogDefaultValues(defaultServerConfig);
@@ -154,6 +156,7 @@ export function CreateMCPServerDialog({
       createWithURL,
       createInternalMCPServer,
       onBeforeCreateServer: () => setExternalIsLoading(true),
+      regionInfo: regionContext?.regionInfo ?? null,
     });
 
     if (submitRes.isErr()) {

--- a/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
@@ -2,6 +2,7 @@ import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { RegionInfo } from "@app/lib/api/regions/config";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
@@ -37,6 +38,7 @@ interface SubmitConnectMCPServerDialogFormParams {
   createMCPServerConnection: CreateMCPServerConnectionFn;
   updateServerView: UpdateMCPServerViewFn;
   onBeforeAssociateConnection: () => void;
+  regionInfo: RegionInfo | null;
 }
 
 export async function submitConnectMCPServerDialogForm({
@@ -47,6 +49,7 @@ export async function submitConnectMCPServerDialogForm({
   createMCPServerConnection,
   updateServerView,
   onBeforeAssociateConnection,
+  regionInfo,
 }: SubmitConnectMCPServerDialogFormParams): Promise<Result<null, Error>> {
   if (!values.useCase) {
     return new Err(new Error("Use case is null while trying to connect"));
@@ -64,6 +67,7 @@ export async function submitConnectMCPServerDialogForm({
       ...(values.authCredentials ?? {}),
       ...(scope ? { scope } : {}),
     },
+    regionInfo,
   });
 
   if (connectionResult.isErr()) {

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -2,6 +2,7 @@ import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mc
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerType } from "@app/lib/api/mcp";
+import type { RegionInfo } from "@app/lib/api/regions/config";
 import type { MCPConnectionType } from "@app/lib/swr/mcp_servers";
 import type { CreateMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp";
 import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
@@ -82,6 +83,7 @@ interface SubmitCreateMCPServerDialogFormParams {
   createWithURL: CreateRemoteMCPServerFn;
   createInternalMCPServer: CreateInternalMCPServerFn;
   onBeforeCreateServer: () => void;
+  regionInfo: RegionInfo | null;
 }
 
 export async function submitCreateMCPServerDialogForm({
@@ -94,6 +96,7 @@ export async function submitCreateMCPServerDialogForm({
   createWithURL,
   createInternalMCPServer,
   onBeforeCreateServer,
+  regionInfo,
 }: SubmitCreateMCPServerDialogFormParams): Promise<
   Result<CreateMCPServerDialogSubmitResult, Error>
 > {
@@ -167,6 +170,7 @@ export async function submitCreateMCPServerDialogForm({
         ...(values.authCredentials ?? {}),
         ...(scope ? { scope } : {}),
       },
+      regionInfo,
     });
 
     if (cRes.isErr()) {

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -11,7 +11,9 @@ import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionM
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { RegionInfo } from "@app/lib/api/regions/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
   CONNECTOR_UI_CONFIGURATIONS,
@@ -96,7 +98,8 @@ export async function handleUpdatePermissions(
   dataSource: DataSourceType,
   owner: LightWorkspaceType,
   extraConfig: Record<string, string>,
-  sendNotification: (notification: NotificationType) => void
+  sendNotification: (notification: NotificationType) => void,
+  regionInfo: RegionInfo | null
 ) {
   const provider = connector.type;
 
@@ -104,6 +107,7 @@ export async function handleUpdatePermissions(
     owner,
     provider,
     extraConfig,
+    regionInfo,
   });
   if (connectionRes.isErr()) {
     sendNotification({
@@ -698,6 +702,7 @@ export function ConnectorPermissionsModal({
   readOnly,
 }: ConnectorPermissionsModalProps) {
   const { mutate } = useSWRConfig();
+  const regionContext = useRegionContextSafe();
 
   const confirm = useContext(ConfirmContext);
   const [selectedNodes, setSelectedNodes] = useState<
@@ -1125,7 +1130,8 @@ export function ConnectorPermissionsModal({
                     dataSource,
                     owner,
                     extraConfig,
-                    sendNotification
+                    sendNotification,
+                    regionContext?.regionInfo ?? null
                   );
                   closeModal(false);
                 }}

--- a/front/components/labs/transcripts/ProviderSelection.tsx
+++ b/front/components/labs/transcripts/ProviderSelection.tsx
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   useLabsTranscriptsDefaultConfiguration,
@@ -36,6 +37,7 @@ export function ProviderSelection({
   owner,
 }: ProviderSelectionProps) {
   const sendNotification = useSendNotification();
+  const regionContext = useRegionContextSafe();
   const [apiKey, setApiKey] = useState("");
   const [selectedProvider, setSelectedProvider] =
     useState<LabsTranscriptsProviderType | null>(
@@ -113,6 +115,7 @@ export function ProviderSelection({
       provider: "google_drive",
       useCase: "labs_transcripts",
       extraConfig: {},
+      regionInfo: regionContext?.regionInfo ?? null,
     });
 
     if (cRes.isErr()) {
@@ -125,7 +128,7 @@ export function ProviderSelection({
     }
 
     await saveOAuthConnection(cRes.value.connection_id, "google_drive");
-  }, [owner, sendNotification, saveOAuthConnection]);
+  }, [owner, sendNotification, saveOAuthConnection, regionContext?.regionInfo]);
 
   const saveApiConnection = useCallback(
     async (apiKey: string, provider: string) => {

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -3,7 +3,9 @@ import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_sour
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { RegionInfo } from "@app/lib/api/regions/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import {
   CONNECTOR_CONFIGURATIONS,
   isConnectionIdRequiredForProvider,
@@ -72,11 +74,13 @@ export async function setupConnection({
   provider,
   useCase = "connection",
   extraConfig,
+  regionInfo,
 }: {
   owner: LightWorkspaceType;
   provider: ConnectorProvider;
   useCase?: OAuthUseCase;
   extraConfig: Record<string, string>;
+  regionInfo: RegionInfo | null;
 }): Promise<
   Result<{ connectionId: string; relatedCredentialId?: string }, Error>
 > {
@@ -90,6 +94,7 @@ export async function setupConnection({
     provider,
     useCase,
     extraConfig,
+    regionInfo,
   });
   if (!cRes.isOk()) {
     return cRes;
@@ -130,6 +135,7 @@ export const AddConnectionMenu = ({
   const { isDark } = useTheme();
   const { featureFlags } = useFeatureFlags();
   const { systemSpace } = useSystemSpace({ workspaceId: owner.sId });
+  const regionContext = useRegionContextSafe();
 
   const handleOnClose = useCallback(
     () =>
@@ -239,6 +245,7 @@ export const AddConnectionMenu = ({
         owner,
         provider,
         extraConfig,
+        regionInfo: regionContext?.regionInfo ?? null,
       });
       if (connectionRes.isErr()) {
         throw connectionRes.error;

--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { OAuthConnectionType } from "@app/types/oauth/lib";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -35,6 +36,7 @@ export function CreateWebhookSourceWithProviderForm({
   onReadyToSubmitChange,
 }: CreateWebhookSourceWithProviderFormProps) {
   const sendNotification = useSendNotification();
+  const regionContext = useRegionContextSafe();
   const [connection, setConnection] = useState<OAuthConnectionType | null>(
     null
   );
@@ -57,6 +59,7 @@ export function CreateWebhookSourceWithProviderForm({
         provider,
         useCase: "webhooks",
         extraConfig,
+        regionInfo: regionContext?.regionInfo ?? null,
       });
 
       if (connectionRes.isErr()) {

--- a/front/components/workspace/settings/BotToggle.tsx
+++ b/front/components/workspace/settings/BotToggle.tsx
@@ -1,5 +1,6 @@
 import { updateConnectorConnectionId } from "@app/components/data_source/ConnectorPermissionsModal";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig, useToggleChatBot } from "@app/lib/swr/connectors";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
@@ -58,6 +59,7 @@ export function BotToggle({
 
   const [isChangingBot, setIsChangingBot] = useState(false);
   const sendNotification = useSendNotification();
+  const regionContext = useRegionContextSafe();
 
   const createBotConnectionAndDataSource = async () => {
     // OAuth flow
@@ -66,6 +68,7 @@ export function BotToggle({
       provider: oauth.provider,
       useCase: oauth.useCase ?? "connection",
       extraConfig: oauth.extraConfig,
+      regionInfo: regionContext?.regionInfo ?? null,
     });
     if (!cRes.isOk()) {
       return cRes;
@@ -153,6 +156,7 @@ export function BotToggle({
                   provider: oauth.provider,
                   useCase: oauth.useCase ?? "connection",
                   extraConfig: oauth.extraConfig,
+                  regionInfo: regionContext?.regionInfo ?? null,
                 });
                 if (!cRes.isOk()) {
                   sendNotification({

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -12,6 +12,7 @@ import type {
   MCPServerTypeWithViews,
   MCPServerViewType,
 } from "@app/lib/api/mcp";
+import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type {
   MCPServerConnectionConnectionType,
@@ -849,6 +850,7 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
     owner,
     connectionType: "personal",
   });
+  const regionContext = useRegionContextSafe();
 
   const createPersonalConnection = async ({
     mcpServerId,
@@ -905,6 +907,7 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
         provider,
         useCase,
         extraConfig,
+        regionInfo: regionContext?.regionInfo ?? null,
       });
 
       if (cRes.isErr()) {

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -1,6 +1,0 @@
-import { OAuthFinalizePage } from "@app/components/pages/oauth/OAuthFinalizePage";
-
-// This endpoint is authenticated but cannot be workspace specific as it is hard-coded at each
-// provider as our callback URI. Authentication is handled client-side by the component using
-// useAuthContext() which redirects to login if the user is not authenticated.
-export default OAuthFinalizePage;

--- a/front/pages/w/[wId]/oauth/[provider]/setup.tsx
+++ b/front/pages/w/[wId]/oauth/[provider]/setup.tsx
@@ -1,3 +1,0 @@
-import { OAuthSetupRedirectPage } from "@app/components/pages/oauth/OAuthSetupRedirectPage";
-
-export default OAuthSetupRedirectPage;

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import type { RegionInfo } from "@app/lib/api/regions/config";
 import type {
   OAuthConnectionType,
   OAuthCredentials,
@@ -16,11 +17,13 @@ export async function setupOAuthConnection({
   provider,
   useCase,
   extraConfig,
+  regionInfo,
 }: {
   owner: LightWorkspaceType;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
   extraConfig: OAuthCredentials;
+  regionInfo: RegionInfo | null;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
     const oauthBaseUrl = config.getAppUrl();
@@ -29,6 +32,10 @@ export async function setupOAuthConnection({
     let url = `${oauthBaseUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}&openerOrigin=${encodeURIComponent(openerOrigin)}`;
     if (extraConfig) {
       url += `&extraConfig=${encodeURIComponent(JSON.stringify(extraConfig))}`;
+    }
+    // Pass region info so the OAuth popup's RegionContext initializes with the correct region.
+    if (regionInfo) {
+      url += `&region=${encodeURIComponent(regionInfo.name)}&regionUrl=${encodeURIComponent(regionInfo.url)}`;
     }
     const oauthPopup = window.open(url);
     let authComplete = false;

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -23,7 +23,7 @@ export async function setupOAuthConnection({
   extraConfig: OAuthCredentials;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
-    const oauthBaseUrl = config.getApiBaseUrl();
+    const oauthBaseUrl = config.getAppUrl();
     // Pass opener origin through OAuth flow so finalize page can postMessage back
     const openerOrigin = window.location.origin;
     let url = `${oauthBaseUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}&openerOrigin=${encodeURIComponent(openerOrigin)}`;
@@ -64,8 +64,8 @@ export async function setupOAuthConnection({
     };
 
     // Method 1: window.postMessage (preferred, direct communication)
-    // Accept messages from oauthBaseUrl origin (OAuth popup runs on NextJS server)
-    // In dev, bypass origin check as an extra safeguard for cross-port communication
+    // The finalize page runs on the app (SPA), same origin as the opener.
+    // In dev, bypass origin check as an extra safeguard for cross-port communication.
     const expectedOrigin = new URL(oauthBaseUrl).origin;
     const handleWindowMessage = (event: MessageEvent) => {
       if (!isDevelopment() && event.origin !== expectedOrigin) {


### PR DESCRIPTION
## Description

Redirect OAuth pages (setup and finalize) from Next.js to the SPA.

- Delete Next.js page wrappers (`/oauth/[provider]/finalize` and `/w/[wId]/oauth/[provider]/setup`) — these routes are already handled by the SPA's `OAuthApp`.
- Fix `setupOAuthConnection` to use `config.getAppUrl()` instead of `config.getApiBaseUrl()`, since OAuth pages now live on the SPA (same origin as the opener).
- Fix Vite dev server `serveHtmlPlugin`: the file-extension regex was matching against query string parameters (e.g. `.readonly` in Google OAuth scopes), causing OAuth URLs to bypass the HTML rewrite and serve `index.html` instead of `oauth.html`. Now strips the query string before checking.

The OAuth flow itself is unchanged — the redirect URL still points to the Next.js server, which serves the SPA. This avoids having to reconfigure OAuth apps and authorized redirect URLs at each provider.

## Tests

Manually tested OAuth flow (Google Drive) in dev — finalize page now correctly loads the OAuth SPA app.

## Risk

Low — OAuth pages were already implemented in the SPA, this just removes the Next.js duplicates and fixes routing.

## Deploy Plan

Standard deploy, no special steps needed.