### PR TITLE
[extension] Upgraded router

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -80,7 +80,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.5",
-    "react-router-dom": "^6.26.2",
+    "react-router-dom": "^7.0.0",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "swr": "^2.2.5",

--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -4,21 +4,20 @@ import type { RouteChangeMesssage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import type { StoredUser } from "@extension/shared/services/auth";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
-import type { ReactNode } from "react";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useOutletContext } from "react-router-dom";
 
-interface ProtectedRouteProps {
-  children: ReactNode | ((props: ProtectedRouteChildrenProps) => ReactNode);
-}
-
-export interface ProtectedRouteChildrenProps {
+export interface ProtectedRouteOutletContext {
   user: StoredUser;
   workspace: ExtensionWorkspaceType;
   handleLogout: () => void;
 }
 
-export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+export function useProtectedRouteContext() {
+  return useOutletContext<ProtectedRouteOutletContext>();
+}
+
+export const ProtectedRoute = () => {
   const platform = usePlatform();
   const {
     isLoading,
@@ -77,9 +76,7 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
         "dark:bg-background-night dark:text-foreground-night"
       )}
     >
-      {typeof children === "function"
-        ? children({ user, workspace, handleLogout })
-        : children}
+      <Outlet context={{ user, workspace, handleLogout }} />
     </div>
   );
 };

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -17,7 +17,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@dust-tt/sparkle";
-import type { ProtectedRouteChildrenProps } from "@extension/ui/components/auth/ProtectedRoute";
+import { useProtectedRouteContext } from "@extension/ui/components/auth/ProtectedRoute";
 import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
 import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
 import { DropzoneContainer } from "@extension/ui/components/DropzoneContainer";
@@ -25,11 +25,8 @@ import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdo
 import { useContext, useMemo } from "react";
 import { useParams } from "react-router-dom";
 
-export const MainPage = ({
-  user,
-  workspace,
-  handleLogout,
-}: ProtectedRouteChildrenProps) => {
+export const MainPage = () => {
+  const { user, workspace, handleLogout } = useProtectedRouteContext();
   const { subscription } = useAuth();
   const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
   const shortcut = isMac ? "⇧⌘E" : "⇧+Ctrl+E";

--- a/extension/ui/pages/RunPage.tsx
+++ b/extension/ui/pages/RunPage.tsx
@@ -4,7 +4,7 @@ import { postConversation } from "@extension/shared/lib/conversation";
 import { useDustAPI } from "@extension/shared/lib/dust_api";
 import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export const RunPage = () => {
   const platform = usePlatform();

--- a/extension/ui/pages/SubscribePage.tsx
+++ b/extension/ui/pages/SubscribePage.tsx
@@ -6,15 +6,12 @@ import {
   Page,
   RocketIcon,
 } from "@dust-tt/sparkle";
-import type { ProtectedRouteChildrenProps } from "@extension/ui/components/auth/ProtectedRoute";
+import { useProtectedRouteContext } from "@extension/ui/components/auth/ProtectedRoute";
 import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
 import { Link } from "react-router-dom";
 
-export const SubscribePage = ({
-  user,
-  workspace,
-  handleLogout,
-}: ProtectedRouteChildrenProps) => {
+export const SubscribePage = () => {
+  const { user, workspace, handleLogout } = useProtectedRouteContext();
   return (
     <div>
       <BarHeader

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -10,37 +10,22 @@ export const routes = [
     element: <LoginPage />,
   },
   {
-    path: "/run",
-    element: <ProtectedRoute>{() => <RunPage />}</ProtectedRoute>,
-  },
-  {
-    path: "/subscribe",
-    element: (
-      <ProtectedRoute>
-        {({ user, workspace, handleLogout }) => (
-          <SubscribePage
-            user={user}
-            workspace={workspace}
-            handleLogout={handleLogout}
-          />
-        )}
-      </ProtectedRoute>
-    ),
-  },
-  // Keep catch-all route last. This will handle both root path and /conversations/:conversationId
-  // Since we catch all, we will need to manually handle the conversationId in the MainPage component.
-  {
-    path: "*",
-    element: (
-      <ProtectedRoute>
-        {({ user, workspace, handleLogout }) => (
-          <MainPage
-            user={user}
-            workspace={workspace}
-            handleLogout={handleLogout}
-          />
-        )}
-      </ProtectedRoute>
-    ),
+    element: <ProtectedRoute />,
+    children: [
+      {
+        path: "/run",
+        element: <RunPage />,
+      },
+      {
+        path: "/subscribe",
+        element: <SubscribePage />,
+      },
+      // Keep catch-all route last. This will handle both root path and /conversations/:conversationId
+      // Since we catch all, we will need to manually handle the conversationId in the MainPage component.
+      {
+        path: "*",
+        element: <MainPage />,
+      },
+    ],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
     },
     "cli/node_modules/@dust-tt/client/node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -137,6 +138,7 @@
     },
     "cli/node_modules/@dust-tt/client/node_modules/@modelcontextprotocol/sdk/node_modules/eventsource-parser": {
       "version": "3.0.6",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -145,6 +147,7 @@
     },
     "cli/node_modules/@dust-tt/client/node_modules/express-rate-limit": {
       "version": "8.2.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -162,6 +165,7 @@
     },
     "cli/node_modules/@dust-tt/client/node_modules/ip-address": {
       "version": "10.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -483,7 +487,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.5",
-        "react-router-dom": "^6.26.2",
+        "react-router-dom": "^7.0.0",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "swr": "^2.2.5",
@@ -536,6 +540,57 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "extension/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "extension/node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "extension/node_modules/react-router-dom/node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "front": {
@@ -17760,15 +17815,6 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "license": "MIT"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -49517,38 +49563,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-runner": {


### PR DESCRIPTION
## Description

Upgrades `react-router-dom` from v6 to v7 in the extension package (consistent with `front-spa` which already runs v7) and refactors `ProtectedRoute` from a render-function-as-children wrapper into a layout route using `<Outlet />`.

**Changes:**
- `extension/package.json`: `react-router-dom` `^6.26.2` → `^7.0.0`
- `extension/ui/components/auth/ProtectedRoute.tsx`: Removed children prop / render-function pattern, now renders `<Outlet context={{ user, workspace, handleLogout }} />`. Exports `useProtectedRouteContext()` hook and `ProtectedRouteOutletContext` type.
- `extension/ui/pages/routes.tsx`: Restructured to nested route config with `ProtectedRoute` as a pathless layout route wrapping `/run`, `/subscribe`, and `*` catch-all.
- `extension/ui/pages/MainPage.tsx` & `SubscribePage.tsx`: Removed props, now call `useProtectedRouteContext()` to get `user`, `workspace`, `handleLogout`.
- `extension/ui/pages/RunPage.tsx`: Fixed import from `"react-router"` → `"react-router-dom"`.

## Tests

- Front platform build passes with 0 TypeScript errors
- Manual testing: login flow, protected route redirect, conversation navigation, subscribe page

## Risk

Low. The v6→v7 migration is low-risk for this extension: it doesn't use loaders, actions, fetchers, or forms, so most breaking changes don't apply. The refactor is a straightforward move from render props to outlet context.

## Deploy Plan

Standard deploy — no migrations or feature flags needed.