### PR TITLE
Add timings and haiku to copilot test suite

### DIFF
--- a/front/tests/copilot-evals/copilot-eval.test.ts
+++ b/front/tests/copilot-evals/copilot-eval.test.ts
@@ -1,4 +1,5 @@
 import {
+  COPILOT_AGENT,
   COPILOT_ON_COPILOT,
   COPILOT_ON_COPILOT_TIMEOUT_MS,
   createMockAuthenticator,
@@ -78,7 +79,7 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
           async () => {
             const auth = createMockAuthenticator();
 
-            const { responseText, toolCalls } = await executeCopilot(
+            const { responseText, toolCalls, modelTimeMs } = await executeCopilot(
               auth,
               copilotConfig,
               testCase.userMessage,
@@ -108,6 +109,7 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
               toolCalls,
               judgeResult,
               passed,
+              copilotModelTimeMs: modelTimeMs,
             });
 
             const actualToolNames = toolCalls.map((t) => t.name);
@@ -128,6 +130,40 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
       }
     });
   }
+
+  afterAll(() => {
+    if (evalResults.length === 0) {
+      return;
+    }
+
+    const totalCopilotTimeMs = evalResults.reduce(
+      (sum, r) => sum + r.copilotModelTimeMs,
+      0
+    );
+
+    console.log("\n" + "=".repeat(60));
+    console.log(`COPILOT EVAL TIMING SUMMARY (agent: ${COPILOT_AGENT})`);
+    console.log("=".repeat(60));
+    const passedCount = evalResults.filter((r) => r.passed).length;
+    const passRate = ((passedCount / evalResults.length) * 100).toFixed(0);
+
+    console.log(`Total scenarios: ${evalResults.length}`);
+    console.log(`Passed: ${passedCount}/${evalResults.length} (${passRate}%)`);
+    console.log(
+      `Total copilot model time: ${(totalCopilotTimeMs / 1000).toFixed(1)}s`
+    );
+    console.log(
+      `Average copilot model time per scenario: ${(totalCopilotTimeMs / evalResults.length / 1000).toFixed(1)}s`
+    );
+    console.log("-".repeat(60));
+    for (const r of evalResults) {
+      const status = r.passed ? "PASS" : "FAIL";
+      console.log(
+        `  [${status}] ${r.testCase.category}/${r.testCase.scenarioId}: ${(r.copilotModelTimeMs / 1000).toFixed(1)}s`
+      );
+    }
+    console.log("=".repeat(60) + "\n");
+  });
 
   if (COPILOT_ON_COPILOT) {
     afterAll(async () => {

--- a/front/tests/copilot-evals/copilot-eval.test.ts
+++ b/front/tests/copilot-evals/copilot-eval.test.ts
@@ -79,12 +79,13 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
           async () => {
             const auth = createMockAuthenticator();
 
-            const { responseText, toolCalls, modelTimeMs } = await executeCopilot(
-              auth,
-              copilotConfig,
-              testCase.userMessage,
-              testCase.mockState
-            );
+            const { responseText, toolCalls, modelTimeMs } =
+              await executeCopilot(
+                auth,
+                copilotConfig,
+                testCase.userMessage,
+                testCase.mockState
+              );
 
             // Require either text response or tool calls (judge has access to tool calls)
             expect(
@@ -141,28 +142,26 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
       0
     );
 
-    console.log("\n" + "=".repeat(60));
-    console.log(`COPILOT EVAL TIMING SUMMARY (agent: ${COPILOT_AGENT})`);
-    console.log("=".repeat(60));
     const passedCount = evalResults.filter((r) => r.passed).length;
     const passRate = ((passedCount / evalResults.length) * 100).toFixed(0);
-
-    console.log(`Total scenarios: ${evalResults.length}`);
-    console.log(`Passed: ${passedCount}/${evalResults.length} (${passRate}%)`);
-    console.log(
-      `Total copilot model time: ${(totalCopilotTimeMs / 1000).toFixed(1)}s`
-    );
-    console.log(
-      `Average copilot model time per scenario: ${(totalCopilotTimeMs / evalResults.length / 1000).toFixed(1)}s`
-    );
-    console.log("-".repeat(60));
-    for (const r of evalResults) {
-      const status = r.passed ? "PASS" : "FAIL";
-      console.log(
-        `  [${status}] ${r.testCase.category}/${r.testCase.scenarioId}: ${(r.copilotModelTimeMs / 1000).toFixed(1)}s`
-      );
-    }
-    console.log("=".repeat(60) + "\n");
+    const lines = [
+      "",
+      "=".repeat(60),
+      `COPILOT EVAL TIMING SUMMARY (agent: ${COPILOT_AGENT})`,
+      "=".repeat(60),
+      `Total scenarios: ${evalResults.length}`,
+      `Passed: ${passedCount}/${evalResults.length} (${passRate}%)`,
+      `Total copilot model time: ${(totalCopilotTimeMs / 1000).toFixed(1)}s`,
+      `Average copilot model time per scenario: ${(totalCopilotTimeMs / evalResults.length / 1000).toFixed(1)}s`,
+      "-".repeat(60),
+      ...evalResults.map((r) => {
+        const status = r.passed ? "PASS" : "FAIL";
+        return `  [${status}] ${r.testCase.category}/${r.testCase.scenarioId}: ${(r.copilotModelTimeMs / 1000).toFixed(1)}s`;
+      }),
+      "=".repeat(60),
+      "",
+    ];
+    console.log(lines.join("\n"));
   });
 
   if (COPILOT_ON_COPILOT) {

--- a/front/tests/copilot-evals/lib/config.ts
+++ b/front/tests/copilot-evals/lib/config.ts
@@ -2,6 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { AGENT_COPILOT_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/agent_copilot_agent_state/metadata";
 import { AGENT_COPILOT_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
 import { _getCopilotGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
+import { _getCopilotHaikuGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot_haiku";
 import {
   type CopilotContext,
   formatAvailableModels,
@@ -23,6 +24,7 @@ export const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
 export const FILTER_CATEGORY = process.env.FILTER_CATEGORY;
 export const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
 export const COPILOT_ON_COPILOT = process.env.COPILOT_ON_COPILOT === "true";
+export const COPILOT_AGENT = process.env.COPILOT_AGENT ?? "default";
 
 export const TIMEOUT_MS = 300_000;
 export const COPILOT_ON_COPILOT_TIMEOUT_MS = 600_000;
@@ -117,7 +119,19 @@ export async function getCopilotConfig(): Promise<CopilotConfig> {
   const workspace = await WorkspaceFactory.basic();
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const mockCopilotContext = getMockCopilotContext();
-  const copilotConfig = _getCopilotGlobalAgent(auth, mockCopilotContext);
+  let copilotConfig;
+  switch (COPILOT_AGENT) {
+    case "default":
+      copilotConfig = _getCopilotGlobalAgent(auth, mockCopilotContext);
+      break;
+    case "haiku":
+      copilotConfig = _getCopilotHaikuGlobalAgent(auth, mockCopilotContext);
+      break;
+    default:
+      throw new Error(
+        `Unknown COPILOT_AGENT: "${COPILOT_AGENT}". Must be "default" or "haiku".`
+      );
+  }
 
   const tools: AgentActionSpecification[] = [GET_AGENT_CONFIG_SPEC];
 

--- a/front/tests/copilot-evals/lib/copilot-executor.ts
+++ b/front/tests/copilot-evals/lib/copilot-executor.ts
@@ -37,7 +37,9 @@ export async function executeCopilot(
 
   const allToolCalls: ToolCall[] = [];
   let responseText = "";
+  let totalModelTimeMs = 0;
 
+  let streamStart = Date.now();
   let events = llm.stream({
     conversation: { messages },
     prompt: config.instructions,
@@ -66,6 +68,8 @@ export async function executeCopilot(
           throw new Error(`Copilot LLM error: ${event.content.message}`);
       }
     }
+
+    totalModelTimeMs += Date.now() - streamStart;
 
     // No more tool calls - we have the final response
     if (currentRoundToolCalls.length === 0) {
@@ -107,6 +111,7 @@ export async function executeCopilot(
     }
 
     // Continue conversation with tool results
+    streamStart = Date.now();
     events = llm.stream({
       conversation: { messages },
       prompt: config.instructions,
@@ -114,5 +119,5 @@ export async function executeCopilot(
     });
   }
 
-  return { responseText, toolCalls: allToolCalls };
+  return { responseText, toolCalls: allToolCalls, modelTimeMs: totalModelTimeMs };
 }

--- a/front/tests/copilot-evals/lib/copilot-executor.ts
+++ b/front/tests/copilot-evals/lib/copilot-executor.ts
@@ -119,5 +119,9 @@ export async function executeCopilot(
     });
   }
 
-  return { responseText, toolCalls: allToolCalls, modelTimeMs: totalModelTimeMs };
+  return {
+    responseText,
+    toolCalls: allToolCalls,
+    modelTimeMs: totalModelTimeMs,
+  };
 }

--- a/front/tests/copilot-evals/lib/types.ts
+++ b/front/tests/copilot-evals/lib/types.ts
@@ -70,6 +70,7 @@ export interface JudgeResult {
 export interface CopilotExecutionResult {
   responseText: string;
   toolCalls: ToolCall[];
+  modelTimeMs: number;
 }
 
 export interface EvalResult {
@@ -78,4 +79,5 @@ export interface EvalResult {
   toolCalls: ToolCall[];
   judgeResult: JudgeResult;
   passed: boolean;
+  copilotModelTimeMs: number;
 }


### PR DESCRIPTION
## Description

Add timings, add possibility to pick between models

## Tests

Results look like this:

```
============================================================
COPILOT EVAL TIMING SUMMARY (agent: sonnet 4.6)
============================================================
Total scenarios: 42
Passed: 42/42 (100%)
Total copilot model time: 788.3s
Average copilot model time per scenario: 18.8s
------------------------------------------------------------

============================================================
COPILOT EVAL TIMING SUMMARY (agent: haiku)
============================================================
Total scenarios: 42
Passed: 40/42 (95%)
Total copilot model time: 329.4s
Average copilot model time per scenario: 7.8s
------------------------------------------------------------
  [FAIL] minimal-instructions/improve-basic: 4.3s
  [FAIL] with-tools/unreferenced-review-setup: 6.6s
============================================================
```

## Risk

low

## Deploy Plan

none