### PR TITLE
Make sure there is some whitespace between content blocks

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -70,6 +70,24 @@ import { startActiveObservation } from "@langfuse/tracing";
 import { Context, heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
+// Concatenate two content strings, ensuring at least one whitespace character
+// between them when both are non-empty. This prevents words from being glued
+// together across successive LLM calls.
+function concatWithNewlineBoundary(
+  previous: string | null,
+  current: string | null
+): string {
+  if (!previous?.length || !current?.length) {
+    return (previous ?? "") + (current ?? "");
+  }
+  const prevEndsWs = /\s$/.test(previous);
+  const currStartsWs = /^\s/.test(current);
+  if (!prevEndsWs && !currStartsWs) {
+    return previous + "\n" + current;
+  }
+  return previous + current;
+}
+
 // This method is used by the multi-actions execution loop to pick the next action to execute and
 // generate its inputs.
 export async function runModel(
@@ -650,7 +668,10 @@ export async function runModel(
     const updatedAgentMessage = {
       ...agentMessage,
       chainOfThought: (agentMessage.chainOfThought ?? "") + chainOfThought,
-      content: (agentMessage.content ?? "") + processedContent,
+      content: concatWithNewlineBoundary(
+        agentMessage.content,
+        processedContent
+      ),
       completedTs,
       status: "succeeded",
       completionDurationMs: getCompletionDuration(
@@ -821,8 +842,10 @@ export async function runModel(
   const chainOfThought =
     (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
 
-  agentMessage.content =
-    (agentMessage.content ?? "") + (contentParser.getContent() ?? "");
+  agentMessage.content = concatWithNewlineBoundary(
+    agentMessage.content,
+    contentParser.getContent()
+  );
 
   if (chainOfThought.length) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing


### PR DESCRIPTION
## Description

- When an agent makes multiple LLM calls (e.g., generates content, calls a tool, then generates more content), the content strings from each call were concatenated directly without any separator, potentially gluing words together. This was particularly bad in copilot scenarios that include directives (https://github.com/dust-tt/tasks/issues/6763).
- Added concatWithNewlineBoundary helper that inserts a \n between content strings when neither ends/starts with whitespace, matching the existing interleaveConditionalNewlines logic used for the display path

## Tests

Manual

## Risk

Should be limited to the very specific no-whitespace scenario. Easy to revert if any problem.

## Deploy Plan

Front.