### PR TITLE
Refactor authentication

### DIFF
--- a/extension/platforms/chrome/ChromeApp.tsx
+++ b/extension/platforms/chrome/ChromeApp.tsx
@@ -1,4 +1,5 @@
 import { RootLayout } from "@app/components/app/RootLayout";
+import { RegionProvider } from "@app/lib/auth/RegionContext";
 import { SparkleContext } from "@dust-tt/sparkle";
 import { ChromeExtensionWrapper } from "@extension/platforms/chrome/ChromeExtensionWrapper";
 import { PortProvider } from "@extension/platforms/chrome/context/PortContext";
@@ -17,19 +18,21 @@ export const ChromeApp = () => {
   return (
     <PlatformProvider platformService={platformService}>
       <PortProvider>
-        <ExtensionAuthProvider>
-          <ExtensionFetcherProvider>
-            <SparkleContext.Provider
-              value={{ components: { link: ReactRouterLinkWrapper } }}
-            >
-              <RootLayout>
-                <ChromeExtensionWrapper>
-                  <RouterProvider router={router} />
-                </ChromeExtensionWrapper>
-              </RootLayout>
-            </SparkleContext.Provider>
-          </ExtensionFetcherProvider>
-        </ExtensionAuthProvider>
+        <RegionProvider>
+          <ExtensionAuthProvider>
+            <ExtensionFetcherProvider>
+              <SparkleContext.Provider
+                value={{ components: { link: ReactRouterLinkWrapper } }}
+              >
+                <RootLayout>
+                  <ChromeExtensionWrapper>
+                    <RouterProvider router={router} />
+                  </ChromeExtensionWrapper>
+                </RootLayout>
+              </SparkleContext.Provider>
+            </ExtensionFetcherProvider>
+          </ExtensionAuthProvider>
+        </RegionProvider>
       </PortProvider>
     </PlatformProvider>
   );

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -79,16 +79,28 @@ const shouldDisableContextMenuForDomain = async (
     return true;
   }
 
-  const user = await platform.auth.getStoredUser();
-  if (!user || !user.selectedWorkspace) {
+  const token = await platform.auth.getAccessToken();
+  const regionInfo = await platform.auth.getRegionInfoFromStorage();
+  const selectedWorkspace = await platform.auth.getSelectedWorkspace();
+
+  if (!token || !regionInfo || !selectedWorkspace) {
     return false;
   }
 
-  const blacklistedDomains =
-    user.workspaces.find((w) => w.sId === user.selectedWorkspace)
-      ?.blacklistedDomains || [];
-
-  return blacklistedDomains.some((d) => url.includes(d));
+  try {
+    const res = await fetch(
+      `${regionInfo.url}/api/w/${selectedWorkspace}/extension/config`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    if (!res.ok) {
+      return false;
+    }
+    const data = await res.json();
+    const blacklistedDomains: string[] = data.blacklistedDomains ?? [];
+    return blacklistedDomains.some((d) => url.includes(d));
+  } catch {
+    return false;
+  }
 };
 
 const toggleContextMenus = (isDisabled: boolean) => {
@@ -401,9 +413,9 @@ chrome.runtime.onMessageExternal.addListener((request) => {
         })
         .then(() => {
           chrome.storage.local.get(
-            ["extensionReady", "user"],
-            ({ extensionReady, user }) => {
-              if (request.workspaceId != user?.selectedWorkspace) {
+            ["extensionReady", "selectedWorkspace"],
+            ({ extensionReady, selectedWorkspace }) => {
+              if (request.workspaceId != selectedWorkspace) {
                 log("[onMessageExternal] User selected another workspace.");
                 return;
               }
@@ -561,22 +573,22 @@ const refreshToken = async (
         refresh_token: refreshToken,
       };
 
-      const user = await platform.auth.getStoredUser();
-      if (!user) {
-        log("No user found for token refresh.");
+      const regionInfo = await platform.auth.getRegionInfoFromStorage();
+      if (!regionInfo) {
+        log("No region info found for token refresh.");
         const handlers = state.refreshRequests;
         state.refreshRequests = [];
         handlers.forEach((sendResponse) => {
           sendResponse({
             success: false,
-            error: "No user found for token refresh.",
+            error: "No region info found for token refresh.",
           });
         });
         return;
       }
 
       const response = await fetch(
-        `${user.dustDomain}/api/workos/authenticate`,
+        `${regionInfo.url}/api/workos/authenticate`,
         {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -683,11 +695,6 @@ const logout = async (
     log("No access token found for WorkOS logout.");
     sendResponse({ success: false, error: "No access token found." });
     return;
-  }
-
-  const user = await platform.auth.getStoredUser();
-  if (!user) {
-    return true;
   }
 
   const logoutUrl = `${DUST_US_URL}/api/workos/logout-url?${new URLSearchParams(

--- a/extension/platforms/chrome/components/ChromeCaptureActions.tsx
+++ b/extension/platforms/chrome/components/ChromeCaptureActions.tsx
@@ -1,3 +1,4 @@
+import { useExtensionConfig } from "@app/lib/swr/extension";
 import { Button, CameraIcon, DocumentPlusIcon } from "@dust-tt/sparkle";
 import { useCurrentUrlAndDomain } from "@extension/platforms/chrome/hooks/useCurrentDomain";
 import type { CaptureActionsProps } from "@extension/shared/services/platform";
@@ -9,11 +10,11 @@ export function ChromeCaptureActions({
   owner,
 }: CaptureActionsProps) {
   const { currentDomain, currentUrl } = useCurrentUrlAndDomain();
-  const blacklistedConfig: string[] = owner.blacklistedDomains ?? [];
+  const { blacklistedDomains } = useExtensionConfig(owner);
 
   const isBlacklisted =
     currentDomain === "chrome" ||
-    blacklistedConfig.some((d) =>
+    blacklistedDomains.some((d: string) =>
       d.startsWith("http://") || d.startsWith("https://")
         ? currentUrl.startsWith(d)
         : currentDomain.endsWith(d)

--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -6,12 +6,12 @@ import {
   sendRefreshTokenMessage,
   sentLogoutMessage,
 } from "@extension/platforms/chrome/messages";
-import type { StoredTokens, StoredUser } from "@extension/shared/services/auth";
+import type { StoredTokens } from "@extension/shared/services/auth";
 import {
   AuthError,
   AuthService,
   getConnectionDetails,
-  getDustDomain,
+  getRegionInfoFromClaims,
 } from "@extension/shared/services/auth";
 import type { StorageService } from "@extension/shared/services/storage";
 import { jwtDecode } from "jwt-decode";
@@ -21,16 +21,6 @@ const log = console.error;
 export class ChromeAuthService extends AuthService {
   constructor(storage: StorageService) {
     super(storage);
-  }
-
-  // Internal methods.
-
-  // We store the basic user information with list of workspaces and currently selected
-  // workspace in Chrome storage.
-  async saveUser(user: StoredUser) {
-    await this.storage.set("user", user);
-
-    return user;
   }
 
   // Refresh token sends a message to the background script to call the workos refresh token endpoint.
@@ -68,8 +58,7 @@ export class ChromeAuthService extends AuthService {
   }
 
   // Login sends a message to the background script to call the workos login endpoint.
-  // It saves the tokens in the extension and schedules a token refresh.
-  // Then it calls the /me route to get the user info.
+  // It saves the tokens and auth metadata (dustDomain, connectionDetails).
   async login({ forcedConnection }: { forcedConnection?: string }) {
     try {
       const response = await sendAuthMessage(forcedConnection);
@@ -85,7 +74,7 @@ export class ChromeAuthService extends AuthService {
 
       const claims = jwtDecode<Record<string, string>>(tokens.accessToken);
 
-      const dustDomain = getDustDomain(claims);
+      const regionInfo = getRegionInfoFromClaims(claims);
       const connectionDetails = getConnectionDetails(claims);
 
       if (
@@ -95,32 +84,11 @@ export class ChromeAuthService extends AuthService {
         connectionDetails.connectionStrategy = response.authentication_method;
       }
 
-      const res = await this.fetchMe({
-        accessToken: tokens.accessToken,
-        dustDomain,
-      });
-      if (res.isErr()) {
-        return res;
-      }
-      const workspaces = res.value.user.workspaces;
+      // Store regionInfo and connectionDetails separately.
+      await this.storage.set("regionInfo", regionInfo);
+      await this.storage.set("connectionDetails", connectionDetails);
 
-      const selectedWorkspace =
-        workspaces.find((w) => w.sId === res.value.user.selectedWorkspace) ||
-        workspaces[0];
-
-      const user = await this.saveUser({
-        ...res.value.user,
-        ...connectionDetails,
-        dustDomain,
-        selectedWorkspace: selectedWorkspace?.sId ?? null,
-      });
-      datadogLogs.setUser({
-        id: user.sId,
-      });
-      if (workspaces.length === 1) {
-        datadogLogs.setGlobalContext({ workspaceId: workspaces[0].sId });
-      }
-      return new Ok({ tokens, user });
+      return new Ok({ tokens, regionInfo, connectionDetails });
     } catch (error) {
       return new Err(new AuthError("not_authenticated", error?.toString()));
     }
@@ -179,20 +147,5 @@ export class ChromeAuthService extends AuthService {
       refreshToken: refreshToken || "",
       expiresAt,
     };
-  }
-
-  async getStoredUser() {
-    const result = await this.storage.get<StoredUser>("user");
-
-    if (result) {
-      datadogLogs.setUser({
-        id: result.sId,
-      });
-      if (result.selectedWorkspace) {
-        datadogLogs.setGlobalContext({ workspaceId: result.selectedWorkspace });
-      }
-    }
-
-    return result ?? null;
   }
 }

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -7,6 +7,7 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
+import { RegionProvider } from "@app/lib/auth/RegionContext";
 import { Notification } from "@dust-tt/sparkle";
 import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
 import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
@@ -53,13 +54,15 @@ const AppWrapper = () => {
   return (
     <FrontContextProvider>
       <FrontPlatformProvider>
-        <ExtensionAuthProvider>
-          <ExtensionFetcherProvider>
-            <Notification.Area>
-              <RouterProvider router={router} key="front-router" />
-            </Notification.Area>
-          </ExtensionFetcherProvider>
-        </ExtensionAuthProvider>
+        <RegionProvider>
+          <ExtensionAuthProvider>
+            <ExtensionFetcherProvider>
+              <Notification.Area>
+                <RouterProvider router={router} key="front-router" />
+              </Notification.Area>
+            </ExtensionFetcherProvider>
+          </ExtensionAuthProvider>
+        </RegionProvider>
       </FrontPlatformProvider>
     </FrontContextProvider>
   );

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -7,7 +7,7 @@ import {
   AuthError,
   AuthService,
   getConnectionDetails,
-  getDustDomain,
+  getRegionInfoFromClaims,
 } from "@extension/shared/services/auth";
 import type { StorageService } from "@extension/shared/services/storage";
 import { jwtDecode } from "jwt-decode";
@@ -167,7 +167,7 @@ export class FrontAuthService extends AuthService {
 
       const claims = jwtDecode<Record<string, string>>(data.access_token);
 
-      const dustDomain = getDustDomain(claims);
+      const regionInfo = getRegionInfoFromClaims(claims);
       const connectionDetails = getConnectionDetails(claims);
 
       if (
@@ -177,29 +177,11 @@ export class FrontAuthService extends AuthService {
         connectionDetails.connectionStrategy = data.authentication_method;
       }
 
-      // Get user details and workspaces
-      const res = await this.fetchMe({
-        accessToken: data.access_token,
-        dustDomain,
-      });
+      // Store regionInfo and connectionDetails separately.
+      await this.storage.set("regionInfo", regionInfo);
+      await this.storage.set("connectionDetails", connectionDetails);
 
-      if (res.isErr()) {
-        return res;
-      }
-
-      const workspaces = res.value.user.workspaces;
-
-      const selectedWorkspace =
-        workspaces.find((w) => w.sId === res.value.user.selectedWorkspace) ||
-        workspaces[0];
-
-      const storedUser = await this.saveUser({
-        ...res.value.user,
-        ...connectionDetails,
-        dustDomain,
-        selectedWorkspace: selectedWorkspace?.sId ?? null,
-      });
-      return new Ok({ tokens, user: storedUser });
+      return new Ok({ tokens, regionInfo, connectionDetails });
     } catch (error) {
       return new Err(new AuthError("not_authenticated", error?.toString()));
     }
@@ -218,12 +200,12 @@ export class FrontAuthService extends AuthService {
       }
     }
 
-    const user = await this.getStoredUser();
-    if (!user) {
+    const regionInfo = await this.getRegionInfoFromStorage();
+    if (!regionInfo) {
       return true;
     }
 
-    const logoutUrl = `${user.dustDomain}/api/v1/auth/logout?${new URLSearchParams(
+    const logoutUrl = `${regionInfo.url}/api/v1/auth/logout?${new URLSearchParams(
       queryParams
     )}`;
 
@@ -277,15 +259,15 @@ export class FrontAuthService extends AuthService {
         );
       }
 
-      const user = await this.getStoredUser();
-      if (!user) {
+      const regionInfo = await this.getRegionInfoFromStorage();
+      if (!regionInfo) {
         return new Err(
-          new AuthError("invalid_oauth_token_error", "No user found")
+          new AuthError("invalid_oauth_token_error", "No region info found")
         );
       }
 
       const response = await fetch(
-        `${user.dustDomain}/api/v1/auth/authenticate`,
+        `${regionInfo.url}/api/v1/auth/authenticate`,
         {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/extension/shared/lib/FetcherProvider.tsx
+++ b/extension/shared/lib/FetcherProvider.tsx
@@ -1,10 +1,10 @@
-import { setBaseUrlResolver } from "@app/lib/api/config";
+import { getBaseUrlFromResolver } from "@app/lib/api/config";
 import { FetcherProvider } from "@app/lib/swr/FetcherContext";
 import type { FetcherFn, FetcherWithBodyFn } from "@app/lib/swr/fetcher";
 import { resHandler } from "@extension/shared/lib/swr";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import type { ReactNode } from "react";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 interface ExtensionFetcherProviderProps {
   children: ReactNode;
@@ -13,20 +13,16 @@ interface ExtensionFetcherProviderProps {
 export function ExtensionFetcherProvider({
   children,
 }: ExtensionFetcherProviderProps) {
-  const { token, user } = useExtensionAuth();
-
-  useEffect(() => {
-    if (user?.dustDomain) {
-      setBaseUrlResolver(() => user.dustDomain);
-    }
-    return () => setBaseUrlResolver(null);
-  }, [user?.dustDomain]);
+  const { token } = useExtensionAuth();
 
   const { fetcher, fetcherWithBody } = useMemo(() => {
-    const dustDomain = user?.dustDomain ?? "";
-
-    const resolveUrl = (url: string) =>
-      url.startsWith("/") ? `${dustDomain}${url}` : url;
+    const resolveUrl = (url: string) => {
+      if (url.startsWith("/")) {
+        const baseUrl = getBaseUrlFromResolver();
+        return `${baseUrl}${url}`;
+      }
+      return url;
+    };
 
     const addAuthHeaders = (headers: HeadersInit = {}): HeadersInit => ({
       ...headers,
@@ -58,7 +54,7 @@ export function ExtensionFetcherProvider({
     };
 
     return { fetcher, fetcherWithBody };
-  }, [token, user?.dustDomain]);
+  }, [token]);
 
   return (
     <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>

--- a/extension/shared/lib/dust_api.ts
+++ b/extension/shared/lib/dust_api.ts
@@ -1,3 +1,4 @@
+import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { DustAPI } from "@dust-tt/client";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
@@ -5,12 +6,18 @@ import { useMemo } from "react";
 
 export const useDustAPI = () => {
   const platform = usePlatform();
-  const { token, isAuthenticated, isUserSetup, user, workspace } =
-    useExtensionAuth();
+  const { token, isAuthenticated, isUserSetup, workspace } = useExtensionAuth();
+  const { regionInfo } = useRegionContext();
 
   const commitHash = process.env.COMMIT_HASH;
   const extensionVersion = process.env.VERSION;
-  if (!isAuthenticated || !isUserSetup || !user || !workspace || !token) {
+  if (
+    !isAuthenticated ||
+    !isUserSetup ||
+    !regionInfo?.url ||
+    !workspace ||
+    !token
+  ) {
     throw new Error("Not authenticated");
   }
 
@@ -21,7 +28,7 @@ export const useDustAPI = () => {
   return useMemo(() => {
     return new DustAPI(
       {
-        url: user.dustDomain,
+        url: regionInfo.url,
       },
       {
         apiKey: () => platform.auth.getAccessToken(),
@@ -33,5 +40,5 @@ export const useDustAPI = () => {
       },
       console
     );
-  }, [user.dustDomain, workspace.sId, platform]);
+  }, [regionInfo.url, workspace.sId, platform]);
 };

--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -1,6 +1,5 @@
-import type { ExtensionWorkspaceType, UserType } from "@app/types/user";
+import type { RegionInfo } from "@app/lib/api/regions/config";
 import type { Result, WorkspaceType } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
 import {
   DEFAULT_DUST_API_DOMAIN,
   DUST_EU_URL,
@@ -9,26 +8,13 @@ import {
 } from "@extension/shared/lib/config";
 import type { StorageService } from "@extension/shared/services/storage";
 
-export type Organization = {
-  id: string;
-  name: string;
-};
-
-export type UserTypeWithExtensionWorkspaces = UserType & {
-  workspaces: ExtensionWorkspaceType[];
-  organizations: Organization[];
-  selectedWorkspace: string | null;
-};
-
 export type StoredTokens = {
   accessToken: string;
   refreshToken: string;
   expiresAt: number;
 };
 
-export type StoredUser = UserTypeWithExtensionWorkspaces & {
-  selectedWorkspace: string | null;
-  dustDomain: string;
+export type ConnectionDetails = {
   connectionStrategy: SupportedEnterpriseConnectionStrategy | undefined;
   connection?: string;
 };
@@ -58,6 +44,12 @@ export class AuthError extends Error {
   }
 }
 
+export type LoginResult = {
+  tokens: StoredTokens;
+  regionInfo: RegionInfo;
+  connectionDetails: ConnectionDetails;
+};
+
 export abstract class AuthService {
   protected storage: StorageService;
 
@@ -80,11 +72,6 @@ export abstract class AuthService {
     return tokens;
   }
 
-  async saveUser(user: StoredUser): Promise<StoredUser> {
-    await this.storage.set("user", user);
-    return user;
-  }
-
   async getStoredTokens(): Promise<StoredTokens | null> {
     const accessToken = await this.storage.get<string>("accessToken");
     const refreshToken = await this.storage.get<string>("refreshToken");
@@ -101,15 +88,24 @@ export abstract class AuthService {
     };
   }
 
-  async getStoredUser(): Promise<StoredUser | null> {
-    const result = await this.storage.get<StoredUser>("user");
-    return result ?? null;
+  async getRegionInfoFromStorage(): Promise<RegionInfo | null> {
+    return (await this.storage.get<RegionInfo>("regionInfo")) ?? null;
+  }
+
+  async getConnectionDetailsFromStorage(): Promise<ConnectionDetails | null> {
+    return (
+      (await this.storage.get<ConnectionDetails>("connectionDetails")) ?? null
+    );
+  }
+
+  async getSelectedWorkspace(): Promise<string | null> {
+    return (await this.storage.get<string>("selectedWorkspace")) ?? null;
   }
 
   // Abstract methods that must be implemented by platform-specific services
   abstract login(args: {
     forcedConnection?: string;
-  }): Promise<Result<{ tokens: StoredTokens; user: StoredUser }, AuthError>>;
+  }): Promise<Result<LoginResult, AuthError>>;
 
   abstract logout(): Promise<boolean>;
 
@@ -118,48 +114,32 @@ export abstract class AuthService {
   abstract refreshToken(
     tokens: StoredTokens | null
   ): Promise<Result<StoredTokens, AuthError>>;
-
-  protected async fetchMe({
-    accessToken,
-    dustDomain,
-  }: {
-    accessToken: string;
-    dustDomain: string;
-  }): Promise<Result<{ user: UserTypeWithExtensionWorkspaces }, AuthError>> {
-    const response = await fetch(`${dustDomain}/api/v1/me`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "X-Request-Origin": "extension",
-      },
-    });
-    const me = await response.json();
-
-    if (!response.ok) {
-      return new Err(new AuthError(me.error.type, me.error.message));
-    }
-
-    return new Ok(me);
-  }
 }
 
 const REGION_CLAIM = `${WORKOS_CLAIM_NAMESPACE}region`;
 const CONNECTION_STRATEGY_CLAIM = `${WORKOS_CLAIM_NAMESPACE}connection.strategy`;
 const WORKSPACE_ID_CLAIM = `${WORKOS_CLAIM_NAMESPACE}workspaceId`;
 
-export function getDustDomain(claims: Record<string, string>) {
+export function getRegionInfoFromClaims(
+  claims: Record<string, string>
+): RegionInfo {
   const region = claims[REGION_CLAIM];
-
-  return (
-    (isRegionType(region) && DOMAIN_FOR_REGION[region]) ||
-    DEFAULT_DUST_API_DOMAIN
-  );
+  const regionName: RegionType = isRegionType(region) ? region : "us-central1";
+  return {
+    name: regionName,
+    url:
+      (isRegionType(region) && DOMAIN_FOR_REGION[region]) ||
+      DEFAULT_DUST_API_DOMAIN,
+  };
 }
 
 export function makeEnterpriseConnectionName(workspaceId: string) {
   return `workspace-${workspaceId}`;
 }
 
-export function getConnectionDetails(claims: Record<string, string>) {
+export function getConnectionDetails(
+  claims: Record<string, string>
+): ConnectionDetails {
   const connectionStrategy = claims[CONNECTION_STRATEGY_CLAIM];
   const ws = claims[WORKSPACE_ID_CLAIM];
   return {
@@ -185,7 +165,7 @@ function isSupportedEnterpriseConnectionStrategy(
 }
 
 export function isValidEnterpriseConnection(
-  user: StoredUser,
+  connectionDetails: ConnectionDetails,
   workspace: WorkspaceType
 ) {
   if (!workspace.ssoEnforced) {
@@ -193,9 +173,11 @@ export function isValidEnterpriseConnection(
   }
 
   return (
-    user.connectionStrategy &&
-    isSupportedEnterpriseConnectionStrategy(user.connectionStrategy) &&
-    makeEnterpriseConnectionName(workspace.sId) === user.connection
+    connectionDetails.connectionStrategy &&
+    isSupportedEnterpriseConnectionStrategy(
+      connectionDetails.connectionStrategy
+    ) &&
+    makeEnterpriseConnectionName(workspace.sId) === connectionDetails.connection
   );
 }
 

--- a/extension/shared/services/platform.ts
+++ b/extension/shared/services/platform.ts
@@ -1,7 +1,7 @@
-import type { ExtensionWorkspaceType } from "@app/types/user";
+import type { WorkspaceType } from "@app/types/user";
 import type { ContentFragmentType } from "@dust-tt/client";
 import type { UploadedContentFragmentTypeWithKind } from "@extension/shared/lib/types";
-import type { AuthService, StoredUser } from "@extension/shared/services/auth";
+import type { AuthService } from "@extension/shared/services/auth";
 import type { CaptureService } from "@extension/shared/services/capture";
 import { createMockCaptureService } from "@extension/shared/services/capture";
 import type { McpService } from "@extension/shared/services/mcp";
@@ -20,7 +20,7 @@ export type Theme = "light" | "dark" | "system";
 export const DEFAULT_THEME: Theme = "system";
 
 export interface CaptureActionsProps {
-  owner: ExtensionWorkspaceType;
+  owner: WorkspaceType;
   isBlinking: boolean;
   isLoading: boolean;
   fileUploaderService: FileUploaderService;
@@ -105,14 +105,8 @@ export abstract class CorePlatformService {
     workspaceId,
   }: {
     workspaceId: string;
-  }): Promise<StoredUser> {
-    const storedUser = await this.auth.getStoredUser();
-    if (!storedUser) {
-      throw new Error("No user found.");
-    }
-    storedUser.selectedWorkspace = workspaceId;
-    await this.storage.set("user", storedUser);
-    return storedUser;
+  }): Promise<void> {
+    await this.storage.set("selectedWorkspace", workspaceId);
   }
 
   async clearStoredData(): Promise<void> {
@@ -120,7 +114,9 @@ export abstract class CorePlatformService {
       this.storage.delete("accessToken"),
       this.storage.delete("expiresAt"),
       this.storage.delete("refreshToken"),
-      this.storage.delete("user"),
+      this.storage.delete("regionInfo"),
+      this.storage.delete("connectionDetails"),
+      this.storage.delete("selectedWorkspace"),
     ]);
   }
 

--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -1,11 +1,12 @@
 import { AuthContext } from "@app/lib/auth/AuthContext";
+import { useRegionContext } from "@app/lib/auth/RegionContext";
 import type { SubscriptionType } from "@app/types/plan";
-import type { ExtensionWorkspaceType, WorkspaceType } from "@app/types/user";
+import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin, isBuilder } from "@app/types/user";
-import type { AuthError, StoredUser } from "@extension/shared/services/auth";
+import type { AuthError } from "@extension/shared/services/auth";
 import { useAuthHook } from "@extension/ui/components/auth/useAuth";
 import type { ReactNode } from "react";
-import { createContext, useContext, useMemo } from "react";
+import { createContext, useCallback, useContext, useMemo } from "react";
 
 // Extension-specific auth context (bearer token, login/logout, etc.)
 type ExtensionAuthContextType = {
@@ -14,8 +15,8 @@ type ExtensionAuthContextType = {
   authError: AuthError | null;
   setAuthError: (error: AuthError | null) => void;
   redirectToSSOLogin: (workspace: WorkspaceType) => void;
-  user: StoredUser | null;
-  workspace: ExtensionWorkspaceType | undefined;
+  user: UserTypeWithWorkspaces | null;
+  workspace: WorkspaceType | undefined;
   isUserSetup: boolean;
   isLoading: boolean;
   handleLogin: () => void;
@@ -91,12 +92,24 @@ interface ExtensionAuthProviderProps {
  *   ExtensionAuthContext — consumed with useExtensionAuth().
  * - Bridges to the front's AuthContext so that shared front components (e.g.
  *   ConversationViewer sub-components) can call useAuth() without error.
+ * - Uses RegionContext for URL resolution (dustDomain).
  *
  * Mirrors the ExtensionFetcherProvider / FetcherProvider pattern.
  */
 export function ExtensionAuthProvider({
   children,
 }: ExtensionAuthProviderProps) {
+  const { regionInfo, setRegionInfo } = useRegionContext();
+
+  const dustDomain = regionInfo?.url ?? null;
+
+  const setDustDomain = useCallback(
+    (url: string) => {
+      setRegionInfo({ name: regionInfo?.name ?? "us-central1", url });
+    },
+    [setRegionInfo, regionInfo?.name]
+  );
+
   const {
     token,
     isAuthenticated,
@@ -111,7 +124,7 @@ export function ExtensionAuthProvider({
     handleLogout,
     handleSelectWorkspace,
     featureFlags,
-  } = useAuthHook();
+  } = useAuthHook({ dustDomain, setDustDomain });
 
   const extensionAuthValue = useMemo(
     () => ({

--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -1,15 +1,14 @@
-import type { ExtensionWorkspaceType } from "@app/types/user";
+import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { classNames, Spinner } from "@dust-tt/sparkle";
 import type { RouteChangeMesssage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
-import type { StoredUser } from "@extension/shared/services/auth";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useEffect } from "react";
 import { Outlet, useNavigate, useOutletContext } from "react-router-dom";
 
 export interface ProtectedRouteOutletContext {
-  user: StoredUser;
-  workspace: ExtensionWorkspaceType;
+  user: UserTypeWithWorkspaces;
+  workspace: WorkspaceType;
   handleLogout: () => void;
 }
 

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -1,7 +1,11 @@
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { WorkspaceType } from "@dust-tt/client";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
-import type { StoredTokens, StoredUser } from "@extension/shared/services/auth";
+import type {
+  ConnectionDetails,
+  StoredTokens,
+} from "@extension/shared/services/auth";
 import {
   AuthError,
   isValidEnterpriseConnection,
@@ -12,11 +16,22 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 const PROACTIVE_REFRESH_WINDOW_MS = 1000 * 60; // 1 minute
 const log = console.error;
 
-export const useAuthHook = () => {
+export const useAuthHook = ({
+  dustDomain,
+  setDustDomain,
+}: {
+  dustDomain: string | null;
+  setDustDomain: (url: string) => void;
+}) => {
   const platform = usePlatform();
 
   const [tokens, setTokens] = useState<StoredTokens | null>(null);
-  const [user, setUser] = useState<StoredUser | null>(null);
+  const [connectionDetails, setConnectionDetails] =
+    useState<ConnectionDetails | null>(null);
+  const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(
+    null
+  );
+  const [user, setUser] = useState<UserTypeWithWorkspaces | null>(null);
   const [authError, setAuthError] = useState<AuthError | null>(null);
   const [forcedConnection, setForcedConnection] = useState<
     string | undefined
@@ -25,28 +40,33 @@ export const useAuthHook = () => {
 
   const isAuthenticated = useMemo(
     () =>
-      !!(
-        tokens?.accessToken &&
-        tokens.expiresAt > Date.now() &&
-        user?.dustDomain
-      ),
-    [tokens, user]
+      !!(tokens?.accessToken && tokens.expiresAt > Date.now() && dustDomain),
+    [tokens, dustDomain]
   );
 
-  const isUserSetup = !!(user && user.sId && user.selectedWorkspace);
+  const isUserSetup = !!(user && user.sId && selectedWorkspace);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isUserLoading, setIsUserLoading] = useState<boolean>(false);
 
   const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Derive workspace from user workspaces + selectedWorkspace
+  const workspace = useMemo(
+    () => user?.workspaces.find((w) => w.sId === selectedWorkspace),
+    [user, selectedWorkspace]
+  );
 
   const handleLogout = useCallback(async () => {
     setIsLoading(true);
     const success = await platform.auth.logout();
     if (!success) {
-      // TODO(EXT): User facing error message if logout failed.
       setIsLoading(false);
       return;
     }
     setTokens(null);
+    setConnectionDetails(null);
+    setSelectedWorkspace(null);
+    setUser(null);
     setAuthError(null);
     setForcedConnection(undefined);
     if (refreshTimerRef.current) {
@@ -56,7 +76,6 @@ export const useAuthHook = () => {
   }, []);
 
   const handleRefreshToken = useCallback(async () => {
-    // Call getAccessToken, it will refresh the token if needed.
     const newAccessToken = await platform.auth.getAccessToken(true);
     if (!newAccessToken) {
       setAuthError(
@@ -80,7 +99,7 @@ export const useAuthHook = () => {
     setAuthError(null);
   }, []);
 
-  // Listen for changes in storage to make sure we always have the latest user and tokens.
+  // Listen for changes in storage to make sure we always have the latest tokens.
   useEffect(() => {
     const unsub = platform.storage.onChanged((changes) => {
       if ("accessToken" in changes && !changes.accessToken) {
@@ -93,21 +112,59 @@ export const useAuthHook = () => {
     return () => unsub();
   }, []);
 
+  // Fetch user data from /api/v1/me when authenticated.
+  useEffect(() => {
+    if (!isAuthenticated || !tokens?.accessToken || !dustDomain) {
+      return;
+    }
+
+    setIsUserLoading(true);
+    void (async () => {
+      try {
+        const res = await fetch(`${dustDomain}/api/v1/me`, {
+          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const fetchedUser = data.user as UserTypeWithWorkspaces;
+          setUser(fetchedUser);
+
+          // If user has a selectedWorkspace from the server (org-scoped login),
+          // and we don't have one stored, use it.
+          if (!selectedWorkspace && fetchedUser.selectedWorkspace) {
+            setSelectedWorkspace(fetchedUser.selectedWorkspace);
+            await platform.storage.set(
+              "selectedWorkspace",
+              fetchedUser.selectedWorkspace
+            );
+          }
+        }
+      } finally {
+        setIsUserLoading(false);
+      }
+    })();
+  }, [isAuthenticated, tokens?.accessToken, dustDomain]);
+
+  // Initialize from storage on mount.
   useEffect(() => {
     void (async () => {
       setIsLoading(true);
 
-      // Fetch tokens & user from storage.
       const storedTokens = await platform.auth.getStoredTokens();
-      const savedUser = await platform.auth.getStoredUser();
+      const storedRegionInfo = await platform.auth.getRegionInfoFromStorage();
+      const storedConnectionDetails =
+        await platform.auth.getConnectionDetailsFromStorage();
+      const storedSelectedWorkspace =
+        await platform.auth.getSelectedWorkspace();
 
-      if (!storedTokens || !savedUser) {
-        // TODO(EXT): User facing error message if no tokens found.
+      if (!storedTokens || !storedRegionInfo) {
         setIsLoading(false);
         return;
       }
       setTokens(storedTokens);
-      setUser(savedUser);
+      setDustDomain(storedRegionInfo.url);
+      setConnectionDetails(storedConnectionDetails);
+      setSelectedWorkspace(storedSelectedWorkspace);
 
       // Token refresh.
       if (storedTokens.expiresAt < Date.now() + PROACTIVE_REFRESH_WINDOW_MS) {
@@ -124,27 +181,16 @@ export const useAuthHook = () => {
     };
   }, []);
 
-  const workspace = useMemo(
-    () => user?.workspaces.find((w) => w.sId === user.selectedWorkspace),
-    [user]
-  );
-
-  // Note that we do not use useSWRWithDefaults from extension/shared/lib/swr.ts
-  // because it depends on the auth context being initialized.
+  // Fetch feature flags when workspace is ready.
   useEffect(() => {
-    if (
-      !isAuthenticated ||
-      !workspace ||
-      !tokens?.accessToken ||
-      !user?.dustDomain
-    ) {
+    if (!isAuthenticated || !workspace || !tokens?.accessToken || !dustDomain) {
       setFeatureFlags([]);
       return;
     }
 
     void (async () => {
       const res = await fetch(
-        `${user.dustDomain}/api/w/${workspace.sId}/feature-flags`,
+        `${dustDomain}/api/w/${workspace.sId}/feature-flags`,
         { headers: { Authorization: `Bearer ${tokens.accessToken}` } }
       );
       if (res.ok) {
@@ -154,7 +200,7 @@ export const useAuthHook = () => {
         setFeatureFlags([]);
       }
     })();
-  }, [workspace, tokens?.accessToken, user, isAuthenticated]);
+  }, [workspace, tokens?.accessToken, dustDomain, isAuthenticated]);
 
   const redirectToSSOLogin = useCallback(
     async (workspace: WorkspaceType) => {
@@ -172,14 +218,15 @@ export const useAuthHook = () => {
   );
 
   const handleSelectWorkspace = async (workspace: WorkspaceType) => {
-    const updatedUser = await platform.saveSelectedWorkspace({
-      workspaceId: workspace.sId,
-    });
-    if (!isValidEnterpriseConnection(updatedUser, workspace)) {
-      return;
-    }
+    await platform.storage.set("selectedWorkspace", workspace.sId);
+    setSelectedWorkspace(workspace.sId);
 
-    setUser(updatedUser);
+    if (
+      connectionDetails &&
+      !isValidEnterpriseConnection(connectionDetails, workspace)
+    ) {
+      await redirectToSSOLogin(workspace);
+    }
   };
 
   const handleLogin = useCallback(async () => {
@@ -194,27 +241,35 @@ export const useAuthHook = () => {
       return;
     }
 
-    const { tokens, user } = response.value;
+    const {
+      tokens: newTokens,
+      regionInfo: newRegionInfo,
+      connectionDetails: newConnectionDetails,
+    } = response.value;
 
-    if (user.selectedWorkspace) {
-      const selectedWorkspace = user.workspaces.find(
-        (w) => w.sId === user.selectedWorkspace
+    // Restore selectedWorkspace from storage if available.
+    const storedSelectedWorkspace = await platform.auth.getSelectedWorkspace();
+
+    if (storedSelectedWorkspace && user) {
+      const selectedWs = user.workspaces.find(
+        (w) => w.sId === storedSelectedWorkspace
       );
       if (
-        selectedWorkspace &&
-        !isValidEnterpriseConnection(user, selectedWorkspace)
+        selectedWs &&
+        !isValidEnterpriseConnection(newConnectionDetails, selectedWs)
       ) {
-        await redirectToSSOLogin(selectedWorkspace);
+        await redirectToSSOLogin(selectedWs);
         setIsLoading(false);
         return;
       }
     }
 
-    setTokens(tokens);
+    setTokens(newTokens);
+    setDustDomain(newRegionInfo.url);
+    setConnectionDetails(newConnectionDetails);
     setAuthError(null);
-    setUser(user);
     setIsLoading(false);
-  }, [forcedConnection]);
+  }, [forcedConnection, user]);
 
   return {
     token: tokens?.accessToken ?? null,
@@ -225,7 +280,7 @@ export const useAuthHook = () => {
     user,
     workspace,
     isUserSetup,
-    isLoading,
+    isLoading: isLoading || isUserLoading,
     handleLogin,
     handleLogout,
     handleSelectWorkspace,

--- a/extension/ui/components/navigation/UserDropdownMenu.tsx
+++ b/extension/ui/components/navigation/UserDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import type { UserTypeWithWorkspaces } from "@app/types/user";
 import {
   Avatar,
   DropdownMenu,
@@ -13,13 +14,12 @@ import {
   LightModeIcon,
   LogoutIcon,
 } from "@dust-tt/sparkle";
-import type { StoredUser } from "@extension/shared/services/auth";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useTheme } from "@extension/ui/hooks/useTheme";
 
 interface UserDropdownMenuProps {
   handleLogout: () => void;
-  user: StoredUser;
+  user: UserTypeWithWorkspaces;
 }
 
 export const UserDropdownMenu = ({

--- a/extension/ui/pages/SubscribePage.tsx
+++ b/extension/ui/pages/SubscribePage.tsx
@@ -1,3 +1,4 @@
+import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
   BarHeader,
   Button,
@@ -12,6 +13,7 @@ import { Link } from "react-router-dom";
 
 export const SubscribePage = () => {
   const { user, workspace, handleLogout } = useProtectedRouteContext();
+  const { regionInfo } = useRegionContext();
   return (
     <div>
       <BarHeader
@@ -43,22 +45,24 @@ export const SubscribePage = () => {
             Subscribe to start using Dust agent from anywhere in your browser.
           </div>
 
-          <div className="m-1 flex text-center">
-            <Link to={`${user.dustDomain}/w/${workspace.sId}/subscribe`}>
-              <Button
-                icon={RocketIcon}
-                variant="primary"
-                label="Get started"
-                onClick={() => {
-                  window.open(
-                    `${user.dustDomain}/w/${workspace.sId}/subscribe`,
-                    "_blank"
-                  );
-                }}
-                size="sm"
-              />
-            </Link>
-          </div>
+          {regionInfo && (
+            <div className="m-1 flex text-center">
+              <Link to={`${regionInfo.url}/w/${workspace.sId}/subscribe`}>
+                <Button
+                  icon={RocketIcon}
+                  variant="primary"
+                  label="Get started"
+                  onClick={() => {
+                    window.open(
+                      `${regionInfo.url}/w/${workspace.sId}/subscribe`,
+                      "_blank"
+                    );
+                  }}
+                  size="sm"
+                />
+              </Link>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -143,6 +143,7 @@ export async function fetchRevokedWorkspace(
 
 export async function getUserWithWorkspaces<T extends boolean>(
   user: UserResource,
+  /** @deprecated Will be removed once all extension clients use the new config endpoint. */
   populateExtensionConfig: T = false as T
 ): Promise<
   T extends true ? UserTypeWithExtensionWorkspaces : UserTypeWithWorkspaces

--- a/front/lib/swr/extension.ts
+++ b/front/lib/swr/extension.ts
@@ -1,0 +1,20 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetExtensionConfigResponseBody } from "@app/pages/api/w/[wId]/extension/config";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+export function useExtensionConfig(owner: LightWorkspaceType) {
+  const { fetcher } = useFetcher();
+  const configFetcher: Fetcher<GetExtensionConfigResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/extension/config`,
+    configFetcher
+  );
+
+  return {
+    blacklistedDomains: data?.blacklistedDomains ?? emptyArray(),
+    isExtensionConfigLoading: !error && !data,
+    isExtensionConfigError: error,
+  };
+}

--- a/front/pages/api/w/[wId]/extension/config.ts
+++ b/front/pages/api/w/[wId]/extension/config.ts
@@ -1,0 +1,38 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetExtensionConfigResponseBody = {
+  blacklistedDomains: string[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetExtensionConfigResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET": {
+      const config =
+        await ExtensionConfigurationResource.fetchForWorkspace(auth);
+
+      return res.status(200).json({
+        blacklistedDomains: config?.blacklistedDomains ?? [],
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -59,6 +59,7 @@ export type WorkspaceType = LightWorkspaceType & {
   ssoEnforced?: boolean;
 };
 
+/** @deprecated Use WorkspaceType + separate extension config endpoint instead. */
 export type ExtensionWorkspaceType = WorkspaceType & {
   blacklistedDomains: string[] | null;
 };
@@ -98,6 +99,7 @@ export type UserTypeWithWorkspaces = UserType & {
   selectedWorkspace?: string;
 };
 
+/** @deprecated Use UserTypeWithWorkspaces + separate extension config endpoint instead. */
 export type UserTypeWithExtensionWorkspaces = UserType & {
   workspaces: ExtensionWorkspaceType[];
   organizations: WorkOSOrganizationType[];

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -749,12 +749,14 @@ const LightWorkspaceSchema = z.object({
 
 export type LightWorkspaceType = z.infer<typeof LightWorkspaceSchema>;
 export type WorkspaceType = z.infer<typeof WorkspaceSchema>;
+/** @deprecated Use WorkspaceType + separate extension config endpoint instead. */
 export type ExtensionWorkspaceType = z.infer<typeof ExtensionWorkspaceSchema>;
 
 const WorkspaceSchema = LightWorkspaceSchema.extend({
   ssoEnforced: z.boolean().optional(),
 });
 
+/** @deprecated Use WorkspaceSchema + separate extension config endpoint instead. */
 const ExtensionWorkspaceSchema = WorkspaceSchema.extend({
   blacklistedDomains: z.array(z.string()).nullable(),
 });


### PR DESCRIPTION
## Description

Refactors the extension authentication layer to decouple user data, region configuration, and blacklisted domains from the login flow.

### Key changes:

**1. Remove `StoredUser` / `fetchMe` from login flow**
- Login no longer calls `/api/v1/me` synchronously during the auth handshake
- Instead, `useAuth` fetches user data asynchronously via a `useEffect` after tokens are obtained
- Auth state is split: `isAuthenticated` (tokens + region) vs `isUserSetup` (user + workspace selected)
- Added `isUserLoading` to prevent the "Something unexpected" flash while user data loads

**2. Use `RegionProvider` / `RegionContext` instead of `dustDomain`**
- Wrapped both Chrome and Front entry points with `RegionProvider` (from `@app/lib/auth/RegionContext`)
- `FetcherProvider` and `useDustAPI` now resolve URLs via the region context instead of reading `dustDomain` from user
- `regionInfo` is persisted in extension storage for background script access (e.g., context menu, token refresh)

**3. New `/api/w/[wId]/extension/config` endpoint + `useExtensionConfig` hook**
- New endpoint returns `{ blacklistedDomains: string[] }` for a workspace
- New SWR hook `useExtensionConfig(owner)` in `front/lib/swr/extension.ts`
- `ChromeCaptureActions` and `background.ts` now fetch blacklisted domains via this endpoint instead of reading from workspace type

**4. Backward compatibility preserved**
- `ExtensionWorkspaceType`, `UserTypeWithExtensionWorkspaces` kept in `front/types/user.ts` and `sdks/js/src/types.ts` (marked `@deprecated`)
- `/api/v1/me` still returns `blacklistedDomains` in workspace objects when called from extension (via `x-request-origin` header)
- `MeResponseSchema` still accepts both `WorkspaceSchema` and `ExtensionWorkspaceSchema` arrays

**5. Cleanup**
- Removed `extension/shared/lib/conversation.ts` (no longer imported — `RunPage` uses `useCreateConversationWithMessage` hook)
- Removed `StoredUser`, `Organization`, `fetchMe`, `saveUser`, `getStoredUser` from extension auth services
- Simplified `saveSelectedWorkspace` and `clearStoredData` in platform service

### Files changed:
- **New**: `front/pages/api/w/[wId]/extension/config.ts`, `front/lib/swr/extension.ts`
- **Deleted**: `extension/shared/lib/conversation.ts`
- **Modified**: Extension auth services, useAuth hook, AuthProvider, FetcherProvider, DustAPI, platform service, Chrome background script, capture actions, entry points, and type files

## Tests

- `tsgo --noEmit` passes on `front/`
- Manual testing of login flow, workspace selection, blacklisted domain blocking

## Risk

**Low-Medium.** The `/api/v1/me` endpoint and SDK types are kept backward-compatible for older extension versions. The new extension code uses a separate config endpoint for blacklisted domains. The main risk is the async user loading during login — mitigated by the `isUserLoading` flag that keeps the spinner visible until data arrives.

## Deploy Plan

1. Deploy `front` first (new `/api/w/[wId]/extension/config` endpoint must be available)
2. Deploy extension update — new auth flow will use the new endpoint
3. Old extension versions continue working via the unchanged `/api/v1/me` response