### PR TITLE
[front] enh: Reset cached resource after tx commit

### DIFF
--- a/front/lib/resources/key_resource.test.ts
+++ b/front/lib/resources/key_resource.test.ts
@@ -53,6 +53,13 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>): void => {
+        void invalidateFn();
+      }
+    ),
 }));
 
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -54,6 +54,13 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>): void => {
+        void invalidateFn();
+      }
+    ),
 }));
 
 import { Authenticator } from "@app/lib/auth";

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -9,7 +9,11 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
+import {
+  cacheWithRedis,
+  invalidateCacheAfterCommit,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
@@ -635,7 +639,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       this.workspaceId,
     ]);
     if (workspace) {
-      await MembershipResource.invalidateActiveSeatsCache(workspace.sId);
+      const workspaceId = workspace.sId;
+      invalidateCacheAfterCommit(transaction, () =>
+        MembershipResource.invalidateActiveSeatsCache(workspaceId)
+      );
     }
 
     return result;
@@ -757,10 +764,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     // Invalidate the active seats cache for this workspace.
-    await MembershipResource.invalidateActiveSeatsCache(workspace.sId);
-    await MembershipResource.invalidateRoleCache({
-      userModelId: user.id,
-      workspaceModelId: workspace.id,
+    const workspaceId = workspace.sId;
+    const userModelId = user.id;
+    const workspaceModelId = workspace.id;
+    invalidateCacheAfterCommit(transaction, async () => {
+      await MembershipResource.invalidateActiveSeatsCache(workspaceId);
+      await MembershipResource.invalidateRoleCache({
+        userModelId,
+        workspaceModelId,
+      });
     });
 
     return new MembershipResource(MembershipModel, newMembership.get());
@@ -858,10 +870,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     // Invalidate the active seats cache for this workspace.
-    await MembershipResource.invalidateActiveSeatsCache(workspace.sId);
-    await MembershipResource.invalidateRoleCache({
-      userModelId: user.id,
-      workspaceModelId: workspace.id,
+    const workspaceId = workspace.sId;
+    const userModelId = user.id;
+    const workspaceModelId = workspace.id;
+    invalidateCacheAfterCommit(transaction, async () => {
+      await MembershipResource.invalidateActiveSeatsCache(workspaceId);
+      await MembershipResource.invalidateRoleCache({
+        userModelId,
+        workspaceModelId,
+      });
     });
 
     // We do not invalidate GroupMembership here
@@ -959,16 +976,21 @@ export class MembershipResource extends BaseResource<MembershipModel> {
         { where: { id: membership.id }, transaction }
       );
 
-      await MembershipResource.invalidateActiveSeatsCache(workspace.sId);
+      const workspaceId = workspace.sId;
+      const userModelId = user.id;
+      const workspaceModelId = workspace.id;
+      invalidateCacheAfterCommit(transaction, async () => {
+        await MembershipResource.invalidateActiveSeatsCache(workspaceId);
+        await MembershipResource.invalidateRoleCache({
+          userModelId,
+          workspaceModelId,
+        });
+      });
 
       await this.updateWorkOSMembershipRole({
         user,
         workspace,
         newRole,
-      });
-      await MembershipResource.invalidateRoleCache({
-        userModelId: user.id,
-        workspaceModelId: workspace.id,
       });
     } else {
       // If the last membership was terminated, we create a new membership with the new role.
@@ -1136,12 +1158,17 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       transaction,
     });
 
-    if (workspace) {
-      await MembershipResource.invalidateActiveSeatsCache(workspace.sId);
-    }
-    await MembershipResource.invalidateRoleCache({
-      userModelId: this.userId,
-      workspaceModelId: this.workspaceId,
+    const workspaceId = workspace?.sId;
+    const userModelId = this.userId;
+    const workspaceModelId = this.workspaceId;
+    invalidateCacheAfterCommit(transaction, async () => {
+      if (workspaceId) {
+        await MembershipResource.invalidateActiveSeatsCache(workspaceId);
+      }
+      await MembershipResource.invalidateRoleCache({
+        userModelId,
+        workspaceModelId,
+      });
     });
 
     return new Ok(undefined);

--- a/front/lib/resources/subscription_resource.test.ts
+++ b/front/lib/resources/subscription_resource.test.ts
@@ -1,0 +1,259 @@
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+const deletedKeys = vi.hoisted(() => [] as string[]);
+
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<JsonSerializable<T>> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          const cached = inMemoryCache.get(key);
+          if (cached) {
+            return JSON.parse(cached) as JsonSerializable<T>;
+          }
+          const result = await fn(...args);
+          inMemoryCache.set(key, JSON.stringify(result));
+          return result;
+        };
+      }
+    ),
+  invalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+          return Promise.resolve();
+        };
+      }
+    ),
+  batchInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (argsList: Args[]): Promise<void> => {
+          for (const args of argsList) {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            inMemoryCache.delete(key);
+            deletedKeys.push(key);
+          }
+        };
+      }
+    ),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>): void => {
+        void invalidateFn();
+      }
+    ),
+}));
+
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+
+function getCacheKeyForWorkspace(workspaceModelId: number): string {
+  return `cacheWithRedis-_fetchActiveByWorkspaceModelIdUncached-subscription:active:workspaceId:${workspaceModelId}`;
+}
+
+describe("SubscriptionResource", () => {
+  let workspace: WorkspaceType;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    inMemoryCache.clear();
+    deletedKeys.length = 0;
+  });
+
+  describe("caching behavior", () => {
+    describe("fetchActiveByWorkspaceModelId", () => {
+      it("caches the subscription on first call", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceModelId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+
+      it("serves from cache on second call", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceModelId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceModelId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+    });
+
+    describe("makeNew", () => {
+      it("invalidates cache when subscription is created", async () => {
+        const newWorkspace = await WorkspaceFactory.basic();
+        const newWorkspaceModelId = newWorkspace.id;
+        const cacheKey = getCacheKeyForWorkspace(newWorkspaceModelId);
+
+        expect(deletedKeys).toContain(cacheKey);
+      });
+    });
+
+    describe("markAsEnded", () => {
+      it("invalidates cache when subscription is ended", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.markAsEnded("ended");
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("clearPaymentFailingStatus", () => {
+      it("invalidates cache when payment status is cleared", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.clearPaymentFailingStatus();
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("setPaymentFailingStatus", () => {
+      it("invalidates cache when payment status is set", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.setPaymentFailingStatus({
+          paymentFailingSince: new Date(),
+        });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("markAsCanceled", () => {
+      it("invalidates cache when subscription is canceled", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.markAsCanceled({ endDate: new Date() });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+
+      it("invalidates cache when subscription cancellation is reverted", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        await subscription?.markAsCanceled({ endDate: new Date() });
+
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceModelId
+        );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.markAsCanceled({ endDate: null });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("markAsActive", () => {
+      it("invalidates cache when subscription is marked active", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.markAsActive({ trialing: false });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+
+      it("invalidates cache when subscription is marked as trialing", async () => {
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceModelId);
+
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspaceModelId
+          );
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+        deletedKeys.length = 0;
+
+        await subscription?.markAsActive({ trialing: true });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+  });
+});

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -38,7 +38,11 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
+import {
+  cacheWithRedis,
+  invalidateCacheAfterCommit,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import {
   getWorkspaceFirstAdmin,
@@ -118,8 +122,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       { ...blob },
       { transaction }
     );
-    await SubscriptionResource.invalidateSubscriptionCache(
-      subscription.workspaceId
+    const workspaceId = subscription.workspaceId;
+    invalidateCacheAfterCommit(transaction, () =>
+      SubscriptionResource.invalidateSubscriptionCache(workspaceId)
     );
     return new SubscriptionResource(
       SubscriptionModel,
@@ -1032,7 +1037,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       },
       transaction
     );
-    await SubscriptionResource.invalidateSubscriptionCache(this.workspaceId);
+    const workspaceId = this.workspaceId;
+    invalidateCacheAfterCommit(transaction, () =>
+      SubscriptionResource.invalidateSubscriptionCache(workspaceId)
+    );
   }
 
   // Payment status.
@@ -1044,7 +1052,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       },
       transaction
     );
-    await SubscriptionResource.invalidateSubscriptionCache(this.workspaceId);
+    const workspaceId = this.workspaceId;
+    invalidateCacheAfterCommit(transaction, () =>
+      SubscriptionResource.invalidateSubscriptionCache(workspaceId)
+    );
   }
 
   async setPaymentFailingStatus(
@@ -1057,7 +1068,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       },
       transaction
     );
-    await SubscriptionResource.invalidateSubscriptionCache(this.workspaceId);
+    const workspaceId = this.workspaceId;
+    invalidateCacheAfterCommit(transaction, () =>
+      SubscriptionResource.invalidateSubscriptionCache(workspaceId)
+    );
   }
 
   async markAsCanceled(
@@ -1073,7 +1087,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       },
       transaction
     );
-    await SubscriptionResource.invalidateSubscriptionCache(this.workspaceId);
+    const workspaceId = this.workspaceId;
+    invalidateCacheAfterCommit(transaction, () =>
+      SubscriptionResource.invalidateSubscriptionCache(workspaceId)
+    );
   }
 
   async markAsActive(
@@ -1081,7 +1098,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     transaction?: Transaction
   ): Promise<void> {
     await this.update({ status: "active", trialing }, transaction);
-    await SubscriptionResource.invalidateSubscriptionCache(this.workspaceId);
+    const workspaceId = this.workspaceId;
+    invalidateCacheAfterCommit(transaction, () =>
+      SubscriptionResource.invalidateSubscriptionCache(workspaceId)
+    );
   }
 
   /**

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -1,10 +1,79 @@
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+const deletedKeys = vi.hoisted(() => [] as string[]);
+
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<JsonSerializable<T>> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          const cached = inMemoryCache.get(key);
+          if (cached) {
+            return JSON.parse(cached) as JsonSerializable<T>;
+          }
+          const result = await fn(...args);
+          inMemoryCache.set(key, JSON.stringify(result));
+          return result;
+        };
+      }
+    ),
+  invalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+          return Promise.resolve();
+        };
+      }
+    ),
+  batchInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (argsList: Args[]): Promise<void> => {
+          for (const args of argsList) {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            inMemoryCache.delete(key);
+            deletedKeys.push(key);
+          }
+        };
+      }
+    ),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>): void => {
+        void invalidateFn();
+      }
+    ),
+}));
+
 import { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
+
+function getCacheKeyForWorkOSUserId(workOSUserId: string): string {
+  return `cacheWithRedis-_fetchByWorkOSUserIdUncached-user:workos:${workOSUserId}`;
+}
 
 describe("UserResource", () => {
   let user: UserResource;
@@ -15,6 +84,114 @@ describe("UserResource", () => {
     workspace = await WorkspaceFactory.basic();
     user = await UserFactory.basic();
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  describe("caching behavior", () => {
+    beforeEach(async () => {
+      inMemoryCache.clear();
+      deletedKeys.length = 0;
+    });
+
+    describe("fetchByWorkOSUserId", () => {
+      it("caches the user on first call", async () => {
+        const workOSUserId = `workos-cache-test-${Date.now()}`;
+        await UserFactory.withWorkOSId(workOSUserId);
+        const cacheKey = getCacheKeyForWorkOSUserId(workOSUserId);
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+        const { UserResource } = await import(
+          "@app/lib/resources/user_resource"
+        );
+        await UserResource.fetchByWorkOSUserId(workOSUserId);
+
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+
+      it("serves from cache on second call", async () => {
+        const workOSUserId = `workos-cache-serve-${Date.now()}`;
+        await UserFactory.withWorkOSId(workOSUserId);
+        const cacheKey = getCacheKeyForWorkOSUserId(workOSUserId);
+
+        const { UserResource } = await import(
+          "@app/lib/resources/user_resource"
+        );
+        await UserResource.fetchByWorkOSUserId(workOSUserId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await UserResource.fetchByWorkOSUserId(workOSUserId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+    });
+
+    describe("update (via updateName)", () => {
+      it("invalidates cache when user with workOSUserId is updated", async () => {
+        const workOSUserId = `workos-update-test-${Date.now()}`;
+        const userWithWorkOS = await UserFactory.withWorkOSId(workOSUserId);
+        const cacheKey = getCacheKeyForWorkOSUserId(workOSUserId);
+
+        const { UserResource } = await import(
+          "@app/lib/resources/user_resource"
+        );
+        await UserResource.fetchByWorkOSUserId(workOSUserId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await userWithWorkOS.updateName("NewFirst", "NewLast");
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("updateInfo", () => {
+      it("invalidates cache for both old and new workOSUserId when changed", async () => {
+        const oldWorkOSUserId = `workos-old-${Date.now()}`;
+        const newWorkOSUserId = `workos-new-${Date.now()}`;
+        const userWithWorkOS = await UserFactory.withWorkOSId(oldWorkOSUserId);
+
+        const oldCacheKey = getCacheKeyForWorkOSUserId(oldWorkOSUserId);
+
+        const { UserResource } = await import(
+          "@app/lib/resources/user_resource"
+        );
+        await UserResource.fetchByWorkOSUserId(oldWorkOSUserId);
+        expect(inMemoryCache.has(oldCacheKey)).toBe(true);
+
+        await userWithWorkOS.updateInfo(
+          userWithWorkOS.username,
+          userWithWorkOS.firstName,
+          userWithWorkOS.lastName,
+          userWithWorkOS.email,
+          newWorkOSUserId
+        );
+
+        expect(deletedKeys).toContain(oldCacheKey);
+        const newCacheKey = getCacheKeyForWorkOSUserId(newWorkOSUserId);
+        expect(deletedKeys).toContain(newCacheKey);
+      });
+    });
+
+    describe("setWorkOSUserId", () => {
+      it("invalidates cache for old workOSUserId when changed", async () => {
+        const oldWorkOSUserId = `workos-set-old-${Date.now()}`;
+        const newWorkOSUserId = `workos-set-new-${Date.now()}`;
+        const userWithWorkOS = await UserFactory.withWorkOSId(oldWorkOSUserId);
+
+        const oldCacheKey = getCacheKeyForWorkOSUserId(oldWorkOSUserId);
+
+        const { UserResource } = await import(
+          "@app/lib/resources/user_resource"
+        );
+        await UserResource.fetchByWorkOSUserId(oldWorkOSUserId);
+        expect(inMemoryCache.has(oldCacheKey)).toBe(true);
+
+        await userWithWorkOS.setWorkOSUserId(newWorkOSUserId);
+
+        expect(deletedKeys).toContain(oldCacheKey);
+        const newCacheKey = getCacheKeyForWorkOSUserId(newWorkOSUserId);
+        expect(deletedKeys).toContain(newCacheKey);
+      });
+    });
   });
 
   describe("getMetadataAsArray", () => {
@@ -86,9 +263,9 @@ describe("UserResource", () => {
 
       const metadata = await user.getMetadata(key);
       expect(metadata).toBeTruthy();
-      expect(metadata!.value).toBe(value);
-      expect(metadata!.key).toBe(key);
-      expect(metadata!.userId).toBe(user.id);
+      expect(metadata?.value).toBe(value);
+      expect(metadata?.key).toBe(key);
+      expect(metadata?.userId).toBe(user.id);
     });
 
     it("should add value to existing metadata array", async () => {
@@ -244,9 +421,9 @@ describe("UserResource", () => {
 
         const metadata = await user.getMetadata(key);
         expect(metadata).not.toBeNull();
-        expect(metadata!.key).toBe(key);
-        expect(metadata!.value).toBe(value);
-        expect(metadata!.userId).toBe(user.id);
+        expect(metadata?.key).toBe(key);
+        expect(metadata?.value).toBe(value);
+        expect(metadata?.userId).toBe(user.id);
       });
 
       it("should update existing metadata", async () => {
@@ -258,7 +435,7 @@ describe("UserResource", () => {
         await user.setMetadata(key, updatedValue);
 
         const metadata = await user.getMetadata(key);
-        expect(metadata!.value).toBe(updatedValue);
+        expect(metadata?.value).toBe(updatedValue);
       });
 
       it("should return null for non-existent key", async () => {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -9,7 +9,11 @@ import {
 } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { searchUsers } from "@app/lib/user_search/search";
-import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
+import {
+  cacheWithRedis,
+  invalidateCacheAfterCommit,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
@@ -84,8 +88,11 @@ export class UserResource extends BaseResource<UserModel> {
   ): Promise<[affectedCount: number]> {
     const result = await super.update(blob, transaction);
 
-    if (this.workOSUserId) {
-      await UserResource.invalidateUserByWorkOSIdCache(this.workOSUserId);
+    const workOSUserId = this.workOSUserId;
+    if (workOSUserId) {
+      invalidateCacheAfterCommit(transaction, () =>
+        UserResource.invalidateUserByWorkOSIdCache(workOSUserId)
+      );
     }
 
     return result;

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -1,5 +1,68 @@
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+const deletedKeys = vi.hoisted(() => [] as string[]);
+
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<JsonSerializable<T>> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          const cached = inMemoryCache.get(key);
+          if (cached) {
+            return JSON.parse(cached) as JsonSerializable<T>;
+          }
+          const result = await fn(...args);
+          inMemoryCache.set(key, JSON.stringify(result));
+          return result;
+        };
+      }
+    ),
+  invalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+          return Promise.resolve();
+        };
+      }
+    ),
+  batchInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (argsList: Args[]): Promise<void> => {
+          for (const args of argsList) {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            inMemoryCache.delete(key);
+            deletedKeys.push(key);
+          }
+        };
+      }
+    ),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>): void => {
+        void invalidateFn();
+      }
+    ),
+}));
 
 vi.mock("@app/lib/api/workos/organization_primitives", async () => {
   const actual = await vi.importActual(
@@ -11,14 +74,95 @@ vi.mock("@app/lib/api/workos/organization_primitives", async () => {
   };
 });
 
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
+
+function getCacheKeyForWorkspace(workspaceId: string): string {
+  return `cacheWithRedis-_fetchByIdUncached-workspace:sid:${workspaceId}`;
+}
 
 describe("WorkspaceResource", () => {
   let workspace: WorkspaceType;
 
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
+  });
+
+  describe("caching behavior", () => {
+    beforeEach(() => {
+      inMemoryCache.clear();
+      deletedKeys.length = 0;
+    });
+
+    describe("fetchById", () => {
+      it("caches the workspace on first call", async () => {
+        const workspaceId = workspace.sId;
+        const cacheKey = getCacheKeyForWorkspace(workspaceId);
+
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+        await WorkspaceResource.fetchById(workspaceId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+
+      it("serves from cache on second call", async () => {
+        const workspaceId = workspace.sId;
+        const cacheKey = getCacheKeyForWorkspace(workspaceId);
+
+        await WorkspaceResource.fetchById(workspaceId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await WorkspaceResource.fetchById(workspaceId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+      });
+    });
+
+    describe("makeNew", () => {
+      it("invalidates cache after creation", async () => {
+        const newWorkspace = await WorkspaceResource.makeNew({
+          sId: `ws-new-${Date.now()}`,
+          name: "New Workspace",
+        });
+
+        const newWorkspaceId = newWorkspace.sId;
+        const cacheKey = getCacheKeyForWorkspace(newWorkspaceId);
+        expect(deletedKeys).toContain(cacheKey);
+      });
+    });
+
+    describe("update (via updateWorkspaceSettings)", () => {
+      it("invalidates cache when workspace is updated", async () => {
+        const workspaceId = workspace.sId;
+        const cacheKey = getCacheKeyForWorkspace(workspaceId);
+
+        await WorkspaceResource.fetchById(workspaceId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        const resource = await WorkspaceResource.fetchById(workspaceId);
+        await resource?.updateWorkspaceSettings({ name: "Updated Name" });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
+
+    describe("updateMetadata", () => {
+      it("invalidates cache when metadata is updated", async () => {
+        const workspaceId = workspace.sId;
+        const workspaceModelId = workspace.id;
+        const cacheKey = getCacheKeyForWorkspace(workspaceId);
+
+        await WorkspaceResource.fetchById(workspaceId);
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await WorkspaceResource.updateMetadata(workspaceModelId, {
+          testKey: "testValue",
+        });
+
+        expect(deletedKeys).toContain(cacheKey);
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      });
+    });
   });
 
   describe("updateConversationsRetention", () => {
@@ -116,20 +260,20 @@ describe("WorkspaceResource", () => {
       it("should return empty array when no domains", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
 
-        const domains = await resource!.getVerifiedDomains();
+        const domains = await resource?.getVerifiedDomains();
 
         expect(domains).toEqual([]);
       });
 
       it("should return domains when added", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "example.com" });
+        await resource?.upsertWorkspaceDomain({ domain: "example.com" });
 
-        const domains = await resource!.getVerifiedDomains();
+        const domains = await resource?.getVerifiedDomains();
 
         expect(domains).toHaveLength(1);
-        expect(domains[0].domain).toBe("example.com");
-        expect(domains[0].domainAutoJoinEnabled).toBe(false);
+        expect(domains?.[0].domain).toBe("example.com");
+        expect(domains?.[0].domainAutoJoinEnabled).toBe(false);
       });
     });
 
@@ -137,12 +281,12 @@ describe("WorkspaceResource", () => {
       it("should create a new domain", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
 
-        const result = await resource!.upsertWorkspaceDomain({
+        const result = await resource?.upsertWorkspaceDomain({
           domain: "newdomain.com",
         });
 
-        expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
+        expect(result?.isOk()).toBe(true);
+        if (result?.isOk()) {
           expect(result.value.domain).toBe("newdomain.com");
           expect(result.value.domainAutoJoinEnabled).toBe(false);
         }
@@ -150,33 +294,33 @@ describe("WorkspaceResource", () => {
 
       it("should return existing domain if already linked to same workspace", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "existing.com" });
+        await resource?.upsertWorkspaceDomain({ domain: "existing.com" });
 
-        const result = await resource!.upsertWorkspaceDomain({
+        const result = await resource?.upsertWorkspaceDomain({
           domain: "existing.com",
         });
 
-        expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
+        expect(result?.isOk()).toBe(true);
+        if (result?.isOk()) {
           expect(result.value.domain).toBe("existing.com");
         }
       });
 
       it("should return error if domain belongs to another workspace", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "taken.com" });
+        await resource?.upsertWorkspaceDomain({ domain: "taken.com" });
 
         const otherWorkspace = await WorkspaceFactory.basic();
         const otherResource = await WorkspaceResource.fetchById(
           otherWorkspace.sId
         );
 
-        const result = await otherResource!.upsertWorkspaceDomain({
+        const result = await otherResource?.upsertWorkspaceDomain({
           domain: "taken.com",
         });
 
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
+        expect(result?.isErr()).toBe(true);
+        if (result?.isErr()) {
           expect(result.error.message).toContain("already exists in workspace");
         }
       });
@@ -185,24 +329,24 @@ describe("WorkspaceResource", () => {
     describe("deleteDomain", () => {
       it("should delete an existing domain", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "todelete.com" });
+        await resource?.upsertWorkspaceDomain({ domain: "todelete.com" });
 
-        const result = await resource!.deleteDomain({ domain: "todelete.com" });
+        const result = await resource?.deleteDomain({ domain: "todelete.com" });
 
-        expect(result.isOk()).toBe(true);
-        const domains = await resource!.getVerifiedDomains();
+        expect(result?.isOk()).toBe(true);
+        const domains = await resource?.getVerifiedDomains();
         expect(domains).toEqual([]);
       });
 
       it("should return error when domain not found", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
 
-        const result = await resource!.deleteDomain({
+        const result = await resource?.deleteDomain({
           domain: "nonexistent.com",
         });
 
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
+        expect(result?.isErr()).toBe(true);
+        if (result?.isErr()) {
           expect(result.error.message).toContain("not found");
         }
       });
@@ -211,45 +355,45 @@ describe("WorkspaceResource", () => {
     describe("updateDomainAutoJoinEnabled", () => {
       it("should enable auto-join for a domain", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "autojoin.com" });
+        await resource?.upsertWorkspaceDomain({ domain: "autojoin.com" });
 
-        const result = await resource!.updateDomainAutoJoinEnabled({
+        const result = await resource?.updateDomainAutoJoinEnabled({
           domainAutoJoinEnabled: true,
           domain: "autojoin.com",
         });
 
-        expect(result.isOk()).toBe(true);
-        const domains = await resource!.getVerifiedDomains();
-        expect(domains[0].domainAutoJoinEnabled).toBe(true);
+        expect(result?.isOk()).toBe(true);
+        const domains = await resource?.getVerifiedDomains();
+        expect(domains?.[0].domainAutoJoinEnabled).toBe(true);
       });
 
       it("should disable auto-join for a domain", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "autojoin2.com" });
-        await resource!.updateDomainAutoJoinEnabled({
+        await resource?.upsertWorkspaceDomain({ domain: "autojoin2.com" });
+        await resource?.updateDomainAutoJoinEnabled({
           domainAutoJoinEnabled: true,
           domain: "autojoin2.com",
         });
 
-        const result = await resource!.updateDomainAutoJoinEnabled({
+        const result = await resource?.updateDomainAutoJoinEnabled({
           domainAutoJoinEnabled: false,
           domain: "autojoin2.com",
         });
 
-        expect(result.isOk()).toBe(true);
-        const domains = await resource!.getVerifiedDomains();
-        expect(domains[0].domainAutoJoinEnabled).toBe(false);
+        expect(result?.isOk()).toBe(true);
+        const domains = await resource?.getVerifiedDomains();
+        expect(domains?.[0].domainAutoJoinEnabled).toBe(false);
       });
 
       it("should return error when workspace has no verified domains", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
 
-        const result = await resource!.updateDomainAutoJoinEnabled({
+        const result = await resource?.updateDomainAutoJoinEnabled({
           domainAutoJoinEnabled: true,
         });
 
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
+        expect(result?.isErr()).toBe(true);
+        if (result?.isErr()) {
           expect(result.error.message).toBe(
             "The workspace does not have any verified domain."
           );
@@ -260,12 +404,12 @@ describe("WorkspaceResource", () => {
     describe("fetchByDomain", () => {
       it("should return workspace when domain exists", async () => {
         const resource = await WorkspaceResource.fetchById(workspace.sId);
-        await resource!.upsertWorkspaceDomain({ domain: "findme.com" });
+        await resource?.upsertWorkspaceDomain({ domain: "findme.com" });
 
         const found = await WorkspaceResource.fetchByDomain("findme.com");
 
         expect(found).not.toBeNull();
-        expect(found!.sId).toBe(workspace.sId);
+        expect(found?.sId).toBe(workspace.sId);
       });
 
       it("should return null when domain does not exist", async () => {

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -11,7 +11,11 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
+import {
+  cacheWithRedis,
+  invalidateCacheAfterCommit,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
@@ -194,7 +198,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     transaction?: Transaction
   ): Promise<[affectedCount: number]> {
     const result = await super.update(blob, transaction);
-    await WorkspaceResource.invalidateWorkspaceCache(this.sId);
+    const sId = this.sId;
+    invalidateCacheAfterCommit(transaction, () =>
+      WorkspaceResource.invalidateWorkspaceCache(sId)
+    );
     return result;
   }
 
@@ -758,7 +765,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         where: { id: this.blob.id },
         transaction,
       });
-      await WorkspaceResource.invalidateWorkspaceCache(this.sId);
+      const sId = this.sId;
+      invalidateCacheAfterCommit(transaction, () =>
+        WorkspaceResource.invalidateWorkspaceCache(sId)
+      );
       return new Ok(deletedCount);
     } catch (error) {
       return new Err(normalizeError(error));

--- a/front/tests/utils/UserFactory.ts
+++ b/front/tests/utils/UserFactory.ts
@@ -19,6 +19,13 @@ export class UserFactory {
     return UserResource.makeNew(this.defaultParams(false, new Date(), null));
   }
 
+  static async withWorkOSId(workOSUserId: string) {
+    return UserResource.makeNew({
+      ...this.defaultParams(false),
+      workOSUserId,
+    });
+  }
+
   private static defaultParams = (
     superUser: boolean = false,
     createdAt: Date = new Date(),


### PR DESCRIPTION
## Description

- follow up of #22171 
- this pr is a global pass on the 5 cached resources used in `fromSession` + `KeyResource` and added that invalidateAfterCommit wherever we have a transaction passed to the method invalidating
- added a few tests / fixed mocks

## Tests

- Unit tests
- front-edge deploy (ongoing) to test: signup, login/logout, agent creation, project creation, space creation/edit

## Risk

Low
Blast radius: whole application (authN + authZ)

## Deploy Plan

- [ ] Deploy front