### PR TITLE
Simplifed contexts usage

### DIFF
--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -1,31 +1,14 @@
-import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { classNames, Spinner } from "@dust-tt/sparkle";
 import type { RouteChangeMesssage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useEffect } from "react";
-import { Outlet, useNavigate, useOutletContext } from "react-router-dom";
-
-export interface ProtectedRouteOutletContext {
-  user: UserTypeWithWorkspaces;
-  workspace: WorkspaceType;
-  handleLogout: () => void;
-}
-
-export function useProtectedRouteContext() {
-  return useOutletContext<ProtectedRouteOutletContext>();
-}
+import { Outlet, useNavigate } from "react-router-dom";
 
 export const ProtectedRoute = () => {
   const platform = usePlatform();
-  const {
-    isLoading,
-    isAuthenticated,
-    isUserSetup,
-    user,
-    workspace,
-    handleLogout,
-  } = useExtensionAuth();
+  const { isLoading, isAuthenticated, isUserSetup, user, workspace } =
+    useExtensionAuth();
 
   const navigate = useNavigate();
 
@@ -75,7 +58,7 @@ export const ProtectedRoute = () => {
         "dark:bg-background-night dark:text-foreground-night"
       )}
     >
-      <Outlet context={{ user, workspace, handleLogout }} />
+      <Outlet />
     </div>
   );
 };

--- a/extension/ui/components/navigation/UserDropdownMenu.tsx
+++ b/extension/ui/components/navigation/UserDropdownMenu.tsx
@@ -1,4 +1,3 @@
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import {
   Avatar,
   DropdownMenu,
@@ -17,17 +16,14 @@ import {
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useTheme } from "@extension/ui/hooks/useTheme";
 
-interface UserDropdownMenuProps {
-  handleLogout: () => void;
-  user: UserTypeWithWorkspaces;
-}
-
-export const UserDropdownMenu = ({
-  user,
-  handleLogout,
-}: UserDropdownMenuProps) => {
+export const UserDropdownMenu = () => {
   const { theme, updateTheme } = useTheme();
-  const { workspace, handleSelectWorkspace } = useExtensionAuth();
+  const { user, workspace, handleLogout, handleSelectWorkspace } =
+    useExtensionAuth();
+
+  if (!user) {
+    return null;
+  }
 
   return (
     <DropdownMenu>

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -21,7 +21,6 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@dust-tt/sparkle";
-import { useProtectedRouteContext } from "@extension/ui/components/auth/ProtectedRoute";
 import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
 import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
 import { DropzoneContainer } from "@extension/ui/components/DropzoneContainer";
@@ -30,8 +29,7 @@ import { useContext, useMemo } from "react";
 import { useParams } from "react-router-dom";
 
 export const MainPage = () => {
-  const { user, workspace, handleLogout } = useProtectedRouteContext();
-  const { subscription } = useAuth();
+  const { user, workspace, subscription } = useAuth();
   const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
   const shortcut = isMac ? "⇧⌘E" : "⇧+Ctrl+E";
 
@@ -131,7 +129,7 @@ export const MainPage = () => {
                 />
               ) : (
                 <div className="items-right flex flex-row space-x-1">
-                  <UserDropdownMenu user={user} handleLogout={handleLogout} />
+                  <UserDropdownMenu />
                 </div>
               )
             }

--- a/extension/ui/pages/SubscribePage.tsx
+++ b/extension/ui/pages/SubscribePage.tsx
@@ -1,3 +1,4 @@
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
   BarHeader,
@@ -7,12 +8,11 @@ import {
   Page,
   RocketIcon,
 } from "@dust-tt/sparkle";
-import { useProtectedRouteContext } from "@extension/ui/components/auth/ProtectedRoute";
 import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
 import { Link } from "react-router-dom";
 
 export const SubscribePage = () => {
-  const { user, workspace, handleLogout } = useProtectedRouteContext();
+  const { workspace } = useAuth();
   const { regionInfo } = useRegionContext();
   return (
     <div>
@@ -21,7 +21,7 @@ export const SubscribePage = () => {
         tooltip=""
         rightActions={
           <div className="items-right flex flex-row space-x-1">
-            <UserDropdownMenu user={user} handleLogout={handleLogout} />
+            <UserDropdownMenu />
           </div>
         }
       />


### PR DESCRIPTION
## Description

Simplify extension context usage to be consistent with the main app pattern.

- **Remove `ProtectedRouteOutletContext`**: Pages no longer receive `user`/`workspace`/`handleLogout` via React Router outlet context. Instead they use the standard `useAuth()` hook (from `AuthContext`), which is already bridged by the extension's `AuthProvider`.
- **`MainPage` / `SubscribePage`**: Use `useAuth()` for `user`, `workspace`, `subscription` — same pattern as main app pages.
- **`UserDropdownMenu`**: No longer takes props. Gets `user`, `workspace`, `handleLogout`, `handleSelectWorkspace` from `useExtensionAuth()` internally.
- **`ProtectedRoute`**: Simplified to just guard + `<Outlet />` without context passing.

## Tests

Manual testing of login, workspace selection, logout, and conversation flow.

## Risk

Low — only moves where context values are read from, no behavioral changes.

## Deploy Plan

Deploy with extension update, no ordering constraints.