### PR TITLE
Revert setup.ts file

### DIFF
--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -89,19 +89,7 @@ export async function setupOAuthConnection({
       // BroadcastChannel not supported
     }
 
-    // Poll for popup closure — if the user closes the popup without completing
-    // OAuth, the promise would otherwise hang forever.
-    const popupPollIntervalMs = 500;
-    const popupPollInterval = setInterval(() => {
-      if (oauthPopup?.closed && !authComplete) {
-        authComplete = true;
-        cleanup();
-        resolve(new Err(new Error("Authentication window was closed.")));
-      }
-    }, popupPollIntervalMs);
-
     const cleanup = () => {
-      clearInterval(popupPollInterval);
       window.removeEventListener("message", handleWindowMessage);
       if (channel) {
         channel.close();


### PR DESCRIPTION
## Description

Reverts the popup polling logic introduced in a previous commit that breaks Microsoft Service Principal authentication. 
Users were unable to create or update Microsoft connections when using Service Principal auth because the polling mechanism incorrectly treated the authentication as incomplete and closed the popup prematurely. This fix removes the popup polling interval code to restore Service Principal functionality.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
