### PR TITLE
Simplify region resolution

### DIFF
--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -1,5 +1,6 @@
 import { setBaseUrlResolver } from "@app/lib/api/config";
 import type { RegionInfo } from "@app/lib/api/regions/config";
+import { isRegionType } from "@app/lib/api/regions/config";
 import {
   createContext,
   useCallback,
@@ -52,13 +53,33 @@ export function RegionProvider({ children }: { children: React.ReactNode }) {
   // Store the current URL to use in the resolver.
   const currentUrlRef = useRef<string>(DEFAULT_URL);
 
-  // On mount, restore region and URLs from localStorage.
+  // On mount, restore region from URL params (post-login) or localStorage.
   useEffect(() => {
-    const storedRegionInfo = getStoredRegionInfo();
+    let regionInfo: RegionInfo | null = null;
 
-    if (storedRegionInfo) {
-      setCurrentRegionInfo(storedRegionInfo);
-      currentUrlRef.current = storedRegionInfo.url;
+    // Check URL params first (set by /api/login after authentication).
+    const params = new URLSearchParams(window.location.search);
+    const region = params.get("region");
+    const regionUrl = params.get("regionUrl");
+
+    if (region && regionUrl && isRegionType(region)) {
+      regionInfo = { name: region, url: regionUrl };
+      setStoredRegionInfo(regionInfo);
+
+      // Clean region params from URL.
+      params.delete("region");
+      params.delete("regionUrl");
+      const qs = params.toString();
+      const newUrl =
+        window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;
+      window.history.replaceState(null, "", newUrl);
+    } else {
+      regionInfo = getStoredRegionInfo();
+    }
+
+    if (regionInfo) {
+      setCurrentRegionInfo(regionInfo);
+      currentUrlRef.current = regionInfo.url;
     }
 
     // Set up resolver that reads from ref (so it always gets latest value).

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import { makeEnterpriseConnectionInitiateLoginUrl } from "@app/lib/api/enterprise_connection";
+import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import {
   handleEnterpriseSignUpFlow,
   handleMembershipInvite,
@@ -272,6 +273,10 @@ const buildPostLoginUrl = (
       searchParams.set(key, value);
     }
   }
+
+  const currentRegion = multiRegionsConfig.getCurrentRegion();
+  searchParams.set("region", currentRegion);
+  searchParams.set("regionUrl", multiRegionsConfig.getRegionUrl(currentRegion));
 
   const queryString = searchParams.toString();
   return queryString ? `${path}?${queryString}` : path;


### PR DESCRIPTION
## Description

Avoid a wasted round-trip to discover the workspace region after login.

Today, after login the SPA boots with no region info, fetches `/api/w/{wId}/auth-context`, gets a `workspace_in_different_region` error if the workspace is on another region, then sets the region and refetches. The WorkOS callback already knows the correct region (it redirected to the right region server before hitting `/api/login`), so we can pass it through.

**Changes:**
- **`/api/login`** (`buildPostLoginUrl`): append `region` and `regionUrl` query params to the post-login redirect URL, sourced from the server multi-region config
- **`RegionProvider`**: on mount, check URL search params for `region` + `regionUrl` before falling back to localStorage. If present and valid, persist to localStorage and clean the params from the URL via `history.replaceState`

## Tests

- Login from US region with US workspace → region param in URL, cleaned after mount, no auth-context redirect
- Login from EU region with EU workspace → same behavior, correct region set immediately
- Cross-region login → WorkOS callback redirects to correct region first → `/api/login` appends correct region → SPA sets it immediately
- Direct navigation without `region` param (e.g. bookmark) → falls back to localStorage then auth-context redirect as before (backward compatible)

## Risk

Low. The change is additive — if URL params are missing or invalid, the existing localStorage + auth-context fallback kicks in unchanged. No breaking change to the API.

## Deploy Plan

Standard deploy, no special ordering needed.