### PR TITLE
[Agent Email] Simplify to single-workspace selection in email trigger

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -364,6 +364,7 @@ export async function userAndWorkspaceFromEmail({
         },
       },
     ],
+    order: [["id", "DESC"]],
   });
 
   if (workspaceModels.length === 0) {
@@ -392,8 +393,8 @@ export async function userAndWorkspaceFromEmail({
     return sub && isUpgraded(sub.getPlan());
   });
 
-  // Workspaces are returned by findAll in id ASC order; last = most recent.
-  const mostRecentWorkspace = workspaceModels[workspaceModels.length - 1];
+  // Ordered by id DESC, so first = most recently created.
+  const mostRecentWorkspace = workspaceModels[0];
 
   const selectedWorkspace =
     payingWorkspace ?? upgradedWorkspace ?? mostRecentWorkspace;

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -14,9 +14,11 @@ import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
+import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { filterAndSortAgents } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -36,8 +38,6 @@ import { Op } from "sequelize";
 import { Readable } from "stream";
 
 import { toFileContentFragment } from "../conversation/content_fragment";
-
-const { PRODUCTION_DUST_WORKSPACE_ID } = process.env;
 
 // Redis configuration for email reply context storage.
 const REDIS_ORIGIN: RedisUsageTagsType = "email_context";
@@ -329,33 +329,15 @@ export function buildSuccessReplyRecipients(email: InboundEmail): {
 
   return { to, cc };
 }
-export function getTargetEmailsForWorkspace({
-  allTargetEmails,
-  workspace,
-  isDefault,
-}: {
-  allTargetEmails: string[];
-  workspace: LightWorkspaceType;
-  isDefault: boolean;
-}): string[] {
-  return allTargetEmails.filter(
-    (email) =>
-      email.split("@")[0].endsWith(`[${workspace.sId}]`) ||
-      // calls with no brackets go to default workspace
-      (!email.split("@")[0].endsWith("]") && isDefault)
-  );
-}
-
-export async function userAndWorkspacesFromEmail({
+export async function userAndWorkspaceFromEmail({
   email,
 }: {
   email: string;
 }): Promise<
   Result<
     {
-      workspaces: LightWorkspaceType[];
+      workspace: LightWorkspaceType;
       user: UserResource;
-      defaultWorkspace: LightWorkspaceType;
     },
     EmailTriggerError
   >
@@ -370,7 +352,7 @@ export async function userAndWorkspacesFromEmail({
         `Please sign up for Dust at https://dust.tt to interact with assitsants over email.`,
     });
   }
-  const workspaces = await WorkspaceModel.findAll({
+  const workspaceModels = await WorkspaceModel.findAll({
     include: [
       {
         model: MembershipModel,
@@ -384,7 +366,7 @@ export async function userAndWorkspacesFromEmail({
     ],
   });
 
-  if (!workspaces) {
+  if (workspaceModels.length === 0) {
     return new Err({
       type: "workspace_not_found",
       message:
@@ -393,48 +375,32 @@ export async function userAndWorkspacesFromEmail({
     });
   }
 
-  /* get latest conversation participation from user
-    uncomment when ungating
-  const latestParticipation = await ConversationParticipant.findOne({
-    where: {
-      userId: user.id,
-    },
-    include: [
-      {
-        model: Conversation,
-      },
-    ],
-    order: [["createdAt", "DESC"]],
-  });*/
+  // Pick the best workspace: prefer paying plans, then upgraded free plans,
+  // then fall back to the most recently created workspace.
+  const subscriptionsByWorkspaceId =
+    await SubscriptionResource.fetchActiveByWorkspacesModelId(
+      workspaceModels.map((w) => w.id)
+    );
 
-  // TODO: when ungating, implement good default logic to pick workspace
-  // a. most members?
-  // b. latest participation as above using the above (latestParticipation?.conversation?.workspaceId)
-  // c. most frequent-recent activity? (return 10 results with participants and pick the workspace with most convos)
-  // (will work fine since most users likely use only one workspace with a given email)
-  const workspace = isDevelopment()
-    ? workspaces[0] // In dev, use the first available workspace.
-    : workspaces.find(
-        (w) => w.sId === PRODUCTION_DUST_WORKSPACE_ID // Gating to dust workspace
-      );
-  if (!workspace) {
-    return new Err({
-      type: "unexpected_error",
-      message: "Failed to find a valid default workspace for user.",
-    });
-  }
-
-  const defaultWorkspace = renderLightWorkspaceType({
-    workspace,
+  const payingWorkspace = workspaceModels.find((w) => {
+    const sub = subscriptionsByWorkspaceId[w.id];
+    return sub && !isFreePlan(sub.getPlan().code);
   });
 
-  // TODO: when ungating, replace [workspace] with workspaces here
+  const upgradedWorkspace = workspaceModels.find((w) => {
+    const sub = subscriptionsByWorkspaceId[w.id];
+    return sub && isUpgraded(sub.getPlan());
+  });
+
+  // Workspaces are returned by findAll in id ASC order; last = most recent.
+  const mostRecentWorkspace = workspaceModels[workspaceModels.length - 1];
+
+  const selectedWorkspace =
+    payingWorkspace ?? upgradedWorkspace ?? mostRecentWorkspace;
+
   return new Ok({
-    workspaces: [workspace].map((workspace) =>
-      renderLightWorkspaceType({ workspace })
-    ),
+    workspace: renderLightWorkspaceType({ workspace: selectedWorkspace }),
     user,
-    defaultWorkspace,
   });
 }
 

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -6,10 +6,9 @@ import type {
 import {
   ASSISTANT_EMAIL_SUBDOMAIN,
   emailAssistantMatcher,
-  getTargetEmailsForWorkspace,
   replyToEmail,
   triggerFromEmail,
-  userAndWorkspacesFromEmail,
+  userAndWorkspaceFromEmail,
 } from "@app/lib/api/assistant/email/email_trigger";
 import apiConfig from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
@@ -253,7 +252,7 @@ async function handler(
         return;
       }
 
-      const userRes = await userAndWorkspacesFromEmail({
+      const userRes = await userAndWorkspaceFromEmail({
         email: email.envelope.from,
       });
       if (userRes.isErr()) {
@@ -261,86 +260,72 @@ async function handler(
         return;
       }
 
-      const { user, workspaces, defaultWorkspace } = userRes.value;
+      const { user, workspace } = userRes.value;
 
-      // find target email in [...to, ...cc, ...bcc], that is email whose domain is
+      // Find target emails in [...to, ...cc, ...bcc] whose domain is
       // ASSISTANT_EMAIL_SUBDOMAIN.
-      const allTargetEmails = [
+      const targetEmails = [
         ...(email.envelope.to ?? []),
         ...(email.envelope.cc ?? []),
         ...(email.envelope.bcc ?? []),
-      ].filter((email) => email.endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`));
+      ].filter((e) => e.endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`));
 
-      const workspacesAndEmails = workspaces
-        .map((workspace) => {
-          return {
-            workspace,
-            targetEmails: getTargetEmailsForWorkspace({
-              allTargetEmails,
-              workspace,
-              isDefault: workspace.sId === defaultWorkspace.sId,
-            }),
-          };
-        })
-        .filter(({ targetEmails }) => (targetEmails as string[]).length > 0);
-
-      if (workspacesAndEmails.length === 0) {
+      if (targetEmails.length === 0) {
         await replyToError(email, {
           type: "invalid_email_error",
           message:
             `Failed to match any valid agent email. ` +
             `Expected agent email format: {ASSISTANT_NAME}@${ASSISTANT_EMAIL_SUBDOMAIN}.`,
         });
+        return;
       }
 
-      for (const { workspace, targetEmails } of workspacesAndEmails) {
-        const auth = await Authenticator.fromUserIdAndWorkspaceId(
-          user.sId,
-          workspace.sId
-        );
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
 
-        const agentConfigurations = removeNulls(
-          await Promise.all(
-            targetEmails.map(async (targetEmail) => {
-              const matchRes = await emailAssistantMatcher({
-                auth,
-                targetEmail,
-              });
-              if (matchRes.isErr()) {
-                await replyToError(email, matchRes.error);
-                return null;
-              }
+      const agentConfigurations = removeNulls(
+        await Promise.all(
+          targetEmails.map(async (targetEmail) => {
+            const matchRes = await emailAssistantMatcher({
+              auth,
+              targetEmail,
+            });
+            if (matchRes.isErr()) {
+              await replyToError(email, matchRes.error);
+              return null;
+            }
 
-              return matchRes.value.agentConfiguration;
-            })
-          )
-        );
+            return matchRes.value.agentConfiguration;
+          })
+        )
+      );
 
-        if (agentConfigurations.length === 0) {
-          return;
-        }
-
-        // Trigger async processing - reply will be sent by finalization activity.
-        const triggerRes = await triggerFromEmail({
-          auth,
-          agentConfigurations,
-          email,
-        });
-
-        if (triggerRes.isErr()) {
-          await replyToError(email, triggerRes.error);
-          return;
-        }
-
-        logger.info(
-          {
-            conversationId: triggerRes.value.conversation.sId,
-            workspaceId: workspace.sId,
-            agentCount: agentConfigurations.length,
-          },
-          "[email] Triggered async email processing"
-        );
+      if (agentConfigurations.length === 0) {
+        return;
       }
+
+      // Trigger async processing - reply will be sent by finalization activity.
+      const triggerRes = await triggerFromEmail({
+        auth,
+        agentConfigurations,
+        email,
+      });
+
+      if (triggerRes.isErr()) {
+        await replyToError(email, triggerRes.error);
+        return;
+      }
+
+      logger.info(
+        {
+          conversationId: triggerRes.value.conversation.sId,
+          workspaceId: workspace.sId,
+          agentCount: agentConfigurations.length,
+        },
+        "[email] Triggered async email processing"
+      );
       return;
 
     default:

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -224,7 +224,6 @@ async function handler(
       // WARNING: DO NOT UNGATE. Todo before ungating:
       // - ! check security, including but not limited to SPF dkim approach thorough review
       // - review from https://github.com/dust-tt/dust/pull/5365 for code refactoring and cleanup
-      // - also, need to ungate the workspace check in email/email_trigger/userAndWorkspacesFromEmail
       if (!email.envelope.from.endsWith("@dust.tt")) {
         return apiError(req, res, {
           status_code: 401,


### PR DESCRIPTION
## Description

Remove multi-workspace logic from the email trigger system. Previously, `userAndWorkspacesFromEmail` returned an array of workspaces and a default workspace, with the webhook handler looping over workspaces and routing emails via bracket-based `[workspaceId]` suffixes. In practice, only one workspace was ever used (hardcoded to Dust workspace in prod).

This replaces it with `userAndWorkspaceFromEmail` that returns a single workspace, selected with a proper heuristic:
1. Prefer a workspace with a paying plan
2. Otherwise, prefer an upgraded free plan (excludes `FREE_NO_PLAN` / `FREE_TEST_PLAN`)
3. Fall back to the most recently created workspace

Also removes `getTargetEmailsForWorkspace`, commented-out `latestParticipation` block, and all related TODO comments.

## Risks

Blast radius: email-triggered agent conversations (currently gated to @dust.tt senders)
Risk: low

## Deploy Plan
- pmrr
- deploy front