### PR TITLE
[front] feat(sandbox): add GitHub skill detection utility

### DIFF
--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -27,10 +27,6 @@ export { parseGitHubRepoUrl };
 
 const FETCH_CONCURRENCY = 4;
 
-/**
- * Fetches the repository tree from GitHub. Try/catch is scoped to the
- * external API call only; the response is validated via Zod immediately.
- */
 async function fetchRepoTree(
   octokit: InstanceType<typeof Octokit>,
   {

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -7,6 +7,7 @@ import {
 import type {
   DetectedSkill,
   DetectedSkillAttachment,
+  GitHubRepo,
   GitHubTreeEntry,
   SkillDetectionError,
   SkillDirectory,
@@ -33,9 +34,10 @@ const FETCH_CONCURRENCY = 4;
  */
 async function fetchRepoTree(
   octokit: InstanceType<typeof Octokit>,
-  owner: string,
-  repo: string
+  githubRepo: GitHubRepo
 ): Promise<Result<GitHubTreeEntry[], SkillDetectionError>> {
+  const { owner, repo } = githubRepo;
+
   let rawData: unknown;
   try {
     const response = await octokit.request(

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -4,21 +4,23 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Octokit } from "@octokit/core";
-
-import type {
-  DetectedSkill,
-  DetectedSkillAttachment,
-  GitHubTreeEntry,
-  GitHubTreeResponse,
-  SkillDetectionError,
-  SkillDirectory,
-} from "./types";
 import {
   extractDescription,
   findSkillDirectories,
   getContentType,
   parseGitHubRepoUrl,
-} from "./parsing";
+} from "@app/lib/api/skills/github_detection/parsing";
+import type {
+  DetectedSkill,
+  DetectedSkillAttachment,
+  GitHubTreeEntry,
+  SkillDetectionError,
+  SkillDirectory,
+} from "@app/lib/api/skills/github_detection/types";
+import {
+  GitHubBlobResponseSchema,
+  GitHubTreeResponseSchema,
+} from "@app/lib/api/skills/github_detection/types";
 
 export type { DetectedSkill, DetectedSkillAttachment, SkillDetectionError };
 export { parseGitHubRepoUrl };
@@ -26,47 +28,21 @@ export { parseGitHubRepoUrl };
 const FETCH_CONCURRENCY = 4;
 
 /**
- * Detects skills in a GitHub repository by fetching its tree and looking for
- * directories containing skill.md or SKILL.md files.
- *
- * Does not clone the repository — uses the GitHub Git Trees API for lightweight access.
+ * Fetches the repository tree from GitHub. Try/catch is scoped to the
+ * external API call only; the response is validated via Zod immediately.
  */
-export async function detectSkillsFromGitHubRepo({
-  repoUrl,
-  accessToken,
-}: {
-  repoUrl: string;
-  accessToken?: string;
-}): Promise<Result<DetectedSkill[], SkillDetectionError>> {
-  const parseResult = parseGitHubRepoUrl(repoUrl);
-  if (parseResult.isErr()) {
-    return parseResult;
-  }
-  const { owner, repo } = parseResult.value;
-
-  const octokit = new Octokit(accessToken ? { auth: accessToken } : {});
-
-  // Fetch the full repository tree.
-  let tree: GitHubTreeEntry[];
+async function fetchRepoTree(
+  octokit: InstanceType<typeof Octokit>,
+  owner: string,
+  repo: string
+): Promise<Result<GitHubTreeEntry[], SkillDetectionError>> {
+  let rawData: unknown;
   try {
     const response = await octokit.request(
       "GET /repos/{owner}/{repo}/git/trees/{tree_sha}",
-      {
-        owner,
-        repo,
-        tree_sha: "HEAD",
-        recursive: "1",
-      }
+      { owner, repo, tree_sha: "HEAD", recursive: "1" }
     );
-    const data = response.data as GitHubTreeResponse;
-    tree = data.tree;
-
-    if (data.truncated) {
-      logger.warn(
-        { owner, repo },
-        "GitHub tree response was truncated; some skills may be missed."
-      );
-    }
+    rawData = response.data;
   } catch (err) {
     const error = normalizeError(err);
     if (error.message.includes("Not Found")) {
@@ -90,29 +66,99 @@ export async function detectSkillsFromGitHubRepo({
     });
   }
 
-  // Find directories that contain a skill.md / SKILL.md at their root.
-  const skillDirs = findSkillDirectories(tree);
+  const parsed = GitHubTreeResponseSchema.safeParse(rawData);
+  if (!parsed.success) {
+    return new Err({
+      type: "api_error",
+      message: `Invalid tree response from GitHub: ${parsed.error.message}`,
+    });
+  }
 
+  if (parsed.data.truncated) {
+    logger.warn(
+      { owner, repo },
+      "GitHub tree response was truncated; some skills may be missed."
+    );
+  }
+
+  return new Ok(parsed.data.tree);
+}
+
+/**
+ * Fetches a blob's content from GitHub and returns it as a UTF-8 string.
+ */
+async function fetchBlobContent(
+  octokit: InstanceType<typeof Octokit>,
+  owner: string,
+  repo: string,
+  fileSha: string
+): Promise<Result<string, SkillDetectionError>> {
+  let rawData: unknown;
+  try {
+    const response = await octokit.request(
+      "GET /repos/{owner}/{repo}/git/blobs/{file_sha}",
+      { owner, repo, file_sha: fileSha }
+    );
+    rawData = response.data;
+  } catch (err) {
+    return new Err({
+      type: "api_error",
+      message: `Failed to fetch blob: ${normalizeError(err).message}`,
+    });
+  }
+
+  const parsed = GitHubBlobResponseSchema.safeParse(rawData);
+  if (!parsed.success) {
+    return new Err({
+      type: "api_error",
+      message: `Invalid blob response from GitHub: ${parsed.error.message}`,
+    });
+  }
+
+  return new Ok(
+    Buffer.from(parsed.data.content, "base64").toString("utf-8")
+  );
+}
+
+/**
+ * Detects skills in a GitHub repository by fetching its tree and looking for
+ * directories containing skill.md or SKILL.md files.
+ *
+ * Does not clone the repository — uses the GitHub Git Trees API for lightweight access.
+ */
+export async function detectSkillsFromGitHubRepo({
+  repoUrl,
+  accessToken,
+}: {
+  repoUrl: string;
+  accessToken?: string;
+}): Promise<Result<DetectedSkill[], SkillDetectionError>> {
+  const parseResult = parseGitHubRepoUrl(repoUrl);
+  if (parseResult.isErr()) {
+    return parseResult;
+  }
+  const { owner, repo } = parseResult.value;
+
+  const octokit = new Octokit(accessToken ? { auth: accessToken } : {});
+
+  const treeResult = await fetchRepoTree(octokit, owner, repo);
+  if (treeResult.isErr()) {
+    return treeResult;
+  }
+  const tree = treeResult.value;
+
+  const skillDirs = findSkillDirectories(tree);
   if (skillDirs.length === 0) {
     return new Ok([]);
   }
 
-  // Fetch skill.md content for each detected skill directory.
   const skills = await concurrentExecutor(
     skillDirs,
-    async (skillDir) => {
-      return fetchSkillFromDirectory({
-        octokit,
-        owner,
-        repo,
-        skillDir,
-        tree,
-      });
-    },
+    async (skillDir) =>
+      buildDetectedSkill({ octokit, owner, repo, skillDir, tree }),
     { concurrency: FETCH_CONCURRENCY }
   );
 
-  // Filter out failed fetches.
   const detectedSkills: DetectedSkill[] = [];
   for (const result of skills) {
     if (result.isOk()) {
@@ -124,9 +170,10 @@ export async function detectSkillsFromGitHubRepo({
 }
 
 /**
- * Fetches skill details from a detected skill directory.
+ * Builds a DetectedSkill from a skill directory by fetching its skill.md
+ * and collecting attachment metadata from the tree.
  */
-async function fetchSkillFromDirectory({
+async function buildDetectedSkill({
   octokit,
   owner,
   repo,
@@ -139,39 +186,29 @@ async function fetchSkillFromDirectory({
   skillDir: SkillDirectory;
   tree: GitHubTreeEntry[];
 }): Promise<Result<DetectedSkill, SkillDetectionError>> {
-  // Fetch the skill.md content.
-  let instructions: string;
-  try {
-    const response = await octokit.request(
-      "GET /repos/{owner}/{repo}/git/blobs/{file_sha}",
+  const blobResult = await fetchBlobContent(
+    octokit,
+    owner,
+    repo,
+    skillDir.skillMdSha
+  );
+  if (blobResult.isErr()) {
+    logger.error(
       {
+        err: new Error(blobResult.error.message),
         owner,
         repo,
-        file_sha: skillDir.skillMdSha,
-      }
-    );
-    const data = response.data as { content: string; encoding: string };
-    instructions = Buffer.from(data.content, "base64").toString("utf-8");
-  } catch (err) {
-    const error = normalizeError(err);
-    logger.error(
-      { err: error, owner, repo, skillMdPath: skillDir.skillMdPath },
+        skillMdPath: skillDir.skillMdPath,
+      },
       "Failed to fetch skill.md content."
     );
-    return new Err({
-      type: "api_error",
-      message: `Failed to fetch ${skillDir.skillMdPath}: ${error.message}`,
-    });
+    return blobResult;
   }
+  const instructions = blobResult.value;
 
-  // Extract the skill name from the directory path.
   const name = skillDir.dirPath.split("/").pop() ?? skillDir.dirPath;
-
-  // Extract description from the skill.md content.
   const description = extractDescription(instructions);
 
-  // Collect attachments: all other files in the skill directory (files in
-  // subdirectories relative to the skill dir are included — they are part of the skill).
   const attachments: DetectedSkillAttachment[] = [];
   const dirPrefix = skillDir.dirPath ? `${skillDir.dirPath}/` : "";
 
@@ -179,13 +216,9 @@ async function fetchSkillFromDirectory({
     if (entry.type !== "blob") {
       continue;
     }
-
-    // Must be inside the skill directory.
     if (!entry.path.startsWith(dirPrefix)) {
       continue;
     }
-
-    // Skip the skill.md file itself.
     if (entry.path === skillDir.skillMdPath) {
       continue;
     }

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -203,7 +203,7 @@ async function buildDetectedSkill({
   if (blobResult.isErr()) {
     logger.error(
       {
-        err: new Error(blobResult.error.message),
+        error: blobResult.error,
         owner,
         repo,
         skillMdPath: skillDir.skillMdPath,

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -22,9 +22,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Octokit } from "@octokit/core";
 
-export type { DetectedSkill, DetectedSkillAttachment, SkillDetectionError };
-export { parseGitHubRepoUrl };
-
 const FETCH_CONCURRENCY = 4;
 
 async function fetchRepoTree(

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -220,10 +220,8 @@ async function buildDetectedSkill({
     }
 
     const relativePath = entry.path.slice(dirPrefix.length);
-    const fileName = relativePath.split("/").pop() ?? relativePath;
 
     attachments.push({
-      name: fileName,
       path: relativePath,
       sizeBytes: entry.size ?? 0,
     });

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -1,7 +1,6 @@
 import {
   extractDescription,
   findSkillDirectories,
-  getContentType,
   parseGitHubRepoUrl,
 } from "@app/lib/api/skills/github_detection/parsing";
 import type {
@@ -227,7 +226,6 @@ async function buildDetectedSkill({
       name: fileName,
       path: relativePath,
       sizeBytes: entry.size ?? 0,
-      contentType: getContentType(fileName),
     });
   }
 

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -129,7 +129,7 @@ async function fetchBlobContent(
  * Detects skills in a GitHub repository by fetching its tree and looking for
  * directories containing skill.md or SKILL.md files.
  *
- * Does not clone the repository — uses the GitHub Git Trees API for lightweight access.
+ * Uses the GitHub Git Trees API for lightweight access.
  */
 export async function detectSkillsFromGitHubRepo({
   repoUrl,
@@ -174,10 +174,6 @@ export async function detectSkillsFromGitHubRepo({
   return new Ok(detectedSkills);
 }
 
-/**
- * Builds a DetectedSkill from a skill directory by fetching its skill.md
- * and collecting attachment metadata from the tree.
- */
 async function buildDetectedSkill({
   octokit,
   owner,

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -1,9 +1,3 @@
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { Octokit } from "@octokit/core";
 import {
   extractDescription,
   findSkillDirectories,
@@ -21,6 +15,12 @@ import {
   GitHubBlobResponseSchema,
   GitHubTreeResponseSchema,
 } from "@app/lib/api/skills/github_detection/types";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { Octokit } from "@octokit/core";
 
 export type { DetectedSkill, DetectedSkillAttachment, SkillDetectionError };
 export { parseGitHubRepoUrl };
@@ -115,9 +115,7 @@ async function fetchBlobContent(
     });
   }
 
-  return new Ok(
-    Buffer.from(parsed.data.content, "base64").toString("utf-8")
-  );
+  return new Ok(Buffer.from(parsed.data.content, "base64").toString("utf-8"));
 }
 
 /**

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -7,7 +7,6 @@ import {
 import type {
   DetectedSkill,
   DetectedSkillAttachment,
-  GitHubRepo,
   GitHubTreeEntry,
   SkillDetectionError,
   SkillDirectory,
@@ -34,10 +33,14 @@ const FETCH_CONCURRENCY = 4;
  */
 async function fetchRepoTree(
   octokit: InstanceType<typeof Octokit>,
-  githubRepo: GitHubRepo
+  {
+    owner,
+    repo,
+  }: {
+    owner: string;
+    repo: string;
+  }
 ): Promise<Result<GitHubTreeEntry[], SkillDetectionError>> {
-  const { owner, repo } = githubRepo;
-
   let rawData: unknown;
   try {
     const response = await octokit.request(
@@ -91,9 +94,15 @@ async function fetchRepoTree(
  */
 async function fetchBlobContent(
   octokit: InstanceType<typeof Octokit>,
-  owner: string,
-  repo: string,
-  fileSha: string
+  {
+    owner,
+    repo,
+    fileSha,
+  }: {
+    owner: string;
+    repo: string;
+    fileSha: string;
+  }
 ): Promise<Result<string, SkillDetectionError>> {
   let rawData: unknown;
   try {
@@ -141,7 +150,7 @@ export async function detectSkillsFromGitHubRepo({
 
   const octokit = new Octokit(accessToken ? { auth: accessToken } : {});
 
-  const treeResult = await fetchRepoTree(octokit, owner, repo);
+  const treeResult = await fetchRepoTree(octokit, { owner, repo });
   if (treeResult.isErr()) {
     return treeResult;
   }
@@ -186,12 +195,11 @@ async function buildDetectedSkill({
   skillDir: SkillDirectory;
   tree: GitHubTreeEntry[];
 }): Promise<Result<DetectedSkill, SkillDetectionError>> {
-  const blobResult = await fetchBlobContent(
-    octokit,
+  const blobResult = await fetchBlobContent(octokit, {
     owner,
     repo,
-    skillDir.skillMdSha
-  );
+    fileSha: skillDir.skillMdSha,
+  });
   if (blobResult.isErr()) {
     logger.error(
       {

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -1,0 +1,211 @@
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { Octokit } from "@octokit/core";
+
+import type {
+  DetectedSkill,
+  DetectedSkillAttachment,
+  GitHubTreeEntry,
+  GitHubTreeResponse,
+  SkillDetectionError,
+  SkillDirectory,
+} from "./types";
+import {
+  extractDescription,
+  findSkillDirectories,
+  getContentType,
+  parseGitHubRepoUrl,
+} from "./parsing";
+
+export type { DetectedSkill, DetectedSkillAttachment, SkillDetectionError };
+export { parseGitHubRepoUrl };
+
+const FETCH_CONCURRENCY = 4;
+
+/**
+ * Detects skills in a GitHub repository by fetching its tree and looking for
+ * directories containing skill.md or SKILL.md files.
+ *
+ * Does not clone the repository — uses the GitHub Git Trees API for lightweight access.
+ */
+export async function detectSkillsFromGitHubRepo({
+  repoUrl,
+  accessToken,
+}: {
+  repoUrl: string;
+  accessToken?: string;
+}): Promise<Result<DetectedSkill[], SkillDetectionError>> {
+  const parseResult = parseGitHubRepoUrl(repoUrl);
+  if (parseResult.isErr()) {
+    return parseResult;
+  }
+  const { owner, repo } = parseResult.value;
+
+  const octokit = new Octokit(accessToken ? { auth: accessToken } : {});
+
+  // Fetch the full repository tree.
+  let tree: GitHubTreeEntry[];
+  try {
+    const response = await octokit.request(
+      "GET /repos/{owner}/{repo}/git/trees/{tree_sha}",
+      {
+        owner,
+        repo,
+        tree_sha: "HEAD",
+        recursive: "1",
+      }
+    );
+    const data = response.data as GitHubTreeResponse;
+    tree = data.tree;
+
+    if (data.truncated) {
+      logger.warn(
+        { owner, repo },
+        "GitHub tree response was truncated; some skills may be missed."
+      );
+    }
+  } catch (err) {
+    const error = normalizeError(err);
+    if (error.message.includes("Not Found")) {
+      return new Err({
+        type: "not_found",
+        message: `Repository "${owner}/${repo}" not found.`,
+      });
+    }
+    if (
+      error.message.includes("Bad credentials") ||
+      error.message.includes("401")
+    ) {
+      return new Err({
+        type: "auth_error",
+        message: `Authentication failed for repository "${owner}/${repo}".`,
+      });
+    }
+    return new Err({
+      type: "api_error",
+      message: `Failed to fetch repository tree: ${error.message}`,
+    });
+  }
+
+  // Find directories that contain a skill.md / SKILL.md at their root.
+  const skillDirs = findSkillDirectories(tree);
+
+  if (skillDirs.length === 0) {
+    return new Ok([]);
+  }
+
+  // Fetch skill.md content for each detected skill directory.
+  const skills = await concurrentExecutor(
+    skillDirs,
+    async (skillDir) => {
+      return fetchSkillFromDirectory({
+        octokit,
+        owner,
+        repo,
+        skillDir,
+        tree,
+      });
+    },
+    { concurrency: FETCH_CONCURRENCY }
+  );
+
+  // Filter out failed fetches.
+  const detectedSkills: DetectedSkill[] = [];
+  for (const result of skills) {
+    if (result.isOk()) {
+      detectedSkills.push(result.value);
+    }
+  }
+
+  return new Ok(detectedSkills);
+}
+
+/**
+ * Fetches skill details from a detected skill directory.
+ */
+async function fetchSkillFromDirectory({
+  octokit,
+  owner,
+  repo,
+  skillDir,
+  tree,
+}: {
+  octokit: InstanceType<typeof Octokit>;
+  owner: string;
+  repo: string;
+  skillDir: SkillDirectory;
+  tree: GitHubTreeEntry[];
+}): Promise<Result<DetectedSkill, SkillDetectionError>> {
+  // Fetch the skill.md content.
+  let instructions: string;
+  try {
+    const response = await octokit.request(
+      "GET /repos/{owner}/{repo}/git/blobs/{file_sha}",
+      {
+        owner,
+        repo,
+        file_sha: skillDir.skillMdSha,
+      }
+    );
+    const data = response.data as { content: string; encoding: string };
+    instructions = Buffer.from(data.content, "base64").toString("utf-8");
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { err: error, owner, repo, skillMdPath: skillDir.skillMdPath },
+      "Failed to fetch skill.md content."
+    );
+    return new Err({
+      type: "api_error",
+      message: `Failed to fetch ${skillDir.skillMdPath}: ${error.message}`,
+    });
+  }
+
+  // Extract the skill name from the directory path.
+  const name = skillDir.dirPath.split("/").pop() ?? skillDir.dirPath;
+
+  // Extract description from the skill.md content.
+  const description = extractDescription(instructions);
+
+  // Collect attachments: all other files in the skill directory (files in
+  // subdirectories relative to the skill dir are included — they are part of the skill).
+  const attachments: DetectedSkillAttachment[] = [];
+  const dirPrefix = skillDir.dirPath ? `${skillDir.dirPath}/` : "";
+
+  for (const entry of tree) {
+    if (entry.type !== "blob") {
+      continue;
+    }
+
+    // Must be inside the skill directory.
+    if (!entry.path.startsWith(dirPrefix)) {
+      continue;
+    }
+
+    // Skip the skill.md file itself.
+    if (entry.path === skillDir.skillMdPath) {
+      continue;
+    }
+
+    const relativePath = entry.path.slice(dirPrefix.length);
+    const fileName = relativePath.split("/").pop() ?? relativePath;
+
+    attachments.push({
+      name: fileName,
+      path: relativePath,
+      sizeBytes: entry.size ?? 0,
+      contentType: getContentType(fileName),
+    });
+  }
+
+  return new Ok({
+    name,
+    dirPath: skillDir.dirPath,
+    description,
+    instructions,
+    attachments,
+  });
+}

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -202,7 +202,6 @@ async function buildDetectedSkill({
   }
   const instructions = blobResult.value;
 
-  const name = skillDir.dirPath.split("/").pop() ?? skillDir.dirPath;
   const description = extractDescription(instructions);
 
   const attachments: DetectedSkillAttachment[] = [];
@@ -228,7 +227,6 @@ async function buildDetectedSkill({
   }
 
   return new Ok({
-    name,
     dirPath: skillDir.dirPath,
     description,
     instructions,

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -8,33 +8,6 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const SKILL_MD_FILENAME = "skill.md";
 
-// Content type mapping for common file extensions.
-const EXTENSION_CONTENT_TYPES: Record<string, string> = {
-  ".md": "text/markdown",
-  ".txt": "text/plain",
-  ".json": "application/json",
-  ".js": "text/javascript",
-  ".ts": "text/typescript",
-  ".py": "text/x-python",
-  ".sh": "text/x-shellscript",
-  ".html": "text/html",
-  ".css": "text/css",
-  ".xml": "application/xml",
-  ".xsd": "application/xml",
-  ".yaml": "text/yaml",
-  ".yml": "text/yaml",
-  ".svg": "image/svg+xml",
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".pdf": "application/pdf",
-  ".zip": "application/zip",
-  ".ttf": "font/ttf",
-  ".woff": "font/woff",
-  ".woff2": "font/woff2",
-};
-
 /**
  * Parses a GitHub repository identifier from various formats:
  * - "owner/repo"
@@ -80,18 +53,6 @@ export function parseGitHubRepoUrl(
   }
 
   return new Ok({ owner: segments[0], repo: segments[1] });
-}
-
-/**
- * Infers content type from a file's extension.
- */
-export function getContentType(filename: string): string {
-  const lastDot = filename.lastIndexOf(".");
-  if (lastDot === -1) {
-    return "application/octet-stream";
-  }
-  const ext = filename.slice(lastDot).toLowerCase();
-  return EXTENSION_CONTENT_TYPES[ext] ?? "application/octet-stream";
 }
 
 /**

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -1,7 +1,11 @@
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-import type { GitHubTreeEntry, SkillDetectionError, SkillDirectory } from "./types";
+import type {
+  GitHubTreeEntry,
+  SkillDetectionError,
+  SkillDirectory,
+} from "@app/lib/api/skills/github_detection/types";
 
 const SKILL_MD_FILENAMES = ["skill.md", "SKILL.md"];
 

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -39,6 +39,13 @@ export function parseGitHubRepoUrl(
     });
   }
 
+  if (url.hostname !== "github.com") {
+    return new Err({
+      type: "not_found",
+      message: `Unsupported hostname "${url.hostname}". Only github.com repositories are supported.`,
+    });
+  }
+
   // Extract path segments, stripping leading/trailing slashes and .git suffix.
   const segments = url.pathname
     .replace(/\.git$/, "")

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -107,6 +107,7 @@ export function findSkillDirectories(
   tree: GitHubTreeEntry[]
 ): SkillDirectory[] {
   const skillDirs: SkillDirectory[] = [];
+  const seenDirs = new Set<string>();
 
   for (const entry of tree) {
     if (entry.type !== "blob") {
@@ -124,6 +125,12 @@ export function findSkillDirectories(
       continue;
     }
     const dirPath = entry.path.slice(0, lastSlash);
+
+    // Avoid duplicates if a directory has both skill.md and SKILL.md.
+    if (seenDirs.has(dirPath)) {
+      continue;
+    }
+    seenDirs.add(dirPath);
 
     skillDirs.push({
       dirPath,

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -44,7 +44,13 @@ const EXTENSION_CONTENT_TYPES: Record<string, string> = {
 export function parseGitHubRepoUrl(
   input: string
 ): Result<{ owner: string; repo: string }, SkillDetectionError> {
-  let ownerRepo = input.trim();
+  let remainder = input.trim();
+
+  // Strip query params and fragment using URL parsing when it looks like a URL.
+  if (remainder.startsWith("http://") || remainder.startsWith("https://")) {
+    const url = new URL(remainder);
+    remainder = `${url.origin}${url.pathname}`;
+  }
 
   // Strip https://github.com/ or github.com/ prefix.
   ownerRepo = ownerRepo

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -1,0 +1,151 @@
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+import type { GitHubTreeEntry, SkillDetectionError, SkillDirectory } from "./types";
+
+const SKILL_MD_FILENAMES = ["skill.md", "SKILL.md"];
+
+// Content type mapping for common file extensions.
+const EXTENSION_CONTENT_TYPES: Record<string, string> = {
+  ".md": "text/markdown",
+  ".txt": "text/plain",
+  ".json": "application/json",
+  ".js": "text/javascript",
+  ".ts": "text/typescript",
+  ".py": "text/x-python",
+  ".sh": "text/x-shellscript",
+  ".html": "text/html",
+  ".css": "text/css",
+  ".xml": "application/xml",
+  ".xsd": "application/xml",
+  ".yaml": "text/yaml",
+  ".yml": "text/yaml",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".pdf": "application/pdf",
+  ".zip": "application/zip",
+  ".ttf": "font/ttf",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+/**
+ * Parses a GitHub repository identifier from various formats:
+ * - "owner/repo"
+ * - "https://github.com/owner/repo"
+ * - "github.com/owner/repo"
+ */
+export function parseGitHubRepoUrl(
+  input: string
+): Result<{ owner: string; repo: string }, SkillDetectionError> {
+  let ownerRepo = input.trim();
+
+  // Strip https://github.com/ or github.com/ prefix.
+  ownerRepo = ownerRepo
+    .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/^github\.com\//, "");
+
+  // Remove trailing slash or .git suffix.
+  ownerRepo = ownerRepo.replace(/\/+$/, "").replace(/\.git$/, "");
+
+  const parts = ownerRepo.split("/");
+  if (parts.length < 2 || !parts[0] || !parts[1]) {
+    return new Err({
+      type: "not_found",
+      message: `Invalid GitHub repository identifier: "${input}". Expected "owner/repo".`,
+    });
+  }
+
+  return new Ok({ owner: parts[0], repo: parts[1] });
+}
+
+/**
+ * Infers content type from a file's extension.
+ */
+export function getContentType(filename: string): string {
+  const lastDot = filename.lastIndexOf(".");
+  if (lastDot === -1) {
+    return "application/octet-stream";
+  }
+  const ext = filename.slice(lastDot).toLowerCase();
+  return EXTENSION_CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+/**
+ * Extracts the first non-empty paragraph from a markdown string,
+ * skipping YAML frontmatter (--- delimited) and headings.
+ */
+export function extractDescription(markdown: string): string {
+  let content = markdown;
+
+  // Strip YAML frontmatter.
+  if (content.startsWith("---")) {
+    const endIndex = content.indexOf("---", 3);
+    if (endIndex !== -1) {
+      content = content.slice(endIndex + 3);
+    }
+  }
+
+  const lines = content.split("\n");
+  const paragraphLines: string[] = [];
+  let inParagraph = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines before a paragraph starts.
+    if (!trimmed) {
+      if (inParagraph) {
+        break;
+      }
+      continue;
+    }
+
+    // Skip headings.
+    if (trimmed.startsWith("#")) {
+      if (inParagraph) {
+        break;
+      }
+      continue;
+    }
+
+    inParagraph = true;
+    paragraphLines.push(trimmed);
+  }
+
+  return paragraphLines.join(" ");
+}
+
+/**
+ * Scans the tree for directories containing skill.md or SKILL.md.
+ */
+export function findSkillDirectories(
+  tree: GitHubTreeEntry[]
+): SkillDirectory[] {
+  const skillDirs: SkillDirectory[] = [];
+
+  for (const entry of tree) {
+    if (entry.type !== "blob") {
+      continue;
+    }
+
+    const filename = entry.path.split("/").pop() ?? "";
+    if (!SKILL_MD_FILENAMES.includes(filename)) {
+      continue;
+    }
+
+    const lastSlash = entry.path.lastIndexOf("/");
+    const dirPath = lastSlash === -1 ? "" : entry.path.slice(0, lastSlash);
+
+    skillDirs.push({
+      dirPath,
+      skillMdPath: entry.path,
+      skillMdSha: entry.sha,
+    });
+  }
+
+  return skillDirs;
+}

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -1,11 +1,10 @@
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
-
 import type {
   GitHubTreeEntry,
   SkillDetectionError,
   SkillDirectory,
 } from "@app/lib/api/skills/github_detection/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 const SKILL_MD_FILENAMES = ["skill.md", "SKILL.md"];
 

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -6,7 +6,7 @@ import type {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-const SKILL_MD_FILENAMES = ["skill.md", "SKILL.md"];
+const SKILL_MD_FILENAME = "skill.md";
 
 // Content type mapping for common file extensions.
 const EXTENSION_CONTENT_TYPES: Record<string, string> = {
@@ -153,7 +153,7 @@ export function findSkillDirectories(
     }
 
     const filename = entry.path.split("/").pop() ?? "";
-    if (!SKILL_MD_FILENAMES.includes(filename)) {
+    if (filename.toLowerCase() !== SKILL_MD_FILENAME) {
       continue;
     }
 

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -39,36 +39,47 @@ const EXTENSION_CONTENT_TYPES: Record<string, string> = {
  * Parses a GitHub repository identifier from various formats:
  * - "owner/repo"
  * - "https://github.com/owner/repo"
- * - "github.com/owner/repo"
+ * - "https://github.com/owner/repo.git"
  */
 export function parseGitHubRepoUrl(
   input: string
 ): Result<{ owner: string; repo: string }, SkillDetectionError> {
-  let remainder = input.trim();
+  const trimmed = input.trim();
 
-  // Strip query params and fragment using URL parsing when it looks like a URL.
-  if (remainder.startsWith("http://") || remainder.startsWith("https://")) {
-    const url = new URL(remainder);
-    remainder = `${url.origin}${url.pathname}`;
+  // Handles "github.com/owner/repo" (no protocol) and bare "owner/repo".
+  let normalized: string;
+  if (trimmed.includes("://")) {
+    normalized = trimmed;
+  } else if (trimmed.startsWith("github.com/")) {
+    normalized = `https://${trimmed}`;
+  } else {
+    normalized = `https://github.com/${trimmed}`;
   }
 
-  // Strip https://github.com/ or github.com/ prefix.
-  remainder = remainder
-    .replace(/^https?:\/\/github\.com\//, "")
-    .replace(/^github\.com\//, "");
-
-  // Remove trailing slash or .git suffix.
-  remainder = remainder.replace(/\/+$/, "").replace(/\.git$/, "");
-
-  const parts = remainder.split("/");
-  if (parts.length < 2 || !parts[0] || !parts[1]) {
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
     return new Err({
       type: "not_found",
       message: `Invalid GitHub repository identifier: "${input}". Expected "owner/repo".`,
     });
   }
 
-  return new Ok({ owner: parts[0], repo: parts[1] });
+  // Extract path segments, stripping leading/trailing slashes and .git suffix.
+  const segments = url.pathname
+    .replace(/\.git$/, "")
+    .split("/")
+    .filter(Boolean);
+
+  if (segments.length < 2 || !segments[0] || !segments[1]) {
+    return new Err({
+      type: "not_found",
+      message: `Invalid GitHub repository identifier: "${input}". Expected "owner/repo".`,
+    });
+  }
+
+  return new Ok({ owner: segments[0], repo: segments[1] });
 }
 
 /**

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -53,14 +53,14 @@ export function parseGitHubRepoUrl(
   }
 
   // Strip https://github.com/ or github.com/ prefix.
-  ownerRepo = ownerRepo
+  remainder = remainder
     .replace(/^https?:\/\/github\.com\//, "")
     .replace(/^github\.com\//, "");
 
   // Remove trailing slash or .git suffix.
-  ownerRepo = ownerRepo.replace(/\/+$/, "").replace(/\.git$/, "");
+  remainder = remainder.replace(/\/+$/, "").replace(/\.git$/, "");
 
-  const parts = ownerRepo.split("/");
+  const parts = remainder.split("/");
   if (parts.length < 2 || !parts[0] || !parts[1]) {
     return new Err({
       type: "not_found",
@@ -147,7 +147,11 @@ export function findSkillDirectories(
     }
 
     const lastSlash = entry.path.lastIndexOf("/");
-    const dirPath = lastSlash === -1 ? "" : entry.path.slice(0, lastSlash);
+    // Skip skill.md at the repo root, a skill must live in a directory.
+    if (lastSlash === -1) {
+      continue;
+    }
+    const dirPath = entry.path.slice(0, lastSlash);
 
     skillDirs.push({
       dirPath,

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -7,7 +7,6 @@ export interface DetectedSkillAttachment {
 }
 
 export interface DetectedSkill {
-  name: string;
   dirPath: string;
   description: string;
   instructions: string;

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -26,25 +26,28 @@ export interface SkillDirectory {
   skillMdSha: string;
 }
 
-const GitHubTreeEntrySchema = z.object({
-  path: z.string(),
-  mode: z.string(),
-  type: z.enum(["blob", "tree"]),
-  sha: z.string(),
-  size: z.number().optional(),
-  url: z.string(),
-});
+const GitHubTreeEntrySchema = z
+  .object({
+    path: z.string(),
+    type: z.enum(["blob", "tree"]),
+    sha: z.string(),
+    size: z.number().optional(),
+    url: z.string(),
+  })
+  .passthrough();
 
-export const GitHubTreeResponseSchema = z.object({
-  sha: z.string(),
-  tree: z.array(GitHubTreeEntrySchema),
-  truncated: z.boolean(),
-});
+export const GitHubTreeResponseSchema = z
+  .object({
+    tree: z.array(GitHubTreeEntrySchema),
+    truncated: z.boolean(),
+  })
+  .passthrough();
 
-export const GitHubBlobResponseSchema = z.object({
-  content: z.string(),
-  encoding: z.string(),
-});
+export const GitHubBlobResponseSchema = z
+  .object({
+    content: z.string(),
+  })
+  .passthrough();
 
 export type GitHubTreeEntry = z.infer<typeof GitHubTreeEntrySchema>;
 export type GitHubTreeResponse = z.infer<typeof GitHubTreeResponseSchema>;

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 export interface DetectedSkillAttachment {
-  name: string;
   path: string;
   sizeBytes: number;
 }

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface DetectedSkillAttachment {
   name: string;
   path: string;
@@ -18,23 +20,32 @@ export type SkillDetectionError =
   | { type: "not_found"; message: string }
   | { type: "api_error"; message: string };
 
-export interface GitHubTreeEntry {
-  path: string;
-  mode: string;
-  type: "blob" | "tree";
-  sha: string;
-  size?: number;
-  url: string;
-}
-
-export interface GitHubTreeResponse {
-  sha: string;
-  tree: GitHubTreeEntry[];
-  truncated: boolean;
-}
-
 export interface SkillDirectory {
   dirPath: string;
   skillMdPath: string;
   skillMdSha: string;
 }
+
+const GitHubTreeEntrySchema = z.object({
+  path: z.string(),
+  mode: z.string(),
+  type: z.enum(["blob", "tree"]),
+  sha: z.string(),
+  size: z.number().optional(),
+  url: z.string(),
+});
+
+export const GitHubTreeResponseSchema = z.object({
+  sha: z.string(),
+  tree: z.array(GitHubTreeEntrySchema),
+  truncated: z.boolean(),
+});
+
+export const GitHubBlobResponseSchema = z.object({
+  content: z.string(),
+  encoding: z.string(),
+});
+
+export type GitHubTreeEntry = z.infer<typeof GitHubTreeEntrySchema>;
+export type GitHubTreeResponse = z.infer<typeof GitHubTreeResponseSchema>;
+export type GitHubBlobResponse = z.infer<typeof GitHubBlobResponseSchema>;

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -1,0 +1,40 @@
+export interface DetectedSkillAttachment {
+  name: string;
+  path: string;
+  sizeBytes: number;
+  contentType: string;
+}
+
+export interface DetectedSkill {
+  name: string;
+  dirPath: string;
+  description: string;
+  instructions: string;
+  attachments: DetectedSkillAttachment[];
+}
+
+export type SkillDetectionError =
+  | { type: "auth_error"; message: string }
+  | { type: "not_found"; message: string }
+  | { type: "api_error"; message: string };
+
+export interface GitHubTreeEntry {
+  path: string;
+  mode: string;
+  type: "blob" | "tree";
+  sha: string;
+  size?: number;
+  url: string;
+}
+
+export interface GitHubTreeResponse {
+  sha: string;
+  tree: GitHubTreeEntry[];
+  truncated: boolean;
+}
+
+export interface SkillDirectory {
+  dirPath: string;
+  skillMdPath: string;
+  skillMdSha: string;
+}

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -4,7 +4,6 @@ export interface DetectedSkillAttachment {
   name: string;
   path: string;
   sizeBytes: number;
-  contentType: string;
 }
 
 export interface DetectedSkill {

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -45,6 +45,7 @@ export const GitHubTreeResponseSchema = z
 export const GitHubBlobResponseSchema = z
   .object({
     content: z.string(),
+    encoding: z.literal("base64"),
   })
   .passthrough();
 

--- a/front/scripts/detect_github_skills.ts
+++ b/front/scripts/detect_github_skills.ts
@@ -1,0 +1,45 @@
+import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/github_detection/detect_skills";
+import { makeScript } from "@app/scripts/helpers";
+
+// TODO(2026-02-25 aubin): move to a poke plugin or a CLI command if ends up being needed for debugging.
+makeScript(
+  {
+    repoUrl: {
+      type: "string",
+      demandOption: true,
+      describe: "GitHub repository (e.g. anthropics/skills)",
+    },
+    accessToken: {
+      type: "string",
+      demandOption: false,
+      describe: "GitHub access token (required for private repos)",
+    },
+  },
+  async ({ repoUrl, accessToken }, logger) => {
+    const result = await detectSkillsFromGitHubRepo({ repoUrl, accessToken });
+
+    if (result.isErr()) {
+      logger.error(
+        { error: result.error },
+        `Detection failed: ${result.error.message}`
+      );
+      return;
+    }
+
+    const skills = result.value;
+    logger.info(`Found ${skills.length} skill(s) in ${repoUrl}`);
+
+    for (const skill of skills) {
+      logger.info(
+        {
+          name: skill.name,
+          dirPath: skill.dirPath,
+          descriptionLength: skill.description.length,
+          instructionsLength: skill.instructions.length,
+          attachmentCount: skill.attachments.length,
+        },
+        `Skill: ${skill.name}`
+      );
+    }
+  }
+);

--- a/front/scripts/detect_github_skills.ts
+++ b/front/scripts/detect_github_skills.ts
@@ -32,13 +32,12 @@ makeScript(
     for (const skill of skills) {
       logger.info(
         {
-          name: skill.name,
           dirPath: skill.dirPath,
           descriptionLength: skill.description.length,
           instructionsLength: skill.instructions.length,
           attachmentCount: skill.attachments.length,
         },
-        `Skill: ${skill.name}`
+        "Skill"
       );
     }
   }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6795
- Add a backend utility to detect skills from a GitHub repository without cloning
- Fetches the repo tree via GitHub API, identifies directories containing `skill.md`/`SKILL.md`
- For each skill, extracts name, path, description (first paragraph), full instructions, and attachment metadata
- Handles missing repos, auth errors, and repos with no skills gracefully
- Will iterate on it once hooked up to a UI

## Tests

- Tested

## Risk

- N/A

## Deploy Plan

- Deploy front.
