### PR TITLE
Copilot eval tests: Add tests on Gemini

### DIFF
--- a/front/tests/copilot-evals/copilot-eval.test.ts
+++ b/front/tests/copilot-evals/copilot-eval.test.ts
@@ -102,7 +102,12 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
               JUDGE_RUNS
             );
 
-            const passed = judgeResult.finalScore >= PASS_THRESHOLD;
+            const actualToolNames = toolCalls.map((t) => t.name);
+            const missingTools = (testCase.expectedToolCalls ?? []).filter(
+              (expected) => !actualToolNames.includes(expected)
+            );
+            const passedJudge = judgeResult.finalScore >= PASS_THRESHOLD;
+            const passed = passedJudge && missingTools.length === 0;
 
             evalResults.push({
               testCase,
@@ -113,16 +118,15 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
               copilotModelTimeMs: modelTimeMs,
             });
 
-            const actualToolNames = toolCalls.map((t) => t.name);
-            for (const expected of testCase.expectedToolCalls ?? []) {
+            for (const missing of missingTools) {
               expect(
                 actualToolNames,
-                `Expected tool "${expected}" not called. Tools called: [${actualToolNames.join(", ")}]\n\nCopilot response:\n${responseText}`
-              ).toContain(expected);
+                `Expected tool "${missing}" not called. Tools called: [${actualToolNames.join(", ")}]\n\nCopilot response:\n${responseText}`
+              ).toContain(missing);
             }
 
             expect(
-              passed,
+              passedJudge,
               `Judge score ${judgeResult.finalScore} < threshold ${PASS_THRESHOLD}\nReasoning: ${judgeResult.reasoning}\n\nCopilot response:\n${responseText}`
             ).toBe(true);
           },

--- a/front/tests/copilot-evals/lib/config.ts
+++ b/front/tests/copilot-evals/lib/config.ts
@@ -21,6 +21,7 @@ import { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { CopilotConfig } from "@app/tests/copilot-evals/lib/types";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { GEMINI_3_FLASH_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 
 export const RUN_COPILOT_EVAL = process.env.RUN_COPILOT_EVAL === "true";
 export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
@@ -144,9 +145,23 @@ export async function getCopilotConfig(): Promise<CopilotConfig> {
         mcpServerViews: MOCK_MCP_SERVER_VIEWS,
       });
       break;
+    case "gemini-3-light":
+      copilotConfig = _getCopilotGlobalAgent(auth, {
+        copilotContext: mockCopilotContext,
+        preFetchedDataSources: null,
+        mcpServerViews: MOCK_MCP_SERVER_VIEWS,
+      });
+      break;
+    case "gemini-3-medium":
+      copilotConfig = _getCopilotGlobalAgent(auth, {
+        copilotContext: mockCopilotContext,
+        preFetchedDataSources: null,
+        mcpServerViews: MOCK_MCP_SERVER_VIEWS,
+      });
+      break;
     default:
       throw new Error(
-        `Unknown COPILOT_AGENT: "${COPILOT_AGENT}". Must be "default" or "haiku".`
+        `Unknown COPILOT_AGENT: "${COPILOT_AGENT}". Must be "default", "haiku", "gemini-3-light", or "gemini-3-medium".`
       );
   }
 
@@ -164,9 +179,21 @@ export async function getCopilotConfig(): Promise<CopilotConfig> {
     }
   }
 
+  const model = {
+    ...copilotConfig.model,
+    ...(COPILOT_AGENT === "gemini-3-light" && {
+      modelId: GEMINI_3_FLASH_MODEL_ID,
+      reasoningEffort: "light" as const,
+    }),
+    ...(COPILOT_AGENT === "gemini-3-medium" && {
+      modelId: GEMINI_3_FLASH_MODEL_ID,
+      reasoningEffort: "medium" as const,
+    }),
+  };
+
   return {
     instructions: copilotConfig.instructions ?? "",
-    model: copilotConfig.model,
+    model,
     tools,
   };
 }

--- a/front/tests/copilot-evals/lib/copilot-executor.ts
+++ b/front/tests/copilot-evals/lib/copilot-executor.ts
@@ -1,5 +1,6 @@
 import { getLLM } from "@app/lib/api/llm";
 import type { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { MAX_TOOL_CALL_ROUNDS } from "@app/tests/copilot-evals/lib/config";
 import { getMockToolResponse } from "@app/tests/copilot-evals/lib/mock-responses";
 import type {
@@ -8,6 +9,10 @@ import type {
   MockAgentState,
   ToolCall,
 } from "@app/tests/copilot-evals/lib/types";
+import type {
+  AgentContentItemType,
+  AgentErrorContentType,
+} from "@app/types/assistant/agent_message_content";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 
 export async function executeCopilot(
@@ -47,7 +52,15 @@ export async function executeCopilot(
   });
 
   for (let round = 0; round < MAX_TOOL_CALL_ROUNDS; round++) {
-    const currentRoundToolCalls: ToolCall[] = [];
+    const currentRoundToolCalls: Array<{
+      toolCall: ToolCall;
+      id: string;
+      thoughtSignature?: string;
+    }> = [];
+    const reasoningContents: Exclude<
+      AgentContentItemType,
+      AgentErrorContentType
+    >[] = [];
     responseText = "";
 
     for await (const event of events) {
@@ -58,10 +71,27 @@ export async function executeCopilot(
         case "text_generated":
           responseText = event.content.text;
           break;
+        case "reasoning_generated":
+          reasoningContents.push({
+            type: "reasoning",
+            value: {
+              reasoning: event.content.text,
+              metadata: JSON.stringify(event.metadata),
+              tokens: 0,
+              provider:
+                getModelConfigByModelId(config.model.modelId)?.providerId ??
+                "noop",
+            },
+          });
+          break;
         case "tool_call":
           currentRoundToolCalls.push({
-            name: event.content.name,
-            arguments: event.content.arguments,
+            toolCall: {
+              name: event.content.name,
+              arguments: event.content.arguments,
+            },
+            id: event.content.id,
+            thoughtSignature: event.metadata.thoughtSignature,
           });
           break;
         case "error":
@@ -76,37 +106,39 @@ export async function executeCopilot(
       break;
     }
 
-    allToolCalls.push(...currentRoundToolCalls);
+    allToolCalls.push(...currentRoundToolCalls.map((tc) => tc.toolCall));
 
-    // Build messages with tool calls and simulated responses
-    for (let idx = 0; idx < currentRoundToolCalls.length; idx++) {
-      const tc = currentRoundToolCalls[idx];
-      const callId = (
-        allToolCalls.length -
-        currentRoundToolCalls.length +
-        idx +
-        1
-      )
-        .toString()
-        .padStart(9, "0");
+    // Build a single assistant message with reasoning + all function calls
+    const functionCalls = currentRoundToolCalls.map((tc) => ({
+      id: tc.id,
+      name: tc.toolCall.name,
+      arguments: JSON.stringify(tc.toolCall.arguments),
+      metadata: tc.thoughtSignature
+        ? { thoughtSignature: tc.thoughtSignature }
+        : undefined,
+    }));
 
-      const functionCall = {
-        id: callId,
-        name: tc.name,
-        arguments: JSON.stringify(tc.arguments),
-      };
+    const contents: Exclude<AgentContentItemType, AgentErrorContentType>[] = [
+      ...reasoningContents,
+      ...functionCalls.map((fc) => ({
+        type: "function_call" as const,
+        value: fc,
+      })),
+    ];
 
-      messages.push({
-        role: "assistant" as const,
-        function_calls: [functionCall],
-        contents: [{ type: "function_call" as const, value: functionCall }],
-      });
+    messages.push({
+      role: "assistant" as const,
+      function_calls: functionCalls,
+      contents,
+    });
 
+    // Add function response messages
+    for (const tc of currentRoundToolCalls) {
       messages.push({
         role: "function" as const,
-        name: tc.name,
-        function_call_id: callId,
-        content: getMockToolResponse(tc.name, agentState),
+        name: tc.toolCall.name,
+        function_call_id: tc.id,
+        content: getMockToolResponse(tc.toolCall.name, agentState),
       });
     }
 


### PR DESCRIPTION
## Description

 - add gemini-3-light and gemini-3-high models for tests
 - fix issue where number of displayed error is not correct 
 - store reasoning generated by model because gemini need this to be send before tool calls
 
## Tests
 
tests are working, some are failing because prompt is not adapted to gemini

## Risk

low

## Deploy Plan

none