### PR TITLE
[front] - fix(mentions): fix shortcut

### DIFF
--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -308,7 +308,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
           return handled;
         }),
       // Handle Cmd+ArrowRight (Mac) / Ctrl+ArrowRight (Windows/Linux) and End key to jump to end of line
-      "Mod-ArrowRight": jumpToEndOfLine,
+      "Cmd-ArrowRight": jumpToEndOfLine,
       End: jumpToEndOfLine,
     };
   },


### PR DESCRIPTION
## Description

This PR changes keybinding from 'Mod-ArrowRight' to 'Cmd-ArrowRight' to adhere to Mac standards for navigation shortcuts and preserve built in ones for Windows/Linux

**References:**
- Fixes https://github.com/dust-tt/tasks/issues/6804

## Tests

Locally (on Mac)

## Risk

Low

## Deploy Plan

Deploy front