### PR TITLE
Store MCP action output items in GCS (Step 1)

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -26,7 +26,7 @@ import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -77,6 +77,7 @@ function sanitizeStringsDeep<T>(input: T): T {
 }
 
 export async function processToolNotification(
+  auth: Authenticator,
   notification: MCPProgressNotificationType,
   {
     action,
@@ -92,12 +93,11 @@ export async function processToolNotification(
 ): Promise<ToolNotificationEvent> {
   const output = notification.params._meta.data.output;
 
-  // Handle store_resource notifications by creating output items immediately
+  // Handle store_resource notifications by creating output items immediately (fire-and-forget GCS).
   if (isStoreResourceProgressOutput(output)) {
-    await AgentMCPActionOutputItemModel.bulkCreate(
+    await action.createOutputItems(
+      auth,
       output.contents.map((content) => ({
-        workspaceId: action.workspaceId,
-        agentMCPActionId: action.id,
         content: sanitizeStringsDeep(content),
       }))
     );
@@ -365,10 +365,9 @@ export async function processToolResults(
     }
   );
 
-  const outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
+  const outputItems = await action.createOutputItems(
+    auth,
     cleanContent.map((c) => ({
-      workspaceId: action.workspaceId,
-      agentMCPActionId: action.id,
       content: sanitizeStringsDeep(c.content),
       fileId: c.file?.id,
     }))

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,6 +1,5 @@
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
@@ -43,13 +42,11 @@ async function destroyActionsRelatedResources(
     agentMessageIds
   );
 
-  // Destroy MCP action output items.
-  await AgentMCPActionOutputItemModel.destroy({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      agentMCPActionId: mcpActions.map((a) => a.id),
-    },
-  });
+  // Destroy MCP action output items (including GCS cleanup).
+  await AgentMCPActionResource.destroyOutputItemsByActionIds(
+    auth,
+    mcpActions.map((a) => a.id)
+  );
 
   // Destroy the actions.
   await AgentMCPActionResource.deleteByAgentMessageId(auth, {

--- a/front/lib/api/mcp/error.ts
+++ b/front/lib/api/mcp/error.ts
@@ -1,7 +1,7 @@
 import type { MCPErrorEvent, MCPSuccessEvent } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
-import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
@@ -19,20 +19,20 @@ type HandleErrorParams = {
 /**
  * Handles MCP action errors with type-safe discriminated union based on error severity.
  */
-export async function handleMCPActionError({
-  action,
-  agentConfiguration,
-  agentMessage,
-  errorContent,
-  status,
-  executionDurationMs,
-}: HandleErrorParams): Promise<MCPErrorEvent | MCPSuccessEvent> {
-  await AgentMCPActionOutputItemModel.bulkCreate(
-    errorContent.map((item) => ({
-      workspaceId: action.workspaceId,
-      agentMCPActionId: action.id,
-      content: item,
-    }))
+export async function handleMCPActionError(
+  auth: Authenticator,
+  {
+    action,
+    agentConfiguration,
+    agentMessage,
+    errorContent,
+    status,
+    executionDurationMs,
+  }: HandleErrorParams
+): Promise<MCPErrorEvent | MCPSuccessEvent> {
+  await action.createOutputItems(
+    auth,
+    errorContent.map((item) => ({ content: item }))
   );
 
   // If the tool is not already in a final state, we set it to errored (could be denied).

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -100,7 +100,7 @@ export async function* runToolWithStreaming(
     {
       progressToken: action.id,
       makeToolNotificationEvent: (notification) =>
-        processToolNotification(notification, {
+        processToolNotification(auth, notification, {
           action,
           agentConfiguration,
           conversation,
@@ -117,7 +117,7 @@ export async function* runToolWithStreaming(
     statsDClient.increment("mcp_actions_error.count", 1, tags);
 
     const endDate = performance.now();
-    yield await handleMCPActionError({
+    yield await handleMCPActionError(auth, {
       action,
       agentConfiguration,
       agentMessage,

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -334,6 +334,7 @@ export class AgentMCPActionOutputItemModel extends WorkspaceAwareModel<AgentMCPA
 
   declare agentMCPActionId: ForeignKey<AgentMCPActionModel["id"]>;
   declare content: CallToolResult["content"][number];
+  declare contentGcsPath: string | null;
   declare fileId: ForeignKey<FileModel["id"]> | null;
 
   declare file: NonAttribute<FileModel>;
@@ -366,6 +367,10 @@ AgentMCPActionOutputItemModel.init(
         },
       },
     },
+    contentGcsPath: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
   },
   {
     modelName: "agent_mcp_action_output_item",
@@ -390,6 +395,11 @@ AgentMCPActionOutputItemModel.init(
         fields: ["workspaceId", "agentMCPActionId"],
         concurrently: true,
         name: "agent_mcp_action_output_items_workspace_id_agent_mcp_action_id",
+      },
+      {
+        fields: ["workspaceId", "agentMCPActionId", "contentGcsPath"],
+        concurrently: true,
+        name: "agent_mcp_action_output_items_ws_action_gcs_path",
       },
     ],
   }

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -12,7 +12,9 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const GCS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 16;
-const CACHE_TTL_MS = 3_600_000; // 1 hour.
+
+// TODO(2026-02-25 PERF): Remove this once optional `ttlMs` on `cacheWithRedis` has been merged.
+const CACHE_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours.
 
 type OutputContent = CallToolResult["content"][number];
 

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -77,7 +77,12 @@ export async function batchWriteContentsToGcs(
 /**
  * Fetches raw JSON content from GCS. Throws on failure (cacheWithRedis propagates the error).
  */
-async function _fetchGcsContent(gcsPath: string): Promise<string> {
+// itemId is unused in the fetch logic but passed to populate the cache key.
+async function fetchGcsContent(
+  auth: Authenticator,
+  gcsPath: string,
+  _itemId: ModelId
+): Promise<string> {
   const bucket = getPrivateUploadBucket();
   const file = bucket.file(gcsPath);
 
@@ -87,8 +92,9 @@ async function _fetchGcsContent(gcsPath: string): Promise<string> {
 }
 
 const fetchGcsContentCached = cacheWithRedis(
-  _fetchGcsContent,
-  (gcsPath) => gcsPath,
+  fetchGcsContent,
+  (auth, _gcsPath, itemId) =>
+    `w:${auth.getNonNullableWorkspace().sId}:mcp_output:${itemId}`,
   { ttlMs: CACHE_TTL_MS, cacheNullValues: false }
 );
 
@@ -98,10 +104,12 @@ const fetchGcsContentCached = cacheWithRedis(
  * TODO(2026-03-15 PERF): Add retry with exponential backoff to handle transient GCS failures.
  */
 async function fetchContentFromGcs(
-  gcsPath: string
+  auth: Authenticator,
+  gcsPath: string,
+  itemId: ModelId
 ): Promise<Result<OutputContent, Error>> {
   try {
-    const raw = await fetchGcsContentCached(gcsPath);
+    const raw = await fetchGcsContentCached(auth, gcsPath, itemId);
     return new Ok(JSON.parse(raw) as OutputContent);
   } catch (err) {
     logger.error(
@@ -117,6 +125,7 @@ async function fetchContentFromGcs(
  * Batch-fetches content for multiple items from cache/GCS.
  */
 export async function batchFetchContentsFromGcs(
+  auth: Authenticator,
   items: Array<{
     itemId: ModelId;
     gcsPath: string;
@@ -128,7 +137,7 @@ export async function batchFetchContentsFromGcs(
   await concurrentExecutor(
     items,
     async ({ itemId, gcsPath }) => {
-      const result = await fetchContentFromGcs(gcsPath);
+      const result = await fetchContentFromGcs(auth, gcsPath, itemId);
       if (result.isOk()) {
         results.set(itemId, result.value);
       } else if (!firstError) {

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -1,0 +1,177 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { cacheWithRedis } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+const GCS_PREFIX = "mcp_output_items";
+const GCS_CONCURRENCY = 16;
+const CACHE_TTL_MS = 3_600_000; // 1 hour.
+
+type OutputContent = CallToolResult["content"][number];
+
+function getGcsPath(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  itemId: ModelId
+): string {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const actionId = action.sId;
+
+  return `${GCS_PREFIX}/w/${workspaceId}/${actionId}/${itemId}.json`;
+}
+
+/**
+ * Writes multiple output items to GCS concurrently.
+ * Returns Ok with a map of itemId → gcsPath, or Err on failure.
+ *
+ * TODO(2026-03-15): Add retry with exponential backoff to handle transient
+ * GCS failures.
+ */
+export async function batchWriteContentsToGcs(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  items: Array<{
+    itemId: ModelId;
+    content: OutputContent;
+  }>
+): Promise<Result<Map<ModelId, string>, Error>> {
+  const results = new Map<ModelId, string>();
+
+  try {
+    await concurrentExecutor(
+      items,
+      async ({ itemId, content }) => {
+        const gcsPath = getGcsPath(auth, action, itemId);
+        const bucket = getPrivateUploadBucket();
+        const file = bucket.file(gcsPath);
+        const json = JSON.stringify(content);
+        await file.save(Buffer.from(json, "utf-8"), {
+          contentType: "application/json",
+        });
+        results.set(itemId, gcsPath);
+      },
+      { concurrency: GCS_CONCURRENCY }
+    );
+  } catch (err) {
+    logger.error(
+      {
+        err: normalizeError(err),
+        itemCount: items.length,
+        successCount: results.size,
+      },
+      "Failed to write MCP output items to GCS"
+    );
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok(results);
+}
+
+/**
+ * Fetches raw JSON content from GCS. Throws on failure (cacheWithRedis propagates the error).
+ */
+async function _fetchGcsContent(gcsPath: string): Promise<string> {
+  const bucket = getPrivateUploadBucket();
+  const file = bucket.file(gcsPath);
+
+  const [buffer] = await file.download();
+
+  return buffer.toString("utf-8");
+}
+
+const fetchGcsContentCached = cacheWithRedis(
+  _fetchGcsContent,
+  (gcsPath) => gcsPath,
+  { ttlMs: CACHE_TTL_MS, cacheNullValues: false }
+);
+
+/**
+ * Fetches content for a single item from cache (LRU) or GCS.
+ *
+ * TODO(2026-03-15 PERF): Add retry with exponential backoff to handle transient GCS failures.
+ */
+async function fetchContentFromGcs(
+  gcsPath: string
+): Promise<Result<OutputContent, Error>> {
+  try {
+    const raw = await fetchGcsContentCached(gcsPath);
+    return new Ok(JSON.parse(raw) as OutputContent);
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), gcsPath },
+      "Failed to fetch MCP output content from GCS"
+    );
+
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Batch-fetches content for multiple items from cache/GCS.
+ */
+export async function batchFetchContentsFromGcs(
+  items: Array<{
+    itemId: ModelId;
+    gcsPath: string;
+  }>
+): Promise<Result<Map<ModelId, OutputContent>, Error>> {
+  const results = new Map<ModelId, OutputContent>();
+  let firstError: Error | null = null;
+
+  await concurrentExecutor(
+    items,
+    async ({ itemId, gcsPath }) => {
+      const result = await fetchContentFromGcs(gcsPath);
+      if (result.isOk()) {
+        results.set(itemId, result.value);
+      } else if (!firstError) {
+        firstError = result.error;
+      }
+    },
+    { concurrency: GCS_CONCURRENCY }
+  );
+
+  if (firstError) {
+    return new Err(firstError);
+  }
+
+  return new Ok(results);
+}
+
+/**
+ * Deletes GCS files by path. Not-found errors are ignored (already deleted).
+ * Returns Err if any deletion fails for other reasons.
+ */
+export async function deleteContentsFromGcs(
+  gcsPaths: string[]
+): Promise<Result<void, Error>> {
+  if (gcsPaths.length === 0) {
+    return new Ok(undefined);
+  }
+
+  try {
+    const bucket = getPrivateUploadBucket();
+    await concurrentExecutor(
+      gcsPaths,
+      async (gcsPath) => {
+        await bucket.delete(gcsPath, { ignoreNotFound: true });
+      },
+      { concurrency: GCS_CONCURRENCY }
+    );
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), pathCount: gcsPaths.length },
+      "Failed to delete MCP output content from GCS"
+    );
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -11,7 +11,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const GCS_PREFIX = "mcp_output_items";
-const GCS_CONCURRENCY = 16;
+const GCS_CONCURRENCY = 4;
 
 // TODO(2026-02-25 PERF): Remove this once optional `ttlMs` on `cacheWithRedis` has been merged.
 const CACHE_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours.

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -1,7 +1,13 @@
-import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type {
+  LightMCPToolConfigurationType,
+  LightServerSideMCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import {
+  AgentMCPActionModel,
+  AgentMCPActionOutputItemModel,
+} from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -9,9 +15,54 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory GCS mock: writes persist content that reads can return.
+const gcsStore = new Map<string, Buffer>();
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: vi.fn(() => ({
+    file: vi.fn((path: string) => ({
+      save: vi.fn(async (data: Buffer) => {
+        gcsStore.set(path, data);
+      }),
+      download: vi.fn(async () => {
+        const buf = gcsStore.get(path);
+        if (!buf) {
+          throw new Error(`GCS file not found: ${path}`);
+        }
+        return [buf];
+      }),
+    })),
+    delete: vi.fn(async (path: string, opts?: { ignoreNotFound?: boolean }) => {
+      if (!gcsStore.has(path) && !opts?.ignoreNotFound) {
+        throw new Error(`GCS file not found: ${path}`);
+      }
+      gcsStore.delete(path);
+    }),
+  })),
+}));
+
+// Bypass Redis caching, pass through to the underlying function.
+vi.mock("@app/lib/utils/cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/utils/cache")>();
+  return {
+    ...actual,
+    cacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(fn: (...args: Args) => Promise<T>) => {
+          return async (...args: Args): Promise<T> => fn(...args);
+        }
+      ),
+  };
+});
 
 describe("listBlockedActionsForConversation", () => {
   let workspace: WorkspaceType;
@@ -287,5 +338,185 @@ describe("listBlockedActionsForConversation", () => {
       workspaceId: workspace.id,
     });
     expect(result[0].actionId).toBe(expectedActionSId);
+  });
+});
+
+describe("Output items with GCS storage", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let agentConfig: LightAgentConfigurationType;
+  let conversation: ConversationType | ConversationWithoutContentType;
+
+  const toolConfiguration: LightServerSideMCPToolConfigurationType = {
+    id: -1,
+    sId: "test-tool-config",
+    type: "mcp_configuration",
+    name: "test_tool",
+    originalName: "test_tool",
+    mcpServerName: "test_server",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: "test-server-view",
+    dustAppConfiguration: null,
+    internalMCPServerId: null,
+    secretName: null,
+    dustProject: null,
+    availability: "auto",
+    permission: "never_ask",
+    toolServerId: "test-server",
+    retryPolicy: "no_retry",
+  };
+
+  beforeEach(async () => {
+    gcsStore.clear();
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  });
+
+  const createActionWithOutputItems = async (
+    contents: Array<{ type: "text"; text: string }>
+  ) => {
+    const { action } = await ConversationFactory.createAgentMessage(auth, {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction: { toolConfiguration },
+    });
+
+    expect(action).toBeDefined();
+
+    const outputItems = await action!.createOutputItems(
+      auth,
+      contents.map((c) => ({ content: c }))
+    );
+
+    return { action: action!, outputItems };
+  };
+
+  it("should create output items in both DB and GCS", async () => {
+    const { outputItems } = await createActionWithOutputItems([
+      { type: "text", text: "Hello from GCS" },
+    ]);
+
+    expect(outputItems).toHaveLength(1);
+    expect(outputItems[0].content).toEqual({
+      type: "text",
+      text: "Hello from GCS",
+    });
+
+    // contentGcsPath should be set (GCS write succeeded).
+    expect(outputItems[0].contentGcsPath).toBeTruthy();
+
+    // GCS store should have one entry.
+    expect(gcsStore.size).toBe(1);
+  });
+
+  it("should read content from GCS, not from DB", async () => {
+    const { action } = await createActionWithOutputItems([
+      { type: "text", text: "original content" },
+    ]);
+
+    // Overwrite the GCS file with different content to prove the fetch path
+    // reads from GCS (not from the DB, which still has "original content").
+    const [[gcsPath]] = [...gcsStore.entries()];
+    const modified = JSON.stringify({ type: "text", text: "from GCS" });
+    gcsStore.set(gcsPath, Buffer.from(modified, "utf-8"));
+
+    const outputItemsByActionId =
+      await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, [
+        action.id,
+      ]);
+
+    const items = outputItemsByActionId.get(action.id);
+    expect(items).toBeDefined();
+    expect(items).toHaveLength(1);
+
+    // Content should match the GCS version, proving it was read from GCS.
+    expect(items![0].content).toEqual({ type: "text", text: "from GCS" });
+  });
+
+  it("should destroy output items from both DB and GCS", async () => {
+    const { action } = await createActionWithOutputItems([
+      { type: "text", text: "To be deleted" },
+    ]);
+
+    expect(gcsStore.size).toBe(1);
+
+    await AgentMCPActionResource.destroyOutputItemsByActionIds(auth, [
+      action.id,
+    ]);
+
+    // GCS files should be deleted.
+    expect(gcsStore.size).toBe(0);
+
+    // DB rows should be deleted.
+    const remainingItems = await AgentMCPActionOutputItemModel.findAll({
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
+    });
+    expect(remainingItems).toHaveLength(0);
+  });
+
+  it("should handle multiple actions independently", async () => {
+    const { action: action1 } = await createActionWithOutputItems([
+      { type: "text", text: "Action 1 content" },
+    ]);
+
+    // Create a second conversation so the factory can use rank 0 again
+    // (rank is unique per conversation).
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    const { action: action2 } = await createActionWithOutputItems([
+      { type: "text", text: "Action 2 content" },
+    ]);
+
+    expect(gcsStore.size).toBe(2);
+
+    const outputItemsByActionId =
+      await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, [
+        action1.id,
+        action2.id,
+      ]);
+
+    expect(outputItemsByActionId.get(action1.id)).toHaveLength(1);
+    expect(outputItemsByActionId.get(action2.id)).toHaveLength(1);
+
+    // Destroy only action1's items.
+    await AgentMCPActionResource.destroyOutputItemsByActionIds(auth, [
+      action1.id,
+    ]);
+
+    expect(gcsStore.size).toBe(1);
+
+    // action2's items should still be fetchable.
+    const remaining = await AgentMCPActionResource.fetchOutputItemsByActionIds(
+      auth,
+      [action2.id]
+    );
+    const items = remaining.get(action2.id);
+    expect(items).toHaveLength(1);
+    expect(items![0].content).toEqual({
+      type: "text",
+      text: "Action 2 content",
+    });
   });
 });

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -7,6 +7,11 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import {
+  batchFetchContentsFromGcs,
+  batchWriteContentsToGcs,
+  deleteContentsFromGcs,
+} from "@app/lib/resources/agent_mcp_action/output_storage";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
@@ -52,6 +57,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
@@ -67,6 +73,8 @@ import { Op } from "sequelize";
 const OUTPUT_ITEMS_BATCH_SIZE = 32;
 
 const FETCH_OUTPUT_ITEMS_CONCURRENCY = 2;
+
+const CONCURRENCY_UPDATE_OUTPUT_ITEMS = 16;
 
 function getDefaultRemoteDisplayLabels(
   mcpServerName: string,
@@ -621,6 +629,61 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     return actions;
   }
 
+  /**
+   * Creates output items in DB and writes their content to GCS.
+   * Content is also written to DB to ease rollback during the migration period.
+   */
+  async createOutputItems(
+    auth: Authenticator,
+    contents: Array<{
+      content: CallToolResult["content"][number];
+      fileId?: ModelId;
+    }>
+  ): Promise<AgentMCPActionOutputItemModel[]> {
+    const outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
+      contents.map((c) => ({
+        agentMCPActionId: this.id,
+        // Write content to DB (kept during migration period to ease rollback).
+        content: c.content,
+        fileId: c.fileId,
+        workspaceId: this.workspaceId,
+      }))
+    );
+
+    const gcsResult = await batchWriteContentsToGcs(
+      auth,
+      this,
+      outputItems.map((item) => ({
+        itemId: item.id,
+        content: item.content,
+      }))
+    );
+
+    // On GCS failure during migration period, items remain as legacy rows (content read from DB).
+    // Once content column is dropped, this must become a hard error.
+    if (gcsResult.isErr()) {
+      return outputItems;
+    }
+
+    // Update DB rows with their GCS paths.
+    await concurrentExecutor(
+      outputItems,
+      async (item) => {
+        const gcsPath = gcsResult.value.get(item.id);
+        if (gcsPath) {
+          await AgentMCPActionOutputItemModel.update(
+            { contentGcsPath: gcsPath },
+            { where: { id: item.id, workspaceId: this.workspaceId } }
+          );
+          item.contentGcsPath = gcsPath;
+        }
+      },
+      { concurrency: CONCURRENCY_UPDATE_OUTPUT_ITEMS }
+    );
+
+    return outputItems;
+  }
+
   static async fetchOutputItemsByActionIds(
     auth: Authenticator,
     actionIds: ModelId[]
@@ -631,15 +694,76 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     const batches = _.chunk(actionIds, OUTPUT_ITEMS_BATCH_SIZE);
     const batchResults = await concurrentExecutor(
       batches,
-      async (batchActionIds) =>
-        AgentMCPActionOutputItemModel.findAll({
-          where: {
-            workspaceId,
-            agentMCPActionId: {
-              [Op.in]: batchActionIds,
+      async (batchActionIds) => {
+        // Split into two parallel queries:
+        // 1. GCS-backed rows: EXCLUDE content column (avoids TOAST decompression)
+        // 2. Legacy rows: INCLUDE content (old rows without GCS path)
+        const [gcsItems, legacyItems] = await Promise.all([
+          AgentMCPActionOutputItemModel.findAll({
+            attributes: { exclude: ["content"] },
+            where: {
+              workspaceId,
+              agentMCPActionId: { [Op.in]: batchActionIds },
+              contentGcsPath: { [Op.ne]: null },
             },
-          },
-        }),
+          }),
+          AgentMCPActionOutputItemModel.findAll({
+            where: {
+              workspaceId,
+              agentMCPActionId: { [Op.in]: batchActionIds },
+              contentGcsPath: null,
+            },
+          }),
+        ]);
+
+        // Hydrate GCS-backed items from cache/GCS.
+        if (gcsItems.length > 0) {
+          const contentResult = await batchFetchContentsFromGcs(
+            gcsItems.map((item) => ({
+              itemId: item.id,
+              gcsPath: item.contentGcsPath!,
+            }))
+          );
+
+          if (contentResult.isOk()) {
+            for (const item of gcsItems) {
+              const content = contentResult.value.get(item.id);
+              if (content) {
+                item.content = content;
+              }
+            }
+          } else {
+            // TODO(2026-02-25 PERF): Remove this post-migration.
+            // GCS read failed. We re-fetch from DB with content included.
+            // This is a temporary fallback during the migration period while content is still in
+            // DB. Once content column is dropped, this will become a hard error.
+            logger.error(
+              {
+                action: "mcp_output_items",
+                err: contentResult.error,
+                itemCount: gcsItems.length,
+                workspaceId,
+              },
+              "GCS read failed for MCP output items — falling back to DB"
+            );
+            const dbItems = await AgentMCPActionOutputItemModel.findAll({
+              where: {
+                workspaceId,
+                id: { [Op.in]: gcsItems.map((item) => item.id) },
+              },
+            });
+            const dbMap = new Map(dbItems.map((item) => [item.id, item]));
+            for (const item of gcsItems) {
+              const dbItem = dbMap.get(item.id);
+              if (dbItem) {
+                item.content = dbItem.content;
+              }
+            }
+          }
+        }
+
+        return [...gcsItems, ...legacyItems];
+      },
       { concurrency: FETCH_OUTPUT_ITEMS_CONCURRENCY }
     );
 
@@ -657,6 +781,45 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }
 
     return outputItemsByActionId;
+  }
+
+  /**
+   * Destroys output items by action IDs, cleaning up GCS files first.
+   * GCS deletion failures are logged but do not block DB cleanup — orphaned
+   * GCS files can be cleaned up later and don't cause data issues.
+   */
+  static async destroyOutputItemsByActionIds(
+    auth: Authenticator,
+    actionIds: ModelId[]
+  ): Promise<void> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    // Fetch items with GCS paths (only need id + contentGcsPath — no TOAST hit).
+    const gcsItems = await AgentMCPActionOutputItemModel.findAll({
+      attributes: ["id", "contentGcsPath"],
+      where: {
+        workspaceId,
+        agentMCPActionId: { [Op.in]: actionIds },
+        contentGcsPath: { [Op.ne]: null },
+      },
+    });
+
+    // TODO(2026-02-25 PERF): Remove this post-migration.
+    // Delete GCS files. Failures are logged inside deleteContentsFromGcs but do not block DB
+    // cleanup.
+    if (gcsItems.length > 0) {
+      await deleteContentsFromGcs(
+        removeNulls(gcsItems.map((item) => item.contentGcsPath))
+      );
+    }
+
+    // Delete all output items from DB.
+    await AgentMCPActionOutputItemModel.destroy({
+      where: {
+        workspaceId,
+        agentMCPActionId: { [Op.in]: actionIds },
+      },
+    });
   }
 
   static async enrichActionsWithOutputItems(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -7,11 +7,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import {
-  batchFetchContentsFromGcs,
-  batchWriteContentsToGcs,
-  deleteContentsFromGcs,
-} from "@app/lib/resources/agent_mcp_action/output_storage";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
@@ -33,6 +28,11 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import {
+  batchFetchContentsFromGcs,
+  batchWriteContentsToGcs,
+  deleteContentsFromGcs,
+} from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -719,6 +719,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         // Hydrate GCS-backed items from cache/GCS.
         if (gcsItems.length > 0) {
           const contentResult = await batchFetchContentsFromGcs(
+            auth,
             gcsItems.map((item) => ({
               itemId: item.id,
               gcsPath: item.contentGcsPath!,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -666,6 +666,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }
 
     // Update DB rows with their GCS paths.
+    // TODO(2026-02-25 PERF): Optimize by writing items only once.
     await concurrentExecutor(
       outputItems,
       async (item) => {

--- a/front/migrations/db/migration_522.sql
+++ b/front/migrations/db/migration_522.sql
@@ -1,0 +1,3 @@
+-- Migration created on Feb 25, 2026
+ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "contentGcsPath" TEXT;
+CREATE INDEX CONCURRENTLY "agent_mcp_action_output_items_ws_action_gcs_path" ON "agent_mcp_action_output_items" ("workspaceId", "agentMCPActionId", "contentGcsPath");


### PR DESCRIPTION
## Background: how we got here

When Dust migrated agent tool calls to the MCP protocol, we changed how tool outputs are stored. In the old model, each search result chunk was its own small database row. With MCP, the entire output of a tool call can land in a single content `JSONB` column of a single row.
This was fine conceptually, but it created a serious PostgreSQL problem.

## The TOAST problem

PostgreSQL has a mechanism called TOAST (The Oversized-Attribute Storage Technique). When a row exceeds ~2KB (roughly 300 words), PostgreSQL automatically moves the large columns out of the main table into a separate hidden "TOAST table", compresses them, and stores pointers in the main row. Reading those values later means fetching and decompressing the out-of-line chunks. It's extra I/O on every read.

**For context:** 2KB is not a lot. A typical search action returning 10 documents with their content easily produces 500KB+ in a single row. Our `agent_mcp_action_output_items` TOAST table had grown to 157 GB, (in the US) with 252 million accesses tracked over time, of which 15.5 million went to disk (cache miss). The table was the single biggest source of TOAST pressure in the entire database.

A first fix ([PR #22119](https://github.com/dust-tt/dust/pull/22119)) capped the content stored in the content column to 64KB. This helped on the write path, but 64KB still gets TOASTed (2KB is the threshold), and more importantly the read path was unchanged: `batchRenderAgentMessages` was still eagerly fetching the content column for every output item in a conversation, triggering TOAST decompression at scale.

## What we're doing in this PR
We're moving the content of output items to Google Cloud Storage (GCS), keeping only a lightweight pointer (`contentGcsPath`) in the database row. This means new rows will never hit (read) TOAST.

Key design decisions:
- Dual-write during migration: new rows write content to both GCS and the content column in the database. This gives us a safe fallback if anything goes wrong with the GCS path and makes the rollout reversible without a migration.
- Two-query read pattern: instead of a single query that fetches content for all rows (which triggers TOAST even when you don't need the data), we split into two queries:
  - Rows with `contentGcsPath` set -> fetch from GCS (served through a Redis cache)
  - Rows without `contentGcsPath` -> read content from the database (legacy path)
This is the key insight: PostgreSQL only reads TOAST data when you actually access the TOASTed column. By never selecting content for new rows, we avoid the TOAST cost entirely even though the column still exists.
- Redis caching: GCS content is cached per item with a 3-hour TTL. Active conversations stay warm, cold ones pay a ~50ms GCS fetch once and then hit cache.
- Backward compatibility: old rows are untouched. Since most of the conversations are short-lived, old large rows will naturally become cold and stop being read. No backfill needed.
- GCS fallback to DB: if a GCS read fails for any reason, the read path falls back to the content column. Combined with the dual-write, this means zero data loss risk during the transition.

## What comes next
This is step 1 of a longer journey:
- Step 2: Once we've validated GCS in production and are confident in the path, stop writing to the content column for new rows (content = NULL). One-line change on the write path.
Step 3: Evaluate consolidating from the current 1 action → N output items model to 1 action → 1 GCS blob (all items as a JSON array). This would reduce GCS fetches per conversation from N_items to N_actions, which matters when rendering cold conversations. The data to inform this decision (min/max/avg output items per internal MCP server) can be queried once this PR is in production.

## What this PR does NOT change
- The >400KB flow: when a tool output exceeds 400KB, Dust creates a FileResource so the LLM can interact with it via tools (cat, search, etc.). This flow is orthogonal and unchanged. It's about LLM agent interaction, not database storage.
- The public API and rendering contracts: callers of `fetchOutputItemsByActionIds` see the same data shape, the GCS/DB split is fully internal.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply SQL migration
- [ ] Deploy `front`
