### PR TITLE
[front] fix: remove auto save pattern on Gong permissions modal

### DIFF
--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -74,6 +74,7 @@ function PermissionProfileSelector({
 }: PermissionProfileSelectorProps) {
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
+  const [localProfileId, setLocalProfileId] = useState<string | null>(null);
 
   const {
     configValue: permissionProfileIdConfigValue,
@@ -105,17 +106,25 @@ function PermissionProfileSelector({
     }
   }, [permissionProfilesConfigValue]);
 
-  const selectedProfile = useMemo(() => {
-    if (!permissionProfileIdConfigValue) {
+  // The saved profile ID from the server, "" means "all participants".
+  const savedProfileId = permissionProfileIdConfigValue ?? "";
+  // The currently displayed profile ID (local override or saved value).
+  const displayedProfileId = localProfileId ?? savedProfileId;
+  const hasUnsavedChanges = localProfileId !== null;
+
+  const displayedProfile = useMemo(() => {
+    if (!displayedProfileId) {
       return null;
     }
     return (
-      permissionProfiles.find((p) => p.id === permissionProfileIdConfigValue) ??
-      null
+      permissionProfiles.find((p) => p.id === displayedProfileId) ?? null
     );
-  }, [permissionProfileIdConfigValue, permissionProfiles]);
+  }, [displayedProfileId, permissionProfiles]);
 
-  const handleSelect = async (profileId: string) => {
+  const handleSave = async () => {
+    if (localProfileId === null) {
+      return;
+    }
     setLoading(true);
     // The config API only accepts strings, so "" means "no filter" (normalized
     // to null on the connector side).
@@ -124,11 +133,12 @@ function PermissionProfileSelector({
       {
         headers: { "Content-Type": "application/json" },
         method: "POST",
-        body: JSON.stringify({ configValue: profileId }),
+        body: JSON.stringify({ configValue: localProfileId }),
       }
     );
     if (res.ok) {
       await mutatePermissionProfileIdConfig();
+      setLocalProfileId(null);
       sendNotification({
         type: "success",
         title: "Gong configuration updated",
@@ -150,53 +160,64 @@ function PermissionProfileSelector({
       title="Participant Filter"
       visual={<ContextItem.Visual visual={GongLogo} />}
       action={
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              label={
-                selectedProfile
-                  ? selectedProfile.name.length > PROFILE_NAME_MAX_LENGTH
-                    ? selectedProfile.name.slice(0, PROFILE_NAME_MAX_LENGTH) +
-                      "..."
-                    : selectedProfile.name
-                  : "All participants"
-              }
-              isSelect
-              disabled={disabled || loading}
-              tooltip={selectedProfile?.name}
-              className="w-40 overflow-hidden px-4"
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            <DropdownMenuItem
-              label="All participants"
-              onClick={() => handleSelect("")}
-            />
-            {permissionProfiles.map((profile) => {
-              const item = (
-                <DropdownMenuItem
-                  key={profile.id}
-                  label={profile.name}
-                  disabled={!profile.supported}
-                  onClick={() => handleSelect(profile.id)}
-                />
-              );
-              if (profile.reason) {
-                return (
-                  <DropdownTooltipTrigger
+        <div className="flex flex-row space-x-3">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                label={
+                  displayedProfile
+                    ? displayedProfile.name.length > PROFILE_NAME_MAX_LENGTH
+                      ? displayedProfile.name.slice(
+                          0,
+                          PROFILE_NAME_MAX_LENGTH
+                        ) + "..."
+                      : displayedProfile.name
+                    : "All participants"
+                }
+                isSelect
+                disabled={disabled || loading}
+                tooltip={displayedProfile?.name}
+                className="w-40 overflow-hidden px-4"
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem
+                label="All participants"
+                onClick={() => setLocalProfileId("")}
+              />
+              {permissionProfiles.map((profile) => {
+                const item = (
+                  <DropdownMenuItem
                     key={profile.id}
-                    description={profile.reason}
-                  >
-                    {item}
-                  </DropdownTooltipTrigger>
+                    label={profile.name}
+                    disabled={!profile.supported}
+                    onClick={() => setLocalProfileId(profile.id)}
+                  />
                 );
-              }
-              return item;
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+                if (profile.reason) {
+                  return (
+                    <DropdownTooltipTrigger
+                      key={profile.id}
+                      description={profile.reason}
+                    >
+                      {item}
+                    </DropdownTooltipTrigger>
+                  );
+                }
+                return item;
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSave}
+            disabled={disabled || loading || !hasUnsavedChanges}
+            label="Save"
+          />
+        </div>
       }
     >
       <ContextItem.Description>

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -216,7 +216,7 @@ function PermissionProfileSelector({
             size="sm"
             onClick={handleSave}
             disabled={disabled || loading || !hasUnsavedChanges}
-            label="Save"
+            label={loading ? "Saving..." : "Save"}
           />
         </div>
       }

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -275,14 +275,12 @@ export function GongOptionComponent({
   const accountsEnabled = accountsConfigValue === "true";
 
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    retentionPeriodConfigValue || ""
+    retentionPeriodConfigValue ?? ""
   );
 
   const [loading, setLoading] = useState(false);
   const sendNotification = useSendNotification();
 
-  // TODO: fix the auto-save pattern here and replace with an actual save on the sheet.
   const handleConfigUpdate = async (configKey: string, newValue: string) => {
     // Validate that the value is either empty or a positive integer
     if (

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -74,7 +74,6 @@ function PermissionProfileSelector({
 }: PermissionProfileSelectorProps) {
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
-  const [localProfileId, setLocalProfileId] = useState("");
 
   const {
     configValue: permissionProfileIdConfigValue,
@@ -90,13 +89,13 @@ function PermissionProfileSelector({
     dataSource,
     configKey: GONG_PERMISSION_PROFILES_CONFIG_KEY,
   });
-
-  // The saved profile ID from the server, "" means "all participants".
-  const savedProfileId = permissionProfileIdConfigValue ?? "";
+  const [localProfileId, setLocalProfileId] = useState(
+    permissionProfileIdConfigValue ?? ""
+  );
 
   useEffect(() => {
-    setLocalProfileId(savedProfileId);
-  }, [savedProfileId]);
+    setLocalProfileId(permissionProfileIdConfigValue ?? "");
+  }, [permissionProfileIdConfigValue]);
 
   const permissionProfiles = useMemo<GongPermissionProfile[]>(() => {
     if (!permissionProfilesConfigValue) {
@@ -113,7 +112,9 @@ function PermissionProfileSelector({
     }
   }, [permissionProfilesConfigValue]);
 
-  const hasUnsavedChanges = localProfileId !== savedProfileId;
+  const hasUnsavedChanges =
+    permissionProfileIdConfigValue !== undefined &&
+    localProfileId !== permissionProfileIdConfigValue;
 
   const displayedProfile = useMemo(() => {
     if (!localProfileId) {

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -110,7 +110,8 @@ function PermissionProfileSelector({
   const savedProfileId = permissionProfileIdConfigValue ?? "";
   // The currently displayed profile ID (local override or saved value).
   const displayedProfileId = localProfileId ?? savedProfileId;
-  const hasUnsavedChanges = localProfileId !== null;
+  const hasUnsavedChanges =
+    localProfileId !== null && localProfileId !== savedProfileId;
 
   const displayedProfile = useMemo(() => {
     if (!displayedProfileId) {

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -119,9 +119,7 @@ function PermissionProfileSelector({
     if (!localProfileId) {
       return null;
     }
-    return (
-      permissionProfiles.find((p) => p.id === localProfileId) ?? null
-    );
+    return permissionProfiles.find((p) => p.id === localProfileId) ?? null;
   }, [localProfileId, permissionProfiles]);
 
   const handleSave = async () => {

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -18,7 +18,7 @@ import {
   Input,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 // TODO(2025-03-17): share these variables between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
@@ -74,7 +74,7 @@ function PermissionProfileSelector({
 }: PermissionProfileSelectorProps) {
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
-  const [localProfileId, setLocalProfileId] = useState<string | null>(null);
+  const [localProfileId, setLocalProfileId] = useState("");
 
   const {
     configValue: permissionProfileIdConfigValue,
@@ -91,6 +91,13 @@ function PermissionProfileSelector({
     configKey: GONG_PERMISSION_PROFILES_CONFIG_KEY,
   });
 
+  // The saved profile ID from the server, "" means "all participants".
+  const savedProfileId = permissionProfileIdConfigValue ?? "";
+
+  useEffect(() => {
+    setLocalProfileId(savedProfileId);
+  }, [savedProfileId]);
+
   const permissionProfiles = useMemo<GongPermissionProfile[]>(() => {
     if (!permissionProfilesConfigValue) {
       return [];
@@ -106,26 +113,18 @@ function PermissionProfileSelector({
     }
   }, [permissionProfilesConfigValue]);
 
-  // The saved profile ID from the server, "" means "all participants".
-  const savedProfileId = permissionProfileIdConfigValue ?? "";
-  // The currently displayed profile ID (local override or saved value).
-  const displayedProfileId = localProfileId ?? savedProfileId;
-  const hasUnsavedChanges =
-    localProfileId !== null && localProfileId !== savedProfileId;
+  const hasUnsavedChanges = localProfileId !== savedProfileId;
 
   const displayedProfile = useMemo(() => {
-    if (!displayedProfileId) {
+    if (!localProfileId) {
       return null;
     }
     return (
-      permissionProfiles.find((p) => p.id === displayedProfileId) ?? null
+      permissionProfiles.find((p) => p.id === localProfileId) ?? null
     );
-  }, [displayedProfileId, permissionProfiles]);
+  }, [localProfileId, permissionProfiles]);
 
   const handleSave = async () => {
-    if (localProfileId === null) {
-      return;
-    }
     setLoading(true);
     // The config API only accepts strings, so "" means "no filter" (normalized
     // to null on the connector side).
@@ -139,7 +138,6 @@ function PermissionProfileSelector({
     );
     if (res.ok) {
       await mutatePermissionProfileIdConfig();
-      setLocalProfileId(null);
       sendNotification({
         type: "success",
         title: "Gong configuration updated",


### PR DESCRIPTION
## Description

- This PR removes the auto-save pattern we currently have on the Gong option component for selecting a permission profiles.
- Replaces it with a Save button for a more consistent UX pattern.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
