### PR TITLE
fix: do not send notification for test conversations

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -100,6 +101,19 @@ const triggerProjectNewConversationNotifications = async (
   // Wait before triggering the notification. This is useful to ensure that
   // the conversation has a title and its participants are fully created.
   await new Promise((resolve) => setTimeout(resolve, NOTIFICATION_DELAY_MS));
+
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId,
+    {
+      excludeTest: true,
+    }
+  );
+
+  // Conversation was deleted within the delay or conversation has visibility test
+  if (!conversationResource) {
+    return new Ok(undefined);
+  }
 
   // Fetch all members of the project
   const space = await SpaceResource.fetchById(auth, conversation.spaceId);


### PR DESCRIPTION
## Description
This PR makes sure that the notification for new conversation in projects is not sent for conversations deleted or with visibility test.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually.
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
