### PR TITLE
fix: remove frontapp specific instructions

### DIFF
--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -282,14 +282,7 @@ export const FRONT_SERVER = {
     documentationUrl: "https://dev.frontapp.com/reference/introduction",
     // Predates the introduction of the rule, would require extensive work to
     // improve, already widely adopted.
-    instructions:
-      // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
-      "When handling support tickets:\n" +
-      "- Always check customer history before replying using get_customer_history\n" +
-      "- Auto-tag conversations based on issue type (bug, feature-request, billing)\n" +
-      "- Assign to teammate 'ilias' if T1 cannot resolve after three attempts\n" +
-      "- Use LLM-friendly timeline format for conversation data\n" +
-      "- Include full context (metadata, custom fields) in responses",
+    instructions: null,
   },
   tools: Object.values(FRONT_TOOLS_METADATA).map((t) => ({
     name: t.name,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Remove Dust specific instructions from the front app server.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front