### PR TITLE
Exclude tracked key words for titles in Gong transcript syncs

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -430,18 +430,11 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
           .map((k) => k.trim())
           .filter((k) => k.length > 0);
 
-        // Validation
-        if (keywords.some((k) => k.length > 100)) {
-          return new Err(new Error("Keywords must be 100 characters or less"));
+        // Validation and storage handled by resource
+        const result = await configuration.setExcludeTitleKeywords(keywords);
+        if (result.isErr()) {
+          return result;
         }
-        if (keywords.length > 50) {
-          return new Err(new Error("Maximum 50 keywords allowed"));
-        }
-
-        // Store (setter will normalize to lowercase)
-        await configuration.setExcludeTitleKeywords(
-          keywords.length > 0 ? keywords : null
-        );
 
         logger.info(
           { connectorId: connector.id, keywords },

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -51,6 +51,8 @@ const PERMISSION_PROFILE_ID_CONFIG_KEY = "gongPermissionProfileId";
 
 const PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
 
+const EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY = "gongExcludeTitleKeywords";
+
 // This function generates a connector-wise unique schedule ID for the Gong sync.
 // The IDs of the workflows spawned by this schedule will follow the pattern:
 //   gong-sync-${connectorId}-workflow-${isoFormatDate}
@@ -345,6 +347,10 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
         const views = await fetchPermissionProfileViews(connector);
         return new Ok(JSON.stringify(views));
       }
+      case EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY: {
+        const keywords = configuration.excludeTitleKeywords;
+        return new Ok(keywords ? keywords.join(",") : null);
+      }
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
@@ -414,6 +420,33 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
           "[Gong] Update permission profile."
         );
         await configuration.setPermissionProfileId(profileId);
+
+        return new Ok(undefined);
+      }
+      case EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY: {
+        // Parse comma-separated string
+        const keywords = configValue
+          .split(",")
+          .map((k) => k.trim())
+          .filter((k) => k.length > 0);
+
+        // Validation
+        if (keywords.some((k) => k.length > 100)) {
+          return new Err(new Error("Keywords must be 100 characters or less"));
+        }
+        if (keywords.length > 50) {
+          return new Err(new Error("Maximum 50 keywords allowed"));
+        }
+
+        // Store (setter will normalize to lowercase)
+        await configuration.setExcludeTitleKeywords(
+          keywords.length > 0 ? keywords : null
+        );
+
+        logger.info(
+          { connectorId: connector.id, keywords },
+          "[Gong] Updated exclude title keywords"
+        );
 
         return new Ok(undefined);
       }

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -69,12 +69,36 @@ async function resolvePermissionProfile(
  * Excludes private calls. When a permission profile is configured, only syncs
  * calls where at least one participant belongs to the profile's user list.
  */
+function shouldExcludeByTitle(
+  title: string | undefined,
+  excludeKeywords: string[] | null
+): boolean {
+  if (!excludeKeywords || excludeKeywords.length === 0) {
+    return false;
+  }
+  if (!title) {
+    return false;
+  }
+
+  const lowerTitle = title.toLowerCase();
+  return excludeKeywords.some((kw) => lowerTitle.includes(kw));
+  // Note: keywords are already stored lowercase from the resource setter
+}
+
 function shouldSyncTranscript(
   metadata: GongTranscriptMetadata,
-  filter: PermissionProfileFilter
+  filter: PermissionProfileFilter,
+  excludeKeywords: string[] | null
 ): { shouldSync: false; reason: string } | { shouldSync: true; reason: null } {
   if (metadata.metaData.isPrivate) {
     return { shouldSync: false, reason: "transcript is private" };
+  }
+
+  if (shouldExcludeByTitle(metadata.metaData.title, excludeKeywords)) {
+    return {
+      shouldSync: false,
+      reason: "title contains excluded keyword",
+    };
   }
 
   if (filter.type === "unrestricted") {
@@ -168,6 +192,7 @@ export async function gongSyncTranscriptsActivity({
 }) {
   const connector = await fetchGongConnector({ connectorId });
   const configuration = await fetchGongConfiguration(connector);
+  const { excludeTitleKeywords } = configuration;
   const loggerArgs = {
     connectorId: connector.id,
     dataSourceId: connector.dataSourceId,
@@ -279,7 +304,8 @@ export async function gongSyncTranscriptsActivity({
 
       const { shouldSync, reason } = shouldSyncTranscript(
         transcriptMetadata,
-        permissionFilter
+        permissionFilter,
+        excludeTitleKeywords
       );
       if (!shouldSync) {
         logger.info(

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -65,9 +65,7 @@ async function resolvePermissionProfile(
 }
 
 /**
- * Determines whether a transcript should be synced.
- * Excludes private calls. When a permission profile is configured, only syncs
- * calls where at least one participant belongs to the profile's user list.
+ * Checks if a transcript title contains any excluded keywords.
  */
 function shouldExcludeByTitle(
   title: string | undefined,
@@ -85,16 +83,23 @@ function shouldExcludeByTitle(
   // Note: keywords are already stored lowercase from the resource setter
 }
 
+/**
+ * Determines whether a transcript should be synced.
+ * Excludes private calls. When a permission profile is configured, only syncs
+ * calls where at least one participant belongs to the profile's user list.
+ */
 function shouldSyncTranscript(
   metadata: GongTranscriptMetadata,
   filter: PermissionProfileFilter,
-  excludeKeywords: string[] | null
+  configuration: GongConfigurationResource
 ): { shouldSync: false; reason: string } | { shouldSync: true; reason: null } {
+  const { excludeTitleKeywords } = configuration;
+
   if (metadata.metaData.isPrivate) {
     return { shouldSync: false, reason: "transcript is private" };
   }
 
-  if (shouldExcludeByTitle(metadata.metaData.title, excludeKeywords)) {
+  if (shouldExcludeByTitle(metadata.metaData.title, excludeTitleKeywords)) {
     return {
       shouldSync: false,
       reason: "title contains excluded keyword",
@@ -192,7 +197,6 @@ export async function gongSyncTranscriptsActivity({
 }) {
   const connector = await fetchGongConnector({ connectorId });
   const configuration = await fetchGongConfiguration(connector);
-  const { excludeTitleKeywords } = configuration;
   const loggerArgs = {
     connectorId: connector.id,
     dataSourceId: connector.dataSourceId,
@@ -305,7 +309,7 @@ export async function gongSyncTranscriptsActivity({
       const { shouldSync, reason } = shouldSyncTranscript(
         transcriptMetadata,
         permissionFilter,
-        excludeTitleKeywords
+        configuration
       );
       if (!shouldSync) {
         logger.info(

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -143,6 +143,14 @@ export class GongConfigurationResource extends BaseResource<GongConfigurationMod
     });
   }
 
+  async setExcludeTitleKeywords(keywords: string[] | null): Promise<void> {
+    // Normalize to lowercase when storing
+    const normalizedKeywords = keywords?.map((k) => k.toLowerCase()) || null;
+    await this.update({
+      excludeTitleKeywords: normalizedKeywords,
+    });
+  }
+
   /**
    * Returns the timestamp to start syncing from.
    * Offsets the last sync timestamp by an upper bound on the transcript processing time to make sure we do not miss

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -31,6 +31,9 @@ const GC_FREQUENCY_MS = daysToMs(1); // Every day.
 // We use 3 hours as a semi-arbitrary upper bound for the delay.
 const TRANSCRIPT_DELAY_TIME_UPPER_BOUND_MS = hoursToMs(3);
 
+export const MAX_EXCLUDE_KEYWORDS = 50;
+export const MAX_EXCLUDE_KEYWORD_LENGTH = 100;
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
@@ -143,12 +146,31 @@ export class GongConfigurationResource extends BaseResource<GongConfigurationMod
     });
   }
 
-  async setExcludeTitleKeywords(keywords: string[] | null): Promise<void> {
+  async setExcludeTitleKeywords(
+    keywords: string[]
+  ): Promise<Result<void, Error>> {
+    // Validation
+    if (keywords.some((k) => k.length > MAX_EXCLUDE_KEYWORD_LENGTH)) {
+      return new Err(
+        new Error(
+          `Keywords must be ${MAX_EXCLUDE_KEYWORD_LENGTH} characters or less`
+        )
+      );
+    }
+    if (keywords.length > MAX_EXCLUDE_KEYWORDS) {
+      return new Err(
+        new Error(`Maximum ${MAX_EXCLUDE_KEYWORDS} keywords allowed`)
+      );
+    }
+
     // Normalize to lowercase when storing
-    const normalizedKeywords = keywords?.map((k) => k.toLowerCase()) || null;
+    const normalizedKeywords =
+      keywords.length > 0 ? keywords.map((k) => k.toLowerCase()) : null;
     await this.update({
       excludeTitleKeywords: normalizedKeywords,
     });
+
+    return new Ok(undefined);
   }
 
   /**


### PR DESCRIPTION
## Description
This PR adds connectors functionality needed to store exclude keywords for the gong connector and skip titles that contain these keywords
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy connectors

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
