### PR TITLE
Allow user to track key words for exclusion in Gong transcript syncs

### DIFF
--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -26,6 +26,7 @@ const GONG_TRACKERS_CONFIG_KEY = "gongTrackersEnabled";
 const GONG_ACCOUNTS_CONFIG_KEY = "gongAccountsEnabled";
 const GONG_PERMISSION_PROFILE_ID_CONFIG_KEY = "gongPermissionProfileId";
 const GONG_PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
+const GONG_EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY = "gongExcludeTitleKeywords";
 
 const PROFILE_NAME_MAX_LENGTH = 15;
 
@@ -252,9 +253,23 @@ export function GongOptionComponent({
   });
   const accountsEnabled = accountsConfigValue === "true";
 
+  const {
+    configValue: excludeKeywordsConfigValue,
+    mutateConfig: mutateExcludeKeywords,
+  } = useConnectorConfig({
+    owner,
+    dataSource,
+    configKey: GONG_EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY,
+  });
+
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     retentionPeriodConfigValue || ""
+  );
+
+  const [excludeKeywords, setExcludeKeywords] = useState<string>(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    excludeKeywordsConfigValue || ""
   );
 
   const [loading, setLoading] = useState(false);
@@ -335,6 +350,45 @@ export function GongOptionComponent({
           dataSource={dataSource}
           disabled={readOnly || !isAdmin || loading}
         />
+
+        <ContextItem
+          title="Exclude calls by title keywords"
+          visual={<ContextItem.Visual visual={GongLogo} />}
+          action={
+            <div className="flex flex-row space-x-3 pt-6">
+              <Input
+                name="excludeTitleKeywords"
+                placeholder="e.g. internal, test, demo"
+                value={excludeKeywords}
+                onChange={(e) => setExcludeKeywords(e.target.value)}
+                disabled={readOnly || !isAdmin || loading}
+                className="w-64"
+              />
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={async () => {
+                  await handleConfigUpdate(
+                    GONG_EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY,
+                    excludeKeywords
+                  );
+                  await mutateExcludeKeywords();
+                }}
+                disabled={readOnly || !isAdmin || loading}
+                label="Save"
+              />
+            </div>
+          }
+        >
+          <ContextItem.Description>
+            <div className="text-muted-foreground dark:text-muted-foreground-night">
+              Comma-separated keywords. Calls whose title contains any of these
+              terms (case-insensitive) will be excluded from sync.
+              <br />
+              Only applies to newly synced transcripts.
+            </div>
+          </ContextItem.Description>
+        </ContextItem>
 
         <ContextItem
           title="Retention Period"

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -18,7 +18,7 @@ import {
   Input,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 // TODO(2025-03-17): share these variables between connectors and front.
 const GONG_RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
@@ -268,9 +268,15 @@ export function GongOptionComponent({
   );
 
   const [excludeKeywords, setExcludeKeywords] = useState<string>(
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    excludeKeywordsConfigValue || ""
+    excludeKeywordsConfigValue ?? ""
   );
+
+  // Sync state when config value loads/changes
+  useEffect(() => {
+    if (excludeKeywordsConfigValue !== undefined) {
+      setExcludeKeywords(excludeKeywordsConfigValue ?? "");
+    }
+  }, [excludeKeywordsConfigValue]);
 
   const [loading, setLoading] = useState(false);
   const sendNotification = useSendNotification();

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -397,8 +397,9 @@ export function GongOptionComponent({
               (case-insensitive, comma-separated).
               <br />
               Max {MAX_EXCLUDE_KEYWORDS} keywords of{" "}
-              {MAX_EXCLUDE_KEYWORD_LENGTH} characters each. Applies to new syncs
-              only.
+              {MAX_EXCLUDE_KEYWORD_LENGTH} characters each.
+              <br />
+              Only applies to newly synced transcripts.
             </div>
           </ContextItem.Description>
         </ContextItem>

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -29,6 +29,8 @@ const GONG_PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
 const GONG_EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY = "gongExcludeTitleKeywords";
 
 const PROFILE_NAME_MAX_LENGTH = 15;
+const MAX_EXCLUDE_KEYWORDS = 50;
+const MAX_EXCLUDE_KEYWORD_LENGTH = 100;
 
 interface GongPermissionProfile {
   id: string;
@@ -322,6 +324,10 @@ export function GongOptionComponent({
           await mutateAccountsConfig();
           description = "Accounts synchronization successfully updated.";
           break;
+        case GONG_EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY:
+          await mutateExcludeKeywords();
+          description = "Exclude keywords successfully updated.";
+          break;
         default:
           description = "Configuration successfully updated.";
       }
@@ -378,7 +384,6 @@ export function GongOptionComponent({
                     GONG_EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY,
                     excludeKeywords
                   );
-                  await mutateExcludeKeywords();
                 }}
                 disabled={readOnly || !isAdmin || loading}
                 label="Save"
@@ -388,10 +393,12 @@ export function GongOptionComponent({
         >
           <ContextItem.Description>
             <div className="text-muted-foreground dark:text-muted-foreground-night">
-              Comma-separated keywords. Calls whose title contains any of these
-              terms (case-insensitive) will be excluded from sync.
+              Exclude calls whose title contains these keywords
+              (case-insensitive, comma-separated).
               <br />
-              Only applies to newly synced transcripts.
+              Max {MAX_EXCLUDE_KEYWORDS} keywords of{" "}
+              {MAX_EXCLUDE_KEYWORD_LENGTH} characters each. Applies to new syncs
+              only.
             </div>
           </ContextItem.Description>
         </ContextItem>

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -95,6 +95,7 @@ async function handler(
       "gongAccountsEnabled",
       "gongPermissionProfileId",
       "gongPermissionProfiles",
+      "gongExcludeTitleKeywords",
       "privateIntegrationCredentialId",
     ].includes(configKey)
   ) {


### PR DESCRIPTION
## Description
Allow user to track key words for exclusion in Gong transcript syncs
<img width="743" height="152" alt="Screenshot 2026-02-25 at 9 55 26 AM" src="https://github.com/user-attachments/assets/0d9f273f-b912-4c58-be06-623ecd5c281d" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually, currently works for syncs that start after the key words are updated only

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
After deploy of https://github.com/dust-tt/dust/pull/22285/changes,
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
