### PR TITLE
Fix slow conversation list queries by using JOIN instead of IN clause

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -103,6 +103,11 @@ ConversationModel.init(
         fields: ["workspaceId", "createdAt"],
         name: "conversations_workspace_id_created_at_idx",
       },
+      {
+        fields: ["workspaceId", "updatedAt"],
+        name: "conversations_workspace_id_updated_at_idx",
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -35,6 +35,9 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   // Note: Using spaceId for the FK instead of vaultId as it is not a "ResourceWithSpace" and it's aligned with "requestedSpaceIds".
   declare spaceId: ForeignKey<SpaceModel["id"]> | null;
   declare space: NonAttribute<SpaceModel>;
+  declare conversation_participants: NonAttribute<
+    ConversationParticipantModel[]
+  >;
 }
 
 ConversationModel.init(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -67,7 +67,9 @@ interface UserParticipation {
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationResource
-  extends ReadonlyAttributesType<ConversationModel> {}
+  extends ReadonlyAttributesType<ConversationModel> {
+  conversation_participants?: ConversationParticipantModel[];
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ConversationResource extends BaseResource<ConversationModel> {
@@ -803,7 +805,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const pageConversationIds = resultConversations.map((c) => c.id);
     const readMap = await this.fetchReadMapForUser(auth, pageConversationIds);
 
-    // Build participation data from included result + reads
+    // Build participation data from included result + reads.
     resultConversations.forEach((c) => {
       const participation = c.conversation_participants?.[0];
       if (participation) {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -191,6 +191,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         ...options.where,
         workspaceId: workspace.id,
       },
+      include: options.includes,
       limit: options.limit,
       order: options.order,
     });
@@ -745,23 +746,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     hasMore: boolean;
     lastValue: string | null;
   }> {
-    const emptyResult = {
-      conversations: [],
-      hasMore: false,
-      lastValue: null,
-    };
+    const user = auth.user();
+    assert(user, "User is expected to be authenticated");
 
-    const participationMap = await this.fetchParticipationMapForUser(auth);
-    const conversationIds = Array.from(participationMap.keys());
-
-    if (conversationIds.length === 0) {
-      return emptyResult;
-    }
-
+    const workspace = auth.getNonNullableWorkspace();
     const orderDirection = pagination.orderDirection ?? "desc";
 
     const whereClause: WhereOptions<InferAttributes<ConversationModel>> = {
-      id: { [Op.in]: conversationIds },
       spaceId: { [Op.is]: null },
       visibility: { [Op.eq]: "unlisted" },
       ...extraWhereClause,
@@ -784,6 +775,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       {},
       {
         where: whereClause,
+        includes: [
+          {
+            model: ConversationParticipantModel,
+            as: "conversation_participants",
+            where: {
+              userId: user.id,
+              workspaceId: workspace.id,
+            },
+            required: true, // INNER JOIN
+          },
+        ],
         order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
         limit: fetchLimit,
       }
@@ -797,10 +799,19 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       resultConversations = conversations.slice(0, pagination.limit);
     }
 
+    // Fetch read data only for page results (not all conversations).
+    const pageConversationIds = resultConversations.map((c) => c.id);
+    const readMap = await this.fetchReadMapForUser(auth, pageConversationIds);
+
+    // Build participation data from included result + reads
     resultConversations.forEach((c) => {
-      const participation = participationMap.get(c.id);
+      const participation = (c as any).conversation_participants?.[0];
       if (participation) {
-        c.userParticipation = participation;
+        c.userParticipation = {
+          actionRequired: participation.actionRequired,
+          lastReadAt: readMap.get(c.id) ?? null,
+          updated: participation.updatedAt.getTime(),
+        };
       }
     });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -288,9 +288,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator,
     conversationIds?: number[]
   ): Promise<Map<number, UserParticipation>> {
-    const user = auth.user();
-
-    assert(user, "User is expected to be authenticated");
+    const user = auth.getNonNullableUser();
 
     const whereClause: WhereOptions<ConversationParticipantModel> = {
       userId: user.id,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -783,7 +783,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
               userId: user.id,
               workspaceId: workspace.id,
             },
-            required: true, // INNER JOIN
+            required: true,
           },
         ],
         order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
@@ -805,7 +805,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // Build participation data from included result + reads
     resultConversations.forEach((c) => {
-      const participation = (c as any).conversation_participants?.[0];
+      const participation = c.conversation_participants?.[0];
       if (participation) {
         c.userParticipation = {
           actionRequired: participation.actionRequired,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -68,6 +68,7 @@ interface UserParticipation {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationResource
   extends ReadonlyAttributesType<ConversationModel> {
+  // Field name needs to match the included model alias in fetch queries for proper typing.
   conversation_participants?: ConversationParticipantModel[];
 }
 

--- a/front/migrations/db/migration_523.sql
+++ b/front/migrations/db/migration_523.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 25, 2026
+CREATE INDEX CONCURRENTLY "conversations_workspace_id_updated_at_idx" ON "conversations" ("workspaceId", "updatedAt");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The private API `GET /api/w/{wId}/assistant/conversations` generates slow queries with 300+ IDs in a `WHERE IN` clause. The method `fetchPrivateConversationsPaginated` was loading ALL participations into memory, collecting ALL conversation IDs, then passing them all in `WHERE id IN (...)`. This approach:
- Struggles with large IN clauses (query planner inefficiency)
- Loads unnecessary data into application memory
- Forces application-level sorting instead of database-level

This PR replaces the two-step approach with a SQL JOIN via Sequelize `include`:
- Use INNER JOIN on `ConversationParticipantModel` with `required: true`
- Filter at join time by `userId` and `workspaceId`
- Paginate at database level with proper `updatedAt` ordering
- Fetch read data only for page results (not all conversations)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply SQL migration
- [ ] Deploy front