### PR TITLE
Save correctly the message origin

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -90,7 +90,10 @@ const shouldDisableContextMenuForDomain = async (
   try {
     const res = await fetch(
       `${regionInfo.url}/api/w/${selectedWorkspace}/extension/config`,
-      { headers: { Authorization: `Bearer ${token}` } }
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        credentials: "omit", // Ensure cookies are not sent with requests from the extension
+      }
     );
     if (!res.ok) {
       return false;

--- a/extension/shared/lib/ExtensionFetcherProvider.tsx
+++ b/extension/shared/lib/ExtensionFetcherProvider.tsx
@@ -25,6 +25,7 @@ export function ExtensionFetcherProvider({
       const res = await clientFetch(url, {
         ...init,
         headers: addAuthHeaders(init?.headers),
+        credentials: "omit", // Ensure cookies are not sent with requests from the extension
       });
       return resHandler(res);
     };
@@ -41,6 +42,7 @@ export function ExtensionFetcherProvider({
           "Content-Type": "application/json",
         }),
         body: JSON.stringify(body),
+        credentials: "omit", // Ensure cookies are not sent with requests from the extension
       });
       return resHandler(res);
     };

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -123,6 +123,7 @@ export const useAuthHook = ({
       try {
         const res = await fetch(`${dustDomain}/api/v1/me`, {
           headers: { Authorization: `Bearer ${tokens.accessToken}` },
+          credentials: "omit", // Ensure cookies are not sent with requests from the extension
         });
         if (res.ok) {
           const data = await res.json();
@@ -191,7 +192,10 @@ export const useAuthHook = ({
     void (async () => {
       const res = await fetch(
         `${dustDomain}/api/w/${workspace.sId}/feature-flags`,
-        { headers: { Authorization: `Bearer ${tokens.accessToken}` } }
+        {
+          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+          credentials: "omit", // Ensure cookies are not sent with requests from the extension
+        }
       );
       if (res.ok) {
         const { feature_flags } = await res.json();

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -152,7 +152,7 @@ export const MainPage = () => {
             >
               <NoOpConversationSidePanelProvider>
                 <GenerationContextProvider>
-                  <InputBarProvider>
+                  <InputBarProvider origin="extension">
                     <ConversationContainerVirtuoso
                       owner={workspace}
                       user={user}

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -1,9 +1,11 @@
+import type { ClientMessageOrigin } from "@app/types/assistant/conversation";
 import type { RichAgentMention } from "@app/types/assistant/mentions";
 import { createContext, useCallback, useState } from "react";
 
 export const InputBarContext = createContext<{
   animate: boolean;
   getAndClearSelectedAgent: () => RichAgentMention | null;
+  origin: ClientMessageOrigin;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
 }>({
@@ -11,9 +13,16 @@ export const InputBarContext = createContext<{
   getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
+  origin: "web",
 });
 
-export function InputBarProvider({ children }: { children: React.ReactNode }) {
+export function InputBarProvider({
+  children,
+  origin,
+}: {
+  children: React.ReactNode;
+  origin: ClientMessageOrigin;
+}) {
   const [animate, setAnimate] = useState<boolean>(false);
 
   // Useful when a component needs to set the selected agent for the input bar but do not have direct access to the input bar.
@@ -46,6 +55,7 @@ export function InputBarProvider({ children }: { children: React.ReactNode }) {
     <InputBarContext.Provider
       value={{
         animate,
+        origin,
         setAnimate,
         getAndClearSelectedAgent,
         setSelectedAgent: setSelectedAgentOuter,

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -133,7 +133,7 @@ export default function AppRootLayout({
   return (
     <WelcomeTourGuideProvider>
       <DesktopNavigationProvider>
-        <InputBarProvider>
+        <InputBarProvider origin="web">
           <Head>
             <link rel="icon" type="image/png" href={faviconPath} />
 

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,3 +1,4 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useFetcher } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type {
@@ -6,6 +7,7 @@ import type {
 } from "@app/types/api/internal/assistant";
 import { isSupportedContentNodeFragmentContentType } from "@app/types/api/internal/assistant";
 import type {
+  ClientMessageOrigin,
   ConversationMetadata,
   ConversationType,
   ConversationVisibility,
@@ -18,7 +20,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import type * as t from "io-ts";
-import { useCallback } from "react";
+import { useCallback, useContext } from "react";
 
 export function useCreateConversationWithMessage({
   owner,
@@ -28,6 +30,7 @@ export function useCreateConversationWithMessage({
   user: UserType | null;
 }) {
   const { fetcher } = useFetcher();
+  const { origin: contextOrigin } = useContext(InputBarContext);
 
   return useCallback(
     async ({
@@ -45,7 +48,7 @@ export function useCreateConversationWithMessage({
         clientSideMCPServerIds?: string[];
         selectedMCPServerViewIds?: string[];
         selectedSkillIds?: string[];
-        origin?: "web" | "agent_copilot" | "project_kickoff" | "extension";
+        origin?: ClientMessageOrigin;
       };
       visibility?: ConversationVisibility;
       title?: string;
@@ -68,8 +71,9 @@ export function useCreateConversationWithMessage({
         clientSideMCPServerIds,
         selectedMCPServerViewIds,
         selectedSkillIds,
-        origin,
+        origin: messageOrigin,
       } = messageData;
+      const origin = messageOrigin ?? contextOrigin;
 
       const body: t.TypeOf<typeof InternalPostConversationsRequestBodySchema> =
         {
@@ -153,6 +157,6 @@ export function useCreateConversationWithMessage({
         });
       }
     },
-    [owner, user, fetcher]
+    [owner, user, fetcher, contextOrigin]
   );
 }

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -1,12 +1,16 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
-import type { SubmitMessageError } from "@app/types/assistant/conversation";
+import type {
+  ClientMessageOrigin,
+  SubmitMessageError,
+} from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { useCallback } from "react";
+import { useCallback, useContext } from "react";
 
 export function useSubmitMessage({
   owner,
@@ -17,12 +21,15 @@ export function useSubmitMessage({
   user: UserType;
   conversationId: string | null;
 }) {
+  const { origin: contextOrigin } = useContext(InputBarContext);
+
   return useCallback(
     async (messageData: {
       input: string;
       mentions: MentionType[];
       contentFragments: ContentFragmentsType;
       clientSideMCPServerIds?: string[];
+      origin?: ClientMessageOrigin;
       skipToolsValidation?: boolean;
     }): Promise<Result<PostMessagesResponseBody, SubmitMessageError>> => {
       if (!conversationId) {
@@ -38,8 +45,10 @@ export function useSubmitMessage({
         mentions,
         contentFragments,
         clientSideMCPServerIds,
+        origin: messageOrigin,
         skipToolsValidation,
       } = messageData;
+      const origin = messageOrigin ?? contextOrigin;
 
       // Create a new content fragment.
       if (
@@ -122,6 +131,7 @@ export function useSubmitMessage({
                 Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC",
               profilePictureUrl: user.image,
               clientSideMCPServerIds,
+              origin,
             },
             mentions,
             skipToolsValidation,
@@ -151,6 +161,6 @@ export function useSubmitMessage({
 
       return new Ok(await mRes.json());
     },
-    [owner, user, conversationId]
+    [owner, user, conversationId, contextOrigin]
   );
 }

--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -18,7 +18,7 @@ export function clientFetch(
 
     // Include credentials for all requests targeting the API (needed for
     // cross-origin requests from the SPA on app.dust.tt to the API on dust.tt).
-    if (input.startsWith(baseUrl)) {
+    if (input.startsWith(baseUrl) && init?.credentials === undefined) {
       init = { ...init, credentials: "include" };
     }
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -196,10 +196,13 @@ async function handler(
         }
       }
 
-      // Derive origin from conversation metadata - copilot conversations use agent_copilot origin.
-      const origin = isCopilotConversation(conversation.metadata)
-        ? "agent_copilot"
-        : "web";
+      // Derive origin: use explicitly provided origin, fall back to conversation metadata,
+      // then default to "web".
+      const origin =
+        context.origin ??
+        (isCopilotConversation(conversation.metadata)
+          ? "agent_copilot"
+          : "web");
 
       const messageRes = await postUserMessage(auth, {
         conversation,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -67,15 +67,23 @@ export type LightMessageType =
  * origin should be easily categorizable as either "programmatic" or "user".
  *
  */
+
+// Origins set explicitly by front-end clients (web app, extension, etc.).
+export type ClientMessageOrigin =
+  | "web"
+  | "project_kickoff"
+  | "extension"
+  | "agent_copilot";
+
 export type UserMessageOrigin =
   // "api" is Custom API usage, while e.g. extension, gsheets and many other origins
   // below are API usages dedicated to standard product features.
+  | ClientMessageOrigin
   | "api"
   | "cli"
   | "cli_programmatic"
   | "email"
   | "excel"
-  | "extension"
   | "gsheet"
   | "make"
   | "n8n"
@@ -87,17 +95,14 @@ export type UserMessageOrigin =
   | "transcript"
   | "triggered_programmatic"
   | "triggered"
-  | "web"
   | "zapier"
   | "zendesk"
   // TODO onboarding_conversation, agent_copilot, and project_kickoff aren't message origins. They
   // have been used as a hack but should be removed and most likely handled as message metadata
   // (to be created).
   | "onboarding_conversation"
-  | "agent_copilot"
   // for internal use, for the butler in projects
-  | "project_butler"
-  | "project_kickoff";
+  | "project_butler";
 
 export type UserMessageContext = {
   username: string;


### PR DESCRIPTION
## Description

Fixes the origin field not being properly saved to user messages. Previously, the origin was only passed explicitly in certain cases, but wasn't being propagated from the InputBarContext where it's set based on the client (web vs extension). This PR ensures the origin is correctly passed through `useCreateConversationWithMessage` and `useSubmitMessage` hooks by reading it from InputBarContext when not explicitly provided.

This PR also prevents the extension from sending a session cookie. It happened when the user was logged in to Dust in a regular page.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
