### PR TITLE
[front,connectors] fix schemas for Zendesk search tickets response

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -39,6 +39,7 @@ export function shouldSyncTicket(
   }
   if (
     !configuration.syncUnresolvedTickets &&
+    ticket.status &&
     !["closed", "solved"].includes(ticket.status)
   ) {
     return {

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -30,30 +30,32 @@ export const ZendeskTicketSchema = z
   .object({
     id: z.number(),
     url: z.string(),
-    subject: z.string().nullable(),
-    description: z.string().nullable(),
-    priority: z.string().nullable(),
-    status: z.string(),
-    type: z.string().nullable(),
-    requester_id: z.number(),
-    assignee_id: z.number().nullable(),
+    subject: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    priority: z.string().nullable().optional(),
+    status: z.string().optional(),
+    type: z.string().nullable().optional(),
+    requester_id: z.number().optional(),
+    assignee_id: z.number().nullable().optional(),
     group_id: z.number().nullable(),
-    organization_id: z.number().nullable(),
+    organization_id: z.number().nullable().optional(),
     created_at: z.string(),
     updated_at: z.string(),
     tags: z.array(z.string()),
-    custom_fields: z.array(
-      z.object({
-        id: z.number(),
-        value: z.union([
-          z.string(),
-          z.number(),
-          z.boolean(),
-          z.null(),
-          z.array(z.string()),
-        ]),
-      })
-    ),
+    custom_fields: z
+      .array(
+        z.object({
+          id: z.number(),
+          value: z.union([
+            z.string(),
+            z.number(),
+            z.boolean(),
+            z.null(),
+            z.array(z.string()),
+          ]),
+        })
+      )
+      .optional(),
     via: z
       .object({
         channel: z.string(),
@@ -65,8 +67,8 @@ export const ZendeskTicketSchema = z
     collaborator_ids: z.array(z.number()).optional(),
     follower_ids: z.array(z.number()).optional(),
     email_cc_ids: z.array(z.number()).optional(),
-    due_at: z.string().nullable(),
-    has_incidents: z.boolean(),
+    due_at: z.string().nullable().optional(),
+    has_incidents: z.boolean().optional(),
     satisfaction_rating: z
       .object({
         comment: z.string().optional().nullable(),
@@ -74,7 +76,7 @@ export const ZendeskTicketSchema = z
         score: z.string(),
       })
       .optional(),
-    submitter_id: z.number(),
+    submitter_id: z.number().optional(),
   })
   .passthrough();
 

--- a/front/lib/api/actions/servers/zendesk/index.ts
+++ b/front/lib/api/actions/servers/zendesk/index.ts
@@ -1,10 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  ZENDESK_SERVER,
-  ZENDESK_TOOL_NAME,
-} from "@app/lib/api/actions/servers/zendesk/metadata";
+import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/zendesk/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,7 +14,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: ZENDESK_TOOL_NAME,
+      monitoringName: "zendesk",
     });
   }
 

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const ZENDESK_TOOL_NAME = "zendesk" as const;
-
 export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   get_ticket: {
     description:

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -30,30 +30,32 @@ export const ZendeskTicketSchema = z
   .object({
     id: z.number(),
     url: z.string(),
-    subject: z.string().nullable(),
-    description: z.string().nullable(),
-    priority: z.string().nullable(),
-    status: z.string(),
-    type: z.string().nullable(),
-    requester_id: z.number(),
-    assignee_id: z.number().nullable(),
+    subject: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    priority: z.string().nullable().optional(),
+    status: z.string().optional(),
+    type: z.string().nullable().optional(),
+    requester_id: z.number().optional(),
+    assignee_id: z.number().nullable().optional(),
     group_id: z.number().nullable(),
-    organization_id: z.number().nullable(),
+    organization_id: z.number().nullable().optional(),
     created_at: z.string(),
     updated_at: z.string(),
     tags: z.array(z.string()),
-    custom_fields: z.array(
-      z.object({
-        id: z.number(),
-        value: z.union([
-          z.string(),
-          z.number(),
-          z.boolean(),
-          z.null(),
-          z.array(z.string()),
-        ]),
-      })
-    ),
+    custom_fields: z
+      .array(
+        z.object({
+          id: z.number(),
+          value: z.union([
+            z.string(),
+            z.number(),
+            z.boolean(),
+            z.null(),
+            z.array(z.string()),
+          ]),
+        })
+      )
+      .optional(),
     via: z
       .object({
         channel: z.string(),
@@ -65,8 +67,8 @@ export const ZendeskTicketSchema = z
     collaborator_ids: z.array(z.number()).optional(),
     follower_ids: z.array(z.number()).optional(),
     email_cc_ids: z.array(z.number()).optional(),
-    due_at: z.string().nullable(),
-    has_incidents: z.boolean(),
+    due_at: z.string().nullable().optional(),
+    has_incidents: z.boolean().optional(),
     satisfaction_rating: z
       .object({
         comment: z.string().optional().nullable(),
@@ -74,7 +76,7 @@ export const ZendeskTicketSchema = z
         score: z.string(),
       })
       .optional(),
-    submitter_id: z.number(),
+    submitter_id: z.number().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

- Fixes the log [here](https://app.datadoghq.eu/logs?query=%22%5BZendesk%5D%20Invalid%20API%20response%20format%22&additional_filters=%5B%5D&cols=host%2Cservice&event=AwAAAZx1KeC00Yz8zgAAABhBWngxS2ZHUkFBQWJFN1hDOXZvcFhBQUcAAAAkMDE5Yzc1NTYtNDM1My00ZWNhLWFmMGYtYWY0YWM4MGU5MWZlAAK5Kw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=193898&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1771430830237&to_ts=1772035630237&live=true).
- This PR updates the zod schema we use to validate the response of the Zendesk API for the search endpoint.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front
- Deploy connectors
