### PR TITLE
Automatically populate name suggestions

### DIFF
--- a/front/components/agent_builder/settings/AgentBuilderNameSection.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderNameSection.tsx
@@ -1,5 +1,6 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/constants";
 import { getNameSuggestions } from "@app/components/agent_builder/settings/utils";
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -13,15 +14,21 @@ import {
   SparklesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 const NAME_FIELD_NAME = "agentSettings.name";
 const MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS = 20;
 
-export function AgentBuilderNameSection() {
+interface AgentBuilderNameSectionProps {
+  isCreatingNew?: boolean;
+}
+
+export function AgentBuilderNameSection({
+  isCreatingNew = false,
+}: AgentBuilderNameSectionProps) {
   const { owner } = useAgentBuilderContext();
-  const { setValue } = useFormContext<AgentBuilderFormData>();
+  const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
   const sendNotification = useSendNotification();
 
   const instructions = useWatch<AgentBuilderFormData, "instructions">({
@@ -36,6 +43,7 @@ export function AgentBuilderNameSection() {
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [nameSuggestions, setNameSuggestions] = useState<string[]>([]);
+  const userSetNameRef = useRef(false);
 
   const handleGenerateNameSuggestions = async () => {
     if (
@@ -87,6 +95,50 @@ export function AgentBuilderNameSection() {
     });
   };
 
+  const handleAutoGenerateName = useCallback(async () => {
+    if (
+      isGenerating ||
+      userSetNameRef.current ||
+      !instructions ||
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+    ) {
+      return;
+    }
+    const currentName = getValues("agentSettings.name");
+    if (currentName?.trim()) {
+      return;
+    }
+    setIsGenerating(true);
+    const result = await getNameSuggestions({
+      owner,
+      instructions,
+      description: description ?? "",
+    });
+    if (
+      result.isOk() &&
+      result.value.status === "ok" &&
+      result.value.suggestions?.[0]
+    ) {
+      setValue(NAME_FIELD_NAME, result.value.suggestions[0], {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+    setIsGenerating(false);
+  }, [description, getValues, instructions, isGenerating, owner, setValue]);
+
+  useEffect(() => {
+    if (!isCreatingNew) {
+      return;
+    }
+    const onInstructionsBlur = () => {
+      void handleAutoGenerateName();
+    };
+    window.addEventListener(BLUR_EVENT_NAME, onInstructionsBlur);
+    return () =>
+      window.removeEventListener(BLUR_EVENT_NAME, onInstructionsBlur);
+  }, [handleAutoGenerateName, isCreatingNew]);
+
   return (
     <BaseFormFieldSection title="Name" fieldName={NAME_FIELD_NAME}>
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
@@ -95,7 +147,10 @@ export function AgentBuilderNameSection() {
             ref={registerRef}
             placeholder="Enter agent name"
             className="pr-10"
-            onChange={onChange}
+            onChange={(e) => {
+              userSetNameRef.current = true;
+              onChange(e);
+            }}
             message={errorMessage}
             messageStatus={hasError ? "error" : "default"}
             {...registerProps}
@@ -109,19 +164,23 @@ export function AgentBuilderNameSection() {
           >
             <DropdownMenuTrigger asChild>
               <Button
-                icon={SparklesIcon}
+                icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
                 variant="outline"
                 size="xs"
                 className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
                 disabled={
+                  isGenerating ||
                   !instructions ||
                   instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
                 }
                 tooltip={
-                  !instructions ||
-                  instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-                    ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} characters to instructions to get suggestions`
-                    : "Get name suggestions"
+                  isGenerating
+                    ? "Generating name..."
+                    : !instructions ||
+                        instructions.length <
+                          MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+                      ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} characters to instructions to get suggestions`
+                      : "Get name suggestions"
                 }
               />
             </DropdownMenuTrigger>

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -18,7 +18,7 @@ export function AgentBuilderSettingsBlock({
       <div className="space-y-5">
         <div className="flex items-end gap-8">
           <div className="flex-grow">
-            <AgentBuilderNameSection />
+            <AgentBuilderNameSection isCreatingNew={isCreatingNew} />
           </div>
           <AgentBuilderAvatarSection isCreatingNew={isCreatingNew} />
         </div>

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -94,10 +94,13 @@ export async function getBuilderNameSuggestions(
   inputs: BuilderSuggestionInputType
 ): Promise<Result<SuggestionResults, Error>> {
   const prompt =
-    "The user is currently creating an agent based on a large language model." +
+    "The user is currently creating an agent based on a large language model. " +
     "The agent has instructions and a description. You are provided with a single " +
     "message, consisting of this information if it is available. Your role is to " +
-    "suggest good names for the agent. Names can not include whitespaces.";
+    "suggest good names for the agent. Names can not include whitespaces. " +
+    "Names must follow these rules: " +
+    "- Match the tone of the name to the agent instructions. " +
+    "- The name should immediately convey what the agent does.";
   const conversation: ModelConversationTypeMultiActions =
     getConversationContext(inputs);
   const res = await runMultiActionsAgent(

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -12,7 +12,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-// TODO(copilot): Remove useless suggestion types (or whole endpoint) when copilot is released.
+// TODO(copilot): Remove useless suggestion types when copilot is released.
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/6787
* Adding automatic name suggestion using the same logic as description. Minor prompting improvements and manual validation of quality (this was our concerns back in 2023/2024)

## Tests

* Local validation

## Risk

* Low, but will be rolled out to all builders

## Deploy Plan

* Deploy front