### PR TITLE
Hide message actions on all copilot messages

### DIFF
--- a/front/components/agent_builder/AgentBuilderCopilot.tsx
+++ b/front/components/agent_builder/AgentBuilderCopilot.tsx
@@ -115,7 +115,7 @@ function CopilotContent({
               conversationId={conversation.sId}
               agentBuilderContext={{
                 ...agentBuilderContext,
-                isCopilotConversation: true,
+                shouldHideMessageButtons: true,
               }}
               additionalMarkdownComponents={additionalMarkdownComponents}
               additionalMarkdownPlugins={additionalMarkdownPlugins}

--- a/front/components/agent_builder/AgentBuilderCopilot.tsx
+++ b/front/components/agent_builder/AgentBuilderCopilot.tsx
@@ -113,7 +113,10 @@ function CopilotContent({
               owner={owner}
               user={user}
               conversationId={conversation.sId}
-              agentBuilderContext={agentBuilderContext}
+              agentBuilderContext={{
+                ...agentBuilderContext,
+                isCopilotConversation: true,
+              }}
               additionalMarkdownComponents={additionalMarkdownComponents}
               additionalMarkdownPlugins={additionalMarkdownPlugins}
               key={conversation.sId}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -158,7 +158,7 @@ interface AgentMessageProps {
   ) => Promise<Result<undefined, DustError>>;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
-  isCopilotConversation?: boolean;
+  shouldHideMessageButtons?: boolean;
 }
 
 export function AgentMessage({
@@ -172,7 +172,7 @@ export function AgentMessage({
   handleSubmit,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
-  isCopilotConversation = false,
+  shouldHideMessageButtons = false,
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
 
@@ -841,7 +841,7 @@ export function AgentMessage({
           )}
         </ConversationMessageContent>
         {!isCancelledOrDeleted &&
-          !(isCopilotConversation && agentMessage.rank === 1) &&
+          !shouldHideMessageButtons &&
           messageButtons &&
           messageButtons.length > 0 && (
             <div className="flex justify-start gap-3">{messageButtons}</div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -158,6 +158,7 @@ interface AgentMessageProps {
   ) => Promise<Result<undefined, DustError>>;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
+  isCopilotConversation?: boolean;
 }
 
 export function AgentMessage({
@@ -171,6 +172,7 @@ export function AgentMessage({
   handleSubmit,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
+  isCopilotConversation = false,
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
 
@@ -839,6 +841,7 @@ export function AgentMessage({
           )}
         </ConversationMessageContent>
         {!isCancelledOrDeleted &&
+          !(isCopilotConversation && agentMessage.rank === 1) &&
           messageButtons &&
           messageButtons.length > 0 && (
             <div className="flex justify-start gap-3">{messageButtons}</div>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -171,6 +171,9 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 context.additionalMarkdownComponents
               }
               additionalMarkdownPlugins={context.additionalMarkdownPlugins}
+              isCopilotConversation={
+                context.agentBuilderContext?.isCopilotConversation
+              }
             />
           )}
           {data.visibility !== "deleted" &&

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -171,8 +171,8 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 context.additionalMarkdownComponents
               }
               additionalMarkdownPlugins={context.additionalMarkdownPlugins}
-              isCopilotConversation={
-                context.agentBuilderContext?.isCopilotConversation
+              shouldHideMessageButtons={
+                context.agentBuilderContext?.shouldHideMessageButtons
               }
             />
           )}

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -78,7 +78,7 @@ export type VirtuosoMessageListContext = {
     resetConversation: () => void;
     clientSideMCPServerIds?: string[];
     skipToolsValidation?: boolean;
-    isCopilotConversation?: boolean;
+    shouldHideMessageButtons?: boolean;
   };
   feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
   additionalMarkdownComponents?: Components;

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -78,6 +78,7 @@ export type VirtuosoMessageListContext = {
     resetConversation: () => void;
     clientSideMCPServerIds?: string[];
     skipToolsValidation?: boolean;
+    isCopilotConversation?: boolean;
   };
   feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
   additionalMarkdownComponents?: Components;


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/6785
## Description
Hide feedback buttons from all messages in a copilot conversation,
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually. Confirmed no other locations are missing these action buttons
<img width="555" height="414" alt="Screenshot 2026-02-25 at 2 58 20 PM" src="https://github.com/user-attachments/assets/0f034f5b-010a-41a8-9889-90194ab06cb7" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
