### PR TITLE
[front] chore: add `documentationURL` for recently released MCP servers

### DIFF
--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -121,7 +121,7 @@ export const ASHBY_SERVER = {
     description: "Access and manage Ashby ATS data.",
     authorization: null,
     icon: "AshbyLogo",
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/ashby-mcp",
     instructions: null,
   },
   tools: Object.values(ASHBY_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -279,9 +279,7 @@ export const FRONT_SERVER = {
       "Manage support conversations, messages, and customer interactions.",
     authorization: null,
     icon: "FrontLogo",
-    documentationUrl: "https://dev.frontapp.com/reference/introduction",
-    // Predates the introduction of the rule, would require extensive work to
-    // improve, already widely adopted.
+    documentationUrl: "https://docs.dust.tt/docs/front-mcp",
     instructions: null,
   },
   tools: Object.values(FRONT_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -40,7 +40,7 @@ export const SALESLOFT_SERVER = {
     description: "Access Salesloft cadences, tasks, and actions.",
     authorization: null,
     icon: "SalesloftLogo",
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/salesloft-mcp",
     instructions: null,
   },
   tools: Object.values(SALESLOFT_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -111,7 +111,7 @@ export const SLAB_SERVER = {
     description: "Search and read from your Slab knowledge base",
     authorization: null,
     icon: "SlabLogo",
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/slab-mcp",
     instructions: null,
   },
   tools: Object.values(SLAB_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -173,7 +173,7 @@ export const STATUSPAGE_SERVER = {
     description: "Monitor and manage Atlassian Statuspage incidents.",
     authorization: null,
     icon: "StatuspageLogo",
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/statuspage-mcp",
     instructions: null,
   },
   tools: Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => ({


### PR DESCRIPTION
## Description

- Ashby, Slab, Salesloft, Front and Statuspage were recently released and documentation pages were added on our doc.
- This PR adds links to these new documentation pages.

## Tests

## Risk

## Deploy Plan

- Deploy front.
