### PR TITLE
Extension: use clientFetch and rename ExtensionFetcherProvider

### DIFF
--- a/extension/platforms/chrome/ChromeApp.tsx
+++ b/extension/platforms/chrome/ChromeApp.tsx
@@ -5,7 +5,7 @@ import { ChromeExtensionWrapper } from "@extension/platforms/chrome/ChromeExtens
 import { PortProvider } from "@extension/platforms/chrome/context/PortContext";
 import { ChromePlatformService } from "@extension/platforms/chrome/services/platform";
 import { PlatformProvider } from "@extension/shared/context/PlatformContext";
-import { ExtensionFetcherProvider } from "@extension/shared/lib/FetcherProvider";
+import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
 import { ReactRouterLinkWrapper } from "@extension/shared/ReactRouterLinkWrapper";
 import { ExtensionAuthProvider } from "@extension/ui/components/auth/AuthProvider";
 import { routes } from "@extension/ui/pages/routes";

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -11,7 +11,7 @@ import { RegionProvider } from "@app/lib/auth/RegionContext";
 import { Notification } from "@dust-tt/sparkle";
 import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
 import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
-import { ExtensionFetcherProvider } from "@extension/shared/lib/FetcherProvider";
+import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
 import { ExtensionAuthProvider } from "@extension/ui/components/auth/AuthProvider";
 import { routes } from "@extension/ui/pages/routes";
 import { useEffect, useState } from "react";

--- a/extension/shared/lib/ExtensionFetcherProvider.tsx
+++ b/extension/shared/lib/ExtensionFetcherProvider.tsx
@@ -1,4 +1,4 @@
-import { getBaseUrlFromResolver } from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
 import { FetcherProvider } from "@app/lib/swr/FetcherContext";
 import type { FetcherFn, FetcherWithBodyFn } from "@app/lib/swr/fetcher";
 import { resHandler } from "@extension/shared/lib/swr";
@@ -16,21 +16,13 @@ export function ExtensionFetcherProvider({
   const { token } = useExtensionAuth();
 
   const { fetcher, fetcherWithBody } = useMemo(() => {
-    const resolveUrl = (url: string) => {
-      if (url.startsWith("/")) {
-        const baseUrl = getBaseUrlFromResolver();
-        return `${baseUrl}${url}`;
-      }
-      return url;
-    };
-
     const addAuthHeaders = (headers: HeadersInit = {}): HeadersInit => ({
       ...headers,
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     });
 
     const fetcher: FetcherFn = async (url, init) => {
-      const res = await fetch(resolveUrl(url), {
+      const res = await clientFetch(url, {
         ...init,
         headers: addAuthHeaders(init?.headers),
       });
@@ -41,7 +33,7 @@ export function ExtensionFetcherProvider({
       [url, body, method],
       init
     ) => {
-      const res = await fetch(resolveUrl(url), {
+      const res = await clientFetch(url, {
         ...init,
         method,
         headers: addAuthHeaders({


### PR DESCRIPTION
## Summary
- Renamed `extension/shared/lib/FetcherProvider.tsx` to `ExtensionFetcherProvider.tsx` for consistency with the exported component name
- Replaced manual URL resolution (`getBaseUrlFromResolver` + `resolveUrl`) with `clientFetch`, which already handles base URL resolution and cross-origin credentials

## Tests
Manual: extension loads correctly, API requests resolve to correct region base URL.

## Risk
Low — `clientFetch` already does the same URL rewriting that was duplicated in the extension's `resolveUrl` helper, plus it adds `credentials: "include"` for cross-origin requests. No behavior change beyond that.

## Deploy Plan
Standard deploy, no special steps needed.