### PR TITLE
[sparkle] - refactor(CardGrid): update grid column responsive breakpoints

### DIFF
--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -290,7 +290,10 @@ export const CardGrid = React.forwardRef<
       <div
         className={cn(
           "s-grid s-grid-cols-1 s-gap-2",
-          "@xxs:s-grid-cols-2 @sm:s-grid-cols-3 @lg:s-grid-cols-4 @xl:s-grid-cols-5"
+          "@xxs:has-[>:nth-child(2)]:s-grid-cols-2",
+          "@sm:has-[>:nth-child(3)]:s-grid-cols-3",
+          "@lg:has-[>:nth-child(4)]:s-grid-cols-4",
+          "@xl:has-[>:nth-child(5)]:s-grid-cols-5"
         )}
       >
         {children}


### PR DESCRIPTION

## Description
Refactors the `CardGrid` component to conditionally apply grid column layouts based on the actual number of child elements present. Instead of always applying breakpoint classes (e.g., `@xxs:s-grid-cols-2`), the grid now uses the `:has()` pseudo-class with `:nth-child()` selectors to only enable multi-column layouts when enough children are present to fill them.

## Risk

This change relies on the CSS `:has()` pseudo-class, which is widely supported in modern browsers but may not work in older browsers. The change is purely visual and should gracefully degrade to a single-column layout in unsupported browsers.

## Tests

Tested locally and in Storybook. 

## Deploy Plan

Deploy front