### PR TITLE
[Notifications] Add root-cause logging for notification preference load failures

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -68,6 +68,17 @@ const PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_LABELS: Record<
 
 const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay = "1_hour";
 const DEFAULT_NOTIFICATION_CONDITION: NotificationCondition = "all_messages";
+const NOVU_SESSION_ERROR_CODE = "novu_session_initialization_failed";
+const MISSING_WORKFLOW_ERROR_CODE = "missing_conversation_unread_workflow";
+const GENERIC_LOAD_ERROR_CODE = "notification_preferences_not_loaded";
+
+type NotificationPreferencesLoadFailure =
+  | {
+      code: typeof NOVU_SESSION_ERROR_CODE;
+    }
+  | {
+      code: typeof MISSING_WORKFLOW_ERROR_CODE;
+    };
 
 export interface NotificationPreferencesRefProps {
   savePreferences: () => Promise<boolean>;
@@ -110,6 +121,8 @@ export const NotificationPreferences = forwardRef<
     setProjectNewConversationPreferences,
   ] = useState<Preference | undefined>();
   const [isLoadingPreferences, setIsLoadingPreferences] = useState(true);
+  const [loadFailure, setLoadFailure] =
+    useState<NotificationPreferencesLoadFailure | null>(null);
 
   // Email digest delay (for unread conversation email notifications)
   const [conversationEmailDelay, setConversationEmailDelay] =
@@ -231,26 +244,111 @@ export const NotificationPreferences = forwardRef<
     if (!novuClient) {
       return;
     }
-    setIsLoadingPreferences(true);
-    void novuClient.preferences.list().then((preferences) => {
-      const conversationPref = preferences.data?.find(
-        (preference) =>
-          preference.workflow?.identifier === CONVERSATION_UNREAD_TRIGGER_ID
-      );
-      setConversationPreferences(conversationPref);
-      originalConversationPreferencesRef.current = conversationPref;
+    let isCancelled = false;
 
-      const projectNewConvPref = preferences.data?.find(
-        (preference) =>
-          preference.workflow?.identifier ===
-          PROJECT_NEW_CONVERSATION_TRIGGER_ID
-      );
-      setProjectNewConversationPreferences(projectNewConvPref);
-      originalProjectNewConversationPreferencesRef.current = projectNewConvPref;
+    const loadPreferences = async () => {
+      setIsLoadingPreferences(true);
+      setLoadFailure(null);
 
-      setIsLoadingPreferences(false);
-    });
-  }, [novuClient]);
+      try {
+        const preferences = await novuClient.preferences.list();
+        if (isCancelled) {
+          return;
+        }
+
+        if (preferences.error) {
+          console.error(
+            "Failed to load notification preferences from Novu (session error).",
+            {
+              code: NOVU_SESSION_ERROR_CODE,
+              ownerId: owner.sId,
+              message: preferences.error.message,
+            }
+          );
+          setConversationPreferences(undefined);
+          originalConversationPreferencesRef.current = undefined;
+          setProjectNewConversationPreferences(undefined);
+          originalProjectNewConversationPreferencesRef.current = undefined;
+          setLoadFailure({
+            code: NOVU_SESSION_ERROR_CODE,
+          });
+          return;
+        }
+
+        const preferenceList = preferences.data ?? [];
+        const conversationPref = preferenceList.find(
+          (preference) =>
+            preference.workflow?.identifier === CONVERSATION_UNREAD_TRIGGER_ID
+        );
+        setConversationPreferences(conversationPref);
+        originalConversationPreferencesRef.current = conversationPref;
+
+        const projectNewConvPref = preferenceList.find(
+          (preference) =>
+            preference.workflow?.identifier ===
+            PROJECT_NEW_CONVERSATION_TRIGGER_ID
+        );
+        setProjectNewConversationPreferences(projectNewConvPref);
+        originalProjectNewConversationPreferencesRef.current =
+          projectNewConvPref;
+
+        if (!conversationPref) {
+          const availableWorkflowIdentifiers = preferenceList
+            .map((preference) => preference.workflow?.identifier)
+            .filter((identifier): identifier is string => Boolean(identifier));
+
+          console.error(
+            "Failed to load notification preferences from Novu (workflow missing).",
+            {
+              code: MISSING_WORKFLOW_ERROR_CODE,
+              ownerId: owner.sId,
+              missingWorkflowIdentifier: CONVERSATION_UNREAD_TRIGGER_ID,
+              availableWorkflowIdentifiers,
+            }
+          );
+
+          setLoadFailure({
+            code: MISSING_WORKFLOW_ERROR_CODE,
+          });
+          return;
+        }
+
+        setLoadFailure(null);
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+          "Failed to load notification preferences from Novu (unexpected error).",
+          {
+            code: NOVU_SESSION_ERROR_CODE,
+            ownerId: owner.sId,
+            message,
+          }
+        );
+
+        setConversationPreferences(undefined);
+        originalConversationPreferencesRef.current = undefined;
+        setProjectNewConversationPreferences(undefined);
+        originalProjectNewConversationPreferencesRef.current = undefined;
+        setLoadFailure({
+          code: NOVU_SESSION_ERROR_CODE,
+        });
+      } finally {
+        if (!isCancelled) {
+          setIsLoadingPreferences(false);
+        }
+      }
+    };
+
+    void loadPreferences();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [novuClient, owner.sId]);
 
   // Expose methods to parent component
   useImperativeHandle(
@@ -535,10 +633,32 @@ export const NotificationPreferences = forwardRef<
     return <Spinner />;
   }
 
+  if (loadFailure?.code === NOVU_SESSION_ERROR_CODE) {
+    return (
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Unable to load notification preferences. Please refresh and try again.
+        <div className="text-xs">Error code: {NOVU_SESSION_ERROR_CODE}.</div>
+      </div>
+    );
+  }
+
+  if (loadFailure?.code === MISSING_WORKFLOW_ERROR_CODE) {
+    return (
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Notification preferences are temporarily unavailable. Please contact
+        support.
+        <div className="text-xs">
+          Error code: {MISSING_WORKFLOW_ERROR_CODE}.
+        </div>
+      </div>
+    );
+  }
+
   if (!conversationPreferences) {
     return (
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
         Unable to load notification preferences. Please contact support.
+        <div className="text-xs">Error code: {GENERIC_LOAD_ERROR_CODE}.</div>
       </div>
     );
   }

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -3,6 +3,7 @@ import { useNovuClient } from "@app/hooks/useNovuClient";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useSlackNotifications, useUserMetadata } from "@app/lib/swr/user";
 import { setUserMetadataFromClient } from "@app/lib/user";
+import logger from "@app/logger/logger";
 import type {
   NotificationCondition,
   NotificationPreferencesDelay,
@@ -69,12 +70,16 @@ const PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_LABELS: Record<
 const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay = "1_hour";
 const DEFAULT_NOTIFICATION_CONDITION: NotificationCondition = "all_messages";
 const NOVU_SESSION_ERROR_CODE = "novu_session_initialization_failed";
+const NOVU_REQUEST_ERROR_CODE = "novu_preferences_request_failed";
 const MISSING_WORKFLOW_ERROR_CODE = "missing_conversation_unread_workflow";
 const GENERIC_LOAD_ERROR_CODE = "notification_preferences_not_loaded";
 
 type NotificationPreferencesLoadFailure =
   | {
       code: typeof NOVU_SESSION_ERROR_CODE;
+    }
+  | {
+      code: typeof NOVU_REQUEST_ERROR_CODE;
     }
   | {
       code: typeof MISSING_WORKFLOW_ERROR_CODE;
@@ -257,13 +262,13 @@ export const NotificationPreferences = forwardRef<
         }
 
         if (preferences.error) {
-          console.error(
-            "Failed to load notification preferences from Novu (session error).",
+          logger.error(
             {
               code: NOVU_SESSION_ERROR_CODE,
               ownerId: owner.sId,
               message: preferences.error.message,
-            }
+            },
+            "Failed to load notification preferences from Novu (session error)."
           );
           setConversationPreferences(undefined);
           originalConversationPreferencesRef.current = undefined;
@@ -297,14 +302,14 @@ export const NotificationPreferences = forwardRef<
             .map((preference) => preference.workflow?.identifier)
             .filter((identifier): identifier is string => Boolean(identifier));
 
-          console.error(
-            "Failed to load notification preferences from Novu (workflow missing).",
+          logger.error(
             {
               code: MISSING_WORKFLOW_ERROR_CODE,
               ownerId: owner.sId,
               missingWorkflowIdentifier: CONVERSATION_UNREAD_TRIGGER_ID,
               availableWorkflowIdentifiers,
-            }
+            },
+            "Failed to load notification preferences from Novu (workflow missing)."
           );
 
           setLoadFailure({
@@ -320,13 +325,13 @@ export const NotificationPreferences = forwardRef<
         }
 
         const message = error instanceof Error ? error.message : String(error);
-        console.error(
-          "Failed to load notification preferences from Novu (unexpected error).",
+        logger.error(
           {
-            code: NOVU_SESSION_ERROR_CODE,
+            code: NOVU_REQUEST_ERROR_CODE,
             ownerId: owner.sId,
             message,
-          }
+          },
+          "Failed to load notification preferences from Novu (unexpected error)."
         );
 
         setConversationPreferences(undefined);
@@ -334,7 +339,7 @@ export const NotificationPreferences = forwardRef<
         setProjectNewConversationPreferences(undefined);
         originalProjectNewConversationPreferencesRef.current = undefined;
         setLoadFailure({
-          code: NOVU_SESSION_ERROR_CODE,
+          code: NOVU_REQUEST_ERROR_CODE,
         });
       } finally {
         if (!isCancelled) {
@@ -638,6 +643,15 @@ export const NotificationPreferences = forwardRef<
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
         Unable to load notification preferences. Please refresh and try again.
         <div className="text-xs">Error code: {NOVU_SESSION_ERROR_CODE}.</div>
+      </div>
+    );
+  }
+
+  if (loadFailure?.code === NOVU_REQUEST_ERROR_CODE) {
+    return (
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Unable to load notification preferences. Please refresh and try again.
+        <div className="text-xs">Error code: {NOVU_REQUEST_ERROR_CODE}.</div>
       </div>
     );
   }

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -249,6 +249,11 @@ export const NotificationPreferences = forwardRef<
             },
             "Failed to load notification preferences from Novu (session error)."
           );
+          setConversationPreferences(undefined);
+          originalConversationPreferencesRef.current = undefined;
+          setProjectNewConversationPreferences(undefined);
+          originalProjectNewConversationPreferencesRef.current = undefined;
+          return;
         }
 
         const preferenceList = preferences.data ?? [];

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -72,18 +72,6 @@ const DEFAULT_NOTIFICATION_CONDITION: NotificationCondition = "all_messages";
 const NOVU_SESSION_ERROR_CODE = "novu_session_initialization_failed";
 const NOVU_REQUEST_ERROR_CODE = "novu_preferences_request_failed";
 const MISSING_WORKFLOW_ERROR_CODE = "missing_conversation_unread_workflow";
-const GENERIC_LOAD_ERROR_CODE = "notification_preferences_not_loaded";
-
-type NotificationPreferencesLoadFailure =
-  | {
-      code: typeof NOVU_SESSION_ERROR_CODE;
-    }
-  | {
-      code: typeof NOVU_REQUEST_ERROR_CODE;
-    }
-  | {
-      code: typeof MISSING_WORKFLOW_ERROR_CODE;
-    };
 
 export interface NotificationPreferencesRefProps {
   savePreferences: () => Promise<boolean>;
@@ -126,8 +114,6 @@ export const NotificationPreferences = forwardRef<
     setProjectNewConversationPreferences,
   ] = useState<Preference | undefined>();
   const [isLoadingPreferences, setIsLoadingPreferences] = useState(true);
-  const [loadFailure, setLoadFailure] =
-    useState<NotificationPreferencesLoadFailure | null>(null);
 
   // Email digest delay (for unread conversation email notifications)
   const [conversationEmailDelay, setConversationEmailDelay] =
@@ -249,18 +235,11 @@ export const NotificationPreferences = forwardRef<
     if (!novuClient) {
       return;
     }
-    let isCancelled = false;
+    setIsLoadingPreferences(true);
 
-    const loadPreferences = async () => {
-      setIsLoadingPreferences(true);
-      setLoadFailure(null);
-
-      try {
-        const preferences = await novuClient.preferences.list();
-        if (isCancelled) {
-          return;
-        }
-
+    void novuClient.preferences
+      .list()
+      .then((preferences) => {
         if (preferences.error) {
           logger.error(
             {
@@ -270,14 +249,6 @@ export const NotificationPreferences = forwardRef<
             },
             "Failed to load notification preferences from Novu (session error)."
           );
-          setConversationPreferences(undefined);
-          originalConversationPreferencesRef.current = undefined;
-          setProjectNewConversationPreferences(undefined);
-          originalProjectNewConversationPreferencesRef.current = undefined;
-          setLoadFailure({
-            code: NOVU_SESSION_ERROR_CODE,
-          });
-          return;
         }
 
         const preferenceList = preferences.data ?? [];
@@ -311,48 +282,25 @@ export const NotificationPreferences = forwardRef<
             },
             "Failed to load notification preferences from Novu (workflow missing)."
           );
-
-          setLoadFailure({
-            code: MISSING_WORKFLOW_ERROR_CODE,
-          });
-          return;
         }
-
-        setLoadFailure(null);
-      } catch (error) {
-        if (isCancelled) {
-          return;
-        }
-
-        const message = error instanceof Error ? error.message : String(error);
+      })
+      .catch((error) => {
         logger.error(
           {
             code: NOVU_REQUEST_ERROR_CODE,
             ownerId: owner.sId,
-            message,
+            error,
           },
-          "Failed to load notification preferences from Novu (unexpected error)."
+          "Failed to load notification preferences from Novu (request error)."
         );
-
         setConversationPreferences(undefined);
         originalConversationPreferencesRef.current = undefined;
         setProjectNewConversationPreferences(undefined);
         originalProjectNewConversationPreferencesRef.current = undefined;
-        setLoadFailure({
-          code: NOVU_REQUEST_ERROR_CODE,
-        });
-      } finally {
-        if (!isCancelled) {
-          setIsLoadingPreferences(false);
-        }
-      }
-    };
-
-    void loadPreferences();
-
-    return () => {
-      isCancelled = true;
-    };
+      })
+      .finally(() => {
+        setIsLoadingPreferences(false);
+      });
   }, [novuClient, owner.sId]);
 
   // Expose methods to parent component
@@ -638,41 +586,10 @@ export const NotificationPreferences = forwardRef<
     return <Spinner />;
   }
 
-  if (loadFailure?.code === NOVU_SESSION_ERROR_CODE) {
-    return (
-      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Unable to load notification preferences. Please refresh and try again.
-        <div className="text-xs">Error code: {NOVU_SESSION_ERROR_CODE}.</div>
-      </div>
-    );
-  }
-
-  if (loadFailure?.code === NOVU_REQUEST_ERROR_CODE) {
-    return (
-      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Unable to load notification preferences. Please refresh and try again.
-        <div className="text-xs">Error code: {NOVU_REQUEST_ERROR_CODE}.</div>
-      </div>
-    );
-  }
-
-  if (loadFailure?.code === MISSING_WORKFLOW_ERROR_CODE) {
-    return (
-      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Notification preferences are temporarily unavailable. Please contact
-        support.
-        <div className="text-xs">
-          Error code: {MISSING_WORKFLOW_ERROR_CODE}.
-        </div>
-      </div>
-    );
-  }
-
   if (!conversationPreferences) {
     return (
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
         Unable to load notification preferences. Please contact support.
-        <div className="text-xs">Error code: {GENERIC_LOAD_ERROR_CODE}.</div>
       </div>
     );
   }


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/6819
Context: [Front support thread](https://app.frontapp.com/open/top_444q52)

- Keep the existing user-facing behavior unchanged when notification preferences cannot load.
- Add structured diagnostics in `NotificationPreferences` load flow so support can distinguish root causes from logs:
  - `novu_session_initialization_failed`
  - `missing_conversation_unread_workflow`
  - `novu_preferences_request_failed`

## Risks
Blast radius: Notification preferences loading path in account settings.
Risk: low

## Deploy Plan
- pmrr
- deploy front
