### PR TITLE
 Fix: prevent revoking the last admin of a workspace

### DIFF
--- a/front/hooks/useChangeMembersRoles.ts
+++ b/front/hooks/useChangeMembersRoles.ts
@@ -63,12 +63,19 @@ export function useChangeMembersRoles({
         const errors = results.filter((res) => !res.ok);
 
         if (errors.length > 0) {
+          let description: string;
+          if (errors.length === 1) {
+            const body = await errors[0].json().catch(() => null);
+            description =
+              body?.error?.message ?? "Failed to update member role.";
+          } else {
+            description = `Failed to update members role for ${errors.length} member(s) (${members.length - errors.length} succeeded).`;
+          }
+
           sendNotification({
             type: "error",
             title: "Update failed",
-            description: `Failed to update members role for ${
-              errors.length
-            } member(s) (${members.length - errors.length} succeeded).`,
+            description,
           });
           return false;
         } else {

--- a/front/lib/client/members.ts
+++ b/front/lib/client/members.ts
@@ -27,12 +27,18 @@ export async function handleMembersRoleChange({
   const results = await Promise.all(promises);
   const errors = results.filter((res) => !res.ok);
   if (errors.length > 0) {
+    let description: string;
+    if (errors.length === 1) {
+      const body = await errors[0].json().catch(() => null);
+      description = body?.error?.message ?? "Failed to update member role.";
+    } else {
+      description = `Failed to update members role for ${errors.length} member(s) (${members.length - errors.length} succeeded).`;
+    }
+
     sendNotification({
       type: "error",
       title: "Update failed",
-      description: `Failed to update members role for ${
-        errors.length
-      } member(s) (${members.length - errors.length} succeeded).`,
+      description,
     });
   } else {
     sendNotification({

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -798,7 +798,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     Result<
       { role: MembershipRoleType; startAt: Date; endAt: Date },
       {
-        type: "not_found" | "already_revoked" | "invalid_end_at";
+        type: "not_found" | "already_revoked" | "invalid_end_at" | "last_admin";
       }
     >
   > {
@@ -816,6 +816,21 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     if (membership.endAt) {
       return new Err({ type: "already_revoked" });
     }
+
+    // Prevent revoking the last admin of a workspace.
+    if (membership.role === "admin") {
+      const adminsCount = await this.getMembersCountForWorkspace({
+        workspace,
+        activeOnly: true,
+        rolesFilter: ["admin"],
+        transaction,
+      });
+
+      if (adminsCount < 2) {
+        return new Err({ type: "last_admin" });
+      }
+    }
+
     await MembershipModel.update(
       { endAt },
       { where: { id: membership.id }, transaction }

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -69,6 +69,14 @@ async function handler(
                 message: "Could not find the membership.",
               },
             });
+          case "last_admin":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Cannot revoke the last admin of a workspace.",
+              },
+            });
           case "already_revoked":
             // Should not happen, but we ignore.
             break;

--- a/front/pages/api/w/[wId]/members/[uId]/index.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.test.ts
@@ -110,6 +110,64 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
       expect(data.member.workspaces[0].role).toBe("builder");
     });
 
+    it("should return 400 when sole admin tries to revoke themselves", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      req.query.uId = user.sId;
+      req.body = { role: "revoked" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      const data = res._getJSONData();
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(data.error.message).toBe(
+        "Cannot revoke the last admin of a workspace."
+      );
+    });
+
+    it("should return 200 when sole admin revokes a non-admin user", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+
+      req.query.uId = regularUser.sId;
+      req.body = { role: "revoked" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+    });
+
+    it("should return 200 when revoking an admin with multiple admins present", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      // Create another admin
+      const otherAdmin = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherAdmin, {
+        role: "admin",
+      });
+
+      req.query.uId = otherAdmin.sId;
+      req.body = { role: "revoked" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+    });
+
     it("should return 403 when non-admin user tries to change own role", async () => {
       const { req, res, user } = await createPrivateApiMockRequest({
         method: "POST",

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -144,6 +144,14 @@ async function handler(
                   message: "Could not find the membership.",
                 },
               });
+            case "last_admin":
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: "Cannot revoke the last admin of a workspace.",
+                },
+              });
             case "already_revoked":
             case "invalid_end_at":
               break;


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/6823

- The role-change code path (`role: "admin" | "builder" | "user"`) already prevented removing the last admin, but the revocation path (`role: "revoked"`) had no such guard.  This allowed the sole admin to revoke themselves (or be revoked via poke), permanently locking out the workspace with no recovery mechanism. 😅 
- Added a last-admin check to `MembershipResource.revokeMembership()` so all callers (private API, poke endpoint) are protected.
- Handled the new `"last_admin"` error in both the member endpoint and the poke revoke endpoint.

## Tests

Locally + added tests. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front.