### PR TITLE
fix: create gcs stream after tika process

### DIFF
--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -263,15 +263,16 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
       auth,
       version: "original",
     });
-    const writeStream = file.getWriteStream({
-      auth,
-      version: "processed",
-    });
 
     const processedStream = await new TextExtraction(
       config.getTextExtractionUrl(),
       { enableOcr: true, logger }
     ).fromStream(readStream, file.contentType);
+
+    const writeStream = file.getWriteStream({
+      auth,
+      version: "processed",
+    });
 
     await pipeline(processedStream, writeStream);
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR fixes GCS "socket hang up" error when processing PDFs that require OCR via Tika. 
The GCS write stream was opened **before** the Tika extraction call, causing it to sit idle for minutes while Tika performs OCR on PDFs with broken font Unicode mappings. When it was time to write, GCS would have dropped the idle connection because the Tika processing was too long.                                       

This move `getWriteStream()` to after Tika returns so the GCS connection is only opened when we're ready to write.

Closes https://github.com/dust-tt/tasks/issues/6605

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand with a PDF failing before, it's now working.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front