### PR TITLE
fix: draft messages in extension

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -569,8 +569,14 @@ const InputBarContainer = ({
     }
 
     const draft = getDraft();
+    const editorContainsOnlyStickyMentions =
+      !editorService.isEmpty() &&
+      editorService.getTrimmedText() === stickyMentionsTextContent.current;
     // Only restore draft if editor is empty to avoid overwriting existing content or sticky mentions.
-    if (draft && editorService.isEmpty()) {
+    if (
+      draft &&
+      (editorService.isEmpty() || editorContainsOnlyStickyMentions)
+    ) {
       // Schedule content restoration to avoid flushing during render lifecycle.
       queueMicrotask(() => editorService.setContent(draft.text));
     }
@@ -583,7 +589,7 @@ const InputBarContainer = ({
     getDraft,
   ]);
 
-  useHandleMentions(
+  const { stickyMentionsTextContent } = useHandleMentions(
     editorService,
     stickyMentions,
     selectedAgent,

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -50,6 +50,8 @@ const useHandleMentions = (
       }
     }
   }, [selectedAgent, editorService]);
+
+  return { stickyMentionsTextContent };
 };
 
 export default useHandleMentions;


### PR DESCRIPTION




## Description
Fixes https://github.com/dust-tt/tasks/issues/6055
This PR fixes draft message restoration in the Chrome extension when agent mentions are present in the input bar.

- The root cause was a race condition where sticky mentions were populated into the editor before draft restoration could occur, causing the `isEmpty()` check to fail and skip draft restoration
- This worked in the web app because there is a brief loading window where the editor stays empty long enough for drafts to restore
- In the extension, messages are already available when the `ConversationContainer` mounts, so sticky mentions populate immediately on first render, blocking draft restoration
- The fix extends the draft restore condition to also fire when the editor only contains sticky mentions

https://github.com/user-attachments/assets/c996cefa-6985-423c-90a8-3aeb5e16debb
## Tests

Manually tested.

## Risks

Low. The change is isolated to draft restoration logic.

## Deploy Plan

Standard deployment.




