### PR TITLE
[sparkle] - refactor: replace `classNames` with `cn`

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -27,13 +27,7 @@ import type { AgentsUsageType } from "@app/types/data_source";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
-import {
-  Chip,
-  classNames,
-  DataTable,
-  EmptyCTA,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { Chip, cn, DataTable, EmptyCTA, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -53,7 +47,7 @@ const NameCell = ({ row }: { row: RowData }) => {
   return (
     <DataTable.CellContent grow>
       <div
-        className={classNames(
+        className={cn(
           "flex flex-row items-center gap-3 py-3",
           mcpServerView ? "" : "opacity-50"
         )}

--- a/front/components/agent_builder/capabilities/shared/TimeFrameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/TimeFrameSection.tsx
@@ -3,7 +3,7 @@ import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 import {
   Button,
   Checkbox,
-  classNames,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -78,7 +78,7 @@ export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
           }}
         />
         <div
-          className={classNames(
+          className={cn(
             "text-sm font-semibold",
             !isChecked
               ? "text-muted-foreground dark:text-muted-foreground-night"

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -1,5 +1,5 @@
 import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
-import { classNames, Input, SliderToggle, TextArea } from "@dust-tt/sparkle";
+import { cn, Input, SliderToggle, TextArea } from "@dust-tt/sparkle";
 import { useEffect, useRef, useState } from "react";
 
 export function MicrosoftOAuthExtraConfig({
@@ -77,7 +77,7 @@ export function MicrosoftOAuthExtraConfig({
       </div>
       {useServicePrincipal && (
         <div
-          className={classNames(
+          className={cn(
             "flex flex-col gap-2",
             !useServicePrincipal ? "opacity-50" : ""
           )}

--- a/front/components/home/content/Solutions/DemoVideoSection.tsx
+++ b/front/components/home/content/Solutions/DemoVideoSection.tsx
@@ -1,5 +1,5 @@
 import { H2 } from "@app/components/home/ContentComponents";
-import { classNames } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
 import type { FC } from "react";
 
 export interface DemoVideoProps {
@@ -36,7 +36,7 @@ export const DemoVideoSection: FC<DemoVideoSectionProps> = ({
           <H2>{demoVideo.sectionTitle}</H2>
         </div>
       )}
-      <div className={classNames("mx-auto w-full")}>
+      <div className={cn("mx-auto w-full")}>
         <div className="relative w-full rounded-2xl pt-[56.25%]">
           {/* 16:9 aspect ratio */}
           <iframe

--- a/front/components/magicui/pointer.tsx
+++ b/front/components/magicui/pointer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { classNames as cn } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
 import type { HTMLMotionProps } from "framer-motion";
 import { AnimatePresence, motion, useMotionValue } from "framer-motion";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -10,7 +10,7 @@ import {
   Button,
   ChevronRightIcon,
   Chip,
-  classNames,
+  cn,
   DataTable,
   MovingMailIcon,
   Page,
@@ -128,7 +128,7 @@ export function InvitationsList({
         {isInvitationsLoading && (
           <div className="flex flex-col gap-2">
             <div
-              className={classNames(
+              className={cn(
                 "flex animate-pulse cursor-pointer items-center justify-center gap-3 border-t py-2 text-xs sm:text-sm",
                 "border-border-dark bg-background dark:border-border-dark-night dark:bg-background-night"
               )}

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -15,7 +15,6 @@ import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
   CollapseButton,
-  classNames,
   cn,
   LinkWrapper,
   NavigationList,
@@ -168,7 +167,7 @@ export const NavigationSidebar = React.forwardRef<
       )}
       {user && (
         <div
-          className={classNames(
+          className={cn(
             "flex items-center border-t px-2 py-2",
             "border-border-dark dark:border-border-darker-night",
             "text-foreground dark:text-foreground-night"

--- a/front/components/triggers/AdminTriggersList.tsx
+++ b/front/components/triggers/AdminTriggersList.tsx
@@ -15,7 +15,7 @@ import type {
 } from "@app/types/triggers/webhooks";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
-import { classNames, DataTable, EmptyCTA, Spinner } from "@dust-tt/sparkle";
+import { cn, DataTable, EmptyCTA, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -31,7 +31,7 @@ const NameCell = ({ row }: { row: RowData }) => {
   return (
     <DataTable.CellContent grow>
       <div
-        className={classNames(
+        className={cn(
           "flex flex-row items-center gap-3 py-3",
           webhookSource.systemView ? "" : "opacity-50"
         )}

--- a/sparkle/src/components/Page.tsx
+++ b/sparkle/src/components/Page.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
 
 import { Separator } from "@sparkle/components/Separator";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import React, { type ComponentType } from "react";
 
 import { Button, type ButtonProps } from "./Button";
@@ -21,7 +21,7 @@ export function Page({ children, variant = "normal" }: PageProps) {
   return (
     <main className={mainVariantClasses}>
       <div
-        className={classNames(
+        className={cn(
           "s-mx-auto s-flex s-h-full s-max-w-4xl s-flex-col s-text-sm s-font-normal",
           "s-text-foreground dark:s-text-foreground-night",
           divVariantClassNames
@@ -103,7 +103,7 @@ const PsizeClasses = {
 Page.P = function ({ children, variant, size = "sm" }: PagePProps) {
   return (
     <p
-      className={classNames(
+      className={cn(
         PsizeClasses[size],
         variant === "secondary"
           ? "s-text-muted-foreground dark:s-text-muted-foreground-night"
@@ -134,7 +134,7 @@ Page.H = function ({ children, variant = "h3" }: PageHProps) {
 
   return (
     <Component
-      className={classNames(
+      className={cn(
         "s-text-foreground dark:s-text-foreground-night",
         hSizes[variant]
       )}
@@ -215,7 +215,7 @@ Page.Horizontal = function ({
 }: PageDivProps) {
   return (
     <div
-      className={classNames(
+      className={cn(
         "s-flex s-flex-col sm:s-flex-row",
         sizing === "grow" ? "s-grow s-basis-0" : "",
         sizing === "shrink" ? "s-shrink" : "",
@@ -239,7 +239,7 @@ Page.Vertical = function ({
 }: PageDivProps) {
   return (
     <div
-      className={classNames(
+      className={cn(
         "s-flex s-flex-col",
         sizing === "grow" ? "s-grow s-basis-0" : "",
         sizing === "shrink" ? "s-shrink" : "",
@@ -262,7 +262,7 @@ Page.Fluid = function ({
 }: PageDivProps) {
   return (
     <div
-      className={classNames(
+      className={cn(
         "s-flex s-flex-wrap",
         sizing === "grow" ? "s-grow" : "",
         sizing === "shrink" ? "s-shrink" : "",

--- a/sparkle/src/components/PaginatedCitationsGrid.tsx
+++ b/sparkle/src/components/PaginatedCitationsGrid.tsx
@@ -9,7 +9,7 @@ import {
   CitationTitle,
 } from "@sparkle/components/Citation";
 import { Pagination } from "@sparkle/components/Pagination";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import type { PaginationState } from "@tanstack/react-table";
 import React, { useState } from "react";
 
@@ -61,7 +61,7 @@ export function PaginatedCitationsGrid({
       </CitationGrid>
 
       <div
-        className={classNames(
+        className={cn(
           "s-pt-3",
           items.length > maxItemsPerPage ? "s-visible" : "s-collapse"
         )}

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
 
 import { ChevronLeftIcon, ChevronRightIcon } from "@sparkle/icons/app";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import type { PaginationState } from "@tanstack/react-table";
 import React, { useCallback } from "react";
 
@@ -67,13 +67,13 @@ export function Pagination({
 
   return (
     <div
-      className={classNames(
+      className={cn(
         "s-flex s-w-full s-items-center",
         controlsAreHidden ? "s-justify-end" : "s-justify-between"
       )}
     >
       <div
-        className={classNames(
+        className={cn(
           "s-flex",
           controlsAreHidden ? "s-invisible" : "s-visible",
           showPageButtons ? "s-gap-0" : "s-gap-2"
@@ -88,7 +88,7 @@ export function Pagination({
         />
 
         <div
-          className={classNames(
+          className={cn(
             "s-items-center",
             size === "xs" ? "s-gap-3 s-px-3" : "s-gap-4 s-px-4",
             showPageButtons ? "s-flex" : "s-hidden"
@@ -107,7 +107,7 @@ export function Pagination({
       </div>
 
       <span
-        className={classNames(
+        className={cn(
           "s-text-xs",
           "s-text-muted-foreground dark:s-text-muted-foreground-night",
           showDetails ? "s-visible" : "s-collapse"
@@ -132,7 +132,7 @@ function renderPageNumber(
   return (
     <button
       key={pageNumber}
-      className={classNames(
+      className={cn(
         "s-font-medium s-transition-colors s-duration-200",
         currentPage === pageNumber
           ? "s-text-foreground dark:s-text-foreground-night"
@@ -150,7 +150,7 @@ function renderPageNumber(
 function renderEllipses(size: "sm" | "xs") {
   return (
     <span
-      className={classNames(
+      className={cn(
         "s-text-sm s-font-medium",
         "s-text-muted-foreground dark:s-text-muted-foreground-night",
         size === "xs" ? "s-text-xs" : "s-text-sm"

--- a/sparkle/src/components/PriceTable.tsx
+++ b/sparkle/src/components/PriceTable.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, DashIcon, XMarkIcon } from "@sparkle/icons/app";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import React, { type ReactNode } from "react";
 
 import { Icon } from "./Icon";
@@ -62,7 +62,7 @@ export function PriceTable({
 
   return (
     <div
-      className={classNames(
+      className={cn(
         "s-w-full",
         "s-flex s-cursor-default s-flex-col s-border s-border-white/30",
         sizeTable[size],
@@ -74,13 +74,13 @@ export function PriceTable({
       )}
     >
       <div
-        className={classNames(
+        className={cn(
           "s-flex s-flex-col",
           size === "xs" ? "s-px-4 s-py-3" : "s-px-5 s-py-4"
         )}
       >
         <div
-          className={classNames(
+          className={cn(
             size === "xs" ? "s-heading-2xl" : "s-heading-3xl",
             "s-w-full s-text-right",
             "s-text-foreground"
@@ -90,7 +90,7 @@ export function PriceTable({
         </div>
         <div className="-s-mt-2 s-flex s-flex-row s-items-baseline s-gap-2">
           <span
-            className={classNames(
+            className={cn(
               size === "xs" ? "s-heading-3xl" : "s-heading-4xl",
               textColorTable[color]
             )}
@@ -98,7 +98,7 @@ export function PriceTable({
             {price}
           </span>
           <span
-            className={classNames(
+            className={cn(
               "s-text-foreground",
               size === "xs" ? "s-heading-base" : "s-heading-lg"
             )}
@@ -114,7 +114,7 @@ export function PriceTable({
           borderTopRightRadius: "4px",
           borderTopLeftRadius: "4px",
         }}
-        className={classNames(
+        className={cn(
           "s-flex s-h-full s-flex-col s-overflow-hidden s-shadow-md",
           "s-bg-background dark:s-bg-muted-background-night"
         )}
@@ -152,7 +152,7 @@ PriceTable.Item = function ({
 }: PriceTableItemProps) {
   return (
     <div
-      className={classNames(
+      className={cn(
         size === "xs"
           ? "s-gap-2 s-p-2.5 s-text-sm"
           : "s-gap-3 s-p-4 s-text-base",
@@ -170,7 +170,7 @@ PriceTable.Item = function ({
         />
       </div>
       <div
-        className={classNames(
+        className={cn(
           variant === "xmark"
             ? "s-text-primery-600 dark:s-text-primery-600-night"
             : "",
@@ -198,7 +198,7 @@ PriceTable.ActionContainer = function ({
     <>
       {position === "bottom" ? <div className="s-h-full s-w-full" /> : null}
       <div
-        className={classNames(
+        className={cn(
           "s-flex s-w-full s-justify-center s-px-2",
           size === "xs" ? "s-py-2" : "s-py-4",
           position === "top"

--- a/sparkle/src/components/Separator.tsx
+++ b/sparkle/src/components/Separator.tsx
@@ -1,5 +1,5 @@
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
 
 const Separator = React.forwardRef<
@@ -14,7 +14,7 @@ const Separator = React.forwardRef<
       ref={ref}
       decorative={decorative}
       orientation={orientation}
-      className={classNames(
+      className={cn(
         "s-shrink-0",
         "s-bg-separator dark:s-bg-separator-night",
         orientation === "horizontal"

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -1,4 +1,4 @@
-import { classNames, cn } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import React, { type MouseEventHandler } from "react";
 
 type SliderToggleProps = {
@@ -49,7 +49,7 @@ export function SliderToggle({
   selected = false,
   size = "xs",
 }: SliderToggleProps) {
-  const combinedStateClasses = classNames(
+  const combinedStateClasses = cn(
     size ? sizeClasses[size] : "",
     selected ? stateClasses.selected : stateClasses.idle,
     disabled ? stateClasses.disabled : ""
@@ -62,7 +62,7 @@ export function SliderToggle({
           onClick?.(e); // Run passed onClick event
         }
       }}
-      className={classNames(className, baseClasses, combinedStateClasses)}
+      className={cn(className, baseClasses, combinedStateClasses)}
     >
       <div
         id="cursor"

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -3,7 +3,7 @@ import {
   KeyboardShortcut,
   type KeyboardShortcutProps,
 } from "@sparkle/components/KeyboardShortcut";
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
 import { useEffect, useState } from "react";
 
@@ -38,7 +38,7 @@ const TooltipContent = React.forwardRef<
       <TooltipPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}
-        className={classNames(
+        className={cn(
           "s-z-50 s-max-w-sm s-overflow-hidden s-whitespace-pre-wrap s-break-words s-rounded-md s-border",
           "s-bg-background dark:s-bg-background-night",
           "s-text-foreground dark:s-text-foreground-night",

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -195,7 +195,7 @@ function JsonValue({
 
       return (
         <span
-          className={`${VALUE_CLASSES} s-whitespace-pre-wrap s-break-normal`}
+          className={cn(VALUE_CLASSES, "s-whitespace-pre-wrap s-break-normal")}
         >
           {isExpanded ? value : value.substring(0, MAX_STRING_LENGTH)}
           {!isExpanded && "…"}{" "}
@@ -212,7 +212,9 @@ function JsonValue({
     }
 
     return (
-      <span className={`${VALUE_CLASSES} s-whitespace-pre-wrap s-break-normal`}>
+      <span
+        className={cn(VALUE_CLASSES, "s-whitespace-pre-wrap s-break-normal")}
+      >
         {value}
       </span>
     );

--- a/sparkle/src/lib/utils.ts
+++ b/sparkle/src/lib/utils.ts
@@ -2,10 +2,6 @@ import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(" ");
-}
-
 export function assertNever(x: never): never {
   throw new Error(`${x} is not of type never. This should never happen.`);
 }

--- a/sparkle/src/stories/Typography.stories.tsx
+++ b/sparkle/src/stories/Typography.stories.tsx
@@ -2,7 +2,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { classNames } from "@sparkle/lib/utils";
+import { cn } from "@sparkle/lib/utils";
 
 // Define the text sizes and weights
 const textSizes = {
@@ -89,7 +89,7 @@ const Typography: React.FC<TypographyProps> = ({ variant }) => {
             Object.entries(fontWeights).map(([weightKey, weightClass]) => (
               <div
                 key={`${sizeKey}-${weightKey}`}
-                className={classNames(sizeClass, weightClass)}
+                className={cn(sizeClass, weightClass)}
               >
                 <div>{`${sizeKey} ${weightKey}`}</div>
                 <p>{loremIpsum}</p>
@@ -99,10 +99,7 @@ const Typography: React.FC<TypographyProps> = ({ variant }) => {
         </div>
         <div className="s-mt-6 s-grid s-gap-16 s-bg-repeat s-py-8">
           {Object.entries(extraTextSizes).map(([sizeKey, sizeClass]) => (
-            <div
-              key={sizeKey}
-              className={classNames(sizeClass, "s-font-medium")}
-            >
+            <div key={sizeKey} className={cn(sizeClass, "s-font-medium")}>
               <div>{`${sizeKey} medium`}</div>
               <p>{loremIpsum}</p>
             </div>
@@ -137,7 +134,7 @@ const Typography: React.FC<TypographyProps> = ({ variant }) => {
                 <p>{copyLoremIpsum}</p>
               </div>
             </div>
-            <div className={classNames(copyClass, "s-italic")}>
+            <div className={cn(copyClass, "s-italic")}>
               <div>{`Copy ${sizeKey} Italic`}</div>
               <div
                 className="s-mt-2"
@@ -157,7 +154,7 @@ const Typography: React.FC<TypographyProps> = ({ variant }) => {
                 <p>{copyLoremIpsum}</p>
               </div>
             </div>
-            <div className={classNames(copyClass, "s-font-mono")}>
+            <div className={cn(copyClass, "s-font-mono")}>
               <div>{`Copy ${sizeKey} Mono`}</div>
               <div
                 className="s-mt-2"


### PR DESCRIPTION
## Description

This PR streamlines the utility import for class concatenation by making use of the `cn` alias function instead of the verbose `classNames`

## Tests

N/A

## Risk

Low

## Deploy Plan

N/A