### PR TITLE
feat: use corepack to upgrade npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dust-monorepo",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "workspaces": [
         "front",
         "front-spa",
@@ -26,13 +27,6 @@
       },
       "engines": {
         "node": "22.22.0"
-      },
-      "optionalDependencies": {
-        "@biomejs/cli-linux-x64": "2.4.0",
-        "@next/swc-linux-x64-gnu": "14.2.33",
-        "@next/swc-linux-x64-musl": "14.2.33",
-        "@rollup/rollup-linux-x64-gnu": "4.55.2",
-        "@swc/core-linux-x64-gnu": "1.15.10"
       }
     },
     "cli": {
@@ -5666,6 +5660,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -7116,7 +7111,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7133,7 +7127,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7150,7 +7143,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7167,7 +7159,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7199,7 +7190,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7216,7 +7206,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7233,7 +7222,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7250,7 +7238,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7267,7 +7254,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7284,7 +7270,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7301,7 +7286,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7318,7 +7302,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7335,7 +7318,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7352,7 +7334,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7369,7 +7350,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7386,7 +7366,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7403,7 +7382,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7420,7 +7398,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7437,7 +7414,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7454,7 +7430,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7471,7 +7446,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7488,7 +7462,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7505,7 +7478,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7522,7 +7494,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7539,7 +7510,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12992,7 +12962,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -13032,7 +13001,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -13044,14 +13012,12 @@
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "7.1.1",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -27769,7 +27735,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "viz",
     "sdks/js"
   ],
+  "packageManager": "npm@11.11.0",
   "scripts": {
+    "preinstall": "corepack enable npm",
     "clean": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "install:all": "npm install",
     "knip": "knip",
@@ -35,13 +37,6 @@
   },
   "engines": {
     "node": "22.22.0"
-  },
-  "optionalDependencies": {
-    "@biomejs/cli-linux-x64": "2.4.0",
-    "@next/swc-linux-x64-gnu": "14.2.33",
-    "@next/swc-linux-x64-musl": "14.2.33",
-    "@rollup/rollup-linux-x64-gnu": "4.55.2",
-    "@swc/core-linux-x64-gnu": "1.15.10"
   },
   "overrides": {
     "eslint-plugin-react-hooks": {


### PR DESCRIPTION
## Description

Fix npm version so the bug on optional dependencies is fixed (fixed in npm v11, node 22 ships with a npm 10.9 faulty). 

We need to install a specific version of `npm`, and corepack is the way™


Run `npm i && npm i`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
