### PR TITLE
dx: "gotta go fast" move Biome noImportCycles check to CI

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Format Check
         run: npm run biome
       - name: Import Cycle Check
-        run: node_modules/.bin/biome check --error-on-warnings --config-path biome.ci.json .
+        run: npm run biome -- --config-path biome.ci.json
       - name: GritQL Plugin Tests
         run: npm run test:grit

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -14,6 +14,7 @@ on:
       - "**/*.yml"
       - "**/*.yaml"
       - biome.json
+      - biome.ci.json
       - "**/biome.json"
       - "biome-plugins/**"
       - ".grit/**"
@@ -42,5 +43,7 @@ jobs:
           echo "$HOME/.grit/bin" >> $GITHUB_PATH
       - name: Format Check
         run: npm run biome
+      - name: Import Cycle Check
+        run: node_modules/.bin/biome check --error-on-warnings --config-path biome.ci.json .
       - name: GritQL Plugin Tests
         run: npm run test:grit

--- a/biome.ci.json
+++ b/biome.ci.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.0/schema.json",
+  "extends": ["./biome.json"],
+  "linter": {
+    "rules": {
+      "suspicious": {
+        "noImportCycles": "error"
+      }
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -75,7 +75,7 @@
         "useImportType": "error"
       },
       "suspicious": {
-        "noImportCycles": "error"
+        "noImportCycles": "off"
       }
     }
   },


### PR DESCRIPTION
## Description

We move the noImportCycles check to CI to drastically cut local check time.
It accounted for ~1.5s (83% of total pre-commit time)

## Tests

```
Baseline — no staged files

  ┌─────────────────────────────────────────┬────────────────────┬──────────┬──────────┐
  │                   Run                   │        Mean        │   Min    │   Max    │
  ├─────────────────────────────────────────┼────────────────────┼──────────┼──────────┤
  │ HEAD                                    │ 341.2 ms ± 58.2 ms │ 284.0 ms │ 450.8 ms │
  └─────────────────────────────────────────┴────────────────────┴──────────┴──────────┘

  With the changes and a staged file 

  ┌────────────────────────────────────────┬────────────────────┬──────────┬──────────┐
  │                Variant                 │        Mean        │   Min    │   Max    │
  ├────────────────────────────────────────┼────────────────────┼──────────┼──────────┤
  │ noImportCycles: "error" + no daemon    │ 1.852s ± 82ms      │ 1.753s   │ 1.927s   │
  ├────────────────────────────────────────┼────────────────────┼──────────┼──────────┤
  │ noImportCycles: "error" + --use-server │ 1.937s ± 77ms      │ 1.813s   │ 2.013s   │
  ├────────────────────────────────────────┼────────────────────┼──────────┼──────────┤
  │ noImportCycles: "off"                  │ 311.9 ms ± 19.8 ms │ 273.5 ms │ 338.1 ms │
  └────────────────────────────────────────┴────────────────────┴──────────┴──────────┘
  ```


## Risk

N/A

## Deploy Plan

N/A