### PR TITLE
Stop using dustAPI in MCP services

### DIFF
--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -1,5 +1,5 @@
-import type { DustAPI } from "@dust-tt/client";
-import { DustMcpServerTransport } from "@dust-tt/client";
+import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
+import type { WorkspaceType } from "@dust-tt/client/src/types";
 import { registerAllTools } from "@extension/platforms/chrome/tools";
 import { McpService } from "@extension/shared/services/mcp";
 import type { BrowserMessagingService } from "@extension/shared/services/platform";
@@ -12,7 +12,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 export class ChromeMcpService extends McpService {
   private messaging: BrowserMessagingService | null;
   private server: McpServer | null = null;
-  private transport: DustMcpServerTransport | null = null;
+  private transport: BrowserMCPTransport | null = null;
   private serverId: string | undefined = undefined;
 
   constructor(messaging?: BrowserMessagingService) {
@@ -39,7 +39,7 @@ export class ChromeMcpService extends McpService {
 
   async connectServer(
     server: McpServer,
-    dustAPI: DustAPI,
+    owner: WorkspaceType,
     onServerIdReceived: (serverId: string) => void
   ): Promise<void> {
     if (!server) {
@@ -51,10 +51,14 @@ export class ChromeMcpService extends McpService {
         return;
       }
 
-      const transport = new DustMcpServerTransport(dustAPI, (serverId) => {
-        this.serverId = serverId;
-        onServerIdReceived(serverId);
-      });
+      const transport = new BrowserMCPTransport(
+        owner.sId,
+        "chrome-extension-client",
+        (serverId) => {
+          this.serverId = serverId;
+          onServerIdReceived(serverId);
+        }
+      );
 
       await server.connect(transport);
 
@@ -66,12 +70,12 @@ export class ChromeMcpService extends McpService {
   }
 
   async getOrCreateServer(
-    dustAPI: DustAPI,
+    owner: WorkspaceType,
     onServerIdReceived: (serverId: string) => void
   ): Promise<{ server: McpServer | null; serverId: string | undefined }> {
     try {
       if (this.server) {
-        await this.connectServer(this.server, dustAPI, onServerIdReceived);
+        await this.connectServer(this.server, owner, onServerIdReceived);
         return { server: this.server, serverId: this.serverId };
       }
 
@@ -80,7 +84,7 @@ export class ChromeMcpService extends McpService {
         return { server: null, serverId: undefined };
       }
 
-      await this.connectServer(server, dustAPI, onServerIdReceived);
+      await this.connectServer(server, owner, onServerIdReceived);
       return { server, serverId: this.serverId };
     } catch (error) {
       console.error("Error getting or creating MCP server:", error);

--- a/extension/platforms/front/services/mcp.ts
+++ b/extension/platforms/front/services/mcp.ts
@@ -1,5 +1,5 @@
-import type { DustAPI } from "@dust-tt/client";
-import { DustMcpServerTransport } from "@dust-tt/client";
+import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
+import type { WorkspaceType } from "@app/types/user";
 import { registerAllTools } from "@extension/platforms/front/tools";
 import { McpService } from "@extension/shared/services/mcp";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
@@ -12,7 +12,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 export class FrontMcpService extends McpService {
   private frontContext: WebViewContext | null = null;
   private server: McpServer | null = null;
-  private transport: DustMcpServerTransport | null = null;
+  private transport: BrowserMCPTransport | null = null;
   private serverId: string | undefined = undefined;
 
   constructor() {
@@ -55,7 +55,7 @@ export class FrontMcpService extends McpService {
    */
   async connectServer(
     server: McpServer,
-    dustAPI: DustAPI,
+    owner: WorkspaceType,
     onServerIdReceived: (serverId: string) => void
   ): Promise<void> {
     if (!server) {
@@ -70,10 +70,14 @@ export class FrontMcpService extends McpService {
       }
 
       // Create our custom transport with workspace-scoped registration.
-      const transport = new DustMcpServerTransport(dustAPI, (serverId) => {
-        this.serverId = serverId;
-        onServerIdReceived(serverId);
-      });
+      const transport = new BrowserMCPTransport(
+        owner.sId,
+        "front-extension-client",
+        (serverId) => {
+          this.serverId = serverId;
+          onServerIdReceived(serverId);
+        }
+      );
 
       // Connect the server to the transport.
       await server.connect(transport);
@@ -91,14 +95,14 @@ export class FrontMcpService extends McpService {
    * This is a convenience method that provides the main API for client code
    */
   async getOrCreateServer(
-    dustAPI: DustAPI,
+    owner: WorkspaceType,
     onServerIdReceived: (serverId: string) => void
   ): Promise<{ server: McpServer | null; serverId: string | undefined }> {
     try {
       // Reuse existing server if we have one
       if (this.server) {
         // Connect if not already connected
-        await this.connectServer(this.server, dustAPI, onServerIdReceived);
+        await this.connectServer(this.server, owner, onServerIdReceived);
         return {
           server: this.server,
           serverId: this.serverId,
@@ -115,7 +119,7 @@ export class FrontMcpService extends McpService {
       }
 
       // Connect the server
-      await this.connectServer(server, dustAPI, onServerIdReceived);
+      await this.connectServer(server, owner, onServerIdReceived);
 
       return {
         server: server,

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,6 +1,6 @@
 import { usePlatform } from "@extension/shared/context/PlatformContext";
-import { useDustAPI } from "@extension/shared/lib/dust_api";
 import { normalizeError } from "@extension/shared/lib/utils";
+import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
@@ -18,7 +18,7 @@ export function useMcpServer() {
   const [error, setError] = useState<Error | null>(null);
   const serverRef = useRef<any>(null);
 
-  const dustAPI = useDustAPI();
+  const { workspace } = useExtensionAuth();
 
   // Function to disconnect the server.
   const disconnectServer = useCallback(async () => {
@@ -58,8 +58,12 @@ export function useMcpServer() {
           return;
         }
 
+        if (!workspace) {
+          return;
+        }
+
         const result = await platform.mcp.getOrCreateServer(
-          dustAPI,
+          workspace,
           (serverId) => {
             setServerId(serverId);
           }

--- a/extension/shared/services/mcp.ts
+++ b/extension/shared/services/mcp.ts
@@ -1,4 +1,4 @@
-import type { DustAPI } from "@dust-tt/client";
+import type { WorkspaceType } from "@app/types/user";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 /**
@@ -10,7 +10,7 @@ export abstract class McpService {
    * Primary method for workspace-scoped MCP implementation
    */
   abstract getOrCreateServer(
-    dustAPI: DustAPI,
+    owner: WorkspaceType,
     onServerIdReceived: (serverId: string) => void
   ): Promise<{ server: McpServer | null; serverId: string | undefined }>;
 
@@ -20,7 +20,7 @@ export abstract class McpService {
    */
   abstract connectServer(
     server: McpServer,
-    dustAPI: DustAPI,
+    owner: WorkspaceType,
     onServerIdReceived: (serverId: string) => void
   ): Promise<void>;
 


### PR DESCRIPTION
## Description

Replaces `DustMcpServerTransport` (from @dust-tt/client) with `BrowserMCPTransport` in the Chrome and Front extension MCP services. The new transport uses private API endpoints. The MCP service now takes a WorkspaceType owner object instead of DustAPI, passing only the workspace sId and a client identifier to the transport.

## Tests

Make an agent use the `get-current-page` tool (client-side MCP server)

## Risk

Medium.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
