### PR TITLE
Lower tokenization batch size from 100 to 50

### DIFF
--- a/front/lib/tokenization.ts
+++ b/front/lib/tokenization.ts
@@ -13,7 +13,7 @@ import config from "./api/config";
 
 // Tokenizing large text payloads causes memory stress in core API, leading to OOM issues.
 // We limit batch size to 100 texts per request to prevent memory exhaustion.
-const MAX_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 50;
 
 // Limit concurrent requests to core API to avoid overloading.
 const TOKENIZATION_CONCURRENCY = 3;

--- a/front/lib/tokenization.ts
+++ b/front/lib/tokenization.ts
@@ -12,7 +12,7 @@ import _ from "lodash";
 import config from "./api/config";
 
 // Tokenizing large text payloads causes memory stress in core API, leading to OOM issues.
-// We limit batch size to 100 texts per request to prevent memory exhaustion.
+// We limit batch size to 50 texts per request to prevent memory exhaustion.
 const MAX_BATCH_SIZE = 50;
 
 // Limit concurrent requests to core API to avoid overloading.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR reduces the `MAX_BATCH_SIZE` used to tokenized the conversation in the agent loop worker from 100 to 50 to help reduces memory pressures on core deployments.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
