### PR TITLE
fix(mcp): route SSE connections through correct proxy for static IP egress

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -51,7 +51,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import type { ProxyAgent } from "undici";
+
 
 const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
 
@@ -111,10 +111,7 @@ export type MCPConnectionParams =
  * Without a custom `fetch`, those connections fall through to the global fetch
  * which may use a different proxy (e.g. squid-proxy instead of http-proxy).
  */
-async function createMCPProxyConfig(
-  auth: Authenticator,
-  host: string
-) {
+async function createMCPProxyConfig(auth: Authenticator, host: string) {
   const workspace = auth.getNonNullableWorkspace();
 
   // Check if workspace should use static IP:

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -28,6 +28,7 @@ import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_ac
 import { isHostUnderVerifiedDomain } from "@app/lib/api/workspace_has_domains";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  createProxyFetch,
   getStaticIPProxyAgent,
   getUntrustedEgressAgent,
 } from "@app/lib/egress/server";
@@ -100,10 +101,20 @@ export type MCPConnectionParams =
   | ServerSideMCPConnectionParams
   | ClientSideMCPConnectionParams;
 
-async function createMCPDispatcher(
+/**
+ * Build the proxy configuration for a remote MCP server connection.
+ *
+ * Returns both a `dispatcher` (for POST requests via `send()`) and a custom
+ * `fetch` function. The custom `fetch` is necessary because the MCP SDK's
+ * SSEClientTransport and StreamableHTTPClientTransport do NOT forward
+ * `requestInit.dispatcher` to their internal EventSource/GET fetch calls.
+ * Without a custom `fetch`, those connections fall through to the global fetch
+ * which may use a different proxy (e.g. squid-proxy instead of http-proxy).
+ */
+async function createMCPProxyConfig(
   auth: Authenticator,
   host: string
-): Promise<ProxyAgent | undefined> {
+) {
   const workspace = auth.getNonNullableWorkspace();
 
   // Check if workspace should use static IP:
@@ -113,18 +124,25 @@ async function createMCPDispatcher(
     isWorkspaceUsingStaticIP(workspace) ||
     (await isHostUnderVerifiedDomain(auth, host));
 
-  if (useStaticIP) {
-    const staticIPProxy = getStaticIPProxyAgent();
-    if (staticIPProxy) {
-      logger.info(
-        { workspaceId: workspace.sId, host, useStaticIP },
-        "Using static IP proxy for MCP request"
-      );
-      return staticIPProxy;
-    }
+  const dispatcher = useStaticIP
+    ? getStaticIPProxyAgent()
+    : getUntrustedEgressAgent();
+
+  if (useStaticIP && dispatcher) {
+    logger.info(
+      { workspaceId: workspace.sId, host, useStaticIP },
+      "Using static IP proxy for MCP request"
+    );
   }
 
-  return getUntrustedEgressAgent();
+  if (!dispatcher) {
+    return {};
+  }
+
+  return {
+    dispatcher,
+    fetch: createProxyFetch(dispatcher),
+  };
 }
 
 export async function connectToMCPServer(
@@ -410,13 +428,16 @@ export async function connectToMCPServer(
           }
 
           try {
+            const { dispatcher, fetch: proxyFetch } =
+              await createMCPProxyConfig(auth, url.hostname);
             const req = {
               requestInit: {
                 // Include stored custom headers
                 headers: remoteMCPServer.customHeaders ?? {},
-                dispatcher: await createMCPDispatcher(auth, url.hostname),
+                dispatcher,
               },
               authProvider: new MCPOAuthProvider(token),
+              fetch: proxyFetch,
             };
 
             await connectToRemoteMCPServer(mcpClient, url, req);
@@ -483,12 +504,17 @@ export async function connectToMCPServer(
           )
         );
       }
+      const { dispatcher, fetch: proxyFetch } = await createMCPProxyConfig(
+        auth,
+        url.hostname
+      );
       const req = {
         requestInit: {
-          dispatcher: await createMCPDispatcher(auth, url.hostname),
+          dispatcher,
           headers: { ...(params.headers ?? {}) },
         },
         authProvider: new MCPOAuthProvider(),
+        fetch: proxyFetch,
       };
       try {
         await connectToRemoteMCPServer(mcpClient, url, req);

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -52,7 +52,6 @@ import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
-
 const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
 
 // Short timeout: the Redis round-trip is near-instant when the browser

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -121,17 +121,22 @@ async function createMCPProxyConfig(auth: Authenticator, host: string) {
     isWorkspaceUsingStaticIP(workspace) ||
     (await isHostUnderVerifiedDomain(auth, host));
 
-  const dispatcher = useStaticIP
-    ? getStaticIPProxyAgent()
-    : getUntrustedEgressAgent();
-
-  if (useStaticIP && dispatcher) {
-    logger.info(
-      { workspaceId: workspace.sId, host, useStaticIP },
-      "Using static IP proxy for MCP request"
+  if (useStaticIP) {
+    const staticAgent = getStaticIPProxyAgent();
+    if (staticAgent) {
+      logger.info(
+        { workspaceId: workspace.sId, host },
+        "Using static IP proxy for MCP request"
+      );
+      return { dispatcher: staticAgent, fetch: createProxyFetch(staticAgent) };
+    }
+    logger.warn(
+      { workspaceId: workspace.sId, host },
+      "Static IP proxy required but not configured, falling back to untrusted egress"
     );
   }
 
+  const dispatcher = getUntrustedEgressAgent();
   if (!dispatcher) {
     return {};
   }

--- a/front/lib/egress/server.ts
+++ b/front/lib/egress/server.ts
@@ -48,6 +48,27 @@ export function untrustedFetch(
   return undiciFetch(input, finalInit);
 }
 
+/**
+ * Creates a fetch function that routes all requests through the given proxy agent.
+ *
+ * Used by MCP transports: the MCP SDK does NOT forward `requestInit.dispatcher`
+ * to its internal EventSource/GET connections. Passing this as `opts.fetch`
+ * ensures ALL fetch calls (SSE GET + POST) go through the proxy.
+ *
+ * Node.js 22+ global fetch IS undici under the hood and reads `dispatcher`
+ * from the init object at runtime, even though the DOM TS types don't
+ * declare it. Using globalThis.fetch keeps the types in DOM-land, which
+ * is compatible with the MCP SDK's FetchLike type.
+ */
+export function createProxyFetch(
+  agent: ProxyAgent
+): (input: string | URL, init?: globalThis.RequestInit) => Promise<globalThis.Response> {
+  // Capture dispatcher in a plain object so it can be spread into init
+  // without triggering excess-property checks.
+  const proxyInit = { dispatcher: agent };
+  return (input, init) => globalThis.fetch(input, { ...init, ...proxyInit });
+}
+
 // Fetch helper for trusted, first‑party egress or intra‑VPC calls.
 // This is just the regular fetch without any proxy injection.
 export function trustedFetch(

--- a/front/lib/egress/server.ts
+++ b/front/lib/egress/server.ts
@@ -62,7 +62,10 @@ export function untrustedFetch(
  */
 export function createProxyFetch(
   agent: ProxyAgent
-): (input: string | URL, init?: globalThis.RequestInit) => Promise<globalThis.Response> {
+): (
+  input: string | URL,
+  init?: globalThis.RequestInit
+) => Promise<globalThis.Response> {
   // Capture dispatcher in a plain object so it can be spread into init
   // without triggering excess-property checks.
   const proxyInit = { dispatcher: agent };


### PR DESCRIPTION
## Description

Fixes proxy routing for remote MCP servers behind static-IP-restricted firewalls .

The MCP SDK's `SSEClientTransport` and `StreamableHTTPClientTransport` do **not** forward `requestInit.dispatcher` to their internal EventSource/GET fetch calls — only POST requests (via `send()`) use the dispatcher. This means the initial SSE connection bypasses the configured proxy agent and falls through to the global fetch, which may route through a different proxy (squid-proxy/untrusted egress instead of http-proxy/static IP).

**Fix:** alongside the `dispatcher`, pass a custom `fetch` function via `opts.fetch` that wraps `globalThis.fetch` with the proxy agent baked in. The MCP SDK transports pick up `opts.fetch` for *all* their internal fetch calls (including EventSource SSE connections), ensuring every request goes through the correct proxy.

Changes:
- Add `createProxyFetch()` to `front/lib/egress/server.ts` — creates a fetch wrapper that routes through a given `ProxyAgent`
- Replace `createMCPDispatcher()` with `createMCPProxyConfig()` in `front/lib/actions/mcp_metadata.ts` — returns both the dispatcher (for `requestInit`) and the custom fetch (for `opts.fetch`)
- Update both remote MCP connection call sites to pass the custom fetch

## Tests

- Typecheck passes
- The fix addresses a production issue, confirmed through Datadog logs showing the proxy selection log fires correctly but traffic was misrouted

## Risk

**Low.** The change only adds a `fetch` option to the MCP transport constructor — the dispatcher is still passed via `requestInit` as before (for POST), and the new custom fetch uses the same proxy agent. Rollback-safe: reverting simply removes the custom fetch and returns to the previous (broken) behavior.

## Deploy Plan

Standard front deployment. After deploy, verify in Datadog traffic.