### PR TITLE
feat: add workflow for butler

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -64,6 +64,10 @@ import {
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import {
+  launchOrSignalButlerWorkflow,
+  signalButlerComplete,
+} from "@app/temporal/butler/client";
 import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
@@ -818,6 +822,26 @@ export async function postUserMessage(
       : Promise.resolve(undefined),
   ]);
 
+  const featureFlags = await getFeatureFlags(owner);
+  if (
+    featureFlags.includes("conversation_butler") &&
+    isProjectConversation(conversation)
+  ) {
+    // Fire-and-forget: butler failures must not block message posting.
+    void launchOrSignalButlerWorkflow({
+      authType: auth.toJSON(),
+      conversationId: conversation.sId,
+      messageId: userMessage.sId,
+    });
+
+    if (agentMessages.length === 0) {
+      void signalButlerComplete({
+        authType: auth.toJSON(),
+        conversationId: conversation.sId,
+      });
+    }
+  }
+
   return new Ok({
     userMessage,
     agentMessages,
@@ -1127,6 +1151,26 @@ export async function editUserMessage(
     agentMessages
   );
 
+  const featureFlags = await getFeatureFlags(owner);
+  if (
+    featureFlags.includes("conversation_butler") &&
+    isProjectConversation(conversation)
+  ) {
+    // Fire-and-forget: butler failures must not block message editing.
+    void launchOrSignalButlerWorkflow({
+      authType: auth.toJSON(),
+      conversationId: conversation.sId,
+      messageId: userMessage.sId,
+    });
+
+    if (agentMessages.length === 0) {
+      void signalButlerComplete({
+        authType: auth.toJSON(),
+        conversationId: conversation.sId,
+      });
+    }
+  }
+
   return new Ok({
     userMessage,
     agentMessages,
@@ -1190,6 +1234,8 @@ export async function retryAgentMessage(
     message: AgentMessageType;
   }
 ): Promise<Result<AgentMessageType, APIErrorWithStatusCode>> {
+  const owner = auth.getNonNullableWorkspace();
+
   // Find the parent user message to get the original context for rate limiting.
   // This ensures retries are counted with the same origin (web vs programmatic) as the original.
   const parentUserMessage = conversation.content
@@ -1385,6 +1431,19 @@ export async function retryAgentMessage(
     startStep: 0,
   });
 
+  const featureFlags = await getFeatureFlags(owner);
+  if (
+    featureFlags.includes("conversation_butler") &&
+    isProjectConversation(conversation)
+  ) {
+    // Fire-and-forget: butler failures must not block retries.
+    void launchOrSignalButlerWorkflow({
+      authType: auth.toJSON(),
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+    });
+  }
+
   // TODO(DURABLE-AGENTS 2025-07-17): Publish message events to all open tabs to maintain
   // conversation state synchronization in multiplex mode. This is a temporary solution -
   // we should move this to a dedicated real-time sync mechanism.
@@ -1524,6 +1583,23 @@ export async function postNewContentFragment(
     conversationId: conversation.sId,
     message: messageRow,
   });
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (
+    featureFlags.includes("conversation_butler") &&
+    isProjectConversation(conversation)
+  ) {
+    // Fire-and-forget: butler failures must not block content fragment posting.
+    void launchOrSignalButlerWorkflow({
+      authType: auth.toJSON(),
+      conversationId: conversation.sId,
+      messageId,
+    });
+    void signalButlerComplete({
+      authType: auth.toJSON(),
+      conversationId: conversation.sId,
+    });
+  }
 
   return new Ok(render);
 }

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -40,6 +40,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/triggers/webhook");
     case "analytics_queue":
       return path.join(baseDir, "temporal/analytics_queue");
+    case "butler":
+      return path.join(baseDir, "temporal/butler");
     case "credit_alerts":
       return path.join(baseDir, "temporal/credit_alerts");
     case "data_retention":

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -2,7 +2,12 @@ import {
   sendEmailReplyOnCompletion,
   sendEmailReplyOnError,
 } from "@app/lib/api/assistant/email/email_reply";
-import type { AuthenticatorType } from "@app/lib/auth";
+import {
+  Authenticator,
+  type AuthenticatorType,
+  getFeatureFlags,
+} from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
@@ -12,12 +17,30 @@ import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import { launchTrackProgrammaticUsage } from "@app/temporal/agent_loop/activities/usage_tracking";
+import { signalButlerComplete } from "@app/temporal/butler/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+
+  const auth = authResult.value;
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
+  let shouldSignalButler = false;
+  if (featureFlags.includes("conversation_butler")) {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      agentLoopArgs.conversationId
+    );
+    shouldSignalButler = conversation?.spaceId !== null;
+  }
+
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
@@ -25,6 +48,12 @@ export async function finalizeSuccessfulAgentLoopActivity(
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentions(authType, agentLoopArgs),
     sendEmailReplyOnCompletion(authType, agentLoopArgs),
+    shouldSignalButler
+      ? signalButlerComplete({
+          authType,
+          conversationId: agentLoopArgs.conversationId,
+        })
+      : Promise.resolve(),
   ]);
 }
 

--- a/front/temporal/butler/activities.ts
+++ b/front/temporal/butler/activities.ts
@@ -1,0 +1,17 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+
+export async function analyzeConversationActivity({
+  authType,
+  conversationId,
+  messageId,
+}: {
+  authType: AuthenticatorType;
+  conversationId: string;
+  messageId: string;
+}): Promise<void> {
+  logger.info(
+    { workspaceId: authType.workspaceId, conversationId, messageId },
+    "Butler: analyzing conversation (stub)"
+  );
+}

--- a/front/temporal/butler/client.ts
+++ b/front/temporal/butler/client.ts
@@ -1,0 +1,86 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/butler/config";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { butlerCompleteSignal, butlerRefreshSignal } from "./signals";
+import { butlerWorkflow } from "./workflows";
+
+function makeButlerWorkflowId(
+  workspaceId: string,
+  conversationId: string
+): string {
+  return `butler-${workspaceId}-${conversationId}`;
+}
+
+export async function launchOrSignalButlerWorkflow({
+  authType,
+  conversationId,
+  messageId,
+}: {
+  authType: AuthenticatorType;
+  conversationId: string;
+  messageId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeButlerWorkflowId(authType.workspaceId, conversationId);
+
+  try {
+    await client.workflow.signalWithStart(butlerWorkflow, {
+      args: [{ authType, conversationId, messageId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: butlerRefreshSignal,
+      signalArgs: undefined,
+      workflowExecutionTimeout: "1 hour",
+      memo: {
+        workspaceId: authType.workspaceId,
+        conversationId,
+        messageId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        workspaceId: authType.workspaceId,
+        conversationId,
+        messageId,
+        error: e,
+      },
+      "Failed starting butler workflow"
+    );
+
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function signalButlerComplete({
+  authType,
+  conversationId,
+}: {
+  authType: AuthenticatorType;
+  conversationId: string;
+}): Promise<void> {
+  try {
+    const client = await getTemporalClientForFrontNamespace();
+    const workflowId = makeButlerWorkflowId(
+      authType.workspaceId,
+      conversationId
+    );
+    await client.workflow.getHandle(workflowId).signal(butlerCompleteSignal);
+  } catch (e) {
+    // Swallow errors — workflow may have already completed or timed out.
+    logger.warn(
+      {
+        conversationId,
+        error: normalizeError(e),
+      },
+      "Failed signaling butler complete (workflow may have already finished)"
+    );
+  }
+}

--- a/front/temporal/butler/config.ts
+++ b/front/temporal/butler/config.ts
@@ -1,0 +1,4 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `butler-queue-v${QUEUE_VERSION}`;
+export const DEBOUNCE_DELAY_MS = 3_000;

--- a/front/temporal/butler/signals.ts
+++ b/front/temporal/butler/signals.ts
@@ -1,0 +1,8 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const butlerRefreshSignal = defineSignal<[void]>(
+  "butler_refresh_signal"
+);
+export const butlerCompleteSignal = defineSignal<[void]>(
+  "butler_complete_signal"
+);

--- a/front/temporal/butler/worker.ts
+++ b/front/temporal/butler/worker.ts
@@ -1,0 +1,50 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/butler/activities";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
+import { QUEUE_NAME } from "./config";
+
+export async function runButlerWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "butler",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 16,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json. This let us import code
+      // in the workflows and activities files using the @app/ prefix. We also need to ignore some
+      // modules that are not available in Temporal environment.
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
+      ignoreModules: ["child_process", "crypto", "stream"],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/butler/workflows.ts
+++ b/front/temporal/butler/workflows.ts
@@ -1,0 +1,51 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import type * as activities from "@app/temporal/butler/activities";
+import { DEBOUNCE_DELAY_MS } from "@app/temporal/butler/config";
+import {
+  condition,
+  proxyActivities,
+  setHandler,
+  sleep,
+} from "@temporalio/workflow";
+import { butlerCompleteSignal, butlerRefreshSignal } from "./signals";
+
+const { analyzeConversationActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+export async function butlerWorkflow({
+  authType,
+  conversationId,
+  messageId,
+}: {
+  authType: AuthenticatorType;
+  conversationId: string;
+  messageId: string;
+}): Promise<void> {
+  let needsAnalysis = true;
+  let complete = false;
+
+  setHandler(butlerRefreshSignal, () => {
+    needsAnalysis = true;
+  });
+
+  setHandler(butlerCompleteSignal, () => {
+    needsAnalysis = true;
+    complete = true;
+  });
+
+  while (!complete) {
+    await condition(() => needsAnalysis);
+    needsAnalysis = false;
+    await sleep(DEBOUNCE_DELAY_MS);
+
+    if (needsAnalysis) {
+      continue;
+    }
+
+    await analyzeConversationActivity({ authType, conversationId, messageId });
+  }
+
+  // Final analysis after completion signal.
+  await analyzeConversationActivity({ authType, conversationId, messageId });
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -1,6 +1,7 @@
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runAgentLoopWorker } from "@app/temporal/agent_loop/worker";
 import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
+import { runButlerWorker } from "@app/temporal/butler/worker";
 import { runCreditAlertsWorker } from "@app/temporal/credit_alerts/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
 import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
@@ -27,6 +28,7 @@ export type WorkerName =
   | "agent_schedule"
   | "agent_trigger_webhook"
   | "analytics_queue"
+  | "butler"
   | "credit_alerts"
   | "data_retention"
   | "es_indexation_queue"
@@ -52,6 +54,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   agent_schedule: runAgentTriggerWorker,
   agent_trigger_webhook: runAgentTriggerWebhookWorker,
   analytics_queue: runAnalyticsWorker,
+  butler: runButlerWorker,
   credit_alerts: runCreditAlertsWorker,
   data_retention: runDataRetentionWorker,
   hard_delete: runHardDeleteWorker,


### PR DESCRIPTION
## Description

Now that we have the model we can hook to the message flow (user/agent) to generate suggestions.

This adds all the temporal skeleton and a dummy `analyzeConversationActivity`

We are using events as per the design doc https://www.notion.so/dust-tt/Conversation-butler-31228599d94180d59083fa77fd1b5a55

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
