### PR TITLE
[MCP zendesk] added satisfaction_rating (+ due_at and has_incidents) missing fields

### DIFF
--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -16,50 +16,69 @@ export function renderTicket(
   ticketFieldsResult: Result<ZendeskTicketField[], Error>
 ): string {
   const lines = [
-    `ID: ${ticket.id}`,
-    `URL: ${apiUrlToDocumentUrl(ticket.url)}`,
-    `Subject: ${ticket.subject ?? "No subject"}`,
-    `Status: ${ticket.status}`,
+    `## Ticket ID: ${ticket.id}`,
+    `- URL: ${apiUrlToDocumentUrl(ticket.url)}`,
+    `- Subject: ${ticket.subject ?? "No subject"}`,
+    `- Status: ${ticket.status}`,
   ];
 
   if (ticket.priority) {
-    lines.push(`Priority: ${ticket.priority}`);
+    lines.push(`- Priority: ${ticket.priority}`);
   }
 
   if (ticket.type) {
-    lines.push(`Type: ${ticket.type}`);
+    lines.push(`- Type: ${ticket.type}`);
   }
 
   if (ticket.description) {
-    lines.push(`\nDescription:\n${ticket.description}`);
+    lines.push(
+      `- Description: ${ticket.description.trim().replace(/\n+/g, " ")}`
+    );
   }
 
   if (ticket.requester_id) {
-    lines.push(`\nRequester ID: ${ticket.requester_id}`);
+    lines.push(`- Requester ID: ${ticket.requester_id}`);
   }
 
   if (ticket.assignee_id) {
-    lines.push(`Assignee ID: ${ticket.assignee_id}`);
+    lines.push(`- Assignee ID: ${ticket.assignee_id}`);
   }
 
   if (ticket.group_id) {
-    lines.push(`Group ID: ${ticket.group_id}`);
+    lines.push(`- Group ID: ${ticket.group_id}`);
   }
 
   if (ticket.organization_id) {
-    lines.push(`Organization ID: ${ticket.organization_id}`);
+    lines.push(`- Organization ID: ${ticket.organization_id}`);
   }
 
   if (ticket.tags.length > 0) {
-    lines.push(`\nTags: ${ticket.tags.join(", ")}`);
+    lines.push(`- Tags: ${ticket.tags.join(", ")}`);
   }
 
   if (ticket.via?.channel) {
-    lines.push(`\nChannel: ${ticket.via.channel}`);
+    lines.push(`- Channel: ${ticket.via.channel}`);
   }
 
-  lines.push(`\nCreated: ${new Date(ticket.created_at).toISOString()}`);
-  lines.push(`Updated: ${new Date(ticket.updated_at).toISOString()}`);
+  if (ticket.satisfaction_rating) {
+    const { score, comment } = ticket.satisfaction_rating;
+    lines.push(
+      comment
+        ? `- Satisfaction: ${score} ("${comment}")`
+        : `- Satisfaction: ${score}`
+    );
+  }
+
+  if (ticket.due_at) {
+    lines.push(`- Due At: ${new Date(ticket.due_at).toISOString()}`);
+  }
+
+  if (ticket.has_incidents) {
+    lines.push(`- Has Incidents: ${ticket.has_incidents}`);
+  }
+
+  lines.push(`- Created: ${new Date(ticket.created_at).toISOString()}`);
+  lines.push(`- Updated: ${new Date(ticket.updated_at).toISOString()}`);
 
   if (ticket.custom_fields && ticket.custom_fields.length > 0) {
     if (ticketFieldsResult.isErr()) {

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -16,7 +16,7 @@ export function renderTicket(
   ticketFieldsResult: Result<ZendeskTicketField[], Error>
 ): string {
   const lines = [
-    `## Ticket ID: ${ticket.id}`,
+    `# Ticket ID: ${ticket.id}`,
     `- URL: ${apiUrlToDocumentUrl(ticket.url)}`,
     `- Subject: ${ticket.subject ?? "No subject"}`,
     `- Status: ${ticket.status}`,
@@ -62,11 +62,7 @@ export function renderTicket(
 
   if (ticket.satisfaction_rating) {
     const { score, comment } = ticket.satisfaction_rating;
-    lines.push(
-      comment
-        ? `- Satisfaction: ${score} ("${comment}")`
-        : `- Satisfaction: ${score}`
-    );
+    lines.push(`- Satisfaction: ${score}` + (comment ? ` ("${comment}")` : ""));
   }
 
   if (ticket.due_at) {

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -15,73 +15,62 @@ export function renderTicket(
   ticket: ZendeskTicket,
   ticketFieldsResult: Result<ZendeskTicketField[], Error>
 ): string {
-  const lines = [
-    `# Ticket ID: ${ticket.id}`,
-    `- URL: ${apiUrlToDocumentUrl(ticket.url)}`,
-    `- Subject: ${ticket.subject ?? "No subject"}`,
-    `- Status: ${ticket.status}`,
-  ];
+  const lines = [`# Ticket ID: ${ticket.id}`, `\n## Fields`];
+
+  lines.push(`URL: ${apiUrlToDocumentUrl(ticket.url)}`);
+  lines.push(`Subject: ${ticket.subject ?? "No subject"}`);
+  lines.push(`Status: ${ticket.status}`);
 
   if (ticket.priority) {
-    lines.push(`- Priority: ${ticket.priority}`);
+    lines.push(`Priority: ${ticket.priority}`);
   }
 
   if (ticket.type) {
-    lines.push(`- Type: ${ticket.type}`);
-  }
-
-  if (ticket.description) {
-    lines.push(
-      `- Description: ${ticket.description.trim().replace(/\n+/g, " ")}`
-    );
+    lines.push(`Type: ${ticket.type}`);
   }
 
   if (ticket.requester_id) {
-    lines.push(`- Requester ID: ${ticket.requester_id}`);
+    lines.push(`Requester ID: ${ticket.requester_id}`);
   }
 
   if (ticket.assignee_id) {
-    lines.push(`- Assignee ID: ${ticket.assignee_id}`);
+    lines.push(`Assignee ID: ${ticket.assignee_id}`);
   }
 
   if (ticket.group_id) {
-    lines.push(`- Group ID: ${ticket.group_id}`);
+    lines.push(`Group ID: ${ticket.group_id}`);
   }
 
   if (ticket.organization_id) {
-    lines.push(`- Organization ID: ${ticket.organization_id}`);
+    lines.push(`Organization ID: ${ticket.organization_id}`);
   }
 
   if (ticket.tags.length > 0) {
-    lines.push(`- Tags: ${ticket.tags.join(", ")}`);
+    lines.push(`Tags: ${ticket.tags.join(", ")}`);
   }
 
   if (ticket.via?.channel) {
-    lines.push(`- Channel: ${ticket.via.channel}`);
+    lines.push(`Channel: ${ticket.via.channel}`);
   }
 
   if (ticket.satisfaction_rating) {
     const { score, comment } = ticket.satisfaction_rating;
-    lines.push(`- Satisfaction: ${score}` + (comment ? ` ("${comment}")` : ""));
+    lines.push(`Satisfaction: ${score}` + (comment ? ` ("${comment}")` : ""));
   }
 
   if (ticket.due_at) {
-    lines.push(`- Due At: ${new Date(ticket.due_at).toISOString()}`);
+    lines.push(`Due At: ${new Date(ticket.due_at).toISOString()}`);
   }
 
   if (ticket.has_incidents) {
-    lines.push(`- Has Incidents: ${ticket.has_incidents}`);
+    lines.push(`Has Incidents: ${ticket.has_incidents}`);
   }
 
-  lines.push(`- Created: ${new Date(ticket.created_at).toISOString()}`);
-  lines.push(`- Updated: ${new Date(ticket.updated_at).toISOString()}`);
+  lines.push(`Created: ${new Date(ticket.created_at).toISOString()}`);
+  lines.push(`Updated: ${new Date(ticket.updated_at).toISOString()}`);
 
   if (ticket.custom_fields && ticket.custom_fields.length > 0) {
-    if (ticketFieldsResult.isErr()) {
-      lines.push(
-        "\nNote: Custom field names could not be retrieved. Only field IDs would be shown if displayed."
-      );
-    } else {
+    if (ticketFieldsResult.isOk()) {
       const fieldMap = new Map(
         ticketFieldsResult.value.map((f) => [f.id, f.title])
       );
@@ -95,7 +84,7 @@ export function renderTicket(
             const valueStr = Array.isArray(field.value)
               ? field.value.join(", ")
               : String(field.value);
-            fieldsWithNames.push(`- ${fieldName}: ${valueStr}`);
+            fieldsWithNames.push(`${fieldName}: ${valueStr}`);
           } else {
             fieldsAreMissing = true;
           }
@@ -111,6 +100,10 @@ export function renderTicket(
         lines.push("\nNote: Some custom fields could not be displayed.");
       }
     }
+  }
+
+  if (ticket.description) {
+    lines.push(`\n## Description\n${ticket.description.trim()}`);
   }
 
   return lines.join("\n");

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -15,7 +15,7 @@ export function renderTicket(
   ticket: ZendeskTicket,
   ticketFieldsResult: Result<ZendeskTicketField[], Error>
 ): string {
-  const lines = [`# Ticket ID: ${ticket.id}`, `\n## Fields`];
+  const lines = [`# Ticket ID: ${ticket.id}\n`, `## Fields\n`];
 
   lines.push(`URL: ${apiUrlToDocumentUrl(ticket.url)}`);
   lines.push(`Subject: ${ticket.subject ?? "No subject"}`);
@@ -103,7 +103,8 @@ export function renderTicket(
   }
 
   if (ticket.description) {
-    lines.push(`\n## Description\n${ticket.description.trim()}`);
+    lines.push("\n## Description\n");
+    lines.push(ticket.description.trim());
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## Description

Adds three missing fields to the Zendesk MCP ticket rendering: `satisfaction_rating` (with optional comment), `due_at` (for SLA tracking), and `has_incidents` (for incident tracking). Updates the rendering format to use markdown bullet points (prefixed with `-`) and a level 2 heading (`##`) for the ticket ID, making the output consistent with the existing Metrics and Conversation sections. The description field now collapses newlines into spaces for cleaner bullet point display.

## Risk
Low. Only affects the text rendering output of Zendesk tickets in MCP tools. No API or database changes.

## Tests
Manually tested locally.

## Deploy
Run front