### PR TITLE
[sparkle] - refacto: standardization / `useSheetContainer`

### DIFF
--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -162,5 +162,3 @@ export const ButtonsSwitch = React.forwardRef<
   );
 });
 ButtonsSwitch.displayName = "ButtonsSwitch";
-
-export default ButtonsSwitch;

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -225,6 +225,8 @@ interface CardPropsWithButton
   href?: never;
 }
 
+InnerCard.displayName = "InnerCard";
+
 export type CardProps = CardPropsWithLink | CardPropsWithButton;
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>(

--- a/sparkle/src/components/CollapseButton.tsx
+++ b/sparkle/src/components/CollapseButton.tsx
@@ -159,4 +159,4 @@ const CollapseButton: React.FC<CollapseButtonProps> = ({
   );
 };
 
-export default CollapseButton;
+export { CollapseButton };

--- a/sparkle/src/components/ConfettiBackground.tsx
+++ b/sparkle/src/components/ConfettiBackground.tsx
@@ -100,4 +100,4 @@ const ConfettiBackground: React.FC<ConfettiBackgroundProps> = ({
   }
 };
 
-export default ConfettiBackground;
+export { ConfettiBackground };

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -18,6 +18,7 @@ import {
   SearchInput,
   type SearchInputProps,
 } from "@sparkle/components/SearchInput";
+import { useSheetContainer } from "@sparkle/hooks/useSheetContainer";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
@@ -316,24 +317,10 @@ const DropdownMenuContent = React.forwardRef<
       </DropdownMenuPrimitive.Content>
     );
 
-    const [container, setContainer] = React.useState<Element | undefined>(
-      mountPortalContainer
-    );
-
-    React.useEffect(() => {
-      if (mountPortal && !container) {
-        const dialogElements = document.querySelectorAll(
-          ".s-sheet[role=dialog][data-state=open]"
-        );
-        const defaultContainer = dialogElements[dialogElements.length - 1];
-        setContainer(defaultContainer);
-      }
-    }, []);
+    const container = useSheetContainer(mountPortalContainer);
 
     return mountPortal ? (
-      <DropdownMenuPrimitive.Portal
-        container={mountPortalContainer ?? container}
-      >
+      <DropdownMenuPrimitive.Portal container={container}>
         {content}
       </DropdownMenuPrimitive.Portal>
     ) : (
@@ -816,19 +803,7 @@ const DropdownTooltipTrigger = React.forwardRef<
       </TooltipPrimitive.Content>
     );
 
-    const [container, setContainer] = React.useState<Element | undefined>(
-      mountPortalContainer
-    );
-
-    React.useEffect(() => {
-      if (mountPortal && !container) {
-        const dialogElements = document.querySelectorAll(
-          ".s-sheet[role=dialog][data-state=open]"
-        );
-        const defaultContainer = dialogElements[dialogElements.length - 1];
-        setContainer(defaultContainer);
-      }
-    }, [mountPortal, container]);
+    const container = useSheetContainer(mountPortalContainer);
 
     return (
       <TooltipPrimitive.Provider delayDuration={300}>

--- a/sparkle/src/components/DropzoneOverlay.tsx
+++ b/sparkle/src/components/DropzoneOverlay.tsx
@@ -12,7 +12,7 @@ export interface DropzoneOverlayProps {
   visual?: React.ReactNode;
 }
 
-export default function DropzoneOverlay({
+export function DropzoneOverlay({
   description,
   isDragActive,
   title,

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -1,4 +1,5 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { useSheetContainer } from "@sparkle/hooks/useSheetContainer";
 import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
 import { useEffect, useState } from "react";
@@ -67,19 +68,7 @@ const PopoverContent = React.forwardRef<
       />
     );
 
-    const [container, setContainer] = useState<Element | undefined>(
-      mountPortalContainer
-    );
-
-    useEffect(() => {
-      if (mountPortal && !container) {
-        const dialogElements = document.querySelectorAll(
-          ".s-sheet[role=dialog][data-state=open]"
-        );
-        const defaultContainer = dialogElements[dialogElements.length - 1];
-        setContainer(defaultContainer);
-      }
-    }, [mountPortal, container]);
+    const container = useSheetContainer(mountPortalContainer);
 
     return mountPortal ? (
       <PopoverPrimitive.Portal container={container}>

--- a/sparkle/src/components/Spinner.tsx
+++ b/sparkle/src/components/Spinner.tsx
@@ -248,4 +248,4 @@ const Spinner: React.FC<SpinnerProps> = ({ size = "md", variant = "mono" }) => {
   );
 };
 
-export default Spinner;
+export { Spinner };

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -126,6 +126,7 @@ const TabsTrigger = React.forwardRef<
     );
   }
 );
+TabsTrigger.displayName = "TabsTrigger";
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -109,6 +109,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
     </TooltipProvider>
   )
 );
+Tooltip.displayName = "Tooltip";
 
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -3,9 +3,9 @@ import {
   KeyboardShortcut,
   type KeyboardShortcutProps,
 } from "@sparkle/components/KeyboardShortcut";
+import { useSheetContainer } from "@sparkle/hooks/useSheetContainer";
 import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
-import { useEffect, useState } from "react";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
@@ -52,19 +52,7 @@ const TooltipContent = React.forwardRef<
       />
     );
 
-    const [container, setContainer] = useState<Element | undefined>(
-      mountPortalContainer
-    );
-
-    useEffect(() => {
-      if (mountPortal && !container) {
-        const dialogElements = document.querySelectorAll(
-          ".s-sheet[role=dialog][data-state=open]"
-        );
-        const defaultContainer = dialogElements[dialogElements.length - 1];
-        setContainer(defaultContainer);
-      }
-    }, [mountPortal, container]);
+    const container = useSheetContainer(mountPortalContainer);
 
     return mountPortal ? (
       <TooltipPrimitive.Portal container={container}>

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -32,13 +32,13 @@ export {
 } from "./Checkbox";
 export { Chip } from "./Chip";
 export * from "./Citation";
-export { default as CollapseButton } from "./CollapseButton";
+export { CollapseButton } from "./CollapseButton";
 export {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "./Collapsible";
-export { default as ConfettiBackground } from "./ConfettiBackground";
+export { ConfettiBackground } from "./ConfettiBackground";
 export { Container } from "./Container";
 export {
   ContainerWithTopBar,
@@ -115,7 +115,7 @@ export {
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
 } from "./Dropdown";
-export { default as DropzoneOverlay } from "./DropzoneOverlay";
+export { DropzoneOverlay } from "./DropzoneOverlay";
 export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";
@@ -214,7 +214,7 @@ export {
 export type { SidebarLayoutProps, SidebarLayoutRef } from "./SidebarLayout";
 export { SidebarLayout } from "./SidebarLayout";
 export { SliderToggle } from "./SliderToggle";
-export { default as Spinner } from "./Spinner";
+export { Spinner } from "./Spinner";
 export { FlexSplitButton } from "./SplitButton";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
 export { ReadOnlyTextArea, TextArea } from "./TextArea";

--- a/sparkle/src/hooks/index.ts
+++ b/sparkle/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useCopyToClipboard";
+export * from "./useSheetContainer";

--- a/sparkle/src/hooks/useSheetContainer.ts
+++ b/sparkle/src/hooks/useSheetContainer.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export function useSheetContainer(
+  mountPortalContainer?: Element
+): Element | undefined {
+  const [container, setContainer] = useState<Element | undefined>(
+    mountPortalContainer
+  );
+
+  useEffect(() => {
+    if (!container) {
+      const dialogElements = document.querySelectorAll(
+        ".s-sheet[role=dialog][data-state=open]"
+      );
+      const lastDialog = dialogElements[dialogElements.length - 1];
+      if (lastDialog) {
+        setContainer(lastDialog);
+      }
+    }
+  }, [container]);
+
+  return container;
+}


### PR DESCRIPTION
## Description

This PR continues the sparkle component cleanup effort (wave 2) by standardizing component exports and reducing code duplication. 

It introduces a new `useSheetContainer` hook that centralizes the logic for managing portal containers when mounting components inside sheet dialogs. This hook replaces duplicate state management code that was scattered across the `Dropdown`, `Popover`, and `Tooltip` components. 

Additionally, it standardizes component exports by converting `ButtonsSwitch`, `CollapseButton`, `ConfettiBackground`, `DropzoneOverlay`, and `Spinner` from default exports to named exports for consistency with other sparkle components. Finally, it adds explicit `displayName` properties to `InnerCard`, `TabsTrigger`, and `Tooltip` components to improve debugging in React DevTools.

## Risk

Low - these are internal refactoring changes with no API modifications.

## Tests

Storybook

## Deploy Plan

Deploy front