### PR TITLE
Increase notification display time

### DIFF
--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -12,7 +12,7 @@ import { Toaster, toast } from "sonner";
 
 import { Icon } from "./Icon";
 
-const NOTIFICATION_DELAY = 5000;
+const NOTIFICATION_DELAY_MS = 5000;
 
 export type NotificationType = {
   title?: string;
@@ -127,7 +127,7 @@ export const Notification = {
             />
           ),
           {
-            duration: NOTIFICATION_DELAY,
+            duration: NOTIFICATION_DELAY_MS,
           }
         );
       },
@@ -149,7 +149,7 @@ export const Notification = {
             ),
           }}
           className="s-flex s-flex-col s-items-end"
-          duration={NOTIFICATION_DELAY}
+          duration={NOTIFICATION_DELAY_MS}
           visibleToasts={9}
           closeButton={false}
           expand={false}

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -12,7 +12,7 @@ import { Toaster, toast } from "sonner";
 
 import { Icon } from "./Icon";
 
-const NOTIFICATION_DELAY = 3000;
+const NOTIFICATION_DELAY = 5000;
 
 export type NotificationType = {
   title?: string;


### PR DESCRIPTION
## Description

Increase notification display time from 3s to 5s.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Publish Sparkle
