### PR TITLE
chore(copilot-edge): remove prompt caching when development mode is on

### DIFF
--- a/front/lib/api/assistant/global_agents/langfuse_prompts.ts
+++ b/front/lib/api/assistant/global_agents/langfuse_prompts.ts
@@ -6,6 +6,7 @@ import {
   clampReasoningEffort,
 } from "@app/types/assistant/agent";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -32,7 +33,10 @@ export async function fetchLangfusePromptConfig(
   }
 
   try {
-    const prompt = await client.prompt.get(promptName);
+    const prompt = await client.prompt.get(promptName, {
+      // In development, we want to avoid caching prompts to ensure we always get the latest version.
+      cacheTtlSeconds: isDevelopment() ? 0 : undefined,
+    });
     const instructions = prompt.compile(variables);
     const parsedConfig = LangfuseModelConfigSchema.parse(prompt.config);
 


### PR DESCRIPTION
## Description

For enhanced DX when iterating on copilot prompt locally with langfuse, remove the default cache of langfuse prompts in dev mode.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
