### PR TITLE
Ignore FF outside of a workspace

### DIFF
--- a/front/lib/auth/AuthContext.tsx
+++ b/front/lib/auth/AuthContext.tsx
@@ -26,7 +26,8 @@ export function useAuth(): AuthContextValue {
 }
 
 export function useFeatureFlags() {
-  const { featureFlags } = useAuth();
+  const ctx = useContext(AuthContext);
+  const featureFlags = ctx?.featureFlags ?? [];
 
   const hasFeature = useCallback(
     (flag: WhitelistableFeature | null | undefined) => {


### PR DESCRIPTION
## Description

When accessing the no-workspace page, we don't have a workspace so can't check the FF -> this currently fails as the context cannot be found, return gracefully empty feature flags in that case.
Feature flags are checked in the user menu, displayed on the no-workspace page.


## Tests

locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
