### PR TITLE
[front] feat(Zendesk): add tool to post reply

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -570,6 +570,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "draft_reply": "low",
     "get_ticket": "never_ask",
     "list_ticket_fields": "never_ask",
+    "post_reply": "high",
     "search_tickets": "never_ask",
   },
 }

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -229,6 +229,33 @@ class ZendeskClient {
     return new Ok(result.value.ticket);
   }
 
+  async postReply(
+    ticketId: number,
+    body: string
+  ): Promise<Result<ZendeskTicket, Error>> {
+    const result = await this.request(
+      `tickets/${ticketId}`,
+      ZendeskTicketResponseSchema,
+      {
+        method: "PUT",
+        body: {
+          ticket: {
+            comment: {
+              body,
+              public: true,
+            },
+          },
+        },
+      }
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value.ticket);
+  }
+
   async getTicketFieldsByIds(
     fieldIds: number[]
   ): Promise<Result<ZendeskTicketField[], Error>> {

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -99,8 +99,25 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low", // Low because it's a draft.
     displayLabels: {
-      running: "Drafting Zendesk reply",
-      done: "Draft Zendesk reply",
+      running: "Drafting reply to Zendesk",
+      done: "Draft reply to Zendesk",
+    },
+  },
+  post_reply: {
+    description:
+      "Post a public reply to a Zendesk ticket. The reply will be visible to the end user.",
+    schema: {
+      ticketId: z
+        .number()
+        .int()
+        .positive()
+        .describe("The ID of the Zendesk ticket to reply to."),
+      body: z.string().describe("The content of the reply."),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Posting reply to Zendesk",
+      done: "Post reply to Zendesk",
     },
   },
 });

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -208,6 +208,31 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
       },
     ]);
   },
+
+  post_reply: async ({ ticketId, body }, { authInfo }) => {
+    const clientResult = getZendeskClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.postReply(ticketId, body);
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to post reply: ${result.error.message}`, {
+          tracked: isTrackedError(result.error),
+        })
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Public reply successfully posted to ticket ${ticketId}. The comment is visible to the end user.`,
+      },
+    ]);
+  },
 };
 
 export const TOOLS = buildTools(ZENDESK_TOOLS_METADATA, handlers);


### PR DESCRIPTION
## Description

- This PR adds a tool to the Zendesk internal MCP server to post a reply.
- Mimics the one we have for drafting replies but actually posts them.

## Tests

- Tested locally [here](https://d3v-dust.zendesk.com/agent/tickets/26).

## Risk

- Low.

## Deploy Plan

- Deploy front.
