### PR TITLE
[extension] - refactor: deprecate `classNames` utils

### DIFF
--- a/extension/platforms/chrome/ChromeExtensionWrapper.tsx
+++ b/extension/platforms/chrome/ChromeExtensionWrapper.tsx
@@ -1,4 +1,4 @@
-import { Button, classNames, DustLogo, Page } from "@dust-tt/sparkle";
+import { Button, cn, DustLogo, Page } from "@dust-tt/sparkle";
 import type { ChromePlatformService } from "@extension/platforms/chrome/services/platform";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { compare } from "compare-versions";
@@ -38,7 +38,7 @@ export const ChromeExtensionWrapper = ({
   if (!isLatestVersion) {
     return (
       <div
-        className={classNames(
+        className={cn(
           "flex h-screen flex-col gap-2 p-4",
           "bg-background text-foreground",
           "dark:bg-background-night dark:text-foreground-night"

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -41,10 +41,6 @@ export const generatePKCE = async (): Promise<{
  * COPYED FROM FRONT LIB, MAYBE WE SHOULD SHARE THIS CODE
  */
 
-export function classNames(...classes: (string | null | boolean)[]) {
-  return classes.filter(Boolean).join(" ");
-}
-
 /**
  * Checks if a is a subfilter of b, i.e. all characters in a are present in b in
  * the same order, and returns the biggest index of the first character of a in b.

--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { classNames, Spinner } from "@dust-tt/sparkle";
+import { cn, Spinner } from "@dust-tt/sparkle";
 import type { RouteChangeMesssage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
@@ -37,7 +37,7 @@ export const ProtectedRoute = () => {
   if (isLoading || !isAuthenticated || !isUserSetup || !user || !workspace) {
     return (
       <div
-        className={classNames(
+        className={cn(
           "flex h-screen flex-col gap-2 p-4",
           "bg-background text-foreground",
           "dark:bg-background-night dark:text-foreground-night"
@@ -52,7 +52,7 @@ export const ProtectedRoute = () => {
 
   return (
     <div
-      className={classNames(
+      className={cn(
         "flex h-screen flex-col gap-2 overflow-y-auto px-4",
         "bg-background text-foreground",
         "dark:bg-background-night dark:text-foreground-night"


### PR DESCRIPTION
## Description

This PR deprecates the use of `classNames` within the `extension/`

## Tests

N/A

## Risk

None

## Deploy Plan

Deploy front
