### PR TITLE
Add error boundaries in router

### DIFF
--- a/front-spa/src/app/routes.tsx
+++ b/front-spa/src/app/routes.tsx
@@ -1,4 +1,5 @@
 import Custom404 from "@dust-tt/front/pages/404";
+import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
 import { AppContentRouterLayout } from "@spa/app/layouts/AppContentRouterLayout";
 import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
@@ -45,6 +46,7 @@ function PokeRedirect() {
 export const routes: RouteObject[] = [
   {
     element: <RootRouterLayout />,
+    errorElement: <GlobalErrorFallback />,
     children: [
       { path: "/", element: <IndexPage /> },
       {

--- a/front-spa/src/oauth/OAuthApp.tsx
+++ b/front-spa/src/oauth/OAuthApp.tsx
@@ -5,19 +5,26 @@ import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
 import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
 import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
+import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 const router = createBrowserRouter(
   [
-    // Setup: /w/:wId/oauth/:provider/setup
     {
-      path: "/w/:wId/oauth/:provider/setup",
-      element: <OAuthSetupRedirectPage />,
-    },
-    // Finalize: /oauth/:provider/finalize
-    {
-      path: "/oauth/:provider/finalize",
-      element: <OAuthFinalizePage />,
+      element: <RootRouterLayout />,
+      errorElement: <GlobalErrorFallback />,
+      children: [
+        // Setup: /w/:wId/oauth/:provider/setup
+        {
+          path: "/w/:wId/oauth/:provider/setup",
+          element: <OAuthSetupRedirectPage />,
+        },
+        // Finalize: /oauth/:provider/finalize
+        {
+          path: "/oauth/:provider/finalize",
+          element: <OAuthFinalizePage />,
+        },
+      ],
     },
   ],
   {

--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -30,6 +30,7 @@ import { TriggerDetailsPage } from "@dust-tt/front/components/poke/pages/Trigger
 import { WebhookSourceDetailsPage } from "@dust-tt/front/components/poke/pages/WebhookSourceDetailsPage";
 import { WorkspacePage } from "@dust-tt/front/components/poke/pages/WorkspacePage";
 import Custom404 from "@dust-tt/front/pages/404";
+import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
 import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { PokePage } from "@spa/poke/layouts/PokePage";
 import { PokeWorkspacePage } from "@spa/poke/layouts/PokeWorkspacePage";
@@ -47,6 +48,7 @@ function PokeRedirect() {
 export const routes: RouteObject[] = [
   {
     element: <RootRouterLayout />,
+    errorElement: <GlobalErrorFallback />,
     children: [
       {
         path: "/",

--- a/front-spa/src/share/ShareApp.tsx
+++ b/front-spa/src/share/ShareApp.tsx
@@ -12,6 +12,7 @@ const router = createBrowserRouter(
   [
     {
       element: <RootRouterLayout />,
+      errorElement: <GlobalErrorFallback />,
       children: [
         // Frame: /share/frame/:token
         {


### PR DESCRIPTION
## Description

Add `errorElement` to React Router route definitions across all front-spa apps (App, ShareApp, OAuthApp, PokeApp).

Previously, the `ErrorBoundary` component in each app wrapped `RouterProvider`, but React Router catches errors internally before they bubble up to React error boundaries. This meant unhandled errors in route components showed React Router's default "Unexpected Application Error!" screen instead of our `GlobalErrorFallback`.

Also adds the missing `RootRouterLayout` wrapper to OAuthApp for consistency with the other apps.

## Tests

Manual — verified the error boundary renders correctly when a route component throws.

## Risk

Low — only adds error handling fallbacks that were previously missing. No behavior change for the happy path.

## Deploy Plan

Standard deploy, no special steps needed.