### PR TITLE
copilot: add eval test to check that the agent output contain the sug…

### DIFF
--- a/front/tests/copilot-evals/copilot-eval.test.ts
+++ b/front/tests/copilot-evals/copilot-eval.test.ts
@@ -1,8 +1,8 @@
+import type { Authenticator } from "@app/lib/auth";
 import {
   COPILOT_AGENT,
   COPILOT_ON_COPILOT,
   COPILOT_ON_COPILOT_TIMEOUT_MS,
-  createMockAuthenticator,
   FILTER_CATEGORY,
   FILTER_SCENARIO,
   getCopilotConfig,
@@ -66,9 +66,12 @@ for (const testCase of testCases) {
 
 describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
   let copilotConfig: CopilotConfig;
+  let auth: Authenticator;
 
   beforeAll(async () => {
-    copilotConfig = await getCopilotConfig();
+    const result = await getCopilotConfig();
+    copilotConfig = result.config;
+    auth = result.auth;
   }, TIMEOUT_MS);
 
   for (const [category, scenarios] of testGroups) {
@@ -77,8 +80,6 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
         it.concurrent(
           scenarioId,
           async () => {
-            const auth = createMockAuthenticator();
-
             const { responseText, toolCalls, modelTimeMs } =
               await executeCopilot(
                 auth,
@@ -174,7 +175,6 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
         return;
       }
 
-      const auth = createMockAuthenticator();
       await generateCopilotImprovementSuggestions(
         auth,
         copilotConfig,

--- a/front/tests/copilot-evals/lib/config.ts
+++ b/front/tests/copilot-evals/lib/config.ts
@@ -140,7 +140,10 @@ const MOCK_MCP_SERVER_VIEWS: MCPServerViewsForGlobalAgentsMap =
     MCP_SERVERS_FOR_GLOBAL_AGENTS.map((name) => [name, null])
   ) as MCPServerViewsForGlobalAgentsMap;
 
-export async function getCopilotConfig(): Promise<CopilotConfig> {
+export async function getCopilotConfig(): Promise<{
+  config: CopilotConfig;
+  auth: Authenticator;
+}> {
   const workspace = await WorkspaceFactory.basic();
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const mockCopilotContext = getMockCopilotContext();
@@ -215,19 +218,11 @@ export async function getCopilotConfig(): Promise<CopilotConfig> {
   }
 
   return {
-    instructions: copilotConfig.instructions ?? "",
-    model: copilotConfig.model,
-    tools,
+    config: {
+      instructions: copilotConfig.instructions ?? "",
+      model: copilotConfig.model,
+      tools,
+    },
+    auth,
   };
-}
-
-export function createMockAuthenticator(): Authenticator {
-  return new Authenticator({
-    workspace: null,
-    user: null,
-    role: "none",
-    groupModelIds: [],
-    subscription: null,
-    authMethod: "internal",
-  });
 }

--- a/front/tests/copilot-evals/lib/copilot-executor.ts
+++ b/front/tests/copilot-evals/lib/copilot-executor.ts
@@ -160,7 +160,11 @@ export async function executeCopilot(
         role: "function" as const,
         name: tc.toolCall.name,
         function_call_id: tc.id,
-        content: getMockToolResponse(tc.toolCall.name, agentState),
+        content: getMockToolResponse(
+          tc.toolCall.name,
+          agentState,
+          tc.toolCall.arguments
+        ),
       });
     }
 

--- a/front/tests/copilot-evals/lib/mock-responses.ts
+++ b/front/tests/copilot-evals/lib/mock-responses.ts
@@ -13,11 +13,21 @@ function instructionsToHtml(instructions: string): string {
   return `<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}" data-block-id="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}">${blocks}</div>`;
 }
 
+let mockSuggestionCounter = 0;
+
+function getSuggestionsArray(
+  toolArguments: Record<string, unknown> | undefined
+): unknown[] {
+  const raw = toolArguments?.suggestions;
+  return Array.isArray(raw) ? raw : [null];
+}
+
 export function getMockToolResponse(
   toolName: string,
-  agentState: MockAgentState
+  agentState: MockAgentState,
+  toolArguments?: Record<string, unknown>
 ): string {
-  const mockResponses: Record<string, () => object> = {
+  const mockResponses: Record<string, () => object | string> = {
     get_agent_info: () => agentState,
 
     get_agent_config: () => ({
@@ -222,41 +232,38 @@ export function getMockToolResponse(
       ],
     }),
 
-    suggest_prompt_edits: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Suggestion created successfully",
-    }),
+    suggest_prompt_edits: () =>
+      getSuggestionsArray(toolArguments)
+        .map(() => {
+          const sId = `mock_sId_${++mockSuggestionCounter}`;
+          return `:agent_suggestion[]{sId=${sId} kind=instructions}`;
+        })
+        .join("\n\n"),
 
-    suggest_tools: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Tool suggestion created successfully",
-    }),
+    suggest_tools: () =>
+      getSuggestionsArray(toolArguments)
+        .map(() => {
+          const sId = `mock_sId_${++mockSuggestionCounter}`;
+          return `:agent_suggestion[]{sId=${sId} kind=tools}`;
+        })
+        .join("\n\n"),
 
-    suggest_skills: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Skill suggestion created successfully",
-    }),
+    suggest_skills: () =>
+      getSuggestionsArray(toolArguments)
+        .map(() => {
+          const sId = `mock_sId_${++mockSuggestionCounter}`;
+          return `:agent_suggestion[]{sId=${sId} kind=skills}`;
+        })
+        .join("\n\n"),
 
-    suggest_model: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Model suggestion created successfully",
-    }),
+    suggest_model: () =>
+      `:agent_suggestion[]{sId=mock_sId_${++mockSuggestionCounter} kind=model}`,
 
-    suggest_knowledge: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Knowledge suggestion created successfully",
-    }),
+    suggest_knowledge: () =>
+      `:agent_suggestion[]{sId=mock_sId_${++mockSuggestionCounter} kind=knowledge}`,
 
-    suggest_sub_agent: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Sub-agent suggestion created successfully",
-    }),
+    suggest_sub_agent: () =>
+      `:agent_suggestion[]{sId=mock_sId_${++mockSuggestionCounter} kind=sub_agent}`,
 
     search_knowledge: () => ({
       results: [
@@ -345,5 +352,12 @@ export function getMockToolResponse(
     throw new Error(`Unknown tool: ${toolName}`);
   }
 
-  return JSON.stringify(responseFactory(), null, 2);
+  const result = responseFactory();
+
+  // Suggestion tools return plain-text directives, not JSON objects.
+  if (typeof result === "string") {
+    return result;
+  }
+
+  return JSON.stringify(result, null, 2);
 }

--- a/front/tests/copilot-evals/test-suites/new-agent.ts
+++ b/front/tests/copilot-evals/test-suites/new-agent.ts
@@ -22,6 +22,43 @@ export const newAgentSuite: TestSuite = {
       judgeCriteria: `Intent is clear: engineering docs agent. Must call suggest_prompt_edits with technical instructions; may suggest tools. Score 0-1 if instructions are generic or missing technical/docs focus.`,
     },
     {
+      scenarioId: "shows-suggestions-in-response",
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Build me an agent that creates support issues on GitHub when customers report bugs.",
+        },
+        {
+          role: "assistant",
+          content:
+            "Before I set this up, a couple of quick questions:\n\n1. Which GitHub repo should issues go to?\n2. What details should the agent collect (title, steps to reproduce, severity, environment)?",
+        },
+        {
+          role: "user",
+          content:
+            "Use the acme/support repo. Collect title, description, steps to reproduce, and severity. Tag issues with the 'bug' label.",
+        },
+      ],
+      mockState: BLANK_AGENT,
+      expectedToolCalls: [
+        "get_agent_config",
+        "suggest_prompt_edits",
+        "suggest_tools",
+      ],
+      judgeCriteria: `This test checks that the copilot includes suggestion directives in its response text.
+
+CRITICAL CHECK — the copilot response MUST contain:
+1. At least one \`:agent_suggestion[]{sId=... kind=instructions}\` directive (from suggest_prompt_edits)
+2. At least one \`:agent_suggestion[]{sId=... kind=tools}\` directive (from suggest_tools)
+
+These directives are returned by the suggest_prompt_edits and suggest_tools tools and MUST be included verbatim in the copilot's text response so they render as interactive suggestion cards for the user.
+
+Score 0 if ANY of the directives are missing from the response text.
+Score 1 if directives are present but the surrounding explanation is poor.
+Score 2-3 if directives are present and the response clearly explains what was suggested (instructions for bug collection/formatting and GitHub tool).`,
+    },
+    {
       scenarioId: "vague-make-agent",
       userMessage: "Make me an agent",
       mockState: BLANK_AGENT,


### PR DESCRIPTION
## Description
We hjave seen haiku being bad at this so let's add a unit test to make sure the output of the tool is included in the conv.

## Tests

Test actually fails for current haiku but succeeds for sonnet

## Risk

low

## Deploy Plan

none