### PR TITLE
Make start/end date inclusive for users and builders analytics

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -371,8 +371,8 @@ export async function getUserUsageData(
         where: {
           workspaceId: wId,
           createdAt: {
-            [Op.gt]: startDate,
-            [Op.lt]: endDate,
+            [Op.gte]: startDate,
+            [Op.lte]: endDate,
           },
         },
         include: [
@@ -574,8 +574,8 @@ export async function getBuildersUsageData(
         where: {
           workspaceId: wId,
           createdAt: {
-            [Op.gt]: startDate,
-            [Op.lt]: endDate,
+            [Op.gte]: startDate,
+            [Op.lte]: endDate,
           },
           status: {
             [Op.not]: "draft",


### PR DESCRIPTION
## Description

In workspace_usage analytics, the start and end date boundaries were treated as exclusive for the `users` and `builders` tables — meaning any activity recorded exactly on the start or end date was silently excluded from the results. The other tables (`assistant_messages`, `assistants`, `feedback`) were correctly using inclusive boundaries.

The users and builders tables now use inclusive boundaries

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
