### PR TITLE
Avoid unnecessary workspace update

### DIFF
--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -74,10 +74,12 @@ export async function getOrCreateWorkOSOrganization(
       );
     }
 
-    await WorkspaceResource.updateWorkOSOrganizationId(
-      workspace.id,
-      organization.id
-    );
+    if (workspace.workOSOrganizationId !== organization.id) {
+      await WorkspaceResource.updateWorkOSOrganizationId(
+        workspace.id,
+        organization.id
+      );
+    }
 
     return new Ok(organization);
   } catch (error) {


### PR DESCRIPTION
## Description

`getOrCreateWorkOSOrganization()` was unconditionally calling `WorkspaceResource.updateWorkOSOrganizationId()` every time, even when the workspace already had the correct `workOSOrganizationId`. This caused unnecessary `updatedAt` bumps on the workspace record on every GET to `/api/w/[wId]/domains`.

Now the update is skipped when `workspace.workOSOrganizationId` already matches `organization.id`.

## Tests

Manual — verified that workspace `updatedAt` is no longer bumped when loading the domains page.

## Risk

Low — the change only adds a guard condition; behavior is unchanged when the ID actually differs.

## Deploy Plan

Standard deploy, no special steps needed.