### PR TITLE
Sidekick: dot not list knowledge in available tools + reject knowledge suggestions in tools

### DIFF
--- a/front/components/shared/tools_picker/MCPServerViewsContext.tsx
+++ b/front/components/shared/tools_picker/MCPServerViewsContext.tsx
@@ -1,9 +1,9 @@
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import {
   getMcpServerViewDisplayName,
+  isToolWithKnowledge,
   mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import type { SpaceType } from "@app/types/space";
@@ -98,29 +98,11 @@ function getGroupedMCPServerViews({
   });
 
   const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
-    groupBy(mcpServerViewsWithLabel, (view) => {
-      const {
-        requiresDataSourceConfiguration,
-        requiresDataWarehouseConfiguration,
-        requiresTableConfiguration,
-      } = getMCPServerRequirements(view);
-
-      // Special handling for interactive_content server:
-      // The interactive_content server includes list and cat tools for convenience, but its primary purpose is
-      // not data source operations. We don't want it to be classified as requiring knowledge.
-      const isInteractiveContentServer =
-        view.server.name === "interactive_content";
-
-      const isWithKnowledge =
-        !isInteractiveContentServer &&
-        (requiresDataSourceConfiguration ||
-          requiresDataWarehouseConfiguration ||
-          requiresTableConfiguration);
-
-      return isWithKnowledge
+    groupBy(mcpServerViewsWithLabel, (view) =>
+      isToolWithKnowledge(view)
         ? "mcpServerViewsWithKnowledge"
-        : "mcpServerViewsWithoutKnowledge";
-    });
+        : "mcpServerViewsWithoutKnowledge"
+    );
 
   const grouped = groupBy(
     mcpServerViewsWithoutKnowledge,

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -9,6 +9,7 @@ import {
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type {
   MCPServerType,
   MCPServerTypeWithViews,
@@ -228,6 +229,31 @@ export function isKnowledgeTemplateAction(
     presetAction.type === "RETRIEVAL_SEARCH" ||
     presetAction.type === "TABLES_QUERY" ||
     presetAction.type === "PROCESS"
+  );
+}
+
+/**
+ * Checks whether an MCP server view is a "knowledge" tool — i.e. it requires
+ * data source, data warehouse, or table configuration.
+ *
+ * The interactive_content server is explicitly excluded because it includes
+ * list/cat tools for convenience but is not primarily a data source tool.
+ */
+export function isToolWithKnowledge(view: MCPServerViewType): boolean {
+  if (view.server.name === "interactive_content") {
+    return false;
+  }
+
+  const {
+    requiresDataSourceConfiguration,
+    requiresDataWarehouseConfiguration,
+    requiresTableConfiguration,
+  } = getMCPServerRequirements(view);
+
+  return (
+    requiresDataSourceConfiguration ||
+    requiresDataWarehouseConfiguration ||
+    requiresTableConfiguration
   );
 }
 

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -447,6 +447,40 @@ describe("agent_copilot_context tools", () => {
         }
       }
     });
+
+    it("excludes knowledge tools (search, query_tables, include_data, extract_data)", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      // Create all auto internal tools so knowledge tools exist.
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+      const tool = getToolByName("get_available_tools");
+      const result = await tool.handler({}, createTestExtra(authenticator));
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          const toolNames = parsed.tools.map((t: { name: string }) => t.name);
+
+          // Knowledge tools should be excluded.
+          const knowledgeToolNames = [
+            "Search",
+            "Query Tables",
+            "Include Data",
+            "Extract Data",
+          ];
+          for (const knowledgeName of knowledgeToolNames) {
+            expect(toolNames).not.toContain(knowledgeName);
+          }
+
+          // Non-knowledge auto tools should still be present.
+          expect(toolNames.length).toBeGreaterThan(0);
+        }
+      }
+    });
   });
 
   describe("get_available_agents", () => {
@@ -1312,6 +1346,49 @@ describe("agent_copilot_context tools", () => {
           { states: ["pending"], kind: "tools" }
         );
       expect(pendingSuggestions).toHaveLength(3);
+    });
+
+    it("returns error when suggesting a knowledge tool (e.g. search) instead of using suggest_knowledge", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+      // Get the search tool view — it's a knowledge tool.
+      const searchView =
+        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          authenticator,
+          "search"
+        );
+      expect(searchView).not.toBeNull();
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const { getAgentConfigurationIdFromContext } = await import(
+        "@app/lib/api/actions/servers/agent_copilot_helpers"
+      );
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        agentConfiguration.sId
+      );
+
+      const tool = getToolByName("suggest_tools");
+      const result = await tool.handler(
+        {
+          suggestions: [
+            {
+              action: "add",
+              toolId: searchView!.sId,
+              analysis: "Adding search tool",
+            },
+          ],
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("knowledge tools");
+        expect(result.error.message).toContain("suggest_knowledge");
+      }
     });
   });
 

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -1,5 +1,6 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { isToolWithKnowledge } from "@app/lib/actions/mcp_helper";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
@@ -769,6 +770,24 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
         new MCPError(
           `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}. ` +
             `Check <workspace_context> for valid tool IDs.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    // Reject knowledge tools — they should be suggested via suggest_knowledge.
+    const knowledgeTools = tools.filter((t) => {
+      const json = t.toJSON();
+      return json !== null && isToolWithKnowledge(json);
+    });
+    if (knowledgeTools.length > 0) {
+      const knowledgeToolNames = knowledgeTools
+        .map((t) => `${t.sId} (${t.toJSON()?.server.name ?? "unknown"})`)
+        .join(", ");
+      return new Err(
+        new MCPError(
+          `The following ID(s) are knowledge tools, not regular tools: ${knowledgeToolNames}. ` +
+            `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`,
           { tracked: false }
         )
       );

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -2,6 +2,7 @@ import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
+  isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { isModelAvailableAndWhitelisted } from "@app/lib/assistant";
@@ -52,6 +53,8 @@ export async function getAvailableModelsForWorkspace(
  * Lists available tools (MCP server views) that can be added to agents.
  * Returns tools from all spaces the user is a member of, filtered to only
  * include tools with "manual" or "auto" availability.
+ * Excludes knowledge tools (search, query tables, include data, etc.) that
+ * require data source configuration, these are handled separately as knowledge.
  */
 export async function listAvailableTools(
   auth: Authenticator
@@ -72,6 +75,7 @@ export async function listAvailableTools(
       (v) =>
         v.server.availability === "manual" || v.server.availability === "auto"
     )
+    .filter((v) => !isToolWithKnowledge(v))
     .map((mcpServerView) => ({
       sId: mcpServerView.sId,
       name: getMcpServerViewDisplayName(mcpServerView),


### PR DESCRIPTION
## Description

Sidekick was suggesting to use the the "search" tools without actual knowledge because:
 - the tools appeared in the list of available tools
 - the tool was not rejected when suggested

## Tests

Added unit tests

## Risk

low

## Deploy Plan

deploy front