### PR TITLE
Add (alpha version) dedicated UI renderer for sandbox bash tool

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -6,6 +6,7 @@ interface ActionDetailsWrapperProps {
   actionName: string;
   children?: React.ReactNode;
   displayContext: ActionDetailsDisplayContext;
+  headerAction?: React.ReactNode;
   visual: ComponentType<{ className?: string }>;
 }
 
@@ -13,6 +14,7 @@ export function ActionDetailsWrapper({
   actionName,
   children,
   displayContext,
+  headerAction,
   visual,
 }: ActionDetailsWrapperProps) {
   if (displayContext === "conversation") {
@@ -27,6 +29,7 @@ export function ActionDetailsWrapper({
           <Icon visual={visual} size="xs" />
           <span className="heading-sm font-medium">{actionName}</span>
           <span className="flex-grow"></span>
+          {headerAction}
           {/* TODO: Align spinner with CoT spinner: <div className="self-start"> */}
           <div>
             <Spinner size="xs" />
@@ -47,6 +50,8 @@ export function ActionDetailsWrapper({
       >
         <Icon visual={visual} />
         <span className="heading-base">{actionName}</span>
+        <span className="flex-grow"></span>
+        {headerAction}
       </div>
       {children}
     </div>

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -25,6 +25,7 @@ import { MCPGetDatabaseSchemaActionDetails } from "@app/components/actions/mcp/d
 import { MCPImageGenerationActionDetails } from "@app/components/actions/mcp/details/MCPImageGenerationActionDetails";
 import { MCPListToolsActionDetails } from "@app/components/actions/mcp/details/MCPListToolsActionDetails";
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
+import { MCPSandboxActionDetails } from "@app/components/actions/mcp/details/MCPSandboxActionDetails";
 import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details/MCPSkillEnableActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
@@ -371,6 +372,10 @@ export function MCPActionDetails({
     toolName === CONVERSATION_CAT_FILE_ACTION_NAME
   ) {
     return <MCPConversationCatFileDetails {...toolOutputDetailsProps} />;
+  }
+
+  if (internalMCPServerName === "sandbox") {
+    return <MCPSandboxActionDetails {...toolOutputDetailsProps} />;
   }
 
   return (

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -29,11 +29,6 @@ function setStoredRawMode(value: boolean): void {
 }
 
 /**
- * Derive a short user-friendly summary from the command string and output.
- * Used as the default (summary) view — will be replaced by model-generated
- * summaries once the backend supports them.
- */
-/**
  * Extract a clean, short command name from a potentially complex command string.
  * Strips heredocs, pipes, semicolons, and env vars to find the core binary/script.
  */
@@ -156,13 +151,12 @@ interface SandboxViewProps {
   exitCode: number | null;
 }
 
-function ToggleButton({
-  isRawMode,
-  onToggle,
-}: {
+interface ToggleButtonProps {
   isRawMode: boolean;
   onToggle: () => void;
-}) {
+}
+
+function ToggleButton({ isRawMode, onToggle }: ToggleButtonProps) {
   return (
     <Button
       size="xs"
@@ -174,7 +168,11 @@ function ToggleButton({
   );
 }
 
-function CommandPreview({ command }: { command: string }) {
+interface CommandPreviewProps {
+  command: string;
+}
+
+function CommandPreview({ command }: CommandPreviewProps) {
   return (
     <code className="rounded bg-muted px-1 py-0.5 text-xs dark:bg-muted-night">
       {extractCommandName(command)}
@@ -182,7 +180,11 @@ function CommandPreview({ command }: { command: string }) {
   );
 }
 
-function ExitCodeBadge({ exitCode }: { exitCode: number | null }) {
+interface ExitCodeBadgeProps {
+  exitCode: number | null;
+}
+
+function ExitCodeBadge({ exitCode }: ExitCodeBadgeProps) {
   if (exitCode === null) {
     return null;
   }

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -58,7 +58,11 @@ function deriveSummary(command: string, exitCode: number | null): string {
     return `\`${name}\` failed with exit code ${exitCode}.`;
   }
 
-  return `Ran \`${name}\` successfully.`;
+  if (exitCode === 0) {
+    return `Ran \`${name}\` successfully.`;
+  }
+
+  return `Ran \`${name}\`.`;
 }
 
 /**

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -1,0 +1,320 @@
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import {
+  ActionDocumentTextIcon,
+  Button,
+  CodeBlock,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  CommandLineIcon,
+  cn,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+const STORAGE_KEY = "dust:sandbox:rawMode";
+
+function getStoredRawMode(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+function setStoredRawMode(value: boolean): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }
+}
+
+/**
+ * Derive a short user-friendly summary from the command string and output.
+ * Used as the default (summary) view — will be replaced by model-generated
+ * summaries once the backend supports them.
+ */
+/**
+ * Extract a clean, short command name from a potentially complex command string.
+ * Strips heredocs, pipes, semicolons, and env vars to find the core binary/script.
+ */
+function extractCommandName(command: string): string {
+  const firstLine = command.trim().split("\n")[0];
+
+  // Strip heredoc markers (e.g. `python3 << 'EOF'` → `python3`)
+  const beforeHeredoc = firstLine.split("<<")[0].trim();
+
+  // Strip pipes and take the first command
+  const firstCmd = beforeHeredoc.split("|")[0].trim();
+
+  // Strip leading env vars (e.g. `FOO=bar python3` → `python3`)
+  const tokens = firstCmd.split(/\s+/);
+  const cmdToken = tokens.find((t) => !t.includes("=")) ?? tokens[0];
+
+  // Strip path (e.g. `/usr/bin/python3` → `python3`)
+  const basename = cmdToken.split("/").pop() ?? cmdToken;
+
+  return basename;
+}
+
+function deriveSummary(command: string, exitCode: number | null): string {
+  const name = extractCommandName(command);
+
+  if (exitCode !== null && exitCode !== 0) {
+    return `\`${name}\` failed with exit code ${exitCode}.`;
+  }
+
+  return `Ran \`${name}\` successfully.`;
+}
+
+/**
+ * Parse the raw text output to extract the exit code if present.
+ * The sandbox tool formats output as: stdout + [stderr]\n... + [exit code: N]
+ */
+function parseExitCode(rawText: string): number | null {
+  const match = rawText.match(/\[exit code: (\d+)\]\s*$/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export function MCPSandboxActionDetails({
+  displayContext,
+  toolParams,
+  toolOutput,
+}: ToolExecutionDetailsProps) {
+  const [isRawMode, setIsRawMode] = useState(getStoredRawMode);
+
+  const command =
+    typeof toolParams.command === "string" ? toolParams.command : null;
+
+  const rawOutputText = useMemo(() => {
+    if (!toolOutput) {
+      return null;
+    }
+    const textBlocks = toolOutput.filter(isTextContent);
+    return textBlocks.map((b) => b.text).join("\n") || null;
+  }, [toolOutput]);
+
+  const exitCode = useMemo(() => {
+    return rawOutputText ? parseExitCode(rawOutputText) : null;
+  }, [rawOutputText]);
+
+  const isRunning = toolOutput === null;
+
+  const summary = useMemo(() => {
+    if (!command) {
+      return "Executed command in sandbox";
+    }
+    return deriveSummary(command, exitCode);
+  }, [command, exitCode]);
+
+  const toggleRawMode = useCallback(() => {
+    setIsRawMode((prev) => {
+      const next = !prev;
+      setStoredRawMode(next);
+      return next;
+    });
+  }, []);
+
+  const actionName = isRunning
+    ? "Executing command in sandbox"
+    : "Executed command in sandbox";
+
+  const viewProps: SandboxViewProps = {
+    command,
+    summary,
+    rawOutputText,
+    isRawMode,
+    isRunning,
+    exitCode,
+  };
+
+  return (
+    <ActionDetailsWrapper
+      displayContext={displayContext}
+      actionName={actionName}
+      visual={CommandLineIcon}
+      headerAction={
+        !isRunning ? (
+          <ToggleButton isRawMode={isRawMode} onToggle={toggleRawMode} />
+        ) : undefined
+      }
+    >
+      {displayContext === "conversation" ? (
+        <ConversationView {...viewProps} />
+      ) : (
+        <SidebarView {...viewProps} />
+      )}
+    </ActionDetailsWrapper>
+  );
+}
+
+interface SandboxViewProps {
+  command: string | null;
+  summary: string;
+  rawOutputText: string | null;
+  isRawMode: boolean;
+  isRunning: boolean;
+  exitCode: number | null;
+}
+
+function ToggleButton({
+  isRawMode,
+  onToggle,
+}: {
+  isRawMode: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      size="xs"
+      variant="ghost"
+      label={isRawMode ? "Show summary" : "Show code"}
+      icon={isRawMode ? ActionDocumentTextIcon : CommandLineIcon}
+      onClick={onToggle}
+    />
+  );
+}
+
+function CommandPreview({ command }: { command: string }) {
+  return (
+    <code className="rounded bg-muted px-1 py-0.5 text-xs dark:bg-muted-night">
+      {extractCommandName(command)}
+    </code>
+  );
+}
+
+function ExitCodeBadge({ exitCode }: { exitCode: number | null }) {
+  if (exitCode === null) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        "text-xs font-medium",
+        exitCode === 0
+          ? "text-success dark:text-success-night"
+          : "text-warning dark:text-warning-night"
+      )}
+    >
+      exit code: {exitCode}
+    </span>
+  );
+}
+
+function ConversationView({
+  command,
+  summary,
+  rawOutputText,
+  isRawMode,
+  isRunning,
+  exitCode,
+}: SandboxViewProps) {
+  return (
+    <div className="flex flex-col gap-2 pl-6">
+      {isRunning && command && (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Running <CommandPreview command={command} />
+        </p>
+      )}
+
+      {!isRunning && !isRawMode && (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {summary}
+        </p>
+      )}
+
+      {!isRunning && isRawMode && (
+        <div className="flex flex-col gap-1">
+          {command && (
+            <CodeBlock className="language-bash max-h-20 overflow-y-auto">
+              {command}
+            </CodeBlock>
+          )}
+          {rawOutputText && (
+            <CodeBlock className="language-text max-h-40 overflow-y-auto">
+              {rawOutputText}
+            </CodeBlock>
+          )}
+          <ExitCodeBadge exitCode={exitCode} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SidebarView({
+  command,
+  summary,
+  rawOutputText,
+  isRawMode,
+  isRunning,
+  exitCode,
+}: SandboxViewProps) {
+  return (
+    <div className="flex flex-col gap-4 py-4 pl-6">
+      {!isRawMode && (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {isRunning && command
+            ? `Running \`${command}\``
+            : isRunning
+              ? "Running command…"
+              : summary}
+        </p>
+      )}
+
+      {isRawMode && (
+        <>
+          {command && (
+            <Collapsible defaultOpen={true}>
+              <CollapsibleTrigger>
+                <div
+                  className={cn(
+                    "text-foreground dark:text-foreground-night",
+                    "flex flex-row items-center gap-x-2"
+                  )}
+                >
+                  <span className="heading-base">Command</span>
+                </div>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="py-2">
+                  <CodeBlock className="language-bash max-h-40 overflow-y-auto">
+                    {command}
+                  </CodeBlock>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+
+          <Collapsible defaultOpen={!!rawOutputText}>
+            <CollapsibleTrigger>
+              <div
+                className={cn(
+                  "text-foreground dark:text-foreground-night",
+                  "flex flex-row items-center gap-x-2"
+                )}
+              >
+                <span className="heading-base">Output</span>
+              </div>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="py-2">
+                {rawOutputText ? (
+                  <CodeBlock className="language-text max-h-96 overflow-y-auto">
+                    {rawOutputText}
+                  </CodeBlock>
+                ) : (
+                  <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
+                    {isRunning ? "Waiting for output…" : "(no output)"}
+                  </p>
+                )}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+
+          <ExitCodeBadge exitCode={exitCode} />
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Alpha version of a dedicated sandbox action renderer to have a starting point we'll iterate on with design.

- New MCPSandboxActionDetails component replaces the generic fallback for sandbox tool outputs
- Summary mode (default): shows a clean one-liner derived from the command name (e.g. "Ran python3
successfully.")
- Code mode: toggle to see full command + raw stdout/stderr in code blocks, with exit code badge
- Toggle button with icon in the action header row, preference persisted in localStorage
- Adds optional headerAction slot to ActionDetailsWrapper (backwards-compatible)

This is an early iteration. Design polish, file explorer, and sandbox status indicator will come in follow-up PRs. But I'm welcoming feedback from you already if any. 🙏🏻 
Please ignore Soupinou who is not a feature and will not be shipped to production. She is conducting her own independent review and I cannot stop her. 🙇🏻‍♀️ 
<kbd>
<img width="1477" height="600" alt="Screenshot 2026-02-26 at 15 58 48" src="https://github.com/user-attachments/assets/2a449f33-62be-46cd-aa77-00c8313d292c" />
</kbd>
<kbd>
<img width="1480" height="778" alt="Screenshot 2026-02-26 at 15 51 49" src="https://github.com/user-attachments/assets/d752331f-f502-4582-90f4-0477fa8c4594" />
</kbd>
<kbd>
<img width="1480" height="901" alt="Screenshot 2026-02-26 at 15 51 55" src="https://github.com/user-attachments/assets/411de607-c555-485f-b128-c5d26994a6a8" />
</kbd>




## Tests

Locally. 

## Risk

Related to sandbox tool only. 
Can be rolled back;

## Deploy Plan

Deploy front. 