### PR TITLE
[sparkle] - refactor: streamline `useMemo` and `useCallback`

### DIFF
--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -227,7 +227,7 @@ export function Avatar({
       )}
       style={hexBgColor ? { backgroundColor: hexBgColor } : undefined}
     >
-      {size === "auto" && <div className="s-aspect-square" />}
+      {size === "auto" && <div style={{ paddingBottom: "100%" }} />}
       {typeof visualToUse === "string" ? (
         <img
           src={visualToUse}

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -227,7 +227,7 @@ export function Avatar({
       )}
       style={hexBgColor ? { backgroundColor: hexBgColor } : undefined}
     >
-      {size === "auto" && <div style={{ paddingBottom: "100%" }} />}
+      {size === "auto" && <div className="s-aspect-square" />}
       {typeof visualToUse === "string" ? (
         <img
           src={visualToUse}

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -14,7 +14,7 @@ import { ChevronDownIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 const PULSE_ANIMATION_DURATION = 1;
 
@@ -476,17 +476,15 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       </>
     );
 
-    const pointerEventProps = useMemo(() => {
-      if (isLoading || props.disabled) {
-        return {
-          onPointerDown: (e: React.PointerEvent<HTMLButtonElement>) => {
-            e.preventDefault();
-            e.stopPropagation();
-          },
-        };
-      }
-      return {};
-    }, [isLoading, props.disabled]);
+    const pointerEventProps =
+      isLoading || props.disabled
+        ? {
+            onPointerDown: (e: React.PointerEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              e.stopPropagation();
+            },
+          }
+        : {};
 
     // We cannot skip a button tag when it's disabled. We need
     // to apply disabled class manually (currently it has :disabled pseudo-class, which won't work if it's not a button)

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -48,18 +48,14 @@ const Citation = React.forwardRef<HTMLDivElement, CitationProps>(
     },
     ref
   ) => {
-    const { hasDescription, hasImage } = React.useMemo(() => {
-      const childrenArray = React.Children.toArray(children);
-      return {
-        hasDescription: childrenArray.some(
-          (child) =>
-            React.isValidElement(child) && child.type === CitationDescription
-        ),
-        hasImage: childrenArray.some(
-          (child) => React.isValidElement(child) && child.type === CitationImage
-        ),
-      };
-    }, [children]);
+    const childrenArray = React.Children.toArray(children);
+    const hasDescription = childrenArray.some(
+      (child) =>
+        React.isValidElement(child) && child.type === CitationDescription
+    );
+    const hasImage = childrenArray.some(
+      (child) => React.isValidElement(child) && child.type === CitationImage
+    );
 
     // IMPORTANT: The order of elements is crucial for event handling.
     // The CitationDescription must always come after other elements to ensure

--- a/sparkle/src/components/CollapseButton.tsx
+++ b/sparkle/src/components/CollapseButton.tsx
@@ -143,8 +143,7 @@ const CollapseButton: React.FC<CollapseButtonProps> = ({
     <div
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      style={{ width: `24px`, height: `30px` }}
-      className="s-cursor-pointer"
+      className="s-w-6 s-h-[30px] s-cursor-pointer"
     >
       <Lottie
         lottieRef={lottieRef}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -142,7 +142,9 @@ export function DataTable<TData extends TBaseData>({
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const columnFilters: ColumnFiltersState = filterColumn
+    ? [{ id: filterColumn, value: filter }]
+    : [];
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
   const isClientSideSortingEnabled =
@@ -192,7 +194,6 @@ export function DataTable<TData extends TBaseData>({
     }),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: pagination ? getPaginationRowModel() : undefined,
-    onColumnFiltersChange: setColumnFilters,
     ...(enableRowSelection && {
       onRowSelectionChange,
     }),
@@ -212,12 +213,6 @@ export function DataTable<TData extends TBaseData>({
     enableMultiRowSelection,
     getRowId,
   });
-
-  useEffect(() => {
-    if (filterColumn) {
-      table.getColumn(filterColumn)?.setFilterValue(filter);
-    }
-  }, [filter, filterColumn]);
 
   return (
     <div className={cn("s-flex s-flex-col s-gap-2", className, widthClassName)}>

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -104,15 +104,12 @@ const DialogContent = React.forwardRef<
     },
     ref
   ) => {
-    const handleCloseAutoFocus = React.useCallback(
-      (event: Event) => {
-        if (preventAutoFocusOnClose) {
-          event.preventDefault();
-        }
-        onCloseAutoFocus?.(event);
-      },
-      [preventAutoFocusOnClose, onCloseAutoFocus]
-    );
+    const handleCloseAutoFocus = (event: Event) => {
+      if (preventAutoFocusOnClose) {
+        event.preventDefault();
+      }
+      onCloseAutoFocus?.(event);
+    };
 
     return (
       <DialogPortal container={mountPortalContainer}>

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -279,15 +279,12 @@ const DropdownMenuContent = React.forwardRef<
     },
     ref
   ) => {
-    const handleCloseAutoFocus = React.useCallback(
-      (event: Event) => {
-        if (preventAutoFocusOnClose) {
-          event.preventDefault();
-        }
-        onCloseAutoFocus?.(event);
-      },
-      [preventAutoFocusOnClose, onCloseAutoFocus]
-    );
+    const handleCloseAutoFocus = (event: Event) => {
+      if (preventAutoFocusOnClose) {
+        event.preventDefault();
+      }
+      onCloseAutoFocus?.(event);
+    };
 
     const content = (
       <DropdownMenuPrimitive.Content

--- a/sparkle/src/components/DropzoneOverlay.tsx
+++ b/sparkle/src/components/DropzoneOverlay.tsx
@@ -65,13 +65,11 @@ export function DropzoneOverlay({
         <Lottie
           lottieRef={lottieRef}
           animationData={anim}
-          style={{ width: `200px`, height: `200px` }}
+          style={{ width: "200px", height: "200px" }}
           loop={false}
           autoplay
         />
-        <div className="s-absolute" style={{ top: `84px`, left: `84px` }}>
-          {visual}
-        </div>
+        <div className="s-absolute s-top-[84px] s-left-[84px]">{visual}</div>
       </div>
       <div className="s-heading-xl">{title}</div>
       <div className="s-text-base s-text-muted-foreground dark:s-text-muted-foreground-night">

--- a/sparkle/src/components/FaviconIcon.tsx
+++ b/sparkle/src/components/FaviconIcon.tsx
@@ -1,7 +1,7 @@
 import { GlobeAltIcon } from "@sparkle/icons";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 
 const faviconVariants = cva("", {
   variants: {
@@ -37,14 +37,14 @@ export function FaviconIcon({
   const [hasError, setHasError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  const handleError = useCallback(() => {
+  const handleError = () => {
     setHasError(true);
     setIsLoading(false);
-  }, []);
+  };
 
-  const handleLoad = useCallback(() => {
+  const handleLoad = () => {
     setIsLoading(false);
-  }, []);
+  };
 
   // Determine favicon URL
   let finalFaviconUrl = faviconUrl;

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
 
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 
 import { Button } from "./Button";
 
@@ -19,16 +19,12 @@ export function FilterChips<T extends string>({
     defaultFilter && filters.includes(defaultFilter) ? defaultFilter : null
   );
 
-  const handleFilterClick = useCallback(
-    (filterName: T) => {
-      // Avoid unnecessary re-renders by only triggering event if filter has changed.
-      if (filterName !== selectedFilter) {
-        setSelectedFilter(filterName);
-        onFilterClick(filterName);
-      }
-    },
-    [onFilterClick, selectedFilter]
-  );
+  const handleFilterClick = (filterName: T) => {
+    if (filterName !== selectedFilter) {
+      setSelectedFilter(filterName);
+      onFilterClick(filterName);
+    }
+  };
 
   return (
     <div className="s-flex s-flex-row s-flex-wrap s-gap-2">

--- a/sparkle/src/components/Hover3D.tsx
+++ b/sparkle/src/components/Hover3D.tsx
@@ -54,7 +54,7 @@ function Hover3D({
 }: Hover3DProps) {
   const elementRef = useRef<HTMLDivElement>(null);
   const [isHovered, setHovered] = useState(fullscreenSensible);
-  const [isTouch, setIsTouch] = useState(false);
+  const [isTouch] = useState(() => isTouchDevice());
   const [transform, setTransform] = useState(
     `perspective(${perspective}px) translateZ(${
       fullscreenSensible ? depth : 0
@@ -73,11 +73,6 @@ function Hover3D({
   ) => {
     return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
   };
-
-  // Detect touch device on mount
-  useEffect(() => {
-    setIsTouch(isTouchDevice());
-  }, []);
 
   useEffect(() => {
     // Skip 3D effect setup if on a touch device

--- a/sparkle/src/components/ImageZoomDialog.tsx
+++ b/sparkle/src/components/ImageZoomDialog.tsx
@@ -14,7 +14,7 @@ import {
   XMarkIcon,
 } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
-import React, { useCallback, useState } from "react";
+import React, { useRef, useState } from "react";
 
 function downloadFile(url: string, filename: string) {
   const link = document.createElement("a");
@@ -51,20 +51,23 @@ function ImageZoomDialog({
 }: ImageZoomDialogProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
 
-  const handleDownload = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (image.downloadUrl && image.title) {
-        downloadFile(image.downloadUrl, image.title);
-      }
-    },
-    [image.downloadUrl, image.title]
-  );
+  // Reset image loaded state when dialog closes or image changes.
+  const prevSrcRef = useRef(image.src);
+  const prevOpenRef = useRef(open);
+  if (prevSrcRef.current !== image.src || prevOpenRef.current !== open) {
+    prevSrcRef.current = image.src;
+    prevOpenRef.current = open;
+    if (imageLoaded) {
+      setImageLoaded(false);
+    }
+  }
 
-  // Reset image loaded state when dialog closes or image changes
-  React.useEffect(() => {
-    setImageLoaded(false);
-  }, [open, image.src]);
+  const handleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (image.downloadUrl && image.title) {
+      downloadFile(image.downloadUrl, image.title);
+    }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -3,7 +3,7 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import type { PaginationState } from "@tanstack/react-table";
-import React, { useCallback } from "react";
+import React from "react";
 
 import { Button } from "./Button";
 
@@ -50,12 +50,9 @@ export function Pagination({
       ? (pageIndex + 1) * pageSize
       : rowCount;
 
-  const onPaginationButtonClick = useCallback(
-    (pageIndex: number) => {
-      setPagination({ pageSize, pageIndex });
-    },
-    [pageIndex, setPagination]
-  );
+  const onPaginationButtonClick = (pageIndex: number) => {
+    setPagination({ pageSize, pageIndex });
+  };
 
   const pageButtons: React.ReactNode[] = getPageButtons(
     pageIndex,

--- a/sparkle/src/components/Popover.tsx
+++ b/sparkle/src/components/Popover.tsx
@@ -35,15 +35,12 @@ const PopoverContent = React.forwardRef<
     },
     ref
   ) => {
-    const handleCloseAutoFocus = React.useCallback(
-      (event: Event) => {
-        if (preventAutoFocusOnClose) {
-          event.preventDefault();
-        }
-        onCloseAutoFocus?.(event);
-      },
-      [preventAutoFocusOnClose, onCloseAutoFocus]
-    );
+    const handleCloseAutoFocus = (event: Event) => {
+      if (preventAutoFocusOnClose) {
+        event.preventDefault();
+      }
+      onCloseAutoFocus?.(event);
+    };
     const content = (
       <PopoverPrimitive.Content
         ref={ref}

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -19,13 +19,7 @@ import {
   XMarkIcon,
 } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
-import React, {
-  forwardRef,
-  type Ref,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { forwardRef, type Ref, useRef, useState } from "react";
 
 export interface SearchInputProps {
   placeholder?: string;
@@ -175,13 +169,14 @@ function BaseSearchInputWithPopover<T>(
     (items.length > 0 && (displayItemCount || onSelectAll));
   const showBottom = Boolean(stickyBottomContent);
 
-  useEffect(() => {
-    itemRefs.current = new Array(items.length).fill(null);
-  }, [items.length]);
-
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [items]);
+  // Reset selection when items change.
+  const prevItemsRef = useRef(items);
+  if (prevItemsRef.current !== items) {
+    prevItemsRef.current = items;
+    if (selectedIndex !== 0) {
+      setSelectedIndex(0);
+    }
+  }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!open || !items.length) {

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -113,41 +113,32 @@ const SheetContent = React.forwardRef<
     },
     ref
   ) => {
-    const handleCloseAutoFocus = React.useCallback(
-      (event: Event) => {
-        if (preventAutoFocusOnClose) {
-          event.preventDefault();
-        }
-        onCloseAutoFocus?.(event);
-      },
-      [preventAutoFocusOnClose, onCloseAutoFocus]
-    );
+    const handleCloseAutoFocus = (event: Event) => {
+      if (preventAutoFocusOnClose) {
+        event.preventDefault();
+      }
+      onCloseAutoFocus?.(event);
+    };
 
-    const handleOpenAutoFocus = React.useCallback(
-      (event: Event) => {
-        if (preventAutoFocusOnOpen) {
-          event.preventDefault();
-        }
-        onOpenAutoFocus?.(event);
-      },
-      [preventAutoFocusOnOpen, onOpenAutoFocus]
-    );
+    const handleOpenAutoFocus = (event: Event) => {
+      if (preventAutoFocusOnOpen) {
+        event.preventDefault();
+      }
+      onOpenAutoFocus?.(event);
+    };
 
-    const onKeyDownCapture = React.useCallback(
-      (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-          const root = e.currentTarget as HTMLElement;
-          const target = root.querySelector<HTMLButtonElement>(
-            '[data-sheet-save="true"]:not(:disabled)'
-          );
-          if (target) {
-            e.preventDefault();
-            target.click();
-          }
+    const onKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        const root = e.currentTarget as HTMLElement;
+        const target = root.querySelector<HTMLButtonElement>(
+          '[data-sheet-save="true"]:not(:disabled)'
+        );
+        if (target) {
+          e.preventDefault();
+          target.click();
         }
-      },
-      []
-    );
+      }
+    };
 
     return (
       <SheetPortal>

--- a/sparkle/src/components/Spinner.tsx
+++ b/sparkle/src/components/Spinner.tsx
@@ -55,14 +55,24 @@ const hexToRgba = (hex: string): [number, number, number, number] => {
   return [r, g, b, 1];
 };
 
+const isCustomColor = (key: string): key is keyof typeof customColors =>
+  key in customColors;
+
+const isShadeOf = <C extends keyof typeof customColors>(
+  color: C,
+  shade: string
+): shade is Extract<keyof (typeof customColors)[C], string> =>
+  shade in customColors[color];
+
 const colors: Record<Exclude<SpinnerVariantType, "color">, LottieColorType> = {
   ...Object.fromEntries(
     colorVariants.map((variant) => {
-      const color = variant.match(/[a-z]+/)?.[0] as keyof typeof customColors;
-      const shade = variant.match(
-        /\d+/
-      )?.[0] as unknown as keyof (typeof customColors)[typeof color];
-      return [variant, hexToRgba(customColors[color][shade])];
+      const colorMatch = variant.match(/[a-z]+/)?.[0] ?? "";
+      const shadeMatch = variant.match(/\d+/)?.[0] ?? "";
+      if (isCustomColor(colorMatch) && isShadeOf(colorMatch, shadeMatch)) {
+        return [variant, hexToRgba(customColors[colorMatch][shadeMatch])];
+      }
+      return [variant, [0, 0, 0, 1]];
     })
   ),
 };

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -9,7 +9,7 @@ import {
 } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
-import React, { useCallback } from "react";
+import React from "react";
 
 export type SupportedContentType = "application/json" | "text/csv";
 
@@ -99,54 +99,48 @@ export function ContentBlockWrapper({
 }: ContentBlockWrapperProps) {
   const [isCopied, copyToClipboard] = useCopyToClipboard();
 
-  const handleCopyToClipboard = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!content) {
-        return;
-      }
-      const rawContent: ClipboardContent =
-        typeof content === "string" ? { "text/plain": content } : content;
+  const handleCopyToClipboard = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!content) {
+      return;
+    }
+    const rawContent: ClipboardContent =
+      typeof content === "string" ? { "text/plain": content } : content;
 
-      // Replace invisible non-breaking spaces with regular spaces.
-      if (rawContent["text/plain"]) {
-        rawContent["text/plain"] = rawContent["text/plain"]
-          .replaceAll("\xa0", " ")
-          .trim();
-      }
+    // Replace invisible non-breaking spaces with regular spaces.
+    if (rawContent["text/plain"]) {
+      rawContent["text/plain"] = rawContent["text/plain"]
+        .replaceAll("\xa0", " ")
+        .trim();
+    }
 
-      const data = new ClipboardItem(
-        Object.entries(rawContent).reduce(
-          (acc, [type, data]) => {
-            acc[type] = new Blob([data], { type });
-            return acc;
-          },
-          {} as Record<string, Blob>
-        )
-      );
-      void copyToClipboard(data);
-    },
-    [content, copyToClipboard]
-  );
+    const data = new ClipboardItem(
+      Object.entries(rawContent).reduce(
+        (acc, [type, data]) => {
+          acc[type] = new Blob([data], { type });
+          return acc;
+        },
+        {} as Record<string, Blob>
+      )
+    );
+    void copyToClipboard(data);
+  };
 
-  const handleDownload = useCallback(
-    async (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!getContentToDownload) {
-        return;
-      }
-      const { content, filename, type } = await getContentToDownload();
-      const blob = new Blob([content], { type });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${filename}.${contentTypeExtensions[type]}`;
-      a.click();
-    },
-    [getContentToDownload]
-  );
+  const handleDownload = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!getContentToDownload) {
+      return;
+    }
+    const { content, filename, type } = await getContentToDownload();
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${filename}.${contentTypeExtensions[type]}`;
+    a.click();
+  };
 
   return (
     <div

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -315,6 +315,7 @@ function Input({
   ...props
 }: InputProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const checkboxRef = React.useRef<HTMLButtonElement>(null);
   React.useImperativeHandle(ref, () => inputRef.current!);
 
   if (type !== "checkbox") {
@@ -338,7 +339,7 @@ function Input({
   return (
     <div className="s-inline-flex s-items-center">
       <Checkbox
-        ref={inputRef as unknown as React.Ref<HTMLButtonElement>}
+        ref={checkboxRef}
         size="xs"
         checked={checked}
         className="s-translate-y-[3px]"


### PR DESCRIPTION
## Description

This PR continues the sparkle component cleanup effort (wave 3) by removing unnecessary `useMemo` and `useCallback` hooks that provide little to no benefit. 

React hooks like `useMemo` and `useCallback` are designed to optimize performance in specific scenarios, but overusing them can make code harder to read and maintain without meaningful gains. 

This PR simplifies component logic by removing these hooks where the wrapped computation is trivial or where the callbacks don't need stable references

## Risk

Medium

## Tests

Locally

## Deploy Plan

Deploy front