### PR TITLE
[front] feat: add table `skill_file_attachments`

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -49,6 +49,7 @@ import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import {
   SkillConfigurationModel,
   SkillDataSourceConfigurationModel,
+  SkillFileAttachmentModel,
   SkillMCPServerConfigurationModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
@@ -197,6 +198,7 @@ export function loadAllModels() {
     ConversationSkillModel,
     AgentMessageSkillModel,
     SkillMCPServerConfigurationModel,
+    SkillFileAttachmentModel,
     WorkspaceVerificationAttemptModel,
     AgentSuggestionModel,
     UserProjectDigestModel,

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -2,6 +2,7 @@ import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_vie
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
@@ -235,6 +236,84 @@ MCPServerViewModel.hasMany(SkillMCPServerConfigurationModel, {
 SkillMCPServerConfigurationModel.belongsTo(MCPServerViewModel, {
   foreignKey: { name: "mcpServerViewId", allowNull: false },
   as: "mcpServerView",
+});
+
+// Skill File Attachment (files attached to a skill for sandbox sync)
+export class SkillFileAttachmentModel extends WorkspaceAwareModel<SkillFileAttachmentModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
+  declare fileId: ForeignKey<FileModel["id"]>;
+  declare fileName: string;
+}
+
+SkillFileAttachmentModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    skillConfigurationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: SkillConfigurationModel,
+        key: "id",
+      },
+    },
+    fileId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: FileModel,
+        key: "id",
+      },
+    },
+    fileName: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "skill_file_attachment",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "skillConfigurationId"],
+        name: "idx_skill_file_attachment_workspace_skill_config",
+      },
+      {
+        fields: ["workspaceId", "fileModelId"],
+        name: "idx_skill_file_attachment_workspace_file",
+        unique: true,
+      },
+    ],
+  }
+);
+
+// Skill config <> File Attachment
+SkillConfigurationModel.hasMany(SkillFileAttachmentModel, {
+  foreignKey: { name: "skillConfigurationId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "fileAttachments",
+});
+SkillFileAttachmentModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "skillConfigurationId", allowNull: false },
+  as: "skillConfiguration",
+});
+
+// File Attachment <> File
+SkillFileAttachmentModel.belongsTo(FileModel, {
+  foreignKey: { name: "fileModelId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "file",
 });
 
 SkillConfigurationModel.hasMany(SkillVersionModel, {

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -290,7 +290,7 @@ SkillFileAttachmentModel.init(
         name: "idx_skill_file_attachment_workspace_skill_config",
       },
       {
-        fields: ["workspaceId", "fileModelId"],
+        fields: ["workspaceId", "fileId"],
         name: "idx_skill_file_attachment_workspace_file",
         unique: true,
       },
@@ -311,7 +311,7 @@ SkillFileAttachmentModel.belongsTo(SkillConfigurationModel, {
 
 // File Attachment <> File
 SkillFileAttachmentModel.belongsTo(FileModel, {
-  foreignKey: { name: "fileModelId", allowNull: false },
+  foreignKey: { name: "fileId", allowNull: false },
   onDelete: "RESTRICT",
   as: "file",
 });

--- a/front/migrations/db/migration_523.sql
+++ b/front/migrations/db/migration_523.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS "skill_file_attachments" (
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "skillConfigurationId" BIGINT NOT NULL REFERENCES "skill_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-    "fileModelId" BIGINT NOT NULL REFERENCES "files" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "fileId" BIGINT NOT NULL REFERENCES "files" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     "fileName" TEXT NOT NULL,
     PRIMARY KEY ("id")
 );
@@ -14,4 +14,4 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_file_attachment_workspace_ski
     ON "skill_file_attachments" ("workspaceId", "skillConfigurationId");
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_file_attachment_workspace_file"
-    ON "skill_file_attachments" ("workspaceId", "fileModelId");
+    ON "skill_file_attachments" ("workspaceId", "fileId");

--- a/front/migrations/db/migration_523.sql
+++ b/front/migrations/db/migration_523.sql
@@ -1,0 +1,17 @@
+-- Migration created on Feb 26, 2026
+CREATE TABLE IF NOT EXISTS "skill_file_attachments" (
+    "id" BIGSERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "skillConfigurationId" BIGINT NOT NULL REFERENCES "skill_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "fileModelId" BIGINT NOT NULL REFERENCES "files" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "fileName" TEXT NOT NULL,
+    PRIMARY KEY ("id")
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_file_attachment_workspace_skill_config"
+    ON "skill_file_attachments" ("workspaceId", "skillConfigurationId");
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_file_attachment_workspace_file"
+    ON "skill_file_attachments" ("workspaceId", "fileModelId");


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/6800.
- This PR adds a join table between files and skills.
- Next step is to add a new use case `"skill_attachment"` on files.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy front.
