### PR TITLE
[Front] feat(copilot): add Langfuse-driven first message for copilotEdge

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -110,7 +110,7 @@ export const CopilotPanelProvider = ({
       setCreationFailed(true);
       setIsCreatingConversation(false);
       sendNotification({
-        title: "Copilot error",
+        title: "Sidekick error",
         description: firstMessageResult.error.message,
         type: "error",
       });

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -63,8 +63,9 @@ export const CopilotPanelProvider = ({
   const { owner } = useAgentBuilderContext();
   const { user } = useAuth();
   const sendNotification = useSendNotification();
-  const copilotEdge = useSearchParam("copilotEdge");
-  const copilotAgentId = copilotEdge
+  const copilotEdgeParam = useSearchParam("copilotEdge");
+  const isCopilotEdge = copilotEdgeParam === "true";
+  const copilotAgentId = isCopilotEdge
     ? GLOBAL_AGENTS_SID.COPILOT_EDGE
     : GLOBAL_AGENTS_SID.COPILOT;
 
@@ -81,6 +82,7 @@ export const CopilotPanelProvider = ({
     templateInfo,
     conversationId,
     agentConfigurationId: targetAgentConfigurationId ?? undefined,
+    copilotEdge: isCopilotEdge,
   });
 
   const createConversationWithMessage = useCreateConversationWithMessage({
@@ -103,11 +105,21 @@ export const CopilotPanelProvider = ({
 
     setIsCreatingConversation(true);
 
-    const firstMessagePrompt = await getFirstMessage();
+    const firstMessageResult = await getFirstMessage();
+    if (firstMessageResult.isErr()) {
+      setCreationFailed(true);
+      setIsCreatingConversation(false);
+      sendNotification({
+        title: "Copilot error",
+        description: firstMessageResult.error.message,
+        type: "error",
+      });
+      return;
+    }
 
     const result = await createConversationWithMessage({
       messageData: {
-        input: firstMessagePrompt,
+        input: firstMessageResult.value,
         mentions: [{ configurationId: copilotAgentId }],
         contentFragments: { uploaded: [], contentNodes: [] },
         origin: "agent_copilot",

--- a/front/hooks/useCopilotFirstMessage.ts
+++ b/front/hooks/useCopilotFirstMessage.ts
@@ -1,5 +1,9 @@
 import { clientFetch } from "@app/lib/egress/client";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { TemplateInfo } from "@app/types/assistant/templates";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
 
@@ -12,42 +16,48 @@ const COPILOT_USE_CASES = [
 type CopilotUseCase = (typeof COPILOT_USE_CASES)[number];
 
 function getCopilotScenario({
-  workspaceSId,
+  workspaceId,
   isNewAgent,
   templateInfo,
   conversationId,
   agentConfigurationId,
+  copilotEdge,
 }: {
-  workspaceSId: string;
+  workspaceId: string;
   isNewAgent: boolean;
   templateInfo?: TemplateInfo;
   conversationId?: string;
   agentConfigurationId?: string;
+  copilotEdge: boolean;
 }): {
   endpoint: string;
   useCase: CopilotUseCase;
 } {
+  const params = new URLSearchParams();
+  let useCase: CopilotUseCase;
+
   if (templateInfo && templateInfo.copilotInstructions) {
-    return {
-      endpoint: `/api/w/${workspaceSId}/assistant/builder/copilot/prompt/template?templateId=${templateInfo.templateId}`,
-      useCase: "template",
-    };
+    useCase = "template";
+    params.set("templateId", templateInfo.templateId);
+  } else if (!isNewAgent && agentConfigurationId) {
+    useCase = "existing";
+    params.set("agentConfigurationId", agentConfigurationId);
+  } else if (conversationId) {
+    useCase = "shrink-wrap";
+    params.set("conversationId", conversationId);
+  } else {
+    useCase = "new";
   }
-  if (!isNewAgent && agentConfigurationId) {
-    return {
-      endpoint: `/api/w/${workspaceSId}/assistant/builder/copilot/prompt/existing?agentConfigurationId=${agentConfigurationId}`,
-      useCase: "existing",
-    };
+
+  if (copilotEdge) {
+    params.set("copilotEdge", "true");
   }
-  if (conversationId) {
-    return {
-      endpoint: `/api/w/${workspaceSId}/assistant/builder/copilot/prompt/shrink-wrap?conversationId=${conversationId}`,
-      useCase: "shrink-wrap",
-    };
-  }
+
+  const queryString = params.toString();
+  const path = `/api/w/${workspaceId}/assistant/builder/copilot/prompt/${useCase}`;
   return {
-    endpoint: `/api/w/${workspaceSId}/assistant/builder/copilot/prompt/new`,
-    useCase: "new",
+    endpoint: queryString ? `${path}?${queryString}` : path,
+    useCase,
   };
 }
 
@@ -57,38 +67,53 @@ export function useCopilotFirstMessage({
   templateInfo,
   conversationId,
   agentConfigurationId,
+  copilotEdge = false,
 }: {
   owner: WorkspaceType;
   isNewAgent: boolean;
   templateInfo?: TemplateInfo;
   conversationId?: string;
   agentConfigurationId?: string;
+  copilotEdge?: boolean;
 }) {
   const { endpoint, useCase } = useMemo(
     () =>
       getCopilotScenario({
-        workspaceSId: owner.sId,
+        workspaceId: owner.sId,
         isNewAgent,
         templateInfo,
         conversationId,
         agentConfigurationId,
+        copilotEdge,
       }),
-    [owner.sId, isNewAgent, templateInfo, conversationId, agentConfigurationId]
+    [
+      owner.sId,
+      isNewAgent,
+      templateInfo,
+      conversationId,
+      agentConfigurationId,
+      copilotEdge,
+    ]
   );
 
-  const getFirstMessage = useCallback(async (): Promise<string> => {
-    const res = await clientFetch(endpoint, {
-      method: "GET",
-    });
+  const getFirstMessage = useCallback(async (): Promise<
+    Result<string, Error>
+  > => {
+    try {
+      const res = await clientFetch(endpoint, {
+        method: "GET",
+      });
 
-    if (!res.ok) {
-      throw new Error(
-        `Failed to fetch copilot first message: ${res.status} ${res.statusText}`
-      );
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        return new Err(new Error(errorData.message));
+      }
+
+      const data = await res.json();
+      return new Ok(data);
+    } catch (error) {
+      return new Err(normalizeError(error));
     }
-
-    const data = (await res.json()) as string;
-    return data;
   }, [endpoint]);
 
   return { getFirstMessage, useCase };

--- a/front/lib/api/assistant/global_agents/copilot_context.ts
+++ b/front/lib/api/assistant/global_agents/copilot_context.ts
@@ -1,6 +1,6 @@
 import { AGENT_COPILOT_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
 import {
-  fetchLangfusePromptConfig,
+  fetchLangfuseSystemPromptConfig,
   type LangfusePromptConfig,
 } from "@app/lib/api/assistant/global_agents/langfuse_prompts";
 import type {
@@ -175,13 +175,10 @@ export async function buildCopilotContext(
   let langfuseConfig: LangfusePromptConfig | null = null;
 
   if (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_EDGE)) {
-    const result = await fetchLangfusePromptConfig(
-      GLOBAL_AGENTS_SID.COPILOT_EDGE,
-      {
-        userContext: formattedUserContext ?? "",
-        workspaceContext: formattedWorkspaceContext,
-      }
-    );
+    const result = await fetchLangfuseSystemPromptConfig("copilot-edge", {
+      userContext: formattedUserContext ?? "",
+      workspaceContext: formattedWorkspaceContext,
+    });
     if (result.isErr()) {
       logger.error(
         {

--- a/front/lib/api/assistant/global_agents/langfuse_prompts.ts
+++ b/front/lib/api/assistant/global_agents/langfuse_prompts.ts
@@ -11,6 +11,14 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
+type LangfuseFirstMessagePromptName =
+  | "copilot-edge-first-message-new"
+  | "copilot-edge-first-message-existing"
+  | "copilot-edge-first-message-template"
+  | "copilot-edge-first-message-shrink-wrap";
+
+type LangfuseSystemPromptName = "copilot-edge";
+
 const LangfuseModelConfigSchema = z.object({
   modelId: z.string(),
   reasoningEffort: AgentReasoningEffortSchema.optional(),
@@ -22,8 +30,25 @@ export interface LangfusePromptConfig {
   reasoningEffort?: AgentReasoningEffort;
 }
 
-export async function fetchLangfusePromptConfig(
-  promptName: string,
+export async function fetchLangfuseFirstMessagePrompt(
+  promptName: LangfuseFirstMessagePromptName,
+  variables: Record<string, string>
+): Promise<Result<string, Error>> {
+  const client = getLangfuseClient();
+  if (!client) {
+    return new Err(new Error("Langfuse is not enabled"));
+  }
+
+  try {
+    const prompt = await client.prompt.get(promptName);
+    return new Ok(prompt.compile(variables));
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function fetchLangfuseSystemPromptConfig(
+  promptName: LangfuseSystemPromptName,
   variables: Record<string, string>
 ): Promise<Result<LangfusePromptConfig, Error>> {
   const client = getLangfuseClient();

--- a/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/existing.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/existing.ts
@@ -1,6 +1,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
 import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import { fetchLangfuseFirstMessagePrompt } from "@app/lib/api/assistant/global_agents/langfuse_prompts";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -187,7 +188,7 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET": {
-      const { agentConfigurationId } = req.query;
+      const { agentConfigurationId, copilotEdge } = req.query;
 
       if (!isString(agentConfigurationId)) {
         return apiError(req, res, {
@@ -205,11 +206,30 @@ async function handler(
         fetchInsightsMarkdown(auth, agentConfigurationId),
       ]);
 
-      const firstMessage = buildFirstMessage({
-        feedbackMarkdown,
-        insightsMarkdown,
-      });
-      return res.status(200).json(firstMessage);
+      if (copilotEdge !== "true") {
+        return res
+          .status(200)
+          .json(buildFirstMessage({ feedbackMarkdown, insightsMarkdown }));
+      }
+
+      const result = await fetchLangfuseFirstMessagePrompt(
+        "copilot-edge-first-message-existing",
+        {
+          ...(feedbackMarkdown ? { feedbackMarkdown } : {}),
+          ...(insightsMarkdown ? { insightsMarkdown } : {}),
+        }
+      );
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to generate copilot prompt.",
+          },
+        });
+      }
+
+      return res.status(200).json(result.value);
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/new.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/new.ts
@@ -2,6 +2,7 @@ import {
   formatTemplatesAsText,
   getTemplatesForCopilot,
 } from "@app/lib/api/assistant/copilot_templates";
+import { fetchLangfuseFirstMessagePrompt } from "@app/lib/api/assistant/global_agents/langfuse_prompts";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -56,7 +57,7 @@ Example:
 :quickReply[Competitive intel - monitors competitor news]{message="I want to build a competitive intel agent that monitors competitor news and surfaces updates"}"
 
 ## STEP 2: Response
-Respond with the use case suggestions. Provide a succinct explanation that the user can also input a free answer if they do not want to select one of the suggested templates. 
+Respond with the use case suggestions. Provide a succinct explanation that the user can also input a free answer if they do not want to select one of the suggested templates.
 
 Users do not necessarily know they are using a pre-defined template. Avoid using that phrasing in your response.
 
@@ -74,9 +75,29 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET": {
+      const { copilotEdge } = req.query;
       const jobType = await getJobTypeFromAuth(auth);
       const templatesMarkdown = await getTemplatesMarkdown(auth, jobType);
-      return res.status(200).json(buildFirstMessage(templatesMarkdown));
+
+      if (copilotEdge !== "true") {
+        return res.status(200).json(buildFirstMessage(templatesMarkdown));
+      }
+
+      const result = await fetchLangfuseFirstMessagePrompt(
+        "copilot-edge-first-message-new",
+        { templatesMarkdown }
+      );
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to generate copilot prompt.",
+          },
+        });
+      }
+
+      return res.status(200).json(result.value);
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/shrink-wrap.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/shrink-wrap.ts
@@ -1,5 +1,6 @@
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getShrinkWrapedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import { fetchLangfuseFirstMessagePrompt } from "@app/lib/api/assistant/global_agents/langfuse_prompts";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -110,7 +111,8 @@ async function handler(
   }
 
   switch (req.method) {
-    case "GET":
+    case "GET": {
+      const { copilotEdge } = req.query;
       const conversationRes = await getShrinkWrapedConversation(auth, {
         conversationId,
       });
@@ -128,8 +130,28 @@ async function handler(
         return apiErrorForConversation(req, res, error);
       }
 
-      const firstMessage = buildFirstMessage(conversationRes.value.text);
-      return res.status(200).json(firstMessage);
+      if (copilotEdge !== "true") {
+        return res
+          .status(200)
+          .json(buildFirstMessage(conversationRes.value.text));
+      }
+
+      const result = await fetchLangfuseFirstMessagePrompt(
+        "copilot-edge-first-message-shrink-wrap",
+        { conversation: conversationRes.value.text }
+      );
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to generate copilot prompt.",
+          },
+        });
+      }
+
+      return res.status(200).json(result.value);
+    }
     default:
       return apiError(req, res, {
         status_code: 405,

--- a/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/template.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/copilot/prompt/template.ts
@@ -1,3 +1,4 @@
+import { fetchLangfuseFirstMessagePrompt } from "@app/lib/api/assistant/global_agents/langfuse_prompts";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TemplateResource } from "@app/lib/resources/template_resource";
@@ -45,7 +46,8 @@ async function handler(
   }
 
   switch (req.method) {
-    case "GET":
+    case "GET": {
+      const { copilotEdge } = req.query;
       const template = await TemplateResource.fetchByExternalId(templateId);
 
       if (!template || !template.copilotInstructions) {
@@ -58,7 +60,30 @@ async function handler(
         });
       }
 
-      return res.status(200).json(buildTemplateAgentInitMessage(template));
+      if (copilotEdge !== "true") {
+        return res.status(200).json(buildTemplateAgentInitMessage(template));
+      }
+
+      const result = await fetchLangfuseFirstMessagePrompt(
+        "copilot-edge-first-message-template",
+        {
+          handle: template.handle,
+          copilotInstructions: template.copilotInstructions,
+          agentFacingDescription: template.agentFacingDescription ?? "",
+        }
+      );
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to generate copilot prompt.",
+          },
+        });
+      }
+
+      return res.status(200).json(result.value);
+    }
     default:
       return apiError(req, res, {
         status_code: 405,


### PR DESCRIPTION
## Description

Follows up on #22269 (Langfuse-driven model config). This extends the copilotEdge integration to also drive the **first message** (initial user prompt) from Langfuse, per scenario.

When `?copilotEdge=true` is set, each prompt endpoint fetches the compiled first message from Langfuse instead of using the hardcoded `buildFirstMessage()`. On Langfuse failure, endpoints return a 500 instead of silently falling back.

Langfuse prompt names: `copilot-edge-first-message-{new,existing,template,shrink-wrap}`.

### Other changes
- Fix `copilotEdge` param check: strict `=== "true"` instead of truthy
- `useCopilotFirstMessage` returns `Result` instead of throwing
- `CopilotPanelContext` handles first message fetch errors with notification

## TLDR - I want to test

Open copilot builder with `?copilotEdge=true`, verify first message loads from Langfuse. Remove the param, verify hardcoded first message still works.