### PR TITLE
[front] fix `enabled` column in poke trigger data table

### DIFF
--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -122,13 +122,10 @@ export function makeColumnsForTriggers(
       },
     },
     {
-      accessorKey: "enabled",
+      accessorKey: "status",
       header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Enabled" />
+        <PokeColumnSortableHeader column={column} label="Status" />
       ),
-      cell: ({ row }) => {
-        return row.getValue("enabled") ? "Yes" : "No";
-      },
     },
     {
       id: "editorEmail",


### PR DESCRIPTION
## Description

- The data table for triggers in poke contained a column `enabled` that was misleadingly always set to `"No"` as it mapped to a field that does not exist.
- This PR replaces it with the `status` column, which actually does exist.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy poke spa.
