### PR TITLE
[sparkle] - chore(CardGrid): add `adaptColumns` prop

### DIFF
--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -169,7 +169,7 @@ export function AgentObservability({
             <Spinner />
           </div>
         ) : (
-          <CardGrid>
+          <CardGrid adaptColumns>
             <ValueCard
               title="Active Users"
               className="h-24"

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -283,24 +283,38 @@ export const CardActionButton = React.forwardRef<
 
 CardActionButton.displayName = "CardActionButton";
 
-export const CardGrid = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ children, className, ...props }, ref) => {
-  return (
-    <div ref={ref} className={cn("s-@container", className)} {...props}>
-      <div
-        className={cn(
-          "s-grid s-grid-cols-1 s-gap-2",
-          "@xxs:has-[>:nth-child(2)]:s-grid-cols-2",
-          "@sm:has-[>:nth-child(3)]:s-grid-cols-3",
-          "@lg:has-[>:nth-child(4)]:s-grid-cols-4",
-          "@xl:has-[>:nth-child(5)]:s-grid-cols-5"
-        )}
-      >
-        {children}
+const uncappedGridClasses = cn(
+  "@xxs:s-grid-cols-2",
+  "@sm:s-grid-cols-3",
+  "@lg:s-grid-cols-4",
+  "@xl:s-grid-cols-5"
+);
+
+const adaptiveGridClasses = cn(
+  "@xxs:has-[>:nth-child(2)]:s-grid-cols-2",
+  "@sm:has-[>:nth-child(3)]:s-grid-cols-3",
+  "@lg:has-[>:nth-child(4)]:s-grid-cols-4",
+  "@xl:has-[>:nth-child(5)]:s-grid-cols-5"
+);
+
+interface CardGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  adaptColumns?: boolean;
+}
+
+export const CardGrid = React.forwardRef<HTMLDivElement, CardGridProps>(
+  ({ children, className, adaptColumns = false, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn("s-@container", className)} {...props}>
+        <div
+          className={cn(
+            "s-grid s-grid-cols-1 s-gap-2",
+            adaptColumns ? adaptiveGridClasses : uncappedGridClasses
+          )}
+        >
+          {children}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 CardGrid.displayName = "CardGrid";


### PR DESCRIPTION




## Description

This PR adds an `adaptColumns` prop to the `CardGrid` component to provide flexibility in how grid columns respond to content. When `adaptColumns` is `false` (default), the grid always applies responsive column counts regardless of the number of children. When `adaptColumns` is `true`, the grid uses `:has(:nth-child(n))` selectors to only apply multi-column layouts when there are enough children to fill them.

## Risk

Low

## Tests

Storybook and local testing.

## Deploy Plan

Deploy front