### PR TITLE
Handle case where enterprise login is on wrong region

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { makeEnterpriseConnectionInitiateLoginUrl } from "@app/lib/api/enterprise_connection";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
+import { lookupWorkspace } from "@app/lib/api/regions/lookup";
 import {
   handleEnterpriseSignUpFlow,
   handleMembershipInvite,
@@ -111,12 +112,40 @@ async function handler(
       workspaceId
     );
     if (flow === "unauthorized") {
+      // Workspace not found on this region: redirect to the other region's /api/login (cookie is shared).
+      const workspaceRegionRes = await lookupWorkspace(workspaceId);
+      const currentRegion = multiRegionsConfig.getCurrentRegion();
+      if (
+        workspaceRegionRes.isOk() &&
+        workspaceRegionRes.value &&
+        workspaceRegionRes.value !== currentRegion
+      ) {
+        logger.info(
+          {
+            userId: user.sId,
+            workspaceId,
+            targetRegion: workspaceRegionRes.value,
+            sessionIsSSO: session.isSSO,
+            sessionWorkspaceId: session.workspaceId,
+            sessionOrganizationId: session.organizationId,
+            sessionAuthenticationMethod: session.authenticationMethod,
+            sessionRegion: session.region,
+          },
+          "Enterprise connection: redirecting to other region"
+        );
+        const targetUrl = multiRegionsConfig.getRegionUrl(
+          workspaceRegionRes.value
+        );
+        res.redirect(`${targetUrl}/api/login`);
+        return;
+      }
+
       logger.error(
         { userId: user.sId, workspaceId },
         "Enterprise connection : workspace not found"
       );
 
-      // Only happen if the workspace associated with workOSOrganizationId is not found.
+      // Workspace not in other region or lookup failed: show login error.
       res.redirect(
         `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`
       );


### PR DESCRIPTION
## Description

Users could hit **"Enterprise connection: workspace not found"** when logging in via SSO if the request was handled by the wrong region. The workspace exists in another region (e.g. EU vs US), but `/api/login` was running on the region where the user landed (e.g. after WorkOS callback), so `WorkspaceResource.fetchById(workspaceId)` returned `null` and we showed the error.

In theory this should not happen as the region should be resolved from workos/callback before. Still, we have some users not able to login because of this.

## Solution

When `handleEnterpriseSignUpFlow` returns `flow === "unauthorized"` (workspace not found in the current region), we now:

1. **Look up the workspace’s region** via `lookupWorkspace(workspaceId)` (cross-region lookup).
2. **If the workspace is in another region**, redirect to that region’s `/api/login`. The session cookie is shared across regions, so the user is already authenticated and no new WorkOS step is needed.
3. **If the workspace is not in the other region or lookup fails**, keep the existing behavior: redirect to logout and the login-error page.

Add debug information to trace the root cause.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
