### PR TITLE
feat: add UI for butler suggestions

### DIFF
--- a/front/components/assistant/conversation/ButlerSuggestionCard.tsx
+++ b/front/components/assistant/conversation/ButlerSuggestionCard.tsx
@@ -1,0 +1,98 @@
+import type {
+  ButlerSuggestionPublicType,
+  RenameTitleButlerSuggestion,
+} from "@app/types/conversation_butler_suggestion";
+import {
+  Button,
+  CheckIcon,
+  ContentMessage,
+  PencilSquareIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface ButlerSuggestionCardProps {
+  suggestion: ButlerSuggestionPublicType;
+  onAction: (
+    suggestionSId: string,
+    status: "accepted" | "dismissed"
+  ) => Promise<void>;
+}
+
+export function ButlerSuggestionCard({
+  suggestion,
+  onAction,
+}: ButlerSuggestionCardProps) {
+  switch (suggestion.suggestionType) {
+    case "rename_title":
+      return (
+        <RenameTitleSuggestionCard
+          suggestion={suggestion}
+          onAction={onAction}
+        />
+      );
+    case "call_agent":
+      // Not yet implemented.
+      return null;
+  }
+}
+
+interface RenameTitleSuggestionCardProps {
+  suggestion: RenameTitleButlerSuggestion;
+  onAction: (
+    suggestionSId: string,
+    status: "accepted" | "dismissed"
+  ) => Promise<void>;
+}
+
+function RenameTitleSuggestionCard({
+  suggestion,
+  onAction,
+}: RenameTitleSuggestionCardProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleAction = async (status: "accepted" | "dismissed") => {
+    setIsSubmitting(true);
+    try {
+      await onAction(suggestion.sId, status);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <ContentMessage
+      variant="highlight"
+      icon={PencilSquareIcon}
+      title="Rename this conversation?"
+      className="my-3 w-full max-w-full"
+    >
+      <div className="flex flex-col gap-3">
+        <div>
+          Suggested title:{" "}
+          <span className="font-semibold">
+            {suggestion.metadata.suggestedTitle}
+          </span>
+        </div>
+        <div className="flex flex-row gap-2">
+          <Button
+            label="Rename"
+            variant="highlight"
+            size="xs"
+            icon={CheckIcon}
+            disabled={isSubmitting}
+            onClick={() => handleAction("accepted")}
+          />
+          <Button
+            label="Dismiss"
+            variant="outline"
+            size="xs"
+            icon={XMarkIcon}
+            disabled={isSubmitting}
+            onClick={() => handleAction("dismissed")}
+          />
+        </div>
+      </div>
+    </ContentMessage>
+  );
+}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -29,6 +29,7 @@ import { useSubmitMessage } from "@app/hooks/useSubmitMessage";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
+import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -40,6 +41,7 @@ import type {
 } from "@app/types/assistant/agent";
 import type {
   AgentMessageNewEvent,
+  ButlerSuggestionCreatedEvent,
   ConversationTitleEvent,
   ConversationWithoutContentType,
   LightMessageType,
@@ -52,6 +54,7 @@ import {
   toMentionType,
 } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
+import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_suggestion";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -307,6 +310,40 @@ export const ConversationViewer = ({
     workspaceId: owner.sId,
   });
 
+  const [suggestionsByMessageSId, setSuggestionsByMessageSId] = useState(
+    () => new Map<string, ButlerSuggestionPublicType[]>()
+  );
+
+  const handleSuggestionAction = useCallback(
+    async (
+      suggestionSId: string,
+      status: "accepted" | "dismissed"
+    ): Promise<void> => {
+      // Optimistic update: remove the suggestion from local state.
+      // The update of the title is handled backend, so we don't need to do it here.
+      setSuggestionsByMessageSId((prev) => {
+        const next = new Map<string, ButlerSuggestionPublicType[]>();
+        for (const [msgSId, suggestions] of prev) {
+          const filtered = suggestions.filter((s) => s.sId !== suggestionSId);
+          if (filtered.length > 0) {
+            next.set(msgSId, filtered);
+          }
+        }
+        return next;
+      });
+
+      await clientFetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/butler_suggestions/${suggestionSId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        }
+      );
+    },
+    [conversationId, owner.sId]
+  );
+
   // Hooks related to conversation events streaming.
 
   const debouncedMarkAsRead = useMemo(
@@ -326,7 +363,8 @@ export const ConversationViewer = ({
           | AgentMessageNewEvent
           | AgentMessageDoneEvent
           | AgentGenerationCancelledEvent
-          | ConversationTitleEvent;
+          | ConversationTitleEvent
+          | ButlerSuggestionCreatedEvent;
       } = JSON.parse(eventStr);
       const event = eventPayload.data;
 
@@ -465,6 +503,15 @@ export const ConversationViewer = ({
             );
 
             window.dispatchEvent(new AgentMessageCompletedEvent());
+            break;
+          case "butler_suggestion_created":
+            setSuggestionsByMessageSId((prev) => {
+              const { suggestion } = event;
+              const existing = prev.get(suggestion.sourceMessageSId) ?? [];
+              const next = new Map(prev);
+              next.set(suggestion.sourceMessageSId, [...existing, suggestion]);
+              return next;
+            });
             break;
           default:
             ((t: never) => {
@@ -721,6 +768,8 @@ export const ConversationViewer = ({
       draftKey: `conversation-${conversationId}`,
       agentBuilderContext,
       feedbacksByMessageId,
+      suggestionsByMessageSId,
+      handleSuggestionAction,
       additionalMarkdownComponents,
       additionalMarkdownPlugins,
       isProjectMember,
@@ -736,6 +785,8 @@ export const ConversationViewer = ({
     conversationId,
     agentBuilderContext,
     feedbacksByMessageId,
+    suggestionsByMessageSId,
+    handleSuggestionAction,
     additionalMarkdownComponents,
     additionalMarkdownPlugins,
     isProjectMember,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -1,6 +1,7 @@
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { contentFragmentToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import { ButlerSuggestionCard } from "@app/components/assistant/conversation/ButlerSuggestionCard";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { MentionInvalid } from "@app/components/assistant/conversation/MentionInvalid";
 import { MentionValidationRequired } from "@app/components/assistant/conversation/MentionValidationRequired";
@@ -212,6 +213,13 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 );
               }
             })}
+          {context.suggestionsByMessageSId.get(data.sId)?.map((suggestion) => (
+            <ButlerSuggestionCard
+              key={suggestion.sId}
+              suggestion={suggestion}
+              onAction={context.handleSuggestionAction}
+            />
+          ))}
         </div>
       </>
     );

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -16,6 +16,7 @@ import type {
 import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
+import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_suggestion";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -80,6 +81,11 @@ export type VirtuosoMessageListContext = {
     skipToolsValidation?: boolean;
   };
   feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
+  suggestionsByMessageSId: Map<string, ButlerSuggestionPublicType[]>;
+  handleSuggestionAction: (
+    suggestionSId: string,
+    status: "accepted" | "dismissed"
+  ) => Promise<void>;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   // Project membership fields (undefined for non-project conversations)

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -16,6 +16,7 @@ import type {
 } from "@app/types/assistant/agent";
 import type {
   AgentMessageNewEvent,
+  ButlerSuggestionCreatedEvent,
   UserMessageNewEvent,
 } from "@app/types/assistant/conversation";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
@@ -34,7 +35,8 @@ export async function* getConversationEvents({
     data:
       | UserMessageNewEvent
       | AgentMessageNewEvent
-      | AgentGenerationCancelledEvent;
+      | AgentGenerationCancelledEvent
+      | ButlerSuggestionCreatedEvent;
   },
   void
 > {

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -121,6 +121,7 @@ function isMessageEventParams(
     case "tool_params":
     case "tool_personal_auth_required":
       return true;
+    case "butler_suggestion_created":
     case "user_message_new":
     case "agent_message_new":
     case "agent_message_done":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -14,6 +14,7 @@ import type {
 } from "@app/types/assistant/agent";
 import type {
   AgentMessageNewEvent,
+  ButlerSuggestionCreatedEvent,
   ConversationTitleEvent,
   UserMessageNewEvent,
 } from "@app/types/assistant/conversation";
@@ -32,6 +33,7 @@ export type AgentMessageEvents =
   | ToolPersonalAuthRequiredEvent;
 
 export type ConversationEvents =
+  | ButlerSuggestionCreatedEvent
   | ConversationTitleEvent
   | AgentMessageNewEvent
   | UserMessageNewEvent

--- a/front/lib/resources/conversation_butler_suggestion_resource.ts
+++ b/front/lib/resources/conversation_butler_suggestion_resource.ts
@@ -1,13 +1,20 @@
 import type { Authenticator } from "@app/lib/auth";
+
+import { DustError } from "@app/lib/error";
+import {
+  ConversationParticipantModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationButlerSuggestionModel } from "@app/lib/resources/storage/models/conversation_butler_suggestion";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_suggestion";
+import { parseButlerSuggestionData } from "@app/types/conversation_butler_suggestion";
 import type { ModelId } from "@app/types/shared/model_id";
-import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import type {
   Attributes,
   CreationAttributes,
@@ -25,11 +32,23 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
   static model: ModelStaticWorkspaceAware<ConversationButlerSuggestionModel> =
     ConversationButlerSuggestionModel;
 
+  readonly sourceMessageSId: string;
+  readonly resultMessageSId: string | null;
+
   constructor(
     model: ModelStatic<ConversationButlerSuggestionModel>,
-    blob: Attributes<ConversationButlerSuggestionModel>
+    blob: Attributes<ConversationButlerSuggestionModel>,
+    {
+      sourceMessageSId,
+      resultMessageSId,
+    }: {
+      sourceMessageSId: string;
+      resultMessageSId: string | null;
+    }
   ) {
     super(ConversationButlerSuggestionModel, blob);
+    this.sourceMessageSId = sourceMessageSId;
+    this.resultMessageSId = resultMessageSId;
   }
 
   static async makeNew(
@@ -48,7 +67,25 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
       { transaction }
     );
 
-    return new this(ConversationButlerSuggestionModel, suggestion.get());
+    // Batch-fetch the message sIds for the new suggestion.
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const messageIds = [
+      suggestion.sourceMessageId,
+      ...(suggestion.resultMessageId ? [suggestion.resultMessageId] : []),
+    ];
+    const messages = await MessageModel.findAll({
+      attributes: ["id", "sId"],
+      where: { id: messageIds, workspaceId },
+      transaction,
+    });
+    const sIdByMessageId = new Map(messages.map((m) => [m.id, m.sId]));
+
+    return new this(ConversationButlerSuggestionModel, suggestion.get(), {
+      sourceMessageSId: sIdByMessageId.get(suggestion.sourceMessageId) ?? "",
+      resultMessageSId: suggestion.resultMessageId
+        ? (sIdByMessageId.get(suggestion.resultMessageId) ?? null)
+        : null,
+    });
   }
 
   private static async baseFetch(
@@ -67,8 +104,35 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
       transaction,
     });
 
+    // Batch-fetch all referenced message sIds in a single query.
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const messageIds = [
+      ...new Set(
+        suggestions.flatMap((s) =>
+          [s.sourceMessageId, s.resultMessageId].filter(
+            (id): id is ModelId => id !== null
+          )
+        )
+      ),
+    ];
+    const messages =
+      messageIds.length > 0
+        ? await MessageModel.findAll({
+            attributes: ["id", "sId"],
+            where: { id: messageIds, workspaceId },
+            transaction,
+          })
+        : [];
+    const sIdByMessageId = new Map(messages.map((m) => [m.id, m.sId]));
+
     return suggestions.map(
-      (s) => new this(ConversationButlerSuggestionModel, s.get())
+      (s) =>
+        new this(ConversationButlerSuggestionModel, s.get(), {
+          sourceMessageSId: sIdByMessageId.get(s.sourceMessageId) ?? "",
+          resultMessageSId: s.resultMessageId
+            ? (sIdByMessageId.get(s.resultMessageId) ?? null)
+            : null,
+        })
     );
   }
 
@@ -88,16 +152,69 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     return results[0] ?? null;
   }
 
-  async accept(
+  private async checkAccess(
+    auth: Authenticator,
     transaction?: Transaction
-  ): Promise<Result<ConversationButlerSuggestionResource, Error>> {
+  ): Promise<Result<undefined, DustError>> {
+    const user = auth.getNonNullableUser();
+
+    if (this.userId) {
+      // If the suggestion targets a specific user, only that user can act on it.
+      if (this.userId !== user.id) {
+        return new Err(
+          new DustError(
+            "unauthorized",
+            "Only the targeted user can act on this suggestion."
+          )
+        );
+      }
+      return new Ok(undefined);
+    }
+
+    // If no specific user, the acting user must be a conversation participant.
+    const count = await ConversationParticipantModel.count({
+      where: {
+        conversationId: this.conversationId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: user.id,
+      },
+      transaction,
+    });
+
+    if (count === 0) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "Only conversation participants can act on this suggestion."
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
+  async accept(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<ConversationButlerSuggestionResource, DustError>> {
+    const accessResult = await this.checkAccess(auth, transaction);
+    if (accessResult.isErr()) {
+      return accessResult;
+    }
+
     await this.update({ status: "accepted" as const }, transaction);
     return new Ok(this);
   }
 
   async dismiss(
+    auth: Authenticator,
     transaction?: Transaction
-  ): Promise<Result<ConversationButlerSuggestionResource, Error>> {
+  ): Promise<Result<ConversationButlerSuggestionResource, DustError>> {
+    const accessResult = await this.checkAccess(auth, transaction);
+    if (accessResult.isErr()) {
+      return accessResult;
+    }
+
     await this.update({ status: "dismissed" as const }, transaction);
     return new Ok(this);
   }
@@ -115,6 +232,25 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     });
 
     return new Ok(undefined);
+  }
+
+  // Serialization.
+
+  toJSON(): ButlerSuggestionPublicType {
+    const data = parseButlerSuggestionData({
+      suggestionType: this.suggestionType,
+      metadata: this.metadata,
+    });
+
+    return {
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      sourceMessageSId: this.sourceMessageSId,
+      resultMessageSId: this.resultMessageSId,
+      status: this.status,
+      ...data,
+    };
   }
 
   get sId(): string {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -125,6 +125,11 @@ async function handler(
       let backpressureCount = 0;
 
       for await (const event of eventStream) {
+        // Butler suggestions are internal events, not exposed via the public API.
+        if (event.data.type === "butler_suggestion_created") {
+          continue;
+        }
+
         let publicEvent: ConversationEventType | undefined;
 
         if (event.data.type === "agent_message_new") {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/butler_suggestions/[sId].ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/butler_suggestions/[sId].ts
@@ -1,0 +1,146 @@
+import { updateConversationTitle } from "@app/lib/api/assistant/conversation";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_suggestion";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PatchButlerSuggestionResponse = {
+  suggestion: ButlerSuggestionPublicType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PatchButlerSuggestionResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  if (
+    !(typeof req.query.cId === "string") ||
+    !(typeof req.query.sId === "string")
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid query parameters, `cId` and `sId` (strings) are required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const suggestionSId = req.query.sId;
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const suggestion = await ConversationButlerSuggestionResource.fetchById(
+    auth,
+    suggestionSId
+  );
+  if (!suggestion || suggestion.conversationId !== conversationRes.value.id) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The butler suggestion was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "PATCH": {
+      const { status } = req.body as { status?: string };
+      if (status !== "accepted" && status !== "dismissed") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              'Invalid body, `status` must be "accepted" or "dismissed".',
+          },
+        });
+      }
+
+      if (status === "accepted") {
+        // Apply the suggestion side-effect before marking as accepted.
+        if (suggestion.suggestionType === "rename_title") {
+          const metadata = suggestion.metadata as {
+            suggestedTitle: string;
+          };
+          const titleRes = await updateConversationTitle(auth, {
+            conversationId,
+            title: metadata.suggestedTitle,
+          });
+          if (titleRes.isErr()) {
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to update conversation title.",
+              },
+            });
+          }
+
+          // Publish the title change event so the UI updates in real-time.
+          await publishConversationEvent(
+            {
+              type: "conversation_title",
+              created: Date.now(),
+              title: metadata.suggestedTitle,
+            },
+            { conversationId }
+          );
+        }
+        const acceptRes = await suggestion.accept(auth);
+        if (acceptRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "invalid_request_error",
+              message: acceptRes.error.message,
+            },
+          });
+        }
+      } else {
+        const dismissRes = await suggestion.dismiss(auth);
+        if (dismissRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "invalid_request_error",
+              message: dismissRes.error.message,
+            },
+          });
+        }
+      }
+
+      res.status(200).json({
+        suggestion: suggestion.toJSON(),
+      });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/temporal/butler/activities.test.ts
+++ b/front/temporal/butler/activities.test.ts
@@ -1,6 +1,7 @@
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationButlerSuggestionModel } from "@app/lib/resources/storage/models/conversation_butler_suggestion";
 import { analyzeConversationActivity } from "@app/temporal/butler/activities";
@@ -26,6 +27,11 @@ vi.mock("@app/lib/api/assistant/conversation/fetch", () => ({
   getConversation: vi.fn(),
 }));
 
+// Mock event publishing to avoid Redis dependency.
+vi.mock("@app/lib/api/assistant/streaming/events", () => ({
+  publishConversationEvent: vi.fn(),
+}));
+
 // Mock model selection to avoid plan/whitelist dependency.
 vi.mock("@app/types/assistant/assistant", async (importOriginal) => {
   const mod = await importOriginal();
@@ -37,6 +43,7 @@ vi.mock("@app/types/assistant/assistant", async (importOriginal) => {
 
 const mockGetConversation = vi.mocked(getConversation);
 const mockGetFastestModel = vi.mocked(getFastestWhitelistedModel);
+const mockPublishConversationEvent = vi.mocked(publishConversationEvent);
 const mockRenderConversation = vi.mocked(renderConversationForModel);
 const mockRunMultiActionsAgent = vi.mocked(runMultiActionsAgent);
 
@@ -127,9 +134,11 @@ describe("analyzeConversationActivity", () => {
     });
     expect(message).not.toBeNull();
 
-    // Mock getConversation to return a conversation with the real DB id for FK constraints.
+    // Mock getConversation to return a conversation with the real DB id and sId.
     mockGetConversation.mockResolvedValue(
-      new Ok(makeFakeConversation({ id: conversation.id }))
+      new Ok(
+        makeFakeConversation({ id: conversation.id, sId: conversation.sId })
+      )
     );
     setupMocksForHighConfidence();
 
@@ -150,6 +159,20 @@ describe("analyzeConversationActivity", () => {
     expect(suggestions[0].status).toBe("pending");
     expect(suggestions[0].sourceMessageId).toBe(message!.id);
     expect(suggestions[0].conversationId).toBe(conversation.id);
+
+    // Verify the event was published to the conversation channel.
+    expect(mockPublishConversationEvent).toHaveBeenCalledOnce();
+    expect(mockPublishConversationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "butler_suggestion_created",
+        suggestion: expect.objectContaining({
+          suggestionType: "rename_title",
+          metadata: { suggestedTitle: "Better Title" },
+          sourceMessageSId: message!.sId,
+        }),
+      }),
+      { conversationId: conversation.sId }
+    );
   });
 
   it("does not create suggestion when confidence is below threshold", async () => {

--- a/front/temporal/butler/activities.ts
+++ b/front/temporal/butler/activities.ts
@@ -2,12 +2,16 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
 import logger from "@app/logger/logger";
 import { getFastestWhitelistedModel } from "@app/types/assistant/assistant";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type {
+  ButlerSuggestionCreatedEvent,
+  ConversationType,
+} from "@app/types/assistant/conversation";
 
 const RENAME_TITLE_FUNCTION_NAME = "rename_title_decision";
 
@@ -223,12 +227,22 @@ async function evaluateRenameTitleSuggestion(
     return;
   }
 
-  await ConversationButlerSuggestionResource.makeNew(auth, {
+  const suggestion = await ConversationButlerSuggestionResource.makeNew(auth, {
     conversationId: conversation.id,
     sourceMessageId: sourceMessage.id,
     suggestionType: "rename_title",
     metadata: { suggestedTitle: new_title },
     status: "pending",
+  });
+
+  const event: ButlerSuggestionCreatedEvent = {
+    type: "butler_suggestion_created",
+    created: Date.now(),
+    suggestion: suggestion.toJSON(),
+  };
+
+  await publishConversationEvent(event, {
+    conversationId: conversation.sId,
   });
 
   logger.info(

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -4,6 +4,7 @@ import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 
 import type { ContentFragmentType } from "../content_fragment";
+import type { ButlerSuggestionPublicType } from "../conversation_butler_suggestion";
 import type { AllSupportedWithDustSpecificFileContentType } from "../files";
 import type { ModelId } from "../shared/model_id";
 import type { UserType, WorkspaceType } from "../user";
@@ -440,6 +441,13 @@ export type ConversationTitleEvent = {
   type: "conversation_title";
   created: number;
   title: string;
+};
+
+// Event sent when a butler suggestion is created.
+export type ButlerSuggestionCreatedEvent = {
+  type: "butler_suggestion_created";
+  created: number;
+  suggestion: ButlerSuggestionPublicType;
 };
 
 export type ConversationMCPServerViewType = {


### PR DESCRIPTION
## Description

Add UI and events for suggestions:
* reused the current events to push suggestions to a conversation
* reused sparkle component for the approve/dismiss
* add a new endpoint to approve/dismiss


Limitations:
* the title doesn't refresh, we could improve that

## Tests


https://github.com/user-attachments/assets/27747029-3230-4b10-84e4-0855fb4fe084


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
