### PR TITLE
[front] Redact headers displayed in `MCPServerDetailsSheet`

### DIFF
--- a/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
+++ b/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
@@ -29,7 +29,7 @@ export function InternalMCPBearerTokenForm({
   return (
     <div className="space-y-5 text-foreground dark:text-foreground-night">
       <Collapsible>
-        <CollapsibleTrigger>
+        <CollapsibleTrigger className="pb-2">
           <div className="heading-lg">Authorization</div>
         </CollapsibleTrigger>
         <CollapsibleContent>
@@ -48,7 +48,7 @@ export function InternalMCPBearerTokenForm({
         </CollapsibleContent>
       </Collapsible>
       <Collapsible>
-        <CollapsibleTrigger>
+        <CollapsibleTrigger className="pb-2">
           <div className="heading-lg">Headers ({fields.length})</div>
         </CollapsibleTrigger>
         <CollapsibleContent>

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -73,7 +73,12 @@ export function McpServerHeaders({
           </div>
         ))}
       </div>
-      <Button className="mt-4" variant="outline" label="Add Header" onClick={addHeader} />
+      <Button
+        className="mt-4"
+        variant="outline"
+        label="Add Header"
+        onClick={addHeader}
+      />
     </div>
   );
 }

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -39,43 +39,41 @@ export function McpServerHeaders({
   };
 
   return (
-    <div className="flex w-full flex-col gap-6">
-      <div className="flex w-full flex-col gap-3">
-        <div className="flex flex-col gap-4">
-          {headers.map((header, index) => (
-            <div key={index} className="flex items-center gap-2">
-              <div className="grid flex-1 grid-cols-3 gap-2 px-1">
-                <div className="col-span-1">
-                  <Input
-                    placeholder="Header Name"
-                    value={header.key}
-                    name="headerName"
-                    onChange={getChangeHandler(index, "key")}
-                    disabled={header.value === WebCrawlerHeaderRedactedValue}
-                    className="w-full"
-                  />
-                </div>
-                <div className="col-span-2">
-                  <Input
-                    name="headerValue"
-                    placeholder="Header Value"
-                    value={header.value}
-                    onChange={getChangeHandler(index, "value")}
-                    disabled={header.value === WebCrawlerHeaderRedactedValue}
-                    className="w-full"
-                  />
-                </div>
+    <div className="flex w-full flex-col">
+      <div className="flex flex-col gap-4">
+        {headers.map((header, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <div className="grid flex-1 grid-cols-3 gap-2 px-1">
+              <div className="col-span-1">
+                <Input
+                  placeholder="Header Name"
+                  value={header.key}
+                  name="headerName"
+                  onChange={getChangeHandler(index, "key")}
+                  disabled={header.value === WebCrawlerHeaderRedactedValue}
+                  className="w-full"
+                />
               </div>
-              <Button
-                variant="outline"
-                icon={XMarkIcon}
-                onClick={() => removeHeader(index)}
-              />
+              <div className="col-span-2">
+                <Input
+                  name="headerValue"
+                  placeholder="Header Value"
+                  value={header.value}
+                  onChange={getChangeHandler(index, "value")}
+                  disabled={header.value === WebCrawlerHeaderRedactedValue}
+                  className="w-full"
+                />
+              </div>
             </div>
-          ))}
-        </div>
-        <Button variant="outline" label="Add Header" onClick={addHeader} />
+            <Button
+              variant="outline"
+              icon={XMarkIcon}
+              onClick={() => removeHeader(index)}
+            />
+          </div>
+        ))}
       </div>
+      <Button className="mt-4" variant="outline" label="Add Header" onClick={addHeader} />
     </div>
   );
 }

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -517,11 +517,26 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       currentTime.getTime() - createdAt.getTime()
     );
     const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
+    const shouldRedact =
+      differenceInMinutes > SECRET_REDACTION_COOLDOWN_IN_MINUTES;
+
     const secret = this.sharedSecret
-      ? differenceInMinutes > SECRET_REDACTION_COOLDOWN_IN_MINUTES
+      ? shouldRedact
         ? redactString(this.sharedSecret, 4)
         : this.sharedSecret
       : null;
+
+    const headers =
+      this.customHeaders && shouldRedact
+        ? Object.fromEntries(
+            Object.entries(this.customHeaders).map(([key, value]) => [
+              key,
+              value !== null && value !== undefined
+                ? redactString(String(value), 4)
+                : value,
+            ])
+          )
+        : this.customHeaders;
 
     return {
       sId: this.sId,
@@ -541,7 +556,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastSyncAt: this.lastSyncAt?.getTime() ?? null,
       lastError: this.lastError,
       sharedSecret: secret,
-      customHeaders: this.customHeaders,
+      customHeaders: headers,
       documentationUrl: null,
     };
   }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6856.
- This PR redacts the header exposed to the front-end.
- Same logic as for the API key.
- Also adds a bit of padding underneath the collapsible triggers.

<img width="317" alt="Screenshot 2026-02-26 at 4 49 36 PM" src="https://github.com/user-attachments/assets/fe3319ca-f56f-4bb6-9d9a-1bca8f02701b" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
