### PR TITLE
Sidekick: Return markdown when listing skills/tools/models

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -284,12 +284,12 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          // All models should be from anthropic only.
-          expect(parsed.models.length).toBeGreaterThan(0);
-          for (const model of parsed.models) {
-            expect(model.providerId).toBe("anthropic");
-          }
+          // Output is markdown. Should contain anthropic models only.
+          expect(content.text).toContain("## AVAILABLE MODELS");
+          expect(content.text).toContain("### anthropic");
+          // Should not contain other providers.
+          expect(content.text).not.toContain("### openai");
+          expect(content.text).not.toContain("### google_ai_studio");
         }
       }
     });
@@ -305,13 +305,12 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          expect(parsed.count).toBeGreaterThan(0);
-          // Should have multiple providers.
-          const providers = new Set(
-            parsed.models.map((m: { providerId: string }) => m.providerId)
-          );
-          expect(providers.size).toBeGreaterThan(1);
+          // Output is markdown. Should contain models from multiple providers.
+          expect(content.text).toContain("## AVAILABLE MODELS");
+          expect(content.text).toContain("models available.");
+          // Should have multiple provider sections.
+          const providerSections = content.text.match(/^### /gm) ?? [];
+          expect(providerSections.length).toBeGreaterThan(1);
         }
       }
     });
@@ -330,18 +329,18 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          expect(parsed.count).toBeGreaterThan(0);
-          for (const model of parsed.models) {
-            expect(model.providerId).toBe("openai");
-          }
+          // Output is markdown. Should only contain openai models.
+          expect(content.text).toContain("## AVAILABLE MODELS");
+          expect(content.text).toContain("### openai");
+          // Should not contain other providers.
+          expect(content.text).not.toContain("### anthropic");
         }
       }
     });
   });
 
   describe("get_available_skills", () => {
-    it("returns skills with toolSIds array", async () => {
+    it("returns skills in markdown format", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 
       // Create a skill.
@@ -359,16 +358,11 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          expect(parsed.count).toBeGreaterThan(0);
-          // Find our skill.
-          const foundSkill = parsed.skills.find(
-            (s: { sId: string }) => s.sId === skill.sId
-          );
-          expect(foundSkill).toBeDefined();
-          expect(foundSkill.name).toBe("Test Skill");
-          expect(foundSkill.toolSIds).toBeDefined();
-          expect(Array.isArray(foundSkill.toolSIds)).toBe(true);
+          // Output is markdown.
+          expect(content.text).toContain("## AVAILABLE SKILLS");
+          expect(content.text).toContain("skills available.");
+          expect(content.text).toContain(`**Test Skill** (ID: ${skill.sId})`);
+          expect(content.text).toContain("Agent facing description");
         }
       }
     });
@@ -387,7 +381,11 @@ describe("agent_copilot_context tools", () => {
       const server2 = await RemoteMCPServerFactory.create(workspace);
 
       // Create system views (required before creating space views).
-      await MCPServerViewFactory.create(workspace, server1.sId, globalSpace);
+      const view1 = await MCPServerViewFactory.create(
+        workspace,
+        server1.sId,
+        globalSpace
+      );
       await MCPServerViewFactory.create(
         workspace,
         server2.sId,
@@ -402,17 +400,11 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          // Should only include tools from spaces the user can access.
+          // Output is markdown.
+          expect(content.text).toContain("## AVAILABLE TOOLS");
           // server1 view should be present (in global space).
-          expect(
-            parsed.tools.some(
-              (t: { sId: string }) =>
-                t.sId.includes(server1.sId) || parsed.tools.length >= 1
-            )
-          ).toBe(true);
+          expect(content.text).toContain(view1.sId);
           // The tool from restricted space should not be returned.
-          // This is checked implicitly since the user only has access to global space.
         }
       }
     });
@@ -437,13 +429,11 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          expect(parsed.count).toBeGreaterThan(0);
+          // Output is markdown.
+          expect(content.text).toContain("## AVAILABLE TOOLS");
+          expect(content.text).toContain("tools available.");
           // Should find the tool view.
-          const foundTool = parsed.tools.find(
-            (t: { sId: string }) => t.sId === view.sId
-          );
-          expect(foundTool).toBeDefined();
+          expect(content.text).toContain(view.sId);
         }
       }
     });
@@ -462,10 +452,10 @@ describe("agent_copilot_context tools", () => {
         const content = result.value[0];
         expect(content.type).toBe("text");
         if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          const toolNames = parsed.tools.map((t: { name: string }) => t.name);
+          // Output is markdown.
+          expect(content.text).toContain("## AVAILABLE TOOLS");
 
-          // Knowledge tools should be excluded.
+          // Knowledge tools should be excluded from markdown output.
           const knowledgeToolNames = [
             "Search",
             "Query Tables",
@@ -473,11 +463,11 @@ describe("agent_copilot_context tools", () => {
             "Extract Data",
           ];
           for (const knowledgeName of knowledgeToolNames) {
-            expect(toolNames).not.toContain(knowledgeName);
+            expect(content.text).not.toContain(`**${knowledgeName}**`);
           }
 
           // Non-knowledge auto tools should still be present.
-          expect(toolNames.length).toBeGreaterThan(0);
+          expect(content.text).toContain("tools available.");
         }
       }
     });

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -177,6 +177,11 @@ async function markDuplicateSuggestionsAsOutdated(
 }
 
 import {
+  formatAvailableModels,
+  formatAvailableSkills,
+  formatAvailableTools,
+} from "@app/lib/api/assistant/global_agents/copilot_context";
+import {
   getAvailableModelsForWorkspace,
   listAvailableSkills,
   listAvailableTools,
@@ -311,27 +316,10 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       models = models.filter((m) => m.providerId === providerId);
     }
 
-    const modelList = models.map((m) => ({
-      providerId: m.providerId,
-      modelId: m.modelId,
-      displayName: m.displayName,
-      description: m.description,
-      contextSize: m.contextSize,
-      supportsVision: m.supportsVision,
-      isLatest: m.isLatest,
-    }));
-
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify(
-          {
-            count: modelList.length,
-            models: modelList,
-          },
-          null,
-          2
-        ),
+        text: formatAvailableModels(models),
       },
     ]);
   },
@@ -342,14 +330,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify(
-          {
-            count: skillList.length,
-            skills: skillList,
-          },
-          null,
-          2
-        ),
+        text: formatAvailableSkills(skillList),
       },
     ]);
   },
@@ -360,14 +341,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify(
-          {
-            count: toolList.length,
-            tools: toolList,
-          },
-          null,
-          2
-        ),
+        text: formatAvailableTools(toolList),
       },
     ]);
   },

--- a/front/lib/api/assistant/global_agents/copilot_context.ts
+++ b/front/lib/api/assistant/global_agents/copilot_context.ts
@@ -67,7 +67,7 @@ export function formatAvailableSkills(skills: AvailableSkill[]): string {
   const skillLines = skills
     .map(
       (s) =>
-        `- **${s.name}** (ID: ${s.sId}): ${s.agentFacingDescription ?? "No description"}`
+        `- **${s.name}** (ID: ${s.sId}): ${(s.agentFacingDescription ?? "No description").replace(/\n/g, " ")}`
     )
     .join("\n");
   return `## AVAILABLE SKILLS\n${skills.length} skills available.\n\n${skillLines}`;
@@ -75,7 +75,10 @@ export function formatAvailableSkills(skills: AvailableSkill[]): string {
 
 export function formatAvailableTools(tools: AvailableTool[]): string {
   const toolLines = tools
-    .map((t) => `- **${t.name}** (ID: ${t.sId}): ${t.description}`)
+    .map(
+      (t) =>
+        `- **${t.name}** (ID: ${t.sId}): ${t.description.replace(/\n/g, " ")}`
+    )
     .join("\n");
   return `## AVAILABLE TOOLS\n${tools.length} tools available.\n\n${toolLines}`;
 }

--- a/front/tests/copilot-evals/lib/mock-responses.ts
+++ b/front/tests/copilot-evals/lib/mock-responses.ts
@@ -47,67 +47,40 @@ export function getMockToolResponse(
       pendingSuggestions: [],
     }),
 
-    get_available_models: () => ({
-      models: [
-        { modelId: "gpt-4-turbo", providerId: "openai", name: "GPT-4 Turbo" },
-        { modelId: "gpt-5-mini", providerId: "openai", name: "GPT-5 Mini" },
-        {
-          modelId: "claude-sonnet-4-5-20250929",
-          providerId: "anthropic",
-          name: "Claude Sonnet 4.5",
-        },
-        {
-          modelId: "claude-opus-4-20250514",
-          providerId: "anthropic",
-          name: "Claude Opus 4",
-        },
-      ],
-    }),
+    get_available_models: () =>
+      [
+        "## AVAILABLE MODELS",
+        "4 models available.",
+        "",
+        "### openai",
+        "- **GPT-4 Turbo** (modelId: gpt-4-turbo): GPT-4 Turbo (no vision)",
+        "- **GPT-5 Mini** (modelId: gpt-5-mini): GPT-5 Mini (no vision)",
+        "",
+        "### anthropic",
+        "- **Claude Sonnet 4.5** (modelId: claude-sonnet-4-5-20250929): Claude Sonnet 4.5 (no vision)",
+        "- **Claude Opus 4** (modelId: claude-opus-4-20250514): Claude Opus 4 (no vision)",
+      ].join("\n"),
 
-    get_available_skills: () => ({
-      skills: [
-        {
-          sId: "skill_web_search",
-          name: "Web Search",
-          description: "Search the web for information",
-        },
-        {
-          sId: "skill_data_analysis",
-          name: "Data Analysis",
-          description: "Analyze data and generate insights",
-        },
-      ],
-    }),
+    get_available_skills: () =>
+      [
+        "## AVAILABLE SKILLS",
+        "2 skills available.",
+        "",
+        "- **Web Search** (ID: skill_web_search): Search the web for information",
+        "- **Data Analysis** (ID: skill_data_analysis): Analyze data and generate insights",
+      ].join("\n"),
 
-    get_available_tools: () => ({
-      tools: [
-        {
-          sId: "mcp_slack",
-          name: "Slack",
-          description: "Read and send Slack messages",
-        },
-        {
-          sId: "mcp_notion",
-          name: "Notion",
-          description: "Search Notion workspace",
-        },
-        {
-          sId: "mcp_github",
-          name: "GitHub",
-          description: "Access GitHub repositories",
-        },
-        {
-          sId: "mcp_datadog",
-          name: "Datadog",
-          description: "Search and query Datadog logs and metrics",
-        },
-        {
-          sId: "mcp_jira",
-          name: "JIRA",
-          description: "Search and manage JIRA issues and projects",
-        },
-      ],
-    }),
+    get_available_tools: () =>
+      [
+        "## AVAILABLE TOOLS",
+        "5 tools available.",
+        "",
+        "- **Slack** (ID: mcp_slack): Read and send Slack messages",
+        "- **Notion** (ID: mcp_notion): Search Notion workspace",
+        "- **GitHub** (ID: mcp_github): Access GitHub repositories",
+        "- **Datadog** (ID: mcp_datadog): Search and query Datadog logs and metrics",
+        "- **JIRA** (ID: mcp_jira): Search and manage JIRA issues and projects",
+      ].join("\n"),
 
     get_available_knowledge: () => ({
       count: {


### PR DESCRIPTION
## Description

- Return markdown to be more compact and use less context
- remove line break to not pollute the markdown

## Tests

Unit. test + manual tests

## Risk

low

## Deploy Plan

deploy front
