### PR TITLE
Add the github project_v2_item webhook so we can be triggered for issue added to board

### DIFF
--- a/front/lib/triggers/built-in-webhooks/github/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/github/preset.ts
@@ -5,6 +5,10 @@ import {
   issueSchema,
 } from "@app/lib/triggers/built-in-webhooks/github/schemas/issues";
 import {
+  projectsV2ItemExample,
+  projectsV2ItemSchema,
+} from "@app/lib/triggers/built-in-webhooks/github/schemas/projects_v2_item";
+import {
   pullRequestExample,
   pullRequestSchema,
 } from "@app/lib/triggers/built-in-webhooks/github/schemas/pull_request";
@@ -61,6 +65,15 @@ const GITHUB_PUSH_EVENT: WebhookEvent = {
   sample: pushExample,
 };
 
+const GITHUB_PROJECTS_V2_ITEM_EVENT: WebhookEvent = {
+  name: "projects_v2_item (organizations only)",
+  value: "projects_v2_item",
+  description:
+    "Activity related to an item on an organization-level project. Only available for organization webhooks, not repository webhooks. The type of activity is specified in the `action` property of the payload object.",
+  schema: projectsV2ItemSchema,
+  sample: projectsV2ItemExample,
+};
+
 const GITHUB_RELEASE_EVENT: WebhookEvent = {
   name: "release",
   value: "release",
@@ -82,6 +95,7 @@ export const GITHUB_WEBHOOK_PRESET: PresetWebhook<"github"> = {
     GITHUB_PULL_REQUEST_REVIEW_EVENT,
     GITHUB_PUSH_EVENT,
     GITHUB_RELEASE_EVENT,
+    GITHUB_PROJECTS_V2_ITEM_EVENT,
   ],
   event_blacklist: ["ping"],
   icon: "GithubLogo",

--- a/front/lib/triggers/built-in-webhooks/github/schemas/projects_v2_item.ts
+++ b/front/lib/triggers/built-in-webhooks/github/schemas/projects_v2_item.ts
@@ -1,0 +1,179 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const projectsV2ItemSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    action: {
+      type: "string",
+      description:
+        "The action performed on the project item. Can be one of: created, edited, archived, restored, converted, deleted, reordered.",
+      enum: [
+        "archived",
+        "converted",
+        "created",
+        "deleted",
+        "edited",
+        "reordered",
+        "restored",
+      ],
+    },
+    projects_v2_item: {
+      type: "object",
+      description: "The project item that was affected",
+      properties: {
+        id: {
+          type: "integer",
+          description: "Unique identifier of the project item",
+        },
+        node_id: {
+          type: "string",
+          description: "The GraphQL node ID of the project item",
+        },
+        project_node_id: {
+          type: "string",
+          description: "The GraphQL node ID of the project",
+        },
+        content_node_id: {
+          type: "string",
+          description:
+            "The GraphQL node ID of the content (issue or pull request) associated with the item",
+        },
+        content_type: {
+          type: "string",
+          description:
+            "The type of content associated with the item (Issue, PullRequest, or DraftIssue)",
+          enum: ["Issue", "PullRequest", "DraftIssue"],
+        },
+        creator: {
+          type: "object",
+          description: "The user who created the project item",
+          properties: {
+            login: { type: "string", description: "GitHub username" },
+            id: { type: "integer", description: "User ID" },
+            type: { type: "string", description: "Type of user account" },
+          },
+        },
+        created_at: {
+          type: "string",
+          format: "date-time",
+          description: "When the project item was created",
+        },
+        updated_at: {
+          type: "string",
+          format: "date-time",
+          description: "When the project item was last updated",
+        },
+        archived_at: {
+          type: ["string", "null"],
+          format: "date-time",
+          description: "When the project item was archived",
+        },
+      },
+    },
+    changes: {
+      type: "object",
+      description:
+        "The changes made to the project item when the action is edited",
+      properties: {
+        field_value: {
+          type: "object",
+          description: "The field value that was changed",
+          properties: {
+            field_node_id: {
+              type: "string",
+              description: "The GraphQL node ID of the field",
+            },
+            field_type: {
+              type: "string",
+              description: "The type of the field",
+            },
+            field_name: {
+              type: "string",
+              description: "The name of the field",
+            },
+            project_number: {
+              type: "integer",
+              description: "The project number",
+            },
+            from: {
+              description: "The previous value of the field",
+            },
+            to: {
+              description: "The new value of the field",
+            },
+          },
+        },
+      },
+    },
+    organization: {
+      type: "object",
+      description:
+        "The organization that owns the project. Projects v2 items events are only available for organization-level projects.",
+      properties: {
+        login: { type: "string", description: "Organization login/name" },
+        id: { type: "integer", description: "Organization ID" },
+        node_id: {
+          type: "string",
+          description: "The GraphQL node ID of the organization",
+        },
+        description: {
+          type: "string",
+          description: "Organization description",
+        },
+      },
+    },
+    installation: {
+      type: ["object", "null"],
+      description:
+        "GitHub App installation object when the event is configured for and sent to a GitHub App",
+      properties: {
+        id: { type: "integer", description: "Installation ID" },
+      },
+    },
+    sender: {
+      type: "object",
+      description: "The user that triggered the event",
+      properties: {
+        login: { type: "string", description: "GitHub username" },
+        id: { type: "integer", description: "User ID" },
+        type: { type: "string", description: "Type of user account" },
+        site_admin: {
+          type: "boolean",
+          description: "Whether user is a site administrator",
+        },
+      },
+    },
+  },
+  required: ["action", "projects_v2_item", "sender"],
+};
+
+export const projectsV2ItemExample = {
+  action: "created",
+  projects_v2_item: {
+    id: 12345678,
+    node_id: "PVTI_lADOABCDEF",
+    project_node_id: "PVT_kwDOABCDEF",
+    content_node_id: "I_kwDOABCDEF",
+    content_type: "Issue",
+    creator: {
+      login: "octocat",
+      id: 1,
+      type: "User",
+    },
+    created_at: "2024-01-20T10:30:00Z",
+    updated_at: "2024-01-20T10:30:00Z",
+    archived_at: null,
+  },
+  organization: {
+    login: "my-org",
+    id: 123456,
+    node_id: "O_kgDOABCDEF",
+    description: "My organization",
+  },
+  sender: {
+    login: "octocat",
+    id: 1,
+    type: "User",
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/github/service.ts
+++ b/front/lib/triggers/built-in-webhooks/github/service.ts
@@ -11,6 +11,9 @@ import { isString } from "@app/types/shared/utils/general";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
 import { Octokit } from "@octokit/core";
 
+// Events that are only supported on organization webhooks, not repository webhooks.
+const ORG_ONLY_EVENTS = ["projects_v2_item"];
+
 export class GitHubWebhookService implements RemoteWebhookService<"github"> {
   async getServiceData(
     oauthToken: string
@@ -95,6 +98,9 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
       const webhookIds: Record<string, string> = {};
       const errors: string[] = [];
 
+      // Filter out org-only events for repository webhooks.
+      const repoEvents = events.filter((e) => !ORG_ONLY_EVENTS.includes(e));
+
       // Create webhooks for repositories
       for (const repository of repositories) {
         const fullName = repository.fullName;
@@ -134,7 +140,7 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
               repo,
               name: "web",
               active: true,
-              events,
+              events: repoEvents,
               config: {
                 url: webhookUrl,
                 content_type: "json",


### PR DESCRIPTION
## Description

 - add project_v2_item events for github 
 - This only exists for organizations 

## Tests

Manually tested locally
This allows to be triggered when we have a new issue added to the eng runner board:

<img width="792" height="286" alt="image" src="https://github.com/user-attachments/assets/d4a7b28f-73cf-4aa9-969b-6308826a8f88" />


## Risk

low

## Deploy Plan

deploy front
