### PR TITLE
[extension] use regionContext in extension

### DIFF
--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -58,7 +58,7 @@ export class ChromeAuthService extends AuthService {
   }
 
   // Login sends a message to the background script to call the workos login endpoint.
-  // It saves the tokens and auth metadata (dustDomain, connectionDetails).
+  // It saves the tokens and auth metadata (regionInfo, connectionDetails).
   async login({ forcedConnection }: { forcedConnection?: string }) {
     try {
       const response = await sendAuthMessage(forcedConnection);

--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -1,12 +1,11 @@
 import { AuthContext } from "@app/lib/auth/AuthContext";
-import { useRegionContext } from "@app/lib/auth/RegionContext";
 import type { SubscriptionType } from "@app/types/plan";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin, isBuilder } from "@app/types/user";
 import type { AuthError } from "@extension/shared/services/auth";
 import { useAuthHook } from "@extension/ui/components/auth/useAuth";
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 
 // Extension-specific auth context (bearer token, login/logout, etc.)
 type ExtensionAuthContextType = {
@@ -99,17 +98,6 @@ interface ExtensionAuthProviderProps {
 export function ExtensionAuthProvider({
   children,
 }: ExtensionAuthProviderProps) {
-  const { regionInfo, setRegionInfo } = useRegionContext();
-
-  const dustDomain = regionInfo?.url ?? null;
-
-  const setDustDomain = useCallback(
-    (url: string) => {
-      setRegionInfo({ name: regionInfo?.name ?? "us-central1", url });
-    },
-    [setRegionInfo, regionInfo?.name]
-  );
-
   const {
     token,
     isAuthenticated,
@@ -124,7 +112,7 @@ export function ExtensionAuthProvider({
     handleLogout,
     handleSelectWorkspace,
     featureFlags,
-  } = useAuthHook({ dustDomain, setDustDomain });
+  } = useAuthHook();
 
   const extensionAuthValue = useMemo(
     () => ({

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -1,3 +1,5 @@
+import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { clientFetch } from "@app/lib/egress/client";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { WorkspaceType } from "@dust-tt/client";
@@ -16,13 +18,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 const PROACTIVE_REFRESH_WINDOW_MS = 1000 * 60; // 1 minute
 const log = console.error;
 
-export const useAuthHook = ({
-  dustDomain,
-  setDustDomain,
-}: {
-  dustDomain: string | null;
-  setDustDomain: (url: string) => void;
-}) => {
+export const useAuthHook = () => {
   const platform = usePlatform();
 
   const [tokens, setTokens] = useState<StoredTokens | null>(null);
@@ -37,11 +33,11 @@ export const useAuthHook = ({
     string | undefined
   >();
   const [featureFlags, setFeatureFlags] = useState<WhitelistableFeature[]>([]);
+  const { setRegionInfo } = useRegionContext();
 
   const isAuthenticated = useMemo(
-    () =>
-      !!(tokens?.accessToken && tokens.expiresAt > Date.now() && dustDomain),
-    [tokens, dustDomain]
+    () => !!(tokens?.accessToken && tokens.expiresAt > Date.now()),
+    [tokens]
   );
 
   const isUserSetup = !!(user && user.sId && selectedWorkspace);
@@ -112,16 +108,16 @@ export const useAuthHook = ({
     return () => unsub();
   }, []);
 
-  // Fetch user data from /api/v1/me when authenticated.
+  // Fetch user data from /api/user when authenticated.
   useEffect(() => {
-    if (!isAuthenticated || !tokens?.accessToken || !dustDomain) {
+    if (!isAuthenticated || !tokens?.accessToken) {
       return;
     }
 
     setIsUserLoading(true);
     void (async () => {
       try {
-        const res = await fetch(`${dustDomain}/api/v1/me`, {
+        const res = await clientFetch("/api/user", {
           headers: { Authorization: `Bearer ${tokens.accessToken}` },
           credentials: "omit", // Ensure cookies are not sent with requests from the extension
         });
@@ -144,26 +140,26 @@ export const useAuthHook = ({
         setIsUserLoading(false);
       }
     })();
-  }, [isAuthenticated, tokens?.accessToken, dustDomain]);
+  }, [isAuthenticated, tokens?.accessToken]);
 
   // Initialize from storage on mount.
+  // RegionContext already restores region info from localStorage, so we only
+  // need to restore tokens, connection details, and selected workspace here.
   useEffect(() => {
     void (async () => {
       setIsLoading(true);
 
       const storedTokens = await platform.auth.getStoredTokens();
-      const storedRegionInfo = await platform.auth.getRegionInfoFromStorage();
       const storedConnectionDetails =
         await platform.auth.getConnectionDetailsFromStorage();
       const storedSelectedWorkspace =
         await platform.auth.getSelectedWorkspace();
 
-      if (!storedTokens || !storedRegionInfo) {
+      if (!storedTokens) {
         setIsLoading(false);
         return;
       }
       setTokens(storedTokens);
-      setDustDomain(storedRegionInfo.url);
       setConnectionDetails(storedConnectionDetails);
       setSelectedWorkspace(storedSelectedWorkspace);
 
@@ -184,19 +180,18 @@ export const useAuthHook = ({
 
   // Fetch feature flags when workspace is ready.
   useEffect(() => {
-    if (!isAuthenticated || !workspace || !tokens?.accessToken || !dustDomain) {
+    if (!isAuthenticated || !workspace || !tokens?.accessToken) {
       setFeatureFlags([]);
       return;
     }
 
     void (async () => {
-      const res = await fetch(
-        `${dustDomain}/api/w/${workspace.sId}/feature-flags`,
-        {
-          headers: { Authorization: `Bearer ${tokens.accessToken}` },
+      const res = await clientFetch(`/api/w/${workspace.sId}/feature-flags`, {
+        headers: {
+          Authorization: `Bearer ${tokens.accessToken}`,
           credentials: "omit", // Ensure cookies are not sent with requests from the extension
-        }
-      );
+        },
+      });
       if (res.ok) {
         const { feature_flags } = await res.json();
         setFeatureFlags(feature_flags ?? []);
@@ -204,7 +199,7 @@ export const useAuthHook = ({
         setFeatureFlags([]);
       }
     })();
-  }, [workspace, tokens?.accessToken, dustDomain, isAuthenticated]);
+  }, [workspace, tokens?.accessToken, isAuthenticated]);
 
   const redirectToSSOLogin = useCallback(
     async (workspace: WorkspaceType) => {
@@ -269,7 +264,7 @@ export const useAuthHook = ({
     }
 
     setTokens(newTokens);
-    setDustDomain(newRegionInfo.url);
+    setRegionInfo(newRegionInfo);
     setConnectionDetails(newConnectionDetails);
     setAuthError(null);
     setIsLoading(false);


### PR DESCRIPTION
## Description

Make RegionContext the single source of truth for region info in the extension's React UI.

Previously, `useAuth` read `regionInfo` from chrome.storage on mount and called `setDustDomain()` to overwrite RegionContext — this was redundant because RegionContext already restores from localStorage on mount.

Changes:
- Remove `dustDomain` / `setDustDomain` indirection from `useAuth` and `AuthProvider`
- Pass `setRegionInfo` directly so `handleLogin` updates RegionContext with the full `RegionInfo` object
- Replace raw `fetch(${dustDomain}/api/...)` calls with `clientFetch("/api/...")` which uses the base URL resolver from RegionContext
- Remove chrome.storage `regionInfo` read from the mount init effect

The background script (`background.ts`) still reads `regionInfo` from chrome.storage — the write in `ChromeAuthService.login()` is preserved for that purpose.

## Tests

Type-checked with `npm run tsgo` — no new errors (only pre-existing `react-router-dom` module resolution issues).

## Risk

Low. The extension already had RegionContext as the authoritative source via the base URL resolver — this just removes the redundant chrome.storage read path in React code. The background script's chrome.storage usage is unchanged.

## Deploy Plan

Standard deploy — no migration or feature flag needed.