### PR TITLE
[front] feat: add `skill_attachments` use case for files

### DIFF
--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -435,7 +435,12 @@ const getProcessingFunction = ({
   // SVG files are stored as-is without any processing (no resize).
   if (contentType === "image/svg+xml") {
     if (
-      ["conversation", "project_context", "skill_attachment", "tool_output"].includes(useCase)
+      [
+        "conversation",
+        "project_context",
+        "skill_attachment",
+        "tool_output",
+      ].includes(useCase)
     ) {
       return storeRawText;
     }

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -434,13 +434,18 @@ const getProcessingFunction = ({
 
   // SVG files are stored as-is without any processing (no resize).
   if (contentType === "image/svg+xml") {
-    if (["conversation", "project_context", "tool_output"].includes(useCase)) {
+    if (
+      ["conversation", "project_context", "skill_attachment", "tool_output"].includes(useCase)
+    ) {
       return storeRawText;
     }
     return undefined;
   }
 
   if (isSupportedImageContentType(contentType)) {
+    if (useCase === "skill_attachment") {
+      return storeRawText;
+    }
     if (useCase === "conversation" || useCase === "project_context") {
       return makeResizeAndUploadImageToFileStorage(
         CONVERSATION_IMG_MAX_SIZE_PIXELS
@@ -468,6 +473,7 @@ const getProcessingFunction = ({
         "upsert_table",
         "tool_output",
         "project_context",
+        "skill_attachment",
       ].includes(useCase)
     ) {
       return storeRawText;
@@ -500,6 +506,7 @@ const getProcessingFunction = ({
           "upsert_document",
           "folders_document",
           "project_context",
+          "skill_attachment",
         ].includes(useCase)
       ) {
         return extractTextFromFileAndUpload;
@@ -545,6 +552,7 @@ const getProcessingFunction = ({
           "tool_output",
           "folders_document",
           "project_context",
+          "skill_attachment",
         ].includes(useCase)
       ) {
         return storeRawText;

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -65,6 +65,15 @@ const FileUploadUrlRequestSchema = t.union([
       spaceId: t.string,
     }),
   }),
+  t.type({
+    contentType: t.string,
+    fileName: t.string,
+    fileSize: t.number,
+    useCase: t.literal("skill_attachment"),
+    useCaseMetadata: t.type({
+      skillId: t.string,
+    }),
+  }),
 ]);
 
 export interface FileUploadRequestResponseBody {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -25,10 +25,14 @@ export type FileUseCase =
   | "upsert_table"
   // Project context: case in which a file is uploaded to a project's shared
   // context datasource. Accessible to all conversations within the project.
-  | "project_context";
+  | "project_context"
+  // Skill attachment: file attached to a skill configuration, synced to the
+  // sandbox at /dust/skills/<skill-name>/<filename>.
+  | "skill_attachment";
 
 export type FileUseCaseMetadata = {
   conversationId?: string;
+  skillId?: string;
   spaceId?: string;
   sourceConversationId?: string;
   generatedTables?: string[];

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2788,6 +2788,7 @@ const FileTypeUseCaseSchema = FlexibleEnumSchema<
   // See also front/types/files.ts.
   | "folders_document"
   | "project_context"
+  | "skill_attachment"
 >();
 
 export const FileTypeSchema = z.object({


### PR DESCRIPTION
## Description

- This PR adds a new `useCase` for files that will be used for file attachments on skills.
- The skill ID is stored in the `useCaseMetadata`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
