### PR TITLE
[front] fix incorrect form resets on `MCPServerDetails` sheet

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -80,9 +80,12 @@ export function MCPServerDetails({
       : undefined,
   });
 
-  // Reset form when defaults change (e.g., when switching between servers)
+  // Reset form when defaults change (e.g., when switching between servers),
+  // but not if the user has unsaved edits.
   useEffect(() => {
-    form.reset(defaults);
+    if (!form.formState.isDirty) {
+      form.reset(defaults);
+    }
   }, [defaults, form]);
 
   const applyToolChanges = async (

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -23,7 +23,7 @@ import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useRef } from "react";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 
 interface MCPServerDetailsProps {
@@ -55,7 +55,7 @@ export function MCPServerDetails({
     useMutateMCPServersViewsForAdmin(owner);
   const sendNotification = useSendNotification(true);
 
-  const getDefaults = (): MCPServerFormValues => {
+  const defaults = useMemo((): MCPServerFormValues => {
     if (mcpServerView) {
       return getMCPServerFormDefaults(
         mcpServerView,
@@ -69,25 +69,18 @@ export function MCPServerDetails({
       toolSettings: {},
       sharingSettings: {},
     };
-  };
+  }, [mcpServerView, mcpServerWithViews, spaces]);
 
   const form = useForm<MCPServerFormValues>({
-    defaultValues: getDefaults(),
+    values: defaults,
     mode: "onChange",
     shouldUnregister: false, // Keep all fields registered even when not rendered
+    resetOptions: {
+      keepDirtyValues: true, // Preserve user edits on SWR refetch.
+    },
     resolver: mcpServerView
       ? zodResolver(getMCPServerFormSchema(mcpServerView))
       : undefined,
-  });
-
-  // Full reset when switching between servers.
-  const prevServerIdRef = useRef(mcpServerView?.server.sId);
-  useEffect(() => {
-    const serverId = mcpServerView?.server.sId;
-    if (serverId !== prevServerIdRef.current) {
-      prevServerIdRef.current = serverId;
-      form.reset(getDefaults());
-    }
   });
 
   const applyToolChanges = async (
@@ -240,7 +233,7 @@ export function MCPServerDetails({
       async (values) => {
         try {
           // Calculate what changed.
-          const diff = diffMCPServerForm(getDefaults(), values, {
+          const diff = diffMCPServerForm(defaults, values, {
             isRemote: isRemoteMCPServerType(mcpServerView.server),
             requiresBearerToken: requiresBearerTokenConfiguration(
               mcpServerView.server
@@ -332,7 +325,7 @@ export function MCPServerDetails({
   };
 
   const onCancel = () => {
-    form.reset(getDefaults());
+    form.reset(defaults);
   };
 
   return (

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -23,7 +23,7 @@ import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 interface MCPServerDetailsProps {
@@ -55,7 +55,7 @@ export function MCPServerDetails({
     useMutateMCPServersViewsForAdmin(owner);
   const sendNotification = useSendNotification(true);
 
-  const defaults = useMemo<MCPServerFormValues>(() => {
+  const getDefaults = (): MCPServerFormValues => {
     if (mcpServerView) {
       return getMCPServerFormDefaults(
         mcpServerView,
@@ -69,10 +69,10 @@ export function MCPServerDetails({
       toolSettings: {},
       sharingSettings: {},
     };
-  }, [mcpServerView, mcpServerWithViews, spaces]);
+  };
 
   const form = useForm<MCPServerFormValues>({
-    defaultValues: defaults,
+    defaultValues: getDefaults(),
     mode: "onChange",
     shouldUnregister: false, // Keep all fields registered even when not rendered
     resolver: mcpServerView
@@ -80,13 +80,11 @@ export function MCPServerDetails({
       : undefined,
   });
 
-  // Reset form when defaults change (e.g., when switching between servers),
-  // but not if the user has unsaved edits.
+  // Reset form when switching between servers.
+  const serverId = mcpServerView?.server.sId;
   useEffect(() => {
-    if (!form.formState.isDirty) {
-      form.reset(defaults);
-    }
-  }, [defaults, form]);
+    form.reset(getDefaults());
+  }, [form, serverId]);
 
   const applyToolChanges = async (
     toolChanges: Array<{
@@ -238,7 +236,7 @@ export function MCPServerDetails({
       async (values) => {
         try {
           // Calculate what changed.
-          const diff = diffMCPServerForm(defaults, values, {
+          const diff = diffMCPServerForm(getDefaults(), values, {
             isRemote: isRemoteMCPServerType(mcpServerView.server),
             requiresBearerToken: requiresBearerTokenConfiguration(
               mcpServerView.server
@@ -330,7 +328,7 @@ export function MCPServerDetails({
   };
 
   const onCancel = () => {
-    form.reset(defaults);
+    form.reset(getDefaults());
   };
 
   return (

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -55,7 +55,7 @@ export function MCPServerDetails({
     useMutateMCPServersViewsForAdmin(owner);
   const sendNotification = useSendNotification(true);
 
-  const defaults = useMemo((): MCPServerFormValues => {
+  const defaults = useMemo<MCPServerFormValues>(() => {
     if (mcpServerView) {
       return getMCPServerFormDefaults(
         mcpServerView,

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -23,7 +23,7 @@ import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 
 interface MCPServerDetailsProps {
@@ -80,11 +80,15 @@ export function MCPServerDetails({
       : undefined,
   });
 
-  // Reset form when switching between servers.
-  const serverId = mcpServerView?.server.sId;
+  // Full reset when switching between servers.
+  const prevServerIdRef = useRef(mcpServerView?.server.sId);
   useEffect(() => {
-    form.reset(getDefaults());
-  }, [form, serverId]);
+    const serverId = mcpServerView?.server.sId;
+    if (serverId !== prevServerIdRef.current) {
+      prevServerIdRef.current = serverId;
+      form.reset(getDefaults());
+    }
+  });
 
   const applyToolChanges = async (
     toolChanges: Array<{


### PR DESCRIPTION
## Description

- This PR fixes a bug in the `MCPServerDetails` sheet where the content is reset on swr revalidation.
- The values from the db state would reappear after a while, losing every edit made since.
- IIUC the issue comes from the fact that SWR returns a new reference on every refetch, even if the data is the same, causing the `useMemo` to change and the form to reset.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
