### PR TITLE
Prevent OOM crashes by checking CSV file size before download

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -24,7 +24,7 @@ pub const MAX_COLUMN_NAME_LENGTH: usize = 1024;
 const MAX_TABLE_ROWS: usize = 500_000;
 
 // TODO(2026-02-26 INCIDENT): Revisit once we found limit.
-pub const MAX_CSV_FILE_SIZE_BYTES: u64 = 50 * 1024 * 1024; // 50MB
+pub const MAX_CSV_FILE_SIZE_BYTES: u64 = 100 * 1024 * 1024; // 100MB
 
 impl GoogleCloudStorageCSVContent {
     pub async fn parse(&self) -> Result<Vec<Row>> {

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -23,11 +23,33 @@ pub const MAX_TABLE_COLUMNS: usize = 512;
 pub const MAX_COLUMN_NAME_LENGTH: usize = 1024;
 const MAX_TABLE_ROWS: usize = 500_000;
 
+// TODO(2026-02-26 INCIDENT): Revisit once we found limit.
+pub const MAX_CSV_FILE_SIZE_BYTES: u64 = 50 * 1024 * 1024; // 50MB
+
 impl GoogleCloudStorageCSVContent {
     pub async fn parse(&self) -> Result<Vec<Row>> {
         let now = utils::now();
         let bucket = &self.bucket;
         let path = &self.bucket_csv_path;
+
+        // Check file size before downloading to prevent OOM issues.
+        let metadata = Object::read(bucket, path).await?;
+        if metadata.size > MAX_CSV_FILE_SIZE_BYTES {
+            info!(
+                bucket = bucket,
+                path = path,
+                file_size_bytes = metadata.size,
+                max_size_bytes = MAX_CSV_FILE_SIZE_BYTES,
+                "CSV file exceeds maximum size limit"
+            );
+            return Err(anyhow!(
+                "CSV file at {}/{} is too large to process: {} bytes (max {} bytes)",
+                bucket,
+                path,
+                metadata.size,
+                MAX_CSV_FILE_SIZE_BYTES
+            ));
+        }
 
         // This is not the most efficient as we download the entire file here but we will
         // materialize it in memory as Vec<Row> anyway so that's not a massive difference.

--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -174,12 +174,12 @@ impl DatabasesStore for GoogleCloudStorageDatabasesStore {
                     // Use Hashmaps with the row_id as the key.
                     let previous_rows_map = previous_rows
                         .into_iter()
-                        .map(|r| (r.row_id.clone(), r.clone()))
+                        .map(|r| (r.row_id.clone(), r))
                         .collect::<HashMap<_, _>>();
 
                     let new_rows_map = rows
                         .into_iter()
-                        .map(|r| (r.row_id.clone(), r.clone()))
+                        .map(|r| (r.row_id.clone(), r))
                         .collect::<HashMap<_, _>>();
 
                     // Merge the two maps to get the final rows.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See incident channel [here](https://dust4ai.slack.com/archives/C0AHPK87M33)
 
Our pprof analysis 🤓 revealed that CSV parsing was consuming massive amounts of memory (5.63GB+) during table imports. The root cause: we were downloading the entire CSV file into memory (`Vec<u8>`) before any validation, with no size guard. Large files could silently trigger OOM crashes.

Fetch GCS file metadata before downloading using `Object::read()` (metadata-only, no data transfer). If the file exceeds 100MB, reject it immediately with a clear error message logged with the bucket path.

**Why this works:**
- `Object::read()` is just an HTTP metadata call (no `?alt=media`), very fast
- Fails early before the expensive download
- Logs bucket/path for observability
- 100MB limit prevents OOM while allowing reasonable CSV sizes

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
