### PR TITLE
[sparkle] refactor markdown

### DIFF
--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -99,8 +99,10 @@ export function Markdown({
   // Minimal test whenever editing this code: ensure that code block content of a streaming message
   // can be selected without blinking.
 
-  // Memoize markdown components to avoid unnecessary re-renders that disrupt text selection
-  const markdownComponents: Components = useMemo(() => {
+  // Memoized separately from additionalMarkdownComponents so that base component references
+  // (p, pre, ul, etc.) stay stable across re-renders. ReactMarkdown compares component types
+  // by reference — a new function would remount the entire subtree, destroying stateful children.
+  const baseMarkdownComponents: Components = useMemo(() => {
     return {
       pre: ({ children }) => <PreBlock>{children}</PreBlock>,
       a: LinkBlock,
@@ -224,9 +226,21 @@ export function Markdown({
         <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
       ),
       code: CodeBlockWithExtendedSupport,
-      ...additionalMarkdownComponents,
     };
-  }, [textColor, compactSpacing, additionalMarkdownComponents]);
+  }, [textColor, compactSpacing, forcedTextSize, canCopyQuotes]);
+
+  // Merge base components with additional directive components.
+  // Even though this creates a new object when additionalMarkdownComponents changes,
+  // the spread copies the same function references from baseMarkdownComponents —
+  // it doesn't re-execute the arrow functions that define them.
+  // So base elements (p, pre, ul…) keep stable identities and won't remount.
+  const markdownComponents: Components = useMemo(
+    () => ({
+      ...baseMarkdownComponents,
+      ...additionalMarkdownComponents,
+    }),
+    [baseMarkdownComponents, additionalMarkdownComponents]
+  );
 
   const markdownPlugins: PluggableList = useMemo(
     () => [


### PR DESCRIPTION
## Description
This PR is to refactor sparkle Markdown component to avoid accidental un-mouting/re-mounting when you forget to correctly memoize the dependencies of `additionalMarkdownComponents`. Before it was so easy to break because  additionalMarkdownComponents can have many dependencies and it's hard to track where each of them come from: 
https://github.com/dust-tt/dust/blob/80c4f342ee3fc5e66b6bf0e4b48ca10a86209620/front/components/assistant/conversation/AgentMessage.tsx#L967-L992

You can test it here: https://a88ede72--app.preview.dust.tt/w/0ec9852c2f/conversation/lNJqtYTUtF

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
