### PR TITLE
feat(sbx): mint jwt on sandbox exec

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -6,6 +6,7 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
+import { generateSandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -87,9 +88,17 @@ export function createSandboxTools(
 
       const { sandbox } = ensureResult.value;
 
+      const sandboxToken = generateSandboxExecToken({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        conversationId: conversation.sId,
+        userId: auth.getNonNullableUser().sId,
+        sandboxId: sandbox.sId,
+      });
+
       const execResult = await sandbox.exec(auth, command, {
         workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
         timeoutMs: timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
+        envVars: { DUST_SANDBOX_TOKEN: sandboxToken },
       });
       if (execResult.isErr()) {
         return new Err(new MCPError(execResult.error.message));

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -173,6 +173,9 @@ const config = {
   getAcademyJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_ACADEMY_JWT_SECRET");
   },
+  getSandboxJwtSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_SANDBOX_JWT_SECRET");
+  },
   getOAuthAPIConfig: (): { url: string; apiKey: string | null } => {
     return {
       url: EnvironmentConfig.getEnvVariable("OAUTH_API"),

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -1,0 +1,62 @@
+import {
+  generateSandboxExecToken,
+  SANDBOX_TOKEN_PREFIX,
+  verifySandboxExecToken,
+} from "@app/lib/api/sandbox/access_tokens";
+
+import jwt from "jsonwebtoken";
+import { describe, expect, test, vi } from "vitest";
+
+const TEST_SECRET = "test-sandbox-jwt-secret";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getSandboxJwtSecret: () => TEST_SECRET,
+  },
+}));
+
+const TOKEN_ARGS = {
+  workspaceId: "wks_abc123",
+  conversationId: "cnv_def456",
+  userId: "usr_ghi789",
+  sandboxId: "sbx_jkl012",
+} as const;
+
+describe("sandbox access tokens", () => {
+  test("round-trip: generate → verify → check claims", () => {
+    const token = generateSandboxExecToken(TOKEN_ARGS);
+
+    expect(token.startsWith(SANDBOX_TOKEN_PREFIX)).toBe(true);
+
+    const payload = verifySandboxExecToken(token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.wId).toBe(TOKEN_ARGS.workspaceId);
+    expect(payload!.cId).toBe(TOKEN_ARGS.conversationId);
+    expect(payload!.uId).toBe(TOKEN_ARGS.userId);
+    expect(payload!.sbId).toBe(TOKEN_ARGS.sandboxId);
+  });
+
+  test("tampered token is rejected", () => {
+    const token = generateSandboxExecToken(TOKEN_ARGS);
+
+    // Decode, modify, re-sign with a wrong secret.
+    const jwtPart = token.slice(SANDBOX_TOKEN_PREFIX.length);
+    const decoded = jwt.decode(jwtPart) as Record<string, unknown>;
+    const tampered =
+      SANDBOX_TOKEN_PREFIX +
+      jwt.sign({ ...decoded, wId: "hacked" }, "wrong-secret", {
+        algorithm: "HS256",
+      });
+
+    const payload = verifySandboxExecToken(tampered);
+    expect(payload).toBeNull();
+  });
+
+  test("token without sbt- prefix is rejected", () => {
+    const token = generateSandboxExecToken(TOKEN_ARGS);
+    const raw = token.slice(SANDBOX_TOKEN_PREFIX.length);
+
+    expect(verifySandboxExecToken(raw)).toBeNull();
+  });
+});

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -1,0 +1,80 @@
+import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+
+export const SANDBOX_TOKEN_PREFIX = "sbt-";
+
+const SandboxExecTokenPayloadSchema = z.object({
+  wId: z.string(),
+  cId: z.string(),
+  uId: z.string(),
+  sbId: z.string(),
+});
+
+export type SandboxExecTokenPayload = z.infer<
+  typeof SandboxExecTokenPayloadSchema
+>;
+
+export function generateSandboxExecToken({
+  workspaceId,
+  conversationId,
+  userId,
+  sandboxId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+  userId: string;
+  sandboxId: string;
+}): string {
+  const payload: SandboxExecTokenPayload = {
+    wId: workspaceId,
+    cId: conversationId,
+    uId: userId,
+    sbId: sandboxId,
+  };
+
+  const secret = config.getSandboxJwtSecret();
+
+  // Sign JWT with HS256 algorithm, valid for 2 minutes.
+  const token = jwt.sign(payload, secret, {
+    algorithm: "HS256",
+    expiresIn: "2m",
+  });
+
+  return `${SANDBOX_TOKEN_PREFIX}${token}`;
+}
+
+export function verifySandboxExecToken(
+  token: string
+): SandboxExecTokenPayload | null {
+  if (!token.startsWith(SANDBOX_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const jwtToken = token.slice(SANDBOX_TOKEN_PREFIX.length);
+  const secret = config.getSandboxJwtSecret();
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = jwt.verify(jwtToken, secret, { algorithms: ["HS256"] });
+  } catch (error) {
+    logger.error(
+      { error: normalizeError(error) },
+      "Failed to verify sandbox exec token"
+    );
+    return null;
+  }
+
+  const parseResult = SandboxExecTokenPayloadSchema.safeParse(rawPayload);
+  if (!parseResult.success) {
+    logger.error(
+      { error: parseResult.error.flatten() },
+      "Invalid sandbox exec token payload structure"
+    );
+    return null;
+  }
+
+  return parseResult.data;
+}

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -35,6 +35,7 @@ export default async function setup() {
     DUST_US_URL: "http://fake-url",
     LOG_LEVEL: process.env.TEST_LOG_LEVEL ?? "silent",
     VIZ_JWT_SECRET: "viz-secret-for-tests",
+    DUST_SANDBOX_JWT_SECRET: "sandbox-secret-for-tests",
     REGION: "us-central1",
     DUST_MCP_SERVER_CREDENTIALS_SECRET: "test-secret",
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/6844

On each sandbox execution, we mint a short-lived, scoped credential that the agent process can use to call the Dust API. The token is available as an environment variable inside the sandbox and is cleaned up on completion.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not yet.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front