### PR TITLE
[Notifications] Use client Datadog logger for preference load diagnostics

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -3,7 +3,7 @@ import { useNovuClient } from "@app/hooks/useNovuClient";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useSlackNotifications, useUserMetadata } from "@app/lib/swr/user";
 import { setUserMetadataFromClient } from "@app/lib/user";
-import logger from "@app/logger/logger";
+import datadogLogger from "@app/logger/datadogLogger";
 import type {
   NotificationCondition,
   NotificationPreferencesDelay,
@@ -241,7 +241,7 @@ export const NotificationPreferences = forwardRef<
       .list()
       .then((preferences) => {
         if (preferences.error) {
-          logger.error(
+          datadogLogger.error(
             {
               code: NOVU_SESSION_ERROR_CODE,
               ownerId: owner.sId,
@@ -278,7 +278,7 @@ export const NotificationPreferences = forwardRef<
             .map((preference) => preference.workflow?.identifier)
             .filter((identifier): identifier is string => Boolean(identifier));
 
-          logger.error(
+          datadogLogger.error(
             {
               code: MISSING_WORKFLOW_ERROR_CODE,
               ownerId: owner.sId,
@@ -290,7 +290,7 @@ export const NotificationPreferences = forwardRef<
         }
       })
       .catch((error) => {
-        logger.error(
+        datadogLogger.error(
           {
             code: NOVU_REQUEST_ERROR_CODE,
             ownerId: owner.sId,


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/22312

- Replace `@app/logger/logger` with `@app/logger/datadogLogger` in `NotificationPreferences` (client component).
- Keep the same root-cause logging fields/codes; only the client logging backend changes.

## Risks
Blast radius: Notification preferences client-side diagnostics only.
Risk: low

## Deploy Plan
- pmrr
- deploy front
