### PR TITLE
feat(sbx): fromSandbox authenticator and wrapper

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -88,11 +88,10 @@ export function createSandboxTools(
 
       const { sandbox } = ensureResult.value;
 
-      const sandboxToken = generateSandboxExecToken({
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        conversationId: conversation.sId,
-        userId: auth.getNonNullableUser().sId,
-        sandboxId: sandbox.sId,
+      const sandboxToken = generateSandboxExecToken(auth, {
+        conversation,
+        sandbox,
+        expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
       });
 
       const execResult = await sandbox.exec(auth, command, {

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -4,7 +4,7 @@ import {
   getAPIKey,
   getApiKeyNameFromHeaders,
   getSession,
-  isSandboxToken,
+  isSandboxTokenPrefix,
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -15,6 +15,8 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types/error";
 import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
 import { getUserEmailFromHeaders } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -373,19 +375,8 @@ export function withPublicAPIAuthentication<T>(
 
       // Sandbox token authentication.
       const token = req.headers.authorization?.replace("Bearer ", "");
-      if (token && isSandboxToken(token)) {
-        const payload = verifySandboxExecToken(token);
-        if (!payload) {
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "invalid_sandbox_token_error",
-              message: "The sandbox token is invalid or expired.",
-            },
-          });
-        }
-
-        const authRes = await Authenticator.fromSandboxToken(payload, wId);
+      if (token && isSandboxTokenPrefix(token)) {
+        const authRes = await handleSandboxAuth(token, wId);
         if (authRes.isErr()) {
           return apiError(req, res, authRes.error);
         }
@@ -535,6 +526,27 @@ export function withTokenAuthentication<T>(
       return handler(req, res, session);
     }
   );
+}
+
+/**
+ * Verifies a sandbox token and returns an Authenticator for the sandbox user.
+ */
+async function handleSandboxAuth(
+  token: string,
+  wId: string
+): Promise<Result<Authenticator, APIErrorWithStatusCode>> {
+  const payload = verifySandboxExecToken(token);
+  if (!payload) {
+    return new Err({
+      status_code: 401,
+      api_error: {
+        type: "invalid_sandbox_token_error",
+        message: "The sandbox token is invalid or expired.",
+      },
+    });
+  }
+
+  return Authenticator.fromSandboxToken(payload, wId);
 }
 
 /**

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -1,8 +1,10 @@
+import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import {
   Authenticator,
   getAPIKey,
   getApiKeyNameFromHeaders,
   getSession,
+  isSandboxToken,
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -367,6 +369,29 @@ export function withPublicAPIAuthentication<T>(
               "The request does not have valid authentication credentials.",
           },
         });
+      }
+
+      // Sandbox token authentication.
+      const token = req.headers.authorization?.replace("Bearer ", "");
+      if (token && isSandboxToken(token)) {
+        const payload = verifySandboxExecToken(token);
+        if (!payload) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "invalid_sandbox_token_error",
+              message: "The sandbox token is invalid or expired.",
+            },
+          });
+        }
+
+        const authRes = await Authenticator.fromSandboxToken(payload, wId);
+        if (authRes.isErr()) {
+          return apiError(req, res, authRes.error);
+        }
+        const auth = authRes.value;
+
+        return handler(req, res, auth, null);
       }
 
       // Bearer token authentication (resolved by withLogging).

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -3,9 +3,16 @@ import {
   SANDBOX_TOKEN_PREFIX,
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
-
+import { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import jwt from "jsonwebtoken";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const TEST_SECRET = "test-sandbox-jwt-secret";
 
@@ -15,30 +22,53 @@ vi.mock("@app/lib/api/config", () => ({
   },
 }));
 
-const TOKEN_ARGS = {
-  workspaceId: "wks_abc123",
-  conversationId: "cnv_def456",
-  userId: "usr_ghi789",
-  sandboxId: "sbx_jkl012",
-} as const;
+async function setupTest() {
+  const user = await UserFactory.basic();
+  const workspace = await WorkspaceFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  await SpaceFactory.defaults(auth);
+
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfig.sId,
+    messagesCreatedAt: [],
+  });
+
+  const sandbox = await SandboxResource.makeNew(auth, {
+    conversationId: conversation.id,
+    providerId: "test-provider-id",
+    status: "running",
+  });
+
+  return { auth, conversation, sandbox };
+}
 
 describe("sandbox access tokens", () => {
-  test("round-trip: generate → verify → check claims", () => {
-    const token = generateSandboxExecToken(TOKEN_ARGS);
+  it("round-trip: generate → verify → check claims", async () => {
+    const { auth, conversation, sandbox } = await setupTest();
+
+    const token = generateSandboxExecToken(auth, { conversation, sandbox });
 
     expect(token.startsWith(SANDBOX_TOKEN_PREFIX)).toBe(true);
 
     const payload = verifySandboxExecToken(token);
 
     expect(payload).not.toBeNull();
-    expect(payload!.wId).toBe(TOKEN_ARGS.workspaceId);
-    expect(payload!.cId).toBe(TOKEN_ARGS.conversationId);
-    expect(payload!.uId).toBe(TOKEN_ARGS.userId);
-    expect(payload!.sbId).toBe(TOKEN_ARGS.sandboxId);
+    expect(payload!.wId).toBe(auth.getNonNullableWorkspace().sId);
+    expect(payload!.cId).toBe(conversation.sId);
+    expect(payload!.uId).toBe(auth.getNonNullableUser().sId);
+    expect(payload!.sbId).toBe(sandbox.sId);
   });
 
-  test("tampered token is rejected", () => {
-    const token = generateSandboxExecToken(TOKEN_ARGS);
+  it("tampered token is rejected", async () => {
+    const { auth, conversation, sandbox } = await setupTest();
+
+    const token = generateSandboxExecToken(auth, { conversation, sandbox });
 
     // Decode, modify, re-sign with a wrong secret.
     const jwtPart = token.slice(SANDBOX_TOKEN_PREFIX.length);
@@ -53,8 +83,10 @@ describe("sandbox access tokens", () => {
     expect(payload).toBeNull();
   });
 
-  test("token without sbt- prefix is rejected", () => {
-    const token = generateSandboxExecToken(TOKEN_ARGS);
+  it("token without sbt- prefix is rejected", async () => {
+    const { auth, conversation, sandbox } = await setupTest();
+
+    const token = generateSandboxExecToken(auth, { conversation, sandbox });
     const raw = token.slice(SANDBOX_TOKEN_PREFIX.length);
 
     expect(verifySandboxExecToken(raw)).toBeNull();

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -1,5 +1,8 @@
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import jwt from "jsonwebtoken";
 import { z } from "zod";
@@ -17,30 +20,30 @@ export type SandboxExecTokenPayload = z.infer<
   typeof SandboxExecTokenPayloadSchema
 >;
 
-export function generateSandboxExecToken({
-  workspaceId,
-  conversationId,
-  userId,
-  sandboxId,
-}: {
-  workspaceId: string;
-  conversationId: string;
-  userId: string;
-  sandboxId: string;
-}): string {
+export function generateSandboxExecToken(
+  auth: Authenticator,
+  {
+    conversation,
+    sandbox,
+    expiryMs = 2 * 60 * 1000, // Default to 2 minutes
+  }: {
+    conversation: ConversationType;
+    sandbox: SandboxResource;
+    expiryMs?: number;
+  }
+): string {
   const payload: SandboxExecTokenPayload = {
-    wId: workspaceId,
-    cId: conversationId,
-    uId: userId,
-    sbId: sandboxId,
+    wId: auth.getNonNullableWorkspace().sId,
+    cId: conversation.sId,
+    uId: auth.getNonNullableUser().sId,
+    sbId: sandbox.sId,
   };
 
   const secret = config.getSandboxJwtSecret();
 
-  // Sign JWT with HS256 algorithm, valid for 2 minutes.
   const token = jwt.sign(payload, secret, {
     algorithm: "HS256",
-    expiresIn: "2m",
+    expiresIn: expiryMs / 1000, // expiresIn is in seconds
   });
 
   return `${SANDBOX_TOKEN_PREFIX}${token}`;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,5 +1,7 @@
 import config from "@app/lib/api/config";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
+import type { SandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { SANDBOX_TOKEN_PREFIX } from "@app/lib/api/sandbox/access_tokens";
 import type { WorkOSJwtPayload } from "@app/lib/api/workos";
 import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import { getWorkOSSession } from "@app/lib/api/workos/user";
@@ -57,16 +59,23 @@ const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 
 const DustApiKeyNameHeader = "x-dust-api-key-name";
 
+const SANDBOX_TOKEN_AUTH_METHOD = "sandbox_token" as const;
+
 export type AuthMethodType =
   | "system_api_key"
   | "api_key"
   | "oauth"
   | "session"
+  | typeof SANDBOX_TOKEN_AUTH_METHOD
   | "internal";
 
-// Any token which do not start with sk- is considered an OAuth token.
+export const isSandboxToken = (token: string): boolean => {
+  return token.startsWith(SANDBOX_TOKEN_PREFIX);
+};
+
+// Any token which does not start with sk- or sbt- is considered an OAuth token.
 export const isOAuthToken = (token: string): boolean => {
-  return !token.startsWith(SECRET_KEY_PREFIX);
+  return !token.startsWith(SECRET_KEY_PREFIX) && !isSandboxToken(token);
 };
 
 export interface AuthenticatorType {
@@ -396,6 +405,62 @@ export class Authenticator {
         groupModelIds: authData.groupModelIds,
         user,
         role: authData.role,
+        subscription: authData.subscription,
+      })
+    );
+  }
+
+  static async fromSandboxToken(
+    claims: SandboxExecTokenPayload,
+    wId: string
+  ): Promise<Result<Authenticator, APIErrorWithStatusCode>> {
+    if (claims.wId !== wId) {
+      return new Err({
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "The sandbox token workspace does not match the request.",
+        },
+      });
+    }
+
+    const [workspace, user] = await Promise.all([
+      WorkspaceResource.fetchById(wId),
+      UserResource.fetchById(claims.uId),
+    ]);
+
+    if (!workspace) {
+      return new Err({
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The workspace was not found.",
+        },
+      });
+    }
+
+    if (!user) {
+      return new Err({
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "The user referenced by the sandbox token was not found.",
+        },
+      });
+    }
+
+    const authData = await this.fetchRoleGroupsAndSubscription({
+      user,
+      workspace,
+    });
+
+    return new Ok(
+      new Authenticator({
+        authMethod: SANDBOX_TOKEN_AUTH_METHOD,
+        workspace,
+        user,
+        role: authData.role,
+        groupModelIds: authData.groupModelIds,
         subscription: authData.subscription,
       })
     );
@@ -740,6 +805,10 @@ export class Authenticator {
 
   isKey(): boolean {
     return !!this._key;
+  }
+
+  isSandboxToken(): boolean {
+    return this._authMethod === SANDBOX_TOKEN_AUTH_METHOD;
   }
 
   authMethod(): AuthMethodType {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -6,6 +6,7 @@ import type { WorkOSJwtPayload } from "@app/lib/api/workos";
 import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import { getWorkOSSession } from "@app/lib/api/workos/user";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -16,6 +17,7 @@ import {
   SECRET_KEY_PREFIX,
 } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -69,14 +71,12 @@ export type AuthMethodType =
   | typeof SANDBOX_TOKEN_AUTH_METHOD
   | "internal";
 
-export const isSandboxToken = (token: string): boolean => {
-  return token.startsWith(SANDBOX_TOKEN_PREFIX);
-};
+export const isSandboxTokenPrefix = (token: string): boolean =>
+  token.startsWith(SANDBOX_TOKEN_PREFIX);
 
 // Any token which does not start with sk- or sbt- is considered an OAuth token.
-export const isOAuthToken = (token: string): boolean => {
-  return !token.startsWith(SECRET_KEY_PREFIX) && !isSandboxToken(token);
-};
+export const isOAuthToken = (token: string): boolean =>
+  !token.startsWith(SECRET_KEY_PREFIX) && !isSandboxTokenPrefix(token);
 
 export interface AuthenticatorType {
   authMethod: AuthMethodType;
@@ -454,16 +454,68 @@ export class Authenticator {
       workspace,
     });
 
+    if (authData.role === "none") {
+      return new Err({
+        status_code: 401,
+        api_error: {
+          type: "invalid_sandbox_token_error",
+          message: "The user is not a member of this workspace.",
+        },
+      });
+    }
+
+    // Restrict groups to the conversation's spaces so the sandbox auth can only
+    // access resources visible to the conversation, not everything the user can.
+    const groupModelIds = await this.restrictGroupsToConversationSpaces(
+      authData.groupModelIds,
+      claims.cId,
+      workspace.id
+    );
+
     return new Ok(
       new Authenticator({
         authMethod: SANDBOX_TOKEN_AUTH_METHOD,
         workspace,
         user,
         role: authData.role,
-        groupModelIds: authData.groupModelIds,
+        groupModelIds,
         subscription: authData.subscription,
       })
     );
+  }
+
+  /**
+   * Given a user's full group IDs, restricts them to only the groups associated
+   * with the conversation's requested spaces. Falls back to the full set if the
+   * conversation is not found or has no requested spaces.
+   */
+  private static async restrictGroupsToConversationSpaces(
+    userGroupIds: ModelId[],
+    conversationId: string,
+    workspaceId: ModelId
+  ): Promise<ModelId[]> {
+    const conversation = await ConversationModel.findOne({
+      where: { sId: conversationId, workspaceId: workspaceId },
+      attributes: ["requestedSpaceIds"],
+    });
+
+    if (!conversation || conversation.requestedSpaceIds.length === 0) {
+      return userGroupIds;
+    }
+
+    const spaceGroups = await GroupSpaceModel.findAll({
+      where: {
+        vaultId: conversation.requestedSpaceIds,
+        workspaceId: workspaceId,
+      },
+      attributes: ["groupId"],
+    });
+
+    const allowedGroupIds = new Set(
+      spaceGroups.map((sg) => Number(sg.groupId) as ModelId)
+    );
+
+    return userGroupIds.filter((id) => allowedGroupIds.has(id));
   }
 
   /**

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -19,6 +19,7 @@ const API_ERROR_TYPES = [
   "invalid_oauth_token_error",
   "expired_oauth_token_error",
   "invalid_api_key_error",
+  "invalid_sandbox_token_error",
   "internal_server_error",
   "invalid_request_error",
   "invalid_rows_request_error",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/6845
Closes https://github.com/dust-tt/tasks/issues/6846

This PR creates a `Authenticator.fromSandboxToken()` method, giving a properly scoped Authenticator from a verified sandbox JWT, with the same group membership and permission checks as a regular session. It uses it in a new branch in `withPublicAPIAuthentication` that triggers on the `sbt-` token prefix.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not yet

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front