### PR TITLE
[front] perf: optimize queries on `agent_message_feedbacks`

### DIFF
--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -306,7 +306,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     }
 
     const conversations = await ConversationModel.findAll({
-      attributes: ["id", "sId"] ,
+      attributes: ["id", "sId"],
       where: {
         workspaceId: workspace.id,
         id: feedbackRows.map((f) => f.conversationId),

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -92,20 +92,13 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   }
 
   static async makeNew(
-    blob: CreationAttributes<AgentMessageFeedbackModel>,
-    {
-      message,
-      user,
-    }: {
-      message?: Attributes<MessageModel>;
-      user?: Attributes<UserModel>;
-    } = {}
+    blob: CreationAttributes<AgentMessageFeedbackModel>
   ): Promise<AgentMessageFeedbackResource> {
     const agentMessageFeedback = await this.model.create({
       ...blob,
     });
 
-    return new this(this.model, agentMessageFeedback.get(), { message, user });
+    return new this(this.model, agentMessageFeedback.get());
   }
 
   async delete(

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -47,9 +47,10 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   static model: ModelStatic<AgentMessageFeedbackModel> =
     AgentMessageFeedbackModel;
 
-  readonly messageId?: string;
   readonly user?: Attributes<UserModel>;
-  readonly conversationId?: string;
+
+  readonly _conversationId?: string;
+  readonly _messageId?: string;
 
   constructor(
     _: ModelStatic<AgentMessageFeedbackModel>,
@@ -66,9 +67,9 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   ) {
     super(AgentMessageFeedbackModel, blob);
 
-    this.messageId = messageId;
+    this._conversationId = conversationId;
+    this._messageId = messageId;
     this.user = user;
-    this.conversationId = conversationId;
   }
 
   get sId(): string {
@@ -543,7 +544,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     return {
       id: this.id,
       sId: this.sId,
-      messageId: this.messageId,
+      messageId: this._messageId,
       agentMessageId: this.agentMessageId,
       userId: this.userId,
       thumbDirection: this.thumbDirection,
@@ -553,7 +554,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       createdAt: this.createdAt,
       agentConfigurationId: this.agentConfigurationId,
       agentConfigurationVersion: this.agentConfigurationVersion,
-      conversationId: this.conversationId,
+      conversationId: this._conversationId,
       ...(this.user
         ? {
             userName: this.user.name,

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -267,9 +267,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       const conversationId = feedback.conversationId
         ? conversationIdByModelId.get(feedback.conversationId)
         : undefined;
-      const messageId = messageIdByAgentMessageId.get(
-        feedback.agentMessageId
-      );
+      const messageId = messageIdByAgentMessageId.get(feedback.agentMessageId);
       return new this(this.model, feedback.get(), {
         user: feedback.user,
         conversationId,
@@ -398,9 +396,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     );
 
     return feedbackRows.map((feedback) => {
-      const messageId = messageIdByAgentMessageId.get(
-        feedback.agentMessageId
-      );
+      const messageId = messageIdByAgentMessageId.get(feedback.agentMessageId);
       return new this(this.model, feedback.get(), {
         messageId,
       });

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -47,28 +47,28 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   static model: ModelStatic<AgentMessageFeedbackModel> =
     AgentMessageFeedbackModel;
 
-  readonly message?: Attributes<MessageModel>;
+  readonly messageId?: string;
   readonly user?: Attributes<UserModel>;
-  readonly conversation?: Attributes<ConversationModel>;
+  readonly conversationId?: string;
 
   constructor(
     _: ModelStatic<AgentMessageFeedbackModel>,
     blob: Attributes<AgentMessageFeedbackModel>,
     {
-      message,
+      messageId,
       user,
-      conversation,
+      conversationId,
     }: {
-      message?: Attributes<MessageModel>;
+      messageId?: string;
       user?: Attributes<UserModel>;
-      conversation?: Attributes<ConversationModel>;
+      conversationId?: string;
     } = {}
   ) {
     super(AgentMessageFeedbackModel, blob);
 
-    this.message = message;
+    this.messageId = messageId;
     this.user = user;
-    this.conversation = conversation;
+    this.conversationId = conversationId;
   }
 
   get sId(): string {
@@ -548,7 +548,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     return {
       id: this.id,
       sId: this.sId,
-      messageId: this.message?.sId,
+      messageId: this.messageId,
       agentMessageId: this.agentMessageId,
       userId: this.userId,
       thumbDirection: this.thumbDirection,
@@ -558,7 +558,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       createdAt: this.createdAt,
       agentConfigurationId: this.agentConfigurationId,
       agentConfigurationVersion: this.agentConfigurationVersion,
-      conversationId: this.conversation?.sId,
+      conversationId: this.conversationId,
       ...(this.user
         ? {
             userName: this.user.name,

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -49,7 +49,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
   readonly user?: Attributes<UserModel>;
 
-  readonly _conversationId?: string;
+  readonly _conversationId?: string; // conversationId is already taken via the Sequelize model (it's the FK).
   readonly _messageId?: string;
 
   constructor(

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -239,9 +239,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
     // Fetch conversation sIds and message sIds in separate queries.
     const conversationIds = [
-      ...new Set(
-        feedbackRows.map((f) => f.conversationId)
-      ),
+      ...new Set(feedbackRows.map((f) => f.conversationId)),
     ];
     const conversations = await ConversationModel.findAll({
       attributes: ["id", "sId"],
@@ -307,9 +305,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     }
 
     const conversationIds = [
-      ...new Set(
-        feedbackRows.map((f) => f.conversationId)
-      ),
+      ...new Set(feedbackRows.map((f) => f.conversationId)),
     ];
     const conversations = await ConversationModel.findAll({
       attributes: ["id", "sId"],

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -213,28 +213,9 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       };
     }
 
-    const agentMessageFeedback = await this.model.findAll({
+    const feedbackRows = await this.model.findAll({
       where,
       include: [
-        {
-          model: AgentMessageModel,
-          attributes: ["id"],
-          as: "agentMessage",
-          include: [
-            {
-              model: MessageModel,
-              as: "message",
-              attributes: ["id", "sId"],
-              include: [
-                {
-                  model: ConversationModel,
-                  as: "conversation",
-                  attributes: ["id", "sId"],
-                },
-              ],
-            },
-          ],
-        },
         {
           model: UserResource.model,
           as: "user",
@@ -252,11 +233,47 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       limit: paginationParams.limit,
     });
 
-    return agentMessageFeedback.map((feedback) => {
+    if (feedbackRows.length === 0) {
+      return [];
+    }
+
+    // Fetch conversation sIds and message sIds in separate queries.
+    const conversationIds = [
+      ...new Set(
+        feedbackRows.map((f) => f.conversationId).filter((id) => id !== null)
+      ),
+    ];
+    const conversations = await ConversationModel.findAll({
+      attributes: ["id", "sId"],
+      where: { id: conversationIds },
+    });
+    const conversationIdByModelId = new Map(
+      conversations.map((c) => [c.id, c.sId])
+    );
+
+    const agentMessageIds = feedbackRows.map((f) => f.agentMessageId);
+    const messages = await MessageModel.findAll({
+      attributes: ["sId", "agentMessageId"],
+      where: {
+        agentMessageId: agentMessageIds,
+        workspaceId: workspace.id,
+      },
+    });
+    const messageIdByAgentMessageId = new Map(
+      messages.map((m) => [m.agentMessageId, m.sId])
+    );
+
+    return feedbackRows.map((feedback) => {
+      const conversationId = feedback.conversationId
+        ? conversationIdByModelId.get(feedback.conversationId)
+        : undefined;
+      const messageId = messageIdByAgentMessageId.get(
+        feedback.agentMessageId
+      );
       return new this(this.model, feedback.get(), {
-        message: feedback.agentMessage?.message,
         user: feedback.user,
-        conversation: feedback.agentMessage?.message?.conversation,
+        conversationId,
+        messageId,
       });
     });
   }
@@ -272,7 +289,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     workspace: WorkspaceType;
     transaction?: Transaction;
   }) {
-    const agentMessageFeedback = await this.model.findAll({
+    const feedbackRows = await this.model.findAll({
       where: {
         // IMPORTANT: Necessary for global models who share ids across workspaces.
         workspaceId: workspace.id,
@@ -280,27 +297,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
           [Op.and]: [{ [Op.lt]: endDate }, { [Op.gt]: startDate }],
         },
       },
-
       include: [
-        {
-          model: AgentMessageModel,
-          attributes: ["id"],
-          as: "agentMessage",
-          include: [
-            {
-              model: MessageModel,
-              as: "message",
-              attributes: ["id", "sId"],
-              include: [
-                {
-                  model: ConversationModel,
-                  as: "conversation",
-                  attributes: ["id", "sId"],
-                },
-              ],
-            },
-          ],
-        },
         {
           model: UserResource.model,
           as: "user",
@@ -311,12 +308,33 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       transaction,
     });
 
-    return agentMessageFeedback
+    if (feedbackRows.length === 0) {
+      return [];
+    }
+
+    const conversationIds = [
+      ...new Set(
+        feedbackRows.map((f) => f.conversationId).filter((id) => id !== null)
+      ),
+    ];
+    const conversations = await ConversationModel.findAll({
+      attributes: ["id", "sId"],
+      where: { id: conversationIds },
+      transaction,
+    });
+    const conversationIdByModelId = new Map(
+      conversations.map((c) => [c.id, c.sId])
+    );
+
+    return feedbackRows
       .filter((feedback) => Boolean(feedback.user))
       .map((feedback) => {
+        const conversationId = feedback.conversationId
+          ? conversationIdByModelId.get(feedback.conversationId)
+          : undefined;
         return new this(this.model, feedback.get(), {
           user: feedback.user,
-          conversation: feedback.agentMessage?.message?.conversation,
+          conversationId,
         });
       });
   }
@@ -354,38 +372,37 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   ) {
     const user = auth.getNonNullableUser();
 
-    // Start from feedbacks (filtered by userId + workspaceId) and join back to
-    // messages (filtered by conversationId). This is more selective than scanning
-    // all messages in the conversation.
     const feedbackRows = await this.model.findAll({
       where: {
         userId: user.id,
         workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
       },
-      include: [
-        {
-          model: AgentMessageModel,
-          as: "agentMessage",
-          attributes: ["id"],
-          required: true,
-          include: [
-            {
-              model: MessageModel,
-              as: "message",
-              attributes: ["id", "sId"],
-              required: true,
-              where: {
-                conversationId: conversation.id,
-              },
-            },
-          ],
-        },
-      ],
     });
 
+    if (feedbackRows.length === 0) {
+      return [];
+    }
+
+    // Fetch message sIds in a separate query.
+    const agentMessageIds = feedbackRows.map((f) => f.agentMessageId);
+    const messages = await MessageModel.findAll({
+      attributes: ["sId", "agentMessageId"],
+      where: {
+        agentMessageId: agentMessageIds,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    const messageIdByAgentMessageId = new Map(
+      messages.map((m) => [m.agentMessageId, m.sId])
+    );
+
     return feedbackRows.map((feedback) => {
+      const messageId = messageIdByAgentMessageId.get(
+        feedback.agentMessageId
+      );
       return new this(this.model, feedback.get(), {
-        message: feedback.agentMessage?.message,
+        messageId,
       });
     });
   }

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -239,12 +239,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     }
 
     // Fetch conversation sIds and message sIds in separate queries.
-    const conversationIds = [
-      ...new Set(feedbackRows.map((f) => f.conversationId)),
-    ];
     const conversations = await ConversationModel.findAll({
       attributes: ["id", "sId"],
-      where: { id: conversationIds },
+      where: {
+        workspaceId: workspace.id,
+        id: feedbackRows.map((f) => f.conversationId),
+      },
     });
     const conversationIdByModelId = new Map(
       conversations.map((c) => [c.id, c.sId])
@@ -305,12 +305,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       return [];
     }
 
-    const conversationIds = [
-      ...new Set(feedbackRows.map((f) => f.conversationId)),
-    ];
     const conversations = await ConversationModel.findAll({
-      attributes: ["id", "sId"],
-      where: { id: conversationIds },
+      attributes: ["id", "sId"] ,
+      where: {
+        workspaceId: workspace.id,
+        id: feedbackRows.map((f) => f.conversationId),
+      },
       transaction,
     });
     const conversationIdByModelId = new Map(

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -240,7 +240,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     // Fetch conversation sIds and message sIds in separate queries.
     const conversationIds = [
       ...new Set(
-        feedbackRows.map((f) => f.conversationId).filter((id) => id !== null)
+        feedbackRows.map((f) => f.conversationId)
       ),
     ];
     const conversations = await ConversationModel.findAll({
@@ -264,14 +264,10 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     );
 
     return feedbackRows.map((feedback) => {
-      const conversationId = feedback.conversationId
-        ? conversationIdByModelId.get(feedback.conversationId)
-        : undefined;
-      const messageId = messageIdByAgentMessageId.get(feedback.agentMessageId);
       return new this(this.model, feedback.get(), {
         user: feedback.user,
-        conversationId,
-        messageId,
+        conversationId: conversationIdByModelId.get(feedback.conversationId),
+        messageId: messageIdByAgentMessageId.get(feedback.agentMessageId),
       });
     });
   }
@@ -312,7 +308,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
     const conversationIds = [
       ...new Set(
-        feedbackRows.map((f) => f.conversationId).filter((id) => id !== null)
+        feedbackRows.map((f) => f.conversationId)
       ),
     ];
     const conversations = await ConversationModel.findAll({
@@ -327,12 +323,9 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     return feedbackRows
       .filter((feedback) => Boolean(feedback.user))
       .map((feedback) => {
-        const conversationId = feedback.conversationId
-          ? conversationIdByModelId.get(feedback.conversationId)
-          : undefined;
         return new this(this.model, feedback.get(), {
           user: feedback.user,
-          conversationId,
+          conversationId: conversationIdByModelId.get(feedback.conversationId),
         });
       });
   }


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/22126
- Simplify feedback queries in AgentMessageFeedbackResource to use the direct `conversationId` FK instead of joining through agentMessage → message → conversation
- Replace nested 3-level includes with simple batch lookups (fetch feedbacks first, then resolve sIds in separate queries)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
