### PR TITLE
Don't keep retrying in background worker if csv is too large

### DIFF
--- a/core/src/databases/table_upserts_background_worker.rs
+++ b/core/src/databases/table_upserts_background_worker.rs
@@ -111,6 +111,15 @@ impl TableUpsertsBackgroundWorker {
                         "TableUpsertsBackgroundWorker: Too many columns in CSV file, ignoring: {}",
                         e
                     );
+                } else if e.to_string().contains("CSV file is too large") {
+                    // Likewise, if the csv file is too large, it's best to ignore those errors to prevent constant retries.
+                    error!(
+                        project_id = table_data.project_id,
+                        data_source_id = table_data.data_source_id,
+                        table_id = table_data.table_id,
+                        "TableUpsertsBackgroundWorker: CSV file is too large, ignoring: {}",
+                        e
+                    );
                 } else {
                     return Err(e);
                 }


### PR DESCRIPTION
## Description

This is a follow-up to #22370 and #22371. Even though we no longer process when it's too large, we end up retrying forever in the background worker.

Fix is to special case this error. It's a bit dirty to do it by message instead of code, but we might revisit more of this later, and for now this prevents the retry.

## Tests


## Risk

Low

## Deploy Plan

Core