### PR TITLE
feat(sbx-cli): add authentication

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +133,7 @@ name = "dust-sandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "serde",
  "serde_json",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -13,3 +13,4 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"

--- a/cli/dust-sandbox/src/auth.rs
+++ b/cli/dust-sandbox/src/auth.rs
@@ -1,0 +1,66 @@
+use anyhow::{bail, Context};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde::Deserialize;
+
+pub const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
+
+#[derive(Debug, Deserialize)]
+pub struct SandboxClaims {
+    #[serde(rename = "wId")]
+    pub w_id: String,
+    #[serde(rename = "cId")]
+    pub c_id: String,
+    #[serde(rename = "uId")]
+    pub u_id: String,
+    #[serde(rename = "sbId")]
+    pub sb_id: String,
+    #[serde(default)]
+    pub exp: Option<u64>,
+}
+
+pub fn decode_jwt_claims(token: &str) -> anyhow::Result<SandboxClaims> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        bail!("invalid JWT: expected 3 parts, got {}", parts.len());
+    }
+    let payload = URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .context("failed to base64-decode JWT payload")?;
+    let claims: SandboxClaims =
+        serde_json::from_slice(&payload).context("failed to parse JWT claims")?;
+    Ok(claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_valid_token() {
+        let header = URL_SAFE_NO_PAD.encode(b"{}");
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::json!({
+                "wId": "ws-123",
+                "cId": "conv-456",
+                "uId": "user-789",
+                "sbId": "sb-abc",
+                "exp": 9999999999u64
+            })
+            .to_string()
+            .as_bytes(),
+        );
+        let token = format!("{header}.{payload}.fakesig");
+
+        let claims = decode_jwt_claims(&token).expect("should decode valid token");
+        assert_eq!(claims.w_id, "ws-123");
+        assert_eq!(claims.c_id, "conv-456");
+        assert_eq!(claims.u_id, "user-789");
+        assert_eq!(claims.sb_id, "sb-abc");
+        assert_eq!(claims.exp, Some(9999999999));
+    }
+
+    #[test]
+    fn decode_invalid_token() {
+        assert!(decode_jwt_claims("not-a-jwt").is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -1,3 +1,5 @@
+mod status;
 mod version;
 
+pub use status::cmd_status;
 pub use version::cmd_version;

--- a/cli/dust-sandbox/src/commands/status.rs
+++ b/cli/dust-sandbox/src/commands/status.rs
@@ -1,0 +1,33 @@
+use crate::auth::{decode_jwt_claims, SANDBOX_TOKEN_ENV};
+
+pub fn cmd_status() -> anyhow::Result<()> {
+    let token = match std::env::var(SANDBOX_TOKEN_ENV) {
+        Ok(t) if !t.is_empty() => t,
+        _ => {
+            println!("Not logged in ({SANDBOX_TOKEN_ENV} is not set)");
+            return Ok(());
+        }
+    };
+
+    let claims = decode_jwt_claims(&token)?;
+
+    println!("Logged in via sandbox token");
+    println!("  Workspace:    {}", claims.w_id);
+    println!("  Conversation: {}", claims.c_id);
+    println!("  User:         {}", claims.u_id);
+    println!("  Sandbox:      {}", claims.sb_id);
+
+    if let Some(exp) = claims.exp {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| anyhow::anyhow!("system clock error: {e}"))?
+            .as_secs();
+        if exp <= now {
+            println!("  Token:        EXPIRED");
+        } else {
+            println!("  Expires in:   {}s", exp - now);
+        }
+    }
+
+    Ok(())
+}

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod commands;
 
 use clap::{Parser, Subcommand};
@@ -13,6 +14,8 @@ struct Cli {
 enum Commands {
     /// Print version information
     Version,
+    /// Show sandbox login status
+    Status,
 }
 
 #[tokio::main]
@@ -21,6 +24,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Version => commands::cmd_version(),
+        Commands::Status => commands::cmd_status()?,
     }
 
     Ok(())


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Contributes to https://github.com/dust-tt/tasks/issues/6851

Give the CLI a way to authenticate to the Dust API using the sandbox token. 
Scaffhold the token read code and give a `status` command to see the current user, conversation, workspace, and sandbox.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Auth decoding by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

