### PR TITLE
[front] - fix(Teams MCP): add last message preview

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
@@ -84,6 +84,9 @@ export interface TeamsChat {
   chatType: "oneOnOne" | "group" | "meeting";
   webUrl: string;
   tenantId: string;
+  lastMessagePreview?: {
+    createdDateTime: string;
+  };
 }
 
 export interface TeamsChannel {

--- a/front/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering.ts
@@ -66,7 +66,7 @@ export function renderChats(chats: TeamsChat[]): string {
         `Chat Type: ${chat.chatType}`,
         `Web URL: ${chat.webUrl}`,
         `Created: ${new Date(chat.createdDateTime).toISOString()}`,
-        `Last Updated: ${new Date(chat.lastUpdatedDateTime).toISOString()}`,
+        `Last Updated: ${new Date(chat.lastMessagePreview?.createdDateTime ?? chat.lastUpdatedDateTime).toISOString()}`,
       ];
 
       if (chat.topic) {

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -174,6 +174,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       let apiCall = client
         .api("/me/chats")
         .orderby("lastMessagePreview/createdDateTime desc")
+        .expand("lastMessagePreview")
         .top(maxLimit);
 
       // Build filter conditions


### PR DESCRIPTION





## Description

Fixes the issue where `list_chats` was displaying stale "Last Updated" timestamps for Microsoft Teams chats. The Microsoft Graph API's `lastUpdatedDateTime` field can be months out of date even for chats with recent messages. By expanding the API call to include `lastMessagePreview` and using its `createdDateTime`, the tool now shows accurate timestamps reflecting when the most recent message was sent. This fixes a critical use case where agents would exclude active chats when filtering by date (e.g., "summarize today's conversations").

**References:**
 - Fixes https://github.com/dust-tt/tasks/issues/6830

## Tests

N/A

## Risk

Low. The change falls back to `lastUpdatedDateTime` if `lastMessagePreview` is unavailable, maintaining backward compatibility.

## Deploy Plan

Deploy front
