### PR TITLE
[front] enh: Use LFU for cached resources (fromSession)

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -49,7 +49,6 @@ import { Op, QueryTypes } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
-const GROUP_IDS_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -114,6 +113,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static dangerouslyListUserGroupsForAuthCached = cacheWithRedis(
     ({
       user,
@@ -127,7 +127,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         workspace,
       }),
     GroupResource.groupIdsCacheKeyResolver,
-    { ttlMs: GROUP_IDS_CACHE_TTL_MS, cacheNullValues: false }
+    { cacheNullValues: false }
   );
 
   static invalidateGroupIdsCacheForUser = invalidateCacheWithRedis(

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -24,8 +24,6 @@ import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
-const KEY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes.
-
 type CachedKeyData = Omit<
   Attributes<KeyModel>,
   "secret" | "lastUsedAt" | "createdAt" | "updatedAt"
@@ -89,10 +87,11 @@ export class KeyResource extends BaseResource<KeyModel> {
     };
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static fetchBySecretCached = cacheWithRedis(
     KeyResource._fetchBySecretUncached,
     KeyResource.keyCacheKeyResolver,
-    { ttlMs: KEY_CACHE_TTL_MS }
+    {}
   );
 
   private static invalidateKeyCache = invalidateCacheWithRedis(

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -368,8 +368,6 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return memberships[0];
   }
 
-  private static readonly ROLE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-
   private static readonly roleCacheKeyResolver = ({
     userModelId,
     workspaceModelId,
@@ -401,11 +399,12 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return membership?.role ?? "none";
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static getActiveRoleForUserInWorkspaceCached = cacheWithRedis(
     MembershipResource._getActiveRoleForUserInWorkspaceUncached,
     (params: { userModelId: ModelId; workspaceModelId: ModelId }) =>
       MembershipResource.roleCacheKeyResolver(params),
-    { ttlMs: MembershipResource.ROLE_CACHE_TTL_MS, cacheNullValues: false }
+    { cacheNullValues: false }
   );
 
   private static invalidateRoleCache = invalidateCacheWithRedis(
@@ -592,8 +591,6 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return result;
   }
 
-  private static readonly SEATS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
   // Seat counting with caching - used to track active seats in a workspace
   private static readonly seatsCacheKeyResolver = (workspaceId: string) =>
     `count-active-seats-in-workspace:${workspaceId}`;
@@ -612,10 +609,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static countActiveSeatsInWorkspaceCached = cacheWithRedis(
     MembershipResource._countActiveSeatsInWorkspaceUncached,
     MembershipResource.seatsCacheKeyResolver,
-    { ttlMs: MembershipResource.SEATS_CACHE_TTL_MS, cacheNullValues: false }
+    { cacheNullValues: false }
   );
 
   private static invalidateActiveSeatsCache = invalidateCacheWithRedis(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -76,8 +76,6 @@ import type Stripe from "stripe";
 const DEFAULT_PLAN_WHEN_NO_SUBSCRIPTION: PlanAttributes = FREE_NO_PLAN_DATA;
 const FREE_NO_PLAN_SUBSCRIPTION_ID = -1;
 
-const SUBSCRIPTION_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-
 type CachedSubscription = {
   id: number;
   planId: number;
@@ -194,10 +192,11 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return new SubscriptionResource(SubscriptionModel, blob, data.plan);
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static fetchActiveByWorkspaceModelIdCached = cacheWithRedis(
     SubscriptionResource._fetchActiveByWorkspaceModelIdUncached,
     SubscriptionResource.subscriptionCacheKeyResolver,
-    { ttlMs: SUBSCRIPTION_CACHE_TTL_MS, cacheNullValues: false }
+    { cacheNullValues: false }
   );
 
   static async fetchActiveByWorkspaceModelId(

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -48,8 +48,6 @@ const USER_METADATA_COMMA_SEPARATOR = ",";
 const USER_METADATA_COMMA_REPLACEMENT = "DUST_COMMA";
 const TOOLS_VALIDATION_WILDCARD = "*";
 
-const USER_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-
 type CachedUserData = {
   id: ModelId;
   sId: string;
@@ -219,10 +217,11 @@ export class UserResource extends BaseResource<UserModel> {
     };
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static fetchByWorkOSUserIdCached = cacheWithRedis(
     UserResource._fetchByWorkOSUserIdUncached,
     UserResource.userByWorkOSIdCacheKeyResolver,
-    { ttlMs: USER_CACHE_TTL_MS, cacheNullValues: false }
+    { cacheNullValues: false }
   );
 
   private static invalidateUserByWorkOSIdCache = invalidateCacheWithRedis(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -36,7 +36,6 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-const WORKSPACE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const WORKSPACE_FULLY_BLOCKED_ERROR_MESSAGE =
   "Workspace is fully blocked. Use `workspace unblock` before managing conversation blocks.";
 const INVALID_WORKSPACE_KILL_SWITCH_METADATA_ERROR_PREFIX =
@@ -164,10 +163,11 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     };
   }
 
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static fetchByIdCached = cacheWithRedis(
     WorkspaceResource._fetchByIdUncached,
     WorkspaceResource.workspaceCacheKeyResolver,
-    { ttlMs: WORKSPACE_CACHE_TTL_MS, cacheNullValues: false }
+    { cacheNullValues: false }
   );
 
   private static invalidateWorkspaceCache = invalidateCacheWithRedis(


### PR DESCRIPTION
## Description

Remove the TTL on fromSession + api key cached resources to fully leverage redis' lfu policy

## Tests

None

## Risk

Low - If we forgot to invalidate cache in some code-path, and were saved by the 30 minutes TTL, now we will have to fix these. We left it run in production for 1 week with some issues that were addressed. Confident we are now good to go.
Blast radius: Potentially large as we're caching auth

## Deploy Plan

- [ ] Deploy front