### PR TITLE
feat: microphone permission in extension

### DIFF
--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -192,6 +192,14 @@ export const getConfig = async ({
             to: path.join(buildDirPath, "main.html"),
           },
           {
+            from: resolvePath("../../ui/request-mic.html"),
+            to: path.join(buildDirPath, "request-mic.html"),
+          },
+          {
+            from: resolvePath("../../ui/request-mic.js"),
+            to: path.join(buildDirPath, "request-mic.js"),
+          },
+          {
             context: resolvePath("../../ui/images"),
             from: "**/*.png",
             to: path.resolve(buildDirPath, "images"),

--- a/extension/ui/request-mic.html
+++ b/extension/ui/request-mic.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Microphone Access</title>
+  </head>
+  <body>
+    <script src="request-mic.js"></script>
+  </body>
+</html>

--- a/extension/ui/request-mic.js
+++ b/extension/ui/request-mic.js
@@ -1,0 +1,17 @@
+// Chrome's side panel cannot display the microphone permission prompt.
+// To work around this, we open this page as a popup window, which can display the prompt.
+// Once the user grants (or dismisses) the permission, the popup closes itself.
+// The permission grant is tied to the extension origin (chrome-extension://...),
+// so it persists and is available to the side panel after this popup closes.
+navigator.mediaDevices
+  .getUserMedia({ audio: true })
+  .then((stream) => {
+    // Permission granted — immediately stop the stream since we only needed the grant,
+    // not an actual recording. The side panel will open its own stream after this.
+    stream.getTracks().forEach((track) => track.stop());
+    window.close();
+  })
+  .catch(() => {
+    // Permission dismissed or denied — close the popup anyway.
+    window.close();
+  });

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -1,6 +1,7 @@
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { isChromeExtension } from "@app/lib/utils/extension";
 import type { AugmentedMessage } from "@app/lib/utils/find_agents_in_message";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -12,6 +13,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 // A 1-minute recording will be around 400kB
 // 60 seconds * 48000bps / 8 => 360 000 bit, round up to 400kB
 const MAXIMUM_FILE_SIZE_FOR_INPUT_BAR_IN_BYTES = 400 * 1024;
+
+const MICROPHONE_POPUP_TIMEOUT_MS = 60_000; // 1 minute
 
 type VoiceTranscriberStatus =
   | "idle"
@@ -346,7 +349,70 @@ const buildAudioFile = (chunks: Blob[], mimeType: string) => {
   return new File([blob], filename, { type: mimeType });
 };
 
-const requestMicrophone = async (): Promise<MediaStream> => {
+const getMicrophonePermissionState = async (): Promise<PermissionState> => {
+  const status = await navigator.permissions.query({
+    name: "microphone",
+  });
+  return status.state;
+};
+
+const openMicrophoneAccessPopup = async (): Promise<void> => {
+  const createdWindow = await chrome.windows.create({
+    url: `chrome-extension://${chrome.runtime.id}/request-mic.html`,
+    type: "popup",
+    width: 400,
+    height: 400,
+  });
+
+  if (!createdWindow?.id) {
+    return;
+  }
+
+  const windowId = createdWindow.id;
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      chrome.windows.onRemoved.removeListener(onWindowClose);
+      chrome.windows.remove(windowId);
+      reject(new Error("Microphone access popup timed out"));
+    }, MICROPHONE_POPUP_TIMEOUT_MS);
+
+    function onWindowClose(closedWindowId: number) {
+      if (closedWindowId === windowId) {
+        clearTimeout(timeout);
+        chrome.windows.onRemoved.removeListener(onWindowClose);
+        resolve();
+      }
+    }
+
+    chrome.windows.onRemoved.addListener(onWindowClose);
+  });
+};
+
+const extensionRequestMicrophonePermission = async (): Promise<MediaStream> => {
+  const state = await getMicrophonePermissionState();
+
+  if (state === "denied") {
+    // Open extension settings so user can manually re-enable microphone
+    await chrome.tabs.create({
+      url: `chrome://settings/content/siteDetails?site=chrome-extension%3A%2F%2F${chrome.runtime.id}%2F`,
+    });
+    throw new DOMException("Microphone permission denied", "NotAllowedError");
+  }
+
+  if (state === "prompt") {
+    // Side panel can't show the prompt — fall back to popup window
+    await openMicrophoneAccessPopup();
+    return navigator.mediaDevices.getUserMedia({ audio: true });
+  }
+  // Permission is already granted
+  return navigator.mediaDevices.getUserMedia({ audio: true });
+};
+
+export const requestMicrophone = async (): Promise<MediaStream> => {
+  if (isChromeExtension()) {
+    return extensionRequestMicrophonePermission();
+  }
   return navigator.mediaDevices.getUserMedia({ audio: true });
 };
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6774

This PR implements microphone permission handling for the Chrome extension's side panel.

- Works around a Chrome bug where microphone permission prompts are silently dismissed in side panels by opening a temporary popup window to trigger the permission request
- Added `request-mic.html` and `request-mic.js` to handle the permission flow in a popup context  
- Implemented `extensionRequestMicrophonePermission()` that checks permission state and routes to appropriate flows (popup for prompt, settings page for denied, direct access for granted)



https://github.com/user-attachments/assets/1cad1bb0-fd60-4220-a9d7-6f00e3f7477c


## Tests

Manually tested.

## Risks

Low risk. The changes only affect the Chrome extension's microphone permission flow.

## Deploy Plan

Standard deployment.
