### PR TITLE
[front] - fix(snowflake): improve handling of snowflake warehouse configuration

### DIFF
--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -102,7 +102,7 @@ export class SnowflakeClient {
       const connectionOptions: ConnectionOptions = {
         // Replace any `_` with `-` in the account name for nginx proxy
         account: this.account.replace(/_/g, "-"),
-        warehouse: this.warehouse,
+        warehouse: this.warehouse || undefined,
 
         // Use proxy if defined to have all requests coming from the same IP.
         proxyHost: EnvironmentConfig.getOptionalEnvVariable("PROXY_HOST"),
@@ -184,16 +184,19 @@ export class SnowflakeClient {
         });
       });
 
-      // Explicitly set the warehouse - the connectionOptions.warehouse isn't always respected
-      try {
-        await this.runSql(
-          connection,
-          `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`
-        );
-      } catch (error) {
-        // Clean up connection on USE WAREHOUSE failure
-        await this.closeConnection(connection);
-        return new Err(normalizeError(error));
+      // Explicitly set the warehouse - the connectionOptions.warehouse isn't always respected.
+      // If no warehouse is configured, skip — Snowflake will use the user's default warehouse.
+      if (this.warehouse) {
+        try {
+          await this.runSql(
+            connection,
+            `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`
+          );
+        } catch (error) {
+          // Clean up connection on USE WAREHOUSE failure
+          await this.closeConnection(connection);
+          return new Err(normalizeError(error));
+        }
       }
 
       // Set query timeout to 2 minutes.

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -14,6 +14,7 @@ import { SnowflakeKeyPairCredentialsSchema } from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 
@@ -71,12 +72,13 @@ async function getClientFromAuthInfo(
   const warehouse = authInfo?.extra?.snowflake_warehouse;
   const token = authInfo?.token;
 
-  if (typeof account === "string" && typeof warehouse === "string" && token) {
+  if (typeof account === "string" && token) {
+    const warehouseStr = isString(warehouse) ? warehouse : "";
     return new Ok(
       new SnowflakeClient(
         account,
         { type: "oauth", token },
-        warehouse,
+        warehouseStr,
         queryTagMetadata
       )
     );

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -72,7 +72,7 @@ async function getClientFromAuthInfo(
   const warehouse = authInfo?.extra?.snowflake_warehouse;
   const token = authInfo?.token;
 
-  if (typeof account === "string" && token) {
+  if (isString(account) && token) {
     const warehouseStr = isString(warehouse) ? warehouse : "";
     return new Ok(
       new SnowflakeClient(

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -103,21 +103,21 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       throw new Error("Missing client ID for Snowflake");
     }
 
-    if (!extraConfig.snowflake_role) {
-      throw new Error("Missing Snowflake role");
-    }
-
     const account = extraConfig.snowflake_account;
-    const role = extraConfig.snowflake_role;
+    const role = isString(extraConfig.snowflake_role)
+      ? extraConfig.snowflake_role.trim()
+      : "";
 
-    // For Custom OAuth, use session:role:<ROLE> to specify the role.
-    // The role is set by admin as default, users can override during personal auth.
+    // For Custom OAuth, use session:role:<ROLE> to specify the role if provided.
+    // If no role is specified, use refresh_token scope to let Snowflake use the user's default role.
+    const scope = role ? `session:role:${role.toUpperCase()}` : "refresh_token";
+
     const qs = querystring.stringify({
       response_type: "code",
       client_id: clientId,
       state: connection.connection_id,
       redirect_uri: finalizeUriForProvider("snowflake"),
-      scope: `session:role:${role.toUpperCase()}`,
+      scope,
     });
 
     // Build account-specific authorization URL
@@ -139,13 +139,11 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       if (extraConfig.mcp_server_id) {
         return true;
       }
-      // Initial admin setup - requires full credentials including default role and warehouse
+      // Initial admin setup - requires client credentials and account; role and warehouse are optional
       return !!(
         extraConfig.client_id &&
         extraConfig.client_secret &&
-        extraConfig.snowflake_account &&
-        extraConfig.snowflake_role &&
-        extraConfig.snowflake_warehouse
+        extraConfig.snowflake_account
       );
     }
     return Object.keys(extraConfig).length === 0;
@@ -198,18 +196,16 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       snowflake_warehouse,
     } = extraConfig;
 
-    // Validate that all are strings before using them
+    // Validate required fields are strings
     if (
       !isString(client_secret) ||
       !isString(client_id) ||
-      !isString(snowflake_account) ||
-      !isString(snowflake_role) ||
-      !isString(snowflake_warehouse)
+      !isString(snowflake_account)
     ) {
       return new Err({
         code: "credential_retrieval_failed",
         message:
-          "Missing or invalid client_id, client_secret, snowflake_account, snowflake_role, or snowflake_warehouse in extraConfig",
+          "Missing or invalid client_id, client_secret, or snowflake_account in extraConfig",
       });
     }
 
@@ -218,8 +214,10 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
         client_secret,
         client_id,
         snowflake_account,
-        snowflake_role,
-        snowflake_warehouse,
+        snowflake_role: isString(snowflake_role) ? snowflake_role : "",
+        snowflake_warehouse: isString(snowflake_warehouse)
+          ? snowflake_warehouse
+          : "",
       },
       metadata: { workspace_id: workspaceId, user_id: userId },
     });
@@ -258,36 +256,29 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
           snowflake_warehouse: wsWarehouse,
         } = connectionResult.value.metadata;
 
-        if (
-          !isString(wsClientId) ||
-          !isString(wsAccount) ||
-          !isString(wsRole) ||
-          !isString(wsWarehouse)
-        ) {
+        if (!isString(wsClientId) || !isString(wsAccount)) {
           throw new Error(
             "Workspace connection is missing required Snowflake configuration. " +
               "Please ask an admin to reconfigure the MCP server connection."
           );
         }
 
-        // Use user-provided role if specified, otherwise use the default from workspace connection.
-        let role = wsRole;
         const trimmedUserRole = isString(userRole) ? userRole.trim() : "";
-        if (trimmedUserRole) {
-          if (!isValidSnowflakeRole(trimmedUserRole)) {
-            throw new Error(
-              `Invalid Snowflake role format: "${trimmedUserRole}". ` +
-                "Role must start with a letter or underscore and contain only alphanumeric characters and underscores."
-            );
-          }
-          role = trimmedUserRole;
+        if (trimmedUserRole && !isValidSnowflakeRole(trimmedUserRole)) {
+          throw new Error(
+            `Invalid Snowflake role format: "${trimmedUserRole}". ` +
+              "Role must start with a letter or underscore and contain only alphanumeric characters and underscores."
+          );
         }
+
+        // Use user-provided role if specified, otherwise fall back to workspace default.
+        const role = trimmedUserRole || (isString(wsRole) ? wsRole : "");
 
         return {
           client_id: wsClientId,
           snowflake_account: wsAccount,
           snowflake_role: role,
-          snowflake_warehouse: wsWarehouse,
+          snowflake_warehouse: isString(wsWarehouse) ? wsWarehouse : "",
         };
       }
     }
@@ -303,11 +294,18 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
   ): Promise<Result<void, { message: string }>> {
     const { snowflake_account, snowflake_warehouse } = connection.metadata;
 
-    if (!isString(snowflake_account) || !isString(snowflake_warehouse)) {
+    if (!isString(snowflake_account)) {
       return new Err({
-        message:
-          "Missing Snowflake account or warehouse configuration. Please try again.",
+        message: "Missing Snowflake account configuration. Please try again.",
       });
+    }
+
+    // If no warehouse is configured, skip warehouse validation — Snowflake will use the default
+    const warehouse = isString(snowflake_warehouse)
+      ? snowflake_warehouse.trim()
+      : "";
+    if (!warehouse) {
+      return new Ok(undefined);
     }
 
     // Get the access token
@@ -329,7 +327,7 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
     const testResult = await this.testWarehouseAccess(
       snowflake_account,
       accessToken,
-      snowflake_warehouse
+      warehouse
     );
 
     if (testResult.isErr()) {

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -300,13 +300,9 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       });
     }
 
-    // If no warehouse is configured, skip warehouse validation — Snowflake will use the default
     const warehouse = isString(snowflake_warehouse)
       ? snowflake_warehouse.trim()
       : "";
-    if (!warehouse) {
-      return new Ok(undefined);
-    }
 
     // Get the access token
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
@@ -323,11 +319,11 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
 
     const accessToken = accessTokenRes.value.access_token;
 
-    // Test the connection and warehouse access
-    const testResult = await this.testWarehouseAccess(
+    // Test the connection (and warehouse access if configured)
+    const testResult = await this.testConnectionAndWarehouse(
       snowflake_account,
       accessToken,
-      warehouse
+      warehouse || undefined
     );
 
     if (testResult.isErr()) {
@@ -340,12 +336,13 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
   }
 
   /**
-   * Test that the OAuth token can connect and use the specified warehouse.
+   * Test that the OAuth token can connect to Snowflake, and optionally
+   * verify access to the specified warehouse.
    */
-  private async testWarehouseAccess(
+  private async testConnectionAndWarehouse(
     account: string,
     accessToken: string,
-    warehouse: string
+    warehouse?: string
   ): Promise<Result<void, Error>> {
     // Configure SDK to suppress verbose logging
     snowflake.configure({ logLevel: "OFF" });
@@ -369,29 +366,31 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
         });
       });
 
-      // Try to use the warehouse
-      try {
-        await new Promise<void>((resolve, reject) => {
-          connection.execute({
-            sqlText: `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`,
-            complete: (err: SnowflakeError | undefined) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            },
+      // Try to use the warehouse if one is configured
+      if (warehouse) {
+        try {
+          await new Promise<void>((resolve, reject) => {
+            connection.execute({
+              sqlText: `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`,
+              complete: (err: SnowflakeError | undefined) => {
+                if (err) {
+                  reject(err);
+                } else {
+                  resolve();
+                }
+              },
+            });
           });
-        });
-      } catch {
-        // Clean up connection
-        connection.destroy(() => {});
-        return new Err(
-          new Error(
-            `The role does not have access to warehouse "${warehouse}". ` +
-              `Please ensure the role has USAGE privilege on the warehouse, or choose a different warehouse.`
-          )
-        );
+        } catch {
+          // Clean up connection
+          connection.destroy(() => {});
+          return new Err(
+            new Error(
+              `The role does not have access to warehouse "${warehouse}". ` +
+                `Please ensure the role has USAGE privilege on the warehouse, or choose a different warehouse.`
+            )
+          );
+        }
       }
 
       // Clean up connection

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -415,9 +415,10 @@ export function getProviderRequiredOAuthCredentialInputs({
             value: undefined,
             helpMessage:
               useCase === "platform_actions"
-                ? "The Snowflake role for all users (e.g., ANALYST)."
-                : "The default Snowflake role (e.g., ANALYST). Users can override this during their personal authentication.",
-            validator: isValidSnowflakeRole,
+                ? "Optional. The Snowflake role for all users (e.g., ANALYST). If empty, Snowflake uses the user's default role."
+                : "Optional. The default Snowflake role (e.g., ANALYST). If empty, Snowflake uses the user's default role. Users can override this during their personal authentication.",
+            validator: (s: unknown) =>
+              isOptionalSnowflakeIdentifier(s, isValidSnowflakeRole),
             overridableAtPersonalAuth: true,
             personalAuthLabel: "Snowflake Role",
             personalAuthHelpMessage:
@@ -426,8 +427,10 @@ export function getProviderRequiredOAuthCredentialInputs({
           snowflake_warehouse: {
             label: "Snowflake Warehouse",
             value: undefined,
-            helpMessage: "The warehouse to use for queries (e.g., COMPUTE_WH).",
-            validator: isValidSnowflakeWarehouse,
+            helpMessage:
+              "Optional. The warehouse to use for queries (e.g., COMPUTE_WH). If empty, Snowflake uses the user's default warehouse.",
+            validator: (s: unknown) =>
+              isOptionalSnowflakeIdentifier(s, isValidSnowflakeWarehouse),
           },
         };
         return result;
@@ -549,24 +552,36 @@ export function isValidSnowflakeAccount(s: unknown): s is string {
   return /^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$/.test(v);
 }
 
+const SNOWFLAKE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export function isValidSnowflakeRole(s: unknown): s is string {
-  // Snowflake role names are uppercase identifiers
-  // Allow alphanumeric and underscores
   return (
     typeof s === "string" &&
     s.trim().length > 0 &&
-    /^[A-Za-z_][A-Za-z0-9_]*$/.test(s.trim())
+    SNOWFLAKE_IDENTIFIER_REGEX.test(s.trim())
   );
 }
 
 export function isValidSnowflakeWarehouse(s: unknown): s is string {
-  // Snowflake warehouse names follow same rules as roles
-  // Allow alphanumeric and underscores
   return (
     typeof s === "string" &&
     s.trim().length > 0 &&
-    /^[A-Za-z_][A-Za-z0-9_]*$/.test(s.trim())
+    SNOWFLAKE_IDENTIFIER_REGEX.test(s.trim())
   );
+}
+
+/**
+ * Validator that accepts empty/falsy values or a valid Snowflake identifier.
+ * Used for optional fields like role and warehouse in OAuth config.
+ */
+export function isOptionalSnowflakeIdentifier(
+  s: unknown,
+  validator: (s: unknown) => boolean
+): boolean {
+  if (!s || (typeof s === "string" && s.trim() === "")) {
+    return true;
+  }
+  return validator(s);
 }
 
 // Credentials Providers


### PR DESCRIPTION
## Description

This PR: 
- Make Snowflake OAuth Role and Warehouse fields truly optional, matching the UI labels
- When left empty, Snowflake uses the user's default role/warehouse instead of failing
- OAuth scope falls back to refresh_token (Snowflake default role + offline access) when no role is specified
- USE WAREHOUSE commands are skipped when warehouse is empty
- Post-finalize validation still verifies the OAuth token connects successfully, even when no warehouse is configured

**References:**
- Fixes https://github.com/dust-tt/tasks/issues/6861

## Tests



## Risk

Low

## Deploy Plan

Deploy front
