### PR TITLE
[sparkle] fix(`DataTable`): add memo in column filter

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -52,7 +52,13 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import React, { type ReactNode, useEffect, useRef, useState } from "react";
+import React, {
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { breakpoints, useWindowSize } from "./WindowUtility";
 
@@ -142,9 +148,10 @@ export function DataTable<TData extends TBaseData>({
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
-  const columnFilters: ColumnFiltersState = filterColumn
-    ? [{ id: filterColumn, value: filter }]
-    : [];
+  const columnFilters: ColumnFiltersState = useMemo(
+    () => (filterColumn ? [{ id: filterColumn, value: filter }] : []),
+    [filterColumn, filter]
+  );
 
   const isServerSidePagination = !!totalRowCount && totalRowCount > data.length;
   const isClientSideSortingEnabled =


### PR DESCRIPTION
## Description

- See [thread](https://dust4ai.slack.com/archives/C0AHD9R5NLB/p1772199308355689).
- According to the documentation [here](https://tanstack.com/table/v8/docs/guide/data#give-data-a-stable-reference), we have to give a stable reference to the table. https://github.com/dust-tt/dust/pull/22352 changed the column filter from a state to a js variable that changes reference (underlying data staying the same, but pointer changes) on every re-render. This PR makes it stable with a `useMemo`.

## Tests

- Tested locally.

## Risk

## Deploy Plan

- Deploy front.