### PR TITLE
[Agent Email] Update production email domain to dust.team

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -188,7 +188,7 @@ export async function deleteEmailReplyContext(
 
 export const ASSISTANT_EMAIL_SUBDOMAIN = isDevelopment()
   ? "dev.dust.help"
-  : "run.dust.help";
+  : "dust.team";
 
 export type EmailAttachment = {
   filepath: string; // Temp file path from formidable


### PR DESCRIPTION
## Description

Update the production email domain from `run.dust.help` to `dust.team` for agent-triggered email conversations. This aligns the codebase with the new SendGrid Inbound Parse configuration.

Dev environment (`dev.dust.help`) is unchanged.

## Risks

Blast radius: all email-triggered agent conversations (currently gated to @dust.tt senders)
Risk: low

## Deploy Plan
- deploy front