### PR TITLE
[front] - refactor(AddToolsMenu): move search bar to dropdown header

### DIFF
--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -67,27 +67,30 @@ export const AddToolsMenu = ({
         className="w-96"
         align="end"
         mountPortalContainer={portalContainer}
+        dropdownHeaders={
+          <DropdownMenuSearchbar
+            autoFocus
+            placeholder="Search tools..."
+            name="search"
+            value={searchText}
+            onChange={setSearchText}
+            disabled={isAvailableMCPServersLoading}
+            button={
+              <Button
+                icon={PlusIcon}
+                label="Add MCP Server"
+                // Empty call is required given onClick passes a MouseEvent
+                onClick={withTracking(
+                  TRACKING_AREAS.TOOLS,
+                  "add_mcp_server",
+                  () => createRemoteMCPServer()
+                )}
+                size="sm"
+              />
+            }
+          />
+        }
       >
-        <DropdownMenuSearchbar
-          placeholder="Search tools..."
-          name="search"
-          value={searchText}
-          onChange={setSearchText}
-          disabled={isAvailableMCPServersLoading}
-          button={
-            <Button
-              icon={PlusIcon}
-              label="Add MCP Server"
-              // Empty call is required given onClick passes a MouseEvent
-              onClick={withTracking(
-                TRACKING_AREAS.TOOLS,
-                "add_mcp_server",
-                () => createRemoteMCPServer()
-              )}
-              size="sm"
-            />
-          }
-        />
         {isAvailableMCPServersLoading && (
           <div className="flex justify-center py-4">
             <Spinner size="sm" />{" "}


### PR DESCRIPTION
## Description

Refactors the `AddToolsMenu` component to move the search bar into the dropdown header using the `dropdownHeaders` prop. This creates a cleaner, more consistent UI where the search bar remains fixed at the top of the dropdown, following the same pattern already used in `SpaceManagedActionsViewsModal`

## Risk

Low

## Tests

Locally

## Deploy Plan

Deploy front
