### PR TITLE
[front] fix name conflict check on MCP server creation

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -155,6 +155,18 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     const viewJson = systemView.toJSON();
     const name = viewJson.name ?? viewJson.server.name;
 
+    return this.hasNameConflictInSpaceByName(auth, name, space);
+  }
+
+  /**
+   * Check whether a view with the given name already exists in the target
+   * space. This variant can be called before the server/view is created.
+   */
+  static async hasNameConflictInSpaceByName(
+    auth: Authenticator,
+    name: string,
+    space: SpaceResource
+  ): Promise<{ hasConflict: boolean; name: string }> {
     const existingViews = await this.listBySpace(auth, space);
     const hasConflict = existingViews.some((v) => {
       const view = v.toJSON();

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -233,6 +233,29 @@ async function handler(
             });
           }
 
+          // Check for name conflicts before creating the server.
+          if (body.includeGlobal) {
+            const globalSpace =
+              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
+            const { hasConflict } =
+              await MCPServerViewResource.hasNameConflictInSpaceByName(
+                auth,
+                name,
+                globalSpace
+              );
+
+            if (hasConflict) {
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: `An existing Tool is already using the name "${name}"`,
+                },
+              });
+            }
+          }
+
           const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(
             auth,
             {
@@ -300,29 +323,9 @@ async function handler(
               });
             }
 
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
-            const { hasConflict, name } =
-              await MCPServerViewResource.hasNameConflictInSpace(
-                auth,
-                systemView,
-                globalSpace
-              );
-
-            if (hasConflict) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: `An existing Tool is already using the name "${name}"`,
-                },
-              });
-            }
-
             await MCPServerViewResource.create(auth, {
               systemView,
-              space: globalSpace,
+              space: await SpaceResource.fetchWorkspaceGlobalSpace(auth),
             });
           }
 
@@ -363,6 +366,29 @@ async function handler(
                   type: "invalid_request_error",
                   message:
                     "This internal tool has already been added and only one instance is allowed.",
+                },
+              });
+            }
+          }
+
+          // Check for name conflicts before creating the server.
+          if (body.includeGlobal) {
+            const globalSpace =
+              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
+            const { hasConflict } =
+              await MCPServerViewResource.hasNameConflictInSpaceByName(
+                auth,
+                name,
+                globalSpace
+              );
+
+            if (hasConflict) {
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: `An existing Tool is already using the name "${name}"`,
                 },
               });
             }
@@ -441,23 +467,6 @@ async function handler(
                   type: "invalid_request_error",
                   message:
                     "Missing system view for internal MCP server, it should have been created when creating the internal server.",
-                },
-              });
-            }
-
-            const { hasConflict, name } =
-              await MCPServerViewResource.hasNameConflictInSpace(
-                auth,
-                systemView,
-                globalSpace
-              );
-
-            if (hasConflict) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: `An existing Tool is already using the name "${name}"`,
                 },
               });
             }


### PR DESCRIPTION
## Description

- Fix duplicate MCP server views being created despite the name conflict check returning an error 
- The name conflict check was running after the server resource was already persisted, so when includeGlobal was true and a conflict existed, the API returned 400 but the server was already in the DB
- Added hasNameConflictInSpaceByName to check by name string before the server exists, and moved the conflict check before makeNew for both remote and internal server creation flows.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
