### PR TITLE
[ON-CALL] Skip cache look ups for empty docs

### DIFF
--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -896,7 +896,9 @@ impl DataSource {
         let now = utils::now();
         let mut embeddings: HashMap<String, EmbedderVector> = HashMap::new();
 
-        if use_cache {
+        // Only look for cached embeddings if we have chunks and caching is enabled.
+        // This avoids expensive scroll operations on empty documents.
+        if use_cache && !splits_with_hash.is_empty() {
             let mut page_offset: Option<PointId> = None;
             loop {
                 let scroll_results = qdrant_client


### PR DESCRIPTION
## Description

**Fix: Prevent timeout on empty document upserts by skipping cache lookup**

Temporal workflows for document upserts were timing out with this error:

```
Upsert error: Failed to upsert document 
(error: Error scrolling points: The operation was cancelled Timeout expired)
```

Impact: Multiple workflows failing across different workspaces and data sources:

- Google Drive data source
- OneDrive data source

Root Cause

When upserting a document, the system performs an embedding cache optimization:

Before computing new embeddings, it scrolls through QDrant to find existing embeddings for unchanged text chunks

Purpose: Reuse embeddings for unchanged text to save embedding API costs

The problem: For empty documents (0 bytes content), it still tries to scroll through ALL historical chunks in QDrant

What was happening:

```
// Before: Always looked for cached embeddings when use_cache=true
if use_cache {
    // Scroll through potentially thousands of historical QDrant points
    // Even when the new document has 0 chunks to embed!
    loop { ... }
}
```

Documents that were deleted or emptied in Google Drive/OneDrive still had thousands of embedding chunks from previous versions in QDrant. The system was timing out trying to retrieve all these chunks, only to realize it didn't need any of them.

Solution
One line fix - Skip cache lookup when there are no chunks to embed:

```
// After: Only look for cached embeddings if we have chunks
if use_cache && !splits_with_hash.is_empty() {
    loop { ... }
}
```

Why This Works
The cache lookup is an optimization to avoid recomputing embeddings. If splits_with_hash.is_empty(), it means:

The document has 0 text content after splitting
We have 0 chunks to embed
Therefore, we need 0 cached embeddings
Conclusion: Skip the entire cache lookup
This prevents the expensive QDrant scroll operation that was timing out.

## Tests

no

## Risk

low

## Deploy Plan

core
