### PR TITLE
Cleaned workspace selection

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -487,7 +487,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
  * Authenticate the user using WorkOS.
  */
 const authenticate = async (
-  { connection }: AuthBackgroundMessage,
+  { connection, organizationId }: AuthBackgroundMessage,
   sendResponse: (
     auth: OAuthAuthorizeResponse | AuthBackgroundResponseError
   ) => void
@@ -503,6 +503,7 @@ const authenticate = async (
   const options: Record<string, string> = {
     redirect_uri: redirectUrl,
     workspaceId: workspaceId,
+    ...(organizationId ? { organizationId } : {}),
   };
 
   const queryString = new URLSearchParams(options).toString();

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -16,6 +16,7 @@ export type AuthBackgroundResponseSuccess = {
 export type AuthBackgroundMessage = {
   type: "AUTHENTICATE" | "REFRESH_TOKEN" | "LOGOUT" | "SIGN_CONNECT";
   connection?: string;
+  organizationId?: string;
   refreshToken?: string;
 };
 
@@ -77,12 +78,14 @@ const sendMessage = <T, U>(message: T): Promise<U> => {
  */
 
 export const sendAuthMessage = (
-  connection?: string
+  connection?: string,
+  organizationId?: string
 ): Promise<OAuthAuthorizeResponse | AuthBackgroundResponseError> => {
   return new Promise((resolve, reject) => {
     const message: AuthBackgroundMessage = {
       type: "AUTHENTICATE",
       connection,
+      organizationId,
     };
     chrome.runtime.sendMessage(
       message,

--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -59,9 +59,15 @@ export class ChromeAuthService extends AuthService {
 
   // Login sends a message to the background script to call the workos login endpoint.
   // It saves the tokens and auth metadata (regionInfo, connectionDetails).
-  async login({ forcedConnection }: { forcedConnection?: string }) {
+  async login({
+    forcedConnection,
+    organizationId,
+  }: {
+    forcedConnection?: string;
+    organizationId?: string;
+  }) {
     try {
-      const response = await sendAuthMessage(forcedConnection);
+      const response = await sendAuthMessage(forcedConnection, organizationId);
       if (!response.success) {
         log(`Authentication error: ${response.error}`);
         throw new Error(response.error);

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -100,7 +100,13 @@ export class FrontAuthService extends AuthService {
     return result.data;
   }
 
-  async login({ forcedConnection }: { forcedConnection?: string }) {
+  async login({
+    forcedConnection,
+    organizationId,
+  }: {
+    forcedConnection?: string;
+    organizationId?: string;
+  }) {
     const { codeVerifier, codeChallenge } = await generatePKCE();
 
     // Store code verifier for later use
@@ -114,6 +120,7 @@ export class FrontAuthService extends AuthService {
         code_challenge: codeChallenge,
         provider: "authkit",
         connection: forcedConnection ?? "",
+        ...(organizationId ? { organizationId } : {}),
       };
 
       const result = await this.openAuthPopup(options);

--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -105,6 +105,7 @@ export abstract class AuthService {
   // Abstract methods that must be implemented by platform-specific services
   abstract login(args: {
     forcedConnection?: string;
+    organizationId?: string;
   }): Promise<Result<LoginResult, AuthError>>;
 
   abstract logout(): Promise<boolean>;

--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -18,9 +18,9 @@ type ExtensionAuthContextType = {
   workspace: WorkspaceType | undefined;
   isUserSetup: boolean;
   isLoading: boolean;
-  handleLogin: () => void;
+  handleLogin: (args?: { organizationId?: string }) => void;
   handleLogout: () => void;
-  handleSelectWorkspace: (workspace: WorkspaceType) => void;
+  handleSelectOrganization: (organizationId: string) => void;
 };
 
 const ExtensionAuthContext = createContext<ExtensionAuthContextType | null>(
@@ -110,7 +110,7 @@ export function ExtensionAuthProvider({
     isLoading,
     handleLogin,
     handleLogout,
-    handleSelectWorkspace,
+    handleSelectOrganization,
     featureFlags,
   } = useAuthHook();
 
@@ -127,7 +127,7 @@ export function ExtensionAuthProvider({
       isLoading,
       handleLogin,
       handleLogout,
-      handleSelectWorkspace,
+      handleSelectOrganization,
     }),
     [
       token,
@@ -141,7 +141,7 @@ export function ExtensionAuthProvider({
       isLoading,
       handleLogin,
       handleLogout,
-      handleSelectWorkspace,
+      handleSelectOrganization,
     ]
   );
 

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -4,13 +4,9 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { WorkspaceType } from "@dust-tt/client";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
-import type {
-  ConnectionDetails,
-  StoredTokens,
-} from "@extension/shared/services/auth";
+import type { StoredTokens } from "@extension/shared/services/auth";
 import {
   AuthError,
-  isValidEnterpriseConnection,
   makeEnterpriseConnectionName,
 } from "@extension/shared/services/auth";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -22,12 +18,8 @@ export const useAuthHook = () => {
   const platform = usePlatform();
 
   const [tokens, setTokens] = useState<StoredTokens | null>(null);
-  const [connectionDetails, setConnectionDetails] =
-    useState<ConnectionDetails | null>(null);
-  const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(
-    null
-  );
   const [user, setUser] = useState<UserTypeWithWorkspaces | null>(null);
+  const [workspace, setWorkspace] = useState<WorkspaceType | undefined>();
   const [authError, setAuthError] = useState<AuthError | null>(null);
   const [forcedConnection, setForcedConnection] = useState<
     string | undefined
@@ -40,17 +32,10 @@ export const useAuthHook = () => {
     [tokens]
   );
 
-  const isUserSetup = !!(user && user.sId && selectedWorkspace);
+  const isUserSetup = !!(user && user.sId && workspace);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [isUserLoading, setIsUserLoading] = useState<boolean>(false);
 
   const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
-
-  // Derive workspace from user workspaces + selectedWorkspace
-  const workspace = useMemo(
-    () => user?.workspaces.find((w) => w.sId === selectedWorkspace),
-    [user, selectedWorkspace]
-  );
 
   const handleLogout = useCallback(async () => {
     setIsLoading(true);
@@ -60,8 +45,7 @@ export const useAuthHook = () => {
       return;
     }
     setTokens(null);
-    setConnectionDetails(null);
-    setSelectedWorkspace(null);
+    setWorkspace(undefined);
     setUser(null);
     setAuthError(null);
     setForcedConnection(undefined);
@@ -114,7 +98,6 @@ export const useAuthHook = () => {
       return;
     }
 
-    setIsUserLoading(true);
     void (async () => {
       try {
         const res = await clientFetch("/api/user", {
@@ -126,49 +109,41 @@ export const useAuthHook = () => {
           const fetchedUser = data.user as UserTypeWithWorkspaces;
           setUser(fetchedUser);
 
-          // If user has a selectedWorkspace from the server (org-scoped login),
-          // and we don't have one stored, use it.
-          if (!selectedWorkspace && fetchedUser.selectedWorkspace) {
-            setSelectedWorkspace(fetchedUser.selectedWorkspace);
-            await platform.storage.set(
-              "selectedWorkspace",
-              fetchedUser.selectedWorkspace
-            );
+          const ws = fetchedUser.selectedWorkspace
+            ? fetchedUser.workspaces.find(
+                (w) => w.sId === fetchedUser.selectedWorkspace
+              )
+            : fetchedUser.workspaces[0];
+          setWorkspace(ws);
+          if (ws) {
+            await platform.storage.set("selectedWorkspace", ws.sId);
           }
         }
       } finally {
-        setIsUserLoading(false);
+        setIsLoading(false);
       }
     })();
   }, [isAuthenticated, tokens?.accessToken]);
 
   // Initialize from storage on mount.
   // RegionContext already restores region info from localStorage, so we only
-  // need to restore tokens, connection details, and selected workspace here.
+  // need to restore tokens here.
   useEffect(() => {
     void (async () => {
-      setIsLoading(true);
-
       const storedTokens = await platform.auth.getStoredTokens();
-      const storedConnectionDetails =
-        await platform.auth.getConnectionDetailsFromStorage();
-      const storedSelectedWorkspace =
-        await platform.auth.getSelectedWorkspace();
 
       if (!storedTokens) {
         setIsLoading(false);
         return;
       }
       setTokens(storedTokens);
-      setConnectionDetails(storedConnectionDetails);
-      setSelectedWorkspace(storedSelectedWorkspace);
 
       // Token refresh.
       if (storedTokens.expiresAt < Date.now() + PROACTIVE_REFRESH_WINDOW_MS) {
         await handleRefreshToken();
       }
 
-      setIsLoading(false);
+      // isLoading stays true — the user fetch effect will clear it.
     })();
 
     return () => {
@@ -216,59 +191,36 @@ export const useAuthHook = () => {
     [setAuthError, setForcedConnection]
   );
 
-  const handleSelectWorkspace = async (workspace: WorkspaceType) => {
-    await platform.storage.set("selectedWorkspace", workspace.sId);
-    setSelectedWorkspace(workspace.sId);
-
-    if (
-      connectionDetails &&
-      !isValidEnterpriseConnection(connectionDetails, workspace)
-    ) {
-      await redirectToSSOLogin(workspace);
-    }
-  };
-
-  const handleLogin = useCallback(async () => {
-    setIsLoading(true);
-    const response = await platform.auth.login({
-      forcedConnection,
-    });
-    if (response.isErr()) {
-      setAuthError(response.error);
-      setIsLoading(false);
-      void platform.clearStoredData();
-      return;
-    }
-
-    const {
-      tokens: newTokens,
-      regionInfo: newRegionInfo,
-      connectionDetails: newConnectionDetails,
-    } = response.value;
-
-    // Restore selectedWorkspace from storage if available.
-    const storedSelectedWorkspace = await platform.auth.getSelectedWorkspace();
-
-    if (storedSelectedWorkspace && user) {
-      const selectedWs = user.workspaces.find(
-        (w) => w.sId === storedSelectedWorkspace
-      );
-      if (
-        selectedWs &&
-        !isValidEnterpriseConnection(newConnectionDetails, selectedWs)
-      ) {
-        await redirectToSSOLogin(selectedWs);
+  const handleLogin = useCallback(
+    async (args?: { organizationId?: string }) => {
+      setIsLoading(true);
+      const response = await platform.auth.login({
+        forcedConnection,
+        organizationId: args?.organizationId,
+      });
+      if (response.isErr()) {
+        setAuthError(response.error);
         setIsLoading(false);
+        void platform.clearStoredData();
         return;
       }
-    }
 
-    setTokens(newTokens);
-    setRegionInfo(newRegionInfo);
-    setConnectionDetails(newConnectionDetails);
-    setAuthError(null);
-    setIsLoading(false);
-  }, [forcedConnection, user]);
+      const { tokens: newTokens, regionInfo: newRegionInfo } = response.value;
+
+      setTokens(newTokens);
+      setRegionInfo(newRegionInfo, { keepInStorage: true });
+      setAuthError(null);
+      // isLoading stays true — the user fetch effect will clear it.
+    },
+    [forcedConnection]
+  );
+
+  const handleSelectOrganization = useCallback(
+    async (organizationId: string) => {
+      await handleLogin({ organizationId });
+    },
+    [handleLogin]
+  );
 
   return {
     token: tokens?.accessToken ?? null,
@@ -279,10 +231,10 @@ export const useAuthHook = () => {
     user,
     workspace,
     isUserSetup,
-    isLoading: isLoading || isUserLoading,
+    isLoading,
     handleLogin,
     handleLogout,
-    handleSelectWorkspace,
+    handleSelectOrganization,
     featureFlags,
   };
 };

--- a/extension/ui/components/navigation/UserDropdownMenu.tsx
+++ b/extension/ui/components/navigation/UserDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import { WorkspacePickerRadioGroup } from "@app/components/WorkspacePicker";
 import {
   Avatar,
   DropdownMenu,
@@ -15,11 +16,17 @@ import {
 } from "@dust-tt/sparkle";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useTheme } from "@extension/ui/hooks/useTheme";
+import { useMemo } from "react";
 
 export const UserDropdownMenu = () => {
   const { theme, updateTheme } = useTheme();
-  const { user, workspace, handleLogout, handleSelectWorkspace } =
+  const { user, workspace, handleLogout, handleSelectOrganization } =
     useExtensionAuth();
+
+  const hasMultipleOrgs = useMemo(
+    () => !!user?.organizations && user.organizations.length > 1,
+    [user]
+  );
 
   if (!user) {
     return null;
@@ -44,21 +51,14 @@ export const UserDropdownMenu = () => {
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        {workspace && (
+        {hasMultipleOrgs && workspace && (
           <>
             <DropdownMenuLabel label="Workspace" />
-            <DropdownMenuRadioGroup value={workspace.sId}>
-              {user.workspaces.map((w) => {
-                return (
-                  <DropdownMenuRadioItem
-                    key={w.sId}
-                    onClick={() => void handleSelectWorkspace(w)}
-                    label={w.name}
-                    value={w.sId}
-                  />
-                );
-              })}
-            </DropdownMenuRadioGroup>
+            <WorkspacePickerRadioGroup
+              user={user}
+              workspace={workspace}
+              onSelectOrganization={handleSelectOrganization}
+            />
           </>
         )}
         <DropdownMenuLabel label="Preferences" />

--- a/extension/ui/pages/LoginPage.tsx
+++ b/extension/ui/pages/LoginPage.tsx
@@ -1,11 +1,6 @@
 import {
   Button,
-  ChevronDownIcon,
   cn,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   DustLogo,
   LoginIcon,
   Page,
@@ -23,7 +18,6 @@ export const LoginPage = () => {
     authError,
     isUserSetup,
     handleLogin,
-    handleSelectWorkspace,
     isLoading,
     handleLogout,
   } = useExtensionAuth();
@@ -122,42 +116,6 @@ export const LoginPage = () => {
           </Link>
           .
         </p>
-      </div>
-    );
-  }
-
-  if (isAuthenticated && !isUserSetup && user?.workspaces.length) {
-    return (
-      <div
-        className={cn(
-          "flex h-screen flex-col gap-2 p-4",
-          "bg-background text-foreground",
-          "dark:bg-background-night dark:text-foreground-night"
-        )}
-      >
-        <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center">
-          <Page.SectionHeader title="Almost there!" />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                label="Pick a workspace"
-                variant="outline"
-                icon={ChevronDownIcon}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {user.workspaces.map((w) => {
-                return (
-                  <DropdownMenuItem
-                    key={w.sId}
-                    onClick={() => void handleSelectWorkspace(w)}
-                    label={w.name}
-                  />
-                );
-              })}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
       </div>
     );
   }

--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -18,11 +18,15 @@ import {
 interface WorkspacePickerRadioGroupProps {
   user: UserTypeWithWorkspaces;
   workspace: LightWorkspaceType;
+  onSelectOrganization?: (organizationId: string) => void;
+  onSelectWorkspace?: (workspaceSId: string) => void;
 }
 
 export const WorkspacePickerRadioGroup = ({
   user,
   workspace,
+  onSelectOrganization,
+  onSelectWorkspace,
 }: WorkspacePickerRadioGroupProps) => {
   const router = useAppRouter();
 
@@ -40,9 +44,13 @@ export const WorkspacePickerRadioGroup = ({
                 value={org.externalId || ""}
                 onClick={async () => {
                   if (org.externalId && org.externalId !== workspace.sId) {
-                    await router.push(
-                      `${config.getApiBaseUrl()}/api/workos/login?organizationId=${org.id}`
-                    );
+                    if (onSelectOrganization) {
+                      onSelectOrganization(org.id);
+                    } else {
+                      await router.push(
+                        `${config.getApiBaseUrl()}/api/workos/login?organizationId=${org.id}`
+                      );
+                    }
                   }
                 }}
               >
@@ -58,7 +66,11 @@ export const WorkspacePickerRadioGroup = ({
                   value={ws.sId}
                   onClick={async () => {
                     if (ws.sId !== workspace.sId) {
-                      await router.push(`/w/${ws.sId}/`);
+                      if (onSelectWorkspace) {
+                        onSelectWorkspace(ws.sId);
+                      } else {
+                        await router.push(`/w/${ws.sId}/`);
+                      }
                     }
                   }}
                 >


### PR DESCRIPTION
## Description

Refactors workspace selection in the Chrome extension:

- **Remove manual workspace picker**: The old "Almost there! Pick a workspace" screen and `handleSelectWorkspace` are removed. The workspace is now auto-selected from `selectedWorkspace` returned by `/api/user` (org-scoped login), falling back to the first workspace.
- **Add org-targeted re-login**: When users with multiple orgs switch workspace from the dropdown, the extension re-authenticates with the target `organizationId` via WorkOS (no manual login prompt).
- **Replace `WorkspacePicker` with `WorkspacePickerRadioGroup`**: Uses the shared component from `@app/components/WorkspacePicker` in the user dropdown.
- **Remove `connectionDetails` state**: Was only used by the removed `handleSelectWorkspace`/`isValidEnterpriseConnection` logic.
- **Fix loading state race conditions**: Merged `isLoading` and `isUserLoading` into a single `isLoading` state that stays `true` from mount until the `/api/user` fetch completes, preventing flash of error page on extension reopen.
- **Persist region info to localStorage**: `setRegionInfo` now called with `keepInStorage: true` so `clientFetch` has the correct base URL after extension reopen.

## Tests

Manual testing:
- Fresh login → auto-selects workspace → navigates to main page
- Close/reopen extension → restores session without error flash
- Org switch from dropdown → seamless re-login to different org

## Risk

Low — changes are scoped to the extension auth flow. No server-side changes.

## Deploy Plan

Standard extension deploy.