### PR TITLE
Auto scroll to first suggestion of each batch when loaded

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -130,6 +130,7 @@ function CopilotSuggestionsProviderContent({
   const editorRef = useRef<Editor | null>(null);
   const appliedSuggestionsRef = useRef<Set<string>>(new Set());
   const refetchAttemptedRef = useRef<Set<string>>(new Set());
+  const prevSuggestionCountRef = useRef(0);
 
   // Local state for processed (accepted/rejected/outdated) suggestions - prevents card "blink"
   const [processedSuggestions, setProcessedSuggestions] = useState<
@@ -482,7 +483,7 @@ function CopilotSuggestionsProviderContent({
   );
 
   const scrollToNextSuggestion = useCallback(
-    (acceptedSuggestionId: string) => {
+    (acceptedSuggestionId?: string) => {
       const editor = editorRef.current;
       const pendingInstructions = getPendingSuggestions().filter(
         (s) => s.kind === "instructions" && s.sId !== acceptedSuggestionId
@@ -685,6 +686,25 @@ function CopilotSuggestionsProviderContent({
     // Get HTML and strip styling attributes while preserving data-block-id.
     return stripHtmlAttributes(editor.getHTML());
   }, []);
+
+  // Auto-scroll to the first suggestion when new suggestions are applied
+  useEffect(() => {
+    const pendingInstructions = suggestions.filter(
+      (s) =>
+        s.state === "pending" &&
+        s.kind === "instructions" &&
+        appliedSuggestionsRef.current.has(s.sId)
+    );
+
+    const currentCount = pendingInstructions.length;
+    const prevCount = prevSuggestionCountRef.current;
+
+    // Only auto-scroll when we transition from 0 to >0 suggestions (new batch arrived)
+    if (prevCount === 0 && currentCount > 0) {
+      scrollToNextSuggestion();
+    }
+    prevSuggestionCountRef.current = currentCount;
+  }, [scrollToNextSuggestion, suggestions]);
 
   const value: CopilotSuggestionsContextType = useMemo(
     () => ({


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/6788
## Description
We want to auto-scroll to the first suggestion in a batch when it is populated. This reuses the "scrollToNextSuggestion" logic and just fires that callback when a new batch of pending suggestions comes through
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
