### PR TITLE
Stop redirecting logged-in users from home page to app

### DIFF
--- a/front/lib/swr/website.ts
+++ b/front/lib/swr/website.ts
@@ -1,19 +1,29 @@
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
-import type { Fetcher } from "swr";
+
+// A fetcher that does NOT redirect to login on auth errors.
+// The global fetcher in fetcher.ts redirects to /api/workos/login on
+// "not_authenticated" responses, which is correct for the app but wrong for the
+// public website — visitors with a stale session cookie should just see the
+// landing page, not be forced through the login flow.
+async function landingFetcher(
+  url: string
+): Promise<GetNoWorkspaceAuthContextResponseType> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  }
+  return res.json();
+}
 
 export function useLandingAuthContext({
   hasSessionCookie,
 }: {
   hasSessionCookie: boolean;
 }) {
-  const { fetcher } = useFetcher();
-  const authContextFetcher: Fetcher<GetNoWorkspaceAuthContextResponseType> =
-    fetcher;
-
   const { data, error } = useSWRWithDefaults(
     "/api/auth-context",
-    authContextFetcher,
+    landingFetcher,
     {
       disabled: !hasSessionCookie,
       shouldRetryOnError: false,

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -1,11 +1,6 @@
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
-import config from "@app/lib/api/config";
-import { getSession } from "@app/lib/auth";
-import {
-  getUserFromSession,
-  makeGetServerSidePropsRequirementsWrapper,
-} from "@app/lib/iam/session";
+import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { Landing } from "@app/pages/home";
 import type { ReactElement } from "react";
 
@@ -15,31 +10,8 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 })<{
   postLoginReturnToUrl: string;
 }>(async (context) => {
-  const session = await getSession(context.req, context.res);
-  const user = await getUserFromSession(session);
-
   const { inviteToken } = context.query;
 
-  // We keep redirecting to the app if user is authenticated and has workspaces.
-  // This is to keep previous behavior and users using https://dust.tt ,
-  // but we should consider keeping https://dust.tt as a landing page.
-  if (user && user.workspaces.length > 0) {
-    // Authenticated user: redirect to the SPA, forwarding query params.
-    const queryString = new URLSearchParams(
-      context.query as Record<string, string>
-    ).toString();
-    const baseUrl = config.getAppUrl();
-    const destination = queryString ? `${baseUrl}?${queryString}` : baseUrl;
-
-    return {
-      redirect: {
-        destination,
-        permanent: false,
-      },
-    };
-  }
-
-  // Unauthenticated user: show the landing page.
   let postLoginCallbackUrl = "/api/login";
   if (inviteToken) {
     postLoginCallbackUrl += `?inviteToken=${inviteToken}`;


### PR DESCRIPTION
## Summary
- Removes the server-side redirect that sent authenticated users from `dust.tt` to `app.dust.tt`
- Logged-in users now see the landing page like everyone else and can click "Open Dust" in the nav to go to the app
- Cleans up unused imports (`config`, `getSession`, `getUserFromSession`)
