### PR TITLE
Fix table update error in Google Slides

### DIFF
--- a/front/lib/api/actions/servers/google_drive/format_presentation.ts
+++ b/front/lib/api/actions/servers/google_drive/format_presentation.ts
@@ -100,7 +100,7 @@ export function formatPresentationStructure(
                 });
               }
               lines.push(
-                `  - Table Location: Use {tableObjectId: "${element.objectId}", rowIndex: N, columnIndex: M} for cell operations`
+                `  - Table Location: Use objectId "${element.objectId}" in request + cellLocation: {rowIndex: N, columnIndex: M}`
               );
             }
 

--- a/front/lib/api/actions/servers/google_drive/google_slides_request_types.ts
+++ b/front/lib/api/actions/servers/google_drive/google_slides_request_types.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 
 const DimensionSchema = z.object({
   magnitude: z.number(),
-  unit: z.enum(["EMU", "PT"]),
+  unit: z.enum(["UNIT_UNSPECIFIED", "EMU", "PT"]),
 });
 
 const SizeSchema = z.object({
@@ -65,7 +65,7 @@ const AffineTransformSchema = z.object({
   shearY: z.number().optional(),
   translateX: z.number().optional(),
   translateY: z.number().optional(),
-  unit: z.enum(["EMU", "PT"]).optional(),
+  unit: z.enum(["UNIT_UNSPECIFIED", "EMU", "PT"]).optional(),
 });
 
 const PageElementPropertiesSchema = z.object({
@@ -75,7 +75,6 @@ const PageElementPropertiesSchema = z.object({
 });
 
 const TableCellLocationSchema = z.object({
-  tableObjectId: z.string(),
   rowIndex: z.number().int(),
   columnIndex: z.number().int(),
 });
@@ -99,6 +98,7 @@ const CreateImageSchema = z.object({
 const CreateLineSchema = z.object({
   objectId: z.string().optional(),
   elementProperties: PageElementPropertiesSchema,
+  category: z.enum(["STRAIGHT", "BENT", "CURVED"]).optional(),
   lineCategory: z
     .enum([
       "LINE",
@@ -134,12 +134,12 @@ const CreateParagraphBulletsSchema = z.object({
       "BULLET_LEFTTRIANGLE_DIAMOND_DISC",
       "BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE",
       "BULLET_DIAMOND_CIRCLE_SQUARE",
-      "NUMBERED_DECIMAL_ALPHA_ROMAN",
-      "NUMBERED_DECIMAL_ALPHA_ROMAN_PARENS",
-      "NUMBERED_DECIMAL_NESTED",
+      "NUMBERED_DIGIT_ALPHA_ROMAN",
+      "NUMBERED_DIGIT_ALPHA_ROMAN_PARENS",
+      "NUMBERED_DIGIT_NESTED",
       "NUMBERED_UPPERALPHA_ALPHA_ROMAN",
-      "NUMBERED_UPPERROMAN_UPPERALPHA_DECIMAL",
-      "NUMBERED_ZERODECIMAL_ALPHA_ROMAN",
+      "NUMBERED_UPPERROMAN_UPPERALPHA_DIGIT",
+      "NUMBERED_ZERODIGIT_ALPHA_ROMAN",
     ])
     .optional(),
   cellLocation: TableCellLocationSchema.optional(),
@@ -334,7 +334,8 @@ const CreateSlideSchema = z.object({
   placeholderIdMappings: z
     .array(
       z.object({
-        layoutPlaceholder: z.record(z.unknown()),
+        layoutPlaceholder: z.record(z.unknown()).optional(),
+        layoutPlaceholderObjectId: z.string().optional(),
         objectId: z.string(),
       })
     )


### PR DESCRIPTION
## Description
A customer was trying to create a sheets style table within a Google Slide and got an error because our agent passed in `tableObjectId` when google's API requests `objectId`
I also had dust run a thorough audit of our zod schema vs google api and it found a few other small discrepancies so I'm fixing those as well
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="980" height="578" alt="Screenshot 2026-02-27 at 4 50 08 PM" src="https://github.com/user-attachments/assets/2fb7bd91-9c6f-46fa-ae6b-04789c8dfef8" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
