### PR TITLE
Reapply "[front] Allow oauth token in endpoints (#22394)" (#22414)

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -1,17 +1,11 @@
-import { getUserWithWorkspaces } from "@app/lib/api/user";
-import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import {
   Authenticator,
   getAPIKey,
   getApiKeyNameFromHeaders,
-  getBearerToken,
   getSession,
-  isOAuthToken,
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import logger from "@app/logger/logger";
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type {
@@ -19,12 +13,8 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types/error";
 import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { getUserEmailFromHeaders } from "@app/types/user";
-import { TokenExpiredError } from "jsonwebtoken";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 function getMaintenanceError(
@@ -101,6 +91,60 @@ function getConversationKillSwitchErrorForRequest(
   )
     ? getConversationKillSwitchError()
     : null;
+}
+
+/**
+ * Checks workspace-level guards: owner/plan existence, canUseProduct, maintenance, and kill switches.
+ * Returns an APIErrorWithStatusCode if any check fails, or null if all pass.
+ */
+function validateWorkspace(
+  req: NextApiRequest,
+  auth: Authenticator,
+  opts: { doesNotRequireCanUseProduct?: boolean } = {}
+): APIErrorWithStatusCode | null {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  if (!owner || !plan) {
+    return {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    };
+  }
+
+  if (!opts.doesNotRequireCanUseProduct && !plan.limits.canUseProduct) {
+    return {
+      status_code: 403,
+      api_error: {
+        type: "workspace_can_use_product_required_error",
+        message:
+          "Your current plan does not allow API access. Please upgrade your plan.",
+      },
+    };
+  }
+
+  const maintenance = owner.metadata?.maintenance;
+  if (maintenance) {
+    return getMaintenanceError(maintenance);
+  }
+  if (
+    WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+      owner.metadata?.killSwitched
+    )
+  ) {
+    return getWorkspaceKillSwitchError();
+  }
+  const conversationKillSwitchError = getConversationKillSwitchErrorForRequest(
+    req,
+    owner.metadata?.killSwitched
+  );
+  if (conversationKillSwitchError) {
+    return conversationKillSwitchError;
+  }
+
+  return null;
 }
 
 /**
@@ -197,10 +241,11 @@ export function withSessionAuthenticationForWorkspace<T>(
   return withLogging(
     async (
       req: NextApiRequestWithContext,
-      res: NextApiResponse<WithAPIErrorResponse<T>>
+      res: NextApiResponse<WithAPIErrorResponse<T>>,
+      { session }
     ) => {
       const { wId } = req.query;
-      if (typeof wId !== "string" || !wId) {
+      if (!isString(wId)) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -210,106 +255,29 @@ export function withSessionAuthenticationForWorkspace<T>(
         });
       }
 
-      // Try to get session from cookies first
-      const session = await getSession(req, res);
-      let auth: Authenticator;
-
-      if (session) {
-        // Use session-based authentication
-        auth = await Authenticator.fromSession(session, wId);
-      } else {
-        // Try bearer token authentication as fallback
-        const bearerTokenRes = await getBearerToken(req);
-        if (bearerTokenRes.isErr()) {
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "not_authenticated",
-              message:
-                "The user does not have an active session or is not authenticated.",
-            },
-          });
-        }
-
-        const token = bearerTokenRes.value;
-        if (!isOAuthToken(token)) {
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "not_authenticated",
-              message:
-                "The request does not have valid authentication credentials.",
-            },
-          });
-        }
-
-        try {
-          const authRes = await handleWorkOSAuth(req, res, token, wId);
-          if (authRes.isErr()) {
-            return apiError(req, res, authRes.error);
-          }
-          auth = authRes.value;
-        } catch (error) {
-          logger.error({ error }, "Failed to verify token");
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "invalid_oauth_token_error",
-              message:
-                "The request does not have valid authentication credentials.",
-            },
-          });
-        }
+      if (!session) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "not_authenticated",
+            message:
+              "The user does not have an active session or is not authenticated.",
+          },
+        });
       }
 
-      const owner = auth.workspace();
-      const plan = auth.plan();
+      // Session is either from cookies or synthesized from a bearer token by withLogging.
+      const auth = await Authenticator.fromSession(session, wId);
 
-      if (opts.allowMissingWorkspace && (!owner || !plan)) {
+      if (opts.allowMissingWorkspace && (!auth.workspace() || !auth.plan())) {
         return handler(req, res, auth, session);
       }
 
-      if (!owner || !plan) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "workspace_not_found",
-            message: "The workspace was not found.",
-          },
-        });
-      }
-
-      if (
-        !opts.doesNotRequireCanUseProduct &&
-        !auth?.subscription()?.plan.limits.canUseProduct
-      ) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_can_use_product_required_error",
-            message: "The workspace was not found.",
-          },
-        });
-      }
-
-      const maintenance = owner.metadata?.maintenance;
-      if (maintenance) {
-        return apiError(req, res, getMaintenanceError(maintenance));
-      }
-      if (
-        WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
-          owner.metadata?.killSwitched
-        )
-      ) {
-        return apiError(req, res, getWorkspaceKillSwitchError());
-      }
-      const conversationKillSwitchError =
-        getConversationKillSwitchErrorForRequest(
-          req,
-          owner.metadata?.killSwitched
-        );
-      if (conversationKillSwitchError) {
-        return apiError(req, res, conversationKillSwitchError);
+      const workspaceError = validateWorkspace(req, auth, {
+        doesNotRequireCanUseProduct: opts.doesNotRequireCanUseProduct,
+      });
+      if (workspaceError) {
+        return apiError(req, res, workspaceError);
       }
 
       const user = auth.user();
@@ -344,6 +312,8 @@ export function withSessionAuthenticationForWorkspace<T>(
  * This function is a wrapper for Public API routes that require authentication for a workspace.
  * It must be used on all routes that require workspace authentication (prefix: /v1/w/[wId]/).
  *
+ * Only accepts bearer tokens and API keys, not cookie-based sessions.
+ *
  * @param handler
  * @param opts
  * @returns
@@ -373,10 +343,11 @@ export function withPublicAPIAuthentication<T>(
   return withLogging(
     async (
       req: NextApiRequestWithContext,
-      res: NextApiResponse<WithAPIErrorResponse<T>>
+      res: NextApiResponse<WithAPIErrorResponse<T>>,
+      { session }
     ) => {
-      const wId = typeof req.query.wId === "string" ? req.query.wId : undefined;
-      if (!wId) {
+      const { wId } = req.query;
+      if (!isString(wId)) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -386,8 +357,8 @@ export function withPublicAPIAuthentication<T>(
         });
       }
 
-      const bearerTokenRes = await getBearerToken(req);
-      if (bearerTokenRes.isErr()) {
+      // Require an Authorization header for all public API endpoints.
+      if (!req.headers.authorization) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {
@@ -397,100 +368,43 @@ export function withPublicAPIAuthentication<T>(
           },
         });
       }
-      const token = bearerTokenRes.value;
 
-      // Authentification with a token.
-      // Straightforward since the token is attached to the user.
-      if (isOAuthToken(token)) {
-        try {
-          const authRes = await handleWorkOSAuth(req, res, token, wId);
-          if (authRes.isErr()) {
-            // If WorkOS errors return an ApiError.
-            return apiError(req, res, authRes.error);
-          }
+      // Bearer token authentication (resolved by withLogging).
+      // Only accept bearer tokens for the public API, not cookie-based sessions.
+      if (session?.authenticationMethod === "bearer") {
+        const auth = await Authenticator.fromSession(session, wId);
 
-          const auth = authRes.value;
-
-          if (auth.user() === null) {
-            return apiError(req, res, {
-              status_code: 401,
-              api_error: {
-                type: "user_not_found",
-                message:
-                  "The user does not have an active session or is not authenticated.",
-              },
-            });
-          }
-          if (!auth.isUser()) {
-            return apiError(req, res, {
-              status_code: 401,
-              api_error: {
-                type: "workspace_auth_error",
-                message: "Only users of the workspace can access this route.",
-              },
-            });
-          }
-
-          const owner = auth.workspace();
-          const plan = auth.plan();
-          if (!owner || !plan) {
-            return apiError(req, res, {
-              status_code: 404,
-              api_error: {
-                type: "workspace_not_found",
-                message: "The workspace was not found.",
-              },
-            });
-          }
-
-          if (!plan.limits.canUseProduct) {
-            return apiError(req, res, {
-              status_code: 403,
-              api_error: {
-                type: "workspace_can_use_product_required_error",
-                message:
-                  "Your current plan does not allow API access. Please upgrade your plan.",
-              },
-            });
-          }
-
-          req.addResourceToLog?.(auth.getNonNullableUser());
-
-          const maintenance = auth.workspace()?.metadata?.maintenance;
-          if (maintenance) {
-            return apiError(req, res, getMaintenanceError(maintenance));
-          }
-          if (
-            WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
-              auth.workspace()?.metadata?.killSwitched
-            )
-          ) {
-            return apiError(req, res, getWorkspaceKillSwitchError());
-          }
-          const conversationKillSwitchError =
-            getConversationKillSwitchErrorForRequest(
-              req,
-              auth.workspace()?.metadata?.killSwitched
-            );
-          if (conversationKillSwitchError) {
-            return apiError(req, res, conversationKillSwitchError);
-          }
-
-          return await handler(req, res, auth, null);
-        } catch (error) {
-          logger.error({ error }, "Failed to verify token");
+        if (auth.user() === null) {
           return apiError(req, res, {
             status_code: 401,
             api_error: {
-              type: "invalid_oauth_token_error",
+              type: "user_not_found",
               message:
-                "The request does not have valid authentication credentials.",
+                "The user does not have an active session or is not authenticated.",
             },
           });
         }
+        if (!auth.isUser()) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "Only users of the workspace can access this route.",
+            },
+          });
+        }
+
+        const workspaceError = validateWorkspace(req, auth);
+        if (workspaceError) {
+          return apiError(req, res, workspaceError);
+        }
+
+        req.addResourceToLog?.(auth.getNonNullableUser());
+
+        return await handler(req, res, auth, null);
       }
 
-      // Authentification with an API key.
+      // API key authentication.
       const keyRes = await getAPIKey(req);
       if (keyRes.isErr()) {
         return apiError(req, res, keyRes.error);
@@ -504,48 +418,12 @@ export function withPublicAPIAuthentication<T>(
       );
       let { workspaceAuth } = keyAndWorkspaceAuth;
 
-      const owner = workspaceAuth.workspace();
-      const plan = workspaceAuth.plan();
-      if (!owner || !plan) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "workspace_not_found",
-            message: "The workspace was not found.",
-          },
-        });
+      const workspaceError = validateWorkspace(req, workspaceAuth);
+      if (workspaceError) {
+        return apiError(req, res, workspaceError);
       }
 
-      if (!plan.limits.canUseProduct) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_can_use_product_required_error",
-            message:
-              "Your current plan does not allow API access. Please upgrade your plan.",
-          },
-        });
-      }
-
-      const maintenance = owner.metadata?.maintenance;
-      if (maintenance) {
-        return apiError(req, res, getMaintenanceError(maintenance));
-      }
-      if (
-        WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
-          owner.metadata?.killSwitched
-        )
-      ) {
-        return apiError(req, res, getWorkspaceKillSwitchError());
-      }
-      const conversationKillSwitchError =
-        getConversationKillSwitchErrorForRequest(
-          req,
-          owner.metadata?.killSwitched
-        );
-      if (conversationKillSwitchError) {
-        return apiError(req, res, conversationKillSwitchError);
-      }
+      const owner = workspaceAuth.workspace()!;
 
       // Authenticator created from a key has the builder role if the key is associated with
       // the workspace. System keys can bypass this when allowSystemKeyBypassBuilderCheck is set.
@@ -600,35 +478,25 @@ export function withPublicAPIAuthentication<T>(
 }
 
 /**
- * This function is a wrapper for Public API routes that require authentication without a workspace.
- * It automatically detects whether to use WorkOS authentication based on the token's issuer.
+ * This function is a wrapper for Public API routes that require bearer token authentication
+ * without a workspace context (e.g., /api/v1/me).
+ * Only accepts bearer tokens, not cookie-based sessions or API keys.
+ * The bearer token is validated by withLogging which synthesizes a SessionWithUser.
  */
 export function withTokenAuthentication<T>(
   handler: (
     req: NextApiRequest,
     res: NextApiResponse<WithAPIErrorResponse<T>>,
-    user: UserTypeWithWorkspaces
+    session: SessionWithUser
   ) => Promise<void> | void
 ) {
   return withLogging(
     async (
       req: NextApiRequestWithContext,
-      res: NextApiResponse<WithAPIErrorResponse<T>>
+      res: NextApiResponse<WithAPIErrorResponse<T>>,
+      { session }
     ) => {
-      const bearerTokenRes = await getBearerToken(req);
-      if (bearerTokenRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "not_authenticated",
-            message:
-              "The request does not have valid authentication credentials.",
-          },
-        });
-      }
-      const bearerToken = bearerTokenRes.value;
-
-      if (!isOAuthToken(bearerToken)) {
+      if (session?.authenticationMethod !== "bearer") {
         return apiError(req, res, {
           status_code: 401,
           api_error: {
@@ -639,134 +507,9 @@ export function withTokenAuthentication<T>(
         });
       }
 
-      try {
-        let user: UserResource | null = null;
-
-        // Try WorkOS token first
-        const workOSDecoded = await verifyWorkOSToken(bearerToken);
-        if (workOSDecoded.isOk()) {
-          user = await getUserFromWorkOSToken(workOSDecoded.value);
-        } else if (
-          workOSDecoded.isErr() &&
-          workOSDecoded.error instanceof TokenExpiredError
-        ) {
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "expired_oauth_token_error",
-              message: "The access token expired.",
-            },
-          });
-        }
-
-        if (workOSDecoded.isErr()) {
-          // We were not able to decode the token for Workos,
-          // so we log the error and return an API error.
-          logger.error(
-            {
-              workOSError: workOSDecoded.error,
-            },
-            "Failed to verify token with WorkOS"
-          );
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "invalid_oauth_token_error",
-              message:
-                "The request does not have valid authentication credentials.",
-            },
-          });
-        }
-
-        if (!user) {
-          return apiError(req, res, {
-            status_code: 401,
-            api_error: {
-              type: "user_not_found",
-              message: "The user is not registered.",
-            },
-          });
-        }
-
-        req.addResourceToLog?.(user);
-
-        const isFromExtension = req.headers["x-request-origin"] === "extension";
-        const userWithWorkspaces = await getUserWithWorkspaces(
-          user,
-          isFromExtension
-        );
-
-        const orgId = workOSDecoded.value.org_id;
-        if (orgId) {
-          const workspace = userWithWorkspaces.workspaces.find(
-            (w) => w.workOSOrganizationId === orgId
-          );
-          userWithWorkspaces.selectedWorkspace = workspace?.sId;
-        }
-
-        return await handler(req, res, userWithWorkspaces);
-      } catch (error) {
-        logger.error({ error }, "Failed to verify token");
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "invalid_oauth_token_error",
-            message:
-              "The request does not have valid authentication credentials.",
-          },
-        });
-      }
+      return handler(req, res, session);
     }
   );
-}
-
-/**
- * Helper function to handle WorkOS authentication
- */
-async function handleWorkOSAuth<T>(
-  req: NextApiRequestWithContext,
-  res: NextApiResponse<WithAPIErrorResponse<T>>,
-  token: string,
-  wId: string
-): Promise<Result<Authenticator, APIErrorWithStatusCode>> {
-  const decoded = await verifyWorkOSToken(token);
-  if (decoded.isErr()) {
-    const error = decoded.error;
-    if (error instanceof TokenExpiredError) {
-      return new Err({
-        status_code: 401,
-        api_error: {
-          type: "expired_oauth_token_error",
-          message: "The access token expired.",
-        },
-      });
-    }
-
-    return new Err({
-      status_code: 401,
-      api_error: {
-        type: "invalid_oauth_token_error",
-        message: "The request does not have valid authentication credentials.",
-      },
-    });
-  }
-
-  const authRes = await Authenticator.fromWorkOSToken({
-    token: decoded.value,
-    wId,
-  });
-  if (authRes.isErr()) {
-    return new Err({
-      status_code: 403,
-      api_error: {
-        type: authRes.error.code,
-        message:
-          "The user does not have an active session or is not authenticated.",
-      },
-    });
-  }
-
-  return new Ok(authRes.value);
 }
 
 /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,5 +1,7 @@
 import config from "@app/lib/api/config";
+import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import type { WorkOSJwtPayload } from "@app/lib/api/workos";
+import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import { getWorkOSSession } from "@app/lib/api/workos/user";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
@@ -40,6 +42,7 @@ import type {
 } from "@app/types/user";
 import { isAdmin, isBuilder, isUser } from "@app/types/user";
 import assert from "assert";
+import { TokenExpiredError } from "jsonwebtoken";
 import memoizer from "lru-memoizer";
 import type {
   GetServerSidePropsContext,
@@ -245,7 +248,8 @@ export class Authenticator {
       }
 
       return new Authenticator({
-        authMethod: "session",
+        authMethod:
+          session?.authenticationMethod === "bearer" ? "oauth" : "session",
         workspace,
         user,
         role,
@@ -1087,6 +1091,77 @@ export async function getBearerToken(
   }
 
   return new Ok(parse[1]);
+}
+
+export type BearerTokenError =
+  | "not_authenticated"
+  | "invalid_oauth_token_error"
+  | "expired_oauth_token_error"
+  | "user_not_found";
+
+/**
+ * Attempts to create a SessionWithUser from a bearer token in the request.
+ *
+ * This is used as a fallback in withLogging when no cookie-based session is available.
+ * It validates the bearer token, resolves the user, and synthesizes a SessionWithUser
+ * object so that downstream handlers (getUserFromSession, etc.) work transparently.
+ *
+ * Returns an Err with a BearerTokenError if the token is present but invalid/expired,
+ * or Ok(null) if no bearer token is present, or Ok(session) on success.
+ */
+export async function getSessionFromBearerToken(
+  req: NextApiRequest
+): Promise<Result<SessionWithUser | null, BearerTokenError>> {
+  const bearerTokenRes = await getBearerToken(req);
+  if (bearerTokenRes.isErr()) {
+    return new Ok(null);
+  }
+
+  const bearerToken = bearerTokenRes.value;
+  if (!isOAuthToken(bearerToken)) {
+    return new Ok(null);
+  }
+
+  let workOSDecoded: Result<WorkOSJwtPayload, Error>;
+  try {
+    workOSDecoded = await verifyWorkOSToken(bearerToken);
+  } catch {
+    // verifyWorkOSToken can throw if config is missing (e.g. WORKOS_CLIENT_ID).
+    return new Ok(null);
+  }
+  if (workOSDecoded.isErr()) {
+    if (workOSDecoded.error instanceof TokenExpiredError) {
+      // Token signature was valid but expired — this is definitely a WorkOS token.
+      return new Err("expired_oauth_token_error");
+    }
+    // Verification failed — could be a non-WorkOS token (e.g. viz JWT).
+    // Return null to let the handler do its own auth.
+    return new Ok(null);
+  }
+
+  const user = await getUserFromWorkOSToken(workOSDecoded.value);
+  if (!user) {
+    return new Err("user_not_found");
+  }
+
+  return new Ok({
+    type: "workos",
+    sessionId: "bearer-token",
+    user: {
+      email: user.email,
+      email_verified: true,
+      name: user.name,
+      nickname: user.username,
+      workOSUserId: user.workOSUserId ?? "",
+      given_name: user.firstName,
+      family_name: user.lastName ?? undefined,
+      picture: user.imageUrl ?? undefined,
+    },
+    region: multiRegionsConfig.getCurrentRegion(),
+    organizationId: workOSDecoded.value.org_id,
+    isSSO: false,
+    authenticationMethod: "bearer",
+  });
 }
 
 /**

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -15,6 +15,7 @@ import type {
   APIErrorWithStatusCode,
   WithAPIErrorResponse,
 } from "@app/types/error";
+import { Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type {
@@ -22,7 +23,6 @@ import type {
   NextApiRequest,
   NextApiResponse,
 } from "next";
-
 import logger from "./logger";
 import { statsDClient } from "./statsDClient";
 
@@ -116,27 +116,29 @@ export function withLogging<T>(
     const clientIp = getClientIp(req);
     const now = new Date();
 
-    // Try cookie-based session first, then fall back to bearer token.
-    let session = await tracer.trace(
-      "workos.getSession",
-      async () => await getSession(req, res)
-    );
-    if (!session) {
+    // Try bearer token first, then fall back to cookie-based session.
+    const sessionResult = await tracer.trace("auth.getSession", async () => {
       const bearerTokenRes = await getSessionFromBearerToken(req);
-      if (bearerTokenRes.isOk()) {
-        session = bearerTokenRes.value;
-      } else {
-        // Bearer token was present but invalid/expired — fail fast.
-        apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: bearerTokenRes.error,
-            message: BEARER_TOKEN_ERROR_MESSAGES[bearerTokenRes.error],
-          },
-        });
-        return;
+      if (bearerTokenRes.isErr() || bearerTokenRes.value) {
+        return bearerTokenRes;
       }
+      // No bearer token present — try cookie-based session.
+      const cookieSession = await getSession(req, res);
+      return new Ok(cookieSession);
+    });
+
+    if (sessionResult.isErr()) {
+      apiError(req, res, {
+        status_code: 401,
+        api_error: {
+          type: sessionResult.error,
+          message: BEARER_TOKEN_ERROR_MESSAGES[sessionResult.error],
+        },
+      });
+      return;
     }
+    const session = sessionResult.value;
+
     const sessionId = session?.sessionId ?? "unknown";
 
     // Use freeze to make sure we cannot update `req.logContext` down the callstack

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,5 +1,6 @@
 import { shouldForceClientReload } from "@app/lib/api/force_client_reload";
-import { getSession } from "@app/lib/auth";
+import type { BearerTokenError } from "@app/lib/auth";
+import { getSession, getSessionFromBearerToken } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import type {
   CustomGetServerSideProps,
@@ -27,6 +28,15 @@ import { statsDClient } from "./statsDClient";
 
 export type RequestContext = {
   [key: string]: ResourceLogJSON;
+};
+
+const BEARER_TOKEN_ERROR_MESSAGES: Record<BearerTokenError, string> = {
+  expired_oauth_token_error: "The access token expired.",
+  invalid_oauth_token_error:
+    "The request does not have valid authentication credentials.",
+  user_not_found: "The user is not registered.",
+  not_authenticated:
+    "The request does not have valid authentication credentials.",
 };
 
 // Sequelize errors (ValidationError, UniqueConstraintError, etc.) have a
@@ -106,10 +116,27 @@ export function withLogging<T>(
     const clientIp = getClientIp(req);
     const now = new Date();
 
-    const session = await tracer.trace(
+    // Try cookie-based session first, then fall back to bearer token.
+    let session = await tracer.trace(
       "workos.getSession",
       async () => await getSession(req, res)
     );
+    if (!session) {
+      const bearerTokenRes = await getSessionFromBearerToken(req);
+      if (bearerTokenRes.isOk()) {
+        session = bearerTokenRes.value;
+      } else {
+        // Bearer token was present but invalid/expired — fail fast.
+        apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: bearerTokenRes.error,
+            message: BEARER_TOKEN_ERROR_MESSAGES[bearerTokenRes.error],
+          },
+        });
+        return;
+      }
+    }
     const sessionId = session?.sessionId ?? "unknown";
 
     // Use freeze to make sure we cannot update `req.logContext` down the callstack

--- a/front/pages/api/user/index.test.ts
+++ b/front/pages/api/user/index.test.ts
@@ -27,6 +27,7 @@ describe("GET /api/user", () => {
         createdAt: user.createdAt.getTime(),
         lastLoginAt: user.lastLoginAt?.getTime(),
         organizations: [],
+        selectedWorkspace: workspace.sId,
         workspaces: [
           {
             id: workspace.id,
@@ -67,6 +68,7 @@ describe("GET /api/user", () => {
         createdAt: user.createdAt.getTime(),
         lastLoginAt: user.lastLoginAt?.getTime(),
         organizations: [],
+        selectedWorkspace: workspace.sId,
         workspaces: [
           {
             id: workspace.id,

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -55,6 +55,16 @@ async function handler(
     });
   }
 
+  // Set selectedWorkspace from the organization ID.
+  if (session.organizationId) {
+    const workspace = user.workspaces.find(
+      (w) => w.workOSOrganizationId === session.organizationId
+    );
+    if (workspace) {
+      user.selectedWorkspace = workspace.sId;
+    }
+  }
+
   switch (req.method) {
     case "GET":
       ServerSideTracking.trackGetUser({ user }).catch((err) => {

--- a/front/pages/api/v1/me.ts
+++ b/front/pages/api/v1/me.ts
@@ -1,9 +1,13 @@
+// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { withTokenAuthentication } from "@app/lib/api/auth_wrappers";
+import { getUserWithWorkspaces } from "@app/lib/api/user";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { MeResponseType } from "@dust-tt/client";
-import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiResponse } from "next";
 
 /**
  * @ignoreswagger
@@ -12,13 +16,38 @@ import type { NextApiRequest, NextApiResponse } from "next";
  */
 
 async function handler(
-  req: NextApiRequest,
+  req: NextApiRequestWithContext,
   res: NextApiResponse<WithAPIErrorResponse<MeResponseType>>,
-  user: UserTypeWithWorkspaces
+  session: SessionWithUser
 ): Promise<void> {
   switch (req.method) {
-    case "GET":
+    case "GET": {
+      const userResource = await UserResource.fetchByWorkOSUserId(
+        session.user.workOSUserId
+      );
+      if (!userResource) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "user_not_found",
+            message: "The user is not registered.",
+          },
+        });
+      }
+
+      const isFromExtension = req.headers["x-request-origin"] === "extension";
+      const user = await getUserWithWorkspaces(userResource, isFromExtension);
+
+      // Set selectedWorkspace from the organization in the bearer token.
+      if (session.organizationId) {
+        const workspace = user.workspaces.find(
+          (w) => w.workOSOrganizationId === session.organizationId
+        );
+        user.selectedWorkspace = workspace?.sId;
+      }
+
       return res.status(200).json({ user });
+    }
 
     default:
       return apiError(req, res, {


### PR DESCRIPTION
## Description

Reapply "[front] Allow oauth token in endpoints (#22394)"
Check authorization header before session cookie - issue was that extension was sending both headers (auth + cookie) if already logged on web, and `/api/v1/me` explicitly rejects cookie auth. (new extension does not send it anymore with credentials:omit)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
