### PR TITLE
Support showing readonly plugins in maintenance mode

### DIFF
--- a/front/lib/api/poke/plugins/data_source_views/fetch_document_content.ts
+++ b/front/lib/api/poke/plugins/data_source_views/fetch_document_content.ts
@@ -11,6 +11,7 @@ export const fetchDocumentContentPlugin = createPlugin({
     description:
       "Retrieves the full content of a specific document from a data source view",
     resourceTypes: ["data_source_views"],
+    readonly: true,
     args: {
       documentId: {
         type: "string",

--- a/front/lib/api/poke/plugins/data_sources/check_slack_channel.ts
+++ b/front/lib/api/poke/plugins/data_sources/check_slack_channel.ts
@@ -13,6 +13,7 @@ export const checkSlackChannelPlugin = createPlugin({
   manifest: {
     id: "check-slack-channel",
     name: "Check Slack Channel",
+    readonly: true,
     description:
       "Check if a Slack channel exists and is accessible by the connector",
     resourceTypes: ["data_sources"],

--- a/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
+++ b/front/lib/api/poke/plugins/data_sources/compute_statistics.ts
@@ -9,6 +9,7 @@ export const computeStatsPlugin = createPlugin({
     name: "Compute statistics",
     description: "Gather statistics for the data source",
     resourceTypes: ["data_sources"],
+    readonly: true,
     args: {},
   },
   execute: async (auth, dataSource) => {

--- a/front/lib/api/poke/plugins/data_sources/confluence_page_checker.ts
+++ b/front/lib/api/poke/plugins/data_sources/confluence_page_checker.ts
@@ -12,6 +12,7 @@ export const confluencePageCheckerPlugin = createPlugin({
   manifest: {
     id: "confluence-page-checker",
     name: "Check Confluence Page Exists",
+    readonly: true,
     description:
       "Check if a Confluence page exists and return its ancestors in a markdown tree format",
     resourceTypes: ["data_sources"],

--- a/front/lib/api/poke/plugins/data_sources/get_access_token.ts
+++ b/front/lib/api/poke/plugins/data_sources/get_access_token.ts
@@ -11,6 +11,7 @@ export const getAccessTokenPlugin = createPlugin({
     name: "Get Access Token",
     description: "Retrieve the OAuth access token for this data source.",
     resourceTypes: ["data_sources"],
+    readonly: true,
     args: {},
     redactResult: true,
   },

--- a/front/lib/api/poke/plugins/global/get_admins_for_workspaces.ts
+++ b/front/lib/api/poke/plugins/global/get_admins_for_workspaces.ts
@@ -13,6 +13,7 @@ export const getAdminsForWorkspacesPlugin = createPlugin({
     name: "Get Admins for Workspaces",
     description: "Retrieve admin users for a list of workspaces",
     resourceTypes: ["global"],
+    readonly: true,
     args: {
       workspaceIds: {
         type: "string",

--- a/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-access-token.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-access-token.ts
@@ -11,6 +11,7 @@ export const getMcpServerViewAccessTokenPlugin = createPlugin({
     name: "Get MCP Server View Access Token",
     description: "Retrieve the OAuth access token for this MCP server view.",
     resourceTypes: ["mcp_server_views"],
+    readonly: true,
     args: {
       userId: {
         type: "string",

--- a/front/lib/api/poke/plugins/workspaces/check_message_usage.ts
+++ b/front/lib/api/poke/plugins/workspaces/check_message_usage.ts
@@ -8,6 +8,7 @@ export const checkMessageUsagePlugin = createPlugin({
     name: "Check Message Usage",
     description: "Returns the current message usage count and the limit.",
     resourceTypes: ["workspaces"],
+    readonly: true,
     args: {},
   },
   execute: async (auth, workspace) => {

--- a/front/lib/api/poke/plugins/workspaces/compute_statistics.ts
+++ b/front/lib/api/poke/plugins/workspaces/compute_statistics.ts
@@ -11,6 +11,7 @@ export const computeWorkspaceStatsPlugin = createPlugin({
     name: "Compute Workspace Statistics",
     description: "Gather statistics for the workspace",
     resourceTypes: ["workspaces"],
+    readonly: true,
     args: {},
   },
   execute: async (auth, workspace) => {

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -176,5 +176,5 @@ export function createPlugin<
 
 export type PluginListItem = Pick<
   PluginManifest<PluginArgs, SupportedResourceType>,
-  "id" | "name" | "description"
+  "id" | "name" | "description" | "readonly"
 >;

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -106,19 +106,6 @@ async function handler(
         });
       }
 
-      // Block non-readonly plugins during workspace maintenance.
-      const workspace = auth.workspace();
-      const maintenance = workspace?.metadata?.maintenance;
-      if (maintenance && !plugin.manifest.readonly) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "This plugin is disabled during workspace maintenance.",
-          },
-        });
-      }
-
       const resource = resourceId
         ? await fetchPluginResource(auth, resourceType, resourceId)
         : null;

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -106,6 +106,20 @@ async function handler(
         });
       }
 
+      // Block non-readonly plugins during workspace maintenance.
+      const workspace = auth.workspace();
+      const maintenance = workspace?.metadata?.maintenance;
+      if (maintenance && !plugin.manifest.readonly) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "This plugin is disabled during workspace maintenance.",
+          },
+        });
+      }
+
       const resource = resourceId
         ? await fetchPluginResource(auth, resourceType, resourceId)
         : null;

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -114,8 +114,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message:
-              "This plugin is disabled during workspace maintenance.",
+            message: "This plugin is disabled during workspace maintenance.",
           },
         });
       }

--- a/front/pages/api/poke/plugins/index.ts
+++ b/front/pages/api/poke/plugins/index.ts
@@ -70,25 +70,10 @@ async function handler(
       // If the run targets a specific workspace, use a workspace-scoped authenticator.
       if (workspaceId) {
         auth = await Authenticator.fromSuperUserSession(session, workspaceId);
-
-        // Hide plugins during any workspace maintenance.
-        const workspace = auth.workspace();
-        const maintenance = workspace?.metadata?.maintenance;
-        if (maintenance) {
-          // Return a fake plugin explaining why plugins are unavailable.
-          res.status(200).json({
-            plugins: [
-              {
-                id: "maintenance",
-                name: "Plugins are disabled during maintenance",
-                description:
-                  "All plugins are temporarily unavailable while workspace maintenance is in progress.",
-              },
-            ],
-          });
-          return;
-        }
       }
+
+      const workspace = auth.workspace();
+      const maintenance = workspace?.metadata?.maintenance;
 
       const plugins = pluginManager.getPluginsForResourceType(resourceType);
 
@@ -99,10 +84,13 @@ async function handler(
       const pluginList = plugins
         .filter((p) => !resourceId || p.isApplicableTo(auth, resource))
         .filter((p) => !p.manifest.isHidden)
+        // During maintenance, only show readonly plugins.
+        .filter((p) => !maintenance || p.manifest.readonly)
         .map((p) => ({
           id: p.manifest.id,
           name: p.manifest.name,
           description: p.manifest.description,
+          readonly: p.manifest.readonly,
         }));
 
       res.status(200).json({ plugins: pluginList });

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -129,6 +129,7 @@ export interface PluginManifest<
   resourceTypes: R[];
   warning?: string;
   isHidden?: boolean;
+  readonly?: boolean;
   redactResult?: boolean;
 }
 


### PR DESCRIPTION
## Description

Previously, we'd disable all plugins in Maintenance mode. But some are harmless and can be useful.

This change introduces the concept of a readonly plugin, which we allow in maintenance mode. I made a pass through the list and marked a number of them as such.

## Tests

Manual.

## Risk

Poke only.

## Deploy Plan

Front.