### PR TITLE
Update logic to position accept/reject floating menu buttons

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -478,7 +478,7 @@ function CopilotSuggestionsProviderContent({
           block: "center",
         });
 
-        highlightSuggestion(suggestionId, true);
+        highlightSuggestion(suggestionId);
       }
     },
     [getSuggestion, highlightSuggestion]

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -466,15 +466,17 @@ function CopilotSuggestionsProviderContent({
       if (!suggestion || suggestion.kind !== "instructions") {
         return;
       }
-      const position = getSuggestionPosition(editor, suggestionId);
 
-      if (position !== null) {
-        editor
-          .chain()
-          .focus()
-          .setTextSelection(position)
-          .scrollIntoView()
-          .run();
+      // Find the suggestion element in the DOM and scroll to it
+      const suggestionElement = editor.view.dom.querySelector(
+        `[data-suggestion-id="${suggestionId}"]`
+      );
+
+      if (suggestionElement) {
+        suggestionElement.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
 
         highlightSuggestion(suggestionId, true);
       }

--- a/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
+++ b/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
@@ -12,7 +12,8 @@ import {
 } from "react";
 
 // Suggestion bubble menu positioning constants
-const MENU_ABOVE_CURSOR_PX = 80; // Distance above cursor
+const MENU_ABOVE_CURSOR_PX = 80; // Distance above cursor when hovering
+const MENU_ABOVE_SUGGESTION_TOP_PX = 5; // Distance above suggestion top when opened without cursor
 const MENU_RIGHT_EDGE_PADDING_PX = 20; // Distance from right edge
 const MENU_VERTICAL_REPOSITION_THRESHOLD_PX = 380; // Vertical distance before repositioning
 
@@ -75,8 +76,35 @@ export function SuggestionBubbleMenu({
     if (!highlightedSuggestionId) {
       activeBlockRef.current = null;
       setActiveMenu(null);
+      return;
     }
-  }, [highlightedSuggestionId]);
+
+    // If a suggestion is highlighted but no menu is shown (e.g., from clicking the eye button),
+    // position the menu at the top of the suggestion element
+    if (!activeMenu || activeMenu.sId !== highlightedSuggestionId) {
+      const suggestionElement = editor.view.dom.querySelector(
+        `[data-suggestion-id="${highlightedSuggestionId}"]`
+      );
+
+      if (suggestionElement && containerRef.current) {
+        const suggestionRect = suggestionElement.getBoundingClientRect();
+        const containerRect = containerRef.current.getBoundingClientRect();
+
+        // Position menu just above suggestion top, fixed to right edge
+        // When opened without cursor (e.g., from eye button)
+        const viewportTop = suggestionRect.top - MENU_ABOVE_SUGGESTION_TOP_PX;
+        const containerRelativeLeft =
+          containerRect.width - MENU_RIGHT_EDGE_PADDING_PX;
+
+        setActiveMenu({
+          sId: highlightedSuggestionId,
+          top: viewportTop - containerRect.top,
+          left: containerRelativeLeft,
+          measured: false,
+        });
+      }
+    }
+  }, [highlightedSuggestionId, activeMenu, editor, containerRef]);
 
   // After menu is in DOM, clamp with real dimensions so it stays inside the form.
   useLayoutEffect(() => {

--- a/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
+++ b/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
@@ -1,6 +1,5 @@
 import { useCopilotHighlight } from "@app/components/agent_builder/copilot/CopilotHighlightContext";
 import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
-import { getSuggestionEndPosition } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { Button, CheckIcon, HoveringBar, XMarkIcon } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import type { RefObject } from "react";
@@ -12,7 +11,10 @@ import {
   useState,
 } from "react";
 
-const MENU_SPACING_PX = 10;
+// Suggestion bubble menu positioning constants
+const MENU_ABOVE_CURSOR_PX = 80; // Distance above cursor
+const MENU_RIGHT_EDGE_PADDING_PX = 20; // Distance from right edge
+const MENU_VERTICAL_REPOSITION_THRESHOLD_PX = 380; // Vertical distance before repositioning
 
 interface SuggestionBubbleMenuProps {
   editor: Editor;
@@ -48,44 +50,25 @@ export function SuggestionBubbleMenu({
 
   const setPositionAtMouse = useCallback(
     (sId: string, clientX: number, clientY: number) => {
-      const viewportTop = clientY + MENU_SPACING_PX;
-      const viewportLeft = clientX + MENU_SPACING_PX;
       const container = containerRef.current;
       if (!container) {
         return;
       }
       const containerRect = container.getBoundingClientRect();
+
+      // Position at fixed right edge of container
+      const viewportTop = clientY - MENU_ABOVE_CURSOR_PX;
+      const containerRelativeLeft =
+        containerRect.width - MENU_RIGHT_EDGE_PADDING_PX;
+
       setActiveMenu({
         sId,
         top: viewportTop - containerRect.top,
-        left: viewportLeft - containerRect.left,
+        left: containerRelativeLeft,
         measured: false,
       });
     },
     [containerRef]
-  );
-
-  const setPositionAtSuggestion = useCallback(
-    (sId: string) => {
-      const endPos = getSuggestionEndPosition(editor, sId);
-      const container = containerRef.current;
-      if (endPos === null || !container) {
-        return;
-      }
-      const coordsPos = endPos > 0 ? endPos - 1 : endPos;
-      const coords = editor.view.coordsAtPos(coordsPos);
-      const viewportTop = coords.bottom + MENU_SPACING_PX;
-      const viewportLeft = coords.right + MENU_SPACING_PX;
-
-      const containerRect = container.getBoundingClientRect();
-      setActiveMenu({
-        sId,
-        top: viewportTop - containerRect.top,
-        left: viewportLeft - containerRect.left,
-        measured: false,
-      });
-    },
-    [editor, containerRef]
   );
 
   useEffect(() => {
@@ -94,27 +77,6 @@ export function SuggestionBubbleMenu({
       setActiveMenu(null);
     }
   }, [highlightedSuggestionId]);
-
-  useLayoutEffect(() => {
-    if (!highlightedSuggestionId || !isHighlightedSuggestionPinned) {
-      return;
-    }
-
-    const suggestionEl = editor.view.dom.querySelector<HTMLElement>(
-      `[data-suggestion-id="${highlightedSuggestionId}"]`
-    );
-    const blockEl = suggestionEl?.closest<HTMLElement>("[data-block-id]");
-    if (blockEl) {
-      activeBlockRef.current = blockEl;
-      blockEl.scrollIntoView({ behavior: "smooth", block: "center" });
-    }
-    setPositionAtSuggestion(highlightedSuggestionId);
-  }, [
-    highlightedSuggestionId,
-    isHighlightedSuggestionPinned,
-    editor,
-    setPositionAtSuggestion,
-  ]);
 
   // After menu is in DOM, clamp with real dimensions so it stays inside the form.
   useLayoutEffect(() => {
@@ -168,8 +130,16 @@ export function SuggestionBubbleMenu({
 
   const handleMouseMove = useCallback(
     (event: MouseEvent) => {
-      if (isHighlightedSuggestionPinned) {
-        return;
+      // Check if mouse has moved far vertically from the current menu position
+      let isMouseFarFromMenu = false;
+      if (activeMenu && containerRef.current) {
+        const containerRect = containerRef.current.getBoundingClientRect();
+        // Convert menu position to viewport coordinates
+        const menuViewportTop = containerRect.top + activeMenu.top;
+        // Calculate vertical distance only
+        const verticalDistance = Math.abs(event.clientY - menuViewportTop);
+        isMouseFarFromMenu =
+          verticalDistance > MENU_VERTICAL_REPOSITION_THRESHOLD_PX;
       }
 
       const id = getSuggestionId(event.target);
@@ -178,6 +148,15 @@ export function SuggestionBubbleMenu({
       }
 
       const isNewSuggestion = id !== highlightedSuggestionId;
+
+      // Reposition if: new suggestion, menu not yet positioned, or mouse is far from menu
+      if (isNewSuggestion || isMouseFarFromMenu || !activeMenu) {
+        setPositionAtMouse(id, event.clientX, event.clientY);
+      }
+
+      if (isHighlightedSuggestionPinned) {
+        return;
+      }
       highlightSuggestion(id);
       const blockEl =
         event.target instanceof HTMLElement
@@ -186,9 +165,6 @@ export function SuggestionBubbleMenu({
       if (blockEl) {
         activeBlockRef.current = blockEl;
       }
-      if (isNewSuggestion) {
-        setPositionAtMouse(id, event.clientX, event.clientY);
-      }
     },
     [
       getSuggestionId,
@@ -196,27 +172,9 @@ export function SuggestionBubbleMenu({
       isHighlightedSuggestionPinned,
       highlightSuggestion,
       setPositionAtMouse,
+      activeMenu,
+      containerRef,
     ]
-  );
-
-  const handleClick = useCallback(
-    (event: MouseEvent) => {
-      const id = getSuggestionId(event.target);
-      if (id) {
-        highlightSuggestion(id, true);
-        const blockEl =
-          event.target instanceof HTMLElement
-            ? event.target.closest<HTMLElement>("[data-block-id]")
-            : null;
-        if (blockEl) {
-          activeBlockRef.current = blockEl;
-        }
-        setPositionAtMouse(id, event.clientX, event.clientY);
-      } else {
-        clearSelection();
-      }
-    },
-    [getSuggestionId, highlightSuggestion, setPositionAtMouse, clearSelection]
   );
 
   useEffect(() => {
@@ -224,15 +182,13 @@ export function SuggestionBubbleMenu({
     const container = containerRef.current;
 
     editorDom.addEventListener("mousemove", handleMouseMove);
-    editorDom.addEventListener("click", handleClick);
     container?.addEventListener("mouseleave", clearSelection);
 
     return () => {
       editorDom.removeEventListener("mousemove", handleMouseMove);
-      editorDom.removeEventListener("click", handleClick);
       container?.removeEventListener("mouseleave", clearSelection);
     };
-  }, [editor, containerRef, handleMouseMove, handleClick, clearSelection]);
+  }, [editor, containerRef, handleMouseMove, clearSelection]);
 
   const handleAccept = useCallback(() => {
     if (!highlightedSuggestionId) {

--- a/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
+++ b/front/components/agent_builder/copilot/SuggestionBubbleMenu.tsx
@@ -154,7 +154,9 @@ export function SuggestionBubbleMenu({
         setPositionAtMouse(id, event.clientX, event.clientY);
       }
 
-      if (isHighlightedSuggestionPinned) {
+      // Skip updating highlight only if it's the SAME pinned suggestion
+      // Always allow switching to a new suggestion, even if old one was pinned
+      if (!isNewSuggestion && isHighlightedSuggestionPinned) {
         return;
       }
       highlightSuggestion(id);


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/6734 
## Description
Revamping the behavior of the suggestion menu. Instead of appearing on default, sticking, and then following your click, the buttons will now follow your hover (as will which suggestion is highlighted)
For ease of use with long suggestions, buttons will reposition if your hover is >300 vertical pixels from its current position within the same suggestion
Also changed the scrollToNextSuggestion behavior to stop focusing the editor since this adds a cursor at the location of the suggestion and we block user edits here so it was a bit confusing
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
