### PR TITLE
Fix the migration to keep an index without a where criteria

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -729,6 +729,13 @@ MessageModel.init(
         unique: true,
         fields: ["sId"],
       },
+      // Index when the branchId criteria is not set in queries.
+      // No uniqueness constraint as uniqueness is enforced by the branchId null/not null indexes below.
+      {
+        fields: ["workspaceId", "conversationId", "rank", "version"],
+        name: "messages_workspace_id_conversation_id_rank_version",
+        concurrently: true,
+      },
       // We need two separate indexes for the different cases of branchId being null or not.
       // Because a null value is not considered distinct in an unique index.
       {
@@ -739,6 +746,7 @@ MessageModel.init(
             [Op.is]: null,
           },
         },
+        name: "messages_workspace_id_conversation_id_rank_version_branch_null",
         concurrently: true,
       },
       {
@@ -755,6 +763,7 @@ MessageModel.init(
             [Op.ne]: null,
           },
         },
+        name: "messages_workspace_id_conversation_id_rank_version_branch_id",
         concurrently: true,
       },
       {

--- a/front/migrations/db/migration_527.sql
+++ b/front/migrations/db/migration_527.sql
@@ -1,1 +1,14 @@
+-- Create a new version of the index without the branchId condition and the uniqness so that it can be leveraged by queries not specifying a branchId.
+CREATE INDEX CONCURRENTLY "messages_workspace_id_conversation_id_rank_version_new" ON "messages" (
+    "workspaceId",
+    "conversationId",
+    "rank",
+    "version"
+);
+
+-- Drop the old index.
 DROP INDEX CONCURRENTLY IF EXISTS "messages_workspace_id_conversation_id_rank_version";
+
+-- Rename the new index to the old index name.
+ALTER INDEX messages_workspace_id_conversation_id_rank_version_new
+RENAME TO messages_workspace_id_conversation_id_rank_version;


### PR DESCRIPTION
## Description

Keep the old index on queries without branchId criteria on "where".

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front