### PR TITLE
fix: biome noNextImport

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,6 @@
     "./biome-plugins/noRawSql.grit",
     "./biome-plugins/noBulkLodash.grit",
     "./biome-plugins/noDirectSparkleNotification.grit",
-    "./biome-plugins/noNextImports.grit",
     "./biome-plugins/noUnverifiedWorkspaceBypass.grit",
     "./biome-plugins/noMcpServerInstructions.grit",
     "./biome-plugins/enforceClientTypesInPublicApi.grit",
@@ -80,6 +79,10 @@
     }
   },
   "overrides": [
+    {
+      "includes": ["**", "!front/pages/**"],
+      "plugins": ["./biome-plugins/noNextImports.grit"]
+    },
     {
       "includes": ["cli/dust-cli/**", "sparkle/**"],
       "javascript": {

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 // Tailwind base globals
 import "@app/styles/global.css";
 // Use sparkle styles, override local globals

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { setupGracefulShutdown } from "@app/lib/api/graceful_shutdown";
 import Document, { Head, Html, Main, NextScript } from "next/document";
 import Script from "next/script";

--- a/front/pages/academy/[slug].tsx
+++ b/front/pages/academy/[slug].tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { AcademyQuiz } from "@app/components/academy/AcademyQuiz";
 import {
   AcademySidebar,

--- a/front/pages/academy/[slug]/chapter/[chapterSlug].tsx
+++ b/front/pages/academy/[slug]/chapter/[chapterSlug].tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { AcademyQuiz } from "@app/components/academy/AcademyQuiz";
 import {
   ChapterMobileMenuButton,

--- a/front/pages/academy/index.tsx
+++ b/front/pages/academy/index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   ACADEMY_PAGE_SIZE,
   AcademyHeader,

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { AcademyQuiz } from "@app/components/academy/AcademyQuiz";
 import {
   AcademySidebar,

--- a/front/pages/api/academy/progress/backfill.ts
+++ b/front/pages/api/academy/progress/backfill.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { fetchUserFromSession } from "@app/lib/iam/users";

--- a/front/pages/api/academy/progress/courses.ts
+++ b/front/pages/api/academy/progress/courses.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyQuizAttemptResource } from "@app/lib/resources/academy_quiz_attempt_resource";

--- a/front/pages/api/academy/progress/index.ts
+++ b/front/pages/api/academy/progress/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyQuizAttemptResource } from "@app/lib/resources/academy_quiz_attempt_resource";

--- a/front/pages/api/academy/progress/visit.ts
+++ b/front/pages/api/academy/progress/visit.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyChapterVisitResource } from "@app/lib/resources/academy_chapter_visit_resource";

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { Authenticator } from "@app/lib/auth";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { TableOfContents } from "@app/components/blog/TableOfContents";
 import { BlogBlock } from "@app/components/home/ContentBlocks";
 import { Grid, H1, H2 } from "@app/components/home/ContentComponents";

--- a/front/pages/blog/index.tsx
+++ b/front/pages/blog/index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   BLOG_PAGE_SIZE,
   BlogHeader,

--- a/front/pages/blog/page/[page].tsx
+++ b/front/pages/blog/page/[page].tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   BLOG_PAGE_SIZE,
   BlogHeader,

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { TableOfContents } from "@app/components/blog/TableOfContents";
 import { A, Grid, H1, H2 } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { Grid, H1, P } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";

--- a/front/pages/email/validation.tsx
+++ b/front/pages/email/validation.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import config from "@app/lib/api/config";
 import { useSearchParam } from "@app/lib/platform";
 import { Button, DustLogoSquare, Icon, Page, Spinner } from "@dust-tt/sparkle";

--- a/front/pages/home/about.tsx
+++ b/front/pages/home/about.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   Grid,
   H1,

--- a/front/pages/home/api-pricing.tsx
+++ b/front/pages/home/api-pricing.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { HeaderContentBlock } from "@app/components/home/ContentBlocks";
 import { Grid } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";

--- a/front/pages/home/brand-resources.tsx
+++ b/front/pages/home/brand-resources.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   Grid,
   H1,

--- a/front/pages/home/chrome-extension.tsx
+++ b/front/pages/home/chrome-extension.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   Grid,
   H1,

--- a/front/pages/home/contact.tsx
+++ b/front/pages/home/contact.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { ContactForm } from "@app/components/home/ContactForm";
 import { HeaderContentBlock } from "@app/components/home/ContentBlocks";
 import { Grid } from "@app/components/home/ContentComponents";

--- a/front/pages/home/enterprise.tsx
+++ b/front/pages/home/enterprise.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { H1, H2, H3, P } from "@app/components/home/ContentComponents";
 import { TestimonialSection } from "@app/components/home/content/Product/TestimonialSection";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";

--- a/front/pages/home/frames.tsx
+++ b/front/pages/home/frames.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { Grid, H1, H2, H3, P } from "@app/components/home/ContentComponents";
 import { DemoVideoSection } from "@app/components/home/content/Solutions/DemoVideoSection";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";

--- a/front/pages/home/index.tsx
+++ b/front/pages/home/index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { QuoteSection } from "@app/components/home/ContentBlocks";
 import {
   CloudConnectorsSection,

--- a/front/pages/home/partner.tsx
+++ b/front/pages/home/partner.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { Grid } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";

--- a/front/pages/home/platform-privacy.tsx
+++ b/front/pages/home/platform-privacy.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   A,
   Grid,

--- a/front/pages/home/pricing.tsx
+++ b/front/pages/home/pricing.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { HeaderContentBlock } from "@app/components/home/ContentBlocks";
 import { Grid } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";

--- a/front/pages/home/product.tsx
+++ b/front/pages/home/product.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { H2 } from "@app/components/home/ContentComponents";
 import { CapabilitySection } from "@app/components/home/content/Product/CapabilitySection";
 import { InteractiveFeaturesSection } from "@app/components/home/content/Product/InteractiveFeaturesSection";

--- a/front/pages/home/security.tsx
+++ b/front/pages/home/security.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   Grid,
   H1,

--- a/front/pages/home/slack/slack-integration.tsx
+++ b/front/pages/home/slack/slack-integration.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   Grid,
   H1,

--- a/front/pages/home/solutions/customer-support.tsx
+++ b/front/pages/home/solutions/customer-support.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/data-analytics.tsx
+++ b/front/pages/home/solutions/data-analytics.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { QuoteSection } from "@app/components/home/ContentBlocks";
 import { Grid } from "@app/components/home/ContentComponents";
 import { BenefitsSection } from "@app/components/home/content/Solutions/BenefitsSection";

--- a/front/pages/home/solutions/dust-platform.tsx
+++ b/front/pages/home/solutions/dust-platform.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { ImgBlock, QuoteSection } from "@app/components/home/ContentBlocks";
 import { Grid } from "@app/components/home/ContentComponents";
 import { ExtensibilitySection } from "@app/components/home/content/Product/ExtensibilitySection";

--- a/front/pages/home/solutions/engineering.tsx
+++ b/front/pages/home/solutions/engineering.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/it.tsx
+++ b/front/pages/home/solutions/it.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/knowledge.tsx
+++ b/front/pages/home/solutions/knowledge.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/legal.tsx
+++ b/front/pages/home/solutions/legal.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/marketing.tsx
+++ b/front/pages/home/solutions/marketing.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/productivity.tsx
+++ b/front/pages/home/solutions/productivity.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/recruiting-people.tsx
+++ b/front/pages/home/solutions/recruiting-people.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/solutions/sales.tsx
+++ b/front/pages/home/solutions/sales.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   MetricSection,
   QuoteSection,

--- a/front/pages/home/support.tsx
+++ b/front/pages/home/support.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import {
   Grid,
   H1,

--- a/front/pages/home/vulnerability.tsx
+++ b/front/pages/home/vulnerability.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { Grid, H1, H2, H3, P } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";


### PR DESCRIPTION
## Description

The linter noNextImport shouldn;t be enabled in `/pages`, it was lost in the migration to biome.

This PR fixes it
## Tests

CI
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
