### PR TITLE
Bump Anthropic Cache TTL For System Prompt

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -41,17 +41,21 @@ import type { WorkspaceType } from "@app/types/user";
  */
 function buildSystemBlocks(
   [instructions, context]: [SystemPromptInstruction[], SystemPromptContext[]],
-  _: { hasConditionalJITTools?: boolean }
+  { hasConditionalJITTools }: { hasConditionalJITTools?: boolean }
 ) {
   const instructionsText = instructions.map((s) => s.content).join("\n");
   const contextText = context.map((s) => s.content).join("\n");
 
   const system: Anthropic.Beta.Messages.BetaTextBlockParam[] = [];
   if (instructionsText) {
+    // If we have conditional JIT tools, we expect more variability in the instructions, so we keep
+    // the default ephemeral cache. Otherwise, we can set a longer TTL to maximize cache hits.
+    const ttl: "1h" | undefined = hasConditionalJITTools ? undefined : "1h";
+
     system.push({
       type: "text",
       text: instructionsText,
-      cache_control: { type: "ephemeral" },
+      cache_control: { type: "ephemeral", ttl },
     });
   }
   if (contextText) {

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -84,8 +84,8 @@ export async function* streamLLMEvents(
   }
 
   try {
-    // Anthropic does not send the output token coutn details
-    // This allows a rough estimation of the reasoning tokens
+    // Anthropic does not send the output token count details.
+    // This allows a rough estimation of the reasoning tokens.
     const tokenCount = (await countTokensCallback?.({
       model: metadata.modelId,
       messages: outputTokensWithoutReasoning,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR enables longer cache (1h) for whitelisted global agents (`@dust` and `@deep-dive`) that uses Anthropic models. We cache for 1h, globally shared system prompt, only if there is no JIT tools associated. 

Indeed, Anthropic cache controls works in the following way: `tools` -> `system` -> `message` if any item changes, it burst the rest of the items.

Will monitor for one day before deciding if we push this more or revert.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
