### PR TITLE
[front] feat(sandbox): add support for files in skills backend

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -569,15 +569,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
       });
 
-      const allFileResources =
-        await FileResource.fetchByModelIdsWithAuth(
-              auth,
-              fileAttachmentModels.map((a) => a.fileId)
-            )
-
-      const fileResourceById = new Map(
-        allFileResources.map((f) => [f.id, f])
+      const allFileResources = await FileResource.fetchByModelIdsWithAuth(
+        auth,
+        fileAttachmentModels.map((a) => a.fileId)
       );
+
+      const fileResourceById = new Map(allFileResources.map((f) => [f.id, f]));
 
       const fileAttachmentsBySkillId = groupBy(
         fileAttachmentModels,
@@ -648,8 +645,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           editorGroup: skillEditorGroupsMap.get(customSkill.id),
           dataSourceConfigurations: skillDataSourceConfigs,
           fileAttachments: removeNulls(
-            (fileAttachmentsBySkillId[customSkill.id] ?? []).map((a) =>
-              fileResourceById.get(a.fileId) ?? null
+            (fileAttachmentsBySkillId[customSkill.id] ?? []).map(
+              (a) => fileResourceById.get(a.fileId) ?? null
             )
           ),
         });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1865,7 +1865,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     // Delete removed attachments and their underlying files.
-    // Deleting the files first, then remove the join table rows.
+    // Remove join table rows first (FK constraint), then delete the files.
     const toRemove = existingAttachments.filter(
       (a) => !desiredFileModelIds.has(a.fileId)
     );
@@ -1874,18 +1874,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         auth,
         toRemove.map((a) => a.fileId)
       );
-      for (const file of filesToDelete) {
-        const res = await file.delete(auth);
-        if (res.isErr()) {
-          throw res.error;
-        }
-      }
       await SkillFileAttachmentModel.destroy({
         where: {
           id: { [Op.in]: toRemove.map((a) => a.id) },
           workspaceId: workspace.id,
         },
       });
+      for (const file of filesToDelete) {
+        const res = await file.delete(auth);
+        if (res.isErr()) {
+          throw res.error;
+        }
+      }
     }
 
     // Create new attachments.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -369,6 +369,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           workspaceId: owner.id,
           skillConfigurationId: skill.id,
           fileId: file.id,
+          fileName: file.fileName,
         })),
         { transaction }
       );
@@ -1899,6 +1900,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           workspaceId: workspace.id,
           skillConfigurationId: this.id,
           fileId: file.id,
+          fileName: file.fileName,
         })),
         { transaction }
       );

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1865,6 +1865,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     // Delete removed attachments and their underlying files.
+    // Delete from cloud storage first, then remove the join table rows.
     const toRemove = existingAttachments.filter(
       (a) => !desiredFileModelIds.has(a.fileId)
     );
@@ -1873,15 +1874,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         auth,
         toRemove.map((a) => a.fileId)
       );
+      for (const file of filesToDelete) {
+        const res = await file.delete(auth);
+        if (res.isErr()) {
+          throw res.error;
+        }
+      }
       await SkillFileAttachmentModel.destroy({
         where: {
           id: { [Op.in]: toRemove.map((a) => a.id) },
           workspaceId: workspace.id,
         },
       });
-      for (const file of filesToDelete) {
-        await file.delete(auth);
-      }
     }
 
     // Create new attachments.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1865,7 +1865,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     // Delete removed attachments and their underlying files.
-    // Delete from cloud storage first, then remove the join table rows.
+    // Deleting the files first, then remove the join table rows.
     const toRemove = existingAttachments.filter(
       (a) => !desiredFileModelIds.has(a.fileId)
     );

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1641,16 +1641,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { transaction }
       );
 
-      if (fileAttachments) {
-        await this.setFileAttachments(auth, fileAttachments, { transaction });
-      }
-
       await this.updateActiveAgentsRequirements(
         auth,
         { previousRequestedSpaceIds },
         { transaction }
       );
     });
+
+    if (fileAttachments) {
+      await this.setFileAttachments(auth, fileAttachments);
+    }
   }
 
   /**
@@ -1848,8 +1848,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private async setFileAttachments(
     auth: Authenticator,
-    fileAttachments: FileResource[],
-    { transaction }: { transaction?: Transaction } = {}
+    fileAttachments: FileResource[]
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -1858,7 +1857,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         skillConfigurationId: this.id,
         workspaceId: workspace.id,
       },
-      transaction,
     });
 
     const desiredFileModelIds = new Set(fileAttachments.map((f) => f.id));
@@ -1880,7 +1878,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           id: { [Op.in]: toRemove.map((a) => a.id) },
           workspaceId: workspace.id,
         },
-        transaction,
       });
       for (const file of filesToDelete) {
         await file.delete(auth);
@@ -1898,8 +1895,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           skillConfigurationId: this.id,
           fileId: file.id,
           fileName: file.fileName,
-        })),
-        { transaction }
+        }))
       );
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -187,7 +187,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
 
   readonly dataSourceConfigurations: SkillDataSourceConfigurationModel[];
-  private readonly fileAttachments: FileResource[];
+  private fileAttachments: FileResource[];
   readonly editorGroup: GroupResource | null = null;
   readonly version: number | null = null;
 
@@ -1902,6 +1902,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { transaction }
       );
     }
+
+    // Update instance to avoid stale data.
+    this.fileAttachments = fileAttachments;
   }
 
   async delete(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2152,7 +2152,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         where: { workspaceId },
       });
       for (const file of filesToDelete) {
-        await file.delete(auth);
+        const res = await file.delete(auth);
+        if (res.isErr()) {
+          throw res.error;
+        }
       }
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -9,6 +9,7 @@ import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import {
   SkillConfigurationModel,
   SkillDataSourceConfigurationModel,
+  SkillFileAttachmentModel,
   SkillMCPServerConfigurationModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
@@ -19,6 +20,7 @@ import {
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
@@ -86,6 +88,7 @@ type SkillResourceConstructorOptions =
       // For global skills, there is no editor group.
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: undefined;
+      fileAttachments?: FileResource[];
       globalSId: string;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
@@ -93,6 +96,7 @@ type SkillResourceConstructorOptions =
   | {
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: GroupResource;
+      fileAttachments?: FileResource[];
       globalSId?: undefined;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
@@ -183,6 +187,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
 
   readonly dataSourceConfigurations: SkillDataSourceConfigurationModel[];
+  private readonly fileAttachments: FileResource[];
   readonly editorGroup: GroupResource | null = null;
   readonly version: number | null = null;
 
@@ -195,6 +200,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     blob: Attributes<SkillConfigurationModel>,
     {
       dataSourceConfigurations,
+      fileAttachments,
       globalSId,
       mcpServerConfigurations,
       editorGroup,
@@ -205,6 +211,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     this.dataSourceConfigurations = dataSourceConfigurations;
     this.editorGroup = editorGroup ?? null;
+    this.fileAttachments = fileAttachments ?? [];
     this.globalSId = globalSId ?? null;
     this._mcpServerConfigurations = mcpServerConfigurations;
     this.version = version ?? null;
@@ -319,10 +326,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViews,
       addCurrentUserAsEditor = true,
       attachedKnowledge = [],
+      fileAttachments = [],
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
+      fileAttachments?: FileResource[];
     }
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
@@ -354,6 +363,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { transaction }
       );
 
+      // File attachments for the skill.
+      await SkillFileAttachmentModel.bulkCreate(
+        fileAttachments.map((file) => ({
+          workspaceId: owner.id,
+          skillConfigurationId: skill.id,
+          fileId: file.id,
+        })),
+        { transaction }
+      );
+
       // Compute what data source configurations to create (no existing configs for new skill).
       const { toUpsert } = this.computeDataSourceConfigurationChanges(owner, {
         attachedKnowledge,
@@ -369,6 +388,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return new this(this.model, skill.get(), {
         dataSourceConfigurations,
         editorGroup,
+        fileAttachments,
         mcpServerConfigurations: mcpServerViews.map((view) => ({
           view,
         })),
@@ -539,6 +559,30 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         "skillConfigurationId"
       );
 
+      const fileAttachmentModels = await SkillFileAttachmentModel.findAll({
+        where: {
+          workspaceId: workspace.id,
+          skillConfigurationId: {
+            [Op.in]: allowedCustomSkillIds,
+          },
+        },
+      });
+
+      const allFileResources =
+        await FileResource.fetchByModelIdsWithAuth(
+              auth,
+              fileAttachmentModels.map((a) => a.fileId)
+            )
+
+      const fileResourceById = new Map(
+        allFileResources.map((f) => [f.id, f])
+      );
+
+      const fileAttachmentsBySkillId = groupBy(
+        fileAttachmentModels,
+        "skillConfigurationId"
+      );
+
       // Fetch editor groups for all skills.
       const skillEditorGroupsMap = new Map<number, GroupResource>();
 
@@ -602,6 +646,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           })),
           editorGroup: skillEditorGroupsMap.get(customSkill.id),
           dataSourceConfigurations: skillDataSourceConfigs,
+          fileAttachments: removeNulls(
+            (fileAttachmentsBySkillId[customSkill.id] ?? []).map((a) =>
+              fileResourceById.get(a.fileId) ?? null
+            )
+          ),
         });
       });
     }
@@ -1538,6 +1587,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentFacingDescription,
       attachedKnowledge,
+      fileAttachments,
       icon,
       instructions,
       mcpServerViews,
@@ -1548,6 +1598,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       agentFacingDescription: string;
       attachedKnowledge: SkillAttachedKnowledge[];
+      fileAttachments?: FileResource[];
       icon: string | null;
       instructions: string;
       mcpServerViews: MCPServerViewResource[];
@@ -1591,6 +1642,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
         { transaction }
       );
+
+      if (fileAttachments) {
+        await this.setFileAttachments(auth, fileAttachments, { transaction });
+      }
 
       await this.updateActiveAgentsRequirements(
         auth,
@@ -1793,6 +1848,63 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
   }
 
+  private async setFileAttachments(
+    auth: Authenticator,
+    fileAttachments: FileResource[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const existingAttachments = await SkillFileAttachmentModel.findAll({
+      where: {
+        skillConfigurationId: this.id,
+        workspaceId: workspace.id,
+      },
+      transaction,
+    });
+
+    const desiredFileModelIds = new Set(fileAttachments.map((f) => f.id));
+    const existingFileModelIds = new Set(
+      existingAttachments.map((a) => a.fileId)
+    );
+
+    // Delete removed attachments and their underlying files.
+    const toRemove = existingAttachments.filter(
+      (a) => !desiredFileModelIds.has(a.fileId)
+    );
+    if (toRemove.length > 0) {
+      const filesToDelete = await FileResource.fetchByModelIdsWithAuth(
+        auth,
+        toRemove.map((a) => a.fileId)
+      );
+      await SkillFileAttachmentModel.destroy({
+        where: {
+          id: { [Op.in]: toRemove.map((a) => a.id) },
+          workspaceId: workspace.id,
+        },
+        transaction,
+      });
+      for (const file of filesToDelete) {
+        await file.delete(auth);
+      }
+    }
+
+    // Create new attachments.
+    const toCreate = fileAttachments.filter(
+      (f) => !existingFileModelIds.has(f.id)
+    );
+    if (toCreate.length > 0) {
+      await SkillFileAttachmentModel.bulkCreate(
+        toCreate.map((file) => ({
+          workspaceId: workspace.id,
+          skillConfigurationId: this.id,
+          fileId: file.id,
+        })),
+        { transaction }
+      );
+    }
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
@@ -1827,6 +1939,25 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       if (this.editorGroup) {
         await this.editorGroup.delete(auth, { transaction });
+      }
+
+      // Delete file attachments and their underlying files.
+      const fileAttachments = await SkillFileAttachmentModel.findAll({
+        where: whereWorkspaceIdAndSkillId,
+        transaction,
+      });
+      if (fileAttachments.length > 0) {
+        const filesToDelete = await FileResource.fetchByModelIdsWithAuth(
+          auth,
+          fileAttachments.map((a) => a.fileId)
+        );
+        await SkillFileAttachmentModel.destroy({
+          where: whereWorkspaceIdAndSkillId,
+          transaction,
+        });
+        for (const file of filesToDelete) {
+          await file.delete(auth);
+        }
       }
 
       await SkillDataSourceConfigurationModel.destroy({
@@ -2006,6 +2137,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       await editorGroup.delete(auth);
     }
 
+    // Delete file attachments and their underlying files.
+    const fileAttachments = await SkillFileAttachmentModel.findAll({
+      where: { workspaceId },
+    });
+    if (fileAttachments.length > 0) {
+      const filesToDelete = await FileResource.fetchByModelIdsWithAuth(
+        auth,
+        fileAttachments.map((a) => a.fileId)
+      );
+      await SkillFileAttachmentModel.destroy({
+        where: { workspaceId },
+      });
+      for (const file of filesToDelete) {
+        await file.delete(auth);
+      }
+    }
+
     await SkillDataSourceConfigurationModel.destroy({
       where: { workspaceId },
     });
@@ -2062,6 +2210,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           },
         };
       }),
+      fileAttachments: this.fileAttachments.map((file) => ({
+        fileId: file.sId,
+        fileName: file.fileName,
+      })),
       canWrite: this.canWrite(auth),
       isExtendable: this.isExtendable,
       extendedSkillId: this.extendedSkillId,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -1,8 +1,13 @@
 import { Authenticator } from "@app/lib/auth";
-import { SkillVersionModel } from "@app/lib/models/skill";
+import {
+  SkillFileAttachmentModel,
+  SkillVersionModel,
+} from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -548,6 +553,172 @@ describe("PATCH /api/w/[wId]/skills/[sId] - Suggested skill activation", () => {
     });
     expect(versions).toHaveLength(1);
     expect(versions[0].editedBy).toBeNull();
+  });
+});
+
+describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
+  it("should update file attachments when sandbox_tools is enabled", async () => {
+    const { req, res, skill, workspace, requestUser, requestUserAuth } =
+      await setupTest({
+        skillOwnerRole: "builder",
+        requestUserRole: "builder",
+        method: "PATCH",
+      });
+
+    await FeatureFlagFactory.basic("sandbox_tools", workspace);
+
+    const file = await FileFactory.create(workspace, requestUser, {
+      contentType: "text/plain",
+      fileName: "template.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      fileAttachments: [{ fileId: file.sId }],
+    };
+
+    await handler(req, res);
+
+    const data = res._getJSONData();
+    expect(data).not.toHaveProperty("error");
+    expect(res._getStatusCode()).toBe(200);
+    expect(data.skill.fileAttachments).toHaveLength(1);
+    expect(data.skill.fileAttachments[0].fileName).toBe("template.txt");
+
+    // Verify persistence.
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill).not.toBeNull();
+    expect(updatedSkill!.toJSON(requestUserAuth).fileAttachments).toHaveLength(
+      1
+    );
+  });
+
+  // Test that checks the retro-compatibility.
+  it("should succeed without file attachments when sandbox_tools is not enabled", async () => {
+    const { req, res, skill } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+      method: "PATCH",
+    });
+
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: "Updated description",
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  // Test that checks the retro-compatibility.
+  it("should succeed without file attachments", async () => {
+    const { req, res, skill } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+      method: "PATCH",
+    });
+
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: "Updated description",
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("should remove file attachments when updating with empty array", async () => {
+    const { req, res, skill, workspace, requestUser, requestUserAuth } =
+      await setupTest({
+        skillOwnerRole: "builder",
+        requestUserRole: "builder",
+        method: "PATCH",
+      });
+
+    await FeatureFlagFactory.basic("sandbox_tools", workspace);
+
+    // Add a file attachment via the resource directly.
+    const file = await FileFactory.create(workspace, requestUser, {
+      contentType: "text/plain",
+      fileName: "to-remove.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+
+    await skill.updateSkill(requestUserAuth, {
+      agentFacingDescription: skill.agentFacingDescription,
+      attachedKnowledge: [],
+      fileAttachments: [file],
+      icon: null,
+      instructions: skill.instructions,
+      mcpServerViews: [],
+      name: skill.name,
+      requestedSpaceIds: [],
+      userFacingDescription: skill.userFacingDescription,
+    });
+
+    // Verify the file was added.
+    const skillAfterAdd = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillAfterAdd!.toJSON(requestUserAuth).fileAttachments).toHaveLength(
+      1
+    );
+
+    // Now remove via the API.
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      fileAttachments: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().skill.fileAttachments).toHaveLength(0);
+
+    // Verify persistence.
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill!.toJSON(requestUserAuth).fileAttachments).toHaveLength(
+      0
+    );
+
+    // Verify the join table row was deleted.
+    const remainingAttachments = await SkillFileAttachmentModel.findAll({
+      where: { skillConfigurationId: skill.id, workspaceId: workspace.id },
+    });
+    expect(remainingAttachments).toHaveLength(0);
   });
 });
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -17,9 +17,55 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { RequestMethod } from "node-mocks-http";
 import type { WhereOptions } from "sequelize";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
+
+// Mock FileStorage to avoid GCS calls during file deletion.
+vi.mock("@app/lib/file_storage", () => {
+  const createMockGCSFile = () => ({
+    createReadStream: vi.fn().mockReturnValue({
+      on: vi.fn().mockImplementation(function (this: any) {
+        return this;
+      }),
+      pipe: vi.fn(),
+    }),
+    getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
+    createWriteStream: vi.fn().mockReturnValue({
+      on: vi.fn().mockImplementation(function (
+        this: any,
+        event: string,
+        cb: any
+      ) {
+        if (event === "finish") {
+          // eslint-disable-next-line @typescript-eslint/no-implied-eval
+          setImmediate(cb);
+        }
+        return this;
+      }),
+      write: vi.fn(),
+      end: vi.fn(),
+    }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
+  });
+
+  const createMockFileStorage = () => ({
+    file: vi.fn(createMockGCSFile),
+    getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
+    uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
+    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+    fetchFileContent: vi.fn().mockResolvedValue("mock content"),
+    delete: vi.fn().mockResolvedValue(undefined),
+  });
+
+  return {
+    FileStorage: vi.fn().mockImplementation(createMockFileStorage),
+    getPrivateUploadBucket: vi.fn(createMockFileStorage),
+    getPublicUploadBucket: vi.fn(createMockFileStorage),
+    getUpsertQueueBucket: vi.fn(createMockFileStorage),
+  };
+});
 
 async function setupTest(
   options: {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -265,7 +265,7 @@ async function handler(
             status_code: 403,
             api_error: {
               type: "invalid_request_error",
-              message: "File attachments require the sandbox_tools feature.",
+              message: "File attachments are not supported.",
             },
           });
         }

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,6 +1,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
@@ -43,20 +44,25 @@ export type DeleteSkillResponseBody = {
   success: boolean;
 };
 
-// Request body schema for PATCH
-const PatchSkillRequestBodySchema = t.type({
-  name: t.string,
-  agentFacingDescription: t.string,
-  userFacingDescription: t.string,
-  instructions: t.string,
-  icon: t.union([t.string, t.null]),
-  tools: t.array(
-    t.type({
-      mcpServerViewId: t.string,
-    })
-  ),
-  attachedKnowledge: t.array(AttachedKnowledgeSchema),
-});
+// Request body schema for PATCH.
+const PatchSkillRequestBodySchema = t.intersection([
+  t.type({
+    name: t.string,
+    agentFacingDescription: t.string,
+    userFacingDescription: t.string,
+    instructions: t.string,
+    icon: t.union([t.string, t.null]),
+    tools: t.array(
+      t.type({
+        mcpServerViewId: t.string,
+      })
+    ),
+    attachedKnowledge: t.array(AttachedKnowledgeSchema),
+  }),
+  t.partial({
+    fileAttachments: t.array(t.type({ fileId: t.string })),
+  }),
+]);
 
 type PatchSkillRequestBody = t.TypeOf<typeof PatchSkillRequestBodySchema>;
 
@@ -208,8 +214,9 @@ async function handler(
         });
       }
 
+      const { attachedKnowledge, fileAttachments } = body;
+
       // Validate all data source views from attached knowledge exist and user has access.
-      const { attachedKnowledge } = body;
       const dataSourceViewIds = uniq(
         attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
       );
@@ -247,6 +254,47 @@ async function handler(
         }
       );
 
+      // Validate file attachments if provided (gated behind sandbox_tools).
+      let files: FileResource[] | undefined;
+      if (fileAttachments) {
+        const featureFlags = await getFeatureFlags(
+          auth.getNonNullableWorkspace()
+        );
+        if (!featureFlags.includes("sandbox_tools")) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "invalid_request_error",
+              message: "File attachments require the sandbox_tools feature.",
+            },
+          });
+        }
+
+        const fileAttachmentIds = fileAttachments.map((f) => f.fileId);
+        files = await FileResource.fetchByIds(auth, fileAttachmentIds);
+        if (files.length !== fileAttachmentIds.length) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "invalid_request_error",
+              message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
+            },
+          });
+        }
+
+        for (const file of files) {
+          if (!file.isReady || file.useCase !== "skill_attachment") {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: `File ${file.sId} is not ready or not a skill_attachment.`,
+              },
+            });
+          }
+        }
+      }
+
       // When saving a suggested skill, automatically activate it.
       const shouldActivate = skillResource.status === "suggested";
 
@@ -263,6 +311,7 @@ async function handler(
       await skillResource.updateSkill(auth, {
         agentFacingDescription: body.agentFacingDescription,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+        fileAttachments: files,
         icon: body.icon,
         instructions: body.instructions,
         mcpServerViews,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -270,7 +270,7 @@ async function handler(
           });
         }
 
-        const fileAttachmentIds = fileAttachments.map((f) => f.fileId);
+        const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
         files = await FileResource.fetchByIds(auth, fileAttachmentIds);
         if (files.length !== fileAttachmentIds.length) {
           return apiError(req, res, {

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -7,6 +7,8 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -692,6 +694,145 @@ describe("POST /api/w/[wId]/skills", () => {
     });
     expect(skillConfiguration).not.toBeNull();
     expect(skillConfiguration!.requestedSpaceIds).toEqual([regularSpace.id]);
+  });
+});
+
+describe("POST /api/w/[wId]/skills - file attachments", () => {
+  it("creates a skill with file attachments when sandbox_tools is enabled", async () => {
+    const { req, res, workspace, user, authenticator } = await setupTest(
+      "POST",
+      "builder"
+    );
+
+    await FeatureFlagFactory.basic("sandbox_tools", workspace);
+
+    const file1 = await FileFactory.create(workspace, user, {
+      contentType: "text/plain",
+      fileName: "template.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+    const file2 = await FileFactory.create(workspace, user, {
+      contentType: "application/json",
+      fileName: "schema.json",
+      fileSize: 200,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+
+    req.body = {
+      name: "Skill With Files",
+      agentFacingDescription: "A skill with file attachments",
+      userFacingDescription: "User description",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      fileAttachments: [{ fileId: file1.sId }, { fileId: file2.sId }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const data = res._getJSONData();
+    expect(data.skill.fileAttachments).toHaveLength(2);
+
+    const fileNames = data.skill.fileAttachments.map(
+      (f: { fileName: string }) => f.fileName
+    );
+    expect(fileNames).toContain("template.txt");
+    expect(fileNames).toContain("schema.json");
+
+    // Verify persistence.
+    const createdSkill = await SkillResource.fetchById(
+      authenticator,
+      data.skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+    expect(createdSkill!.toJSON(authenticator).fileAttachments).toHaveLength(2);
+  });
+
+  it("rejects file attachments when sandbox_tools is not enabled", async () => {
+    const { req, res, workspace, user } = await setupTest("POST", "admin");
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "text/plain",
+      fileName: "template.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+
+    req.body = {
+      name: "Skill With Files",
+      agentFacingDescription: "A skill with file attachments",
+      userFacingDescription: "User description",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      fileAttachments: [{ fileId: file.sId }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.message).toContain(
+      "File attachments are not supported"
+    );
+  });
+
+  it("succeeds without file attachments when sandbox_tools is not enabled", async () => {
+    const { req, res } = await setupTest("POST", "admin");
+
+    req.body = {
+      name: "Skill Without Files",
+      agentFacingDescription: "A normal skill",
+      userFacingDescription: "User description",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().skill.fileAttachments).toHaveLength(0);
+  });
+
+  it("rejects file attachments with wrong use case", async () => {
+    const { req, res, workspace, user } = await setupTest("POST", "admin");
+
+    await FeatureFlagFactory.basic("sandbox_tools", workspace);
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "text/plain",
+      fileName: "conversation-file.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    req.body = {
+      name: "Skill With Wrong File",
+      agentFacingDescription: "Description",
+      userFacingDescription: "User description",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      fileAttachments: [{ fileId: file.sId }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "not ready or not a skill_attachment"
+    );
   });
 });
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -280,7 +280,7 @@ async function handler(
             status_code: 403,
             api_error: {
               type: "invalid_request_error",
-              message: "File attachments require the sandbox_tools feature.",
+              message: "File attachments are not supported.",
             },
           });
         }

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,7 +1,8 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -48,20 +49,25 @@ export const AttachedKnowledgeSchema = t.type({
 });
 
 // Request body schema for POST.
-const PostSkillRequestBodySchema = t.type({
-  name: t.string,
-  agentFacingDescription: t.string,
-  userFacingDescription: t.string,
-  instructions: t.string,
-  icon: t.union([t.string, t.null]),
-  tools: t.array(
-    t.type({
-      mcpServerViewId: t.string,
-    })
-  ),
-  extendedSkillId: t.union([t.string, t.null]),
-  attachedKnowledge: t.array(AttachedKnowledgeSchema),
-});
+const PostSkillRequestBodySchema = t.intersection([
+  t.type({
+    name: t.string,
+    agentFacingDescription: t.string,
+    userFacingDescription: t.string,
+    instructions: t.string,
+    icon: t.union([t.string, t.null]),
+    tools: t.array(
+      t.type({
+        mcpServerViewId: t.string,
+      })
+    ),
+    extendedSkillId: t.union([t.string, t.null]),
+    attachedKnowledge: t.array(AttachedKnowledgeSchema),
+  }),
+  t.partial({
+    fileAttachments: t.array(t.type({ fileId: t.string })),
+  }),
+]);
 
 type PostSkillRequestBody = t.TypeOf<typeof PostSkillRequestBodySchema>;
 
@@ -201,8 +207,9 @@ async function handler(
         });
       }
 
+      const { attachedKnowledge, fileAttachments } = body;
+
       // Validate all data source views from attached knowledge exist and user has access.
-      const { attachedKnowledge } = body;
       const dataSourceViewIds = uniq(
         attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
       );
@@ -262,6 +269,44 @@ async function handler(
         });
       }
 
+      // Validate file attachments if provided (gated behind sandbox_tools).
+      if (fileAttachments && fileAttachments.length > 0) {
+        const featureFlags = await getFeatureFlags(
+          auth.getNonNullableWorkspace()
+        );
+        if (!featureFlags.includes("sandbox_tools")) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "invalid_request_error",
+              message: "File attachments require the sandbox_tools feature.",
+            },
+          });
+        }
+      }
+      const fileAttachmentIds = fileAttachments?.map((f) => f.fileId) ?? [];
+      const files = await FileResource.fetchByIds(auth, fileAttachmentIds);
+      if (files.length !== fileAttachmentIds.length) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
+          },
+        });
+      }
+      for (const file of files) {
+        if (!file.isReady || file.useCase !== "skill_attachment") {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `File ${file.sId} is not ready or not a skill_attachment.`,
+            },
+          });
+        }
+      }
+
       // Generate icon suggestion if not provided.
       let icon = body.icon;
       if (!icon) {
@@ -296,6 +341,7 @@ async function handler(
         {
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+          fileAttachments: files,
         }
       );
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -285,7 +285,7 @@ async function handler(
           });
         }
 
-        const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
+        const fileAttachmentIds = fileAttachments.map((f) => f.fileId);
         files = await FileResource.fetchByIds(auth, fileAttachmentIds);
         if (files.length !== fileAttachmentIds.length) {
           return apiError(req, res, {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -284,6 +284,7 @@ async function handler(
           });
         }
       }
+
       const fileAttachmentIds = fileAttachments?.map((f) => f.fileId) ?? [];
       const files = await FileResource.fetchByIds(auth, fileAttachmentIds);
       if (files.length !== fileAttachmentIds.length) {
@@ -295,6 +296,7 @@ async function handler(
           },
         });
       }
+
       for (const file of files) {
         if (!file.isReady || file.useCase !== "skill_attachment") {
           return apiError(req, res, {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -285,7 +285,7 @@ async function handler(
           });
         }
 
-        const fileAttachmentIds = fileAttachments.map((f) => f.fileId);
+        const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
         files = await FileResource.fetchByIds(auth, fileAttachmentIds);
         if (files.length !== fileAttachmentIds.length) {
           return apiError(req, res, {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -270,7 +270,8 @@ async function handler(
       }
 
       // Validate file attachments if provided (gated behind sandbox_tools).
-      if (fileAttachments && fileAttachments.length > 0) {
+      let files: FileResource[] | undefined;
+      if (fileAttachments) {
         const featureFlags = await getFeatureFlags(
           auth.getNonNullableWorkspace()
         );
@@ -283,29 +284,29 @@ async function handler(
             },
           });
         }
-      }
 
-      const fileAttachmentIds = fileAttachments?.map((f) => f.fileId) ?? [];
-      const files = await FileResource.fetchByIds(auth, fileAttachmentIds);
-      if (files.length !== fileAttachmentIds.length) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "invalid_request_error",
-            message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
-          },
-        });
-      }
-
-      for (const file of files) {
-        if (!file.isReady || file.useCase !== "skill_attachment") {
+        const fileAttachmentIds = fileAttachments.map((f) => f.fileId);
+        files = await FileResource.fetchByIds(auth, fileAttachmentIds);
+        if (files.length !== fileAttachmentIds.length) {
           return apiError(req, res, {
-            status_code: 400,
+            status_code: 404,
             api_error: {
               type: "invalid_request_error",
-              message: `File ${file.sId} is not ready or not a skill_attachment.`,
+              message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
             },
           });
+        }
+
+        for (const file of files) {
+          if (!file.isReady || file.useCase !== "skill_attachment") {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: `File ${file.sId} is not ready or not a skill_attachment.`,
+              },
+            });
+          }
         }
       }
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -18,6 +18,7 @@ export type SkillType = {
   icon: string | null;
   requestedSpaceIds: string[];
   tools: MCPServerViewType[];
+  fileAttachments: { fileId: string; fileName: string; }[];
   canWrite: boolean;
   isExtendable: boolean;
   extendedSkillId: string | null;

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -18,7 +18,10 @@ export type SkillType = {
   icon: string | null;
   requestedSpaceIds: string[];
   tools: MCPServerViewType[];
-  fileAttachments: { fileId: string; fileName: string; }[];
+  fileAttachments: {
+    fileId: string;
+    fileName: string;
+  }[];
   canWrite: boolean;
   isExtendable: boolean;
   extendedSkillId: string | null;


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6800.
- This PR adds support for uploading files to skills.
- This PR only contains backend changes, the design for the front-end is not complete.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
