### PR TITLE
Fix PDF export failing with JSON parse error

### DIFF
--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -11,6 +11,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { clientFetch } from "@app/lib/egress/client";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -67,7 +68,6 @@ function ExportContentDropdown({
 }: ExportContentDropdownProps) {
   const sendNotification = useSendNotification();
   const [isExportingPdf, setIsExportingPdf] = useState(false);
-  const { fetcher } = useFetcher();
 
   const exportAsPng = () => {
     if (fileContent) {
@@ -100,7 +100,8 @@ function ExportContentDropdown({
 
     setIsExportingPdf(true);
     try {
-      const response = await fetcher(
+      // Use direct fetch instead of fetcher to avoid JSON parsing of binary PDF data.
+      const response = await clientFetch(
         `/api/w/${owner.sId}/files/${fileId}/export/pdf`,
         {
           method: "POST",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/6877.

Some PDF exports are failing with "SyntaxError: Unexpected token '%'" error when downloading PDFs. The issue comes from the `exportAsPdf` function that is using `fetcher()` which automatically parses all responses as JSON. Since
the PDF endpoint returns binary data, the JSON parser was failing when it encountered the PDF header (`%PDF-1.4`).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
