### PR TITLE
[front] - fix(AB): enable skill data re-fetching after saving

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -138,11 +138,13 @@ export default function AgentBuilder({
 
   const agentConfigurationIdForSkills =
     duplicateAgentId ?? agentConfiguration?.sId ?? null;
-  const { skills, isSkillsLoading } = useAgentConfigurationSkills({
-    owner,
-    agentConfigurationId: agentConfigurationIdForSkills ?? "",
-    disabled: !agentConfigurationIdForSkills,
-  });
+  const { skills, isSkillsLoading, mutateSkills } = useAgentConfigurationSkills(
+    {
+      owner,
+      agentConfigurationId: agentConfigurationIdForSkills ?? "",
+      disabled: !agentConfigurationIdForSkills,
+    }
+  );
 
   const { editors } = useEditors({
     owner,
@@ -438,7 +440,7 @@ export default function AgentBuilder({
       }
 
       // Mutate triggers and actions to refresh from backend
-      await Promise.all([mutateTriggers(), mutateActions()]);
+      await Promise.all([mutateTriggers(), mutateActions(), mutateSkills()]);
       onSaved?.();
 
       if (isCreatingNew && createdAgent.sId) {

--- a/front/lib/swr/skills.ts
+++ b/front/lib/swr/skills.ts
@@ -15,7 +15,7 @@ export function useAgentConfigurationSkills({
   const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetAgentSkillsResponseBody> = fetcher;
 
-  const { data, isLoading } = useSWRWithDefaults(
+  const { data, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/skills`,
     skillsFetcher,
     { disabled }
@@ -24,5 +24,6 @@ export function useAgentConfigurationSkills({
   return {
     skills: data?.skills ?? emptyArray(),
     isSkillsLoading: isLoading,
+    mutateSkills: mutate,
   };
 }


### PR DESCRIPTION
## Description

This PR:
 - Added a mutate function to rerun SWR hooks for fetching skill data post agent configuration updates
 - Ensured skills are refreshed alongside triggers and actions after an agent is saved or created in the AgentBuilder component
 
**References:**
- Fixes https://github.com/dust-tt/tasks/issues/6887

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
