### PR TITLE
Structured Response Format: validate the JSON in UI and on save

### DIFF
--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -120,7 +120,15 @@ export function AdvancedSettings() {
               Structured response format
             </DialogTitle>
             <DialogDescription>
-              Specify a JSON schema to get responses in a consistent structure
+              Specify a JSON schema to get responses in a consistent structure.{" "}
+              <a
+                href="https://docs.dust.tt/docs/structured-output-format"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                See documentation
+              </a>
             </DialogDescription>
           </DialogHeader>
           <DialogContainer>

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -2,11 +2,11 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ModelSelectionSubmenu } from "@app/components/agent_builder/instructions/ModelSelectionSubmenu";
 import { ReasoningEffortSubmenu } from "@app/components/agent_builder/instructions/ReasoningEffortSubmenu";
-import { isInvalidJson } from "@app/components/agent_builder/utils";
 import { SuspensedCodeEditor } from "@app/components/SuspensedCodeEditor";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useModels } from "@app/lib/swr/models";
 import { isSupportingResponseFormat } from "@app/types/assistant/assistant";
+import { validateResponseFormat } from "@app/types/assistant/models/utils";
 import {
   Button,
   cn,
@@ -25,6 +25,14 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 import { useController } from "react-hook-form";
+
+function getResponseFormatError(value: string): string | null {
+  if (value.trim() === "") {
+    return null;
+  }
+  const result = validateResponseFormat(value);
+  return result.isValid ? null : result.errorMessage;
+}
 
 const RESPONSE_FORMAT_PLACEHOLDER =
   "Example:\n\n" +
@@ -71,6 +79,9 @@ export function AdvancedSettings() {
     return null;
   }
 
+  const currentValue = tempResponseFormat ?? responseFormatField.value ?? "";
+  const validationError = getResponseFormatError(currentValue);
+
   const supportsResponseFormat = isSupportingResponseFormat(
     modelSettingsField.value.modelId
   );
@@ -115,16 +126,14 @@ export function AdvancedSettings() {
           <DialogContainer>
             <SuspensedCodeEditor
               data-color-mode={isDark ? "dark" : "light"}
-              value={tempResponseFormat ?? responseFormatField.value ?? ""}
+              value={currentValue}
               placeholder={RESPONSE_FORMAT_PLACEHOLDER}
               name="responseFormat"
               onChange={(e) => setTempResponseFormat(e.target.value)}
-              minHeight={450}
+              minHeight={400}
               className={cn(
                 "rounded-lg bg-slate-100 dark:bg-slate-100-night",
-                isInvalidJson(
-                  tempResponseFormat ?? responseFormatField.value
-                ) &&
+                validationError &&
                   "border-2 border-red-500 bg-slate-100 dark:bg-slate-100-night"
               )}
               style={{
@@ -135,6 +144,9 @@ export function AdvancedSettings() {
               }}
               language="json"
             />
+            {validationError && (
+              <p className="text-sm text-red-500">{validationError}</p>
+            )}
           </DialogContainer>
           <DialogFooter
             className="pt-2"
@@ -148,6 +160,7 @@ export function AdvancedSettings() {
             }}
             rightButtonProps={{
               label: "Save",
+              disabled: !!validationError,
               onClick: () => {
                 if (tempResponseFormat !== null) {
                   responseFormatField.onChange(tempResponseFormat);

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -58,6 +58,7 @@ import type {
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { validateResponseFormat } from "@app/types/assistant/models/utils";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -431,6 +432,15 @@ export async function createAgentConfiguration(
     await isSelfHostedImageWithValidContentType(pictureUrl);
   if (!isValidPictureUrl) {
     return new Err(new Error("Invalid picture url."));
+  }
+
+  if (model.responseFormat) {
+    const formatValidation = validateResponseFormat(model.responseFormat);
+    if (!formatValidation.isValid) {
+      return new Err(
+        new Error(`Invalid response format: ${formatValidation.errorMessage}`)
+      );
+    }
   }
 
   let version = 0;

--- a/front/types/assistant/models/utils.test.ts
+++ b/front/types/assistant/models/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { validateResponseFormat } from "./utils";
+
+const VALID_RESPONSE_FORMAT = JSON.stringify({
+  type: "json_schema",
+  json_schema: {
+    name: "TestSchema",
+    strict: true,
+    schema: {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+      },
+      required: ["foo"],
+      additionalProperties: false,
+    },
+  },
+});
+
+describe("validateResponseFormat", () => {
+  it("returns valid for a correct schema", () => {
+    expect(validateResponseFormat(VALID_RESPONSE_FORMAT)).toEqual({
+      isValid: true,
+    });
+  });
+
+  it("returns an error for missing required field", () => {
+    const input = JSON.stringify({ type: "json_schema" });
+    const result = validateResponseFormat(input);
+
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      expect(result.errorMessage).toContain("Missing required field");
+      expect(result.errorMessage).toContain("json_schema");
+    }
+  });
+
+  it("returns an error for invalid field type", () => {
+    const input = JSON.stringify({
+      type: "json_schema",
+      json_schema: {
+        name: "TestSchema",
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: "yes",
+        },
+      },
+    });
+    const result = validateResponseFormat(input);
+
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      expect(result.errorMessage).toContain("Expected boolean");
+      expect(result.errorMessage).toContain("additionalProperties");
+    }
+  });
+
+  it("returns an error for invalid JSON", () => {
+    const result = validateResponseFormat("not json");
+
+    expect(result).toEqual({
+      isValid: false,
+      errorMessage: "Invalid JSON.",
+    });
+  });
+});

--- a/front/types/assistant/models/utils.ts
+++ b/front/types/assistant/models/utils.ts
@@ -1,0 +1,39 @@
+import { ResponseFormatSchema } from "./types";
+
+const IMPROVED_ZOD_ERROR_MESSAGES = new Map<string, string>([
+  ["Required", "Missing required field"],
+]);
+
+export type ResponseFormatValidationResult =
+  | { isValid: true }
+  | { isValid: false; errorMessage: string };
+
+export function validateResponseFormat(
+  value: string
+): ResponseFormatValidationResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return { isValid: false, errorMessage: "Invalid JSON." };
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return { isValid: false, errorMessage: "Must be a JSON object." };
+  }
+
+  const result = ResponseFormatSchema.safeParse(parsed);
+  if (!result.success) {
+    const firstIssue = result.error.issues[0];
+    const message =
+      IMPROVED_ZOD_ERROR_MESSAGES.get(firstIssue.message) ?? firstIssue.message;
+    const field =
+      firstIssue.path.length > 0 ? ` Field: ${firstIssue.path.join(".")}` : "";
+    return {
+      isValid: false,
+      errorMessage: `Invalid JSON format: ${message}.${field}`,
+    };
+  }
+
+  return { isValid: true };
+}


### PR DESCRIPTION
## Description

We have seen issues where it is not clear for users that their JSON structured output format is invalid.
This adds a check in the UI and a check on save


<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/07b06dce-1997-4c82-a0eb-6b57d0d0b7cd" />

<img width="1700" height="900" alt="image" src="https://github.com/user-attachments/assets/af14ba9a-50f0-4402-8221-373b2895261b" />



## Tests
Manual tests + unit tests on validator

## Risk

We will make it harder to save for people with invalid JSON format, but I think it is a good thing as we don't want them to use an invalid format.

## Deploy Plan

deploy front
