### PR TITLE
[front] feat(sandbox): add UI for files in Skill Builder

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -1,5 +1,6 @@
 import { SkillBuilderAgentFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderAgentFacingDescriptionSection";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import { SkillBuilderFilesSection } from "@app/components/skill_builder/SkillBuilderFilesSection";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import {
   SkillBuilderFormContext,
@@ -18,6 +19,7 @@ import { ExtendedSkillBadge } from "@app/components/skills/ExtendedSkillBadge";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -47,6 +49,7 @@ export default function SkillBuilder({
   onSaved,
 }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
+  const { hasFeature } = useFeatureFlags();
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
@@ -188,6 +191,7 @@ export default function SkillBuilder({
                 <SkillBuilderRequestedSpacesSection />
                 <SkillBuilderAgentFacingDescriptionSection />
                 <SkillBuilderInstructionsSection skill={skill} />
+                {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
                 <SkillBuilderToolsSection />
                 <SkillBuilderSettingsSection />
               </div>

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -154,7 +154,6 @@ export function SkillBuilderFilesSection() {
                 key={field.id}
                 title={field.fileName}
                 visual={<ContextItem.Visual visual={DocumentIcon} />}
-                hasSeparator={false}
                 hoverAction
                 action={
                   <Button

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,0 +1,139 @@
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import {
+  Button,
+  ContextItem,
+  DocumentIcon,
+  EmptyCTA,
+  PlusIcon,
+  Spinner,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useCallback, useRef } from "react";
+import { useFieldArray } from "react-hook-form";
+
+export function SkillBuilderFilesSection() {
+  const { owner, skillId } = useSkillBuilderContext();
+  const { fields, append, remove } = useFieldArray<
+    SkillBuilderFormData,
+    "fileAttachments"
+  >({
+    name: "fileAttachments",
+  });
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
+    owner,
+    useCase: "skill_attachment",
+    useCaseMetadata: skillId ? { skillId } : undefined,
+  });
+
+  const onUploadClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const onFileInputChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (!files || files.length === 0) {
+        return;
+      }
+
+      const uploaded = await handleFilesUpload(Array.from(files));
+      if (uploaded) {
+        for (const blob of uploaded) {
+          if (blob.fileId) {
+            append({ fileId: blob.fileId, fileName: blob.filename });
+          }
+        }
+      }
+
+      // Reset input so re-uploading the same file triggers onChange.
+      e.target.value = "";
+    },
+    [handleFilesUpload, append]
+  );
+
+  const canUpload = !!skillId;
+
+  const headerActions = fields.length > 0 && (
+    <Button
+      type="button"
+      onClick={onUploadClick}
+      label="Upload files"
+      icon={PlusIcon}
+      variant="outline"
+      disabled={!canUpload}
+    />
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+            Files
+          </h3>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Add files that will be available to the skill at runtime. Templates,
+            schemas, scripts, or reference materials.
+          </p>
+        </div>
+        {headerActions}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={onFileInputChange}
+      />
+
+      <div className="flex-1">
+        {isProcessingFiles ? (
+          <div className="flex h-40 w-full items-center justify-center">
+            <Spinner />
+          </div>
+        ) : fields.length === 0 ? (
+          <EmptyCTA
+            action={
+              <Button
+                type="button"
+                onClick={onUploadClick}
+                label="Upload files"
+                icon={PlusIcon}
+                variant="outline"
+                disabled={!canUpload}
+              />
+            }
+            className="py-8"
+          />
+        ) : (
+          <ContextItem.List>
+            {fields.map((field, index) => (
+              <ContextItem
+                key={field.id}
+                title={field.fileName}
+                visual={<ContextItem.Visual visual={DocumentIcon} />}
+                hasSeparator={false}
+                hoverAction
+                action={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    icon={XMarkIcon}
+                    size="xs"
+                    onClick={() => remove(index)}
+                  />
+                }
+              />
+            ))}
+          </ContextItem.List>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -87,13 +87,10 @@ export function SkillBuilderFilesSection() {
   );
 
   // We need to have a skill ID to upload files in order to attach them properly (useCaseMetadata).
-  const canUpload = !!skillId;
+  const uploadDisabled = skillId === null || isProcessingFiles;
 
-  const uploadDisabled = !canUpload || isProcessingFiles;
-
-  const disabledTooltip = !canUpload
-    ? "Save the skill first to upload files."
-    : undefined;
+  const disabledTooltip =
+    skillId === null ? "Save the skill first to upload files." : undefined;
 
   const headerActions = fields.length > 0 && (
     <Button
@@ -145,7 +142,7 @@ export function SkillBuilderFilesSection() {
                   label="Upload files"
                   icon={PlusIcon}
                   variant="outline"
-                  disabled={!canUpload}
+                  disabled={uploadDisabled}
                   tooltip={disabledTooltip}
                 />
               }

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,6 +1,7 @@
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useSendNotification } from "@app/hooks/useNotification";
 import {
   Button,
   ContextItem,
@@ -10,7 +11,7 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useFieldArray } from "react-hook-form";
 
 export function SkillBuilderFilesSection() {
@@ -24,11 +25,18 @@ export function SkillBuilderFilesSection() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const sendNotification = useSendNotification();
+
   const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
     owner,
     useCase: "skill_attachment",
     useCaseMetadata: skillId ? { skillId } : undefined,
   });
+
+  const existingFileNames = useMemo(
+    () => new Set(fields.map((f) => f.fileName)),
+    [fields]
+  );
 
   const onUploadClick = useCallback(() => {
     fileInputRef.current?.click();
@@ -41,11 +49,27 @@ export function SkillBuilderFilesSection() {
         return;
       }
 
-      const uploaded = await handleFilesUpload(Array.from(files));
-      if (uploaded) {
-        for (const blob of uploaded) {
-          if (blob.fileId) {
-            append({ fileId: blob.fileId, fileName: blob.filename });
+      const allFiles = Array.from(files);
+      const newFiles = allFiles.filter(
+        (f) => !existingFileNames.has(f.name)
+      );
+      const duplicates = allFiles.filter((f) => existingFileNames.has(f.name));
+
+      if (duplicates.length > 0) {
+        sendNotification({
+          type: "error",
+          title: "Duplicate files skipped.",
+          description: `Already attached: ${duplicates.map((f) => f.name).join(", ")}`,
+        });
+      }
+
+      if (newFiles.length > 0) {
+        const uploaded = await handleFilesUpload(newFiles);
+        if (uploaded) {
+          for (const blob of uploaded) {
+            if (blob.fileId) {
+              append({ fileId: blob.fileId, fileName: blob.filename });
+            }
           }
         }
       }
@@ -53,7 +77,7 @@ export function SkillBuilderFilesSection() {
       // Reset input so re-uploading the same file triggers onChange.
       e.target.value = "";
     },
-    [handleFilesUpload, append]
+    [handleFilesUpload, append, existingFileNames, sendNotification]
   );
 
   const canUpload = !!skillId;

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -90,6 +90,10 @@ export function SkillBuilderFilesSection() {
 
   const uploadDisabled = !canUpload || isProcessingFiles;
 
+  const disabledTooltip = !canUpload
+    ? "Save the skill first to upload files."
+    : undefined;
+
   const headerActions = fields.length > 0 && (
     <Button
       type="button"
@@ -98,6 +102,7 @@ export function SkillBuilderFilesSection() {
       icon={isProcessingFiles ? Spinner : PlusIcon}
       variant="outline"
       disabled={uploadDisabled}
+      tooltip={disabledTooltip}
     />
   );
 
@@ -140,6 +145,7 @@ export function SkillBuilderFilesSection() {
                   icon={PlusIcon}
                   variant="outline"
                   disabled={!canUpload}
+                  tooltip={disabledTooltip}
                 />
               }
               className="py-8"

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -86,6 +86,7 @@ export function SkillBuilderFilesSection() {
     [handleFilesUpload, append, existingFileNames, sendNotification]
   );
 
+  // We need to have a skill ID to upload files in order to attach them properly (useCaseMetadata).
   const canUpload = !!skillId;
 
   const uploadDisabled = !canUpload || isProcessingFiles;

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -16,6 +16,7 @@ import { useFieldArray } from "react-hook-form";
 
 export function SkillBuilderFilesSection() {
   const { owner, skillId } = useSkillBuilderContext();
+  const sendNotification = useSendNotification();
   const { fields, append, remove } = useFieldArray<
     SkillBuilderFormData,
     "fileAttachments"
@@ -24,8 +25,6 @@ export function SkillBuilderFilesSection() {
   });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const sendNotification = useSendNotification();
 
   const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
     owner,
@@ -154,7 +153,11 @@ export function SkillBuilderFilesSection() {
             {sortedFields.map(({ field, originalIndex }) => (
               <ContextItem
                 key={field.id}
-                title={<span className="font-normal">{field.fileName}</span>}
+                title={
+                  <span className="text-sm font-normal">
+                    {field.fileName}
+                  </span>
+                }
                 visual={<ContextItem.Visual visual={DocumentIcon} />}
                 hoverAction
                 action={

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -58,9 +58,7 @@ export function SkillBuilderFilesSection() {
       }
 
       const allFiles = Array.from(files);
-      const newFiles = allFiles.filter(
-        (f) => !existingFileNames.has(f.name)
-      );
+      const newFiles = allFiles.filter((f) => !existingFileNames.has(f.name));
       const duplicates = allFiles.filter((f) => existingFileNames.has(f.name));
 
       if (duplicates.length > 0) {
@@ -152,9 +150,7 @@ export function SkillBuilderFilesSection() {
             {sortedFields.map(({ field, originalIndex }) => (
               <ContextItem
                 key={field.id}
-                title={
-                  <span className="font-normal">{field.fileName}</span>
-                }
+                title={<span className="font-normal">{field.fileName}</span>}
                 visual={<ContextItem.Visual visual={DocumentIcon} />}
                 hoverAction
                 action={

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -58,14 +58,16 @@ export function SkillBuilderFilesSection() {
 
   const canUpload = !!skillId;
 
+  const uploadDisabled = !canUpload || isProcessingFiles;
+
   const headerActions = fields.length > 0 && (
     <Button
       type="button"
       onClick={onUploadClick}
       label="Upload files"
-      icon={PlusIcon}
+      icon={isProcessingFiles ? Spinner : PlusIcon}
       variant="outline"
-      disabled={!canUpload}
+      disabled={uploadDisabled}
     />
   );
 
@@ -93,24 +95,26 @@ export function SkillBuilderFilesSection() {
       />
 
       <div className="flex-1">
-        {isProcessingFiles ? (
-          <div className="flex h-40 w-full items-center justify-center">
-            <Spinner />
-          </div>
-        ) : fields.length === 0 ? (
-          <EmptyCTA
-            action={
-              <Button
-                type="button"
-                onClick={onUploadClick}
-                label="Upload files"
-                icon={PlusIcon}
-                variant="outline"
-                disabled={!canUpload}
-              />
-            }
-            className="py-8"
-          />
+        {fields.length === 0 ? (
+          isProcessingFiles ? (
+            <div className="flex h-40 w-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : (
+            <EmptyCTA
+              action={
+                <Button
+                  type="button"
+                  onClick={onUploadClick}
+                  label="Upload files"
+                  icon={PlusIcon}
+                  variant="outline"
+                  disabled={!canUpload}
+                />
+              }
+              className="py-8"
+            />
+          )
         ) : (
           <ContextItem.List>
             {fields.map((field, index) => (

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -154,9 +154,7 @@ export function SkillBuilderFilesSection() {
               <ContextItem
                 key={field.id}
                 title={
-                  <span className="text-sm font-normal">
-                    {field.fileName}
-                  </span>
+                  <span className="text-sm font-normal">{field.fileName}</span>
                 }
                 visual={<ContextItem.Visual visual={DocumentIcon} />}
                 hoverAction

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -152,7 +152,9 @@ export function SkillBuilderFilesSection() {
             {sortedFields.map(({ field, originalIndex }) => (
               <ContextItem
                 key={field.id}
-                title={field.fileName}
+                title={
+                  <span className="font-normal">{field.fileName}</span>
+                }
                 visual={<ContextItem.Visual visual={DocumentIcon} />}
                 hoverAction
                 action={

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -38,6 +38,14 @@ export function SkillBuilderFilesSection() {
     [fields]
   );
 
+  const sortedFields = useMemo(
+    () =>
+      fields
+        .map((field, index) => ({ field, originalIndex: index }))
+        .sort((a, b) => a.field.fileName.localeCompare(b.field.fileName)),
+    [fields]
+  );
+
   const onUploadClick = useCallback(() => {
     fileInputRef.current?.click();
   }, []);
@@ -141,7 +149,7 @@ export function SkillBuilderFilesSection() {
           )
         ) : (
           <ContextItem.List>
-            {fields.map((field, index) => (
+            {sortedFields.map(({ field, originalIndex }) => (
               <ContextItem
                 key={field.id}
                 title={field.fileName}
@@ -154,7 +162,7 @@ export function SkillBuilderFilesSection() {
                     variant="ghost"
                     icon={XMarkIcon}
                     size="xs"
-                    onClick={() => remove(index)}
+                    onClick={() => remove(originalIndex)}
                   />
                 }
               />

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -13,6 +13,11 @@ export const attachedKnowledgeSchema = z.object({
   title: z.string(),
 });
 
+const fileAttachmentSchema = z.object({
+  fileId: z.string(),
+  fileName: z.string(),
+});
+
 export const skillBuilderFormSchema = z.object({
   name: z
     .string()
@@ -31,6 +36,7 @@ export const skillBuilderFormSchema = z.object({
   tools: z.array(actionSchema),
   icon: z.string().nullable(),
   extendedSkillId: z.string().nullable(),
+  fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),
 });
 

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -17,6 +17,7 @@ export function transformSkillTypeToFormData(
     instructions: skill.instructions ?? "",
     editors: [], // Will be populated reactively from useEditors hook
     tools: skill.tools.map(getDefaultMCPAction),
+    fileAttachments: skill.fileAttachments,
     icon: skill.icon ?? null,
     extendedSkillId: skill.extendedSkillId,
   };
@@ -39,6 +40,7 @@ export function getDefaultSkillFormData({
     instructions: "",
     editors: [user],
     tools: [],
+    fileAttachments: [],
     icon: null,
     extendedSkillId,
   };

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -45,6 +45,9 @@ export async function submitSkillBuilderForm({
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),
+        fileAttachments: formData.fileAttachments.map((f) => ({
+          fileId: f.fileId,
+        })),
         attachedKnowledge: formData.attachedKnowledge ?? [],
       }),
     });


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6803.
- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=3685-8948&t=hZQdIcbkqO407eEW-0).
- This PR adds the UI for handling files in the Skill Builder.
- Allows viewing currently existing files, adding new ones and deleting existing ones.
- Gated behind the `sandbox_tools` feature flag.
- Will handle the display of the path in a follow up PR.
- Note: we need to save the skill first to upload files because we upload the files first and then save the references.

<img width="1023" height="701" alt="Screenshot 2026-03-02 at 4 05 40 PM" src="https://github.com/user-attachments/assets/814856ec-4f0d-440f-9817-f3f744e6eb23" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
