### PR TITLE
feat: improve docker built time for front

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -90,7 +90,8 @@ ENV CONTENTFUL_ACCESS_TOKEN=$CONTENTFUL_ACCESS_TOKEN
 # Fake PostgreSQL URI is needed because Sequelize validates the connection string
 # during module initialization (imported by `next build`), but doesn't actually connect
 # DATADOG_API_KEY is used to conditionally enable source map generation and upload to Datadog
-RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
+RUN --mount=type=cache,id=next-cache,target=/app/front/.next/cache \
+  BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
   FRONT_DATABASE_URI="postgres://fake:fake@localhost:5432/fake" \
   NODE_OPTIONS="--max-old-space-size=8192" \
   npm run build -- --no-lint && \

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -50,8 +50,7 @@ const config = {
     ],
   },
   transpilePackages: ["@uiw/react-textarea-code-editor"],
-  // As of Next 14.2.3 swc minification creates a bug in the generated client side files.
-  swcMinify: false,
+  swcMinify: true,
   onDemandEntries: {
     // Keep dev-compiled pages around longer to avoid re-compiles on nav
     maxInactiveAge: 1000 * 60 * 60, // 1 hour


### PR DESCRIPTION
## Description

 1. `dockerfiles/front.Dockerfile` - Added `--mount=type=cache,id=next-cache,target=/app/front/.next/cache` to persist Next.js incremental build cache across Docker builds. On Depot, this cache mount survives 
  between builds, so subsequent builds will reuse webpack compilation results for unchanged modules.                                                                                                             
  2. `front/next.config.js` - Changed s`wcMinify: false` → `swcMinify: true`. The bug that motivated disabling this was in Next 14.2.3; we're on 14.2.35 which has had many fixes since. SWC minification is ~7x   
  faster than Terser.                                                                                                                                                                                            
                              

## Tests
validate the SWC minification change by doing a production build and smoke-testing the app (specifically client-side JS) to confirm the original bug doesn't resurface.

I didn't detect a huge improvement, [here](https://github.com/dust-tt/dust/actions/runs/22578371618), but the cache will be visible in consecutive runs

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
