### PR TITLE
[front] feat: track workspace_created event in PostHog (server-side)

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -332,6 +332,12 @@ export async function handleRegularSignupFlow(
       origin: "auto-joined",
     });
 
+    void ServerSideTracking.trackWorkspaceCreated({
+      user: user.toJSON(),
+      workspace: lightWorkspace,
+      utmParams,
+    });
+
     return new Ok({ flow: "joined", workspace: lightWorkspace });
   } else {
     // Redirect the user to their existing workspace if they are not allowed to join the target

--- a/front/lib/tracking/posthog/server.ts
+++ b/front/lib/tracking/posthog/server.ts
@@ -1,7 +1,7 @@
 import config from "@app/lib/api/config";
 import type { UTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
-import type { UserType } from "@app/types/user";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { PostHog } from "posthog-node";
 
 const POSTHOG_HOST = "https://eu.i.posthog.com";
@@ -72,6 +72,48 @@ export class PostHogServerSideTracking {
       logger.error(
         { userId: user.sId, err },
         "Failed to track signup on PostHog"
+      );
+    }
+  }
+
+  static trackWorkspaceCreated({
+    user,
+    workspace,
+    utmParams,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    utmParams?: UTMParams;
+  }): void {
+    const client = getClient();
+    if (!client) {
+      return;
+    }
+
+    try {
+      const utmProperties: Record<string, string> = {};
+      if (utmParams) {
+        for (const [key, value] of Object.entries(utmParams)) {
+          if (value) {
+            utmProperties[key] = value;
+          }
+        }
+      }
+
+      client.capture({
+        distinctId: user.sId,
+        event: "workspace_created",
+        properties: {
+          workspace_sId: workspace.sId,
+          workspace_name: workspace.name,
+          ...utmProperties,
+        },
+        groups: { workspace: workspace.sId },
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, workspaceId: workspace.sId, err },
+        "Failed to track workspace_created on PostHog"
       );
     }
   }

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -53,6 +53,29 @@ export class ServerSideTracking {
     }
   }
 
+  static trackWorkspaceCreated({
+    user,
+    workspace,
+    utmParams,
+  }: {
+    user: UserType;
+    workspace: LightWorkspaceType;
+    utmParams?: UTMParams;
+  }) {
+    try {
+      PostHogServerSideTracking.trackWorkspaceCreated({
+        user,
+        workspace,
+        utmParams,
+      });
+    } catch (err) {
+      logger.error(
+        { userId: user.sId, workspaceId: workspace.sId, err },
+        "Failed to track workspace_created on PostHog"
+      );
+    }
+  }
+
   static async trackGetUser({ user }: { user: UserTypeWithWorkspaces }) {
     try {
       const subscriptionByWorkspaceModelId =

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -4,6 +4,8 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { ServerSideTracking } from "@app/lib/tracking/server";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -58,11 +60,18 @@ async function handler(
     });
   }
 
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+
   await createAndLogMembership({
     user: u,
-    workspace,
+    workspace: lightWorkspace,
     role: "admin",
     origin: "invited",
+  });
+
+  void ServerSideTracking.trackWorkspaceCreated({
+    user: u.toJSON(),
+    workspace: lightWorkspace,
   });
 
   res.status(200).json({ sId: workspace.sId });


### PR DESCRIPTION
Add a workspace_created PostHog event fired when a workspace is created via the regular signup flow or the create-new-workspace API endpoint.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
