### PR TITLE
Add handling of branches in getConversation()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,13 @@
 {
-  "eslint.workingDirectories": ["./front", "./docs", "./connectors", "./xp1"],
-  "rust-analyzer.linkedProjects": ["./core/Cargo.toml"],
+  "eslint.workingDirectories": [
+    "./front",
+    "./docs",
+    "./connectors",
+    "./xp1"
+  ],
+  "rust-analyzer.linkedProjects": [
+    "./core/Cargo.toml"
+  ],
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "github-actions.workflows.pinned.workflows": [],
   "editor.formatOnSave": true,

--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,8 @@
       "!!extension/shared/lib/swr.ts",
       "!!extension/packages",
       "!!**/package-lock.json",
-      "!!**/__snapshots__"
+      "!!**/__snapshots__",
+      "!!**/.git"
     ]
   },
   "formatter": {

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -126,6 +126,7 @@ function createMockConversation(
     content,
     triggerId: null,
     metadata: {},
+    branchId: null,
   };
 }
 

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -13,8 +13,11 @@ import { Authenticator } from "@app/lib/auth";
 import {
   ConversationModel,
   MentionModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -58,6 +61,8 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
   getContentFragmentBlob: vi.fn(),
 }));
 
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId, makeSId } from "@app/lib/resources/string_ids";
 // Mock rateLimiter from the utils module
 import * as rateLimiterModule from "@app/lib/utils/rate_limiter";
 
@@ -792,6 +797,179 @@ describe("retryAgentMessage", () => {
 
       rateLimiterSpy.mockRestore();
     });
+  });
+});
+
+describe("getConversation with branches", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let conversationSId: string;
+  let branchSId: string;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    const user = setup.user;
+
+    const conversation = await ConversationModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      title: "Branching conversation",
+      requestedSpaceIds: [],
+    });
+    conversationSId = conversation.sId;
+
+    const beforeBranchUserMessage = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: "before branch",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+    await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 0,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: beforeBranchUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const atBranchUserMessage = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: "at branch",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+    const atBranchMessage = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 1,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: atBranchUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const afterBranchUserMessage = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: "after branch main",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+    await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 2,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: afterBranchUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const branch = await ConversationBranchModel.create({
+      workspaceId: workspace.id,
+      state: "open",
+      previousMessageId: atBranchMessage.id,
+      conversationId: conversation.id,
+      userId: user.id,
+    });
+    branchSId = makeSId("conversation_branch", {
+      id: branch.id,
+      workspaceId: workspace.id,
+    });
+
+    const branchUserMessage = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: "branch message",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+    await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 3,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: branchUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+      branchId: branch.id,
+    });
+  });
+
+  it("returns only main-thread messages when branchId is not provided", async () => {
+    const result = await getConversation(auth, conversationSId);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const conv = result.value;
+      expect(conv.branchId).toBeNull();
+
+      const userMessages = conv.content.flat().filter(isUserMessageType);
+      const contents = userMessages.map((m) => m.content);
+
+      expect(contents).toEqual(
+        expect.arrayContaining([
+          "before branch",
+          "at branch",
+          "after branch main",
+        ])
+      );
+      expect(contents).not.toContain("branch message");
+    }
+  });
+
+  it("returns messages up to the branch point plus branch messages when branchId is provided, and sets branchId on the conversation", async () => {
+    const result = await getConversation(
+      auth,
+      conversationSId,
+      false,
+      branchSId
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const conv = result.value;
+      expect(conv.branchId).toBe(branchSId);
+
+      const userMessages = conv.content.flat().filter(isUserMessageType);
+      const contents = userMessages.map((m) => m.content);
+
+      expect(contents).toEqual(
+        expect.arrayContaining(["before branch", "at branch", "branch message"])
+      );
+      expect(contents).not.toContain("after branch main");
+    }
   });
 });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -57,7 +57,10 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize, statsDClient } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import {
+  generateRandomModelSId,
+  getResourceIdFromSId,
+} from "@app/lib/resources/string_ids";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import {
   getTimeframeSecondsFromLiteral,
@@ -197,6 +200,7 @@ export async function createConversation(
     spaceId: space?.sId ?? null,
     triggerId: conversation.triggerSId,
     metadata: conversation.metadata,
+    branchId: null,
   };
 }
 
@@ -692,6 +696,9 @@ export async function postUserMessage(
         where: {
           workspaceId: owner.id,
           conversationId: conversation.id,
+          branchId: conversation.branchId
+            ? getResourceIdFromSId(conversation.branchId)
+            : null,
         },
         transaction: t,
       })) ?? -1) + 1;
@@ -1059,6 +1066,9 @@ export async function editUserMessage(
               where: {
                 workspaceId: owner.id,
                 conversationId: conversation.id,
+                branchId: conversation.branchId
+                  ? getResourceIdFromSId(conversation.branchId)
+                  : null,
               },
               transaction: t,
             })) ?? -1) + 1;
@@ -1557,6 +1567,9 @@ export async function postNewContentFragment(
         where: {
           workspaceId: owner.id,
           conversationId: conversation.id,
+          branchId: conversation.branchId
+            ? getResourceIdFromSId(conversation.branchId)
+            : null,
         },
         transaction: t,
       })) ?? -1) + 1;

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -7,6 +7,7 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type {
@@ -31,6 +32,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isArrayOf } from "@app/types/shared/typescipt_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
+import { Op, type WhereOptions } from "sequelize";
 
 // Helper type to map viewType to the correct message type
 type MessageTypeForView<V extends "light" | "full"> = V extends "light"
@@ -81,12 +83,52 @@ async function _getConversation<V extends "light" | "full">(
     return new Err(new ConversationError("conversation_not_found"));
   }
 
+  let where: WhereOptions<MessageModel> = {
+    conversationId: conversation.id,
+    workspaceId: owner.id,
+  };
+
+  if (branchId) {
+    const branch = await ConversationBranchResource.fetchById(auth, branchId);
+    if (!branch) {
+      return new Err(new ConversationError("branch_not_found"));
+    }
+
+    const previousMessage = await MessageModel.findOne({
+      where: {
+        id: branch.previousMessageId,
+        workspaceId: owner.id,
+      },
+    });
+    if (!previousMessage) {
+      return new Err(new ConversationError("message_not_found"));
+    }
+
+    const branchModelId = branch.id;
+
+    // All messages before the branch and the branch itself.
+    where = {
+      ...where,
+      [Op.or]: [
+        {
+          branchId: branchModelId,
+        },
+        {
+          branchId: null,
+          rank: { [Op.lte]: previousMessage.rank },
+        },
+      ],
+    };
+  } else {
+    // All messages not part of a branch.
+    where = {
+      ...where,
+      branchId: { [Op.is]: null },
+    };
+  }
+
   const messages = await MessageModel.findAll({
-    where: {
-      conversationId: conversation.id,
-      workspaceId: owner.id,
-      branchId,
-    },
+    where,
     order: [
       ["rank", "ASC"],
       ["version", "ASC"],
@@ -216,6 +258,7 @@ async function _getConversation<V extends "light" | "full">(
       requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
+      branchId,
     };
 
     return new Ok(conversationType) as Result<
@@ -232,27 +275,29 @@ async function _getConversation<V extends "light" | "full">(
       | AgentMessageType[]
       | UserMessageType[]
       | ContentFragmentType[]
-    )[] = (content as MessageType[][]).map((c) => {
-      if (c.length === 0) {
-        return [];
-      } else if (
-        isArrayOf<MessageType, AgentMessageType>(c, isAgentMessageType)
-      ) {
-        return c.map((m) => m);
-      } else if (
-        isArrayOf<MessageType, UserMessageType>(c, isUserMessageType)
-      ) {
-        return c.map((m) => m);
-      } else if (
-        isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
-      ) {
-        return c.map((m) => m);
-      } else {
-        throw new Error(
-          "Unexpected content type as everything should be array of same type. This should never happen."
-        );
-      }
-    });
+    )[] = removeNulls(
+      (content as MessageType[][]).map((c) => {
+        if (c.length === 0) {
+          return null;
+        } else if (
+          isArrayOf<MessageType, AgentMessageType>(c, isAgentMessageType)
+        ) {
+          return c.map((m) => m);
+        } else if (
+          isArrayOf<MessageType, UserMessageType>(c, isUserMessageType)
+        ) {
+          return c.map((m) => m);
+        } else if (
+          isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
+        ) {
+          return c.map((m) => m);
+        } else {
+          throw new Error(
+            "Unexpected content type as everything should be array of same type. This should never happen."
+          );
+        }
+      })
+    );
 
     const conversationType: ConversationType = {
       id: conversation.id,
@@ -273,6 +318,7 @@ async function _getConversation<V extends "light" | "full">(
       requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
+      branchId,
     };
 
     return new Ok(conversationType) as Result<

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -11,6 +11,7 @@ const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
   user_already_participant: 400,
   message_not_found: 404,
   message_deletion_not_authorized: 403,
+  branch_not_found: 404,
 };
 
 export function apiErrorForConversation(

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -146,6 +146,7 @@ describe("renderAllMessages", () => {
       content: content as ConversationType["content"],
       triggerId: null,
       metadata: {},
+      branchId: null,
     } as ConversationType;
   }
 

--- a/front/lib/models/agent/conversation_branch.ts
+++ b/front/lib/models/agent/conversation_branch.ts
@@ -52,10 +52,7 @@ ConversationBranchModel.init(
         fields: ["workspaceId", "conversationId", "userId"],
       },
       {
-        // We can only have one branch per message.
-        // If the original message is edited, it will be a new message row.
         fields: ["previousMessageId"],
-        unique: true,
       },
     ],
   }

--- a/front/lib/resources/conversation_branch_resource.test.ts
+++ b/front/lib/resources/conversation_branch_resource.test.ts
@@ -1,0 +1,179 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  ConversationModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { generateRandomModelSId, makeSId } from "@app/lib/resources/string_ids";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ConversationBranchResource permissions", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let ownerAuth: Authenticator;
+  let otherAuth: Authenticator;
+  let adminAuth: Authenticator;
+
+  let ownerBranchSId: string;
+  let otherBranchSId: string;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+
+    const ownerUser = await UserFactory.basic();
+    const otherUser = await UserFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    await MembershipFactory.associate(workspace, ownerUser, { role: "user" });
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      ownerUser.sId,
+      workspace.sId
+    );
+    otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      title: "Test conversation for branches",
+      requestedSpaceIds: [],
+    });
+
+    const ownerBaseUserMessage = await UserMessageModel.create({
+      userId: ownerUser.id,
+      workspaceId: workspace.id,
+      content: "Base message for branch",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+
+    const ownerBaseMessage = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 0,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: ownerBaseUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const otherBaseUserMessage = await UserMessageModel.create({
+      userId: otherUser.id,
+      workspaceId: workspace.id,
+      content: "Base message for other branch",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+
+    const otherBaseMessage = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 1,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: otherBaseUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const ownerBranch = await ConversationBranchModel.create({
+      workspaceId: workspace.id,
+      state: "open",
+      previousMessageId: ownerBaseMessage.id,
+      conversationId: conversation.id,
+      userId: ownerUser.id,
+    });
+
+    const otherBranch = await ConversationBranchModel.create({
+      workspaceId: workspace.id,
+      state: "open",
+      previousMessageId: otherBaseMessage.id,
+      conversationId: conversation.id,
+      userId: otherUser.id,
+    });
+
+    ownerBranchSId = makeSId("conversation_branch", {
+      id: ownerBranch.id,
+      workspaceId: workspace.id,
+    });
+
+    otherBranchSId = makeSId("conversation_branch", {
+      id: otherBranch.id,
+      workspaceId: workspace.id,
+    });
+  });
+
+  it("fetchById should only return branches readable by the caller", async () => {
+    const ownerBranchForOwner = await ConversationBranchResource.fetchById(
+      ownerAuth,
+      ownerBranchSId
+    );
+    expect(ownerBranchForOwner).not.toBeNull();
+    expect(ownerBranchForOwner?.userId).toBe(ownerAuth.getNonNullableUser().id);
+
+    const ownerBranchForOther = await ConversationBranchResource.fetchById(
+      otherAuth,
+      ownerBranchSId
+    );
+    expect(ownerBranchForOther).toBeNull();
+
+    const ownerBranchForAdmin = await ConversationBranchResource.fetchById(
+      adminAuth,
+      ownerBranchSId
+    );
+    expect(ownerBranchForAdmin).not.toBeNull();
+    expect(ownerBranchForAdmin?.userId).toBeDefined();
+  });
+
+  it("fetchByIds should filter out branches the user cannot read", async () => {
+    const allBranchSIds = [ownerBranchSId, otherBranchSId];
+
+    const ownerBranches = await ConversationBranchResource.fetchByIds(
+      ownerAuth,
+      allBranchSIds
+    );
+    const ownerBranchIds = ownerBranches.map((b) => b.userId);
+    expect(ownerBranchIds).toContain(ownerAuth.getNonNullableUser().id);
+    expect(ownerBranchIds).not.toContain(otherAuth.getNonNullableUser().id);
+
+    const otherBranches = await ConversationBranchResource.fetchByIds(
+      otherAuth,
+      allBranchSIds
+    );
+    const otherBranchIds = otherBranches.map((b) => b.userId);
+    expect(otherBranchIds).toContain(otherAuth.getNonNullableUser().id);
+    expect(otherBranchIds).not.toContain(ownerAuth.getNonNullableUser().id);
+
+    const adminBranches = await ConversationBranchResource.fetchByIds(
+      adminAuth,
+      allBranchSIds
+    );
+    const adminBranchIds = adminBranches.map((b) => b.userId);
+    expect(adminBranchIds).toContain(ownerAuth.getNonNullableUser().id);
+    expect(adminBranchIds).toContain(otherAuth.getNonNullableUser().id);
+  });
+});

--- a/front/lib/resources/conversation_branch_resource.ts
+++ b/front/lib/resources/conversation_branch_resource.ts
@@ -1,0 +1,143 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type {
+  Attributes,
+  CreationAttributes,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ConversationBranchResource
+  extends ReadonlyAttributesType<ConversationBranchModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ConversationBranchResource extends BaseResource<ConversationBranchModel> {
+  static model: ModelStaticWorkspaceAware<ConversationBranchModel> =
+    ConversationBranchModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<ConversationBranchModel>,
+    blob: Attributes<ConversationBranchModel>
+  ) {
+    super(model, blob);
+  }
+
+  /**
+   * Creates a new conversation branch in the authenticated workspace.
+   */
+  static async makeNew(
+    auth: Authenticator,
+    blob: Omit<CreationAttributes<ConversationBranchModel>, "workspaceId">
+  ): Promise<ConversationBranchResource> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const branch = await this.model.create({
+      ...blob,
+      workspaceId: workspace.id,
+    });
+
+    return new this(this.model, branch.get());
+  }
+
+  /**
+   * Fetches conversation branches by their model IDs within the authenticated workspace.
+   */
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: number[]
+  ): Promise<ConversationBranchResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const branches = await this.model.findAll({
+      where: {
+        workspaceId: workspace.id,
+        id: ids,
+      } as WhereOptions<ConversationBranchModel>,
+    });
+
+    return branches.map(
+      (b) => new this(ConversationBranchResource.model, b.get())
+    );
+  }
+
+  /**
+   * Lists all branches for a given conversation within the authenticated workspace.
+   */
+  static async listForConversation(
+    auth: Authenticator,
+    conversationId: number
+  ): Promise<ConversationBranchResource[]> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const branches = await this.model.findAll({
+      where: {
+        workspaceId: workspace.id,
+        conversationId,
+      } as WhereOptions<ConversationBranchModel>,
+    });
+
+    return branches.map(
+      (b) => new this(ConversationBranchResource.model, b.get())
+    );
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<ConversationBranchResource | null> {
+    const [branch] = await this.fetchByIds(auth, [sId]);
+    return branch ?? null;
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    sIds: string[]
+  ): Promise<ConversationBranchResource[]> {
+    const branches = await this.fetchByModelIds(
+      auth,
+      removeNulls(sIds.map(getResourceIdFromSId))
+    );
+
+    // When fetching by sIds, we check read access to the branches.
+    const allowedBranches = branches.filter((b) => b.canRead(auth));
+    return allowedBranches;
+  }
+
+  // When/If we allow more than one user to read a branch, we will need to change this.
+  canRead(auth: Authenticator) {
+    return auth.isAdmin() || auth.getNonNullableUser().id === this.userId;
+  }
+
+  canWrite(auth: Authenticator) {
+    return auth.getNonNullableUser().id === this.userId;
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      } as WhereOptions<ConversationBranchModel>,
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -621,6 +621,73 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     expect(adminConvoIds).toContain(conversations.restricted[0]);
   });
 
+  it("fetchById should respect space-based permissions", async () => {
+    // Regular user can access conversations in global space
+    const userAccessibleConversation = await ConversationResource.fetchById(
+      userAuth,
+      conversations.accessible[0]
+    );
+    expect(userAccessibleConversation).not.toBeNull();
+    expect(userAccessibleConversation?.sId).toBe(conversations.accessible[0]);
+
+    // Regular user cannot access conversations restricted to admin-only space
+    const userRestrictedConversation = await ConversationResource.fetchById(
+      userAuth,
+      conversations.restricted[0]
+    );
+    expect(userRestrictedConversation).toBeNull();
+
+    // Admin can access both conversations
+    const adminAccessibleConversation = await ConversationResource.fetchById(
+      adminAuth,
+      conversations.accessible[0]
+    );
+    const adminRestrictedConversation = await ConversationResource.fetchById(
+      adminAuth,
+      conversations.restricted[0]
+    );
+
+    expect(adminAccessibleConversation).not.toBeNull();
+    expect(adminAccessibleConversation?.sId).toBe(conversations.accessible[0]);
+    expect(adminRestrictedConversation).not.toBeNull();
+    expect(adminRestrictedConversation?.sId).toBe(conversations.restricted[0]);
+  });
+
+  it("fetchByIds should respect space-based permissions", async () => {
+    const sIds = [conversations.accessible[0], conversations.restricted[0]];
+
+    // Regular user should only get back accessible conversations
+    const userConversations = await ConversationResource.fetchByIds(
+      userAuth,
+      sIds
+    );
+    const userConvoIds = userConversations.map((c) => c.sId);
+    expect(userConvoIds).toContain(conversations.accessible[0]);
+    expect(userConvoIds).not.toContain(conversations.restricted[0]);
+
+    // Admin should get back all conversations
+    const adminConversations = await ConversationResource.fetchByIds(
+      adminAuth,
+      sIds
+    );
+    const adminConvoIds = adminConversations.map((c) => c.sId);
+    expect(adminConvoIds).toContain(conversations.accessible[0]);
+    expect(adminConvoIds).toContain(conversations.restricted[0]);
+  });
+
+  it("fetchByIds should bypass permission checks when dangerouslySkipPermissionFiltering is true", async () => {
+    const sIds = [conversations.accessible[0], conversations.restricted[0]];
+
+    const conversationsWithoutPermissions =
+      await ConversationResource.fetchByIds(userAuth, sIds, {
+        dangerouslySkipPermissionFiltering: true,
+      });
+
+    const convoIds = conversationsWithoutPermissions.map((c) => c.sId);
+    expect(convoIds).toContain(conversations.accessible[0]);
+    expect(convoIds).toContain(conversations.restricted[0]);
+  });
+
   it("should handle conversations with no requested spaces", async () => {
     const emptySpaceConvo = await ConversationFactory.create(adminAuth, {
       agentConfigurationId: agents[0].sId,

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -78,6 +78,9 @@ export const RESOURCES_PREFIX = {
   // Butler
   user_project_digest: "pje",
   conversation_butler_suggestion: "cbs",
+
+  // Conversation branches.
+  conversation_branch: "cbr",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/migrations/db/migration_528.sql
+++ b/front/migrations/db/migration_528.sql
@@ -1,0 +1,9 @@
+-- Create a new version of the index without the uniqueness constraint.
+CREATE INDEX CONCURRENTLY "conversation_branches_previous_message_id_new" ON "conversation_branches" ("previousMessageId");
+
+-- Drop the old index.
+DROP INDEX CONCURRENTLY IF EXISTS "conversation_branches_previous_message_id";
+
+-- Rename the new index to the old index name.
+ALTER INDEX conversation_branches_previous_message_id_new
+RENAME TO conversation_branches_previous_message_id;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -329,6 +329,7 @@ export type ConversationWithoutContentType = {
 export type ConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
+  branchId: string | null;
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
 };
 
@@ -339,6 +340,7 @@ export type ConversationType = ConversationWithoutContentType & {
 export type LightConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
+  branchId: string | null;
   content: (LightAgentMessageType | UserMessageTypeWithContentFragments)[];
 };
 
@@ -381,6 +383,7 @@ export const CONVERSATION_ERROR_TYPES = [
   "user_already_participant",
   "message_not_found",
   "message_deletion_not_authorized",
+  "branch_not_found",
 ] as const;
 
 export type ConversationErrorType = (typeof CONVERSATION_ERROR_TYPES)[number];

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -234,6 +234,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
   },
+  conversation_branches: {
+    description: "Enable conversation branches",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -678,6 +678,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "claude_4_opus_feature"
   | "confluence_tool"
   | "conversation_butler"
+  | "conversation_branches"
   | "project_butler"
   | "projects"
   | "databricks_tool"


### PR DESCRIPTION
## Description

Add support for branches in getConversation(), if a branchId is passed in, it will return all messages from main (branchId == null) before the branch + the branch messages, otherwise, it returns all messages from main.

## Tests

Added

## Risk

Low, we do not call anywhere with a branchId.

## Deploy Plan

Deploy front.