### PR TITLE
[front] - refactor(MCPServerHeaders): streamline custom headers

### DIFF
--- a/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
+++ b/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
@@ -1,5 +1,5 @@
 import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
-import { McpServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
+import { MCPServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
 import { getTokenFieldLabel } from "@app/lib/actions/mcp_internal_actions/server_token_labels";
 import {
   Collapsible,
@@ -52,7 +52,7 @@ export function InternalMCPBearerTokenForm({
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="space-y-2">
-            <McpServerHeaders />
+            <MCPServerHeaders />
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
+++ b/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
@@ -7,7 +7,7 @@ import {
   CollapsibleTrigger,
   Input,
 } from "@dust-tt/sparkle";
-import { useFieldArray, useFormContext } from "react-hook-form";
+import { useFormContext, useWatch } from "react-hook-form";
 
 interface InternalMCPBearerTokenFormProps {
   serverName?: string;
@@ -17,10 +17,7 @@ export function InternalMCPBearerTokenForm({
   serverName,
 }: InternalMCPBearerTokenFormProps) {
   const form = useFormContext<MCPServerFormValues>();
-  const { fields, replace } = useFieldArray<
-    MCPServerFormValues,
-    "customHeaders"
-  >({
+  const customHeaders = useWatch<MCPServerFormValues, "customHeaders">({
     name: "customHeaders",
   });
 
@@ -49,14 +46,13 @@ export function InternalMCPBearerTokenForm({
       </Collapsible>
       <Collapsible>
         <CollapsibleTrigger className="pb-2">
-          <div className="heading-lg">Headers ({fields.length})</div>
+          <div className="heading-lg">
+            Headers ({(customHeaders ?? []).length})
+          </div>
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="space-y-2">
-            <McpServerHeaders
-              headers={fields.map(({ key, value }) => ({ key, value }))}
-              onHeadersChange={(rows) => replace(rows)}
-            />
+            <McpServerHeaders />
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -1,83 +1,67 @@
 import { WebCrawlerHeaderRedactedValue } from "@app/types/connectors/webcrawler";
 import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
-import type { ChangeEvent } from "react";
-import { useCallback } from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
 
-type Header = { key: string; value: string };
-
-type McpServerHeadersProps = {
-  headers: Header[];
-  onHeadersChange: (headers: Header[]) => void;
+type FormWithCustomHeaders = {
+  customHeaders: Array<{ key: string; value: string }>;
 };
 
-export function McpServerHeaders({
-  headers,
-  onHeadersChange,
-}: McpServerHeadersProps) {
-  const updateHeaderField = useCallback(
-    (index: number, field: keyof Header, value: string) => {
-      const newHeaders = [...headers];
-      newHeaders[index] = { ...newHeaders[index], [field]: value };
-      onHeadersChange(newHeaders);
-    },
-    [headers, onHeadersChange]
-  );
-
-  const getChangeHandler = useCallback(
-    (index: number, field: keyof Header) =>
-      (e: ChangeEvent<HTMLInputElement>) =>
-        updateHeaderField(index, field, e.target.value),
-    [updateHeaderField]
-  );
-
-  const removeHeader = (index: number) => {
-    onHeadersChange(headers.filter((_, i) => i !== index));
-  };
-
-  const addHeader = () => {
-    onHeadersChange([...headers, { key: "", value: "" }]);
-  };
+export function McpServerHeaders() {
+  // `register` binds inputs via DOM refs so RHF tracks values natively without triggering React re-renders on each
+  // keystroke. Using `update` instead would replace the field object (regenerating field.id), causing React to remount
+  // the input on every keystroke and lose focus.
+  const { control, register, getValues } =
+    useFormContext<FormWithCustomHeaders>();
+  const { fields, append, remove } = useFieldArray<
+    FormWithCustomHeaders,
+    "customHeaders"
+  >({
+    control,
+    name: "customHeaders",
+  });
 
   return (
     <div className="flex w-full flex-col">
       <div className="flex flex-col gap-4">
-        {headers.map((header, index) => (
-          <div key={index} className="flex items-center gap-2">
-            <div className="grid flex-1 grid-cols-3 gap-2 px-1">
-              <div className="col-span-1">
-                <Input
-                  placeholder="Header Name"
-                  value={header.key}
-                  name="headerName"
-                  onChange={getChangeHandler(index, "key")}
-                  disabled={header.value === WebCrawlerHeaderRedactedValue}
-                  className="w-full"
-                />
+        {fields.map((field, index) => {
+          const isRedacted =
+            field.value === WebCrawlerHeaderRedactedValue ||
+            getValues(`customHeaders.${index}.value`) ===
+              WebCrawlerHeaderRedactedValue;
+          return (
+            <div key={field.id} className="flex items-center gap-2">
+              <div className="grid flex-1 grid-cols-3 gap-2 px-1">
+                <div className="col-span-1">
+                  <Input
+                    {...register(`customHeaders.${index}.key`)}
+                    placeholder="Header Name"
+                    disabled={isRedacted}
+                    className="w-full"
+                  />
+                </div>
+                <div className="col-span-2">
+                  <Input
+                    {...register(`customHeaders.${index}.value`)}
+                    placeholder="Header Value"
+                    disabled={isRedacted}
+                    className="w-full"
+                  />
+                </div>
               </div>
-              <div className="col-span-2">
-                <Input
-                  name="headerValue"
-                  placeholder="Header Value"
-                  value={header.value}
-                  onChange={getChangeHandler(index, "value")}
-                  disabled={header.value === WebCrawlerHeaderRedactedValue}
-                  className="w-full"
-                />
-              </div>
+              <Button
+                variant="outline"
+                icon={XMarkIcon}
+                onClick={() => remove(index)}
+              />
             </div>
-            <Button
-              variant="outline"
-              icon={XMarkIcon}
-              onClick={() => removeHeader(index)}
-            />
-          </div>
-        ))}
+          );
+        })}
       </div>
       <Button
         className="mt-4"
         variant="outline"
         label="Add Header"
-        onClick={addHeader}
+        onClick={() => append({ key: "", value: "" })}
       />
     </div>
   );

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -6,7 +6,7 @@ type FormWithCustomHeaders = {
   customHeaders: Array<{ key: string; value: string }>;
 };
 
-export function McpServerHeaders() {
+export function MCPServerHeaders() {
   // `register` binds inputs via DOM refs so RHF tracks values natively without triggering React re-renders on each
   // keystroke. Using `update` instead would replace the field object (regenerating field.id), causing React to remount
   // the input on every keystroke and lose focus.

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -1,5 +1,5 @@
 import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
-import { McpServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
+import { MCPServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import { useSyncRemoteMCPServer } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -165,7 +165,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="space-y-2">
-            <McpServerHeaders />
+            <MCPServerHeaders />
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -21,7 +21,7 @@ import {
   PopoverTrigger,
 } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
-import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -39,10 +39,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
 
   const { url, lastError, lastSyncAt } = mcpServer;
 
-  const { fields: headerFields, replace } = useFieldArray<
-    MCPServerFormValues,
-    "customHeaders"
-  >({
+  const headerFields = useWatch<MCPServerFormValues, "customHeaders">({
     name: "customHeaders",
   });
   const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.sId);
@@ -163,15 +160,12 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
       <Collapsible>
         <CollapsibleTrigger>
           <div className="heading-lg">
-            Networking & Headers ({headerFields.length})
+            Networking & Headers ({(headerFields ?? []).length})
           </div>
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="space-y-2">
-            <McpServerHeaders
-              headers={headerFields.map(({ key, value }) => ({ key, value }))}
-              onHeadersChange={(rows) => replace(rows)}
-            />
+            <McpServerHeaders />
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
+++ b/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
@@ -10,7 +10,7 @@ import {
   SliderToggle,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
 
 interface CustomHeadersConfigurationSectionProps {
   defaultServerConfig?: DefaultRemoteMCPServerConfig;
@@ -26,11 +26,6 @@ export function CustomHeadersConfigurationSection({
     control: form.control,
     name: "useCustomHeaders",
   });
-  const { fields: customHeaders, replace: replaceCustomHeaders } =
-    useFieldArray({
-      control: form.control,
-      name: "customHeaders",
-    });
 
   const useCustomHeaders = useCustomHeadersField.value;
 
@@ -65,12 +60,7 @@ export function CustomHeadersConfigurationSection({
         </div>
       )}
 
-      {useCustomHeaders && (
-        <McpServerHeaders
-          headers={customHeaders}
-          onHeadersChange={replaceCustomHeaders}
-        />
-      )}
+      {useCustomHeaders && <McpServerHeaders />}
     </>
   );
 }

--- a/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
+++ b/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
@@ -1,5 +1,5 @@
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
-import { McpServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
+import { MCPServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType } from "@app/lib/api/mcp";
@@ -60,7 +60,7 @@ export function CustomHeadersConfigurationSection({
         </div>
       )}
 
-      {useCustomHeaders && <McpServerHeaders />}
+      {useCustomHeaders && <MCPServerHeaders />}
     </>
   );
 }


### PR DESCRIPTION
## Description
This refactors `MCPServerHeaders` to use React Hook Form's native hooks directly instead of callback-based state management. The component now uses `useFieldArray` with `register` to bind inputs via DOM refs. 

Parent components (`InternalMCPBearerTokenForm`, `RemoteMCPForm`, `CustomHeadersConfigurationSection`) no longer need to manage header state - they use `useWatch` to display the header count and pass no props to `MCPServerHeaders`. This eliminates prop drilling and delegates all form state handling to RHF's context.

## Risk

Medium - only changes internal implementation of form state management while maintaining the same user-facing behavior.

## Tests

- [x] Locally

## Deployment plan

Deploy front
