### PR TITLE
security: restrict @claude trigger to repo members and pin CLAUDE.md to base branch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,12 +37,14 @@ jobs:
         with:
           fetch-depth: 0 # Fetch full history for accurate diffs
 
-      # Create symlink from CODING_RULES.md to CLAUDE.md
-      - name: Create symlink for Claude documentation
+      # Pin CLAUDE.md to the base branch to prevent prompt injection via PR-supplied CODING_RULES.md
+      - name: Create CLAUDE.md from trusted base branch
         if: steps.should-run.outputs.result == 'true'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          ln -s front/CODING_RULES.md CLAUDE.md
-          ls -la # Verify the symlink was created correctly
+          git fetch origin "$BASE_REF"
+          git show FETCH_HEAD:front/CODING_RULES.md > CLAUDE.md
 
       - name: Run Code Review with Claude
         if: steps.should-run.outputs.result == 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,8 +43,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "$BASE_REF"
-          git show FETCH_HEAD:front/CODING_RULES.md > CLAUDE.md
+          git show origin/"$BASE_REF":front/CODING_RULES.md > CLAUDE.md
 
       - name: Run Code Review with Claude
         if: steps.should-run.outputs.result == 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,14 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Description


- Add author_association check (OWNER/MEMBER/COLLABORATOR) to claude.yml to prevent external users from triggering the Claude Code agent
- Fix claude-code-review.yml to fetch CODING_RULES.md from the base branch instead of symlinking to the PR branch, preventing prompt injection

## Tests

## Risk

broken Claude review in CI