### PR TITLE
[front] feat(sandbox): display attached files to `SkillsDetails`

### DIFF
--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -121,7 +121,7 @@ export function SkillInfoTab({
         </div>
       )}
       {skill.fileAttachments.length > 0 && (
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Files
           </div>

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -103,10 +103,10 @@ export function SkillInfoTab({
           />
         </div>
       )}
-      {(knowledgeItems.length > 0 || skill.fileAttachments.length > 0) && (
+      {knowledgeItems.length > 0 && (
         <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
-            Knowledge & files
+            Knowledge
           </div>
           <div className="flex flex-wrap gap-2">
             {knowledgeItems.filter(isFullKnowledgeItem).map((item) => (
@@ -117,6 +117,15 @@ export function SkillInfoTab({
                 color="primary"
               />
             ))}
+          </div>
+        </div>
+      )}
+      {skill.fileAttachments.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Files
+          </div>
+          <div className="flex flex-wrap gap-2">
             {skill.fileAttachments.map((file) => (
               <AttachmentChip
                 key={file.fileId}

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -38,6 +39,7 @@ export function SkillInfoTab({
   showDescription = true,
 }: SkillInfoTabProps) {
   const [knowledgeItems, setKnowledgeItems] = useState<KnowledgeItem[]>([]);
+  const { hasFeature } = useFeatureFlags();
 
   const shouldLoadSpaces = skill.requestedSpaceIds.length > 0;
   const { spaces: spacesFromHook, isSpacesLoading } = useSpaces({
@@ -77,7 +79,7 @@ export function SkillInfoTab({
   const showSeparator =
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
-    skill.fileAttachments.length > 0 ||
+    (hasFeature("sandbox_tools") && skill.fileAttachments.length > 0) ||
     sortedMCPServerViews.length > 0 ||
     shouldLoadSpaces;
 
@@ -120,7 +122,7 @@ export function SkillInfoTab({
           </div>
         </div>
       )}
-      {skill.fileAttachments.length > 0 && (
+      {hasFeature("sandbox_tools") && skill.fileAttachments.length > 0 && (
         <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Files

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -106,7 +106,7 @@ export function SkillInfoTab({
         </div>
       )}
       {knowledgeItems.length > 0 && (
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Knowledge
           </div>
@@ -123,7 +123,7 @@ export function SkillInfoTab({
         </div>
       )}
       {hasFeature("sandbox_tools") && skill.fileAttachments.length > 0 && (
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Files
           </div>

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -13,7 +13,14 @@ import { useSpaces } from "@app/lib/swr/spaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Chip, Separator, Spinner, Tooltip } from "@dust-tt/sparkle";
+import {
+  AttachmentChip,
+  Chip,
+  DocumentIcon,
+  Separator,
+  Spinner,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import sortBy from "lodash/sortBy";
 import { useCallback, useMemo, useState } from "react";
 
@@ -70,6 +77,7 @@ export function SkillInfoTab({
   const showSeparator =
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
+    skill.fileAttachments.length > 0 ||
     sortedMCPServerViews.length > 0 ||
     shouldLoadSpaces;
 
@@ -95,10 +103,10 @@ export function SkillInfoTab({
           />
         </div>
       )}
-      {knowledgeItems.length > 0 && (
+      {(knowledgeItems.length > 0 || skill.fileAttachments.length > 0) && (
         <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
-            Knowledge
+            Knowledge & files
           </div>
           <div className="flex flex-wrap gap-2">
             {knowledgeItems.filter(isFullKnowledgeItem).map((item) => (
@@ -107,6 +115,15 @@ export function SkillInfoTab({
                 node={item.node}
                 title={item.label}
                 color="primary"
+              />
+            ))}
+            {skill.fileAttachments.map((file) => (
+              <AttachmentChip
+                key={file.fileId}
+                label={file.fileName}
+                icon={{ visual: DocumentIcon }}
+                color="primary"
+                size="xs"
               />
             ))}
           </div>


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6802.
- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=3676-84803&t=hZQdIcbkqO407eEW-0).
- This PR displays the attached files in the `SkillsDetails` sheet.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
