### PR TITLE
Use clientFetch to prevent JSON parse

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,6 +1,6 @@
 import { useVisualizationRetry } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useFetcher } from "@app/lib/swr/FetcherContext";
+import { clientFetch } from "@app/lib/egress/client";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
   CommandResultMap,
@@ -254,7 +254,6 @@ export const VisualizationActionIframe = forwardRef<
   const [retryClicked, setRetryClicked] = useState(false);
   const [isCodeDrawerOpen, setCodeDrawerOpened] = useState(false);
   const vizIframeRef = useRef<HTMLIFrameElement | null>(null);
-  const { fetcher } = useFetcher();
 
   // Combine internal ref with forwarded ref.
   const combinedRef = useCallback(
@@ -282,7 +281,7 @@ export const VisualizationActionIframe = forwardRef<
 
   const getFileBlob = useCallback(
     async (fileId: string) => {
-      const response = await fetcher(
+      const response = await clientFetch(
         `/api/w/${workspaceId}/files/${fileId}?action=view`
       );
       if (!response.ok) {
@@ -295,7 +294,7 @@ export const VisualizationActionIframe = forwardRef<
         type: response.headers.get("Content-Type") ?? undefined,
       });
     },
-    [workspaceId, fetcher]
+    [workspaceId]
   );
 
   useVisualizationDataHandler({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes a regression introduced in https://github.com/dust-tt/dust/pull/22348 that used the `fetcher` which assumes `JSON` when binary data is actually expected. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
