### PR TITLE
Centralize LLM observability by capturing actual request payloads

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -1,5 +1,6 @@
 import Anthropic, { APIError } from "@anthropic-ai/sdk";
 import type { MessageCountTokensParams } from "@anthropic-ai/sdk/resources";
+import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
 
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
@@ -69,7 +70,7 @@ function buildSystemBlocks(
   return system;
 }
 
-export class AnthropicLLM extends LLM {
+export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   private client: Anthropic;
   private workspace: WorkspaceType;
 
@@ -93,54 +94,60 @@ export class AnthropicLLM extends LLM {
     this.workspace = auth.getNonNullableWorkspace();
   }
 
-  async *internalStream({
+  protected buildRequestPayload({
     conversation,
     hasConditionalJITTools,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): BetaMessageStreamParams {
+    const messages = conversation.messages.map((msg, index, array) =>
+      toMessage(msg, { isLast: index === array.length - 1 })
+    );
+
+    // Build thinking config, use custom type if specified.
+    const thinkingConfig =
+      this.modelConfig.customThinkingType === "auto"
+        ? toAutoThinkingConfig(
+            this.reasoningEffort,
+            this.modelConfig.useNativeLightReasoning
+          )
+        : toThinkingConfig(
+            this.reasoningEffort,
+            this.modelConfig.useNativeLightReasoning
+          );
+
+    // Merge betas, always include structured-outputs, add custom betas if specified.
+    // TODO(fabien): Remove beta tag and beta client when structured outputs are generally available.
+    const betas = [
+      "structured-outputs-2025-11-13",
+      ...(this.modelConfig.customBetas ?? []),
+    ];
+
+    const system = buildSystemBlocks(normalizePrompt(prompt), {
+      hasConditionalJITTools,
+    });
+
+    return {
+      model: this.modelId,
+      ...thinkingConfig,
+      system,
+      messages,
+      temperature: this.temperature ?? undefined,
+      stream: true,
+      tools: specifications.map(toTool),
+      max_tokens: this.modelConfig.generationTokensCount,
+      tool_choice: toToolChoiceParam(specifications, forceToolCall),
+      betas,
+      output_format: toOutputFormatParam(this.responseFormat),
+    };
+  }
+
+  protected async *sendRequest(
+    payload: BetaMessageStreamParams
+  ): AsyncGenerator<LLMEvent> {
     try {
-      const messages = conversation.messages.map((msg, index, array) =>
-        toMessage(msg, { isLast: index === array.length - 1 })
-      );
-
-      // Build thinking config, use custom type if specified.
-      const thinkingConfig =
-        this.modelConfig.customThinkingType === "auto"
-          ? toAutoThinkingConfig(
-              this.reasoningEffort,
-              this.modelConfig.useNativeLightReasoning
-            )
-          : toThinkingConfig(
-              this.reasoningEffort,
-              this.modelConfig.useNativeLightReasoning
-            );
-
-      // Merge betas, always include structured-outputs, add custom betas if specified.
-      // TODO(fabien): Remove beta tag and beta client when structured outputs are generally available.
-      const betas = [
-        "structured-outputs-2025-11-13",
-        ...(this.modelConfig.customBetas ?? []),
-      ];
-
-      const system = buildSystemBlocks(normalizePrompt(prompt), {
-        hasConditionalJITTools,
-      });
-
-      const events = this.client.beta.messages.stream({
-        model: this.modelId,
-        ...thinkingConfig,
-        system,
-        messages,
-        temperature: this.temperature ?? undefined,
-        stream: true,
-        tools: specifications.map(toTool),
-        max_tokens: this.modelConfig.generationTokensCount,
-        tool_choice: toToolChoiceParam(specifications, forceToolCall),
-        betas,
-        output_format: toOutputFormatParam(this.responseFormat),
-      } as Parameters<typeof this.client.beta.messages.stream>[0]);
+      const events = this.client.beta.messages.stream(payload);
 
       const shouldCountReasoningTokens =
         this.reasoningEffort !== "none" &&

--- a/front/lib/api/llm/clients/fireworks/index.ts
+++ b/front/lib/api/llm/clients/fireworks/index.ts
@@ -23,8 +23,9 @@ import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
 import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import { APIError, OpenAI } from "openai";
+import type { ChatCompletionCreateParamsStreaming } from "openai/resources/chat/completions";
 
-export class FireworksLLM extends LLM {
+export class FireworksLLM extends LLM<ChatCompletionCreateParamsStreaming> {
   private client: OpenAI;
 
   constructor(
@@ -48,30 +49,35 @@ export class FireworksLLM extends LLM {
     });
   }
 
-  protected async *internalStream({
+  protected buildRequestPayload({
     conversation,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): ChatCompletionCreateParamsStreaming {
+    const tools =
+      specifications.length > 0 ? toTools(specifications) : undefined;
+
+    return {
+      model: this.modelId,
+      messages: toMessages(systemPromptToText(prompt), conversation),
+      stream: true,
+      temperature: this.temperature ?? undefined,
+      reasoning_effort: toReasoningParam(
+        this.reasoningEffort,
+        this.modelConfig.useNativeLightReasoning
+      ),
+      tool_choice: toToolChoiceParam(specifications, forceToolCall),
+      ...(tools ? { tools } : {}),
+      response_format: toOutputFormatParam(this.responseFormat),
+    };
+  }
+
+  protected async *sendRequest(
+    payload: ChatCompletionCreateParamsStreaming
+  ): AsyncGenerator<LLMEvent> {
     try {
-      const tools =
-        specifications.length > 0 ? toTools(specifications) : undefined;
-
-      const events = await this.client.chat.completions.create({
-        model: this.modelId,
-        messages: toMessages(systemPromptToText(prompt), conversation),
-        stream: true,
-        temperature: this.temperature ?? undefined,
-        reasoning_effort: toReasoningParam(
-          this.reasoningEffort,
-          this.modelConfig.useNativeLightReasoning
-        ),
-        tool_choice: toToolChoiceParam(specifications, forceToolCall),
-        ...(tools ? { tools } : {}),
-        response_format: toOutputFormatParam(this.responseFormat),
-      });
-
+      const events = await this.client.chat.completions.create(payload);
       yield* streamLLMEvents(events, this.metadata);
     } catch (err) {
       if (err instanceof APIError) {

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -27,7 +27,14 @@ import { ApiError, GoogleGenAI } from "@google/genai";
 
 import { handleError } from "./utils/errors";
 
-export class GoogleLLM extends LLM {
+interface GoogleGenerateContentRequestParams {
+  conversation: LLMStreamParameters["conversation"];
+  prompt: LLMStreamParameters["prompt"];
+  specifications: LLMStreamParameters["specifications"];
+  forceToolCall: LLMStreamParameters["forceToolCall"];
+}
+
+export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
   private client: GoogleGenAI;
   protected modelId: GoogleAIStudioWhitelistedModelId;
 
@@ -51,24 +58,39 @@ export class GoogleLLM extends LLM {
     });
   }
 
-  async *internalStream({
+  protected buildRequestPayload({
     conversation,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): GoogleGenerateContentRequestParams {
+    // Just capture the parameters; content conversion happens in sendRequest
+    return {
+      conversation,
+      prompt,
+      specifications,
+      forceToolCall,
+    };
+  }
+
+  protected async *sendRequest(
+    payload: GoogleGenerateContentRequestParams
+  ): AsyncGenerator<LLMEvent> {
     try {
       const contents = await Promise.all(
-        conversation.messages.map((message) => toContent(message, this.modelId))
+        payload.conversation.messages.map((message) =>
+          toContent(message, this.modelId)
+        )
       );
+
       const generateContentResponses =
         await this.client.models.generateContentStream({
           model: this.modelId,
           contents,
           config: {
             temperature: this.temperature ?? undefined,
-            tools: specifications.map(toTool),
-            systemInstruction: { text: systemPromptToText(prompt) },
+            tools: payload.specifications.map(toTool),
+            systemInstruction: { text: systemPromptToText(payload.prompt) },
             // We only need one
             candidateCount: 1,
             thinkingConfig: toThinkingConfig({
@@ -76,7 +98,10 @@ export class GoogleLLM extends LLM {
               reasoningEffort: this.reasoningEffort,
               useNativeLightReasoning: this.modelConfig.useNativeLightReasoning,
             }),
-            toolConfig: toToolConfigParam(specifications, forceToolCall),
+            toolConfig: toToolConfigParam(
+              payload.specifications,
+              payload.forceToolCall
+            ),
             // Structured response format
             responseMimeType: this.responseFormat
               ? "application/json"

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -20,7 +20,14 @@ import { dustManagedCredentials } from "@app/types/api/credentials";
 import { Mistral } from "@mistralai/mistralai";
 import { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
 
-export class MistralLLM extends LLM {
+/**
+ * Extract the request type from Mistral SDK's chat.stream method.
+ * This infers the type directly from the SDK's actual method signature
+ * rather than manually duplicating the interface.
+ */
+type MistralChatStreamRequest = Parameters<Mistral["chat"]["stream"]>[0];
+
+export class MistralLLM extends LLM<MistralChatStreamRequest> {
   private client: Mistral;
 
   constructor(
@@ -40,29 +47,35 @@ export class MistralLLM extends LLM {
     });
   }
 
-  async *internalStream({
+  protected buildRequestPayload({
     conversation,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
-    try {
-      const messages = [
-        {
-          role: "system" as const,
-          content: systemPromptToText(prompt),
-        },
-        ...conversation.messages.map(toMessage),
-      ];
+  }: LLMStreamParameters): MistralChatStreamRequest {
+    const messages = [
+      {
+        role: "system" as const,
+        content: systemPromptToText(prompt),
+      },
+      ...conversation.messages.map(toMessage),
+    ];
 
-      const completionEvents = await this.client.chat.stream({
-        model: this.modelId,
-        messages,
-        temperature: this.temperature,
-        stream: true,
-        toolChoice: toToolChoiceParam(specifications, forceToolCall),
-        tools: specifications.map(toTool),
-      });
+    return {
+      model: this.modelId,
+      messages,
+      temperature: this.temperature ?? undefined,
+      stream: true,
+      toolChoice: toToolChoiceParam(specifications, forceToolCall),
+      tools: specifications.map(toTool),
+    };
+  }
+
+  protected async *sendRequest(
+    payload: MistralChatStreamRequest
+  ): AsyncGenerator<LLMEvent> {
+    try {
+      const completionEvents = await this.client.chat.stream(payload);
 
       yield* streamLLMEvents({
         completionEvents,

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -16,8 +16,13 @@ const metadata = {
   modelId: "noop" as const,
 };
 
+interface NoopRequest {
+  type: "noop_request";
+  lastUserMessage: string;
+}
+
 // NoopLLM is a dummy LLM that can respond to special commands.
-export class NoopLLM extends LLM {
+export class NoopLLM extends LLM<NoopRequest> {
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters & { modelId: "noop" }
@@ -25,10 +30,9 @@ export class NoopLLM extends LLM {
     super(auth, "noop", llmParameters);
   }
 
-  async *internalStream({
+  protected buildRequestPayload({
     conversation,
-    prompt: _prompt,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): NoopRequest {
     const lastUserMessage =
       conversation.messages
         .slice()
@@ -40,13 +44,17 @@ export class NoopLLM extends LLM {
         .split("@noop")[1]
         ?.trim() ?? "";
 
+    return { type: "noop_request", lastUserMessage };
+  }
+
+  protected async *sendRequest(payload: NoopRequest): AsyncGenerator<LLMEvent> {
     let responseText: string;
 
     // Determine response based on the message content.
-    if (lastUserMessage === "long message") {
+    if (payload.lastUserMessage === "long message") {
       // Generate a very long message.
       responseText = "This is a very long message. ".repeat(100);
-    } else if (lastUserMessage === "help") {
+    } else if (payload.lastUserMessage === "help") {
       // Display usage instructions.
       responseText =
         "Noop agent usage:\n" +

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -22,10 +22,11 @@ import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/responses/op
 import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import { APIError, OpenAI } from "openai";
+import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses";
 
 import { handleGenericError } from "../../types/errors";
 
-export class OpenAIResponsesLLM extends LLM {
+export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
   private client: OpenAI;
   protected modelId: OpenAIWhitelistedModelId;
 
@@ -54,30 +55,36 @@ export class OpenAIResponsesLLM extends LLM {
     });
   }
 
-  async *internalStream({
+  protected buildRequestPayload({
     conversation,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
-    try {
-      const promptText = systemPromptToText(prompt);
-      const reasoning = toReasoning(this.modelId, this.reasoningEffort);
-      const events = await this.client.responses.create({
-        model: this.modelId,
-        input: toInput(promptText, conversation),
-        stream: true,
-        temperature: this.temperature ?? undefined,
-        reasoning,
-        tools: specifications.map(toTool),
-        text: {
-          format: toResponseFormat(this.responseFormat, OPENAI_PROVIDER_ID),
-        },
-        // Only models supporting reasoning can do encrypted content for reasoning.
-        include: reasoning !== null ? ["reasoning.encrypted_content"] : [],
-        tool_choice: toToolOption(specifications, forceToolCall),
-      });
+  }: LLMStreamParameters): ResponseCreateParamsStreaming {
+    const promptText = systemPromptToText(prompt);
+    const reasoning = toReasoning(this.modelId, this.reasoningEffort);
 
+    return {
+      model: this.modelId,
+      input: toInput(promptText, conversation),
+      stream: true,
+      temperature: this.temperature ?? undefined,
+      reasoning,
+      tools: specifications.map(toTool),
+      text: {
+        format: toResponseFormat(this.responseFormat, OPENAI_PROVIDER_ID),
+      },
+      // Only models supporting reasoning can do encrypted content for reasoning.
+      include: reasoning !== null ? ["reasoning.encrypted_content"] : [],
+      tool_choice: toToolOption(specifications, forceToolCall),
+    };
+  }
+
+  protected async *sendRequest(
+    payload: ResponseCreateParamsStreaming
+  ): AsyncGenerator<LLMEvent> {
+    try {
+      const events = await this.client.responses.create(payload);
       yield* streamLLMEvents(events, this.metadata);
     } catch (err) {
       if (err instanceof APIError) {

--- a/front/lib/api/llm/clients/xai/index.ts
+++ b/front/lib/api/llm/clients/xai/index.ts
@@ -21,8 +21,9 @@ import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/responses/op
 import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import OpenAI, { APIError } from "openai";
+import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses";
 
-export class XaiLLM extends LLM {
+export class XaiLLM extends LLM<ResponseCreateParamsStreaming> {
   private client: OpenAI;
 
   constructor(
@@ -46,25 +47,30 @@ export class XaiLLM extends LLM {
     });
   }
 
-  protected async *internalStream({
+  protected buildRequestPayload({
     conversation,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
-    try {
-      const events = await this.client.responses.create({
-        model: this.modelId,
-        input: toInput(systemPromptToText(prompt), conversation, "system"),
-        stream: true,
-        // Reasoning not supported by xai responses api yet
-        // Using default value for reasoning models
-        temperature: this.temperature,
-        tools: specifications.map(toTool),
-        include: ["reasoning.encrypted_content"],
-        tool_choice: toToolOption(specifications, forceToolCall),
-      });
+  }: LLMStreamParameters): ResponseCreateParamsStreaming {
+    return {
+      model: this.modelId,
+      input: toInput(systemPromptToText(prompt), conversation, "system"),
+      stream: true,
+      // Reasoning not supported by xai responses api yet
+      // Using default value for reasoning models
+      temperature: this.temperature,
+      tools: specifications.map(toTool),
+      include: ["reasoning.encrypted_content"],
+      tool_choice: toToolOption(specifications, forceToolCall),
+    };
+  }
 
+  protected async *sendRequest(
+    payload: ResponseCreateParamsStreaming
+  ): AsyncGenerator<LLMEvent> {
+    try {
+      const events = await this.client.responses.create(payload);
       yield* streamLLMEvents(events, this.metadata);
     } catch (err) {
       if (err instanceof APIError) {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -26,7 +26,7 @@ import type {
   ModelProviderIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
-import { startObservation } from "@langfuse/tracing";
+import { type LangfuseGeneration, startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
 import startCase from "lodash/startCase";
@@ -45,7 +45,7 @@ export abstract class LLM<TPayload = unknown> {
   protected readonly context?: LLMTraceContext;
   protected readonly traceId: LLMTraceId;
   protected readonly getTraceOutput?: LLMTraceCustomization["getTraceOutput"];
-  protected actualRequestPayload: TPayload | null = null;
+  protected generation: LangfuseGeneration | null = null;
 
   protected constructor(
     auth: Authenticator,
@@ -123,7 +123,7 @@ export abstract class LLM<TPayload = unknown> {
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
     const buffer = new LLMTraceBuffer(this.traceId, workspaceId, this.context);
 
-    const generation = startObservation(
+    this.generation = startObservation(
       "llm-completion",
       {
         input: undefined,
@@ -140,9 +140,8 @@ export abstract class LLM<TPayload = unknown> {
       { asType: "generation" }
     );
 
-    generation.updateTrace({
+    this.generation.updateTrace({
       name: startCase(this.context.operationType),
-      input: this.actualRequestPayload,
       metadata: {
         dustTraceId: this.traceId,
         // All contextual data as key-value pairs for better filtering in Langfuse UI.
@@ -197,7 +196,7 @@ export abstract class LLM<TPayload = unknown> {
 
       if (currentEvent.type === "interaction_id") {
         buffer.setModelInteractionId(currentEvent.content.modelInteractionId);
-        generation.updateTrace({
+        this.generation.updateTrace({
           metadata: {
             modelInteractionId: currentEvent.content.modelInteractionId,
           },
@@ -213,7 +212,7 @@ export abstract class LLM<TPayload = unknown> {
       if (currentEvent.type === "error") {
         // Temporary: track LLM error metric
         statsDClient.increment("llm_error.count", 1, metricTags);
-        generation.updateTrace({
+        this.generation.updateTrace({
           tags: ["isError:true", `errorType:${currentEvent.content.type}`],
         });
 
@@ -251,7 +250,7 @@ export abstract class LLM<TPayload = unknown> {
 
       const { tokenUsage, ...rest } = buffer.currentOutput;
 
-      generation.update({
+      this.generation.update({
         output: { ...rest },
       });
 
@@ -259,14 +258,14 @@ export abstract class LLM<TPayload = unknown> {
       if (this.getTraceOutput) {
         const traceOutput = this.getTraceOutput(rest);
         if (traceOutput) {
-          generation.updateTrace({ output: traceOutput });
+          this.generation.updateTrace({ output: traceOutput });
         }
       } else {
-        generation.updateTrace({ output: { ...rest } });
+        this.generation.updateTrace({ output: { ...rest } });
       }
 
       if (tokenUsage) {
-        generation.update({
+        this.generation.update({
           usageDetails: {
             // Report the uncached input tokens if provider supports it.
             input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
@@ -280,7 +279,7 @@ export abstract class LLM<TPayload = unknown> {
       }
 
       if (buffer.error) {
-        generation.update({
+        this.generation.update({
           level: "ERROR",
           statusMessage: buffer.error.message,
           metadata: {
@@ -290,7 +289,7 @@ export abstract class LLM<TPayload = unknown> {
         });
       }
 
-      generation.end();
+      this.generation.end();
 
       const run = await RunResource.makeNew({
         appId: null,
@@ -333,6 +332,7 @@ export abstract class LLM<TPayload = unknown> {
   async *stream(
     streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {
+    console.log('>> stream <<');
     yield* this.streamWithTracing(streamParameters);
   }
 
@@ -361,9 +361,11 @@ export abstract class LLM<TPayload = unknown> {
     streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {
     const payload = this.buildRequestPayload(streamParameters);
-    // Capture the actual request payload for tracing
-    this.actualRequestPayload = payload;
-    // Send the request to the provider
+
+    // Update trace with the actual payload.
+    this.generation?.updateTrace({ input: payload });
+
+    // Send the request to the provider.
     yield* this.sendRequest(payload);
   }
 }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -13,17 +13,13 @@ import type {
   LLMClientMetadata,
   LLMParameters,
   LLMStreamParameters,
-  SystemPromptInput,
 } from "@app/lib/api/llm/types/options";
-import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
-import type { Content } from "@app/types/assistant/generation";
-import { isTextContent } from "@app/types/assistant/generation";
 import type {
   ModelConfigurationType,
   ModelIdType,
@@ -35,28 +31,6 @@ import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
 import startCase from "lodash/startCase";
 
-function contentToText(contents: Content[]): string {
-  return contents
-    .filter(isTextContent)
-    .map((c) => c.text)
-    .join("\n");
-}
-
-function buildDefaultTraceInput(
-  prompt: SystemPromptInput,
-  conversation: LLMStreamParameters["conversation"]
-): unknown[] {
-  return [
-    { role: "system", content: systemPromptToText(prompt) },
-    ...conversation.messages.map((message): unknown => {
-      if (message.role !== "user") {
-        return message;
-      }
-
-      return { ...message, content: contentToText(message.content) };
-    }),
-  ];
-}
 
 export abstract class LLM<TPayload = unknown> {
   protected modelId: ModelIdType;
@@ -71,7 +45,6 @@ export abstract class LLM<TPayload = unknown> {
   protected readonly authenticator: Authenticator;
   protected readonly context?: LLMTraceContext;
   protected readonly traceId: LLMTraceId;
-  protected readonly getTraceInput?: LLMTraceCustomization["getTraceInput"];
   protected readonly getTraceOutput?: LLMTraceCustomization["getTraceOutput"];
   protected actualRequestPayload: TPayload | null = null;
 
@@ -81,7 +54,6 @@ export abstract class LLM<TPayload = unknown> {
     {
       bypassFeatureFlag = false,
       context,
-      getTraceInput,
       getTraceOutput,
       modelId,
       reasoningEffort = "none",
@@ -111,7 +83,6 @@ export abstract class LLM<TPayload = unknown> {
     this.authenticator = auth;
     this.context = context;
     this.traceId = createLLMTraceId(randomUUID());
-    this.getTraceInput = getTraceInput;
     this.getTraceOutput = getTraceOutput;
   }
 
@@ -153,17 +124,10 @@ export abstract class LLM<TPayload = unknown> {
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
     const buffer = new LLMTraceBuffer(this.traceId, workspaceId, this.context);
 
-    // Use custom trace input if provided, otherwise use the full conversation.
-    // Full conversation with system prompt for observation (actual LLM call details).
-    const observationInput = buildDefaultTraceInput(prompt, conversation);
-
-    // Simplified input for trace if custom getter provided.
-    const traceInput = this.getTraceInput?.(conversation) ?? observationInput;
-
     const generation = startObservation(
       "llm-completion",
       {
-        input: observationInput,
+        input: undefined,
         model: this.modelId,
         modelParameters: {
           reasoningEffort: this.reasoningEffort ?? "",
@@ -179,7 +143,7 @@ export abstract class LLM<TPayload = unknown> {
 
     generation.updateTrace({
       name: startCase(this.context.operationType),
-      input: this.actualRequestPayload ?? traceInput,
+      input: this.actualRequestPayload,
       metadata: {
         dustTraceId: this.traceId,
         // All contextual data as key-value pairs for better filtering in Langfuse UI.
@@ -392,13 +356,7 @@ export abstract class LLM<TPayload = unknown> {
   protected abstract sendRequest(payload: TPayload): AsyncGenerator<LLMEvent>;
 
   /**
-   * Orchestrates the request lifecycle: build → capture for tracing → send.
-   *
-   * Default implementation calls buildRequestPayload() and sendRequest().
-   * Override only if you need custom streaming logic that doesn't fit the two-method pattern.
-   *
-   * Contract: Implement EITHER buildRequestPayload() + sendRequest()
-   * OR override internalStream() entirely. Do not mix approaches.
+   * Orchestrates the request lifecycle: build -> capture for tracing -> send.
    */
   protected async *internalStream(
     streamParameters: LLMStreamParameters

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -58,7 +58,7 @@ function buildDefaultTraceInput(
   ];
 }
 
-export abstract class LLM {
+export abstract class LLM<TPayload = unknown> {
   protected modelId: ModelIdType;
   protected modelConfig: ModelConfigurationType;
   protected temperature: number | null;
@@ -73,6 +73,7 @@ export abstract class LLM {
   protected readonly traceId: LLMTraceId;
   protected readonly getTraceInput?: LLMTraceCustomization["getTraceInput"];
   protected readonly getTraceOutput?: LLMTraceCustomization["getTraceOutput"];
+  protected actualRequestPayload: TPayload | null = null;
 
   protected constructor(
     auth: Authenticator,
@@ -178,7 +179,7 @@ export abstract class LLM {
 
     generation.updateTrace({
       name: startCase(this.context.operationType),
-      input: traceInput,
+      input: this.actualRequestPayload ?? traceInput,
       metadata: {
         dustTraceId: this.traceId,
         // All contextual data as key-value pairs for better filtering in Langfuse UI.
@@ -372,7 +373,40 @@ export abstract class LLM {
     yield* this.streamWithTracing(streamParameters);
   }
 
-  protected abstract internalStream(
+  /**
+   * Build the request payload that will be sent to the LLM provider.
+   *
+   * Contract: Implement this method to return the provider-specific request object.
+   * The payload is automatically captured for tracing.
+   */
+  protected abstract buildRequestPayload(
     streamParameters: LLMStreamParameters
-  ): AsyncGenerator<LLMEvent>;
+  ): TPayload;
+
+  /**
+   * Send the request to the LLM provider and yield events.
+   *
+   * Contract: Implement this method as an async generator to handle
+   * provider-specific API calls and response streaming.
+   */
+  protected abstract sendRequest(payload: TPayload): AsyncGenerator<LLMEvent>;
+
+  /**
+   * Orchestrates the request lifecycle: build → capture for tracing → send.
+   *
+   * Default implementation calls buildRequestPayload() and sendRequest().
+   * Override only if you need custom streaming logic that doesn't fit the two-method pattern.
+   *
+   * Contract: Implement EITHER buildRequestPayload() + sendRequest()
+   * OR override internalStream() entirely. Do not mix approaches.
+   */
+  protected async *internalStream(
+    streamParameters: LLMStreamParameters
+  ): AsyncGenerator<LLMEvent> {
+    const payload = this.buildRequestPayload(streamParameters);
+    // Capture the actual request payload for tracing
+    this.actualRequestPayload = payload;
+    // Send the request to the provider
+    yield* this.sendRequest(payload);
+  }
 }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -31,7 +31,6 @@ import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
 import startCase from "lodash/startCase";
 
-
 export abstract class LLM<TPayload = unknown> {
   protected modelId: ModelIdType;
   protected modelConfig: ModelConfigurationType;

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -361,10 +361,9 @@ export abstract class LLM<TPayload = unknown> {
   ): AsyncGenerator<LLMEvent> {
     const payload = this.buildRequestPayload(streamParameters);
 
-    // Update trace with the actual payload.
-    this.generation?.updateTrace({ input: payload });
+    // Update the generation span with the actual payload.
+    this.generation?.update({ input: payload });
 
-    // Send the request to the provider.
     yield* this.sendRequest(payload);
   }
 }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -332,7 +332,6 @@ export abstract class LLM<TPayload = unknown> {
   async *stream(
     streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {
-    console.log('>> stream <<');
     yield* this.streamWithTracing(streamParameters);
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This refactoring centralizes observability handling for all LLM providers by moving request payload capture into the
base LLM class. Instead of having each provider instrument their own code or pass around payloads through different
mechanisms, we now have one single place where actual API requests are captured and sent to Langfuse.

## The Problem

Previously, Langfuse was receiving simplified trace inputs rather than the actual request payloads sent to each
provider's API. This made it difficult to debug issues or understand the exact parameters being used for each API
call. Observability logic was scattered and inconsistent across the codebase.

## The Solution

By making the base LLM class generic over the request payload type (`LLM<TPayload>`), we created a single point where payloads are captured automatically. Each provider implements two simple methods: `buildRequestPayload()` to
construct their request, and `sendRequest()` to send it. The base class orchestrates this in `internalStream()`,
captures the payload, and passes it directly to `streamWithTracing()` for Langfuse.

Now all observability flows through one centralized location in the base class. Providers don't need to worry about
tracing—they just build and send their requests, and observability happens automatically with zero additional
instrumentation needed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
