### PR TITLE
Retry import before forcing reload

### DIFF
--- a/sparkle/src/lib/index.ts
+++ b/sparkle/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * as avatarUtils from "./avatar/utils";
+export * from "./reportToDatadog";
 export * from "./safeLazy";
 export * from "./utils";

--- a/sparkle/src/lib/reportToDatadog.ts
+++ b/sparkle/src/lib/reportToDatadog.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DDRum = { addError?: (error: unknown, context?: any) => void };
+
+/**
+ * Send an error to Datadog RUM if available (never throws).
+ */
+export function reportToDatadog(
+  error: unknown,
+  context: Record<string, unknown>
+) {
+  try {
+    const ddRum = (window as unknown as { DD_RUM?: DDRum }).DD_RUM;
+    ddRum?.addError?.(error, context);
+  } catch {
+    // Fail-safe: Datadog may not be loaded yet.
+  }
+}

--- a/sparkle/src/lib/safeLazy.ts
+++ b/sparkle/src/lib/safeLazy.ts
@@ -1,22 +1,9 @@
 import { type ComponentType, lazy } from "react";
 
+import { reportToDatadog } from "./reportToDatadog";
+
 export const FORCE_RELOAD_SESSION_KEY = "force_reload_at";
 export const FORCE_RELOAD_INTERVAL_MS = 10_000;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DDRum = { addError?: (error: unknown, context?: any) => void };
-
-/**
- * Send an error to Datadog RUM if available (never throws).
- */
-function reportToDatadog(error: unknown, context: Record<string, unknown>) {
-  try {
-    const ddRum = (window as unknown as { DD_RUM?: DDRum }).DD_RUM;
-    ddRum?.addError?.(error, context);
-  } catch {
-    // Fail-safe: Datadog may not be loaded yet.
-  }
-}
 
 /**
  * Try to extract the chunk URL from the dynamic import error message.

--- a/sparkle/src/lib/safeLazy.ts
+++ b/sparkle/src/lib/safeLazy.ts
@@ -3,6 +3,21 @@ import { type ComponentType, lazy } from "react";
 export const FORCE_RELOAD_SESSION_KEY = "force_reload_at";
 export const FORCE_RELOAD_INTERVAL_MS = 10_000;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DDRum = { addError?: (error: unknown, context?: any) => void };
+
+/**
+ * Send an error to Datadog RUM if available (never throws).
+ */
+function reportToDatadog(error: unknown, context: Record<string, unknown>) {
+  try {
+    const ddRum = (window as unknown as { DD_RUM?: DDRum }).DD_RUM;
+    ddRum?.addError?.(error, context);
+  } catch {
+    // Fail-safe: Datadog may not be loaded yet.
+  }
+}
+
 /**
  * Try to extract the chunk URL from the dynamic import error message.
  * Vite typically produces messages like:
@@ -56,8 +71,7 @@ export function safeLazy<T extends ComponentType<any>>(
 ) {
   return lazy(async () => {
     // In Next.js (detected via __NEXT_DATA__), let the framework handle errors.
-    const isNextJs =
-      typeof window !== "undefined" && "__NEXT_DATA__" in window;
+    const isNextJs = typeof window !== "undefined" && "__NEXT_DATA__" in window;
 
     let lastError: unknown;
 
@@ -73,10 +87,12 @@ export function safeLazy<T extends ComponentType<any>>(
         }
 
         if (attempt < MAX_RETRIES) {
-          console.warn(
-            `[safeLazy] import failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${RETRY_DELAY_MS}ms…`,
-            error instanceof Error ? error.message : String(error)
-          );
+          reportToDatadog(error, {
+            source: "safeLazy",
+            event: "retry",
+            attempt: attempt + 1,
+            maxAttempts: MAX_RETRIES + 1,
+          });
           await delay(RETRY_DELAY_MS);
         }
       }
@@ -100,7 +116,11 @@ export function safeLazy<T extends ComponentType<any>>(
     }
 
     // In SPA (Vite), reload to fetch fresh assets.
-    console.warn(diagnostic + " | reloading page");
+    reportToDatadog(lastError, {
+      source: "safeLazy",
+      event: "reload",
+      diagnostic,
+    });
     sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
     window.location.reload();
     return new Promise<never>(() => {});

--- a/sparkle/src/lib/safeLazy.ts
+++ b/sparkle/src/lib/safeLazy.ts
@@ -40,39 +40,69 @@ async function probeChunk(url: string): Promise<string> {
  * key as the SWR reload guard and skips the reload if one happened within the last
  * 60 seconds.
  */
+const RETRY_DELAY_MS = 1_500;
+const MAX_RETRIES = 2;
+
+/**
+ * Wait for a given number of milliseconds.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function safeLazy<T extends ComponentType<any>>(
   factory: () => Promise<{ default: T }>
 ) {
-  return lazy(() =>
-    factory().catch(async (error) => {
-      // In Next.js (detected via __NEXT_DATA__), let the framework handle errors.
-      if (typeof window !== "undefined" && "__NEXT_DATA__" in window) {
-        throw error;
+  return lazy(async () => {
+    // In Next.js (detected via __NEXT_DATA__), let the framework handle errors.
+    const isNextJs =
+      typeof window !== "undefined" && "__NEXT_DATA__" in window;
+
+    let lastError: unknown;
+
+    // Attempt the import with retries before resorting to a full page reload.
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        return await factory();
+      } catch (error) {
+        lastError = error;
+
+        if (isNextJs) {
+          throw error;
+        }
+
+        if (attempt < MAX_RETRIES) {
+          console.warn(
+            `[safeLazy] import failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${RETRY_DELAY_MS}ms…`,
+            error instanceof Error ? error.message : String(error)
+          );
+          await delay(RETRY_DELAY_MS);
+        }
       }
+    }
 
-      // Enrich the error with diagnostic information.
-      const chunkUrl = extractChunkUrl(error);
-      const probeInfo = chunkUrl ? await probeChunk(chunkUrl) : "no URL found";
-      const online = navigator.onLine ? "online" : "offline";
-      const diagnostic = `[safeLazy] ${error instanceof Error ? error.message : String(error)} | ${probeInfo} | navigator=${online}`;
+    // All retries exhausted — enrich the error with diagnostic information.
+    const chunkUrl = extractChunkUrl(lastError);
+    const probeInfo = chunkUrl ? await probeChunk(chunkUrl) : "no URL found";
+    const online = navigator.onLine ? "online" : "offline";
+    const diagnostic = `[safeLazy] ${lastError instanceof Error ? lastError.message : String(lastError)} | ${probeInfo} | navigator=${online}`;
 
-      // Guard against continuous reload loops.
-      const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
-      const nowMs = Date.now();
-      const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
-      const shouldReload =
-        !Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS;
+    // Guard against continuous reload loops.
+    const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
+    const nowMs = Date.now();
+    const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
+    const shouldReload =
+      !Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS;
 
-      if (!shouldReload) {
-        throw new Error(diagnostic, { cause: error });
-      }
+    if (!shouldReload) {
+      throw new Error(diagnostic, { cause: lastError });
+    }
 
-      // In SPA (Vite), reload to fetch fresh assets.
-      console.warn(diagnostic + " | reloading page");
-      sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
-      window.location.reload();
-      return new Promise<never>(() => {});
-    })
-  );
+    // In SPA (Vite), reload to fetch fresh assets.
+    console.warn(diagnostic + " | reloading page");
+    sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
+    window.location.reload();
+    return new Promise<never>(() => {});
+  });
 }


### PR DESCRIPTION
## Description

When a dynamic `import()` fails (e.g. after a deploy swaps chunk hashes), `safeLazy` currently immediately reloads the entire page. However, we've observed cases where the chunk **is** available (probe returns `status=200, content-type=application/javascript`) but the import still fails — likely due to transient network issues or stale browser/CDN cache layers.

This PR adds a retry mechanism (up to 3 attempts with 1.5s delays) before falling back to the full page reload. The flow becomes:

1. Try `factory()` (dynamic import)
2. On failure, wait 1.5s and retry (up to 2 retries)
3. If all retries fail, probe + diagnostics + page reload (existing behavior)
4. Reload loop guard still prevents infinite reloads

## Tests

Manual — the failure is transient and hard to reproduce reliably. The retry logic is straightforward and the existing reload fallback is unchanged.

## Risk

Low. The retry only adds a small delay (up to 3s total) before the existing reload behavior kicks in. Worst case: user waits 3s longer before the page reloads. Best case: the import succeeds on retry without any visible disruption.

## Deploy Plan

Standard deploy — the change is in the Sparkle library (client-side only).