### PR TITLE
Reenable datadog logger

### DIFF
--- a/front-spa/src/app/main.tsx
+++ b/front-spa/src/app/main.tsx
@@ -8,11 +8,12 @@ import "@dust-tt/front/styles/components.css";
 import "@spa/index.css";
 
 import App from "@spa/app/App";
-import { initDatadogRUM } from "@spa/lib/initDatadog";
+import { initDatadogLogs, initDatadogRUM } from "@spa/lib/initDatadog";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
-// Initialize Datadog RUM before rendering
+// Initialize Datadog before rendering
+initDatadogLogs();
 initDatadogRUM();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/front-spa/src/lib/initDatadog.ts
+++ b/front-spa/src/lib/initDatadog.ts
@@ -1,10 +1,49 @@
+import { datadogLogs } from "@datadog/browser-logs";
+
+// Benign errors filtered from Datadog Logs.
+// See: https://github.com/DataDog/browser-sdk/issues/1616
+const IGNORED_LOG_MESSAGES = [
+  "ResizeObserver loop completed with undelivered notifications",
+  "ResizeObserver loop limit exceeded",
+];
+
+/**
+ * Initialize Datadog Logs so that `datadogLogger` calls from front components
+ * are forwarded to Datadog instead of being silently swallowed.
+ */
+export function initDatadogLogs() {
+  const clientToken = import.meta.env?.VITE_DATADOG_CLIENT_TOKEN;
+
+  if (!clientToken) {
+    return;
+  }
+
+  datadogLogs.init({
+    clientToken,
+    site: "datadoghq.eu",
+    service: `${import.meta.env?.VITE_DATADOG_SERVICE || "front"}-browser`,
+    env: import.meta.env?.MODE === "production" ? "prod" : "dev",
+    version: import.meta.env?.VITE_COMMIT_HASH || "",
+    forwardErrorsToLogs: true,
+    sessionSampleRate: 100,
+    beforeSend: (log) => {
+      if (
+        typeof log.message === "string" &&
+        IGNORED_LOG_MESSAGES.some((m) => log.message.includes(m))
+      ) {
+        return false;
+      }
+      return true;
+    },
+  });
+}
+
 /**
  * Initialize Datadog RUM (Real User Monitoring)
  * This should be called early in the app initialization
  */
 export function initDatadogRUM() {
-  const env = import.meta.env as Record<string, string | undefined>;
-  const clientToken = env.VITE_DATADOG_CLIENT_TOKEN;
+  const clientToken = import.meta.env?.VITE_DATADOG_CLIENT_TOKEN;
 
   // Only initialize if we have a client token
   if (!clientToken || !window.DD_RUM) {
@@ -16,9 +55,9 @@ export function initDatadogRUM() {
       clientToken,
       applicationId: "5e9735e7-87c8-4093-b09f-49d708816bfd",
       site: "datadoghq.eu",
-      service: `${env.VITE_DATADOG_SERVICE || "front"}-browser`,
-      env: env.MODE === "production" ? "prod" : "dev",
-      version: env.VITE_COMMIT_HASH || "",
+      service: `${import.meta.env?.VITE_DATADOG_SERVICE || "front"}-browser`,
+      env: import.meta.env?.MODE === "production" ? "prod" : "dev",
+      version: import.meta.env?.VITE_COMMIT_HASH || "",
       allowedTracingUrls: [
         "https://dust.tt",
         "https://eu.dust.tt",

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -74,7 +74,11 @@ declare global {
   }
   interface ImportMeta {
     env?: {
+      MODE?: string;
       VITE_BASE_PATH?: string;
+      VITE_COMMIT_HASH?: string;
+      VITE_DATADOG_CLIENT_TOKEN?: string;
+      VITE_DATADOG_SERVICE?: string;
       VITE_DUST_CLIENT_FACING_URL?: string;
       VITE_DUST_REGION?: string;
       VITE_DUST_REGION_STORAGE_KEY?: string;


### PR DESCRIPTION
## Summary

- Initialize `@datadog/browser-logs` in `front-spa` so that `datadogLogger` calls from imported front components (e.g. `useNotification`, `AgentBuilder`, `MCPServerDetails`) are forwarded to Datadog Logs instead of being silently swallowed
- Add `initDatadogLogs()` to `front-spa/src/lib/initDatadog.ts`, mirroring the config from `front/pages/_app.tsx`
- Call it at startup in `main.tsx` alongside the existing `initDatadogRUM()`

## Context

The front-spa imports 13+ components from `front/` that use `datadogLogger`, which calls `datadogLogs.logger[level]()`. Since DD_LOGS was never initialized in the SPA, all those log calls were silently swallowed by a try/catch, giving us zero logging visibility.

## Test plan

- [x] Build front-spa to confirm no import errors
- [x] Verify `datadogLogger` calls in front components reach Datadog Logs when running in the SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)