### PR TITLE
Fix ordering logic for the Skills Use By column

### DIFF
--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -89,10 +89,13 @@ const editorsColumn = {
 
 const usedByColumn = (onAgentClick: (agentId: string) => void) => ({
   header: "Used by",
-  accessorKey: "usage",
-  cell: (info: CellContext<RowData, AgentsUsageType>) => (
+  accessorFn: (row: RowData) => row.usage?.count ?? 0,
+  cell: (info: CellContext<RowData, number>) => (
     <DataTable.CellContent>
-      <UsedByButton usage={info.getValue()} onItemClick={onAgentClick} />
+      <UsedByButton
+        usage={info.row.original.usage}
+        onItemClick={onAgentClick}
+      />
     </DataTable.CellContent>
   ),
   meta: {


### PR DESCRIPTION
## Description

The "Used By" column was using accessorKey: "usage" which passes the entire AgentsUsageType object to the sorter, making sorting completely broken (sorts in some arbitrary order).

The correct pattern (used in AdminActionsList.tsx and other tables) uses accessorFn: (row) => row.usage?.count ?? 0 to extract the numeric count for sorting.

Can be tested on https://646a31b3--app.preview.dust.tt/

## Tests

Manual

## Risk

Low

## Deploy Plan

Front