### PR TITLE
[front] chore: update wording on Skills details info tab

### DIFF
--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -86,7 +86,7 @@ export function SkillInfoTab({
       {skill.instructions && (
         <div className="dd-privacy-mask flex flex-col gap-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
-            Instructions
+            Guidelines
           </div>
           <SkillInstructionsReadOnlyEditor
             content={skill.instructions}


### PR DESCRIPTION
## Description

- This PR renames the `Instructions` section in the Skills details info tab to `Guidelines`.
- Goal is to match better the interface of Skill Builder and to avoid using the contextually overloaded word `instructions`.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
