### PR TITLE
feat: add support for non json responses in fetcher

### DIFF
--- a/extension/shared/lib/ExtensionFetcherProvider.tsx
+++ b/extension/shared/lib/ExtensionFetcherProvider.tsx
@@ -21,18 +21,19 @@ export function ExtensionFetcherProvider({
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     });
 
-    const fetcher: FetcherFn = async (url, init) => {
+    const fetcher: FetcherFn = async (url, init, options) => {
       const res = await clientFetch(url, {
         ...init,
         headers: addAuthHeaders(init?.headers),
         credentials: "omit", // Ensure cookies are not sent with requests from the extension
       });
-      return resHandler(res);
+      return resHandler(res, options);
     };
 
     const fetcherWithBody: FetcherWithBodyFn = async (
       [url, body, method],
-      init
+      init,
+      options
     ) => {
       const res = await clientFetch(url, {
         ...init,
@@ -44,7 +45,7 @@ export function ExtensionFetcherProvider({
         body: JSON.stringify(body),
         credentials: "omit", // Ensure cookies are not sent with requests from the extension
       });
-      return resHandler(res);
+      return resHandler(res, options);
     };
 
     return { fetcher, fetcherWithBody };

--- a/extension/shared/lib/swr.ts
+++ b/extension/shared/lib/swr.ts
@@ -1,3 +1,5 @@
+import { FetcherOptions } from "@app/lib/swr/fetcher";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { useAuthErrorCheck } from "@extension/ui/hooks/useAuthErrorCheck";
 import { useCallback } from "react";
 import type { Fetcher, Key, SWRConfiguration } from "swr";
@@ -96,9 +98,23 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
   }
 }
 
-export const resHandler = async (res: Response) => {
+export const resHandler = async (res: Response, options?: FetcherOptions) => {
+  const responseType = options?.responseType ?? "json";
   if (res.status < 300) {
-    return res.json();
+    switch (responseType) {
+      case "arrayBuffer":
+        return res.arrayBuffer();
+      case "blob":
+        return res.blob();
+      case "response":
+        return res;
+      case "text":
+        return res.text();
+      case "json":
+        return res.json();
+      default:
+        assertNever(responseType);
+    }
   }
 
   let error;

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -1,6 +1,6 @@
 import { useVisualizationRetry } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress/client";
+import { useFetcher } from "@app/lib/swr/FetcherContext";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
   CommandResultMap,
@@ -254,6 +254,7 @@ export const VisualizationActionIframe = forwardRef<
   const [retryClicked, setRetryClicked] = useState(false);
   const [isCodeDrawerOpen, setCodeDrawerOpened] = useState(false);
   const vizIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const { fetcher } = useFetcher();
 
   // Combine internal ref with forwarded ref.
   const combinedRef = useCallback(
@@ -281,20 +282,21 @@ export const VisualizationActionIframe = forwardRef<
 
   const getFileBlob = useCallback(
     async (fileId: string) => {
-      const response = await clientFetch(
-        `/api/w/${workspaceId}/files/${fileId}?action=view`
-      );
-      if (!response.ok) {
+      try {
+        const response = await fetcher(
+          `/api/w/${workspaceId}/files/${fileId}?action=view`,
+          {},
+          { responseType: "response" }
+        );
+        const resBuffer = await response.arrayBuffer();
+        return new Blob([resBuffer], {
+          type: response.headers.get("Content-Type") ?? undefined,
+        });
+      } catch (_) {
         return null;
       }
-
-      const resBuffer = await response.arrayBuffer();
-
-      return new Blob([resBuffer], {
-        type: response.headers.get("Content-Type") ?? undefined,
-      });
     },
-    [workspaceId]
+    [workspaceId, fetcher]
   );
 
   useVisualizationDataHandler({

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -11,13 +11,13 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { getErrorFromResponse, useFetcher } from "@app/lib/swr/swr";
+import { useFetcher } from "@app/lib/swr/swr";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
+import { isAPIErrorResponse } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
@@ -68,6 +68,7 @@ function ExportContentDropdown({
 }: ExportContentDropdownProps) {
   const sendNotification = useSendNotification();
   const [isExportingPdf, setIsExportingPdf] = useState(false);
+  const { fetcher } = useFetcher();
 
   const exportAsPng = () => {
     if (fileContent) {
@@ -100,8 +101,7 @@ function ExportContentDropdown({
 
     setIsExportingPdf(true);
     try {
-      // Use direct fetch instead of fetcher to avoid JSON parsing of binary PDF data.
-      const response = await clientFetch(
+      const blob = await fetcher(
         `/api/w/${owner.sId}/files/${fileId}/export/pdf`,
         {
           method: "POST",
@@ -109,15 +109,11 @@ function ExportContentDropdown({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ orientation }),
-        }
+        },
+        { responseType: "blob" }
       );
 
-      if (!response.ok) {
-        throw new Error("Failed to generate PDF");
-      }
-
-      // Get the PDF blob and trigger download.
-      const blob = await response.blob();
+      // Trigger download.
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
@@ -385,23 +381,11 @@ export function FrameRenderer({
     }
     setIsSavingToProject(true);
     try {
-      const res = await fetcher(
-        `/api/w/${owner.sId}/files/${fileId}/save-in-project`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ projectId: projectIdToSave }),
-        }
-      );
-      if (!res.ok) {
-        const errorData = await getErrorFromResponse(res);
-        sendNotification({
-          type: "error",
-          title: "Failed to save to project",
-          description: errorData.message,
-        });
-        return;
-      }
+      await fetcher(`/api/w/${owner.sId}/files/${fileId}/save-in-project`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId: projectIdToSave }),
+      });
       sendNotification({
         type: "success",
         title: "Saved to project",
@@ -410,11 +394,19 @@ export function FrameRenderer({
       // Invalidate file metadata so parent and this component get updated projectId.
       await mutateFileMetadata();
     } catch (e) {
-      sendNotification({
-        type: "error",
-        title: "Failed to save to project",
-        description: e instanceof Error ? e.message : "An error occurred",
-      });
+      if (isAPIErrorResponse(e)) {
+        sendNotification({
+          type: "error",
+          title: "Failed to save to project",
+          description: e.error.message,
+        });
+      } else {
+        sendNotification({
+          type: "error",
+          title: "Failed to save to project",
+          description: e instanceof Error ? e.message : "An error occurred",
+        });
+      }
     } finally {
       setIsSavingToProject(false);
     }

--- a/front/lib/swr/fetcher.ts
+++ b/front/lib/swr/fetcher.ts
@@ -3,6 +3,7 @@ import { BUILD_DATE, COMMIT_HASH } from "@app/lib/commit-hash";
 import { clientFetch } from "@app/lib/egress/client";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { isAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import {
   FORCE_RELOAD_INTERVAL_MS,
@@ -15,7 +16,8 @@ const addClientVersionHeaders = (headers: HeadersInit = {}): HeadersInit => ({
   "X-Build-Date": BUILD_DATE,
 });
 
-const resHandler = async (res: Response) => {
+const resHandler = async (res: Response, options?: FetcherOptions) => {
+  const responseType = options?.responseType ?? "json";
   if (res.headers.get("X-Reload-Required") === "true") {
     const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
     const nowMs = Date.now();
@@ -58,27 +60,50 @@ const resHandler = async (res: Response) => {
 
     throw new Error(errorText);
   }
-  return res.json();
+  switch (responseType) {
+    case "arrayBuffer":
+      return res.arrayBuffer();
+    case "blob":
+      return res.blob();
+    case "response":
+      return res;
+    case "text":
+      return res.text();
+    case "json":
+      return res.json();
+    default:
+      assertNever(responseType);
+  }
 };
 
-export type FetcherFn = (url: string, init?: RequestInit) => Promise<any>;
+export type FetcherOptions = {
+  responseType?: "json" | "blob" | "text" | "arrayBuffer" | "response";
+};
+
+export type FetcherFn = (
+  url: string,
+  init?: RequestInit,
+  options?: FetcherOptions
+) => Promise<any>;
 
 export type FetcherWithBodyFn = (
   args: [url: string, body: object, method: string],
-  init?: RequestInit
+  init?: RequestInit,
+  options?: FetcherOptions
 ) => Promise<any>;
 
-export const fetcher: FetcherFn = async (url, init) => {
+export const fetcher: FetcherFn = async (url, init, options) => {
   const res = await clientFetch(url, {
     ...init,
     headers: addClientVersionHeaders(init?.headers),
   });
-  return resHandler(res);
+  return resHandler(res, options);
 };
 
 export const fetcherWithBody: FetcherWithBodyFn = async (
   [url, body, method],
-  init
+  init,
+  options
 ) => {
   const res = await clientFetch(url, {
     ...init,
@@ -90,7 +115,7 @@ export const fetcherWithBody: FetcherWithBodyFn = async (
     body: JSON.stringify(body),
   });
 
-  return resHandler(res);
+  return resHandler(res, options);
 };
 
 type UrlsAndOptions = { url: string; options: RequestInit };


### PR DESCRIPTION





## Description

This PR adds support for non-JSON response types in the fetcher functions.

- Introduces a `FetcherOptions` type with a `responseType` parameter supporting `"json"`, `"blob"`, `"text"`, `"arrayBuffer"`, and `"response"`
- Updates `resHandler` to handle different response types based on the provided options (defaults to JSON for backward compatibility)
- Replaces `clientFetch` with `fetcher` to support frames in chrome extension

## Tests

Manually

## Risks

Low risk. Changes are backward compatible as response type defaults to `"json"` when not specified. Existing usages of fetcher functions will continue to work as before.

## Deploy Plan

Standard deployment. No special steps required.
