### PR TITLE
[extension] Add pluggable defaultInitResolver to clientFetch

### DIFF
--- a/extension/shared/lib/ExtensionFetcherProvider.tsx
+++ b/extension/shared/lib/ExtensionFetcherProvider.tsx
@@ -2,9 +2,30 @@ import { clientFetch } from "@app/lib/egress/client";
 import { FetcherProvider } from "@app/lib/swr/FetcherContext";
 import type { FetcherFn, FetcherWithBodyFn } from "@app/lib/swr/fetcher";
 import { resHandler } from "@extension/shared/lib/swr";
-import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+
+// Credentials and Authorization headers are handled by the defaultInitResolver
+// (set in useAuth), so fetchers are plain clientFetch wrappers.
+const fetcher: FetcherFn = async (url, init) => {
+  const res = await clientFetch(url, init);
+  return resHandler(res);
+};
+
+const fetcherWithBody: FetcherWithBodyFn = async (
+  [url, body, method],
+  init
+) => {
+  const res = await clientFetch(url, {
+    ...init,
+    method,
+    headers: {
+      ...((init?.headers as Record<string, string>) ?? {}),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  return resHandler(res);
+};
 
 interface ExtensionFetcherProviderProps {
   children: ReactNode;
@@ -13,43 +34,6 @@ interface ExtensionFetcherProviderProps {
 export function ExtensionFetcherProvider({
   children,
 }: ExtensionFetcherProviderProps) {
-  const { token } = useExtensionAuth();
-
-  const { fetcher, fetcherWithBody } = useMemo(() => {
-    const addAuthHeaders = (headers: HeadersInit = {}): HeadersInit => ({
-      ...headers,
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    });
-
-    const fetcher: FetcherFn = async (url, init) => {
-      const res = await clientFetch(url, {
-        ...init,
-        headers: addAuthHeaders(init?.headers),
-        credentials: "omit", // Ensure cookies are not sent with requests from the extension
-      });
-      return resHandler(res);
-    };
-
-    const fetcherWithBody: FetcherWithBodyFn = async (
-      [url, body, method],
-      init
-    ) => {
-      const res = await clientFetch(url, {
-        ...init,
-        method,
-        headers: addAuthHeaders({
-          ...init?.headers,
-          "Content-Type": "application/json",
-        }),
-        body: JSON.stringify(body),
-        credentials: "omit", // Ensure cookies are not sent with requests from the extension
-      });
-      return resHandler(res);
-    };
-
-    return { fetcher, fetcherWithBody };
-  }, [token]);
-
   return (
     <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
       {children}

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -1,3 +1,4 @@
+import { setDefaultInitResolver } from "@app/lib/api/config";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
@@ -26,6 +27,25 @@ export const useAuthHook = () => {
   >();
   const [featureFlags, setFeatureFlags] = useState<WhitelistableFeature[]>([]);
   const { setRegionInfo } = useRegionContext();
+
+  // Set default fetch init for the extension (overrides RegionContext's credentials: "include").
+  // Must be declared before any fetch effects so it's active when they run.
+  useEffect(() => {
+    if (tokens?.accessToken) {
+      setDefaultInitResolver(() => ({
+        credentials: "omit",
+        headers: { Authorization: `Bearer ${tokens.accessToken}` },
+      }));
+    } else {
+      setDefaultInitResolver(() => ({
+        credentials: "omit",
+      }));
+    }
+
+    return () => {
+      setDefaultInitResolver(null);
+    };
+  }, [tokens?.accessToken]);
 
   const isAuthenticated = useMemo(
     () => !!(tokens?.accessToken && tokens.expiresAt > Date.now()),
@@ -100,10 +120,7 @@ export const useAuthHook = () => {
 
     void (async () => {
       try {
-        const res = await clientFetch("/api/user", {
-          headers: { Authorization: `Bearer ${tokens.accessToken}` },
-          credentials: "omit", // Ensure cookies are not sent with requests from the extension
-        });
+        const res = await clientFetch("/api/user");
         if (res.ok) {
           const data = await res.json();
           const fetchedUser = data.user as UserTypeWithWorkspaces;
@@ -161,12 +178,7 @@ export const useAuthHook = () => {
     }
 
     void (async () => {
-      const res = await clientFetch(`/api/w/${workspace.sId}/feature-flags`, {
-        headers: {
-          Authorization: `Bearer ${tokens.accessToken}`,
-          credentials: "omit", // Ensure cookies are not sent with requests from the extension
-        },
-      });
+      const res = await clientFetch(`/api/w/${workspace.sId}/feature-flags`);
       if (res.ok) {
         const { feature_flags } = await res.json();
         setFeatureFlags(feature_flags ?? []);

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -12,8 +12,19 @@ export function setBaseUrlResolver(fn: (() => string) | null): void {
 
 // Returns the resolver's URL if set, or empty string.
 // Used by clientFetch to decide whether to rewrite relative URLs (SPA cross-origin only).
-export function getBaseUrlFromResolver(): string {
+export function getBaseUrl(): string {
   return baseUrlResolver?.() || "";
+}
+
+// Pluggable default RequestInit resolver (e.g. credentials/headers per context).
+let defaultInitResolver: (() => RequestInit) | null = null;
+
+export function setDefaultInitResolver(fn: (() => RequestInit) | null): void {
+  defaultInitResolver = fn;
+}
+
+export function getDefaultInit(): RequestInit | null {
+  return defaultInitResolver?.() ?? null;
 }
 
 const config = {

--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -1,4 +1,5 @@
-import { getBaseUrlFromResolver } from "@app/lib/api/config";
+import { getBaseUrl, getDefaultInit } from "@app/lib/api/config";
+import { isString } from "@app/types/shared/utils/general";
 
 // Client-side fetch helper. This is a simple alias for the global fetch, used to satisfy
 // the linter rule that discourages direct use of `fetch`. On the client, we cannot route
@@ -9,18 +10,32 @@ export function clientFetch(
 ): Promise<Response> {
   // Only rewrite URLs when a base URL resolver is active (SPA context).
   // In Next.js, relative URLs work fine and should not be rewritten.
-  const baseUrl = getBaseUrlFromResolver();
+  const baseUrl = getBaseUrl();
 
-  if (baseUrl && typeof input === "string") {
-    if (input.startsWith("/")) {
-      input = `${baseUrl}${input}`;
-    }
+  if (baseUrl && isString(input) && input.startsWith("/")) {
+    input = `${baseUrl}${input}`;
+  }
 
-    // Include credentials for all requests targeting the API (needed for
-    // cross-origin requests from the SPA on app.dust.tt to the API on dust.tt).
-    if (input.startsWith(baseUrl) && init?.credentials === undefined) {
-      init = { ...init, credentials: "include" };
-    }
+  // Merge default RequestInit from the resolver (caller's init takes precedence,
+  // headers are shallow-merged).
+  // When no resolver is set but a baseUrlResolver is active (SPA context),
+  // default to credentials: "include" for cross-origin cookie auth.
+  const defaults =
+    getDefaultInit() ?? (baseUrl ? { credentials: "include" } : null);
+  if (defaults) {
+    const mergedHeaders =
+      defaults.headers || init?.headers
+        ? {
+            ...defaults.headers,
+            ...init?.headers,
+          }
+        : undefined;
+
+    init = {
+      ...defaults,
+      ...init,
+      ...(mergedHeaders && { headers: mergedHeaders }),
+    };
   }
 
   // eslint-disable-next-line no-restricted-globals


### PR DESCRIPTION
## Description

Add a pluggable `defaultInitResolver` to `clientFetch` (mirroring the existing `baseUrlResolver` pattern) so each context (SPA vs extension) configures its fetch defaults once instead of repeating `credentials` / `Authorization` on every call.

**Problem:**
- The extension manually passed `credentials: "omit"` + `Authorization: Bearer <token>` on every `clientFetch` call
- There was a bug where `credentials: "omit"` was placed inside the `headers` object in the feature-flags fetch (so it was ignored)
- `ExtensionFetcherProvider` re-created fetchers on every token change just to inject auth headers

**Changes:**
- `front/lib/api/config.ts` — Add `setDefaultInitResolver` / `getDefaultInit`
- `front/lib/egress/client.ts` — Merge resolver defaults into every request (caller's init takes precedence, headers are shallow-merged). Falls back to `{ credentials: "include" }` when no resolver is set but a `baseUrlResolver` is active (SPA context)
- `extension/ui/components/auth/useAuth.ts` — Add effect that sets the resolver with `credentials: "omit"` + `Authorization` header based on token; simplify `/api/user` and feature-flags fetches to plain `clientFetch(url)` calls
- `extension/shared/lib/ExtensionFetcherProvider.tsx` — Remove `useExtensionAuth()`, `addAuthHeaders`, manual `credentials: "omit"`. Fetchers become stateless module-level constants

**No changes to `RegionContext.tsx`** — it's shared by both SPA and extension, so the SPA `credentials: "include"` fallback lives in `clientFetch` itself (tied to `baseUrlResolver` being active).

## Tests

- Extension: login, close/reopen, org switch — verify API calls use `credentials: "omit"` + Bearer token
- SPA (front-spa): login and API calls still work with `credentials: "include"`
- Next.js: no resolver set, `clientFetch` remains a plain pass-through (no regression)

## Risk

Low. The SPA behavior is preserved by the `baseUrl` fallback in `clientFetch`. The extension behavior is now centralized instead of scattered — fixes the existing feature-flags credentials bug.

## Deploy Plan

Ship as-is — no migration needed, no env changes.