### PR TITLE
feat: add throttling for rename_title butler suggestions

### DIFF
--- a/front/lib/butler/suggest_rename_title.test.ts
+++ b/front/lib/butler/suggest_rename_title.test.ts
@@ -3,6 +3,7 @@ import { renderConversationForModel } from "@app/lib/api/assistant/conversation_
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { evaluateRenameTitleSuggestion } from "@app/lib/butler/suggest_rename_title";
 import { MessageModel } from "@app/lib/models/agent/conversation";
+import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
 import { ConversationButlerSuggestionModel } from "@app/lib/resources/storage/models/conversation_butler_suggestion";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -283,5 +284,239 @@ describe("evaluateRenameTitleSuggestion", () => {
       where: { workspaceId: workspace.id },
     });
     expect(suggestions).toHaveLength(0);
+  });
+});
+
+describe("shouldProposeRenameTitle (throttling)", () => {
+  it("skips when a pending suggestion exists within cooldown", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    // Create additional messages at known ranks for the trigger message.
+    // The factory creates ranks 0 (user) and 1 (agent). Add a user message at rank 2.
+    const triggerMessage = await ConversationFactory.createUserMessageWithRank({
+      auth: authenticator,
+      workspace,
+      conversationId: conversation.id,
+      rank: 2,
+      content: "trigger",
+    });
+
+    // Create a pending suggestion sourced from the rank-0 message.
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+        rank: 0,
+      },
+    });
+    await ConversationButlerSuggestionResource.makeNew(authenticator, {
+      conversationId: conversation.id,
+      sourceMessageId: sourceMessage!.id,
+      suggestionType: "rename_title",
+      metadata: { suggestedTitle: "Old Suggestion" },
+      status: "pending",
+    });
+
+    // Set up mocks for high confidence — the LLM would suggest a rename.
+    setupMocksForHighConfidence();
+
+    await evaluateRenameTitleSuggestion(authenticator, {
+      conversation: makeFakeConversation({
+        id: conversation.id,
+        sId: conversation.sId,
+      }),
+      messageId: triggerMessage.sId,
+    });
+
+    // Should still have only the original suggestion (throttled).
+    const suggestions = await ConversationButlerSuggestionModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].status).toBe("pending");
+  });
+
+  it("auto-dismisses stale pending suggestion and creates new one", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    // Create a trigger message far away (rank 22, distance > 10 from rank 0).
+    const triggerMessage = await ConversationFactory.createUserMessageWithRank({
+      auth: authenticator,
+      workspace,
+      conversationId: conversation.id,
+      rank: 22,
+      content: "trigger",
+    });
+
+    // Create a pending suggestion sourced from the rank-0 message.
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+        rank: 0,
+      },
+    });
+    await ConversationButlerSuggestionResource.makeNew(authenticator, {
+      conversationId: conversation.id,
+      sourceMessageId: sourceMessage!.id,
+      suggestionType: "rename_title",
+      metadata: { suggestedTitle: "Old Suggestion" },
+      status: "pending",
+    });
+
+    setupMocksForHighConfidence();
+
+    await evaluateRenameTitleSuggestion(authenticator, {
+      conversation: makeFakeConversation({
+        id: conversation.id,
+        sId: conversation.sId,
+      }),
+      messageId: triggerMessage.sId,
+    });
+
+    // Should have 2 suggestions: old one auto-dismissed, new one pending.
+    const suggestions = await ConversationButlerSuggestionModel.findAll({
+      where: { workspaceId: workspace.id },
+      order: [["createdAt", "ASC"]],
+    });
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0].status).toBe("dismissed");
+    expect(suggestions[1].status).toBe("pending");
+    expect(suggestions[1].metadata).toEqual({
+      suggestedTitle: "Better Title",
+    });
+  });
+
+  it("respects cooldown after a dismissed suggestion", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    // Trigger message at rank 4 (distance 4 from rank 0, within cooldown of 10).
+    const triggerMessage = await ConversationFactory.createUserMessageWithRank({
+      auth: authenticator,
+      workspace,
+      conversationId: conversation.id,
+      rank: 4,
+      content: "trigger",
+    });
+
+    // Create a dismissed suggestion sourced from the rank-0 message.
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+        rank: 0,
+      },
+    });
+    await ConversationButlerSuggestionResource.makeNew(authenticator, {
+      conversationId: conversation.id,
+      sourceMessageId: sourceMessage!.id,
+      suggestionType: "rename_title",
+      metadata: { suggestedTitle: "Dismissed Suggestion" },
+      status: "dismissed",
+    });
+
+    setupMocksForHighConfidence();
+
+    await evaluateRenameTitleSuggestion(authenticator, {
+      conversation: makeFakeConversation({
+        id: conversation.id,
+        sId: conversation.sId,
+      }),
+      messageId: triggerMessage.sId,
+    });
+
+    // Should still have only the dismissed suggestion (cooldown respected).
+    const suggestions = await ConversationButlerSuggestionModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].status).toBe("dismissed");
+  });
+
+  it("allows new suggestion after cooldown expires for dismissed suggestion", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    // Trigger message at rank 20 (distance 20 from rank 0, beyond cooldown of 10).
+    const triggerMessage = await ConversationFactory.createUserMessageWithRank({
+      auth: authenticator,
+      workspace,
+      conversationId: conversation.id,
+      rank: 20,
+      content: "trigger",
+    });
+
+    // Create a dismissed suggestion sourced from the rank-0 message.
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+        rank: 0,
+      },
+    });
+    await ConversationButlerSuggestionResource.makeNew(authenticator, {
+      conversationId: conversation.id,
+      sourceMessageId: sourceMessage!.id,
+      suggestionType: "rename_title",
+      metadata: { suggestedTitle: "Old Dismissed" },
+      status: "dismissed",
+    });
+
+    setupMocksForHighConfidence();
+
+    await evaluateRenameTitleSuggestion(authenticator, {
+      conversation: makeFakeConversation({
+        id: conversation.id,
+        sId: conversation.sId,
+      }),
+      messageId: triggerMessage.sId,
+    });
+
+    // Should have 2: old dismissed + new pending.
+    const suggestions = await ConversationButlerSuggestionModel.findAll({
+      where: { workspaceId: workspace.id },
+      order: [["createdAt", "ASC"]],
+    });
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0].status).toBe("dismissed");
+    expect(suggestions[1].status).toBe("pending");
+    expect(suggestions[1].metadata).toEqual({
+      suggestedTitle: "Better Title",
+    });
   });
 });

--- a/front/lib/butler/suggest_rename_title.ts
+++ b/front/lib/butler/suggest_rename_title.ts
@@ -11,8 +11,12 @@ import type {
   ButlerSuggestionCreatedEvent,
   ConversationType,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 
 const RENAME_TITLE_FUNCTION_NAME = "rename_title_decision";
+
+// Minimum number of messages (by rank distance) between two rename_title suggestions.
+const RENAME_TITLE_COOLDOWN_MESSAGES = 10;
 
 const renameTitleSpecifications: AgentActionSpecification[] = [
   {
@@ -49,6 +53,72 @@ const RENAME_TITLE_PROMPT =
   "or the difference is just stylistic.\n" +
   "- Be conservative — most auto-generated titles are adequate.\n" +
   "- You MUST call the tool. Always call it.";
+
+/**
+ * Determine whether a new rename_title suggestion should be proposed.
+ *
+ * Rules:
+ * - If the most recent rename_title suggestion is still pending and was
+ *   created within the last RENAME_TITLE_COOLDOWN_MESSAGES messages → skip
+ *   (the user can still see it).
+ * - If the most recent rename_title suggestion is still pending but is older
+ *   than RENAME_TITLE_COOLDOWN_MESSAGES messages → auto-dismiss it (it's
+ *   far up off-screen) and allow a new one.
+ * - If the most recent rename_title suggestion was dismissed/accepted within
+ *   the last RENAME_TITLE_COOLDOWN_MESSAGES messages → skip (respect cooldown).
+ * - Otherwise → allow.
+ */
+async function shouldProposeRenameTitle(
+  auth: Authenticator,
+  {
+    conversationId,
+    currentMessageRank,
+  }: {
+    conversationId: ModelId;
+    currentMessageRank: number;
+  }
+): Promise<boolean> {
+  const latest =
+    await ConversationButlerSuggestionResource.fetchLatestByConversationAndType(
+      auth,
+      { conversationId, suggestionType: "rename_title" }
+    );
+
+  if (!latest) {
+    return true;
+  }
+
+  // Resolve the rank of the message that triggered the previous suggestion.
+  const previousSourceMessage = await MessageModel.findOne({
+    attributes: ["rank"],
+    where: {
+      id: latest.sourceMessageId,
+      workspaceId: auth.getNonNullableWorkspace().id,
+      visibility: "public", // to check for deletion
+    },
+  });
+
+  // If the source message was deleted/not existing, allow a new suggestion.
+  if (!previousSourceMessage) {
+    return true;
+  }
+
+  const rankDistance = currentMessageRank - previousSourceMessage.rank;
+  const withinCooldown = rankDistance < RENAME_TITLE_COOLDOWN_MESSAGES;
+
+  if (latest.status === "pending") {
+    if (withinCooldown) {
+      // Still visible — skip.
+      return false;
+    }
+    // Stale pending suggestion scrolled off-screen — auto-dismiss it.
+    await latest.autoDismiss();
+    return true;
+  }
+
+  // Dismissed or accepted — respect cooldown.
+  return !withinCooldown;
+}
 
 /**
  * Evaluate whether a conversation title should be renamed using an LLM.
@@ -181,6 +251,16 @@ export async function evaluateRenameTitleSuggestion(
   });
 
   if (!sourceMessage) {
+    return;
+  }
+
+  // Process rename title suggestion with throttling.
+  const shouldPropose = await shouldProposeRenameTitle(auth, {
+    conversationId: conversation.id,
+    currentMessageRank: sourceMessage.rank,
+  });
+
+  if (!shouldPropose) {
     return;
   }
 

--- a/front/lib/resources/conversation_butler_suggestion_resource.ts
+++ b/front/lib/resources/conversation_butler_suggestion_resource.ts
@@ -11,7 +11,10 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_suggestion";
+import type {
+  ButlerSuggestionPublicType,
+  ButlerSuggestionType,
+} from "@app/types/conversation_butler_suggestion";
 import { parseButlerSuggestionData } from "@app/types/conversation_butler_suggestion";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
@@ -152,6 +155,30 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     return results[0] ?? null;
   }
 
+  /**
+   * Fetch the most recent suggestion for a conversation filtered by type.
+   * Returns null if no suggestion of that type exists.
+   */
+  static async fetchLatestByConversationAndType(
+    auth: Authenticator,
+    {
+      conversationId,
+      suggestionType,
+    }: {
+      conversationId: ModelId;
+      suggestionType: ButlerSuggestionType;
+    }
+  ): Promise<ConversationButlerSuggestionResource | null> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const results = await this.baseFetch(auth, {
+      where: { workspaceId, conversationId, suggestionType },
+      order: [["createdAt", "DESC"]],
+      limit: 1,
+    });
+
+    return results[0] ?? null;
+  }
+
   private async checkAccess(
     auth: Authenticator,
     transaction?: Transaction
@@ -217,6 +244,14 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
 
     await this.update({ status: "dismissed" as const }, transaction);
     return new Ok(this);
+  }
+
+  /**
+   * System-level dismissal that bypasses user access checks.
+   * Used by the butler to auto-dismiss stale pending suggestions.
+   */
+  async autoDismiss(transaction?: Transaction): Promise<void> {
+    await this.update({ status: "dismissed" as const }, transaction);
   }
 
   async delete(


### PR DESCRIPTION

## Description

Limit rename_title suggestions to avoid spamming users:
- Skip if a pending suggestion exists within 10 messages
- Auto-dismiss stale pending suggestions scrolled off-screen
- Respect cooldown after dismissed/accepted suggestions


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
