### PR TITLE
[front] feat(skills): allow uploading files when creating skill

### DIFF
--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -85,12 +85,6 @@ export function SkillBuilderFilesSection() {
     [handleFilesUpload, append, existingFileNames, sendNotification]
   );
 
-  // We need to have a skill ID to upload files in order to attach them properly (useCaseMetadata).
-  const uploadDisabled = skillId === null || isProcessingFiles;
-
-  const disabledTooltip =
-    skillId === null ? "Save the skill first to upload files." : undefined;
-
   const headerActions = fields.length > 0 && (
     <Button
       type="button"
@@ -98,8 +92,6 @@ export function SkillBuilderFilesSection() {
       label="Upload files"
       icon={isProcessingFiles ? Spinner : PlusIcon}
       variant="outline"
-      disabled={uploadDisabled}
-      tooltip={disabledTooltip}
     />
   );
 
@@ -141,8 +133,6 @@ export function SkillBuilderFilesSection() {
                   label="Upload files"
                   icon={PlusIcon}
                   variant="outline"
-                  disabled={uploadDisabled}
-                  tooltip={disabledTooltip}
                 />
               }
               className="py-8"

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -92,6 +92,7 @@ export function SkillBuilderFilesSection() {
       label="Upload files"
       icon={isProcessingFiles ? Spinner : PlusIcon}
       variant="outline"
+      disabled={isProcessingFiles}
     />
   );
 
@@ -133,6 +134,7 @@ export function SkillBuilderFilesSection() {
                   label="Upload files"
                   icon={PlusIcon}
                   variant="outline"
+                  disabled={isProcessingFiles}
                 />
               }
               className="py-8"

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -744,7 +744,7 @@ export class FileResource extends BaseResource<FileModel> {
     return this.update({ useCaseMetadata: metadata });
   }
 
-  static async batchSetUseCaseMetadata(
+  static async bulkSetUseCaseMetadata(
     auth: Authenticator,
     files: FileResource[],
     metadata: FileUseCaseMetadata

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -744,6 +744,26 @@ export class FileResource extends BaseResource<FileModel> {
     return this.update({ useCaseMetadata: metadata });
   }
 
+  static async batchSetUseCaseMetadata(
+    auth: Authenticator,
+    files: FileResource[],
+    metadata: FileUseCaseMetadata
+  ): Promise<void> {
+    if (files.length === 0) {
+      return;
+    }
+    const workspace = auth.getNonNullableWorkspace();
+    await this.model.update(
+      { useCaseMetadata: metadata },
+      {
+        where: {
+          id: { [Op.in]: files.map((f) => f.id) },
+          workspaceId: workspace.id,
+        },
+      }
+    );
+  }
+
   /**
    * Move a conversation frame file to a project (change use case to project_context).
    * Preserves existing metadata and sets spaceId and sourceConversationId.

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -92,8 +92,8 @@ async function handler(
     });
   }
 
-  const skillResource = await SkillResource.fetchById(auth, sId);
-  if (!skillResource) {
+  const skill = await SkillResource.fetchById(auth, sId);
+  if (!skill) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -107,18 +107,18 @@ async function handler(
     case "GET": {
       const { withRelations } = req.query;
 
-      const skill = skillResource.toJSON(auth);
+      const serializedSkill = skill.toJSON(auth);
 
       if (withRelations === "true") {
-        const usage = await skillResource.fetchUsage(auth);
-        const editors = await skillResource.listEditors(auth);
-        const editedByUser = await skillResource.fetchEditedByUser(auth);
-        const extendedSkill = skill.extendedSkillId
-          ? await SkillResource.fetchById(auth, skill.extendedSkillId)
+        const usage = await skill.fetchUsage(auth);
+        const editors = await skill.listEditors(auth);
+        const editedByUser = await skill.fetchEditedByUser(auth);
+        const extendedSkill = serializedSkill.extendedSkillId
+          ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
           : null;
 
         const skillWithRelations: SkillWithRelationsType = {
-          ...skill,
+          ...serializedSkill,
           relations: {
             usage,
             editors: editors ? editors.map((e) => e.toJSON()) : null,
@@ -131,7 +131,7 @@ async function handler(
           skill: skillWithRelations,
         });
       }
-      return res.status(200).json({ skill });
+      return res.status(200).json({ skill: serializedSkill });
     }
 
     case "PATCH": {
@@ -162,7 +162,7 @@ async function handler(
       }
 
       // Check if user can write.
-      if (!skillResource.canWrite(auth)) {
+      if (!skill.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -175,7 +175,7 @@ async function handler(
       // Check for existing active skill with the same name (excluding current skill).
       const existingSkill = await SkillResource.fetchActiveByName(auth, name);
 
-      if (existingSkill && existingSkill.id !== skillResource.id) {
+      if (existingSkill && existingSkill.id !== skill.id) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -300,19 +300,19 @@ async function handler(
       }
 
       // When saving a suggested skill, automatically activate it.
-      const shouldActivate = skillResource.status === "suggested";
+      const shouldActivate = skill.status === "suggested";
 
       if (shouldActivate) {
         logger.info(
           {
-            skillId: skillResource.sId,
+            skillId: skill.sId,
             workspaceId: owner.sId,
           },
           "Suggested skill accepted"
         );
       }
 
-      await skillResource.updateSkill(auth, {
+      await skill.updateSkill(auth, {
         agentFacingDescription: body.agentFacingDescription,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
         fileAttachments: files,
@@ -326,13 +326,13 @@ async function handler(
       });
 
       return res.status(200).json({
-        skill: skillResource.toJSON(auth),
+        skill: skill.toJSON(auth),
       });
     }
 
     case "DELETE": {
       // Check if user can write.
-      if (!skillResource.canWrite(auth)) {
+      if (!skill.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -342,17 +342,17 @@ async function handler(
         });
       }
 
-      if (skillResource.status === "suggested") {
+      if (skill.status === "suggested") {
         logger.info(
           {
-            skillId: skillResource.sId,
+            skillId: skill.sId,
             workspaceId: owner.sId,
           },
           "Suggested skill rejected"
         );
       }
 
-      await skillResource.archive(auth);
+      await skill.archive(auth);
 
       return res.status(200).json({ success: true });
     }

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -59,6 +59,7 @@ const PatchSkillRequestBodySchema = t.intersection([
     ),
     attachedKnowledge: t.array(AttachedKnowledgeSchema),
   }),
+  // TODO(2026-03-02): make mandatory once always sent by the client.
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
   }),
@@ -260,7 +261,10 @@ async function handler(
         const featureFlags = await getFeatureFlags(
           auth.getNonNullableWorkspace()
         );
-        if (!featureFlags.includes("sandbox_tools")) {
+        if (
+          !featureFlags.includes("sandbox_tools") &&
+          fileAttachments.length > 0
+        ) {
           return apiError(req, res, {
             status_code: 403,
             api_error: {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -353,7 +353,7 @@ async function handler(
 
       // Update file useCaseMetadata with the newly created skill's sId.
       if (files) {
-        await FileResource.batchSetUseCaseMetadata(auth, files, {
+        await FileResource.bulkSetUseCaseMetadata(auth, files, {
           skillId: skillResource.sId,
         });
       }

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -275,7 +275,10 @@ async function handler(
         const featureFlags = await getFeatureFlags(
           auth.getNonNullableWorkspace()
         );
-        if (!featureFlags.includes("sandbox_tools")) {
+        if (
+          !featureFlags.includes("sandbox_tools") &&
+          fileAttachments.length > 0
+        ) {
           return apiError(req, res, {
             status_code: 403,
             api_error: {
@@ -347,6 +350,13 @@ async function handler(
           fileAttachments: files,
         }
       );
+
+      // Update file useCaseMetadata with the newly created skill's sId.
+      if (files) {
+        await FileResource.batchSetUseCaseMetadata(auth, files, {
+          skillId: skillResource.sId,
+        });
+      }
 
       return res.status(200).json({
         skill: skillResource.toJSON(auth),

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -352,7 +352,7 @@ async function handler(
       );
 
       // Update file useCaseMetadata with the newly created skill's sId.
-      if (files && files.length > 0) {
+      if (files) {
         await FileResource.bulkSetUseCaseMetadata(auth, files, {
           skillId: skill.sId,
         });

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -331,7 +331,7 @@ async function handler(
         }
       }
 
-      const skillResource = await SkillResource.makeNew(
+      const skill = await SkillResource.makeNew(
         auth,
         {
           status: "active",
@@ -354,12 +354,12 @@ async function handler(
       // Update file useCaseMetadata with the newly created skill's sId.
       if (files) {
         await FileResource.bulkSetUseCaseMetadata(auth, files, {
-          skillId: skillResource.sId,
+          skillId: skill.sId,
         });
       }
 
       return res.status(200).json({
-        skill: skillResource.toJSON(auth),
+        skill: skill.toJSON(auth),
       });
     }
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -352,7 +352,7 @@ async function handler(
       );
 
       // Update file useCaseMetadata with the newly created skill's sId.
-      if (files) {
+      if (files && files.length > 0) {
         await FileResource.bulkSetUseCaseMetadata(auth, files, {
           skillId: skill.sId,
         });


### PR DESCRIPTION
## Description

- This PR allows uploading files upon creating a skill.
- Was previously prevented, and required the user to save the skill a first time to get an `sId` for the `useCaseMetadata`. We now instead update the `useCaseMetadata` of the files in the `POST` endpoint handler.
- Also bundles a rename `skillResource` -> `skill`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
