### PR TITLE
Clear applied suggestions on editor register

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -313,6 +313,11 @@ function CopilotSuggestionsProviderContent({
   });
 
   const registerEditor = useCallback((editor: Editor) => {
+    if (editorRef.current !== editor) {
+      appliedSuggestionsRef.current.clear();
+      setIsEditorReady(false);
+    }
+
     editorRef.current = editor;
 
     // Wait for the editor content to be set.

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -209,6 +209,7 @@ export function AgentBuilderInstructionsEditor({
     height: number;
   } | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: owner.sId is intentional — owner is a SWR-deserialized object that gets a new reference on every revalidation (revalidateOnFocus). Using owner.sId (a stable primitive) prevents extensions from changing identity and the editor from being needlessly recreated.
   const extensions = useMemo(() => {
     const extensions: Extensions = [
       ...buildAgentInstructionsReadOnlyExtensions(),
@@ -261,7 +262,7 @@ export function AgentBuilderInstructionsEditor({
     ];
 
     return extensions;
-  }, [owner, suggestionHandler]);
+  }, [owner.sId, suggestionHandler]);
 
   // Debounce serialization to prevent performance issues
   const debouncedUpdate = useMemo(
@@ -305,10 +306,14 @@ export function AgentBuilderInstructionsEditor({
 
   // Set initial content after editor is created, then focus
   // This is separated from useEditor() to avoid Safari race conditions
-  // Only runs once when editor is first created
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
-    if (!editor || editor.isDestroyed || initialContentSetRef.current) {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+
+    // Skip if this exact editor instance was already initialized.
+    if (initialContentSetRef.current && editorRef.current === editor) {
       return;
     }
 


### PR DESCRIPTION
## Description

Root cause: extensions was memoized on the owner object reference, which comes from an SWR-cached auth context. Because SWR's revalidateOnFocus is enabled by default, every time the user switched tabs and came back, SWR re-fetched /api/auth-context and returned a new deserialized object — same data, new reference. This caused extensions to change identity, which made useEditor([extensions]) destroy and recreate the editor. The init useEffect guarded against double-initialization with initialContentSetRef.current, so registerEditor was never called on the new editor, leaving isEditorReady permanently false and the suggestions apply effect stuck in an early return — suggestions existed in SWR (hence "Accept All / Reject All" still showing) but were never visually applied to the editor.

## Tests

* Local testing

## Risk

* Low

## Deploy Plan

* deploy front