### PR TITLE
Have copilot suggest Haiku for simple agents

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -117,6 +117,7 @@ export default function AgentBuilder({
   const { mcpServerViews } = useMCPServerViewsContext();
   const { hasFeature } = useFeatureFlags();
   const { fetcherWithBody } = useFetcher();
+  const hasCopilot = useIsAgentBuilderCopilotEnabled();
 
   const router = useAppRouter();
   const sendNotification = useSendNotification(true);
@@ -250,6 +251,7 @@ export default function AgentBuilder({
     return getDefaultAgentFormData({
       owner,
       user,
+      hasCopilot,
     });
   }, [
     agentConfiguration,
@@ -258,6 +260,7 @@ export default function AgentBuilder({
     user,
     owner,
     hasFeature,
+    hasCopilot,
   ]);
 
   const form = useForm<AgentBuilderFormData>({

--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -1,4 +1,7 @@
-import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import {
+  CLAUDE_4_5_HAIKU_20251001_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_LARGE_MODEL_ID } from "@app/types/assistant/models/mistral";
 import { GPT_5_2_MODEL_ID } from "@app/types/assistant/models/openai";
@@ -11,6 +14,7 @@ import type {
 export const BEST_PERFORMING_MODELS_ID: ModelIdType[] = [
   GPT_5_2_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_4_5_HAIKU_20251001_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
 ] as const;

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -2,9 +2,15 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import { getLargeWhitelistedModel } from "@app/types/assistant/assistant";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/types/assistant/assistant";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
-import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import {
+  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+} from "@app/types/assistant/models/anthropic";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -56,12 +62,18 @@ export function transformAgentConfigurationToFormData(
 export function getDefaultAgentFormData({
   user,
   owner,
+  hasCopilot,
 }: {
   user: UserType;
   owner: WorkspaceType;
+  hasCopilot?: boolean;
 }): AgentBuilderFormData {
-  const preferredModel = CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
-  const fallbackModel = getLargeWhitelistedModel(owner);
+  const preferredModel = hasCopilot
+    ? CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
+    : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+  const fallbackModel = hasCopilot
+    ? getSmallWhitelistedModel(owner)
+    : getLargeWhitelistedModel(owner);
 
   // We use the preferred model unless the provider is deactivated for the workspace but we have a fallback model.
   // (We have no fallback model if all providers are deactivated which can be done in the workspace settings).
@@ -111,9 +123,13 @@ export function transformTemplateToFormData(
   owner: WorkspaceType,
   hasFeature: (flag: WhitelistableFeature | null | undefined) => boolean
 ): AgentBuilderFormData {
-  const defaultFormData = getDefaultAgentFormData({ user, owner });
   const hasCopilotAccess =
     hasFeature("agent_builder_copilot") && owner.role === "admin";
+  const defaultFormData = getDefaultAgentFormData({
+    user,
+    owner,
+    hasCopilot: hasCopilotAccess,
+  });
 
   return {
     ...defaultFormData,

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -61,7 +61,7 @@ Dimensions you MUST consider:
 - Review instructions to determine if the agent is meeting the user intent and properly utilizing the configured capabilities: <instructions_guidance>.
 - Instructions reference/require external actions - Tools or skills are required. See <skills_tools_guidance>.
 - Instructions reference/require internal data -> Knowledge is required. See <knowledge_guidance>.
-- This should be ignored unless the user asks for model suggestions.
+- Model: Haiku is a good default for simple, single-purpose agents. Recommend upgrading to Sonnet only for agents with complex workflows, multi-step reasoning, or advanced tool orchestration. Don't mention models unless you are recommending a change.
 - Refer to <templates> when the user asks for use case ideas or selects a template to build.
 
 From this, determine (1) tools required to perform further research and (2) rough count of estimated suggest_* calls required to complete the plan.

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -170,7 +170,7 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   largeModel: false,
   description:
     "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).",
-  shortDescription: "Anthropic's super-fast model.",
+  shortDescription: "Anthropic's latest super-fast model.",
   isLegacy: false,
   isLatest: true,
   generationTokensCount: 64_000,

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -104,7 +104,7 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   largeModel: true,
   description:
     "Anthropic's Claude 4.5 Sonnet model with enhanced reasoning and tool use (200k context).",
-  shortDescription: "Anthropic's latest model.",
+  shortDescription: "Anthropic's previous balanced model.",
   isLegacy: false,
   isLatest: true,
   generationTokensCount: 64_000,
@@ -170,7 +170,7 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   largeModel: false,
   description:
     "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).",
-  shortDescription: "Anthropic's cost-effective model.",
+  shortDescription: "Anthropic's super-fast model.",
   isLegacy: false,
   isLatest: true,
   generationTokensCount: 64_000,


### PR DESCRIPTION
## Description

- Change the default model to Haiku (only is copilot is enabled)
- Instruct copilot that Haiku is acceptable for simple agents
- Add Haiku to the 'Best performing models' list, and rename it from “Anthropic’s cost-effective model” to “Anthropic’s latest super-fast model” to justify it

Fixes https://github.com/dust-tt/tasks/issues/6900

## Tests

I manually tested:
- For simple agents, copilot doesn't suggest moving up to Sonnet
- For complex agents, it does
- If they already have the right model, it quietly leaves it alone

## Risk

All under copilot flag

## Deploy Plan

Front.