### PR TITLE
feat: relax node version so we can try node 24 locally

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -13,7 +13,7 @@
     "tsgo": "tsgo"
   },
   "engines": {
-    "node": "22.22.0"
+    "node": ">=22.22.0"
   },
   "author": "@dust-tt",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "wrangler": "^4.67.0"
       },
       "engines": {
-        "node": "22.22.0"
+        "node": ">=22.22.0"
       }
     },
     "cli/dust-cli": {
@@ -429,7 +429,7 @@
         "zip-webpack-plugin": "^4.0.1"
       },
       "engines": {
-        "node": "22.22.0"
+        "node": ">=22.22.0"
       }
     },
     "extension/node_modules/@types/node": {
@@ -10785,20 +10785,6 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@openfeature/server-sdk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
-      "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@openfeature/core": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -51659,7 +51645,7 @@
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": "22.22.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "wrangler": "^4.67.0"
   },
   "engines": {
-    "node": "22.22.0"
+    "node": ">=22.22.0"
   },
   "overrides": {
     "eslint-plugin-react-hooks": {

--- a/scripts/try-node24.sh
+++ b/scripts/try-node24.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Opt-in script to test Node 24 locally.
+# Usage: source scripts/try-node24.sh
+# To switch back: nvm use
+
+NODE24_VERSION="24"
+
+if ! command -v nvm &>/dev/null; then
+  # nvm is a shell function, try loading it
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  # shellcheck disable=SC1091
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+fi
+
+if ! command -v nvm &>/dev/null; then
+  echo "Error: nvm is not installed. Install it from https://github.com/nvm-sh/nvm"
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "Installing Node ${NODE24_VERSION} (if not already installed)..."
+nvm install "$NODE24_VERSION"
+
+echo "Switching to Node ${NODE24_VERSION} for this session..."
+nvm use "$NODE24_VERSION"
+
+echo ""
+echo "Node: $(node -v)"
+echo "npm:  $(npm -v)"
+echo ""
+echo "You're now running Node ${NODE24_VERSION}. The .nvmrc still points to 22."
+echo "Run 'nvm use' to switch back."

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -2,7 +2,7 @@
   "name": "@dust-tt/sparkle",
   "version": "0.7.7",
   "engines": {
-    "node": "22.22.0"
+    "node": ">=22.22.0"
   },
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",


### PR DESCRIPTION
## Description

Relax node version so it's easier to test 24 locally
Add a script to easily test locally

Note: as we enforce the version of npm, we won't get any diff for `npm install` with node 24 or 22 with this 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
