### PR TITLE
reduce timeout waiting for LLM events to 2 minutes

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -17,7 +17,7 @@ const LLM_HEARTBEAT_INTERVAL_MS = 10_000;
 // Log heartbeat status periodically to track long-waiting LLM calls.
 const HEARTBEAT_LOG_INTERVAL = 6; // Every minute (6 * 10s)
 // Timeout for waiting on a single LLM event (first or subsequent).
-const LLM_EVENT_TIMEOUT_MINUTES = 5;
+const LLM_EVENT_TIMEOUT_MINUTES = 2;
 const LLM_EVENT_TIMEOUT_MS = LLM_EVENT_TIMEOUT_MINUTES * 60 * 1000;
 
 class LLMStreamTimeoutError extends Error {


### PR DESCRIPTION
## Description

As we are now streaming partial tool events, the timeout generally represent a conv being idle because the provider is slow.
I'll monitor but we should not see more error and the user should have faster answers as they don't have to wait for tiemout

## Tests

no

## Risk

may increase the number of error

## Deploy Plan

deploy front
