### PR TITLE
feat: attach content/screenshot in extension

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -51,7 +51,7 @@ export const ConversationContainer = ({
     [fileUploaderService.uploadContentTab]
   );
 
-  const capureActions = useMemo(
+  const captureActions = useMemo(
     () => ({
       onCapture: handleCapture,
       isCapturing: fileUploaderService.isCapturing,
@@ -76,7 +76,7 @@ export const ConversationContainer = ({
   return (
     <InputBarContextProvider
       origin="extension"
-      captureActions={capureActions}
+      captureActions={captureActions}
       fileUploaderService={fileUploaderService}
     >
       <div className={currentPanel ? "hidden" : "flex flex-col h-full w-full"}>

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -1,10 +1,13 @@
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { InputBarContextProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { useMemo } from "react";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import { useCallback, useMemo, useState } from "react";
 
 interface ConversationContainerProps {
   workspace: LightWorkspaceType;
@@ -23,13 +26,59 @@ export const ConversationContainer = ({
   conversation,
   serverId,
 }: ConversationContainerProps) => {
+  const platform = usePlatform();
   const { currentPanel } = useConversationSidePanelContext();
+  const fileUploaderService = useFileUploaderService(
+    platform.capture,
+    conversationId
+  );
+
+  const handleCapture = useCallback(
+    (type: "text" | "screenshot") => {
+      if (type === "text") {
+        void fileUploaderService.uploadContentTab({
+          includeContent: true,
+          includeCapture: false,
+        });
+        return;
+      }
+
+      void fileUploaderService.uploadContentTab({
+        includeContent: false,
+        includeCapture: true,
+      });
+    },
+    [fileUploaderService.uploadContentTab]
+  );
+
+  const capureActions = useMemo(
+    () => ({
+      onCapture: handleCapture,
+      isCapturing: fileUploaderService.isCapturing,
+    }),
+    [handleCapture, fileUploaderService.isCapturing]
+  );
+
   const clientSideMCPServerIds = useMemo(
     () => (serverId ? [serverId] : undefined),
     [serverId]
   );
+
+  // Reset fileBlobs when conversationId changes.
+  // We intentionally avoid using a key prop as it would remount
+  // the entire page subtree just to reset a single array.
+  const [prevConversationId, setPrevConversationId] = useState(conversationId);
+  if (conversationId !== prevConversationId) {
+    setPrevConversationId(conversationId);
+    fileUploaderService.resetUpload();
+  }
+
   return (
-    <>
+    <InputBarContextProvider
+      origin="extension"
+      captureActions={capureActions}
+      fileUploaderService={fileUploaderService}
+    >
       <div className={currentPanel ? "hidden" : "flex flex-col h-full w-full"}>
         <ConversationContainerVirtuoso
           owner={workspace}
@@ -46,6 +95,6 @@ export const ConversationContainer = ({
           currentPanel={currentPanel}
         />
       )}
-    </>
+    </InputBarContextProvider>
   );
 };

--- a/extension/ui/hooks/useFileUploaderService.ts
+++ b/extension/ui/hooks/useFileUploaderService.ts
@@ -1,520 +1,239 @@
-import type {
-  ConversationPublicType,
-  Result,
-  SupportedFileContentType,
-} from "@dust-tt/client";
-import {
-  Err,
-  isSupportedFileContentType,
-  isSupportedImageContentType,
-  Ok,
-} from "@dust-tt/client";
+import { useFileUploaderService as useFrontFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import type { ConversationPublicType } from "@dust-tt/client";
 // biome-ignore lint/plugin/noDirectSparkleNotification: existing usage
 import { useSendNotification } from "@dust-tt/sparkle";
-import { useDustAPI } from "@extension/shared/lib/dust_api";
-import type { UploadedFileKind } from "@extension/shared/lib/types";
 import type {
   CaptureOptions,
   CaptureService,
 } from "@extension/shared/services/capture";
-import { useState } from "react";
-
-interface FileBlob {
-  contentType: SupportedFileContentType;
-  kind: UploadedFileKind;
-  file: File;
-  filename: string;
-  id: string;
-  fileId: string | null;
-  isUploading: boolean;
-  preview?: string;
-  size: number;
-  publicUrl?: string;
-  sourceUrl?: string;
-  iconName?: string;
-  provider?: string;
-}
-
-type FileBlobUploadErrorCode =
-  | "failed_to_upload_file"
-  | "file_type_not_supported";
-
-class FileBlobUploadError extends Error {
-  constructor(
-    readonly code: FileBlobUploadErrorCode,
-    readonly file: File,
-    msg?: string
-  ) {
-    super(msg);
-  }
-}
+import { useCallback, useMemo, useState } from "react";
 
 export const MAX_FILE_SIZES: Record<"plainText" | "image", number> = {
   plainText: 30 * 1024 * 1024, // 30MB.
   image: 5 * 1024 * 1024, // 5 MB
 };
 
-const COMBINED_MAX_TEXT_FILES_SIZE = MAX_FILE_SIZES["plainText"] * 2;
-const COMBINED_MAX_IMAGE_FILES_SIZE = MAX_FILE_SIZES["image"] * 5;
-
 export function useFileUploaderService(
   captureService: CaptureService,
-  conversationId?: string
+  conversationId: string | null
 ) {
-  const [fileBlobs, setFileBlobs] = useState<FileBlob[]>([]);
   const [isCapturing, setIsCapturing] = useState(false);
-  const [numFilesProcessing, setNumFilesProcessing] = useState(0);
   const sendNotification = useSendNotification();
-  const dustAPI = useDustAPI();
+  const { workspace } = useAuth();
 
-  const isProcessingFiles = numFilesProcessing > 0;
-  const findAvailableTitle = (
-    baseTitle: string,
-    ext: string,
-    existingTitles: string[]
-  ) => {
-    let count = 1;
-    let title = `${baseTitle}.${ext}`;
-    while (existingTitles.includes(title)) {
-      title = `${baseTitle}-${count++}.${ext}`;
+  const useCaseMetadata = useMemo(() => {
+    if (!conversationId) {
+      return undefined;
     }
-    existingTitles.push(title);
-    return title;
-  };
+    return {
+      conversationId,
+    };
+  }, [conversationId]);
 
-  const handleFilesUpload = async ({
-    files,
-    updateBlobs,
-    kind,
-  }: {
-    files: File[];
-    updateBlobs?: boolean;
-    kind: UploadedFileKind;
-  }): Promise<FileBlob[] | undefined> => {
-    setNumFilesProcessing((prev: number) => prev + files.length);
+  const {
+    handleFilesUpload,
+    resetUpload,
+    fileBlobs,
+    handleFileChange,
+    removeFile,
+    addUploadedFile,
+    getFileBlob,
+    getFileBlobs,
+    isProcessingFiles,
+  } = useFrontFileUploaderService({
+    owner: workspace,
+    useCase: "conversation",
+    useCaseMetadata,
+  });
 
-    const { totalTextualSize, totalImageSize } = [
-      ...fileBlobs,
-      ...files,
-    ].reduce(
-      (acc, content) => {
-        const { size } = content;
-        if (
-          isSupportedImageContentType(
-            content instanceof File ? content.type : content.contentType
-          )
-        ) {
-          acc.totalImageSize += size;
-        } else {
-          acc.totalTextualSize += size;
-        }
-        return acc;
-      },
-      { totalTextualSize: 0, totalImageSize: 0 }
-    );
-
-    if (
-      totalTextualSize > COMBINED_MAX_TEXT_FILES_SIZE ||
-      totalImageSize > COMBINED_MAX_IMAGE_FILES_SIZE
-    ) {
-      sendNotification({
-        type: "error",
-        title: "Files too large.",
-        description:
-          "Combined file sizes exceed the limits. Please upload smaller files.",
-      });
-      setNumFilesProcessing((prev: number) => prev - files.length);
-      return;
-    }
-
-    const previewResults = processSelectedFiles(files, kind);
-    const newFileBlobs = processResults(previewResults, updateBlobs);
-
-    const uploadResults = await uploadFiles(newFileBlobs);
-    const finalFileBlobs = processResults(uploadResults, updateBlobs);
-
-    setNumFilesProcessing((prev: number) => prev - files.length);
-
-    return finalFileBlobs;
-  };
-
-  const handleFileChange = async (e: React.ChangeEvent) => {
-    const selectedFiles = Array.from(
-      (e?.target as HTMLInputElement).files ?? []
-    );
-
-    return handleFilesUpload({ files: selectedFiles, kind: "attachment" });
-  };
-
-  const processSelectedFiles = (
-    selectedFiles: File[],
-    kind: UploadedFileKind
-  ): Result<FileBlob, FileBlobUploadError>[] => {
-    return selectedFiles.reduce(
-      (acc, file) => {
-        while (fileBlobs.some((f) => f.id === file.name)) {
-          const [base, ext] = file.name.split(/\.(?=[^.]+$)/);
-          const name = findAvailableTitle(base, ext, [
-            ...fileBlobs.map((f) => f.filename),
-          ]);
-          file = new File([file], name, { type: file.type });
-        }
-
-        const contentType = file.type;
-        if (!isSupportedFileContentType(contentType)) {
-          acc.push(
-            new Err(
-              new FileBlobUploadError(
-                "file_type_not_supported",
-                file,
-                `File "${file.name}" is not supported.`
-              )
-            )
-          );
-          return acc;
-        }
-
-        acc.push(new Ok(createFileBlob({ file, contentType, kind })));
-        return acc;
-      },
-      [] as (Ok<FileBlob> | Err<FileBlobUploadError>)[]
-    );
-  };
-
-  const uploadFiles = async (
-    newFileBlobs: FileBlob[]
-  ): Promise<Result<FileBlob, FileBlobUploadError>[]> => {
-    const uploadPromises = newFileBlobs.map(async (fileBlob) => {
-      // Get upload URL from server.
-      let useCaseMetadata = undefined;
-      if (conversationId) {
-        useCaseMetadata = {
-          conversationId,
-          ...(fileBlob.provider && { sourceProvider: fileBlob.provider }),
-          ...(fileBlob.iconName && { sourceIcon: fileBlob.iconName }),
-        };
+  const findAvailableTitle = useCallback(
+    (baseTitle: string, ext: string, existingTitles: string[]) => {
+      let count = 1;
+      let title = `${baseTitle}.${ext}`;
+      while (existingTitles.includes(title)) {
+        title = `${baseTitle}-${count++}.${ext}`;
       }
-      const fileRes = await dustAPI.uploadFile({
-        contentType: fileBlob.contentType,
-        fileName: fileBlob.filename,
-        fileSize: fileBlob.size,
-        useCase: "conversation",
-        useCaseMetadata,
-        fileObject: fileBlob.file,
-      });
-      if (fileRes.isErr()) {
-        console.error("Error uploading files:", fileRes.error);
+      existingTitles.push(title);
+      return title;
+    },
+    []
+  );
 
-        return new Err(
-          new FileBlobUploadError(
-            "failed_to_upload_file",
-            fileBlob.file,
-            fileRes.error.message
-          )
+  const uploadContentTab = useCallback(
+    async ({
+      conversation,
+      includeContent,
+      includeSelectionOnly,
+      includeCapture,
+      onUpload,
+    }: {
+      conversation?: ConversationPublicType;
+      onUpload?: () => void;
+    } & CaptureOptions) => {
+      setIsCapturing(includeCapture ?? false);
+
+      try {
+        const contentRes = await captureService.handleOperation(
+          "capture-page-content",
+          {
+            includeContent,
+            includeSelectionOnly,
+            includeCapture,
+          }
         );
-      }
-      const fileUploaded = fileRes.value;
+        setIsCapturing(false);
 
-      return new Ok({
-        ...fileBlob,
-        fileId: fileUploaded.sId,
-        isUploading: false,
-        preview: isSupportedImageContentType(fileBlob.contentType)
-          ? `${fileUploaded.downloadUrl}?action=view`
-          : undefined,
-        publicUrl: fileUploaded.publicUrl,
-      });
-    });
-
-    return Promise.all(uploadPromises); // Run all uploads in parallel.
-  };
-
-  const processResults = (
-    results: Result<FileBlob, FileBlobUploadError>[],
-    updateBlobs: boolean = true
-  ) => {
-    const successfulBlobs: FileBlob[] = [];
-    const erroredBlobs: FileBlobUploadError[] = [];
-
-    results.forEach((result) => {
-      if (result.isErr()) {
-        erroredBlobs.push(result.error);
-        sendNotification({
-          type: "error",
-          title: "Failed to upload file.",
-          description: result.error.message,
-        });
-      } else {
-        successfulBlobs.push(result.value);
-      }
-    });
-
-    if (updateBlobs) {
-      if (erroredBlobs.length > 0) {
-        setFileBlobs((prevFiles) =>
-          prevFiles.filter(
-            (f) => !erroredBlobs.some((e) => e.file.name === f.id)
-          )
-        );
-      }
-
-      if (successfulBlobs.length > 0) {
-        setFileBlobs((prevFiles) => {
-          const fileBlobMap = new Map(prevFiles.map((blob) => [blob.id, blob]));
-          successfulBlobs.forEach((blob) => {
-            fileBlobMap.set(blob.id, blob);
-          });
-          return Array.from(fileBlobMap.values());
-        });
-      }
-    }
-
-    return successfulBlobs;
-  };
-
-  const removeFile = (fileId: string) => {
-    const fileBlob = fileBlobs.find((f) => f.id === fileId);
-
-    if (fileBlob) {
-      setFileBlobs((prevFiles) =>
-        prevFiles.filter((f) => f.fileId !== fileBlob?.fileId)
-      );
-
-      if (fileBlob.fileId) {
-        // Intentionally not awaiting the fetch call to allow it to run asynchronously.
-        void dustAPI.deleteFile({ fileID: fileBlob.fileId });
-      }
-
-      const allFilesReady = fileBlobs.every((f) => f.isUploading === false);
-      if (allFilesReady && isProcessingFiles) {
-        setNumFilesProcessing(0);
-      }
-    }
-  };
-
-  const resetUpload = () => {
-    setFileBlobs([]);
-  };
-
-  const uploadContentTab = async ({
-    conversation,
-    updateBlobs,
-    includeContent,
-    includeSelectionOnly,
-    includeCapture,
-    onUpload,
-  }: {
-    conversation?: ConversationPublicType;
-    updateBlobs?: boolean;
-    onUpload?: () => void;
-  } & CaptureOptions) => {
-    setIsCapturing(includeCapture ?? false);
-
-    try {
-      const contentRes = await captureService.handleOperation(
-        "capture-page-content",
-        {
-          includeContent,
-          includeSelectionOnly,
-          includeCapture,
-        }
-      );
-      setIsCapturing(false);
-
-      if (contentRes && contentRes.isErr()) {
-        sendNotification({
-          title: "Cannot get page content",
-          description: contentRes.error.message,
-          type: "error",
-        });
-        return;
-      }
-
-      const tabContent =
-        contentRes && contentRes.isOk() ? contentRes.value : null;
-
-      const existingTitles = fileBlobs.map((f) => f.filename);
-
-      if (includeContent) {
-        if (!tabContent?.content) {
+        if (contentRes && contentRes.isErr()) {
           sendNotification({
             title: "Cannot get page content",
-            description: "No content found.",
+            description: contentRes.error.message,
             type: "error",
           });
           return;
         }
 
-        const title = findAvailableTitle(
-          includeSelectionOnly
-            ? `[selection] ${tabContent.title}`
-            : `[text] ${tabContent.title}`,
-          "txt",
-          existingTitles
-        );
+        const tabContent =
+          contentRes && contentRes.isOk() ? contentRes.value : null;
 
-        // Check if the content is already uploaded - compare the title and the size of the content.
-        const messages =
-          conversation?.content.map((m) => m[m.length - 1]) || [];
-        const alreadyUploaded = messages.some(
-          (m) =>
-            m.type === "content_fragment" &&
-            m.contentFragmentType === "file" &&
-            m.title === title &&
-            m.textBytes === new Blob([tabContent.content ?? ""]).size
-        );
+        const existingTitles = fileBlobs.map((f) => f.filename);
 
-        if (tabContent && tabContent.content && !alreadyUploaded) {
-          const file = new File([tabContent.content], title, {
-            type: "text/plain",
-          });
+        if (includeContent) {
+          if (!tabContent?.content) {
+            sendNotification({
+              title: "Cannot get page content",
+              description: "No content found.",
+              type: "error",
+            });
+            return;
+          }
+
+          const title = findAvailableTitle(
+            includeSelectionOnly
+              ? `[selection] ${tabContent.title}`
+              : `[text] ${tabContent.title}`,
+            "txt",
+            existingTitles
+          );
+
+          // Check if the content is already uploaded - compare the title and the size of the content.
+          const messages =
+            conversation?.content.map((m) => m[m.length - 1]) || [];
+          const alreadyUploaded = messages.some(
+            (m) =>
+              m.type === "content_fragment" &&
+              m.contentFragmentType === "file" &&
+              m.title === title &&
+              m.textBytes === new Blob([tabContent.content ?? ""]).size
+          );
+
+          if (tabContent && tabContent.content && !alreadyUploaded) {
+            const file = new File([tabContent.content], title, {
+              type: "text/plain",
+            });
+
+            if (onUpload) {
+              onUpload();
+            }
+
+            const fragments = await handleFilesUpload([file]);
+            if (fragments) {
+              fragments.forEach((f) => {
+                f.publicUrl = tabContent.url;
+              });
+            }
+
+            return fragments;
+          }
+        }
+
+        if (includeCapture) {
+          if (!tabContent?.captures) {
+            sendNotification({
+              title: "Cannot get page content",
+              description: "No content found.",
+              type: "error",
+            });
+            return;
+          }
+
+          const blobs = await Promise.all(
+            tabContent.captures.map(async (c) => {
+              const response = await fetch(c);
+              return response.blob();
+            })
+          );
+
+          const files = blobs.map(
+            (blob) =>
+              new File(
+                [blob],
+                findAvailableTitle(
+                  `[screenshot] ${tabContent.title}`,
+                  "jpg",
+                  existingTitles
+                ),
+                {
+                  type: blob.type,
+                }
+              )
+          );
 
           if (onUpload) {
             onUpload();
           }
 
-          const fragments = await handleFilesUpload({
-            files: [file],
-            updateBlobs,
-            kind: includeSelectionOnly ? "selection" : "tab_content",
-          });
-          if (fragments) {
-            fragments.forEach((f) => {
-              f.publicUrl = tabContent.url;
-            });
-          }
-
-          return fragments;
+          return await handleFilesUpload(files);
         }
-      }
-
-      if (includeCapture) {
-        if (!tabContent?.captures) {
-          sendNotification({
-            title: "Cannot get page content",
-            description: "No content found.",
-            type: "error",
-          });
-          return;
-        }
-
-        const blobs = await Promise.all(
-          tabContent.captures.map(async (c) => {
-            const response = await fetch(c);
-            return response.blob();
-          })
-        );
-
-        const files = blobs.map(
-          (blob) =>
-            new File(
-              [blob],
-              findAvailableTitle(
-                `[screenshot] ${tabContent.title}`,
-                "jpg",
-                existingTitles
-              ),
-              {
-                type: blob.type,
-              }
-            )
-        );
-
-        if (onUpload) {
-          onUpload();
-        }
-
-        return await handleFilesUpload({
-          files,
-          updateBlobs,
-          // TODO(EXT): supersede the screenshot
-          kind: "attachment",
+      } catch (err) {
+        console.log(err);
+        sendNotification({
+          title: "Cannot get page content",
+          description: "Something wrong happened.",
+          type: "error",
         });
+        setIsCapturing(false);
       }
-    } catch (err) {
-      console.log(err);
-      sendNotification({
-        title: "Cannot get page content",
-        description: "Something wrong happened.",
-        type: "error",
-      });
-      setIsCapturing(false);
-    }
-  };
+    },
+    [
+      captureService.handleOperation,
+      fileBlobs.map,
+      findAvailableTitle,
+      handleFilesUpload,
+      sendNotification,
+    ]
+  );
 
-  type FileBlobWithFileId = FileBlob & { fileId: string };
-  function fileBlobHasFileId(
-    fileBlob: FileBlob
-  ): fileBlob is FileBlobWithFileId {
-    return fileBlob.fileId !== null;
-  }
+  const value = useMemo(
+    () => ({
+      isCapturing,
+      fileBlobs,
+      handleFileChange,
+      removeFile,
+      addUploadedFile,
+      getFileBlob,
+      getFileBlobs,
+      handleFilesUpload,
+      isProcessingFiles,
+      resetUpload,
+      uploadContentTab,
+    }),
+    [
+      isCapturing,
+      fileBlobs,
+      handleFileChange,
+      removeFile,
+      addUploadedFile,
+      getFileBlob,
+      getFileBlobs,
+      handleFilesUpload,
+      isProcessingFiles,
+      resetUpload,
+      uploadContentTab,
+    ]
+  );
 
-  const getFileBlobs: () => FileBlobWithFileId[] = () => {
-    return fileBlobs.filter(fileBlobHasFileId);
-  };
-
-  const addUploadedFile = (fileData: {
-    fileId: string;
-    filename: string;
-    contentType: SupportedFileContentType;
-    size: number;
-    id?: string;
-    sourceUrl?: string;
-    iconName?: string;
-    provider?: string;
-  }) => {
-    const blob: FileBlob = {
-      id: fileData.id ?? fileData.filename,
-      fileId: fileData.fileId,
-      filename: fileData.filename,
-      contentType: fileData.contentType,
-      file: new File([], fileData.filename, { type: fileData.contentType }),
-      kind: "attachment",
-      isUploading: false,
-      size: fileData.size,
-      sourceUrl: fileData.sourceUrl,
-      iconName: fileData.iconName,
-      provider: fileData.provider,
-    };
-
-    setFileBlobs((prevFiles) => [...prevFiles, blob]);
-  };
-
-  return {
-    addUploadedFile,
-    fileBlobs,
-    getFileBlobs,
-    handleFileChange,
-    handleFilesUpload,
-    isProcessingFiles,
-    isCapturing,
-    uploadContentTab,
-    removeFile,
-    resetUpload,
-  };
+  return value;
 }
 
 export type FileUploaderService = ReturnType<typeof useFileUploaderService>;
-
-const createFileBlob = ({
-  file,
-  contentType,
-  kind,
-  preview,
-}: {
-  file: File;
-  contentType: SupportedFileContentType;
-  kind: UploadedFileKind;
-  preview?: string;
-}): FileBlob => ({
-  contentType,
-  file,
-  filename: file.name,
-  id: file.name,
-  // Will be set once the file has been uploaded.
-  fileId: null,
-  isUploading: true,
-  kind,
-  preview,
-  size: file.size,
-});

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -5,7 +5,6 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
-import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useConversation } from "@app/hooks/conversations/useConversation";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
@@ -107,16 +106,14 @@ export const MainPage = () => {
         <BlockedActionsProvider owner={workspace} conversation={conversation}>
           <ConversationSidePanelProvider>
             <GenerationContextProvider>
-              <InputBarProvider origin="extension">
-                <ConversationContainer
-                  workspace={workspace}
-                  user={user}
-                  subscription={subscription}
-                  conversationId={conversationId}
-                  conversation={conversation}
-                  serverId={serverId}
-                />
-              </InputBarProvider>
+              <ConversationContainer
+                workspace={workspace}
+                user={user}
+                subscription={subscription}
+                conversationId={conversationId}
+                conversation={conversation}
+                serverId={serverId}
+              />
             </GenerationContextProvider>
           </ConversationSidePanelProvider>
         </BlockedActionsProvider>

--- a/extension/ui/pages/RunPage.tsx
+++ b/extension/ui/pages/RunPage.tsx
@@ -12,7 +12,7 @@ export const RunPage = () => {
   const location = useLocation();
   const { user, workspace } = useExtensionAuth();
 
-  const fileUploaderService = useFileUploaderService(platform.capture);
+  const fileUploaderService = useFileUploaderService(platform.capture, null);
 
   const createConversationWithMessage = useCreateConversationWithMessage({
     owner: workspace!,
@@ -32,7 +32,6 @@ export const RunPage = () => {
         includeContent: params.includeContent,
         includeCapture: params.includeCapture,
         includeSelectionOnly: params.includeSelectionOnly,
-        updateBlobs: false,
       });
 
       const conversationRes = await createConversationWithMessage({

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -132,7 +132,6 @@ export function AttachmentCitation({
           setViewerOpen={setViewerOpen}
           viewerOpen={viewerOpen}
           attachmentCitation={attachmentCitation}
-          conversationId={conversationId}
           owner={owner}
         />
       )}

--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -4,7 +4,6 @@ import type {
 } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
 import { getIcon } from "@app/components/resources/resources_icons";
-import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import {
   getInternalMCPServerIconByName,
   isInternalMCPServerName,
@@ -30,33 +29,28 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { InputBarContext } from "../input_bar/InputBarContext";
+
+interface AttachmentViewerProps {
+  viewerOpen: boolean;
+  setViewerOpen: (open: boolean) => void;
+  attachmentCitation: FileAttachmentCitation | MCPAttachmentCitation;
+  owner: LightWorkspaceType;
+}
 
 export const AttachmentViewer = ({
   viewerOpen,
   setViewerOpen,
   attachmentCitation,
-  conversationId,
   owner,
-}: {
-  viewerOpen: boolean;
-  setViewerOpen: (open: boolean) => void;
-  attachmentCitation: FileAttachmentCitation | MCPAttachmentCitation;
-  conversationId?: string | null;
-  owner: LightWorkspaceType;
-}) => {
-  const fileUploaderService = useFileUploaderService({
-    owner: owner,
-    useCase: "conversation",
-    useCaseMetadata: {
-      conversationId: conversationId ?? undefined,
-    },
-  });
-
+}: AttachmentViewerProps) => {
   const [text, setText] = useState<string | undefined>();
 
   const isAudio = isAudioContentType(attachmentCitation);
   const isMarkdown = attachmentCitation.contentType === "text/markdown";
+
+  const { fileUploaderService } = useContext(InputBarContext);
 
   // For input bar attachments, try to get the local file blob for reading content directly.
   // For fragments/mcp, we always fetch from server.

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -12,7 +12,6 @@ import {
   useConversationSkills,
   useConversationTools,
 } from "@app/hooks/conversations";
-import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -83,19 +82,12 @@ export const InputBar = React.memo(function InputBar({
     DataSourceViewContentNode[]
   >([]);
 
+  const { animate, setAnimate, getAndClearSelectedAgent, fileUploaderService } =
+    useContext(InputBarContext);
+
   // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations } = useUnifiedAgentConfigurations({
     workspaceId: owner.sId,
-  });
-
-  // Files upload.
-
-  const fileUploaderService = useFileUploaderService({
-    owner,
-    useCase: "conversation",
-    useCaseMetadata: conversation
-      ? { conversationId: conversation.sId }
-      : undefined,
   });
 
   const { droppedFiles, setDroppedFiles } = useFileDrop();
@@ -118,8 +110,6 @@ export const InputBar = React.memo(function InputBar({
   }, [droppedFiles, setDroppedFiles, fileUploaderService]);
 
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
-  const { animate, setAnimate, getAndClearSelectedAgent } =
-    useContext(InputBarContext);
   const animationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const selectedAgent = useMemo(
     () => getAndClearSelectedAgent(),

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,7 +1,6 @@
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
   getDisplayNameFromPastedFileId,
   getPastedFileName,
@@ -42,8 +41,15 @@ import { isBuilder } from "@app/types/user";
 import {
   ArrowUpIcon,
   Button,
+  CameraIcon,
   Chip,
   cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  GlobeAltIcon,
+  PlusIcon,
   TextIcon,
   Toolbar,
   VoicePicker,
@@ -59,6 +65,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { InputBarContext } from "./InputBarContext";
 
 export const INPUT_BAR_ACTIONS = [
   "capabilities",
@@ -537,7 +544,7 @@ const InputBarContainer = ({
 
   // When input bar animation is requested, it means the new button was clicked (removing focus from
   // the input bar), we grab it back.
-  const { animate } = useContext(InputBarContext);
+  const { animate, captureActions } = useContext(InputBarContext);
   useEffect(() => {
     if (animate) {
       // Schedule focus to avoid flushing during render lifecycle.
@@ -814,6 +821,38 @@ const InputBarContainer = ({
                       showStopLabel={!isMobile}
                     />
                   )}
+                {captureActions && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost-secondary"
+                        icon={PlusIcon}
+                        size={buttonSize}
+                        disabled={disableInput}
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuItem
+                        icon={GlobeAltIcon}
+                        label="Attach page content"
+                        disabled={
+                          captureActions.isCapturing ||
+                          fileUploaderService.isProcessingFiles
+                        }
+                        onClick={() => captureActions.onCapture("text")}
+                      />
+                      <DropdownMenuItem
+                        icon={CameraIcon}
+                        label="Take screenshot"
+                        disabled={
+                          captureActions.isCapturing ||
+                          fileUploaderService.isProcessingFiles
+                        }
+                        onClick={() => captureActions.onCapture("screenshot")}
+                      />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
                 <Button
                   size={buttonSize}
                   isLoading={

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -22,6 +22,7 @@ import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
+import { isChromeExtension } from "@app/lib/utils/extension";
 import { getManageSkillsRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -608,6 +609,8 @@ const InputBarContainer = ({
   const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const isRecording = voiceTranscriberService.status === "recording";
 
+  const displayCaptureActionsDropdown = captureActions && isChromeExtension();
+
   return (
     <div
       id="InputBarContainer"
@@ -821,7 +824,7 @@ const InputBarContainer = ({
                       showStopLabel={!isMobile}
                     />
                   )}
-                {captureActions && (
+                {displayCaptureActionsDropdown && (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -1,6 +1,18 @@
+import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
+import {
+  type FileUploaderService,
+  useFileUploaderService,
+} from "@app/hooks/useFileUploaderService";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { ClientMessageOrigin } from "@app/types/assistant/conversation";
 import type { RichAgentMention } from "@app/types/assistant/mentions";
-import { createContext, useCallback, useMemo, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 
 export const InputBarContext = createContext<{
   animate: boolean;
@@ -8,21 +20,46 @@ export const InputBarContext = createContext<{
   origin: ClientMessageOrigin;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
+  fileUploaderService: FileUploaderService;
+  captureActions?: {
+    onCapture: (type: "text" | "screenshot") => void;
+    isCapturing: boolean;
+  };
 }>({
   animate: false,
   getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
   origin: "web",
+  fileUploaderService: {
+    fileBlobs: [],
+    handleFileChange: async () => {},
+    removeFile: () => {},
+    addUploadedFile: () => {},
+    getFileBlob: () => undefined,
+    getFileBlobs: () => [],
+    handleFilesUpload: async () => [],
+    isProcessingFiles: false,
+    resetUpload: () => {},
+  },
 });
 
-export function InputBarProvider({
+interface InputBarContextProviderProps {
+  children: ReactNode;
+  origin: ClientMessageOrigin;
+  fileUploaderService: FileUploaderService;
+  captureActions?: {
+    onCapture: (type: "text" | "screenshot") => void;
+    isCapturing: boolean;
+  };
+}
+
+export function InputBarContextProvider({
   children,
   origin,
-}: {
-  children: React.ReactNode;
-  origin: ClientMessageOrigin;
-}) {
+  fileUploaderService,
+  captureActions,
+}: InputBarContextProviderProps) {
   const [animate, setAnimate] = useState<boolean>(false);
 
   // Useful when a component needs to set the selected agent for the input bar but do not have direct access to the input bar.
@@ -58,13 +95,66 @@ export function InputBarProvider({
       setAnimate,
       getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
+      captureActions,
+      fileUploaderService,
     }),
-    [animate, origin, getAndClearSelectedAgent, setSelectedAgentOuter]
+    [
+      animate,
+      origin,
+      getAndClearSelectedAgent,
+      setSelectedAgentOuter,
+      captureActions,
+      fileUploaderService,
+    ]
   );
 
   return (
     <InputBarContext.Provider value={value}>
       {children}
     </InputBarContext.Provider>
+  );
+}
+interface InputBarProviderProps {
+  children: ReactNode;
+  origin: ClientMessageOrigin;
+}
+
+export function InputBarProvider({ children, origin }: InputBarProviderProps) {
+  const conversationId = useActiveConversationId();
+
+  const { workspace } = useAuth();
+
+  const useCaseMetadata = useMemo(() => {
+    if (!conversationId) {
+      return undefined;
+    }
+    return {
+      conversationId,
+    };
+  }, [conversationId]);
+
+  const fileUploaderService = useFileUploaderService({
+    owner: workspace,
+    useCase: "conversation",
+    useCaseMetadata,
+  });
+
+  // Reset fileBlobs when conversationId changes.
+  // We intentionally avoid using a key prop as it would remount
+  // the entire page subtree (InputBarStateProvider wraps children)
+  // just to reset a single array.
+  const [prevConversationId, setPrevConversationId] = useState(conversationId);
+  if (conversationId !== prevConversationId) {
+    setPrevConversationId(conversationId);
+    fileUploaderService.resetUpload();
+  }
+
+  return (
+    <InputBarContextProvider
+      origin={origin}
+      fileUploaderService={fileUploaderService}
+    >
+      {children}
+    </InputBarContextProvider>
   );
 }

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -1,6 +1,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
 import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";
 import { isAPIErrorResponse } from "@app/types/error";
@@ -151,7 +152,7 @@ export function useFileUploaderService({
               }),
             });
           } catch (err) {
-            console.error("Error uploading files:", err);
+            logger.error({ err }, "Error uploading files");
 
             return new Err(
               new FileBlobUploadError(
@@ -192,7 +193,7 @@ export function useFileUploaderService({
               body: formData,
             });
           } catch (err) {
-            console.error("Error uploading files:", err);
+            logger.error({ err }, "Error uploading files");
 
             return new Err(
               new FileBlobUploadError(

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -21,8 +21,7 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { ChangeEvent } from "react";
-import { useState } from "react";
+import { type ChangeEvent, useCallback, useMemo, useState } from "react";
 
 export interface FileBlob {
   contentType: SupportedFileContentType;
@@ -64,343 +63,385 @@ export function useFileUploaderService({
 
   const sendNotification = useSendNotification();
 
-  const findAvailableTitle = (
-    baseTitle: string,
-    ext: string,
-    existingTitles: string[]
-  ) => {
-    let count = 1;
-    let title = `${baseTitle}.${ext}`;
-    while (existingTitles.includes(title)) {
-      title = `${baseTitle}-${count++}.${ext}`;
-    }
-    existingTitles.push(title);
-    return title;
-  };
-
-  const handleFilesUpload = async (files: File[]) => {
-    setNumFilesProcessing((prev) => prev + files.length);
-
-    const categoryToSize: Map<FileFormatCategory, number> = new Map();
-
-    for (const f of [...fileBlobs, ...files]) {
-      const contentType = f instanceof File ? f.type : f.contentType;
-
-      const category = getFileFormatCategory(contentType) ?? "data";
-      // The fallback should never happen, but let's avoid a crash.
-
-      categoryToSize.set(
-        category,
-        (categoryToSize.get(category) ?? 0) + f.size
-      );
-    }
-
-    const oversizedCategories = [...categoryToSize].filter(([cat, size]) => {
-      return !ensureFileSizeByFormatCategory(cat, size);
-    });
-
-    for (const cat of oversizedCategories) {
-      sendNotification({
-        type: "error",
-        title: "Files too large.",
-        description: `Combined ${cat[0]} file sizes exceed the limit of ${MAX_FILE_SIZES[cat[0]] / 1024 / 1024}MB. Please upload smaller files.`,
-      });
-    }
-
-    if (oversizedCategories.length > 0) {
-      setNumFilesProcessing((prev) => prev - files.length);
-      return;
-    }
-    const previewResults = processSelectedFiles(files);
-    const newFileBlobs = processResults(previewResults, true);
-
-    const uploadResults = await uploadFiles(newFileBlobs);
-    const finalFileBlobs = processResults(uploadResults);
-
-    setNumFilesProcessing((prev) => prev - files.length);
-
-    return finalFileBlobs;
-  };
-
-  const handleFileChange = async (e: ChangeEvent) => {
-    const selectedFiles = Array.from(
-      (e?.target as HTMLInputElement).files ?? []
-    );
-
-    return handleFilesUpload(selectedFiles);
-  };
-
-  const processSelectedFiles = (
-    selectedFiles: File[]
-  ): Result<FileBlob, FileBlobUploadError>[] => {
-    const getRenamedFile = (file: File, fileType: string): File => {
-      let currentFile = file;
-      while (fileBlobs.some((f) => f.id === currentFile.name)) {
-        const [base, ext] = currentFile.name.split(/\.(?=[^.]+$)/);
-        const name = findAvailableTitle(base, ext, [
-          ...fileBlobs.map((f) => f.filename),
-        ]);
-        if (name !== currentFile.name) {
-          currentFile = new File([currentFile], name, { type: fileType });
-        }
+  const findAvailableTitle = useCallback(
+    (baseTitle: string, ext: string, existingTitles: string[]) => {
+      let count = 1;
+      let title = `${baseTitle}.${ext}`;
+      while (existingTitles.includes(title)) {
+        title = `${baseTitle}-${count++}.${ext}`;
       }
-      return currentFile;
-    };
+      existingTitles.push(title);
+      return title;
+    },
+    []
+  );
 
-    return selectedFiles.reduce<Result<FileBlob, FileBlobUploadError>[]>(
-      (acc, file) => {
-        const fileType =
-          resolveFileContentType(file.type, file.name) ||
-          DEFAULT_FILE_CONTENT_TYPE;
+  const processSelectedFiles = useCallback(
+    (selectedFiles: File[]): Result<FileBlob, FileBlobUploadError>[] => {
+      const getRenamedFile = (file: File, fileType: string): File => {
+        let currentFile = file;
+        while (fileBlobs.some((f) => f.id === currentFile.name)) {
+          const [base, ext] = currentFile.name.split(/\.(?=[^.]+$)/);
+          const name = findAvailableTitle(base, ext, [
+            ...fileBlobs.map((f) => f.filename),
+          ]);
+          if (name !== currentFile.name) {
+            currentFile = new File([currentFile], name, { type: fileType });
+          }
+        }
+        return currentFile;
+      };
 
-        // File objects are immutable - we can't modify their properties directly.
-        // When we need to change the name or type, we must create a new File object.
-        const renamedFile = getRenamedFile(file, fileType);
+      return selectedFiles.reduce<Result<FileBlob, FileBlobUploadError>[]>(
+        (acc, file) => {
+          const fileType =
+            resolveFileContentType(file.type, file.name) ||
+            DEFAULT_FILE_CONTENT_TYPE;
 
-        if (!isSupportedFileContentType(fileType)) {
-          acc.push(
-            new Err(
-              new FileBlobUploadError(
-                renamedFile,
-                `File "${renamedFile.name}" is not supported (${fileType}).`
+          // File objects are immutable - we can't modify their properties directly.
+          // When we need to change the name or type, we must create a new File object.
+          const renamedFile = getRenamedFile(file, fileType);
+
+          if (!isSupportedFileContentType(fileType)) {
+            acc.push(
+              new Err(
+                new FileBlobUploadError(
+                  renamedFile,
+                  `File "${renamedFile.name}" is not supported (${fileType}).`
+                )
               )
-            )
-          );
+            );
+            return acc;
+          }
+
+          acc.push(new Ok(createFileBlob(renamedFile, fileType)));
           return acc;
-        }
+        },
+        []
+      );
+    },
+    [fileBlobs, findAvailableTitle]
+  );
 
-        acc.push(new Ok(createFileBlob(renamedFile, fileType)));
-        return acc;
-      },
-      []
-    );
-  };
-
-  const uploadFiles = async (
-    newFileBlobs: FileBlob[]
-  ): Promise<Result<FileBlob, FileBlobUploadError>[]> => {
-    // Browsers have a limit on the number of concurrent network operations.
-    // We have a limit of the allowed time to upload the content of a file once the file object has been created.
-    // If we start a large number of uploads at the same time and the network is somewhat slow, it's possible that we'll
-    // have created the file objects long before the upload of the content finishes.
-    return concurrentExecutor(
-      newFileBlobs,
-      async (fileBlob) => {
-        // Get upload URL from server.
-        let uploadResponse;
-        try {
-          uploadResponse = await clientFetch(`/api/w/${owner.sId}/files`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              contentType: fileBlob.contentType,
-              fileName: fileBlob.filename,
-              fileSize: fileBlob.size,
-              useCase,
-              useCaseMetadata,
-            }),
-          });
-        } catch (err) {
-          console.error("Error uploading files:", err);
-
-          return new Err(
-            new FileBlobUploadError(
-              fileBlob.file,
-              err instanceof Error ? err.message : undefined
-            )
-          );
-        }
-
-        if (!uploadResponse.ok) {
+  const uploadFiles = useCallback(
+    async (
+      newFileBlobs: FileBlob[]
+    ): Promise<Result<FileBlob, FileBlobUploadError>[]> => {
+      // Browsers have a limit on the number of concurrent network operations.
+      // We have a limit of the allowed time to upload the content of a file once the file object has been created.
+      // If we start a large number of uploads at the same time and the network is somewhat slow, it's possible that we'll
+      // have created the file objects long before the upload of the content finishes.
+      return concurrentExecutor(
+        newFileBlobs,
+        async (fileBlob) => {
+          // Get upload URL from server.
+          let uploadResponse;
           try {
-            const res = await uploadResponse.json();
+            uploadResponse = await clientFetch(`/api/w/${owner.sId}/files`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                contentType: fileBlob.contentType,
+                fileName: fileBlob.filename,
+                fileSize: fileBlob.size,
+                useCase,
+                useCaseMetadata,
+              }),
+            });
+          } catch (err) {
+            console.error("Error uploading files:", err);
 
             return new Err(
               new FileBlobUploadError(
                 fileBlob.file,
-                isAPIErrorResponse(res) ? res.error.message : undefined
+                err instanceof Error ? err.message : undefined
               )
             );
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-          } catch (err) {
-            return new Err(new FileBlobUploadError(fileBlob.file));
           }
-        }
 
-        const { file } =
-          (await uploadResponse.json()) as FileUploadRequestResponseBody;
+          if (!uploadResponse.ok) {
+            try {
+              const res = await uploadResponse.json();
 
-        const formData = new FormData();
-        formData.append("file", fileBlob.file);
+              return new Err(
+                new FileBlobUploadError(
+                  fileBlob.file,
+                  isAPIErrorResponse(res) ? res.error.message : undefined
+                )
+              );
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
+            } catch (err) {
+              return new Err(new FileBlobUploadError(fileBlob.file));
+            }
+          }
 
-        // Upload a file to the obtained URL.
-        let uploadResult;
-        try {
-          uploadResult = await clientFetch(file.uploadUrl, {
-            method: "POST",
-            body: formData,
+          const { file } =
+            (await uploadResponse.json()) as FileUploadRequestResponseBody;
+
+          const formData = new FormData();
+          formData.append("file", fileBlob.file);
+
+          // Upload a file to the obtained URL.
+          let uploadResult;
+          try {
+            uploadResult = await clientFetch(file.uploadUrl, {
+              method: "POST",
+              body: formData,
+            });
+          } catch (err) {
+            console.error("Error uploading files:", err);
+
+            return new Err(
+              new FileBlobUploadError(
+                fileBlob.file,
+                err instanceof Error ? err.message : undefined
+              )
+            );
+          }
+
+          if (!uploadResult.ok) {
+            const { error } = await uploadResult.json();
+            return new Err(
+              new FileBlobUploadError(
+                fileBlob.file,
+                error?.message ?? "An unknown error happened."
+              )
+            );
+          }
+
+          const { file: fileUploaded } =
+            (await uploadResult.json()) as FileUploadedRequestResponseBody;
+
+          return new Ok({
+            ...fileBlob,
+            fileId: file.sId,
+            isUploading: false,
+            sourceUrl: fileUploaded.downloadUrl,
+            publicUrl: file.publicUrl,
           });
-        } catch (err) {
-          console.error("Error uploading files:", err);
+        },
+        { concurrency: 4 }
+      );
+    },
+    [owner.sId, useCase, useCaseMetadata]
+  );
 
-          return new Err(
-            new FileBlobUploadError(
-              fileBlob.file,
-              err instanceof Error ? err.message : undefined
-            )
-          );
+  const processResults = useCallback(
+    (
+      results: Result<FileBlob, FileBlobUploadError>[],
+      previewMode: boolean = false
+    ) => {
+      const successfulBlobs: FileBlob[] = [];
+      const erroredBlobs: FileBlobUploadError[] = [];
+
+      results.forEach((result) => {
+        if (result.isErr()) {
+          erroredBlobs.push(result.error);
+          const maybeTruncatedFilename =
+            result.error.file.name.length > 50
+              ? result.error.file.name.slice(0, 47) + "..."
+              : result.error.file.name;
+          sendNotification({
+            type: "error",
+            title: `Failed to upload file${previewMode ? " preview" : ""}`,
+            description: result.error.message
+              ? `${result.error.message} (${maybeTruncatedFilename})`
+              : `Error uploading ${maybeTruncatedFilename}`,
+          });
+        } else {
+          successfulBlobs.push(result.value);
         }
+      });
 
-        if (!uploadResult.ok) {
-          const { error } = await uploadResult.json();
-          return new Err(
-            new FileBlobUploadError(
-              fileBlob.file,
-              error?.message ?? "An unknown error happened."
-            )
-          );
-        }
+      if (erroredBlobs.length > 0) {
+        setFileBlobs((prevFiles) =>
+          prevFiles.filter(
+            (f) => !erroredBlobs.some((e) => e.file.name === f.id)
+          )
+        );
+      }
 
-        const { file: fileUploaded } =
-          (await uploadResult.json()) as FileUploadedRequestResponseBody;
-
-        return new Ok({
-          ...fileBlob,
-          fileId: file.sId,
-          isUploading: false,
-          sourceUrl: fileUploaded.downloadUrl,
-          publicUrl: file.publicUrl,
+      if (successfulBlobs.length > 0) {
+        setFileBlobs((prevFiles) => {
+          const fileBlobMap = new Map(prevFiles.map((blob) => [blob.id, blob]));
+          successfulBlobs.forEach((blob) => {
+            fileBlobMap.set(blob.id, blob);
+          });
+          return Array.from(fileBlobMap.values());
         });
-      },
-      { concurrency: 4 }
-    );
-  };
+      }
 
-  const processResults = (
-    results: Result<FileBlob, FileBlobUploadError>[],
-    previewMode: boolean = false
-  ) => {
-    const successfulBlobs: FileBlob[] = [];
-    const erroredBlobs: FileBlobUploadError[] = [];
+      return successfulBlobs;
+    },
+    [sendNotification]
+  );
 
-    results.forEach((result) => {
-      if (result.isErr()) {
-        erroredBlobs.push(result.error);
-        const maybeTruncatedFilename =
-          result.error.file.name.length > 50
-            ? result.error.file.name.slice(0, 47) + "..."
-            : result.error.file.name;
+  const handleFilesUpload = useCallback(
+    async (files: File[]) => {
+      setNumFilesProcessing((prev) => prev + files.length);
+
+      const categoryToSize: Map<FileFormatCategory, number> = new Map();
+
+      for (const f of [...fileBlobs, ...files]) {
+        const contentType = f instanceof File ? f.type : f.contentType;
+
+        const category = getFileFormatCategory(contentType) ?? "data";
+        // The fallback should never happen, but let's avoid a crash.
+
+        categoryToSize.set(
+          category,
+          (categoryToSize.get(category) ?? 0) + f.size
+        );
+      }
+
+      const oversizedCategories = [...categoryToSize].filter(([cat, size]) => {
+        return !ensureFileSizeByFormatCategory(cat, size);
+      });
+
+      for (const cat of oversizedCategories) {
         sendNotification({
           type: "error",
-          title: `Failed to upload file${previewMode ? " preview" : ""}`,
-          description: result.error.message
-            ? `${result.error.message} (${maybeTruncatedFilename})`
-            : `Error uploading ${maybeTruncatedFilename}`,
+          title: "Files too large.",
+          description: `Combined ${cat[0]} file sizes exceed the limit of ${MAX_FILE_SIZES[cat[0]] / 1024 / 1024}MB. Please upload smaller files.`,
         });
-      } else {
-        successfulBlobs.push(result.value);
       }
-    });
 
-    if (erroredBlobs.length > 0) {
-      setFileBlobs((prevFiles) =>
-        prevFiles.filter((f) => !erroredBlobs.some((e) => e.file.name === f.id))
+      if (oversizedCategories.length > 0) {
+        setNumFilesProcessing((prev) => prev - files.length);
+        return;
+      }
+      const previewResults = processSelectedFiles(files);
+      const newFileBlobs = processResults(previewResults, true);
+
+      const uploadResults = await uploadFiles(newFileBlobs);
+      const finalFileBlobs = processResults(uploadResults);
+
+      setNumFilesProcessing((prev) => prev - files.length);
+
+      return finalFileBlobs;
+    },
+    [
+      fileBlobs,
+      processResults,
+      processSelectedFiles,
+      sendNotification,
+      uploadFiles,
+    ]
+  );
+
+  const handleFileChange = useCallback(
+    async (e: ChangeEvent) => {
+      const selectedFiles = Array.from(
+        (e?.target as HTMLInputElement).files ?? []
       );
-    }
 
-    if (successfulBlobs.length > 0) {
+      return handleFilesUpload(selectedFiles);
+    },
+    [handleFilesUpload]
+  );
+
+  const removeFile = useCallback(
+    (fileId: string) => {
       setFileBlobs((prevFiles) => {
-        const fileBlobMap = new Map(prevFiles.map((blob) => [blob.id, blob]));
-        successfulBlobs.forEach((blob) => {
-          fileBlobMap.set(blob.id, blob);
-        });
-        return Array.from(fileBlobMap.values());
+        const fileBlob = prevFiles.find((f) => f.id === fileId);
+
+        if (!fileBlob) {
+          return prevFiles;
+        }
+
+        // Delete from server if file has been uploaded
+        if (fileBlob.fileId) {
+          void clientFetch(`/api/w/${owner.sId}/files/${fileBlob.fileId}`, {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+        }
+
+        const filtered = prevFiles.filter((f) => f.id !== fileBlob.id);
+
+        const allFilesReady = filtered.every((f) => !f.isUploading);
+        if (allFilesReady && isProcessingFiles) {
+          setNumFilesProcessing(0);
+        }
+
+        return filtered;
       });
-    }
+    },
+    [owner.sId, isProcessingFiles]
+  );
 
-    return successfulBlobs;
-  };
-
-  const removeFile = (fileId: string) => {
-    setFileBlobs((prevFiles) => {
-      const fileBlob = prevFiles.find((f) => f.id === fileId);
-
-      if (!fileBlob) {
-        return prevFiles;
-      }
-
-      // Delete from server if file has been uploaded
-      if (fileBlob.fileId) {
-        void clientFetch(`/api/w/${owner.sId}/files/${fileBlob.fileId}`, {
-          method: "DELETE",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
-      }
-
-      const filtered = prevFiles.filter((f) => f.id !== fileBlob.id);
-
-      const allFilesReady = filtered.every((f) => !f.isUploading);
-      if (allFilesReady && isProcessingFiles) {
-        setNumFilesProcessing(0);
-      }
-
-      return filtered;
-    });
-  };
-
-  const resetUpload = () => {
+  const resetUpload = useCallback(() => {
     setFileBlobs([]);
-  };
+  }, []);
 
-  function fileBlobHasFileId(
-    fileBlob: FileBlob
-  ): fileBlob is FileBlobWithFileId {
-    return fileBlob.fileId !== null;
-  }
+  const fileBlobHasFileId = useCallback(
+    (fileBlob: FileBlob): fileBlob is FileBlobWithFileId => {
+      return fileBlob.fileId !== null;
+    },
+    []
+  );
 
-  const getFileBlobs: () => FileBlobWithFileId[] = () => {
+  const getFileBlobs: () => FileBlobWithFileId[] = useCallback(() => {
     return fileBlobs.filter(fileBlobHasFileId);
-  };
+  }, [fileBlobs, fileBlobHasFileId]);
 
-  const getFileBlob = (blobId: string | null | undefined) => {
-    if (!blobId) {
-      return undefined;
-    }
-    return getFileBlobs().find((blob) => blob.id === blobId);
-  };
+  const getFileBlob = useCallback(
+    (blobId: string | null | undefined) => {
+      if (!blobId) {
+        return undefined;
+      }
+      return getFileBlobs().find((blob) => blob.id === blobId);
+    },
+    [getFileBlobs]
+  );
 
-  const addUploadedFile = (fileData: {
-    fileId: string;
-    filename: string;
-    contentType: SupportedFileContentType;
-    size: number;
-    id?: string;
-    sourceUrl?: string;
-    iconName?: string;
-    provider?: string;
-  }) => {
-    const blob: FileBlob = {
-      contentType: fileData.contentType,
-      file: new File([], fileData.filename, { type: fileData.contentType }),
-      filename: fileData.filename,
-      id: fileData.id ?? fileData.fileId,
-      fileId: fileData.fileId,
-      isUploading: false,
-      size: fileData.size,
-      sourceUrl: fileData.sourceUrl,
-      iconName: fileData.iconName,
-      provider: fileData.provider,
+  const addUploadedFile = useCallback(
+    (fileData: {
+      fileId: string;
+      filename: string;
+      contentType: SupportedFileContentType;
+      size: number;
+      id?: string;
+      sourceUrl?: string;
+      iconName?: string;
+      provider?: string;
+    }) => {
+      const blob: FileBlob = {
+        contentType: fileData.contentType,
+        file: new File([], fileData.filename, { type: fileData.contentType }),
+        filename: fileData.filename,
+        id: fileData.id ?? fileData.fileId,
+        fileId: fileData.fileId,
+        isUploading: false,
+        size: fileData.size,
+        sourceUrl: fileData.sourceUrl,
+        iconName: fileData.iconName,
+        provider: fileData.provider,
+      };
+
+      setFileBlobs((prevFiles) => [...prevFiles, blob]);
+    },
+    []
+  );
+
+  const result = useMemo(() => {
+    return {
+      addUploadedFile,
+      fileBlobs,
+      getFileBlob,
+      getFileBlobs,
+      handleFileChange,
+      handleFilesUpload,
+      isProcessingFiles,
+      removeFile,
+      resetUpload,
     };
-
-    setFileBlobs((prevFiles) => [...prevFiles, blob]);
-  };
-
-  return {
+  }, [
     addUploadedFile,
     fileBlobs,
     getFileBlob,
@@ -410,7 +451,9 @@ export function useFileUploaderService({
     isProcessingFiles,
     removeFile,
     resetUpload,
-  };
+  ]);
+
+  return result;
 }
 
 export type FileUploaderService = ReturnType<typeof useFileUploaderService>;

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -199,7 +199,7 @@ export function useFileContent({
   return {
     error,
     fileContent: data,
-    isFileContentLoading: !error && !data,
+    isFileContentLoading: !error && !data && !config?.disabled,
     mutateFileContent: mutate,
   };
 }


### PR DESCRIPTION
## Description

This PR introduces page content capture (text and screenshot) in the browser extension, and refactors the file upload architecture to enable capture actions to share file state with the input bar.

- Adds a capture dropdown menu in the extension's input bar with two options (the missing attach knowledge option will me added in another pr):
  - Attach page content
  - Take screenshot
- Moves `fileUploaderService` into `InputBarContext` to ensure capture actions and input bar components share the same file upload state. 
- Splits `InputBarContext` into two layers:
  - `InputBarContextProvider`: low-level provider that accepts `fileUploaderService` and optional `captureActions` as props (used by the extension)
  - `InputBarProvider`: convenience wrapper for the web app that instantiates `fileUploaderService` internally
- Updates `InputBar` and `AttachmentViewer` to read `fileUploaderService` from context instead of creating their own instances


https://github.com/user-attachments/assets/d9c962aa-61df-482e-b76f-677de9d6eec2


## Tests

Manually. Checked that file upload is working correctly on the web app and on the extension. Both from the main page and in a specific conversation

## Risks
Medium - Refactoring file upload state to shared context affects all input bar components across both web app and extension. Shared context may cause unnecessary rerenders in components that consume it but don't need all file state updates.

## Deploy Plan
Standard deployment
