### PR TITLE
[MCP Zendesk] add ticket tags update tool

### DIFF
--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -375,8 +375,6 @@ export const ZendeskSearchCountResponseSchema = z.object({
 });
 
 // Tags schemas
-export const ZENDESK_TAG_REGEX = /^[a-z0-9_\-/]+$/;
-
 export const ZendeskTagsResponseSchema = z.object({
   tags: z.array(z.string()),
 });

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -373,3 +373,18 @@ export const ZendeskTicketCommentsResponseSchema =
 export const ZendeskSearchCountResponseSchema = z.object({
   count: z.string(),
 });
+
+// Tags schemas
+export const ZendeskTagSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[a-z0-9_\-/]+$/);
+
+export type ZendeskTag = z.infer<typeof ZendeskTagSchema>;
+
+export const ZendeskTagsResponseSchema = z.object({
+  tags: z.array(z.string()),
+});
+
+export type ZendeskTagsResponse = z.infer<typeof ZendeskTagsResponseSchema>;

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -375,13 +375,7 @@ export const ZendeskSearchCountResponseSchema = z.object({
 });
 
 // Tags schemas
-export const ZendeskTagSchema = z
-  .string()
-  .min(1)
-  .max(255)
-  .regex(/^[a-z0-9_\-/]+$/);
-
-export type ZendeskTag = z.infer<typeof ZendeskTagSchema>;
+export const ZENDESK_TAG_REGEX = /^[a-z0-9_\-/]+$/;
 
 export const ZendeskTagsResponseSchema = z.object({
   tags: z.array(z.string()),

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -572,6 +572,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_ticket_fields": "never_ask",
     "post_reply": "high",
     "search_tickets": "never_ask",
+    "update_ticket_tags": "low",
   },
 }
 `;

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -10,6 +10,7 @@ import type {
 import {
   isValidZendeskSubdomain,
   ZendeskSearchResponseSchema,
+  ZendeskTagsResponseSchema,
   ZendeskTicketCommentsResponseSchema,
   ZendeskTicketFieldsResponseSchema,
   ZendeskTicketMetricsResponseSchema,
@@ -307,6 +308,40 @@ class ZendeskClient {
     }
 
     return new Ok(result.value.comments);
+  }
+
+  async addTicketTags(
+    ticketId: number,
+    tags: string[]
+  ): Promise<Result<string[], Error>> {
+    const result = await this.request(
+      `tickets/${ticketId}/tags`,
+      ZendeskTagsResponseSchema,
+      { method: "PUT", body: { tags } } // PUT = additive
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value.tags);
+  }
+
+  async setTicketTags(
+    ticketId: number,
+    tags: string[]
+  ): Promise<Result<string[], Error>> {
+    const result = await this.request(
+      `tickets/${ticketId}/tags`,
+      ZendeskTagsResponseSchema,
+      { method: "POST", body: { tags } } // POST = full replacement
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value.tags);
   }
 
   async getUsersByIds(

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -120,6 +120,38 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       done: "Post reply to Zendesk",
     },
   },
+  update_ticket_tags: {
+    description:
+      "Add tags to a Zendesk ticket or completely replace its tags. " +
+      "By default (override=false), adds the provided tags to the existing ones without affecting them. " +
+      "When override=true, all existing tags on the ticket are replaced by the provided list — " +
+      "any tag not included in the list will be permanently removed. " +
+      "This is the only way to remove a tag: set override=true and omit the tag from the list.",
+    schema: {
+      ticketId: z
+        .number()
+        .int()
+        .positive()
+        .describe("The ID of the Zendesk ticket to update."),
+      tags: z
+        .array(z.string())
+        .describe(
+          "Tags to add, or the complete new list of tags if override=true."
+        ),
+      override: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, replaces all existing tags with the provided list. It removes any tag not in the list. " +
+            "If false or omitted, adds the tags to the existing ones. Defaults to false."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Updating Zendesk ticket tags",
+      done: "Update Zendesk ticket tags",
+    },
+  },
 });
 
 export const ZENDESK_SERVER = {

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -126,7 +126,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       "By default (override=false), adds the provided tags to the existing ones without affecting them. " +
       "When override=true, all existing tags on the ticket are replaced by the provided list — " +
       "any tag not included in the list will be permanently removed. " +
-      "This is the only way to remove a tag: set override=true and omit the tag from the list.",
+      "To remove a tag: first retrieve the current tags on the ticket, then call this tool with override=true, omitting the tag to remove from the list.",
     schema: {
       ticketId: z
         .number()

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -14,8 +14,11 @@ import {
   renderTicketMetrics,
 } from "@app/lib/api/actions/servers/zendesk/rendering";
 import type { ZendeskUser } from "@app/lib/api/actions/servers/zendesk/types";
-import { ZENDESK_TAG_REGEX } from "@app/lib/api/actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
+
+const ZENDESK_TAG_MAX_LENGTH = 255;
+const ZENDESK_TAG_REGEX = /^[a-z0-9_\-/]+$/;
+
 import { Err, Ok } from "@app/types/shared/result";
 
 function isTrackedError(error: Error): boolean {
@@ -243,7 +246,8 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
     const client = clientResult.value;
 
     const invalidTags = tags.filter(
-      (tag) => tag.length > 255 || !ZENDESK_TAG_REGEX.test(tag)
+      (tag) =>
+        tag.length > ZENDESK_TAG_MAX_LENGTH || !ZENDESK_TAG_REGEX.test(tag)
     );
     if (invalidTags.length > 0) {
       return new Err(

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -14,6 +14,7 @@ import {
   renderTicketMetrics,
 } from "@app/lib/api/actions/servers/zendesk/rendering";
 import type { ZendeskUser } from "@app/lib/api/actions/servers/zendesk/types";
+import { ZendeskTagSchema } from "@app/lib/api/actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -230,6 +231,47 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text: `Public reply successfully posted to ticket ${ticketId}. The comment is visible to the end user.`,
+      },
+    ]);
+  },
+
+  update_ticket_tags: async ({ ticketId, tags, override }, { authInfo }) => {
+    const clientResult = getZendeskClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const invalidTags = tags.filter(
+      (tag) => !ZendeskTagSchema.safeParse(tag).success
+    );
+    if (invalidTags.length > 0) {
+      return new Err(
+        new MCPError(
+          `Invalid tag(s): ${invalidTags.join(", ")}. Tags must be lowercase, max 255 characters, no spaces; only letters, digits, _, -, / are allowed.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const result = override
+      ? await client.setTicketTags(ticketId, tags)
+      : await client.addTicketTags(ticketId, tags);
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to update ticket tags: ${result.error.message}`, {
+          tracked: isTrackedError(result.error),
+        })
+      );
+    }
+
+    const action = override ? "replaced (override)" : "added";
+    const currentTags = result.value.join(", ") || "(none)";
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Tags successfully ${action} on ticket ${ticketId}. Current tags: ${currentTags}`,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -14,7 +14,7 @@ import {
   renderTicketMetrics,
 } from "@app/lib/api/actions/servers/zendesk/rendering";
 import type { ZendeskUser } from "@app/lib/api/actions/servers/zendesk/types";
-import { ZendeskTagSchema } from "@app/lib/api/actions/servers/zendesk/types";
+import { ZENDESK_TAG_REGEX } from "@app/lib/api/actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -243,7 +243,7 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
     const client = clientResult.value;
 
     const invalidTags = tags.filter(
-      (tag) => !ZendeskTagSchema.safeParse(tag).success
+      (tag) => tag.length > 255 || !ZENDESK_TAG_REGEX.test(tag)
     );
     if (invalidTags.length > 0) {
       return new Err(

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -375,8 +375,6 @@ export const ZendeskSearchCountResponseSchema = z.object({
 });
 
 // Tags schemas
-export const ZENDESK_TAG_REGEX = /^[a-z0-9_\-/]+$/;
-
 export const ZendeskTagsResponseSchema = z.object({
   tags: z.array(z.string()),
 });

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -373,3 +373,18 @@ export const ZendeskTicketCommentsResponseSchema =
 export const ZendeskSearchCountResponseSchema = z.object({
   count: z.string(),
 });
+
+// Tags schemas
+export const ZendeskTagSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[a-z0-9_\-/]+$/);
+
+export type ZendeskTag = z.infer<typeof ZendeskTagSchema>;
+
+export const ZendeskTagsResponseSchema = z.object({
+  tags: z.array(z.string()),
+});
+
+export type ZendeskTagsResponse = z.infer<typeof ZendeskTagsResponseSchema>;

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -375,13 +375,7 @@ export const ZendeskSearchCountResponseSchema = z.object({
 });
 
 // Tags schemas
-export const ZendeskTagSchema = z
-  .string()
-  .min(1)
-  .max(255)
-  .regex(/^[a-z0-9_\-/]+$/);
-
-export type ZendeskTag = z.infer<typeof ZendeskTagSchema>;
+export const ZENDESK_TAG_REGEX = /^[a-z0-9_\-/]+$/;
 
 export const ZendeskTagsResponseSchema = z.object({
   tags: z.array(z.string()),


### PR DESCRIPTION
## Description

Adds a new `update_ticket_tags` tool to the Zendesk MCP server that allows adding tags to or replacing all tags on a ticket. The tool has two modes: by default (`override=false`), it adds tags to the ticket's existing ones; when `override=true`, it replaces all tags, which is the only way to remove tags. Includes validation that enforces Zendesk's tag format requirements (lowercase, max 255 characters, only letters/digits/`_`/`-`/`/` allowed) and returns clear error messages when validation fails.

## Risk

Low. New tool with input validation and clear error handling. The `stake` is set to `low` like other similar write operations.

## Tests

Updated snapshot test with new tool definition and its stake.

## Deploy Plan

Run front