### PR TITLE
Add projects route in extension

### DIFF
--- a/extension/ui/components/conversation/ConversationLayout.tsx
+++ b/extension/ui/components/conversation/ConversationLayout.tsx
@@ -1,0 +1,65 @@
+import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { SidebarContext } from "@app/components/sparkle/SidebarContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  BarHeader,
+  Button,
+  MenuIcon,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
+import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
+import type React from "react";
+import { useContext } from "react";
+
+interface ConversationLayoutProps {
+  title?: string;
+  rightActions?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const ConversationLayout = ({
+  title,
+  rightActions,
+  children,
+}: ConversationLayoutProps) => {
+  const { workspace: owner } = useAuth();
+  const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
+
+  return (
+    <FileDropProvider>
+      <ActionValidationProvider>
+        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+          <SheetContent
+            side="left"
+            className="flex w-full max-w-72 flex-1 bg-muted-background dark:bg-muted-background-night"
+          >
+            <SheetHeader className="bg-muted-background p-0" hideButton>
+              <SheetTitle className="hidden" />
+            </SheetHeader>
+            <div className="flex flex-col grow p-1">
+              <AgentSidebarMenu owner={owner} hideActions hideInAppBanner />
+            </div>
+          </SheetContent>
+        </Sheet>
+        <BarHeader
+          title={title}
+          tooltip={title}
+          className="justify-between"
+          leftActions={
+            <Button
+              variant="ghost"
+              icon={MenuIcon}
+              onClick={() => setSidebarOpen(true)}
+            />
+          }
+          rightActions={rightActions}
+        />
+        <div className="h-full w-full pt-16">{children}</div>
+      </ActionValidationProvider>
+    </FileDropProvider>
+  );
+};

--- a/extension/ui/components/conversation/ConversationLayout.tsx
+++ b/extension/ui/components/conversation/ConversationLayout.tsx
@@ -16,7 +16,7 @@ import type React from "react";
 import { useContext } from "react";
 
 interface ConversationLayoutProps {
-  title?: string;
+  title: string;
   rightActions?: React.ReactNode;
   children: React.ReactNode;
 }

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -6,27 +6,15 @@ import {
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useConversation } from "@app/hooks/conversations/useConversation";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import {
-  BarHeader,
-  Button,
-  MenuIcon,
-  MoreIcon,
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@dust-tt/sparkle";
+import { Button, MoreIcon } from "@dust-tt/sparkle";
 import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
-import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
-import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
+import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
 import { DropzoneContainer } from "@extension/ui/components/DropzoneContainer";
 import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
-import { useContext, useMemo } from "react";
+import { useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { ConversationContainer } from "../components/conversation/ConversationContainer";
 
@@ -36,8 +24,6 @@ export const MainPage = () => {
   useSetupNotifications();
   const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
   const shortcut = isMac ? "⇧⌘E" : "⇧+Ctrl+E";
-
-  const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
 
   // Parse conversation ID from catch-all path
   const params = useParams();
@@ -77,100 +63,64 @@ export const MainPage = () => {
   }, [conversation, isConversationLoading, conversationId, conversationError]);
 
   return (
-    <FileDropProvider>
-      <ActionValidationProvider>
-        <DropzoneContainer
-          description="Drag and drop your text files (txt, doc, pdf) and image files (jpg, png) here."
-          title="Attach files to the conversation"
-        >
-          <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-            <SheetContent
-              side="left"
-              className="flex w-full max-w-72 flex-1 bg-muted-background dark:bg-muted-background-night"
-            >
-              <SheetHeader className="bg-muted-background p-0" hideButton>
-                <SheetTitle className="hidden" />
-              </SheetHeader>
-              <div className="flex flex-col grow p-1">
-                <AgentSidebarMenu
-                  owner={workspace}
-                  hideActions
-                  hideInAppBanner
-                />
-              </div>
-            </SheetContent>
-          </Sheet>
-          <BarHeader
-            title={headerTitle}
-            tooltip={headerTitle}
-            className="justify-between"
-            leftActions={
+    <ConversationLayout
+      title={headerTitle}
+      rightActions={
+        conversationId ? (
+          <ConversationMenu
+            activeConversationId={conversationId}
+            conversation={conversation}
+            owner={workspace}
+            trigger={
               <Button
+                size="sm"
                 variant="ghost"
-                icon={MenuIcon}
-                onClick={() => setSidebarOpen(true)}
+                icon={MoreIcon}
+                aria-label="Conversation menu"
               />
             }
-            rightActions={
-              conversationId ? (
-                <ConversationMenu
-                  activeConversationId={conversationId}
-                  conversation={conversation}
-                  owner={workspace}
-                  trigger={
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      icon={MoreIcon}
-                      aria-label="Conversation menu"
-                    />
-                  }
-                  isConversationDisplayed={true}
-                  isOpen={isMenuOpen}
-                  onOpenChange={handleMenuOpenChange}
-                  triggerPosition={menuTriggerPosition}
-                  displayOpenInBrowser
-                  openDetailsInNewTab
-                />
-              ) : (
-                <div className="items-right flex flex-row space-x-1">
-                  <UserDropdownMenu />
-                </div>
-              )
-            }
+            isConversationDisplayed={true}
+            isOpen={isMenuOpen}
+            onOpenChange={handleMenuOpenChange}
+            triggerPosition={menuTriggerPosition}
+            displayOpenInBrowser
+            openDetailsInNewTab
           />
-          {!conversationId && (
-            <div className="flex items-start justify-between">
-              <div className="element fixed bottom-0 right-0 z-10 p-2 text-sm">
-                <p className="text-muted-foreground dark:text-muted-foreground-night text-sm font-normal">
-                  {shortcut}
-                </p>
-              </div>
-            </div>
-          )}
-          <div className="h-full w-full pt-16">
-            <BlockedActionsProvider
-              owner={workspace}
-              conversation={conversation}
-            >
-              <ConversationSidePanelProvider>
-                <GenerationContextProvider>
-                  <InputBarProvider origin="extension">
-                    <ConversationContainer
-                      workspace={workspace}
-                      user={user}
-                      subscription={subscription}
-                      conversationId={conversationId}
-                      conversation={conversation}
-                      serverId={serverId}
-                    />
-                  </InputBarProvider>
-                </GenerationContextProvider>
-              </ConversationSidePanelProvider>
-            </BlockedActionsProvider>
+        ) : (
+          <div className="items-right flex flex-row space-x-1">
+            <UserDropdownMenu />
           </div>
-        </DropzoneContainer>
-      </ActionValidationProvider>
-    </FileDropProvider>
+        )
+      }
+    >
+      {!conversationId && (
+        <div className="element fixed bottom-0 right-0 z-10 p-2 text-sm">
+          <p className="text-muted-foreground dark:text-muted-foreground-night text-sm font-normal">
+            {shortcut}
+          </p>
+        </div>
+      )}
+      <DropzoneContainer
+        description="Drag and drop your text files (txt, doc, pdf) and image files (jpg, png) here."
+        title="Attach files to the conversation"
+      >
+        <BlockedActionsProvider owner={workspace} conversation={conversation}>
+          <ConversationSidePanelProvider>
+            <GenerationContextProvider>
+              <InputBarProvider origin="extension">
+                <ConversationContainer
+                  workspace={workspace}
+                  user={user}
+                  subscription={subscription}
+                  conversationId={conversationId}
+                  conversation={conversation}
+                  serverId={serverId}
+                />
+              </InputBarProvider>
+            </GenerationContextProvider>
+          </ConversationSidePanelProvider>
+        </BlockedActionsProvider>
+      </DropzoneContainer>
+    </ConversationLayout>
   );
 };

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -47,7 +47,8 @@ export const MainPage = () => {
     }
     const match = params["*"].match(/conversation\/([^/]+)/);
     const isNewConversation = match && match[1] === "new";
-    if (isNewConversation) {
+    const isSpaceConversation = match && match[1] === "space";
+    if (isNewConversation || isSpaceConversation) {
       return null;
     }
     return match ? match[1] : null;

--- a/extension/ui/pages/ProjectMainPage.tsx
+++ b/extension/ui/pages/ProjectMainPage.tsx
@@ -1,10 +1,21 @@
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
+import { useParams } from "react-router-dom";
 
-export const SpaceMainPage = () => {
+export const ProjectMainPage = () => {
+  const { workspace } = useAuth();
+  const { spaceId } = useParams<{ spaceId: string }>();
+
+  const { spaceInfo } = useSpaceInfo({
+    workspaceId: workspace.sId,
+    spaceId: spaceId ?? null,
+  });
+
   return (
-    <ConversationLayout>
+    <ConversationLayout title={spaceInfo?.name ?? ""}>
       <InputBarProvider origin="extension">
         <SpaceConversationsPage />
       </InputBarProvider>

--- a/extension/ui/pages/SpaceMainPage.tsx
+++ b/extension/ui/pages/SpaceMainPage.tsx
@@ -1,0 +1,57 @@
+import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
+import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
+import { SidebarContext } from "@app/components/sparkle/SidebarContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  BarHeader,
+  Button,
+  MenuIcon,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
+import { useContext } from "react";
+
+export const SpaceMainPage = () => {
+  const { workspace: owner } = useAuth();
+  const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
+
+  return (
+    <FileDropProvider>
+      <ActionValidationProvider>
+        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+          <SheetContent
+            side="left"
+            className="flex w-full max-w-72 flex-1 bg-muted-background dark:bg-muted-background-night"
+          >
+            <SheetHeader className="bg-muted-background p-0" hideButton>
+              <SheetTitle className="hidden" />
+            </SheetHeader>
+            <div className="flex flex-col grow p-1">
+              <AgentSidebarMenu owner={owner} hideActions hideInAppBanner />
+            </div>
+          </SheetContent>
+        </Sheet>
+        <BarHeader
+          className="justify-between"
+          leftActions={
+            <Button
+              variant="ghost"
+              icon={MenuIcon}
+              onClick={() => setSidebarOpen(true)}
+            />
+          }
+        />
+        <div className="h-full w-full pt-16">
+          <InputBarProvider origin="extension">
+            <SpaceConversationsPage />
+          </InputBarProvider>
+        </div>
+      </ActionValidationProvider>
+    </FileDropProvider>
+  );
+};

--- a/extension/ui/pages/SpaceMainPage.tsx
+++ b/extension/ui/pages/SpaceMainPage.tsx
@@ -1,57 +1,13 @@
-import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
-import { SidebarContext } from "@app/components/sparkle/SidebarContext";
-import { useAuth } from "@app/lib/auth/AuthContext";
-import {
-  BarHeader,
-  Button,
-  MenuIcon,
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@dust-tt/sparkle";
-import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
-import { useContext } from "react";
+import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
 
 export const SpaceMainPage = () => {
-  const { workspace: owner } = useAuth();
-  const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
-
   return (
-    <FileDropProvider>
-      <ActionValidationProvider>
-        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-          <SheetContent
-            side="left"
-            className="flex w-full max-w-72 flex-1 bg-muted-background dark:bg-muted-background-night"
-          >
-            <SheetHeader className="bg-muted-background p-0" hideButton>
-              <SheetTitle className="hidden" />
-            </SheetHeader>
-            <div className="flex flex-col grow p-1">
-              <AgentSidebarMenu owner={owner} hideActions hideInAppBanner />
-            </div>
-          </SheetContent>
-        </Sheet>
-        <BarHeader
-          className="justify-between"
-          leftActions={
-            <Button
-              variant="ghost"
-              icon={MenuIcon}
-              onClick={() => setSidebarOpen(true)}
-            />
-          }
-        />
-        <div className="h-full w-full pt-16">
-          <InputBarProvider origin="extension">
-            <SpaceConversationsPage />
-          </InputBarProvider>
-        </div>
-      </ActionValidationProvider>
-    </FileDropProvider>
+    <ConversationLayout>
+      <InputBarProvider origin="extension">
+        <SpaceConversationsPage />
+      </InputBarProvider>
+    </ConversationLayout>
   );
 };

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -2,6 +2,7 @@ import { ProtectedRoute } from "@extension/ui/components/auth/ProtectedRoute";
 import { LoginPage } from "@extension/ui/pages/LoginPage";
 import { MainPage } from "@extension/ui/pages/MainPage";
 import { RunPage } from "@extension/ui/pages/RunPage";
+import { SpaceMainPage } from "@extension/ui/pages/SpaceMainPage";
 import { SubscribePage } from "@extension/ui/pages/SubscribePage";
 
 export const routes = [
@@ -19,6 +20,10 @@ export const routes = [
       {
         path: "/subscribe",
         element: <SubscribePage />,
+      },
+      {
+        path: "/w/:wId/conversation/space/:spaceId",
+        element: <SpaceMainPage />,
       },
       // Keep catch-all route last. This will handle both root path and /conversations/:conversationId
       // Since we catch all, we will need to manually handle the conversationId in the MainPage component.

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -1,8 +1,8 @@
 import { ProtectedRoute } from "@extension/ui/components/auth/ProtectedRoute";
 import { LoginPage } from "@extension/ui/pages/LoginPage";
 import { MainPage } from "@extension/ui/pages/MainPage";
+import { ProjectMainPage } from "@extension/ui/pages/ProjectMainPage";
 import { RunPage } from "@extension/ui/pages/RunPage";
-import { SpaceMainPage } from "@extension/ui/pages/SpaceMainPage";
 import { SubscribePage } from "@extension/ui/pages/SubscribePage";
 
 export const routes = [
@@ -23,7 +23,7 @@ export const routes = [
       },
       {
         path: "/w/:wId/conversation/space/:spaceId",
-        element: <SpaceMainPage />,
+        element: <ProjectMainPage />,
       },
       // Keep catch-all route last. This will handle both root path and /conversations/:conversationId
       // Since we catch all, we will need to manually handle the conversationId in the MainPage component.


### PR DESCRIPTION
## Description

- Adds support for projects in the extension by creating a new `/w/:wId/conversation/space/:spaceId` route and `ProjectMainPage` component. 
- Refactors common layout logic into a shared `ConversationLayout` component to reduce duplication between `MainPage` and `ProjectMainPage`, enabling users to access project-specific conversations directly from the extension.

## Tests

Navigate in the projects pages in both Chrome and Frontapp extensions.

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
