### PR TITLE
Fixed token refresh

### DIFF
--- a/extension/shared/lib/swr.ts
+++ b/extension/shared/lib/swr.ts
@@ -96,30 +96,40 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
   }
 }
 
+export class APIError extends Error {
+  type: string;
+
+  constructor(type: string, message: string) {
+    super(message);
+    this.type = type;
+  }
+}
+
 export const resHandler = async (res: Response) => {
   if (res.status < 300) {
     return res.json();
   }
 
-  let error;
+  let errorType = "unknown";
+  let errorMessage = "Unknown error";
 
   try {
     const resJson = await res.json();
-    error = resJson.error;
-
-    if (error?.type === "not_authenticated") {
-      error = error.message;
+    const error = resJson.error;
+    if (error?.type) {
+      errorType = error.type;
     }
+    errorMessage = error?.message ?? JSON.stringify(error);
   } catch (e) {
     console.error("Error parsing response: ", e);
-    error = await res.text();
+    errorMessage = await res.text();
   }
 
   console.error(
     "Error returned by the front API: ",
     res.status,
     res.headers,
-    error
+    errorMessage
   );
-  throw new Error(error);
+  throw new APIError(errorType, errorMessage);
 };

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -75,6 +75,27 @@ export const useAuthHook = () => {
     setIsLoading(false);
   }, []);
 
+  const scheduleRefresh = useCallback(
+    (expiresAt: number) => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+
+      // Refresh 1 minute before expiry, but at least 1 second from now.
+      const delayMs = Math.max(
+        expiresAt - Date.now() - PROACTIVE_REFRESH_WINDOW_MS,
+        1000
+      );
+
+      refreshTimerRef.current = setTimeout(() => {
+        void handleRefreshToken();
+      }, delayMs);
+    },
+    // handleRefreshToken is stable (useCallback with []), safe to reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
   const handleRefreshToken = useCallback(async () => {
     const newAccessToken = await platform.auth.getAccessToken(true);
     if (!newAccessToken) {
@@ -86,6 +107,9 @@ export const useAuthHook = () => {
     }
 
     const storedTokens = await platform.auth.getStoredTokens();
+    if (storedTokens) {
+      scheduleRefresh(storedTokens.expiresAt);
+    }
     setTokens((prev) => {
       if (!prev) {
         return null;
@@ -97,7 +121,7 @@ export const useAuthHook = () => {
       };
     });
     setAuthError(null);
-  }, []);
+  }, [scheduleRefresh]);
 
   // Listen for changes in storage to make sure we always have the latest tokens.
   useEffect(() => {
@@ -155,9 +179,11 @@ export const useAuthHook = () => {
       }
       setTokens(storedTokens);
 
-      // Token refresh.
+      // Token refresh: refresh now if about to expire, otherwise schedule.
       if (storedTokens.expiresAt < Date.now() + PROACTIVE_REFRESH_WINDOW_MS) {
         await handleRefreshToken();
+      } else {
+        scheduleRefresh(storedTokens.expiresAt);
       }
 
       // isLoading stays true — the user fetch effect will clear it.


### PR DESCRIPTION
## Description

Fix two bugs that prevented the extension from refreshing expired OAuth tokens:

### Bug 1: `resHandler` loses error type information

`resHandler` in `extension/shared/lib/swr.ts` received the API error object `{ type: "expired_oauth_token_error", message: "The access token expired." }` but threw a plain `new Error(error)` — which calls `.toString()` on the object, producing `"[object Object]"`. The resulting `Error` has no `.type` property, so `useAuthErrorCheck`'s `switch (error.type)` never matches any case and the token refresh is never triggered.

**Fix**: Introduce an `APIError` class that preserves the `.type` property from the server response.

### Bug 2: No scheduled token refresh

The token has a 15-minute lifetime. The only proactive refresh happened once on mount (if within 1 minute of expiry). If the user kept the extension open, the token would expire with no timer to refresh it. The `refreshTimerRef` was declared but never used.

**Fix**: Add `scheduleRefresh()` that sets a timer to call `handleRefreshToken()` 1 minute before expiry. The timer is set on mount (if not already near expiry) and after each successful refresh, creating a continuous refresh chain.

## Tests

Manual: kept extension open past token expiry, verified token refreshes automatically before expiration and that expired token errors trigger refresh + retry.

## Risk

Low. Both changes are extension-only. The `APIError` class is a backwards-compatible replacement for `Error` (has all the same properties plus `.type`). The refresh timer uses the existing `refreshTimerRef` and is cleaned up on unmount.

## Deploy Plan

Standard deploy, extension-only changes.