### PR TITLE
Frontapp extension: fix sidebar and authentication

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -616,7 +616,7 @@ const refreshToken = async (
           success: true,
           accessToken: data.accessToken,
           refreshToken: data.refreshToken || refreshToken,
-          expiresIn: DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
+          expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
           authentication_method: data.authenticationMethod,
         });
       });
@@ -666,7 +666,7 @@ const exchangeCodeForTokens = async (
       success: true,
       accessToken: data.accessToken,
       refreshToken: data.refreshToken,
-      expiresIn: DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
+      expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
       authentication_method: data.authenticationMethod,
     };
   } catch (error) {

--- a/extension/platforms/front/FrontApp.tsx
+++ b/extension/platforms/front/FrontApp.tsx
@@ -1,0 +1,58 @@
+import { RootLayout } from "@app/components/app/RootLayout";
+import { RegionProvider } from "@app/lib/auth/RegionContext";
+import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
+import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
+import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
+import { ExtensionAuthProvider } from "@extension/ui/components/auth/AuthProvider";
+import { routes } from "@extension/ui/pages/routes";
+import { useEffect, useState } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+// Create a router instance outside the component to avoid recreation.
+// Use memory router to avoid interfering with the parent page.
+const router = createMemoryRouter(routes, {
+  initialEntries: ["/"],
+  initialIndex: 0,
+});
+
+export const FrontApp = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  const [isIframeReady, setIsIframeReady] = useState(false);
+
+  // Handle cleanup when the component unmounts.
+  useEffect(() => {
+    // Check if we're in an iframe.
+    const isInIframe = window.self !== window.top;
+
+    // Set iframe ready state.
+    setIsIframeReady(isInIframe ? document.readyState === "complete" : true);
+
+    // Set mounted state.
+    setIsMounted(true);
+
+    return () => {
+      setIsMounted(false);
+    };
+  }, []);
+
+  // Only render the app if it's mounted and iframe is ready.
+  if (!isMounted || !isIframeReady) {
+    return null;
+  }
+
+  return (
+    <FrontContextProvider>
+      <FrontPlatformProvider>
+        <RegionProvider>
+          <ExtensionAuthProvider>
+            <ExtensionFetcherProvider>
+              <RootLayout>
+                <RouterProvider router={router} key="front-router" />
+              </RootLayout>
+            </ExtensionFetcherProvider>
+          </ExtensionAuthProvider>
+        </RegionProvider>
+      </FrontPlatformProvider>
+    </FrontContextProvider>
+  );
+};

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -7,6 +7,7 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
+import { RootLayout } from "@app/components/app/RootLayout";
 import { RegionProvider } from "@app/lib/auth/RegionContext";
 import { Notification } from "@dust-tt/sparkle";
 import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
@@ -58,7 +59,9 @@ const AppWrapper = () => {
           <ExtensionAuthProvider>
             <ExtensionFetcherProvider>
               <Notification.Area>
-                <RouterProvider router={router} key="front-router" />
+                <RootLayout>
+                  <RouterProvider router={router} key="front-router" />
+                </RootLayout>
               </Notification.Area>
             </ExtensionFetcherProvider>
           </ExtensionAuthProvider>

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -7,76 +7,20 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
-import { RootLayout } from "@app/components/app/RootLayout";
-import { RegionProvider } from "@app/lib/auth/RegionContext";
-import { Notification } from "@dust-tt/sparkle";
-import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
-import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
-import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
-import { ExtensionAuthProvider } from "@extension/ui/components/auth/AuthProvider";
-import { routes } from "@extension/ui/pages/routes";
-import { useEffect, useState } from "react";
+import { FrontApp } from "@extension/platforms/front/FrontApp";
+import React from "react";
 import ReactDOM from "react-dom/client";
-import { createMemoryRouter, RouterProvider } from "react-router-dom";
-
-// Create a router instance outside the component to avoid recreation.
-// Use memory router to avoid interfering with the parent page.
-const router = createMemoryRouter(routes, {
-  initialEntries: ["/"],
-  initialIndex: 0,
-});
-
-// Simple wrapper component to handle unmounting.
-const AppWrapper = () => {
-  const [isMounted, setIsMounted] = useState(false);
-  const [isIframeReady, setIsIframeReady] = useState(false);
-
-  // Handle cleanup when the component unmounts.
-  useEffect(() => {
-    // Check if we're in an iframe.
-    const isInIframe = window.self !== window.top;
-
-    // Set iframe ready state.
-    setIsIframeReady(isInIframe ? document.readyState === "complete" : true);
-
-    // Set mounted state.
-    setIsMounted(true);
-
-    return () => {
-      setIsMounted(false);
-    };
-  }, []);
-
-  // Only render the app if it's mounted and iframe is ready.
-  if (!isMounted || !isIframeReady) {
-    return null;
-  }
-
-  return (
-    <FrontContextProvider>
-      <FrontPlatformProvider>
-        <RegionProvider>
-          <ExtensionAuthProvider>
-            <ExtensionFetcherProvider>
-              <Notification.Area>
-                <RootLayout>
-                  <RouterProvider router={router} key="front-router" />
-                </RootLayout>
-              </Notification.Area>
-            </ExtensionFetcherProvider>
-          </ExtensionAuthProvider>
-        </RegionProvider>
-      </FrontPlatformProvider>
-    </FrontContextProvider>
-  );
-};
 
 // Render the app.
 const rootElement = document.getElementById("root");
 if (rootElement) {
   try {
     const root = ReactDOM.createRoot(rootElement);
-    root.render(<AppWrapper />);
+    root.render(
+      <React.StrictMode>
+        <FrontApp />
+      </React.StrictMode>
+    );
   } catch (error) {
     console.error("Error rendering Dust app:", error);
   }

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -73,7 +73,7 @@ export class FrontAuthService extends AuthService {
     options: Record<string, string>
   ): Promise<{ code: string }> {
     const queryString = new URLSearchParams(options).toString();
-    const authUrl = `${DUST_US_URL}/api/v1/auth/authorize?${queryString}`;
+    const authUrl = `${DUST_US_URL}/api/workos/login?${queryString}`;
 
     const result = await openAndWaitForPopup<{
       code: string;
@@ -168,7 +168,7 @@ export class FrontAuthService extends AuthService {
         success: true,
         accessToken: data.accessToken,
         refreshToken: data.refreshToken || "",
-        expiresIn: DEFAULT_TOKEN_EXPIRY,
+        expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY,
       });
 
       const claims = jwtDecode<Record<string, string>>(data.accessToken);
@@ -201,7 +201,7 @@ export class FrontAuthService extends AuthService {
       return true;
     }
 
-    const logoutUrl = `${regionInfo.url}/api/v1/auth/logout?${new URLSearchParams(
+    const logoutUrl = `${regionInfo.url}/api/workos/logout?${new URLSearchParams(
       queryParams
     )}`;
 

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -139,7 +139,7 @@ export class FrontAuthService extends AuthService {
         code: result.code,
         redirect_uri: FRONT_EXTENSION_URL,
       });
-      const response = await fetch(`${DUST_US_URL}/api/v1/auth/authenticate`, {
+      const response = await fetch(`${DUST_US_URL}/api/workos/authenticate`, {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
@@ -166,12 +166,12 @@ export class FrontAuthService extends AuthService {
       // Store tokens
       const tokens = await this.saveTokens({
         success: true,
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token || "",
-        expiresIn: data.expires_in || DEFAULT_TOKEN_EXPIRY,
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken || "",
+        expiresIn: DEFAULT_TOKEN_EXPIRY,
       });
 
-      const claims = jwtDecode<Record<string, string>>(data.access_token);
+      const claims = jwtDecode<Record<string, string>>(data.accessToken);
 
       const regionInfo = getRegionInfoFromClaims(claims);
 
@@ -263,7 +263,7 @@ export class FrontAuthService extends AuthService {
       }
 
       const response = await fetch(
-        `${regionInfo.url}/api/v1/auth/authenticate`,
+        `${regionInfo.url}/api/workos/authenticate`,
         {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -62,6 +62,8 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       returnTo,
       redirect_uri,
       workspaceId,
+      code_challenge,
+      code_challenge_method,
     } = req.query;
 
     const redirectUri =
@@ -139,6 +141,10 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
           : undefined,
       ...(isValidScreenHint(screenHint) ? { screenHint } : {}),
       ...(isString(loginHint) ? { loginHint } : {}),
+      ...(isString(code_challenge) ? { codeChallenge: code_challenge } : {}),
+      ...(isString(code_challenge_method) && code_challenge_method === "S256"
+        ? { codeChallengeMethod: code_challenge_method }
+        : {}),
     });
 
     res.redirect(authorizationUrl);
@@ -185,7 +191,15 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
             clientId: config.getWorkOSClientId(),
           })
         : await authenticate(code);
-    return res.status(200).json(authResult);
+
+    const jwtPayload = JSON.parse(
+      Buffer.from(authResult.accessToken.split(".")[1], "base64").toString()
+    );
+    const expiresIn = jwtPayload.exp
+      ? jwtPayload.exp - Math.floor(Date.now() / 1000)
+      : undefined;
+
+    return res.status(200).json({ ...authResult, expiresIn });
   } catch (error) {
     logger.error({ error }, "Error during WorkOS authentication");
     return res.status(500).json({ error: "Authentication failed" });

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -150,7 +150,7 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
-  const { code, grant_type, refresh_token } = req.body;
+  const { code, grant_type, refresh_token, code_verifier } = req.body;
 
   if (grant_type && !isString(grant_type)) {
     return res.status(400).json({ error: "Invalid grant_type" });
@@ -177,7 +177,14 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
     return res.status(400).json({ error: "Invalid code" });
   }
   try {
-    const authResult = await authenticate(code);
+    const authResult =
+      code_verifier && isString(code_verifier)
+        ? await getWorkOS().userManagement.authenticateWithCodeAndVerifier({
+            code,
+            codeVerifier: code_verifier,
+            clientId: config.getWorkOSClientId(),
+          })
+        : await authenticate(code);
     return res.status(200).json(authResult);
   } catch (error) {
     logger.error({ error }, "Error during WorkOS authentication");


### PR DESCRIPTION
## Description

Adds `RootLayout` wrapper to the Front extension entry point and fixes authentication to use the correct WorkOS endpoint. This fixes the Sidebar display in the Frontapp extension.

The Front extension authentication flow now uses `/api/workos/authenticate` (consistent with the Chrome extension) instead of the public `/api/v1/auth/authenticate` endpoint. 

The backend `handleAuthenticate` handler is updated to accept `code_verifier` parameter and use `authenticateWithCodeAndVerifier` for PKCE flows when provided.

## Tests

Authenticate in the Frontapp extension.

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
