### PR TITLE
Detect missing HTML instructions and log a client error

### DIFF
--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -39,7 +39,10 @@ The response includes:
 
       // Detect timing issue: markdown instructions exist but HTML is empty/stub.
       const markdownInstructions = formData.instructions?.trim() ?? "";
-      if (markdownInstructions && !instructionsHtml.replace(/<[^>]*>/g, "").trim()) {
+      if (
+        markdownInstructions &&
+        !instructionsHtml.replace(/<[^>]*>/g, "").trim()
+      ) {
         datadogLogger.error(
           {
             instructionsHtmlLength: instructionsHtml.length,

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -1,4 +1,5 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import datadogLogger from "@app/logger/datadogLogger";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -35,6 +36,19 @@ The response includes:
 
       // HTML instructions with block IDs for targeting specific blocks.
       const instructionsHtml = getCommittedInstructionsHtml?.() ?? "";
+
+      // Detect timing issue: markdown instructions exist but HTML is empty/stub.
+      const markdownInstructions = formData.instructions?.trim() ?? "";
+      if (markdownInstructions && !instructionsHtml.replace(/<[^>]*>/g, "").trim()) {
+        datadogLogger.error(
+          {
+            instructionsHtmlLength: instructionsHtml.length,
+            markdownInstructionsLength: markdownInstructions.length,
+            instructionsHtml,
+          },
+          "get_agent_config: instructionsHtml is empty but markdown instructions exist"
+        );
+      }
 
       const pendingSuggestions = getPendingSuggestions?.() ?? [];
 


### PR DESCRIPTION
## Description

Log an error when we have no HTML instructions, but have markdown instructions. This is likely a sign of a race condition, and we want to see how often that happens.

## Tests

Deployed to https://3ec9526f--app.preview.dust.tt/ and tested that logs are produced when they should.

## Risk

Low

## Deploy Plan

Front