### PR TITLE
[Front+Connectors] refactor(slack): clarify whitelist-bot plugins and remove unused groupIds from index_messages

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -35,7 +35,7 @@ import type {
   AdminSuccessResponseType,
   SlackCheckChannelResponseType,
   SlackCommandType,
-  SlackJoinResponseType as SlackJoinResponseType,
+  SlackJoinResponseType,
 } from "@connectors/types";
 import {
   INTERNAL_MIME_TYPES,
@@ -274,10 +274,6 @@ export const slack = async ({
         throw new Error("Missing --botName argument");
       }
 
-      if (!groupId) {
-        throw new Error("Missing --groupId argument");
-      }
-
       if (!providerType || !["slack", "slack_bot"].includes(providerType)) {
         throw new Error(
           "--providerType argument must be set to 'slack' or 'slack_bot'"
@@ -324,10 +320,16 @@ export const slack = async ({
         );
       }
 
-      // Handle groupId as either a single string or comma-separated string of group IDs
-      const groupIds = groupId.includes(",")
-        ? groupId.split(",").map((id) => id.trim())
-        : [groupId];
+      let groupIds: string[] = [];
+      if (whitelistType === "summon_agent") {
+        if (!groupId) {
+          throw new Error(
+            "Missing --groupId argument (required for summon_agent)"
+          );
+        }
+        groupIds = groupId.split(",").map((id) => id.trim());
+      }
+
       await slackConfig.whitelistBot(botName, groupIds, whitelistType);
 
       return { success: true };

--- a/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
+++ b/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
@@ -7,136 +7,178 @@ import type { AdminCommandType } from "@app/types/connectors/admin/cli";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { Err, Ok } from "@app/types/shared/result";
 
-type SlackWhitelistConfig = {
-  id: string;
-  name: string;
-  description: string;
-  providerType: "slack" | "slack_bot";
-  whitelistType: "index_messages" | "summon_agent";
-};
-
-function makeSlackWhitelistBotPlugin(cfg: SlackWhitelistConfig) {
-  return createPlugin({
-    manifest: {
-      id: cfg.id,
-      name: cfg.name,
-      description: cfg.description,
-      resourceTypes: ["data_sources"],
-      args: {
-        botName: {
-          type: "string",
-          label: "Bot/Workflow Name",
-          description: "Name of the Slack bot or workflow to whitelist",
-        },
-        groupIds: {
-          type: "enum",
-          label: "Groups",
-          description: "Groups to associate with the whitelisted bot",
-          async: true,
-          values: [],
-          multiple: true,
-        },
-      },
-    },
-    isApplicableTo: (_auth, resource) => {
-      if (!resource) {
-        return false;
-      }
-      return resource.connectorProvider === cfg.providerType;
-    },
-    populateAsyncArgs: async (auth, resource) => {
-      if (!resource) {
-        return new Err(new Error("Data source not found."));
-      }
-
-      const groups = await GroupResource.listAllWorkspaceGroups(auth);
-
-      return new Ok({
-        groupIds: groups.map((group) => ({
-          value: group.sId,
-          label: group.name,
-        })),
-      });
-    },
-    execute: async (auth, resource, args) => {
-      const owner = auth.getNonNullableWorkspace();
-      const { botName, groupIds } = args;
-
-      if (!resource) {
-        return new Err(new Error("Data source not found."));
-      }
-
-      if (!botName.trim()) {
-        return new Err(new Error("Bot name is required"));
-      }
-
-      if (!groupIds || groupIds.length === 0) {
-        return new Err(new Error("Groups selection is required"));
-      }
-
-      // Always include the Workspace (global) group.
-      const workspaceGroupRes =
-        await GroupResource.fetchWorkspaceGlobalGroup(auth);
-      if (workspaceGroupRes.isErr()) {
-        return new Err(new Error("Failed to fetch workspace global group"));
-      }
-
-      if (!groupIds.includes(workspaceGroupRes.value.sId)) {
-        groupIds.push(workspaceGroupRes.value.sId);
-      }
-
-      const connectorsAPI = new ConnectorsAPI(
-        config.getConnectorsAPIConfig(),
-        logger
-      );
-
-      const whitelistBotCmd: AdminCommandType = {
-        majorCommand: "slack",
-        command: "whitelist-bot",
-        args: {
-          botName,
-          wId: owner.sId,
-          groupId: groupIds.join(","),
-          whitelistType: cfg.whitelistType,
-          providerType: cfg.providerType,
-        },
-      };
-
-      const adminCommandRes = await connectorsAPI.admin(whitelistBotCmd);
-      if (adminCommandRes.isErr()) {
-        return new Err(
-          new Error(`Failed to whitelist bot: ${adminCommandRes.error.message}`)
-        );
-      }
-
-      const isEU = regionsConfig.getCurrentRegion() === "europe-west1";
-      const metabaseUrl = isEU
-        ? `https://eu.metabase.dust.tt/question/46-whitelisted-bots-given-connector?connectorId=${resource.connectorId}`
-        : `https://metabase.dust.tt/question/637-whitelisted-bots-given-connector?connectorId=${resource.connectorId}`;
-
-      return new Ok({
-        display: "textWithLink",
-        value: `Successfully whitelisted Slack bot "${botName}" for ${cfg.whitelistType} in the selected group and the Workspace group.`,
-        link: metabaseUrl,
-        linkText: "View all whitelisted bots for this workspace",
-      });
-    },
-  });
+function getMetabaseUrl(connectorId: string | null) {
+  const isEU = regionsConfig.getCurrentRegion() === "europe-west1";
+  return isEU
+    ? `https://eu.metabase.dust.tt/question/46-whitelisted-bots-given-connector?connectorId=${connectorId}`
+    : `https://metabase.dust.tt/question/637-whitelisted-bots-given-connector?connectorId=${connectorId}`;
 }
 
-export const slackIndexBotMessagesPlugin = makeSlackWhitelistBotPlugin({
-  id: "slack-index-bot-messages",
-  name: "Whitelist Slack bot message indexing",
-  description:
-    "Whitelist a Slack bot or workflow so its messages are indexed and searchable in Dust",
-  providerType: "slack",
-  whitelistType: "index_messages",
+export const slackIndexBotMessagesPlugin = createPlugin({
+  manifest: {
+    id: "slack-index-bot-messages",
+    name: "Whitelist Slack bot message indexing",
+    description:
+      "Whitelist a Slack bot or workflow so its messages are indexed and searchable in Dust",
+    resourceTypes: ["data_sources"],
+    args: {
+      botName: {
+        type: "string",
+        label: "Bot/Workflow Name",
+        description: "Name of the Slack bot or workflow to whitelist",
+      },
+    },
+  },
+  isApplicableTo: (_auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+    return resource.connectorProvider === "slack";
+  },
+  execute: async (auth, resource, args) => {
+    const owner = auth.getNonNullableWorkspace();
+    const { botName } = args;
+
+    if (!resource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (!botName.trim()) {
+      return new Err(new Error("Bot name is required"));
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const whitelistBotCmd: AdminCommandType = {
+      majorCommand: "slack",
+      command: "whitelist-bot",
+      args: {
+        botName,
+        wId: owner.sId,
+        whitelistType: "index_messages",
+        providerType: "slack",
+      },
+    };
+
+    const adminCommandRes = await connectorsAPI.admin(whitelistBotCmd);
+    if (adminCommandRes.isErr()) {
+      return new Err(
+        new Error(`Failed to whitelist bot: ${adminCommandRes.error.message}`)
+      );
+    }
+
+    return new Ok({
+      display: "textWithLink",
+      value: `Successfully whitelisted Slack bot "${botName}" for message indexing.`,
+      link: getMetabaseUrl(resource.connectorId),
+      linkText: "View all whitelisted bots for this workspace",
+    });
+  },
 });
 
-export const slackWhitelistBotPlugin = makeSlackWhitelistBotPlugin({
-  id: "slack-whitelist-bot-summoning",
-  name: "Whitelist Slack bot agent summoning",
-  description: "Whitelist a Slack bot or workflow so it can summon dust agents",
-  providerType: "slack_bot",
-  whitelistType: "summon_agent",
+export const slackWhitelistBotPlugin = createPlugin({
+  manifest: {
+    id: "slack-whitelist-bot-summoning",
+    name: "Whitelist Slack bot agent summoning",
+    description:
+      "Whitelist a Slack bot or workflow so it can summon dust agents",
+    resourceTypes: ["data_sources"],
+    args: {
+      botName: {
+        type: "string",
+        label: "Bot/Workflow Name",
+        description: "Name of the Slack bot or workflow to whitelist",
+      },
+      groupIds: {
+        type: "enum",
+        label: "Groups",
+        description:
+          "Groups the bot can access when summoning agents — only agents belonging to these groups will be available to the bot",
+        async: true,
+        values: [],
+        multiple: true,
+      },
+    },
+  },
+  isApplicableTo: (_auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+    return resource.connectorProvider === "slack_bot";
+  },
+  populateAsyncArgs: async (auth, resource) => {
+    if (!resource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const groups = await GroupResource.listAllWorkspaceGroups(auth);
+
+    return new Ok({
+      groupIds: groups.map((group) => ({
+        value: group.sId,
+        label: group.name,
+      })),
+    });
+  },
+  execute: async (auth, resource, args) => {
+    const owner = auth.getNonNullableWorkspace();
+    const { botName, groupIds } = args;
+
+    if (!resource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (!botName.trim()) {
+      return new Err(new Error("Bot name is required"));
+    }
+
+    if (!groupIds || groupIds.length === 0) {
+      return new Err(new Error("Groups selection is required"));
+    }
+
+    // Always include the Workspace (global) group.
+    const workspaceGroupRes =
+      await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (workspaceGroupRes.isErr()) {
+      return new Err(new Error("Failed to fetch workspace global group"));
+    }
+
+    const allGroupIds = groupIds.includes(workspaceGroupRes.value.sId)
+      ? groupIds
+      : [...groupIds, workspaceGroupRes.value.sId];
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const whitelistBotCmd: AdminCommandType = {
+      majorCommand: "slack",
+      command: "whitelist-bot",
+      args: {
+        botName,
+        wId: owner.sId,
+        groupId: allGroupIds.join(","),
+        whitelistType: "summon_agent",
+        providerType: "slack_bot",
+      },
+    };
+
+    const adminCommandRes = await connectorsAPI.admin(whitelistBotCmd);
+    if (adminCommandRes.isErr()) {
+      return new Err(
+        new Error(`Failed to whitelist bot: ${adminCommandRes.error.message}`)
+      );
+    }
+
+    return new Ok({
+      display: "textWithLink",
+      value: `Successfully whitelisted Slack bot "${botName}" for agent summoning in the selected groups and the Workspace group.`,
+      link: getMetabaseUrl(resource.connectorId),
+      linkText: "View all whitelisted bots for this workspace",
+    });
+  },
 });


### PR DESCRIPTION
## Description

`groupIds` in the slack bot whitelist are only used at runtime for the `summon_agent` flow (scoping which agents a bot can invoke via `X-Dust-Group-Ids` header). For `index_messages`, only the bot name matters — the runtime check (`isBotWhitelistedToIndexMessages`) ignores groups entirely.

This splits the shared `makeSlackWhitelistBotPlugin` factory into two separate plugins so the `index_messages` plugin no longer asks for groups it doesn't use, and makes `groupId` optional in the CLI (required only for `summon_agent`). Also clarifies the groups description for `summon_agent` to explain what it actually controls.