### PR TITLE
Fix issue causing text to remain readonly after Accept All

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -278,7 +278,7 @@ describe("InstructionSuggestionExtension", () => {
       expect(getActiveSuggestionIds(editor.state)).toHaveLength(0);
     });
 
-    it("should correctly map positions when accepting multiple suggestions", () => {
+    it("should correctly map positions when accepting multiple suggestions individually", () => {
       // Create two paragraphs.
       editor.commands.setContent("First paragraph\n\nSecond paragraph", {
         contentType: "markdown",
@@ -310,6 +310,38 @@ describe("InstructionSuggestionExtension", () => {
       expect(text).toContain("New second");
       expect(text).not.toContain("First paragraph");
       expect(text).not.toContain("Second paragraph");
+    });
+
+    it("should accept all suggestions at once and remove all from plugin state", () => {
+      editor.commands.setContent("First paragraph\n\nSecond paragraph", {
+        contentType: "markdown",
+      });
+
+      const [blockId1, blockId2] = getBlockIds(editor);
+
+      editor.commands.applySuggestion({
+        id: "batch-1",
+        targetBlockId: blockId1,
+        content: "<p>Updated first</p>",
+      });
+
+      editor.commands.applySuggestion({
+        id: "batch-2",
+        targetBlockId: blockId2,
+        content: "<p>Updated second</p>",
+      });
+
+      expect(getActiveSuggestionIds(editor.state)).toHaveLength(2);
+
+      editor.commands.acceptAllSuggestions();
+
+      const text = editor.getText();
+      expect(text).toContain("Updated first");
+      expect(text).toContain("Updated second");
+      expect(text).not.toContain("First paragraph");
+      expect(text).not.toContain("Second paragraph");
+
+      expect(getActiveSuggestionIds(editor.state)).toHaveLength(0);
     });
   });
 

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -755,52 +755,19 @@ export const InstructionSuggestionExtension = Extension.create({
 
       acceptAllSuggestions:
         () =>
-        ({ state, tr, dispatch }) => {
-          const pluginState = pluginKey.getState(state);
-          if (!pluginState || pluginState.suggestions.size === 0) {
+        ({ commands, state, tr }) => {
+          const ids = getActiveSuggestionIds(state);
+          if (ids.length === 0) {
             return false;
           }
 
-          if (dispatch) {
-            const schema = state.schema;
-            const ids: string[] = [];
-
-            for (const [suggestionId, suggestion] of pluginState.suggestions) {
-              ids.push(suggestionId);
-
-              for (const op of suggestion.operations) {
-                const found = findBlockByBlockId(tr.doc, op.targetBlockId);
-                if (!found) {
-                  continue;
-                }
-
-                const { node: blockNode, pos: blockPos } = found;
-                const newNode = parseHTMLToBlock(
-                  op.newContent,
-                  schema,
-                  op.targetBlockId
-                );
-                if (!newNode) {
-                  continue;
-                }
-
-                if (blockNode.type === newNode.type) {
-                  const from = blockPos + 1;
-                  const to = blockPos + blockNode.nodeSize - 1;
-                  tr.replaceWith(from, to, newNode.content);
-                } else {
-                  tr.replaceWith(
-                    blockPos,
-                    blockPos + blockNode.nodeSize,
-                    newNode
-                  );
-                }
-              }
-            }
-
-            tr.setMeta(pluginKey, { type: "removeAll", ids });
-            dispatch(tr);
-          }
+          // commands.acceptSuggestion shares the same tr, so content
+          // replacements accumulate correctly. However each call overwrites
+          // the plugin meta, so only the last suggestion would be removed
+          // from plugin state. We fix this by overwriting the meta with all
+          // IDs after the loop.
+          ids.forEach((id) => commands.acceptSuggestion(id));
+          tr.setMeta(pluginKey, { type: "removeAll", ids });
 
           return true;
         },
@@ -808,13 +775,12 @@ export const InstructionSuggestionExtension = Extension.create({
       rejectAllSuggestions:
         () =>
         ({ state, tr, dispatch }) => {
-          const pluginState = pluginKey.getState(state);
-          if (!pluginState || pluginState.suggestions.size === 0) {
+          const ids = getActiveSuggestionIds(state);
+          if (ids.length === 0) {
             return false;
           }
 
           if (dispatch) {
-            const ids = Array.from(pluginState.suggestions.keys());
             tr.setMeta(pluginKey, { type: "removeAll", ids });
             dispatch(tr);
           }

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -766,10 +766,12 @@ export const InstructionSuggestionExtension = Extension.create({
           // the plugin meta, so only the last suggestion would be removed
           // from plugin state. We fix this by overwriting the meta with all
           // IDs after the loop.
-          ids.forEach((id) => commands.acceptSuggestion(id));
+          const allSucceeded = ids
+            .map((id) => commands.acceptSuggestion(id))
+            .every(Boolean);
           tr.setMeta(pluginKey, { type: "removeAll", ids });
 
-          return true;
+          return allSucceeded;
         },
 
       rejectAllSuggestions:

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -456,6 +456,14 @@ function createPlugin(getHighlightedId: () => string | null) {
           dirty = true;
         }
 
+        if (meta?.type === "removeAll") {
+          suggestions = new Map(suggestions);
+          for (const id of meta.ids) {
+            suggestions.delete(id);
+          }
+          dirty = true;
+        }
+
         if (meta?.type === "highlight") {
           highlightedId = meta.id;
           dirty = true;
@@ -747,20 +755,71 @@ export const InstructionSuggestionExtension = Extension.create({
 
       acceptAllSuggestions:
         () =>
-        ({ commands, editor }) => {
-          const ids = getActiveSuggestionIds(editor.state);
+        ({ state, tr, dispatch }) => {
+          const pluginState = pluginKey.getState(state);
+          if (!pluginState || pluginState.suggestions.size === 0) {
+            return false;
+          }
 
-          // Process all suggestions even if some fail, return true only if all succeeded.
-          return ids.map((id) => commands.acceptSuggestion(id)).every(Boolean);
+          if (dispatch) {
+            const schema = state.schema;
+            const ids: string[] = [];
+
+            for (const [suggestionId, suggestion] of pluginState.suggestions) {
+              ids.push(suggestionId);
+
+              for (const op of suggestion.operations) {
+                const found = findBlockByBlockId(tr.doc, op.targetBlockId);
+                if (!found) {
+                  continue;
+                }
+
+                const { node: blockNode, pos: blockPos } = found;
+                const newNode = parseHTMLToBlock(
+                  op.newContent,
+                  schema,
+                  op.targetBlockId
+                );
+                if (!newNode) {
+                  continue;
+                }
+
+                if (blockNode.type === newNode.type) {
+                  const from = blockPos + 1;
+                  const to = blockPos + blockNode.nodeSize - 1;
+                  tr.replaceWith(from, to, newNode.content);
+                } else {
+                  tr.replaceWith(
+                    blockPos,
+                    blockPos + blockNode.nodeSize,
+                    newNode
+                  );
+                }
+              }
+            }
+
+            tr.setMeta(pluginKey, { type: "removeAll", ids });
+            dispatch(tr);
+          }
+
+          return true;
         },
 
       rejectAllSuggestions:
         () =>
-        ({ commands, editor }) => {
-          const ids = getActiveSuggestionIds(editor.state);
+        ({ state, tr, dispatch }) => {
+          const pluginState = pluginKey.getState(state);
+          if (!pluginState || pluginState.suggestions.size === 0) {
+            return false;
+          }
 
-          // Process all suggestions even if some fail, return true only if all succeeded.
-          return ids.map((id) => commands.rejectSuggestion(id)).every(Boolean);
+          if (dispatch) {
+            const ids = Array.from(pluginState.suggestions.keys());
+            tr.setMeta(pluginKey, { type: "removeAll", ids });
+            dispatch(tr);
+          }
+
+          return true;
         },
 
       setHighlightedSuggestion:


### PR DESCRIPTION
## Description

- Fix a bug where using "Accept All" on copilot instruction suggestions left the accepted text readonly/uneditable
- Root cause: acceptAllSuggestions called commands.acceptSuggestion(id) in a loop, but tiptap's commands shares a single transaction — each call's setMeta overwrote the previous one, so only the last suggestion was removed from plugin state while the rest kept
  blocking edits via filterTransaction
- Fix: add a removeAll plugin meta type, and after the loop overwrite the meta with all suggestion IDs at once

## Tests

new unit test

## Risk

Low, copilot under flag

## Deploy Plan

Front