### PR TITLE
[front] fix: add document ID fallback in `api/v1` endpoint to upload documents

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,6 +1,5 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
-import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes_constants";
@@ -591,9 +590,9 @@ async function handler(
         ?.substring(6)
         ?.trim();
 
-      // Use titleInTags if no title is provided.
+      // Use titleInTags if no title is provided, then documentId as last resort (same behavior as uploading in the web app).
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      const title = r.data.title?.trim() || titleInTags || UNTITLED_TITLE;
+      const title = r.data.title?.trim() || titleInTags || documentId;
 
       if (!titleInTags) {
         tags.push(`title:${title}`);


### PR DESCRIPTION
## Description

- Related [thread](https://dust4ai.slack.com/archives/C06N6P4M9F1/p1772463733774239).
- This PR adds a fallback for the title on the `document_id` for uploads via the public API.
- This behavior mimics what we do in the web app when uploading to a folder.
- `connectors` always provide a title, enforced by the typing in `_upsertDataSourceDocument`, so this really only target public API users.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
