### PR TITLE
[front] feat: Add dust-base sandbox image

### DIFF
--- a/front/lib/api/sandbox/image/dust-base.ts
+++ b/front/lib/api/sandbox/image/dust-base.ts
@@ -1,0 +1,137 @@
+/**
+ * Dust base sandbox image.
+ *
+ * This module defines the standard Dust sandbox image with all
+ * pre-installed tools and packages using the imperative builder API.
+ */
+
+import type { Authenticator } from "@app/lib/auth";
+
+import { SandboxImage } from "./sandbox_image";
+import type { NetworkPolicy } from "./types";
+
+// TODO(@henry): Change this once S7 is up and running
+export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
+  mode: "deny_all",
+  allowlist: [
+    "storage.googleapis.com",
+    "*.dust.tt",
+    "pypi.org",
+    "registry.npmjs.org",
+    "github.com",
+    "static.rust-lang.org",
+    "crates.io",
+    "static.crates.io",
+    "index.crates.io",
+  ],
+};
+
+export function getSandboxImage(_auth?: Authenticator): SandboxImage {
+  return DUST_BASE_IMAGE;
+}
+
+/**
+ * The base Dust sandbox image.
+ *
+ * Includes common development tools, Python data science packages,
+ * Node.js tooling, and the dust sandbox CLI.
+ */
+export const DUST_BASE_IMAGE = SandboxImage.fromUbuntu("22.04")
+  // Install build essentials (not registered as user-facing tools)
+  // TODO (@jd): build an optimized base docker image that can be pulled
+  // with npm/python/rust bootstrapping
+  .runCmd(
+    "sudo apt-get update && sudo apt-get install -y curl ca-certificates gnupg build-essential"
+  )
+  .setEnv({
+    NPM_CONFIG_PREFIX: "/opt/npm-global",
+    CARGO_HOME: "/opt/cargo",
+    RUSTUP_HOME: "/opt/rustup",
+    VIRTUAL_ENV: "/opt/venv",
+  })
+  // Install uv, then Python 3.14 via uv (not bound to Ubuntu's old Python)
+  .runCmd("curl -LsSf https://astral.sh/uv/install.sh | sh")
+  .runCmd("uv python install 3.14")
+  // Create venv at user-writable location with uv-managed Python
+  .runCmd(
+    "sudo mkdir -p /opt/venv && sudo chmod -R 777 /opt/venv && " +
+      "uv venv /opt/venv --python 3.14"
+  )
+  // Install Node.js via nodesource
+  .runCmd(
+    "curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - " +
+      "&& sudo apt-get install -y --no-install-recommends nodejs"
+  )
+  .runCmd("sudo mkdir -p /opt/npm-global && sudo chmod -R 777 /opt/npm-global")
+  .runCmd("sudo mkdir -p /opt/bin && sudo chmod -R 777 /opt/bin")
+  .runCmd(
+    "sudo mkdir -p /opt/cargo /opt/rustup && sudo chmod -R 777 /opt/cargo /opt/rustup"
+  )
+  // Set environment variables for build-time operations (NOT persisted to runtime).
+  // E2B's setEnvs() only applies during build, not in the snapshot.
+  // Install Rust
+  .runCmd(
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal " +
+      "&& sudo chmod -R 777 /opt/cargo /opt/rustup"
+  )
+  // Everything above would typically be in a Docker image
+  // Install system tools
+  .registerTool(
+    [
+      { name: "git", description: "Version control system" },
+      { name: "jq", description: "JSON processor" },
+      { name: "pandoc", description: "Document converter" },
+      { name: "imagemagick", description: "Image manipulation" },
+      { name: "ffmpeg", description: "Media processing" },
+      { name: "lsb-release", description: "Linux distribution info" },
+    ],
+    {
+      installCmd:
+        "sudo apt-get install -y git jq pandoc imagemagick ffmpeg lsb-release",
+    }
+  )
+  // Register Python runtime
+  .registerTool({ name: "python", description: "Python interpreter" })
+  // Install Python packages
+  .registerTool(
+    [
+      { name: "pandas", description: "Data analysis library" },
+      { name: "numpy", description: "Numerical computing" },
+      { name: "matplotlib", description: "Plotting library" },
+      { name: "requests", description: "HTTP library" },
+      { name: "openpyxl", description: "Excel file support" },
+      { name: "pdfplumber", description: "PDF extraction" },
+    ],
+    {
+      installCmd:
+        "uv pip install --python /opt/venv pandas numpy matplotlib requests openpyxl pdfplumber",
+    }
+  )
+  // Install Node packages
+  .registerTool(
+    [
+      { name: "typescript", description: "TypeScript compiler" },
+      { name: "tsx", description: "TypeScript executor" },
+      { name: "bun", description: "JavaScript runtime" },
+    ],
+    { installCmd: "npm install -g typescript tsx bun" }
+  )
+  // Install Dust sandbox CLI
+  .registerTool(
+    { name: "dsbx", description: "Dust CLI" },
+    {
+      installCmd:
+        "git clone --depth 1 https://github.com/dust-tt/dust.git /tmp/dust && " +
+        "cargo install --path /tmp/dust/cli/dust-sandbox --root /opt/cargo && " +
+        "sudo rm -rf /tmp/dust",
+    }
+  )
+  // Persist PATH and VIRTUAL_ENV to /etc/profile.d/ so they're available at runtime.
+  // E2B's setEnvs() only applies during build, so we write to the filesystem snapshot.
+  .runCmd(
+    'echo "export PATH=/opt/venv/bin:/opt/cargo/bin:/opt/bin:/opt/npm-global/bin:\\$PATH" | sudo tee /etc/profile.d/dust-path.sh && ' +
+      'echo "export VIRTUAL_ENV=/opt/venv" | sudo tee -a /etc/profile.d/dust-path.sh'
+  )
+  .withResources({ vcpu: 2, memoryMb: 2048 })
+  .withNetwork(ALLOWLIST_NETWORK_POLICY)
+  .setWorkdir("/home/user");

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -1,3 +1,4 @@
+export { DUST_BASE_IMAGE, getSandboxImage } from "./dust-base";
 export { SandboxImage } from "./sandbox_image";
 export type {
   BaseImage,

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -33,6 +33,7 @@ export class SandboxImage {
   readonly resources: SandboxResources;
   readonly network: NetworkPolicy;
   readonly workdir: string;
+  readonly startupScript?: string;
 
   private constructor(state: SandboxImageState) {
     this.baseImage = state.baseImage;

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -1,0 +1,202 @@
+import {
+  DUST_BASE_IMAGE,
+  type SandboxImageId,
+} from "@app/lib/api/sandbox/image";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { buildSandboxImage } from "./e2b_template";
+
+const TEST_IMAGE_ID: SandboxImageId = { imageName: "dust-base", tag: "edge" };
+const STAGING_IMAGE_ID: SandboxImageId = {
+  imageName: "dust-base",
+  tag: "staging",
+};
+const PRODUCTION_IMAGE_ID: SandboxImageId = {
+  imageName: "dust-base",
+  tag: "production",
+};
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getE2BSandboxConfig: () => ({
+      apiKey: "default-api-key",
+      domain: "e2b.dev",
+    }),
+  },
+}));
+
+const mockE2BTemplateBuilder = {
+  fromUbuntuImage: vi.fn().mockReturnThis(),
+  fromTemplate: vi.fn().mockReturnThis(),
+  runCmd: vi.fn().mockReturnThis(),
+  copy: vi.fn().mockReturnThis(),
+  setWorkdir: vi.fn().mockReturnThis(),
+  setEnvs: vi.fn().mockReturnThis(),
+};
+
+const mockBuild = vi.fn();
+
+vi.mock("e2b", () => ({
+  Template: Object.assign(() => mockE2BTemplateBuilder, {
+    build: (...args: unknown[]) => mockBuild(...args),
+  }),
+  defaultBuildLogger: vi.fn(() => vi.fn()),
+}));
+
+describe("buildSandboxImage()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls E2B Template builder methods in operation order", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
+
+    const result = await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockE2BTemplateBuilder.fromUbuntuImage).toHaveBeenCalled();
+    expect(mockE2BTemplateBuilder.runCmd).toHaveBeenCalled();
+    expect(mockE2BTemplateBuilder.setEnvs).toHaveBeenCalled();
+    expect(mockE2BTemplateBuilder.setWorkdir).toHaveBeenCalledWith(
+      "/home/user"
+    );
+  });
+
+  test("returns templateId from E2B build result", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "my-template-123" });
+
+    const result = await buildSandboxImage(DUST_BASE_IMAGE, STAGING_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("my-template-123");
+    }
+  });
+
+  test("passes name_tag format to E2B build", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
+
+    await buildSandboxImage(DUST_BASE_IMAGE, PRODUCTION_IMAGE_ID, {
+      apiKey: "test-api-key",
+      domain: "custom.e2b.dev",
+    });
+
+    expect(mockBuild).toHaveBeenCalledWith(
+      mockE2BTemplateBuilder,
+      "dust-base_production",
+      expect.objectContaining({
+        apiKey: "test-api-key",
+        domain: "custom.e2b.dev",
+        cpuCount: DUST_BASE_IMAGE.resources.vcpu,
+        memoryMB: DUST_BASE_IMAGE.resources.memoryMb,
+      })
+    );
+  });
+
+  test("returns Err when E2B build fails", async () => {
+    mockBuild.mockRejectedValueOnce(new Error("Build failed"));
+
+    const result = await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Build failed");
+    }
+  });
+
+  test("installs npm packages via runCmd", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
+
+    await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    const runCmdCalls = mockE2BTemplateBuilder.runCmd.mock.calls;
+    const hasNpmInstall = runCmdCalls.some((call: string[]) =>
+      call[0].includes("npm install -g")
+    );
+    expect(hasNpmInstall).toBe(true);
+  });
+
+  test("processes operations in correct order", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
+
+    const callOrder: string[] = [];
+    mockE2BTemplateBuilder.fromUbuntuImage.mockImplementation(() => {
+      callOrder.push("fromUbuntuImage");
+      return mockE2BTemplateBuilder;
+    });
+    mockE2BTemplateBuilder.setEnvs.mockImplementation(() => {
+      callOrder.push("setEnvs");
+      return mockE2BTemplateBuilder;
+    });
+    mockE2BTemplateBuilder.runCmd.mockImplementation((cmd: string) => {
+      if (cmd.includes("uv pip install")) {
+        callOrder.push("runCmd:pip");
+      } else if (cmd.includes("npm install")) {
+        callOrder.push("runCmd:npm");
+      } else if (cmd.includes("apt-get install")) {
+        callOrder.push("runCmd:apt");
+      } else {
+        callOrder.push("runCmd");
+      }
+      return mockE2BTemplateBuilder;
+    });
+    mockE2BTemplateBuilder.setWorkdir.mockImplementation(() => {
+      callOrder.push("setWorkdir");
+      return mockE2BTemplateBuilder;
+    });
+
+    await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    expect(callOrder[0]).toBe("fromUbuntuImage");
+    expect(callOrder).toContain("setEnvs");
+    expect(callOrder).toContain("runCmd:pip");
+    expect(callOrder).toContain("runCmd:npm");
+    expect(callOrder[callOrder.length - 1]).toBe("setWorkdir");
+  });
+
+  test("passes correct apt packages via runCmd", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
+
+    await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    const runCmdCalls = mockE2BTemplateBuilder.runCmd.mock.calls;
+    const aptInstallCall = runCmdCalls.find(
+      (call: string[]) =>
+        call[0].includes("apt-get install") &&
+        call[0].includes("git") &&
+        call[0].includes("jq") &&
+        call[0].includes("pandoc")
+    );
+    expect(aptInstallCall).toBeDefined();
+  });
+
+  test("passes correct pip packages via runCmd", async () => {
+    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
+
+    await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
+      apiKey: "test-api-key",
+    });
+
+    const runCmdCalls = mockE2BTemplateBuilder.runCmd.mock.calls;
+    const pipInstallCall = runCmdCalls.find(
+      (call: string[]) =>
+        call[0].includes("uv pip install") &&
+        call[0].includes("pandas") &&
+        call[0].includes("numpy") &&
+        call[0].includes("matplotlib")
+    );
+    expect(pipInstallCall).toBeDefined();
+  });
+});

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -17,7 +17,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { TemplateBuilder } from "e2b";
+import type { TemplateBuilder, TemplateClass } from "e2b";
 import { defaultBuildLogger, Template as E2BTemplate } from "e2b";
 
 interface E2BBuildConfig {
@@ -45,7 +45,7 @@ function applyOperation(e2b: TemplateBuilder, op: Operation): TemplateBuilder {
   }
 }
 
-function toE2BTemplate(image: SandboxImage): TemplateBuilder {
+function toE2BTemplate(image: SandboxImage): TemplateClass {
   const baseImage = image.baseImage;
   let e2b: TemplateBuilder;
 

--- a/front/scripts/dev/sandbox_image_build.ts
+++ b/front/scripts/dev/sandbox_image_build.ts
@@ -1,0 +1,111 @@
+import config from "@app/lib/api/config";
+import {
+  getSandboxImage,
+  getSandboxImageNames,
+  getSandboxImageTags,
+  isValidSandboxImageName,
+  isValidSandboxImageTag,
+  type SandboxImageId,
+} from "@app/lib/api/sandbox/image";
+import { buildSandboxImage } from "@app/lib/api/sandbox/providers/e2b_template";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+interface BuildArgs {
+  image: string;
+  tag: string;
+  execute: boolean;
+  skipCache: boolean;
+}
+
+async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
+  const { image: imageName, tag, execute, skipCache } = args;
+
+  if (!isValidSandboxImageName(imageName)) {
+    const available = getSandboxImageNames().join(", ");
+    logger.error(
+      { imageName, available },
+      "Invalid image name. Available images: " + available
+    );
+    return;
+  }
+
+  if (!isValidSandboxImageTag(tag)) {
+    const available = getSandboxImageTags().join(", ");
+    logger.error(
+      { tag, available },
+      "Invalid tag. Available tags: " + available
+    );
+    return;
+  }
+
+  const imageId: SandboxImageId = { imageName, tag };
+  const { apiKey } = config.getE2BSandboxConfig();
+  const sandboxImage = getSandboxImage();
+
+  logger.info(
+    { sandboxImage: "DUST_BASE_IMAGE", imageName, tag },
+    "Using DUST_BASE_IMAGE for build"
+  );
+
+  if (!execute) {
+    logger.info(
+      {
+        imageName,
+        tag,
+        skipCache,
+        hasApiKey: Boolean(apiKey),
+        operationCount: sandboxImage.operations.length,
+        toolCount: sandboxImage.tools.length,
+      },
+      "Would build sandbox image via E2B SDK (dry-run)"
+    );
+    return;
+  }
+
+  const result = await buildSandboxImage(sandboxImage, imageId, {
+    ...(apiKey ? { apiKey } : {}),
+    skipCache,
+  });
+
+  if (result.isErr()) {
+    logger.error({ err: result.error }, "Failed to build sandbox image");
+    return;
+  }
+
+  logger.info(
+    { templateId: result.value, imageName, tag },
+    "Sandbox image built successfully"
+  );
+}
+
+makeScript(
+  {
+    image: {
+      type: "string" as const,
+      demandOption: true,
+      describe: "Image name (e.g., dust-base)",
+    },
+    tag: {
+      type: "string" as const,
+      default: "staging",
+      describe: "E2B image tag",
+    },
+    "skip-cache": {
+      type: "boolean" as const,
+      default: false,
+      describe: "Force rebuild without using cache",
+    },
+  },
+  async (args, logger) => {
+    await buildImage(
+      {
+        image: args.image,
+        tag: args.tag,
+        execute: args.execute,
+        skipCache: args["skip-cache"],
+      },
+      logger
+    );
+  }
+);


### PR DESCRIPTION
## Description

- Add dust-base sandbox image, that contains python rutime (with basic packages), rust (with dsbx) and npm
- Add some scripts to simplify building & testing images 

Fixes https://github.com/dust-tt/tasks/issues/6924

```
# Build an image
npx tsx scripts/dev/sandbox_image_build.ts --image dust-base --tag production --execute

# then 
e2b sandbox create <template>
e2b sandbox exec <sandbox-id> <command>
```

The script is best effort - the goal is just to enable more people to try it and iterate over images.
We will have a better version that won't be in script/dev once we start the CI substream

## Tests

- Tested manually
- Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front