### PR TITLE
[front] feat: add `source` metadata on skills (backend-only)

### DIFF
--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -5,7 +5,11 @@ import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_sour
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { SkillStatus } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillSourceMetadata,
+  SkillSourceType,
+  SkillStatus,
+} from "@app/types/assistant/skill_configuration";
 import isNil from "lodash/isNil";
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 import { DataTypes } from "sequelize";
@@ -53,6 +57,15 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.TEXT,
     allowNull: true,
   },
+  source: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: "manual",
+  },
+  sourceMetadata: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
 } as const satisfies ModelAttributes;
 
 /**
@@ -88,6 +101,9 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare editedBy: ForeignKey<UserModel["id"]> | null;
   // Not a foreign key, only global skills can be extended.
   declare extendedSkillId: string | null;
+
+  declare source: SkillSourceType;
+  declare sourceMetadata: SkillSourceMetadata | null;
 
   declare requestedSpaceIds: number[];
 }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -101,8 +101,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   // Not a foreign key, only global skills can be extended.
   declare extendedSkillId: string | null;
 
-  // TODO(2026-03-03 aubin): make non nullable once backfilled.
-  declare source: SkillSourceType | null;
+  declare source: SkillSourceType;
   declare sourceMetadata: SkillSourceMetadata | null;
 
   declare requestedSpaceIds: number[];

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -59,8 +59,7 @@ const SKILL_MODEL_ATTRIBUTES = {
   },
   source: {
     type: DataTypes.STRING,
-    allowNull: false,
-    defaultValue: "manual",
+    allowNull: true,
   },
   sourceMetadata: {
     type: DataTypes.JSONB,

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -101,7 +101,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   // Not a foreign key, only global skills can be extended.
   declare extendedSkillId: string | null;
 
-  declare source: SkillSourceType;
+  declare source: SkillSourceType | null;
   declare sourceMetadata: SkillSourceMetadata | null;
 
   declare requestedSpaceIds: number[];

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -101,7 +101,8 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   // Not a foreign key, only global skills can be extended.
   declare extendedSkillId: string | null;
 
-  declare source: SkillSourceType;
+  // TODO(2026-03-03 aubin): make non nullable once backfilled.
+  declare source: SkillSourceType | null;
   declare sourceMetadata: SkillSourceMetadata | null;
 
   declare requestedSpaceIds: number[];

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1255,6 +1255,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         workspaceId: auth.getNonNullableWorkspace().id,
         icon: def.icon,
         extendedSkillId: null,
+        source: null,
+        sourceMetadata: null,
       },
       {
         // Global skills do not have data source configurations.
@@ -1463,6 +1465,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           icon: versionModel.icon,
           requestedSpaceIds: versionModel.requestedSpaceIds,
           extendedSkillId: versionModel.extendedSkillId,
+          source: versionModel.source,
+          sourceMetadata: versionModel.sourceMetadata,
         },
         {
           // We ignore data source configurations for historical versions.
@@ -2200,6 +2204,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions: this.globalSId ? null : this.instructions,
       requestedSpaceIds,
       icon: this.icon ?? null,
+      source: this.source,
+      sourceMetadata: this.sourceMetadata,
       tools: this.mcpServerViews.map((view) => {
         const serializedView = view.toJSON();
         const server = serializedView.server;
@@ -2273,6 +2279,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       requestedSpaceIds: this.requestedSpaceIds,
       editedBy: this.editedBy,
       mcpServerViewIds,
+      source: this.source,
+      sourceMetadata: this.sourceMetadata,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/front/migrations/db/migration_528.sql
+++ b/front/migrations/db/migration_528.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "skill_configurations"
+  ADD COLUMN "source" VARCHAR(255),
+  ADD COLUMN "sourceMetadata" JSONB;
+
+ALTER TABLE "skill_versions"
+  ADD COLUMN "source" VARCHAR(255),
+  ADD COLUMN "sourceMetadata" JSONB;

--- a/front/migrations/db/migration_528.sql
+++ b/front/migrations/db/migration_528.sql
@@ -1,7 +1,0 @@
-ALTER TABLE "skill_configurations"
-  ADD COLUMN "source" VARCHAR(255),
-  ADD COLUMN "sourceMetadata" JSONB;
-
-ALTER TABLE "skill_versions"
-  ADD COLUMN "source" VARCHAR(255),
-  ADD COLUMN "sourceMetadata" JSONB;

--- a/front/migrations/db/migration_529.sql
+++ b/front/migrations/db/migration_529.sql
@@ -1,3 +1,7 @@
--- Backfill source to 'web_app' for existing skill_configurations and skill_versions.
-UPDATE "skill_configurations" SET "source" = 'web_app' WHERE "source" IS NULL;
-UPDATE "skill_versions" SET "source" = 'web_app' WHERE "source" IS NULL;
+ALTER TABLE "skill_configurations"
+  ADD COLUMN "source" VARCHAR(255),
+  ADD COLUMN "sourceMetadata" JSONB;
+
+ALTER TABLE "skill_versions"
+  ADD COLUMN "source" VARCHAR(255),
+  ADD COLUMN "sourceMetadata" JSONB;

--- a/front/migrations/db/migration_529.sql
+++ b/front/migrations/db/migration_529.sql
@@ -1,0 +1,3 @@
+-- Backfill source to 'web_app' for existing skill_configurations and skill_versions.
+UPDATE "skill_configurations" SET "source" = 'web_app' WHERE "source" IS NULL;
+UPDATE "skill_versions" SET "source" = 'web_app' WHERE "source" IS NULL;

--- a/front/migrations/db/migration_530.sql
+++ b/front/migrations/db/migration_530.sql
@@ -1,0 +1,3 @@
+-- Backfill source to 'web_app' for existing skill_configurations and skill_versions.
+UPDATE "skill_configurations" SET "source" = 'web_app' WHERE "source" IS NULL;
+UPDATE "skill_versions" SET "source" = 'web_app' WHERE "source" IS NULL;

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -70,9 +70,10 @@ const FileUploadUrlRequestSchema = t.union([
     fileName: t.string,
     fileSize: t.number,
     useCase: t.literal("skill_attachment"),
-    useCaseMetadata: t.type({
-      skillId: t.string,
-    }),
+    useCaseMetadata: t.union([
+      t.type({ skillId: t.string }),
+      t.undefined,
+    ]),
   }),
 ]);
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -66,13 +66,17 @@ const PostSkillRequestBodySchema = t.intersection([
   }),
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
-    source: t.union([
-      t.literal("web_app"),
-      t.literal("github"),
-      t.literal("local_file"),
-    ]),
-    sourceMetadata: t.type({ repoUrl: t.string, filePath: t.string }),
   }),
+  t.union([
+    t.type({
+      source: t.literal("github"),
+      sourceMetadata: t.type({ repoUrl: t.string, filePath: t.string }),
+    }),
+    t.partial({
+      source: t.union([t.literal("web_app"), t.literal("local_file")]),
+      sourceMetadata: t.null,
+    }),
+  ]),
 ]);
 
 type PostSkillRequestBody = t.TypeOf<typeof PostSkillRequestBodySchema>;

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -66,6 +66,12 @@ const PostSkillRequestBodySchema = t.intersection([
   }),
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
+    source: t.union([
+      t.literal("web_app"),
+      t.literal("github"),
+      t.literal("local_file"),
+    ]),
+    sourceMetadata: t.type({ repoUrl: t.string, filePath: t.string }),
   }),
 ]);
 
@@ -340,6 +346,8 @@ async function handler(
           requestedSpaceIds,
           extendedSkillId: body.extendedSkillId,
           icon,
+          source: body.source ?? "web_app",
+          sourceMetadata: body.sourceMetadata ?? null,
         },
         {
           mcpServerViews,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -8,10 +8,10 @@ export const SKILL_SOURCES = ["web_app", "github", "local_file"] as const;
 
 export type SkillSourceType = (typeof SKILL_SOURCES)[number];
 
-export interface SkillSourceMetadata {
+export type SkillSourceMetadata = {
   repoUrl: string;
   filePath: string;
-}
+};
 
 export type SkillType = {
   id: number;

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -4,6 +4,15 @@ import type { UserType } from "@app/types/user";
 
 export type SkillStatus = "active" | "archived" | "suggested";
 
+export const SKILL_SOURCES = ["web_app", "github", "local_file"] as const;
+
+export type SkillSourceType = (typeof SKILL_SOURCES)[number];
+
+export interface SkillSourceMetadata {
+  repoUrl: string;
+  filePath: string;
+}
+
 export type SkillType = {
   id: number;
   sId: string;
@@ -16,6 +25,8 @@ export type SkillType = {
   userFacingDescription: string;
   instructions: string | null;
   icon: string | null;
+  source: SkillSourceType | null;
+  sourceMetadata: SkillSourceMetadata | null;
   requestedSpaceIds: string[];
   tools: MCPServerViewType[];
   fileAttachments: {


### PR DESCRIPTION
## Description

- This PR adds a column to track the source of a skill + some metadata.
- Source can be: created on the web app, imported from github, uploaded from local files.
- This source will be used to handle conflicts on imports: when importing a skill from a repo, if we have a name conflict it's useful to know whether the conflict is on a skill that comes from the same repo or not.
- Backfill is direct SQL, we have ~200k rows to update.
- Will refactor how the front-end passes those once we have github import, for now it's always `web_app`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy front.
- Run backfill.
