### PR TITLE
fix: node24 script to test

### DIFF
--- a/scripts/try-node24.sh
+++ b/scripts/try-node24.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-set -euo pipefail
 
 # Opt-in script to test Node 24 locally.
 # Usage: source scripts/try-node24.sh
-# To switch back: nvm use
+# To switch back: unset DUST_NODE_VERSION && nvm use
+
+# Guard: must be sourced, not executed
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Error: this script must be sourced, not executed."
+  echo "Usage: source scripts/try-node24.sh"
+  exit 1
+fi
 
 NODE24_VERSION="24"
 
@@ -16,7 +22,7 @@ fi
 
 if ! command -v nvm &>/dev/null; then
   echo "Error: nvm is not installed. Install it from https://github.com/nvm-sh/nvm"
-  return 1 2>/dev/null || exit 1
+  return 1
 fi
 
 echo "Installing Node ${NODE24_VERSION} (if not already installed)..."
@@ -25,9 +31,13 @@ nvm install "$NODE24_VERSION"
 echo "Switching to Node ${NODE24_VERSION} for this session..."
 nvm use "$NODE24_VERSION"
 
+# Export so start-mprocs.sh and other scripts respect this choice.
+export DUST_NODE_VERSION="$NODE24_VERSION"
+
 echo ""
 echo "Node: $(node -v)"
 echo "npm:  $(npm -v)"
 echo ""
 echo "You're now running Node ${NODE24_VERSION}. The .nvmrc still points to 22."
-echo "Run 'nvm use' to switch back."
+echo "DUST_NODE_VERSION=${NODE24_VERSION} is exported for downstream scripts."
+echo "Run 'unset DUST_NODE_VERSION && nvm use' to switch back."

--- a/tools/start-mprocs.sh
+++ b/tools/start-mprocs.sh
@@ -3,13 +3,21 @@
 # Where the script is defined, absolute path
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
-# Source and install the correct node version using nvm
-source ~/.nvm/nvm.sh && nvm install
+# Source and install the correct node version using nvm.
+# If DUST_NODE_VERSION is set (e.g. via `source scripts/try-node24.sh`), use that version
+# instead of the .nvmrc default.
+source ~/.nvm/nvm.sh
+if [ -n "${DUST_NODE_VERSION:-}" ]; then
+  nvm install "$DUST_NODE_VERSION"
+  nvm use "$DUST_NODE_VERSION"
+else
+  nvm install
+fi
 
 # Tiny script to start the dev environment using mprocs.
 # Needed to clear the dist of the sdks-js project before starting front so it waits for the sdks-js to be ready.
 
-# Clear the dist of the sdks-js project
+# Clear the dist of the sdks-js projectst
 rm -rf "$SCRIPT_DIR"/../sdks/js/dist
 
 # Install npm workspaces dependencies


### PR DESCRIPTION
## Description

try-node24.sh:                                                                                                                                                                                                                         
  - Removed set -euo pipefail — it was leaking strict shell options into the caller's shell when sourced
  - Added a guard that errors out if you run the script instead of sourcing it (running it creates a subshell, so nvm use changes wouldn't persist)                                                                                      
  - Now exports DUST_NODE_VERSION=24 so downstream scripts know to use node 24

  start-mprocs.sh:
  - Was blindly doing nvm install (which reads .nvmrc → node 22), overriding whatever you set with try-node24.sh
  - Now checks for DUST_NODE_VERSION first — if set, uses that version instead of .nvmrc

  Usage flow:
  source scripts/try-node24.sh   # switches to node 24 + exports DUST_NODE_VERSION <= main diff
  node --version                  # → v24.x
  ./tools/start-mprocs.sh        # respects DUST_NODE_VERSION, stays on node 24


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
