### PR TITLE
[Snowflake MCP] add user_email to Snowflake MCP query tags

### DIFF
--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -27,6 +27,7 @@ interface SnowflakeQueryTagMetadata {
   agent_name: string;
   conversation_id: string;
   user_id: string | null;
+  user_email: string | null;
 }
 
 // Builds Snowflake query tag for agent-level usage tracking.
@@ -49,6 +50,7 @@ function buildQueryTagMetadata(
     agent_name: agentConfiguration.name,
     conversation_id: conversation.sId,
     user_id: user?.sId ?? null,
+    user_email: user?.email ?? null,
   };
 
   return JSON.stringify(metadata);


### PR DESCRIPTION
## Description

Adds `user_email` to the Snowflake MCP query tag metadata. This extends the existing audit tracking (introduced in #21624) to include the user's email address alongside workspace ID, agent ID, agent name, conversation ID, and user ID. This additional information will help customers build more detailed usage reports and dashboards in Snowflake.

## Risk

None - query tags are passive metadata that don't affect query execution.

## Tests

Manually tested with Snowflake MCP connection.

## Deploy Plan

Run front