### PR TITLE
feat(sandbox): add call_tool endpoint

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -151,11 +151,11 @@ export async function connectToMCPServer(
   {
     params,
     agentLoopContext,
-    directToolExecution,
+    allowDirectToolExecution,
   }: {
     params: MCPConnectionParams;
     agentLoopContext?: AgentLoopContextType;
-    directToolExecution?: boolean;
+    allowDirectToolExecution?: boolean;
   }
 ): Promise<
   Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>
@@ -185,7 +185,7 @@ export async function connectToMCPServer(
           await mcpClient.connect(client);
 
           // For internal servers, to avoid any unnecessary work, we only try to fetch the token if we are trying to run a tool.
-          if (agentLoopContext?.runContext || directToolExecution) {
+          if (agentLoopContext?.runContext || allowDirectToolExecution) {
             const bearerTokenCredentials =
               await InternalMCPServerInMemoryResource.fetchDecryptedCredentials(
                 auth,
@@ -368,7 +368,7 @@ export async function connectToMCPServer(
             // Otherwise, for listing tools etc.., we use the workspace token.
             oauthConnectionType =
               params.oAuthUseCase === "personal_actions" &&
-              (agentLoopContext?.runContext || directToolExecution)
+              (agentLoopContext?.runContext || allowDirectToolExecution)
                 ? "personal"
                 : "workspace";
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -151,9 +151,11 @@ export async function connectToMCPServer(
   {
     params,
     agentLoopContext,
+    directToolExecution,
   }: {
     params: MCPConnectionParams;
     agentLoopContext?: AgentLoopContextType;
+    directToolExecution?: boolean;
   }
 ): Promise<
   Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>
@@ -183,7 +185,7 @@ export async function connectToMCPServer(
           await mcpClient.connect(client);
 
           // For internal servers, to avoid any unnecessary work, we only try to fetch the token if we are trying to run a tool.
-          if (agentLoopContext?.runContext) {
+          if (agentLoopContext?.runContext || directToolExecution) {
             const bearerTokenCredentials =
               await InternalMCPServerInMemoryResource.fetchDecryptedCredentials(
                 auth,
@@ -366,7 +368,7 @@ export async function connectToMCPServer(
             // Otherwise, for listing tools etc.., we use the workspace token.
             oauthConnectionType =
               params.oAuthUseCase === "personal_actions" &&
-              agentLoopContext?.runContext
+              (agentLoopContext?.runContext || directToolExecution)
                 ? "personal"
                 : "workspace";
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -1,0 +1,134 @@
+import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { CallMCPToolResponseType } from "@dust-tt/client";
+import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<CallMCPToolResponseType>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { svId } = req.query;
+  if (!isString(svId)) {
+    return res.status(400).json({
+      error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid svId parameter.",
+      },
+    });
+  }
+
+  const view = await MCPServerViewResource.fetchById(auth, svId);
+  if (!view) {
+    return res.status(404).json({
+      error: {
+        type: "mcp_server_view_not_found",
+        message: "MCP server view not found.",
+      },
+    });
+  }
+
+  if (view.space.sId !== space.sId) {
+    return res.status(404).json({
+      error: {
+        type: "mcp_server_view_not_found",
+        message: "MCP server view not found in this space.",
+      },
+    });
+  }
+
+  const { method } = req;
+
+  switch (method) {
+    case "POST": {
+      const bodyRes = CallMCPToolRequestBodySchema.safeParse(req.body);
+      if (!bodyRes.success) {
+        return res.status(400).json({
+          error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${bodyRes.error.message}`,
+          },
+        });
+      }
+
+      const { toolName, arguments: toolArgs } = bodyRes.data;
+
+      const clientRes = await connectToMCPServer(auth, {
+        params: {
+          type: "mcpServerId",
+          mcpServerId: view.mcpServerId,
+          oAuthUseCase: view.oAuthUseCase,
+        },
+        directToolExecution: true,
+      });
+
+      if (clientRes.isErr()) {
+        const err = clientRes.error;
+
+        logger.error({ error: err, svId }, "Failed to connect to MCP server");
+        return res.status(500).json({
+          error: {
+            type: "internal_server_error",
+            message: "Failed to connect to MCP server.",
+          },
+        });
+      }
+
+      const mcpClient = clientRes.value;
+      try {
+        const result = await mcpClient.callTool({
+          name: toolName,
+          arguments: toolArgs,
+        });
+
+        if (!("content" in result) || !Array.isArray(result.content)) {
+          return res.status(500).json({
+            error: {
+              type: "internal_server_error",
+              message: "Unexpected tool result format.",
+            },
+          });
+        }
+
+        const content: CallMCPToolResponseType["result"]["content"] =
+          result.content.map((block: { type: string; text?: string }) => ({
+            type: block.type,
+            ...("text" in block ? { text: block.text } : {}),
+          }));
+
+        return res.status(200).json({
+          success: true,
+          result: {
+            content,
+            isError: result.isError === true,
+          },
+        });
+      } finally {
+        await mcpClient.close();
+      }
+    }
+
+    default:
+      return res.status(405).json({
+        error: {
+          type: "method_not_supported_error",
+          message: "Only POST is supported.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -1,10 +1,11 @@
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { CallMCPToolResponseType } from "@dust-tt/client";
@@ -17,10 +18,24 @@ async function handler(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("sandbox_tools")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "MCP is not enabled for this workspace.",
+      },
+    });
+  }
+
   const { svId } = req.query;
   if (!isString(svId)) {
-    return res.status(400).json({
-      error: {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
         type: "invalid_request_error",
         message: "Missing or invalid svId parameter.",
       },
@@ -29,8 +44,9 @@ async function handler(
 
   const view = await MCPServerViewResource.fetchById(auth, svId);
   if (!view) {
-    return res.status(404).json({
-      error: {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
         type: "mcp_server_view_not_found",
         message: "MCP server view not found.",
       },
@@ -38,8 +54,9 @@ async function handler(
   }
 
   if (view.space.sId !== space.sId) {
-    return res.status(404).json({
-      error: {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
         type: "mcp_server_view_not_found",
         message: "MCP server view not found in this space.",
       },
@@ -52,8 +69,9 @@ async function handler(
     case "POST": {
       const bodyRes = CallMCPToolRequestBodySchema.safeParse(req.body);
       if (!bodyRes.success) {
-        return res.status(400).json({
-          error: {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
             type: "invalid_request_error",
             message: `Invalid request body: ${bodyRes.error.message}`,
           },
@@ -68,15 +86,16 @@ async function handler(
           mcpServerId: view.mcpServerId,
           oAuthUseCase: view.oAuthUseCase,
         },
-        directToolExecution: true,
+        allowDirectToolExecution: true,
       });
 
       if (clientRes.isErr()) {
         const err = clientRes.error;
 
         logger.error({ error: err, svId }, "Failed to connect to MCP server");
-        return res.status(500).json({
-          error: {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
             type: "internal_server_error",
             message: "Failed to connect to MCP server.",
           },
@@ -91,8 +110,9 @@ async function handler(
         });
 
         if (!("content" in result) || !Array.isArray(result.content)) {
-          return res.status(500).json({
-            error: {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
               type: "internal_server_error",
               message: "Unexpected tool result format.",
             },
@@ -118,8 +138,9 @@ async function handler(
     }
 
     default:
-      return res.status(405).json({
-        error: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
           type: "method_not_supported_error",
           message: "Only POST is supported.",
         },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3242,6 +3242,30 @@ export type GetMCPServerViewsQueryType = z.infer<
   typeof GetMCPServerViewsQuerySchema
 >;
 
+export const CallMCPToolRequestBodySchema = z.object({
+  toolName: z.string(),
+  arguments: z.record(z.unknown()).optional(),
+});
+
+export type CallMCPToolRequestBodyType = z.infer<
+  typeof CallMCPToolRequestBodySchema
+>;
+
+const CallMCPToolContentBlockSchema = z.object({
+  type: z.string(),
+  text: z.string().optional(),
+});
+
+export const CallMCPToolResponseSchema = z.object({
+  success: z.literal(true),
+  result: z.object({
+    content: z.array(CallMCPToolContentBlockSchema),
+    isError: z.boolean(),
+  }),
+});
+
+export type CallMCPToolResponseType = z.infer<typeof CallMCPToolResponseSchema>;
+
 export const BaseSearchBodySchema = z.object({
   viewType: ContentNodesViewTypeSchema,
   spaceIds: z.array(z.string()),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  - New `POST .../mcp_server_views/[svId]/call_tool` endpoint for direct MCP tool execution
  - Add `directToolExecContext` param to `connectToMCPServer` to enable OAuth injection without a full agent loop context
  - Add `CallMCPToolRequestBodySchema`, `CallMCPToolResponseSchema` to JS SDK

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

- Tested end-to-end: sandbox token → call_tool → Gmail get_messages returns real emails

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front