### PR TITLE
Use a static first message in copilot new agent scenario

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -132,6 +132,7 @@ export const CopilotPanelProvider = ({
       metadata: {
         copilotTargetAgentConfigurationId: targetAgentConfigurationId,
         copilotTargetAgentConfigurationVersion: targetAgentConfigurationVersion,
+        copilotIsNewAgent: isNewAgent,
       },
       skipToolsValidation: true,
     });
@@ -153,6 +154,7 @@ export const CopilotPanelProvider = ({
     copilotAgentId,
     createConversationWithMessage,
     getFirstMessage,
+    isNewAgent,
     useCase,
     sendNotification,
     targetAgentConfigurationId,

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -132,7 +132,7 @@ export const CopilotPanelProvider = ({
       metadata: {
         copilotTargetAgentConfigurationId: targetAgentConfigurationId,
         copilotTargetAgentConfigurationVersion: targetAgentConfigurationVersion,
-        copilotIsNewAgent: isNewAgent,
+        copilotIsNewAgentFromScratch: useCase === "new",
       },
       skipToolsValidation: true,
     });
@@ -154,7 +154,6 @@ export const CopilotPanelProvider = ({
     copilotAgentId,
     createConversationWithMessage,
     getFirstMessage,
-    isNewAgent,
     useCase,
     sendNotification,
     targetAgentConfigurationId,

--- a/front/hooks/useCopilotFirstMessage.ts
+++ b/front/hooks/useCopilotFirstMessage.ts
@@ -15,7 +15,7 @@ const COPILOT_USE_CASES = [
 type CopilotUseCase = (typeof COPILOT_USE_CASES)[number];
 
 const NEW_AGENT_FIRST_MESSAGE = `<dust_system>
-This is a new agent. To start the conversation, you should NOT call any tools. 
+This is a new agent. To start the conversation, you should NOT call any tools.
 Just ask a very simple question, such as "What would you like to build?"
 </dust_system>`;
 

--- a/front/hooks/useCopilotFirstMessage.ts
+++ b/front/hooks/useCopilotFirstMessage.ts
@@ -15,7 +15,7 @@ const COPILOT_USE_CASES = [
 type CopilotUseCase = (typeof COPILOT_USE_CASES)[number];
 
 const NEW_AGENT_FIRST_MESSAGE = `<dust_system>
-This is a new agent. To start the conversation, you should NOT call any tools.
+This is a new agent. To start the conversation, you should NOT call any tools. 
 Just ask a very simple question, such as "What would you like to build?"
 </dust_system>`;
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -501,7 +501,7 @@ export function _getCopilotGlobalAgent(
   // Use a fast model for other first turns and the full model for follow-ups.
   const isFirstTurn = globalAgentContext?.userMessageRank === 0;
   const isNewAgentFromScratchFirstTurn =
-    isFirstTurn && globalAgentContext?.isNewAgentFromScratchCopilot;
+    isFirstTurn && globalAgentContext?.copilotIsNewAgentFromScratch;
   const modelConfiguration = isNewAgentFromScratchFirstTurn
     ? NOOP_MODEL_CONFIG
     : isFirstTurn

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -462,6 +462,8 @@ export function buildCopilotInstructions(
   return parts.join("\n\n");
 }
 
+const COPILOT_NEW_AGENT_STATIC_RESPONSE = "What would you like to build?";
+
 export function _getCopilotGlobalAgent(
   auth: Authenticator,
   {
@@ -513,14 +515,15 @@ export function _getCopilotGlobalAgent(
         modelId: modelConfiguration.modelId,
         temperature: 0.7,
         reasoningEffort: modelConfiguration.defaultReasoningEffort,
+        ...(isNewAgentFirstTurn && {
+          metaData: { staticResponse: COPILOT_NEW_AGENT_STATIC_RESPONSE },
+        }),
       }
     : dummyModelConfiguration;
 
   const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT);
 
-  const instructions = isNewAgentFirstTurn
-    ? "<static_response>What would you like to build?</static_response>"
-    : buildCopilotInstructions(copilotContext);
+  const instructions = buildCopilotInstructions(copilotContext);
 
   return {
     id: -1,

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -500,9 +500,9 @@ export function _getCopilotGlobalAgent(
   // (static response without calling a real LLM).
   // Use a fast model for other first turns and the full model for follow-ups.
   const isFirstTurn = globalAgentContext?.userMessageRank === 0;
-  const isNewAgentFirstTurn =
-    isFirstTurn && globalAgentContext?.isNewAgentCopilot;
-  const modelConfiguration = isNewAgentFirstTurn
+  const isNewAgentFromScratchFirstTurn =
+    isFirstTurn && globalAgentContext?.isNewAgentFromScratchCopilot;
+  const modelConfiguration = isNewAgentFromScratchFirstTurn
     ? NOOP_MODEL_CONFIG
     : isFirstTurn
       ? isProviderWhitelisted(owner, "anthropic")
@@ -515,7 +515,7 @@ export function _getCopilotGlobalAgent(
         modelId: modelConfiguration.modelId,
         temperature: 0.7,
         reasoningEffort: modelConfiguration.defaultReasoningEffort,
-        ...(isNewAgentFirstTurn && {
+        ...(isNewAgentFromScratchFirstTurn && {
           metaData: { staticResponse: COPILOT_NEW_AGENT_STATIC_RESPONSE },
         }),
       }

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -18,6 +18,7 @@ import {
   getSmallWhitelistedModel,
 } from "@app/types/assistant/assistant";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { getCompanyDataAction } from "./shared";
@@ -493,16 +494,19 @@ export function _getCopilotGlobalAgent(
     ...(companyDataAction ? [companyDataAction] : []),
   ];
 
-  // Use a fast model for the very first turn (when the conversation has no
-  // prior exchanges) and the full model for all follow-ups.
-  // Prefer Haiku on the first turn; fall back to the workspace's small model if
-  // Anthropic is not whitelisted.
+  // Use noop model for the first turn of a new agent copilot conversation
+  // (static "What would you like to build?" response without calling a real LLM).
+  // Use a fast model for other first turns and the full model for follow-ups.
   const isFirstTurn = globalAgentContext?.userMessageRank === 0;
-  const modelConfiguration = isFirstTurn
-    ? isProviderWhitelisted(owner, "anthropic")
-      ? CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
-      : getSmallWhitelistedModel(owner)
-    : getLargeWhitelistedModel(owner);
+  const isNewAgentFirstTurn =
+    isFirstTurn && globalAgentContext?.isNewAgentCopilot;
+  const modelConfiguration = isNewAgentFirstTurn
+    ? NOOP_MODEL_CONFIG
+    : isFirstTurn
+      ? isProviderWhitelisted(owner, "anthropic")
+        ? CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
+        : getSmallWhitelistedModel(owner)
+      : getLargeWhitelistedModel(owner);
   const model = modelConfiguration
     ? {
         providerId: modelConfiguration.providerId,
@@ -514,7 +518,9 @@ export function _getCopilotGlobalAgent(
 
   const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT);
 
-  const instructions = buildCopilotInstructions(copilotContext);
+  const instructions = isNewAgentFirstTurn
+    ? "<static_response>What would you like to build?</static_response>"
+    : buildCopilotInstructions(copilotContext);
 
   return {
     id: -1,

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -497,7 +497,7 @@ export function _getCopilotGlobalAgent(
   ];
 
   // Use noop model for the first turn of a new agent copilot conversation
-  // (static "What would you like to build?" response without calling a real LLM).
+  // (static response without calling a real LLM).
   // Use a fast model for other first turns and the full model for follow-ups.
   const isFirstTurn = globalAgentContext?.userMessageRank === 0;
   const isNewAgentFirstTurn =

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -8,11 +8,8 @@ import type {
   LLMParameters,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
-import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { isTextContent } from "@app/types/assistant/generation";
-
-const STATIC_RESPONSE_REGEX = /<static_response>([\s\S]*?)<\/static_response>/;
 
 const metadata = {
   clientId: "noop" as const,
@@ -27,25 +24,25 @@ interface NoopRequest {
 
 // NoopLLM is a dummy LLM that can respond to special commands.
 export class NoopLLM extends LLM<NoopRequest> {
+  private readonly metaData?: Record<string, unknown>;
+
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters & { modelId: "noop" }
   ) {
     super(auth, "noop", llmParameters);
+    this.metaData = llmParameters.metaData;
   }
 
   protected buildRequestPayload({
     conversation,
-    prompt,
   }: LLMStreamParameters): NoopRequest {
-    // Check for a static response embedded in the system prompt.
-    const promptText = systemPromptToText(prompt);
-    const staticMatch = promptText.match(STATIC_RESPONSE_REGEX);
-    if (staticMatch) {
+    const staticResponse = this.metaData?.staticResponse;
+    if (typeof staticResponse === "string") {
       return {
         type: "noop_request",
         lastUserMessage: "",
-        staticResponse: staticMatch[1].trim(),
+        staticResponse,
       };
     }
 

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -12,8 +12,7 @@ import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { isTextContent } from "@app/types/assistant/generation";
 
-const STATIC_RESPONSE_REGEX =
-  /<static_response>([\s\S]*?)<\/static_response>/;
+const STATIC_RESPONSE_REGEX = /<static_response>([\s\S]*?)<\/static_response>/;
 
 const metadata = {
   clientId: "noop" as const,

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -8,8 +8,12 @@ import type {
   LLMParameters,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
+import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { isTextContent } from "@app/types/assistant/generation";
+
+const STATIC_RESPONSE_REGEX =
+  /<static_response>([\s\S]*?)<\/static_response>/;
 
 const metadata = {
   clientId: "noop" as const,
@@ -19,6 +23,7 @@ const metadata = {
 interface NoopRequest {
   type: "noop_request";
   lastUserMessage: string;
+  staticResponse?: string;
 }
 
 // NoopLLM is a dummy LLM that can respond to special commands.
@@ -32,7 +37,19 @@ export class NoopLLM extends LLM<NoopRequest> {
 
   protected buildRequestPayload({
     conversation,
+    prompt,
   }: LLMStreamParameters): NoopRequest {
+    // Check for a static response embedded in the system prompt.
+    const promptText = systemPromptToText(prompt);
+    const staticMatch = promptText.match(STATIC_RESPONSE_REGEX);
+    if (staticMatch) {
+      return {
+        type: "noop_request",
+        lastUserMessage: "",
+        staticResponse: staticMatch[1].trim(),
+      };
+    }
+
     const lastUserMessage =
       conversation.messages
         .slice()
@@ -51,7 +68,9 @@ export class NoopLLM extends LLM<NoopRequest> {
     let responseText: string;
 
     // Determine response based on the message content.
-    if (payload.lastUserMessage === "long message") {
+    if (payload.staticResponse) {
+      responseText = payload.staticResponse;
+    } else if (payload.lastUserMessage === "long message") {
       // Generate a very long message.
       responseText = "This is a very long message. ".repeat(100);
     } else if (payload.lastUserMessage === "help") {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -26,6 +26,7 @@ export async function getLLM(
     temperature,
     reasoningEffort,
     responseFormat,
+    metaData,
     bypassFeatureFlag = false,
     context,
   }: LLMParameters
@@ -104,6 +105,7 @@ export async function getLLM(
       modelId,
       temperature,
       reasoningEffort,
+      metaData,
     });
   }
 

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -82,7 +82,6 @@ export type LLMParameters = {
   modelId: ModelIdType;
   reasoningEffort?: ReasoningEffort | null;
   responseFormat?: string | null;
-  // Optional metadata passed through to the LLM client.
   metaData?: Record<string, unknown>;
   temperature?: number | null;
 } & LLMTraceCustomization;

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -82,6 +82,8 @@ export type LLMParameters = {
   modelId: ModelIdType;
   reasoningEffort?: ReasoningEffort | null;
   responseFormat?: string | null;
+  // Optional metadata passed through to the LLM client.
+  metaData?: Record<string, unknown>;
   temperature?: number | null;
 } & LLMTraceCustomization;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -479,6 +479,7 @@ export async function runModel(
     temperature: agentConfiguration.model.temperature,
     reasoningEffort: agentConfiguration.model.reasoningEffort,
     responseFormat: agentConfiguration.model.responseFormat,
+    metaData: agentConfiguration.model.metaData,
     context: traceContext,
     // Custom trace input: show only the last user message instead of full conversation.
     getTraceInput: (conv) => {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -126,7 +126,7 @@ export type AgentFetchVariant = "light" | "full" | "extra_light";
 
 export type GlobalAgentContext = {
   userMessageRank: number;
-  isNewAgentFromScratchCopilot?: boolean;
+  copilotIsNewAgentFromScratch?: boolean;
 };
 
 export type LightAgentConfigurationType = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -127,7 +127,7 @@ export type AgentFetchVariant = "light" | "full" | "extra_light";
 
 export type GlobalAgentContext = {
   userMessageRank: number;
-  isNewAgentCopilot?: boolean;
+  isNewAgentFromScratchCopilot?: boolean;
 };
 
 export type LightAgentConfigurationType = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -125,6 +125,7 @@ export type AgentFetchVariant = "light" | "full" | "extra_light";
 
 export type GlobalAgentContext = {
   userMessageRank: number;
+  isNewAgentCopilot?: boolean;
 };
 
 export type LightAgentConfigurationType = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -119,7 +119,6 @@ export type AgentModelConfigurationType = {
   temperature: number;
   reasoningEffort?: AgentReasoningEffort;
   responseFormat?: string;
-  // Optional metadata passed through to the LLM client
   metaData?: Record<string, unknown>;
 };
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -119,6 +119,8 @@ export type AgentModelConfigurationType = {
   temperature: number;
   reasoningEffort?: AgentReasoningEffort;
   responseFormat?: string;
+  // Optional metadata passed through to the LLM client
+  metaData?: Record<string, unknown>;
 };
 
 export type AgentFetchVariant = "light" | "full" | "extra_light";

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -282,7 +282,7 @@ export async function getAgentLoopDataWithAuth(
 
   const globalAgentContext: GlobalAgentContext = {
     userMessageRank: userMessage.rank,
-    isNewAgentFromScratchCopilot:
+    copilotIsNewAgentFromScratch:
       conversation.metadata?.copilotIsNewAgentFromScratch === true || undefined,
   };
 

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -282,8 +282,8 @@ export async function getAgentLoopDataWithAuth(
 
   const globalAgentContext: GlobalAgentContext = {
     userMessageRank: userMessage.rank,
-    isNewAgentCopilot:
-      conversation.metadata?.copilotIsNewAgent === true || undefined,
+    isNewAgentFromScratchCopilot:
+      conversation.metadata?.copilotIsNewAgentFromScratch === true || undefined,
   };
 
   // As the agent configuration is never supposed to change during a loop, we can cache it for a long time.

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -282,6 +282,8 @@ export async function getAgentLoopDataWithAuth(
 
   const globalAgentContext: GlobalAgentContext = {
     userMessageRank: userMessage.rank,
+    isNewAgentCopilot:
+      conversation.metadata?.copilotIsNewAgent === true || undefined,
   };
 
   // As the agent configuration is never supposed to change during a loop, we can cache it for a long time.


### PR DESCRIPTION
## Description

Make the sidekick first message completely static in the case of a new agent. Previously, we were telling a model to output this static message, which added 2 or 3 second latency and was overkill.

The implementation piggybacks on the noop model as a way to output static text.

## Tests

Manual

## Risk

Low, copilot still under flag

## Deploy Plan

Front