### PR TITLE
fix: include current user identity in conversation title prompt [#6863]

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -104,8 +104,11 @@ export async function ensureConversationTitle(
   }
 
   const titleRes = await generateConversationTitle(auth, {
-    ...conversation,
-    content: [...conversation.content, [userMessage]],
+    conversation: {
+      ...conversation,
+      content: [...conversation.content, [userMessage]],
+    },
+    userMessage,
   });
 
   if (titleRes.isErr()) {
@@ -159,7 +162,13 @@ const specifications: AgentActionSpecification[] = [
 
 async function generateConversationTitle(
   auth: Authenticator,
-  conversation: ConversationType
+  {
+    conversation,
+    userMessage,
+  }: {
+    conversation: ConversationType;
+    userMessage: UserMessageType;
+  }
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -173,6 +182,20 @@ async function generateConversationTitle(
   let prompt =
     "Generate a concise conversation title (3-8 words) based on the user's message and context. " +
     "The title should capture the main topic or request without being too generic.";
+
+  const fullName = userMessage.user?.fullName ?? userMessage.context.fullName;
+  const email = userMessage.user?.email ?? userMessage.context.email;
+  if (fullName || email) {
+    const identityParts: string[] = [];
+    if (fullName) {
+      identityParts.push(fullName);
+    }
+    if (email) {
+      identityParts.push(`<${email}>`);
+    }
+    prompt += ` The current user is: ${identityParts.join(" ")}.`;
+  }
+
   if (conversation.triggerId) {
     prompt +=
       " The conversation was triggered either on a schedule or programmatically.";


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#6863 - The project digest agent was confusing user identities 

The conversation title generation prompt was missing information about who the current user is. This adds the user's full name and email to the title generation prompt, matching how user identity is conveyed in the agent loop via `renderUserMessage()` sender metadata.

## Tests

Tested by reviewing that `userMessage` is already available at the call site and carries `user`/`context` with `fullName` and `email`. Type-checked with `tsgo`.
