### PR TITLE
Allow to delete the last_admin via workos event

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -799,11 +799,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     workspace,
     endAt = new Date(),
     transaction,
+    allowLastAdminRevocation = false,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     endAt?: Date;
     transaction?: Transaction;
+    allowLastAdminRevocation?: boolean;
   }): Promise<
     Result<
       { role: MembershipRoleType; startAt: Date; endAt: Date },
@@ -828,7 +830,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     // Prevent revoking the last admin of a workspace.
-    if (membership.role === "admin") {
+    if (membership.role === "admin" && !allowLastAdminRevocation) {
       const adminsCount = await this.getMembersCountForWorkspace({
         workspace,
         activeOnly: true,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1103,14 +1103,10 @@ async function handler(
             });
             const adminEmails = members.map((u) => u.email);
             if (adminEmails.length === 0) {
-              return apiError(req, res, {
-                status_code: 500,
-                api_error: {
-                  type: "internal_server_error",
-                  message:
-                    "[Stripe Webhook] canceling subscription: Error getting admin emails.",
-                },
-              });
+              logger.warn(
+                { workspaceId: workspace.sId, stripeError: true },
+                "[Stripe Webhook] No active admins found, skipping cancel/reactivate email."
+              );
             }
             // send email to admins
             for (const adminEmail of adminEmails) {

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -70,10 +70,7 @@ const FileUploadUrlRequestSchema = t.union([
     fileName: t.string,
     fileSize: t.number,
     useCase: t.literal("skill_attachment"),
-    useCaseMetadata: t.union([
-      t.type({ skillId: t.string }),
-      t.undefined,
-    ]),
+    useCaseMetadata: t.union([t.type({ skillId: t.string }), t.undefined]),
   }),
 ]);
 

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -937,6 +937,7 @@ async function handleDeleteWorkOSUser(
   const membershipRevokeResult = await MembershipResource.revokeMembership({
     user,
     workspace,
+    allowLastAdminRevocation: true,
   });
 
   if (membershipRevokeResult.isErr()) {


### PR DESCRIPTION
## Description

Follow up of github.com/dust-tt/dust/pull/22313

It currently prevents to correctly sync which workos, if we ignore the event it won't be possible to delete the admin later
The account would not be actually locked as users can be added back via workos sync

The only place I found where admin is actually required was in a Strip webhook

## Tests

no

## Risk

Some places may break because we don't have an admin

## Deploy Plan

deploy front