### PR TITLE
Hubspot: list_owners and search_owners return text instead of JSON

### DIFF
--- a/front/lib/api/actions/servers/hubspot/rendering.ts
+++ b/front/lib/api/actions/servers/hubspot/rendering.ts
@@ -1,3 +1,4 @@
+import type { listOwners } from "@app/lib/api/actions/servers/hubspot/client";
 import type { SimplePublicObject } from "@hubspot/api-client/lib/codegen/crm/objects/models/SimplePublicObject";
 
 export interface HubSpotObjectSummary {
@@ -166,6 +167,26 @@ export function formatTransformedPropertiesAsText(
 
   const typeText = creatableOnly ? "creatable properties" : "properties";
   return `Found ${properties.length} ${typeText} for ${objectType}:\n\n${formatted}`;
+}
+
+export function formatOwnersAsText(
+  owners: Awaited<ReturnType<typeof listOwners>>
+): string {
+  const formatted = owners
+    .map((owner) => {
+      const name = [owner.firstName, owner.lastName].filter(Boolean).join(" ");
+      let text = `${name || "Unnamed Owner"} (ID: ${owner.id})`;
+      if (owner.email) {
+        text += ` - ${owner.email}`;
+      }
+      if (owner.archived) {
+        text += ` [archived]`;
+      }
+      return text;
+    })
+    .join("\n\n");
+
+  return `${owners.length} owner(s):\n\n${formatted}`;
 }
 
 export function formatHubSpotCreateSuccess(

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -49,6 +49,7 @@ import {
   formatHubSpotObjectsAsText,
   formatHubSpotSearchResults,
   formatHubSpotUpdateSuccess,
+  formatOwnersAsText,
   formatTransformedPropertiesAsText,
 } from "@app/lib/api/actions/servers/hubspot/rendering";
 import { Err, Ok } from "@app/types/shared/result";
@@ -127,7 +128,7 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
       }
       return new Ok([
         { type: "text" as const, text: "Owners retrieved successfully." },
-        { type: "text" as const, text: JSON.stringify(owners, null, 2) },
+        { type: "text" as const, text: formatOwnersAsText(owners) },
       ]);
     });
   },
@@ -145,7 +146,7 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
           type: "text" as const,
           text: `Found ${owners.length} owner(s) matching "${searchQuery}".`,
         },
-        { type: "text" as const, text: JSON.stringify(owners, null, 2) },
+        { type: "text" as const, text: formatOwnersAsText(owners) },
       ]);
     });
   },


### PR DESCRIPTION
## Description

Updating the rendering of an owner from JSON to raw text, cf https://dust4ai.slack.com/archives/C050SM8NSPK/p1772455958199649

## Tests

Locally, with both tools.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front.