### PR TITLE
Add template backfill script

### DIFF
--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -63,7 +63,9 @@ export function CreateAgentPage() {
     const validTemplates = assistantTemplates.filter(
       (template) =>
         isTemplateTagCodeArray(template.tags) &&
-        (!hasCopilot || template.hasCopilotInstructions)
+        (hasCopilot
+          ? template.hasCopilotInstructions
+          : template.hasPresetInstructions)
     );
 
     const filtered = validTemplates.filter((template) => {

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -173,7 +173,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       tags: this.tags,
       visibility: this.visibility,
       hasCopilotInstructions: this.copilotInstructions !== null,
-      hasPresetInstructions: this.presetInstructions != null,
+      hasPresetInstructions: this.presetInstructions !== null,
     };
   }
 

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -173,6 +173,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       tags: this.tags,
       visibility: this.visibility,
       hasCopilotInstructions: this.copilotInstructions !== null,
+      hasPresetInstructions: this.presetInstructions != null,
     };
   }
 

--- a/front/scripts/migrate_copilot_templates_from_csv.ts
+++ b/front/scripts/migrate_copilot_templates_from_csv.ts
@@ -1,0 +1,225 @@
+/**
+ * Upserts templates from a CSV into the database and
+ * sets copilotInstructions to null on any existing template not present in the CSV.
+ *
+ * Expected CSV columns (all required):
+ *   - "Use Case"                  — used as handle (no transformation)
+ *   - "Agent Facing Description"
+ *   - "User Facing Description"
+ *   - "Sidekick Prompt"           — stored as copilotInstructions
+ *   - "Tag"                       — maps to TemplateTagCodeType
+ *   - "Emoji"                     — e.g. "sparkles/2728"
+ *   - "Background Color"          — e.g. "bg-blue-300"
+ *
+ * Usage (from front/ directory):
+ *   Dry-run:  npx tsx scripts/migrate_copilot_templates_from_csv.ts --csvPath /path/to/file.csv
+ *   Execute:  npx tsx scripts/migrate_copilot_templates_from_csv.ts --csvPath /path/to/file.csv --execute
+ */
+
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import type { Logger } from "@app/logger/logger";
+import type { ArgumentSpecs } from "@app/scripts/helpers";
+import { makeScript } from "@app/scripts/helpers";
+import type {
+  TemplateActionPreset,
+  TemplateTagCodeType,
+} from "@app/types/assistant/templates";
+import { TEMPLATES_TAGS_CONFIG } from "@app/types/assistant/templates";
+import { parse } from "csv-parse/sync";
+import { readFileSync } from "fs";
+
+const CSV_COL = {
+  USE_CASE: "Use Case",
+  AGENT_FACING: "Agent Facing Description",
+  USER_FACING: "User Facing Description",
+  SIDEKICK_PROMPT: "Sidekick Prompt",
+  TAG: "Tag",
+  EMOJI: "Emoji",
+  BACKGROUND_COLOR: "Background Color",
+} as const;
+
+const REQUIRED_COLS = [
+  CSV_COL.USE_CASE,
+  CSV_COL.AGENT_FACING,
+  CSV_COL.USER_FACING,
+  CSV_COL.SIDEKICK_PROMPT,
+  CSV_COL.TAG,
+  CSV_COL.EMOJI,
+  CSV_COL.BACKGROUND_COLOR,
+] as const;
+
+const TAG_LABEL_TO_CODE = Object.fromEntries(
+  Object.entries(TEMPLATES_TAGS_CONFIG).map(([code, { label }]) => [
+    label,
+    code as TemplateTagCodeType,
+  ])
+);
+
+export function resolveTag(label: string): TemplateTagCodeType {
+  const code = TAG_LABEL_TO_CODE[label.trim()];
+  if (!code) {
+    throw new Error(
+      `Unknown tag: "${label}". Must be one of: ${Object.values(
+        TEMPLATES_TAGS_CONFIG
+      )
+        .map((c) => c.label)
+        .join(", ")}`
+    );
+  }
+  return code;
+}
+
+type CsvRecord = Record<string, string | undefined>;
+
+interface TemplateRow {
+  handle: string;
+  agentFacingDescription: string;
+  userFacingDescription: string;
+  copilotInstructions: string;
+  tags: TemplateTagCodeType[];
+  emoji: string;
+  backgroundColor: string;
+}
+
+export function parseCsvRows(csvPath: string, logger?: Logger): TemplateRow[] {
+  const content = readFileSync(csvPath, "utf-8");
+  const records = parse(content, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+    relax_column_count: true,
+  }) as CsvRecord[];
+
+  const rowMap = new Map<string, TemplateRow>();
+
+  for (const record of records) {
+    const values = REQUIRED_COLS.map((col) => record[col]?.trim() ?? "");
+    const missing = REQUIRED_COLS.filter((_col, i) => !values[i]);
+
+    if (missing.length > 0) {
+      if (logger) {
+        logger.warn(
+          { missing, useCase: values[0] || "(empty)" },
+          "Skipping row: missing required columns"
+        );
+      }
+      continue;
+    }
+
+    const [
+      handle,
+      agentFacingDescription,
+      userFacingDescription,
+      copilotInstructions,
+      tagRaw,
+      emoji,
+      backgroundColor,
+    ] = values;
+    const tag = resolveTag(tagRaw);
+
+    rowMap.set(handle, {
+      handle,
+      agentFacingDescription,
+      userFacingDescription,
+      copilotInstructions,
+      tags: [tag],
+      emoji,
+      backgroundColor,
+    });
+  }
+
+  return Array.from(rowMap.values());
+}
+
+const argumentSpecs: ArgumentSpecs = {
+  csvPath: {
+    type: "string",
+    description: "Path to the Internal Dust Use Cases CSV file",
+    demandOption: true,
+  },
+};
+
+const PRESET_DEFAULTS = {
+  // These preset fields will be removed after copilot launch
+  presetTemperature: "balanced" as const,
+  presetProviderId: "anthropic" as const,
+  presetModelId: "claude-sonnet-4-5-20250929" as const,
+  presetActions: [] as TemplateActionPreset[],
+  presetDescription: null,
+  presetInstructions: null,
+  helpInstructions: null,
+  helpActions: null,
+  timeFrameDuration: null,
+  timeFrameUnit: null,
+};
+
+makeScript(argumentSpecs, async ({ csvPath, execute }, logger) => {
+  const rows = parseCsvRows(csvPath, logger);
+  logger.info({ csvPath, rowCount: rows.length }, "Parsed CSV");
+
+  const allTemplates = await TemplateResource.listAll();
+  const templateByHandle = new Map(allTemplates.map((t) => [t.handle, t]));
+  const csvHandles = new Set(rows.map((r) => r.handle));
+
+  let created = 0;
+  let updated = 0;
+
+  for (const row of rows) {
+    const existing = templateByHandle.get(row.handle);
+
+    if (existing) {
+      logger.info({ handle: row.handle, execute }, "Updating template");
+      if (execute) {
+        await existing.updateAttributes({
+          agentFacingDescription: row.agentFacingDescription,
+          userFacingDescription: row.userFacingDescription,
+          copilotInstructions: row.copilotInstructions,
+          tags: row.tags,
+          emoji: row.emoji,
+          backgroundColor: row.backgroundColor,
+        });
+      }
+      updated++;
+    } else {
+      logger.info({ handle: row.handle, execute }, "Creating template");
+      if (execute) {
+        await TemplateResource.makeNew({
+          handle: row.handle,
+          agentFacingDescription: row.agentFacingDescription,
+          userFacingDescription: row.userFacingDescription,
+          copilotInstructions: row.copilotInstructions,
+          tags: row.tags,
+          emoji: row.emoji,
+          backgroundColor: row.backgroundColor,
+          visibility: "published",
+          ...PRESET_DEFAULTS,
+        });
+      }
+      created++;
+    }
+  }
+
+  // Clear copilotInstructions on templates that are not in the CSV.
+  const toClear = allTemplates.filter(
+    (t) =>
+      !csvHandles.has(t.handle) &&
+      t.copilotInstructions !== null &&
+      t.copilotInstructions.trim() !== ""
+  );
+  let cleared = 0;
+
+  if (toClear.length > 0) {
+    logger.info(
+      { count: toClear.length, handles: toClear.map((t) => t.handle), execute },
+      "Clearing copilotInstructions on templates not in CSV"
+    );
+    if (execute) {
+      for (const template of toClear) {
+        await template.updateAttributes({ copilotInstructions: null });
+        cleared++;
+      }
+    }
+  }
+
+  logger.info({ execute, created, updated, cleared }, "Migration complete");
+});

--- a/front/scripts/migrate_copilot_templates_from_csv.ts
+++ b/front/scripts/migrate_copilot_templates_from_csv.ts
@@ -71,6 +71,15 @@ export function resolveTag(label: string): TemplateTagCodeType {
 
 type CsvRecord = Record<string, string | undefined>;
 
+function isCsvRecord(row: unknown): row is CsvRecord {
+  if (row === null || typeof row !== "object" || Array.isArray(row)) {
+    return false;
+  }
+  return Object.values(row as object).every(
+    (v) => v === undefined || typeof v === "string"
+  );
+}
+
 interface TemplateRow {
   handle: string;
   agentFacingDescription: string;
@@ -83,12 +92,22 @@ interface TemplateRow {
 
 export function parseCsvRows(csvPath: string, logger?: Logger): TemplateRow[] {
   const content = readFileSync(csvPath, "utf-8");
-  const records = parse(content, {
+  const raw = parse(content, {
     columns: true,
     skip_empty_lines: true,
     trim: true,
     relax_column_count: true,
-  }) as CsvRecord[];
+  });
+
+  const records: CsvRecord[] = [];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  for (const row of raw) {
+    if (isCsvRecord(row)) {
+      records.push(row);
+    }
+  }
 
   const rowMap = new Map<string, TemplateRow>();
 


### PR DESCRIPTION
## Description

* Script to backfill templates for sidekick based on an inputted CSV
* Only showing templates if copilot is enabled if they have a prompt
* Only showing templates if copilot is not enabled if they have preset instructions

## Tests
Ran it against local:

<img width="1072" height="669" alt="Screenshot 2026-03-03 at 2 05 29 PM" src="https://github.com/user-attachments/assets/4f43922a-d3b8-40fd-b740-b77e89d5681d" />

## Risk

* Low (unintended template change)

## Deploy Plan

1. Deploy front
2. Run migration