### PR TITLE
Remove dependency cycles in sparkle

### DIFF
--- a/sparkle/src/components/ActionCard.tsx
+++ b/sparkle/src/components/ActionCard.tsx
@@ -1,6 +1,7 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Avatar, Button, Card, Chip } from "@sparkle/components/";
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
+import { Card } from "@sparkle/components/Card";
+import { Chip } from "@sparkle/components/Chip";
 import { TruncatedText } from "@sparkle/components/TruncatedText";
 import { PlusIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -1,12 +1,7 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import {
-  Avatar,
-  Card,
-  CardActionButton,
-  type IconOnlyButtonProps,
-} from "@sparkle/components/";
+import { Avatar } from "@sparkle/components/Avatar";
+import type { IconOnlyButtonProps } from "@sparkle/components/Button";
 import type { CardVariantType } from "@sparkle/components/Card";
+import { Card, CardActionButton } from "@sparkle/components/Card";
 import { TruncatedText } from "@sparkle/components/TruncatedText";
 import { MoreIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/AttachmentChip.tsx
+++ b/sparkle/src/components/AttachmentChip.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
 

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -1,6 +1,4 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Tooltip } from "@sparkle/components";
+import { Tooltip } from "@sparkle/components/Tooltip";
 import { UserIcon } from "@sparkle/icons/app";
 import { getEmojiAndBackgroundFromUrl } from "@sparkle/lib/avatar/utils";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/Bar.tsx
+++ b/sparkle/src/components/Bar.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Tooltip } from "@sparkle/components/Tooltip";
 import {
   ArrowUpOnSquareIcon,

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Button, ICON_SIZE_MAP } from "@sparkle/components/Button";
 import {
   DropdownMenu,

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -1,15 +1,13 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Slot } from "@radix-ui/react-slot";
+import { Counter } from "@sparkle/components/Counter";
+import { Icon } from "@sparkle/components/Icon";
 import {
-  Counter,
-  Icon,
   LinkWrapper,
   type LinkWrapperProps,
-  Spinner,
-  Tooltip,
-} from "@sparkle/components/";
+} from "@sparkle/components/LinkWrapper";
 import type { SpinnerProps } from "@sparkle/components/Spinner";
+import { Spinner } from "@sparkle/components/Spinner";
+import { Tooltip } from "@sparkle/components/Tooltip";
 import { ChevronDownIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";

--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Button } from "@sparkle/components/Button";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import type { IconOnlyButtonProps } from "@sparkle/components/Button";
 import { Button } from "@sparkle/components/Button";
 import type { LinkWrapperProps } from "@sparkle/components/LinkWrapper";

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -1,10 +1,8 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
+import { AnimatedText } from "@sparkle/components/AnimatedText";
 import {
-  AnimatedText,
   LinkWrapper,
   type LinkWrapperProps,
-} from "@sparkle/components/";
+} from "@sparkle/components/LinkWrapper";
 import { XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -1,13 +1,8 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import {
-  Button,
-  Card,
-  type CardProps,
-  Spinner,
-  Tooltip,
-} from "@sparkle/components/";
+import { Button } from "@sparkle/components/Button";
+import { Card, type CardProps } from "@sparkle/components/Card";
 import { ImagePreview } from "@sparkle/components/ImagePreview";
+import { Spinner } from "@sparkle/components/Spinner";
+import { Tooltip } from "@sparkle/components/Tooltip";
 import { XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";

--- a/sparkle/src/components/Container.tsx
+++ b/sparkle/src/components/Container.tsx
@@ -1,6 +1,4 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { ScrollArea, ScrollBar } from "@sparkle/components";
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
 import { cn } from "@sparkle/lib";
 import React from "react";
 

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Button, type ButtonProps } from "@sparkle/components/Button";
 import { Icon } from "@sparkle/components/Icon";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/ConversationListItem.tsx
+++ b/sparkle/src/components/ConversationListItem.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Avatar } from "@sparkle/components/Avatar";
 import { ListItem } from "@sparkle/components/ListItem";
 import React, { type ReactNode } from "react";

--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -1,17 +1,13 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import {
-  Avatar,
-  type Button,
-  ConversationMessageContent,
-  IconButton,
-} from "@sparkle/components";
+import { Avatar } from "@sparkle/components/Avatar";
+import type { Button } from "@sparkle/components/Button";
+import { ConversationMessageContent } from "@sparkle/components/ConversationMessages";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@sparkle/components/Dropdown";
+import { IconButton } from "@sparkle/components/IconButton";
 import { MoreIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -1,6 +1,5 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Avatar, CitationGrid } from "@sparkle/components";
+import { Avatar } from "@sparkle/components/Avatar";
+import { CitationGrid } from "@sparkle/components/Citation";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import React from "react";

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1,9 +1,7 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
+import { Checkbox } from "@sparkle/components/Checkbox";
 import {
-  Avatar,
-  Button,
-  Checkbox,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -14,18 +12,17 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  Icon,
-  IconButton,
-  Pagination,
-  ScrollArea,
-  ScrollBar,
-  Spinner,
-  Tooltip,
-} from "@sparkle/components";
+} from "@sparkle/components/Dropdown";
+import { Icon } from "@sparkle/components/Icon";
+import { IconButton } from "@sparkle/components/IconButton";
+import { Pagination } from "@sparkle/components/Pagination";
 import {
   radioIndicatorStyles,
   radioStyles,
 } from "@sparkle/components/RadioGroup";
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
+import { Spinner } from "@sparkle/components/Spinner";
+import { Tooltip } from "@sparkle/components/Tooltip";
 import { useCopyToClipboard } from "@sparkle/hooks";
 import {
   ArrowDownIcon,

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -1,13 +1,8 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { FocusScope } from "@radix-ui/react-focus-scope";
-import {
-  Button,
-  type ButtonProps,
-  ScrollArea,
-  Separator,
-} from "@sparkle/components";
+import { Button, type ButtonProps } from "@sparkle/components/Button";
+import { ScrollArea } from "@sparkle/components/ScrollArea";
+import { Separator } from "@sparkle/components/Separator";
 import { XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";

--- a/sparkle/src/components/DiffBlock.tsx
+++ b/sparkle/src/components/DiffBlock.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { cva } from "class-variance-authority";
 import type { ReactElement } from "react";
 import React, { useLayoutEffect, useRef, useState } from "react";

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { Button } from "@sparkle/components/Button";

--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -1,6 +1,4 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Button, type RegularButtonProps } from "@sparkle/components/";
+import { Button, type RegularButtonProps } from "@sparkle/components/Button";
 import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
 

--- a/sparkle/src/components/FilterChips.tsx
+++ b/sparkle/src/components/FilterChips.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import React, { useCallback, useState } from "react";
 
 import { Button } from "./Button";

--- a/sparkle/src/components/IconButton.tsx
+++ b/sparkle/src/components/IconButton.tsx
@@ -1,7 +1,5 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import type { Tooltip } from "@sparkle/components";
 import { BUTTON_VARIANTS, Button } from "@sparkle/components/Button";
+import type { Tooltip } from "@sparkle/components/Tooltip";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import React, { type ComponentType, type MouseEventHandler } from "react";

--- a/sparkle/src/components/ImagePreview.tsx
+++ b/sparkle/src/components/ImagePreview.tsx
@@ -1,10 +1,9 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Button, Spinner } from "@sparkle/components/";
+import { Button } from "@sparkle/components/Button";
 import {
   downloadFile,
   ImageZoomDialog,
 } from "@sparkle/components/ImageZoomDialog";
+import { Spinner } from "@sparkle/components/Spinner";
 import { ArrowDownOnSquareIcon, XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/sparkle/src/components/ImageZoomDialog.tsx
+++ b/sparkle/src/components/ImageZoomDialog.tsx
@@ -1,12 +1,6 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import {
-  Button,
-  Dialog,
-  DialogClose,
-  DialogContent,
-  Spinner,
-} from "@sparkle/components/";
+import { Button } from "@sparkle/components/Button";
+import { Dialog, DialogClose, DialogContent } from "@sparkle/components/Dialog";
+import { Spinner } from "@sparkle/components/Spinner";
 import {
   ArrowDownOnSquareIcon,
   ChevronLeftIcon,

--- a/sparkle/src/components/InteractiveImageGrid.tsx
+++ b/sparkle/src/components/InteractiveImageGrid.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { ImagePreview } from "@sparkle/components/ImagePreview";
 import { ImageZoomDialog } from "@sparkle/components/ImageZoomDialog";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/MessageCard.tsx
+++ b/sparkle/src/components/MessageCard.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Button } from "@sparkle/components/Button";
 import { cn } from "@sparkle/lib/utils";
 import React from "react";

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -1,6 +1,5 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Avatar, Button, ScrollArea, Separator } from "@sparkle/components";
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
 import {
   Dialog,
   DialogClose,
@@ -10,6 +9,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@sparkle/components/Dialog";
+import { ScrollArea } from "@sparkle/components/ScrollArea";
+import { Separator } from "@sparkle/components/Separator";
 import { ChevronLeftIcon, ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";

--- a/sparkle/src/components/MultiPageSheet.tsx
+++ b/sparkle/src/components/MultiPageSheet.tsx
@@ -1,6 +1,6 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Button, Icon, Separator } from "@sparkle/components";
+import { Button } from "@sparkle/components/Button";
+import { Icon } from "@sparkle/components/Icon";
+import { Separator } from "@sparkle/components/Separator";
 import {
   Sheet,
   SheetClose,

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -1,20 +1,17 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import type * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
-import {
-  Counter,
-  Icon,
-  LinkWrapper,
-  type LinkWrapperProps,
-  ScrollArea,
-  ScrollBar,
-} from "@sparkle/components/";
 import { Button } from "@sparkle/components/Button";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@sparkle/components/Collapsible";
+import { Counter } from "@sparkle/components/Counter";
+import { Icon } from "@sparkle/components/Icon";
+import {
+  LinkWrapper,
+  type LinkWrapperProps,
+} from "@sparkle/components/LinkWrapper";
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
 import { ChevronDownIcon, ChevronUpIcon, MoreIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/sparkle/src/components/NotificationButton.tsx
+++ b/sparkle/src/components/NotificationButton.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Button } from "@sparkle/components/Button";
 import { Counter } from "@sparkle/components/Counter";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/Page.tsx
+++ b/sparkle/src/components/Page.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Separator } from "@sparkle/components/Separator";
 import { cn } from "@sparkle/lib/utils";
 import React, { type ComponentType } from "react";

--- a/sparkle/src/components/PaginatedCitationsGrid.tsx
+++ b/sparkle/src/components/PaginatedCitationsGrid.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import {
   Citation,
   CitationDescription,

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { ChevronLeftIcon, ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import type { PaginationState } from "@tanstack/react-table";

--- a/sparkle/src/components/Picker.tsx
+++ b/sparkle/src/components/Picker.tsx
@@ -1,9 +1,6 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
 import { cn } from "@sparkle/lib";
 import React from "react";
-
-import { ScrollArea, ScrollBar } from "../components";
 
 interface IconSwatchProps {
   icon: React.ComponentType<{ className?: string }>;

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -1,18 +1,15 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
+import { Button } from "@sparkle/components/Button";
+import type { ContentMessageProps } from "@sparkle/components/ContentMessage";
+import { ContentMessage } from "@sparkle/components/ContentMessage";
+import { Icon } from "@sparkle/components/Icon";
+import { Input } from "@sparkle/components/Input";
 import {
-  Button,
-  ContentMessage,
-  Icon,
-  Input,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
-  ScrollArea,
-  ScrollBar,
-  Spinner,
-} from "@sparkle/components";
-import type { ContentMessageProps } from "@sparkle/components/ContentMessage";
+} from "@sparkle/components/Popover";
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
+import { Spinner } from "@sparkle/components/Spinner";
 import {
   ListCheckIcon,
   MagnifyingGlassIcon,

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -1,8 +1,8 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { FocusScope } from "@radix-ui/react-focus-scope";
-import { Button, Icon, ScrollArea } from "@sparkle/components";
+import { Button } from "@sparkle/components/Button";
+import { Icon } from "@sparkle/components/Icon";
+import { ScrollArea } from "@sparkle/components/ScrollArea";
 import { XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";

--- a/sparkle/src/components/SplitButton.tsx
+++ b/sparkle/src/components/SplitButton.tsx
@@ -1,6 +1,4 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import type { ButtonProps } from "@sparkle/components/";
+import type { ButtonProps } from "@sparkle/components/Button";
 import { Button, type ButtonVariantType } from "@sparkle/components/Button";
 import { cn } from "@sparkle/lib";
 import React from "react";

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -1,9 +1,7 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import * as TabsPrimitive from "@radix-ui/react-tabs";
-import { ScrollArea, ScrollBar } from "@sparkle/components/";
 import { Button } from "@sparkle/components/Button";
 import type { LinkWrapperProps } from "@sparkle/components/LinkWrapper";
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Button, type ButtonProps } from "@sparkle/components/Button";
 import {
   Dialog,

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -1,15 +1,13 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
+import { Button } from "@sparkle/components/Button";
+import { Icon } from "@sparkle/components/Icon";
+import { Spinner } from "@sparkle/components/Spinner";
 import {
-  Button,
-  Icon,
-  Spinner,
   TooltipContent,
   TooltipPortal,
   TooltipProvider,
   TooltipRoot,
   TooltipTrigger,
-} from "@sparkle/components/";
+} from "@sparkle/components/Tooltip";
 import { ArrowDownSIcon, ArrowRightSIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import React, {

--- a/sparkle/src/components/ValueCard.tsx
+++ b/sparkle/src/components/ValueCard.tsx
@@ -1,6 +1,5 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Card, Spinner } from "@sparkle/components";
+import { Card } from "@sparkle/components/Card";
+import { Spinner } from "@sparkle/components/Spinner";
 import { cn } from "@sparkle/lib/utils";
 import * as React from "react";
 

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import type {
   ButtonProps,
   RegularButtonSize,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 export { ActionCard } from "./ActionCard";
 export { AnimatedText } from "./AnimatedText";
 export { AspectRatio } from "./AspectRatio";

--- a/sparkle/src/components/markdown/ActionCardBlock.tsx
+++ b/sparkle/src/components/markdown/ActionCardBlock.tsx
@@ -1,7 +1,5 @@
 import type { AvatarProps, AvatarStackProps } from "@sparkle/components/Avatar";
-// biome-ignore lint/suspicious/noImportCycles: I'm too lazy to refactor this right now
 import { Button } from "@sparkle/components/Button";
-// biome-ignore lint/suspicious/noImportCycles: I'm too lazy to refactor this right now
 import { Card, type CardVariantType } from "@sparkle/components/Card";
 import { CheckboxWithText } from "@sparkle/components/Checkbox";
 import {

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -1,6 +1,4 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { ContentBlockWrapper } from "@sparkle/components";
+import { ContentBlockWrapper } from "@sparkle/components/markdown/ContentBlockWrapper";
 import { cva } from "class-variance-authority";
 import React from "react";
 

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -1,11 +1,9 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
+import { Button } from "@sparkle/components/Button";
+import { CodeBlock } from "@sparkle/components/markdown/CodeBlock";
 import {
-  Button,
   ContentBlockWrapper,
   type GetContentToDownloadFunction,
-} from "@sparkle/components";
-import { CodeBlock } from "@sparkle/components/markdown/CodeBlock";
+} from "@sparkle/components/markdown/ContentBlockWrapper";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
 import {
   type JsonValueType,

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -1,6 +1,4 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Button } from "@sparkle/components/";
+import { Button } from "@sparkle/components/Button";
 import { useCopyToClipboard } from "@sparkle/hooks";
 import {
   ArrowDownOnSquareIcon,

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -1,6 +1,5 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { Checkbox, Chip } from "@sparkle/components";
+import { Checkbox } from "@sparkle/components/Checkbox";
+import { Chip } from "@sparkle/components/Chip";
 import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
 import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
 import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 import { Chip } from "@sparkle/components/Chip";
 import { cn } from "@sparkle/lib/utils";
 import React, { useState } from "react";

--- a/sparkle/src/components/markdown/QuickReplyBlock.tsx
+++ b/sparkle/src/components/markdown/QuickReplyBlock.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/suspicious/noImportCycles: Button -> index -> markdown -> this file
 import { Button } from "@sparkle/components/Button";
 import { ChatBubbleLeftRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/markdown/TableBlock.tsx
+++ b/sparkle/src/components/markdown/TableBlock.tsx
@@ -1,7 +1,5 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
-import { ScrollArea, ScrollBar } from "@sparkle/components";
 import { ContentBlockWrapper } from "@sparkle/components/markdown/ContentBlockWrapper";
+import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
 import React, { type ReactNode, useMemo } from "react";
 
 const getNodeText = (node: ReactNode): string => {

--- a/sparkle/src/components/markdown/index.ts
+++ b/sparkle/src/components/markdown/index.ts
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noImportCycles: I'm too lazy to fix that now */
-
 export * from "./ActionCardBlock";
 export * from "./CodeBlock";
 export * from "./CodeBlockWithExtendedSupport";

--- a/sparkle/src/components/markdown/styles.ts
+++ b/sparkle/src/components/markdown/styles.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/suspicious/noImportCycles: I'm too lazy to refactor this right now
 import { blockquoteVariants } from "@sparkle/components/markdown/BlockquoteBlock";
 import {
   codeBlockVariants,


### PR DESCRIPTION
## Description

Fix all circular dependency cycles in `sparkle/src/components/` by replacing barrel imports with direct imports.

**Root cause**: 30 component files were importing sibling components through the barrel `@sparkle/components` (or `@sparkle/components/`), which is the same `index.ts` that re-exports them — creating circular dependency chains.

**Fix**: Every barrel import within `components/` is replaced with a direct import to the specific file. For example:
```ts
// Before
import { Button, ScrollArea, Separator } from "@sparkle/components";

// After
import { Button } from "@sparkle/components/Button";
import { ScrollArea } from "@sparkle/components/ScrollArea";
import { Separator } from "@sparkle/components/Separator";
```

Also removed all 53 `biome-ignore-all lint/suspicious/noImportCycles` suppression comments since the cycles no longer exist.

## Tests

- `tsgo --noEmit` passes
- `npm run build` (ESM + CJS) passes

## Risk

Low. Only import paths changed, no logic changes. All exports remain the same via the barrel `index.ts`, so external consumers are unaffected.

## Deploy Plan

Standard deploy. No infrastructure changes.