### PR TITLE
fix: exclude test conversations from butler analysis

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -104,8 +104,11 @@ export async function ensureConversationTitle(
   }
 
   const titleRes = await generateConversationTitle(auth, {
-    ...conversation,
-    content: [...conversation.content, [userMessage]],
+    conversation: {
+      ...conversation,
+      content: [...conversation.content, [userMessage]],
+    },
+    userMessage,
   });
 
   if (titleRes.isErr()) {
@@ -159,7 +162,13 @@ const specifications: AgentActionSpecification[] = [
 
 async function generateConversationTitle(
   auth: Authenticator,
-  conversation: ConversationType
+  {
+    conversation,
+    userMessage,
+  }: {
+    conversation: ConversationType;
+    userMessage: UserMessageType;
+  }
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -173,6 +182,20 @@ async function generateConversationTitle(
   let prompt =
     "Generate a concise conversation title (3-8 words) based on the user's message and context. " +
     "The title should capture the main topic or request without being too generic.";
+
+  const fullName = userMessage.user?.fullName ?? userMessage.context.fullName;
+  const email = userMessage.user?.email ?? userMessage.context.email;
+  if (fullName || email) {
+    const identityParts: string[] = [];
+    if (fullName) {
+      identityParts.push(fullName);
+    }
+    if (email) {
+      identityParts.push(`<${email}>`);
+    }
+    prompt += ` The current user is: ${identityParts.join(" ")}.`;
+  }
+
   if (conversation.triggerId) {
     prompt +=
       " The conversation was triggered either on a schedule or programmatically.";

--- a/front/temporal/butler/activities.ts
+++ b/front/temporal/butler/activities.ts
@@ -33,6 +33,11 @@ export async function analyzeConversationActivity({
 
   const conversation = conversationRes.value;
 
+  // Skip test conversations (created when users test agents via the "test" button).
+  if (conversation.visibility === "test") {
+    return;
+  }
+
   // Skip conversations without a title (title generation handles those).
   if (!conversation.title) {
     return;


### PR DESCRIPTION
## Description

Exclude conversations with `visibility: "test"` from butler analysis (rename suggestions and agent recommendations). These are conversations created when users test agents via the "test" button, and should not generate butler suggestions.

Fixes dust-tt/tasks#6929

## Tests

Verified the change follows the same pattern used in notifications (`project-new-conversation.ts`) and space conversation listings, which already exclude test conversations.
