### PR TITLE
Fix range workspace-usage

### DIFF
--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -19,6 +19,7 @@ import type {
 } from "@dust-tt/client";
 import { GetWorkspaceUsageRequestSchema } from "@dust-tt/client";
 import { parse as parseCSV } from "csv-parse/sync";
+import { endOfDay } from "date-fns/endOfDay";
 import { endOfMonth } from "date-fns/endOfMonth";
 import JSZip from "jszip";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -248,7 +249,7 @@ function resolveDates(query: GetWorkspaceUsageRequestType) {
     case "range":
       return {
         startDate: parseDate(query.start),
-        endDate: parseDate(query.end),
+        endDate: endOfDay(parseDate(query.end)),
       };
     default:
       assertNever(query);


### PR DESCRIPTION
## Description

Fixes incomplete date range for the workspace-usage API endpoint when using `mode=range`. 
For mode=range, `endDate = parseDate(query.end)` resolves to midnight (00:00:00), causing data from the final day of the range to be excluded. This aligns the range mode behavior with the month mode, which already uses endOfMonth to ensure inclusive boundaries.

Completed PR (https://github.com/dust-tt/dust/pull/22341)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
