### PR TITLE
feat: extension attach content subdropdown

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -29,18 +29,22 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
 import {
   AttachmentIcon,
   Button,
+  ChevronRightIcon,
   CloudArrowUpIcon,
   DoubleIcon,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  type DropdownMenuFilterOption,
   DropdownMenuFilters,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Icon,
   Input,
@@ -65,11 +69,13 @@ interface InputBarAttachmentsPickerProps {
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   attachedNodes: DataSourceViewContentNode[];
+  type: "dropdown" | "subdropdown";
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
+  onFileChange?: () => void;
 }
 
 const PAGE_SIZE = 25;
@@ -195,6 +201,8 @@ export const InputBarAttachmentsPicker = ({
   buttonSize = "xs",
   conversation,
   space,
+  type,
+  onFileChange,
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemsContainerRef = useRef<HTMLDivElement>(null);
@@ -392,30 +400,57 @@ export const InputBarAttachmentsPicker = ({
   );
 
   const allUnselected = selectedFilterKeys.length === 0;
+  const Wrapper = type === "dropdown" ? DropdownMenu : DropdownMenuSub;
+  const ContentWrapper =
+    type === "dropdown" ? DropdownMenuContent : DropdownMenuSubContent;
+
   return (
-    <DropdownMenu
+    <Wrapper
       open={isOpen}
       onOpenChange={(open) => {
+        if (type === "subdropdown") {
+          setIsOpen(open);
+        }
         if (open) {
           setSearch("");
         }
       }}
     >
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost-secondary"
-          icon={AttachmentIcon}
-          size={buttonSize}
-          disabled={disabled || isLoading}
-          onClick={() => setIsOpen(!isOpen)}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
+      {type === "dropdown" ? (
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost-secondary"
+            icon={AttachmentIcon}
+            size={buttonSize}
+            disabled={disabled || isLoading}
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        </DropdownMenuTrigger>
+      ) : (
+        <DropdownMenuSubTrigger
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            setIsOpen(true);
+          }}
+        >
+          <AttachmentIcon className="w-5 h-5" />
+          Attach knowledge
+          <ChevronRightIcon className="w-5 h-5" />
+        </DropdownMenuSubTrigger>
+      )}
+      <ContentWrapper
         className="h-80 w-80 xs:h-96 xs:w-96"
         collisionPadding={15}
-        align="start"
-        onInteractOutside={() => setIsOpen(false)}
         onEscapeKeyDown={() => setIsOpen(false)}
+        {...(type === "subdropdown"
+          ? {
+              onClick: (e) => e.stopPropagation(),
+            }
+          : {
+              align: "start",
+              onInteractOutside: () => setIsOpen(false),
+            })}
         dropdownHeaders={
           <>
             <Input
@@ -423,6 +458,7 @@ export const InputBarAttachmentsPicker = ({
               ref={fileInputRef}
               style={{ display: "none" }}
               onChange={async (e) => {
+                onFileChange?.();
                 setIsOpen(false);
                 await fileUploaderService.handleFileChange(e);
                 if (fileInputRef.current) {
@@ -560,7 +596,7 @@ export const InputBarAttachmentsPicker = ({
             </div>
           </div>
         )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </ContentWrapper>
+    </Wrapper>
   );
 };

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -142,6 +142,7 @@ const InputBarContainer = ({
   >(null);
   const [pastedCount, setPastedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(true);
+  const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
 
   const [selectedNode, setSelectedNode] =
     useState<DataSourceViewContentNode | null>(null);
@@ -749,36 +750,38 @@ const InputBarContainer = ({
                     className="flex sm:hidden"
                     onClick={() => setIsToolbarOpen(!isToolbarOpen)}
                   />
-                  {actions.includes("attachment") && (
-                    <>
-                      <input
-                        accept={getSupportedFileExtensions().join(",")}
-                        onChange={async (e) => {
-                          await fileUploaderService.handleFileChange(e);
-                          if (fileInputRef.current) {
-                            fileInputRef.current.value = "";
-                          }
-                          editorService.focusEnd();
-                        }}
-                        ref={fileInputRef}
-                        style={{ display: "none" }}
-                        type="file"
-                        multiple={true}
-                      />
-                      <InputBarAttachmentsPicker
-                        fileUploaderService={fileUploaderService}
-                        owner={owner}
-                        isLoading={false}
-                        onNodeSelect={onNodeSelect}
-                        onNodeUnselect={onNodeUnselect}
-                        attachedNodes={attachedNodes}
-                        disabled={disableInput}
-                        buttonSize={buttonSize}
-                        conversation={conversation}
-                        space={space}
-                      />
-                    </>
-                  )}
+                  {actions.includes("attachment") &&
+                    !displayCaptureActionsDropdown && (
+                      <>
+                        <input
+                          accept={getSupportedFileExtensions().join(",")}
+                          onChange={async (e) => {
+                            await fileUploaderService.handleFileChange(e);
+                            if (fileInputRef.current) {
+                              fileInputRef.current.value = "";
+                            }
+                            editorService.focusEnd();
+                          }}
+                          ref={fileInputRef}
+                          style={{ display: "none" }}
+                          type="file"
+                          multiple={true}
+                        />
+                        <InputBarAttachmentsPicker
+                          fileUploaderService={fileUploaderService}
+                          owner={owner}
+                          isLoading={false}
+                          onNodeSelect={onNodeSelect}
+                          onNodeUnselect={onNodeUnselect}
+                          attachedNodes={attachedNodes}
+                          disabled={disableInput}
+                          buttonSize={buttonSize}
+                          conversation={conversation}
+                          space={space}
+                          type="dropdown"
+                        />
+                      </>
+                    )}
                   {actions.includes("capabilities") && (
                     <CapabilitiesPicker
                       owner={owner}
@@ -825,7 +828,10 @@ const InputBarContainer = ({
                     />
                   )}
                 {displayCaptureActionsDropdown && (
-                  <DropdownMenu>
+                  <DropdownMenu
+                    open={isCaptureDropdownOpen}
+                    onOpenChange={setIsCaptureDropdownOpen}
+                  >
                     <DropdownMenuTrigger asChild>
                       <Button
                         variant="ghost-secondary"
@@ -835,6 +841,22 @@ const InputBarContainer = ({
                       />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent>
+                      {actions.includes("attachment") && (
+                        <InputBarAttachmentsPicker
+                          fileUploaderService={fileUploaderService}
+                          owner={owner}
+                          isLoading={false}
+                          onNodeSelect={onNodeSelect}
+                          onNodeUnselect={onNodeUnselect}
+                          attachedNodes={attachedNodes}
+                          disabled={disableInput}
+                          buttonSize={buttonSize}
+                          conversation={conversation}
+                          space={space}
+                          type="subdropdown"
+                          onFileChange={() => setIsCaptureDropdownOpen(false)}
+                        />
+                      )}
                       <DropdownMenuItem
                         icon={GlobeAltIcon}
                         label="Attach page content"

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -221,19 +221,32 @@ const DropdownMenuSubTrigger = React.forwardRef<
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName;
 
+interface DropdownMenuSubContentProps
+  extends React.ComponentPropsWithoutRef<
+    typeof DropdownMenuPrimitive.SubContent
+  > {
+  dropdownHeaders?: React.ReactNode;
+}
+
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, children, ...props }, ref) => (
+  DropdownMenuSubContentProps
+>(({ className, children, dropdownHeaders, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
       menuStyleClasses.container,
       "s-flex s-flex-col s-p-0 s-shadow-lg",
+      dropdownHeaders && "s-h-80 xs:s-h-96",
       className
     )}
     {...props}
   >
+    {dropdownHeaders && (
+      <div className="s-sticky s-top-0 s-bg-background dark:s-bg-muted-background-night">
+        {dropdownHeaders}
+      </div>
+    )}
     <ScrollArea
       className="s-w-full s-flex-1"
       hideScrollBar={false}


### PR DESCRIPTION





## Description
Fixes https://github.com/dust-tt/tasks/issues/6782

This PR adds the ability to use the attachment picker as a subdropdown within the browser extension's capture actions menu.

- Added a `type` prop (`"dropdown"` | `"subdropdown"`) to `InputBarAttachmentsPicker` to support both standalone and nested dropdown modes
- Extended `DropdownMenuSubContent` in Sparkle to support `dropdownHeaders` prop

https://github.com/user-attachments/assets/083541e8-965c-4c2c-ac9b-992816bde1d4


## Tests

Manually

## Risks

Low risk. The changes are additive and backward compatible - the existing standalone attachment picker behavior is preserved.

## Deploy Plan

Standard deployment - no special considerations needed.
