### PR TITLE
Hide agents management buttons in extensions

### DIFF
--- a/extension/platforms/chrome/ChromeApp.tsx
+++ b/extension/platforms/chrome/ChromeApp.tsx
@@ -1,5 +1,6 @@
 import { RootLayout } from "@app/components/app/RootLayout";
 import { RegionProvider } from "@app/lib/auth/RegionContext";
+import { ClientTypeProvider } from "@app/lib/context/clientType";
 import { SparkleContext } from "@dust-tt/sparkle";
 import { ChromeExtensionWrapper } from "@extension/platforms/chrome/ChromeExtensionWrapper";
 import { PortProvider } from "@extension/platforms/chrome/context/PortContext";
@@ -16,24 +17,26 @@ export const ChromeApp = () => {
   const router = createBrowserRouter(routes);
 
   return (
-    <PlatformProvider platformService={platformService}>
-      <PortProvider>
-        <RegionProvider>
-          <ExtensionAuthProvider>
-            <ExtensionFetcherProvider>
-              <SparkleContext.Provider
-                value={{ components: { link: ReactRouterLinkWrapper } }}
-              >
-                <RootLayout>
-                  <ChromeExtensionWrapper>
-                    <RouterProvider router={router} />
-                  </ChromeExtensionWrapper>
-                </RootLayout>
-              </SparkleContext.Provider>
-            </ExtensionFetcherProvider>
-          </ExtensionAuthProvider>
-        </RegionProvider>
-      </PortProvider>
-    </PlatformProvider>
+    <ClientTypeProvider value="extension">
+      <PlatformProvider platformService={platformService}>
+        <PortProvider>
+          <RegionProvider>
+            <ExtensionAuthProvider>
+              <ExtensionFetcherProvider>
+                <SparkleContext.Provider
+                  value={{ components: { link: ReactRouterLinkWrapper } }}
+                >
+                  <RootLayout>
+                    <ChromeExtensionWrapper>
+                      <RouterProvider router={router} />
+                    </ChromeExtensionWrapper>
+                  </RootLayout>
+                </SparkleContext.Provider>
+              </ExtensionFetcherProvider>
+            </ExtensionAuthProvider>
+          </RegionProvider>
+        </PortProvider>
+      </PlatformProvider>
+    </ClientTypeProvider>
   );
 };

--- a/extension/platforms/front/FrontApp.tsx
+++ b/extension/platforms/front/FrontApp.tsx
@@ -1,5 +1,6 @@
 import { RootLayout } from "@app/components/app/RootLayout";
 import { RegionProvider } from "@app/lib/auth/RegionContext";
+import { ClientTypeProvider } from "@app/lib/context/clientType";
 import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
 import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
 import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
@@ -41,18 +42,20 @@ export const FrontApp = () => {
   }
 
   return (
-    <FrontContextProvider>
-      <FrontPlatformProvider>
-        <RegionProvider>
-          <ExtensionAuthProvider>
-            <ExtensionFetcherProvider>
-              <RootLayout>
-                <RouterProvider router={router} key="front-router" />
-              </RootLayout>
-            </ExtensionFetcherProvider>
-          </ExtensionAuthProvider>
-        </RegionProvider>
-      </FrontPlatformProvider>
-    </FrontContextProvider>
+    <ClientTypeProvider value="extension">
+      <FrontContextProvider>
+        <FrontPlatformProvider>
+          <RegionProvider>
+            <ExtensionAuthProvider>
+              <ExtensionFetcherProvider>
+                <RootLayout>
+                  <RouterProvider router={router} key="front-router" />
+                </RootLayout>
+              </ExtensionFetcherProvider>
+            </ExtensionAuthProvider>
+          </RegionProvider>
+        </FrontPlatformProvider>
+      </FrontContextProvider>
+    </ClientTypeProvider>
   );
 };

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -75,7 +75,6 @@ export const ConversationContainer = ({
 
   return (
     <InputBarContextProvider
-      origin="extension"
       captureActions={captureActions}
       fileUploaderService={fileUploaderService}
     >

--- a/extension/ui/pages/ProjectMainPage.tsx
+++ b/extension/ui/pages/ProjectMainPage.tsx
@@ -16,7 +16,7 @@ export const ProjectMainPage = () => {
 
   return (
     <ConversationLayout title={spaceInfo?.name ?? ""}>
-      <InputBarProvider origin="extension">
+      <InputBarProvider>
         <SpaceConversationsPage />
       </InputBarProvider>
     </ConversationLayout>

--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -7,6 +7,7 @@ import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideP
 import { useHashParam } from "@app/hooks/useHashParams";
 import { usePersistedAgentBrowserSelection } from "@app/hooks/usePersistedAgentBrowserSelection";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
@@ -212,6 +213,7 @@ export function AgentBrowser({
   >(null);
 
   const router = useAppRouter();
+  const clientType = useClientType();
   const { createAgentButtonRef } = useWelcomeTourGuide();
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [sortType, setSortType] = useState<
@@ -454,30 +456,35 @@ export function AgentBrowser({
           )}
         </SearchDropdownMenu>
 
-        <div className="hidden sm:block">
-          <div className="flex gap-2">
-            {!isRestrictedFromAgentCreation && (
-              <div ref={createAgentButtonRef}>
-                <CreateDropdown owner={owner} dataGtmLocation="homepage" />
-              </div>
-            )}
+        {clientType === "web" && (
+          <div className="hidden sm:block">
+            <div className="flex gap-2">
+              {!isRestrictedFromAgentCreation && (
+                <div ref={createAgentButtonRef}>
+                  <CreateDropdown owner={owner} dataGtmLocation="homepage" />
+                </div>
+              )}
 
-            {isBuilder(owner) ? (
-              <ManageDropdownMenu owner={owner} />
-            ) : (
-              <Button
-                href={getAgentBuilderRoute(owner.sId, "manage")}
-                variant="primary"
-                icon={ContactsRobotIcon}
-                label="Manage agents"
-                data-gtm-label="assistantManagementButton"
-                data-gtm-location="homepage"
-                size="sm"
-                onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_agents")}
-              />
-            )}
+              {isBuilder(owner) ? (
+                <ManageDropdownMenu owner={owner} />
+              ) : (
+                <Button
+                  href={getAgentBuilderRoute(owner.sId, "manage")}
+                  variant="primary"
+                  icon={ContactsRobotIcon}
+                  label="Manage agents"
+                  data-gtm-label="assistantManagementButton"
+                  data-gtm-location="homepage"
+                  size="sm"
+                  onClick={withTracking(
+                    TRACKING_AREAS.BUILDER,
+                    "manage_agents"
+                  )}
+                />
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       <AgentDetails

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -4,7 +4,6 @@ import {
   useFileUploaderService,
 } from "@app/hooks/useFileUploaderService";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import type { ClientMessageOrigin } from "@app/types/assistant/conversation";
 import type { RichAgentMention } from "@app/types/assistant/mentions";
 import {
   createContext,
@@ -17,7 +16,6 @@ import {
 export const InputBarContext = createContext<{
   animate: boolean;
   getAndClearSelectedAgent: () => RichAgentMention | null;
-  origin: ClientMessageOrigin;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   fileUploaderService: FileUploaderService;
@@ -30,7 +28,6 @@ export const InputBarContext = createContext<{
   getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
-  origin: "web",
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -46,7 +43,6 @@ export const InputBarContext = createContext<{
 
 interface InputBarContextProviderProps {
   children: ReactNode;
-  origin: ClientMessageOrigin;
   fileUploaderService: FileUploaderService;
   captureActions?: {
     onCapture: (type: "text" | "screenshot") => void;
@@ -56,7 +52,6 @@ interface InputBarContextProviderProps {
 
 export function InputBarContextProvider({
   children,
-  origin,
   fileUploaderService,
   captureActions,
 }: InputBarContextProviderProps) {
@@ -91,7 +86,6 @@ export function InputBarContextProvider({
   const value = useMemo(
     () => ({
       animate,
-      origin,
       setAnimate,
       getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
@@ -100,7 +94,6 @@ export function InputBarContextProvider({
     }),
     [
       animate,
-      origin,
       getAndClearSelectedAgent,
       setSelectedAgentOuter,
       captureActions,
@@ -116,10 +109,9 @@ export function InputBarContextProvider({
 }
 interface InputBarProviderProps {
   children: ReactNode;
-  origin: ClientMessageOrigin;
 }
 
-export function InputBarProvider({ children, origin }: InputBarProviderProps) {
+export function InputBarProvider({ children }: InputBarProviderProps) {
   const conversationId = useActiveConversationId();
 
   const { workspace } = useAuth();
@@ -150,10 +142,7 @@ export function InputBarProvider({ children, origin }: InputBarProviderProps) {
   }
 
   return (
-    <InputBarContextProvider
-      origin={origin}
-      fileUploaderService={fileUploaderService}
-    >
+    <InputBarContextProvider fileUploaderService={fileUploaderService}>
       {children}
     </InputBarContextProvider>
   );

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -5,6 +5,7 @@ import { QuickStartGuide } from "@app/components/QuickStartGuide";
 import { useDatadogLogs } from "@app/hooks/useDatadogLogs";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { ClientTypeProvider } from "@app/lib/context/clientType";
 import { Head, Script } from "@app/lib/platform";
 import { getFaviconPath } from "@app/lib/utils";
 import type React from "react";
@@ -41,73 +42,75 @@ export default function AppRootLayout({
   }, [user?.email, user?.fullName, user?.sId]);
 
   return (
-    <WelcomeTourGuideProvider>
-      <DesktopNavigationProvider>
-        <InputBarProvider origin="web">
-          <Head>
-            <link rel="icon" type="image/png" href={faviconPath} />
+    <ClientTypeProvider value="web">
+      <WelcomeTourGuideProvider>
+        <DesktopNavigationProvider>
+          <InputBarProvider>
+            <Head>
+              <link rel="icon" type="image/png" href={faviconPath} />
 
-            <meta name="apple-mobile-web-app-title" content="Dust" />
-            <link rel="apple-touch-icon" href="/static/AppIcon.png" />
-            <link
-              rel="apple-touch-icon"
-              sizes="60x60"
-              href="/static/AppIcon_60.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="76x76"
-              href="/static/AppIcon_76.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="120x120"
-              href="/static/AppIcon_120.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="152x152"
-              href="/static/AppIcon_152.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="167x167"
-              href="/static/AppIcon_167.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="180x180"
-              href="/static/AppIcon_180.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="192x192"
-              href="/static/AppIcon_192.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="228x228"
-              href="/static/AppIcon_228.png"
-            />
+              <meta name="apple-mobile-web-app-title" content="Dust" />
+              <link rel="apple-touch-icon" href="/static/AppIcon.png" />
+              <link
+                rel="apple-touch-icon"
+                sizes="60x60"
+                href="/static/AppIcon_60.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="76x76"
+                href="/static/AppIcon_76.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="120x120"
+                href="/static/AppIcon_120.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="152x152"
+                href="/static/AppIcon_152.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="167x167"
+                href="/static/AppIcon_167.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="180x180"
+                href="/static/AppIcon_180.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="192x192"
+                href="/static/AppIcon_192.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="228x228"
+                href="/static/AppIcon_228.png"
+              />
 
-            <meta
-              name="viewport"
-              content="width=device-width, initial-scale=1, maximum-scale=1"
-            />
-          </Head>
-          {children}
-          <QuickStartGuide />
-          <Script id="google-tag-manager" strategy="afterInteractive">
-            {`
+              <meta
+                name="viewport"
+                content="width=device-width, initial-scale=1, maximum-scale=1"
+              />
+            </Head>
+            {children}
+            <QuickStartGuide />
+            <Script id="google-tag-manager" strategy="afterInteractive">
+              {`
               (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
               new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
           `}
-          </Script>
-        </InputBarProvider>
-      </DesktopNavigationProvider>
-    </WelcomeTourGuideProvider>
+            </Script>
+          </InputBarProvider>
+        </DesktopNavigationProvider>
+      </WelcomeTourGuideProvider>
+    </ClientTypeProvider>
   );
 }

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,4 +1,4 @@
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { useFetcher } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type {
@@ -20,7 +20,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import type * as t from "io-ts";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 
 export function useCreateConversationWithMessage({
   owner,
@@ -30,7 +30,7 @@ export function useCreateConversationWithMessage({
   user: UserType | null;
 }) {
   const { fetcher } = useFetcher();
-  const { origin: contextOrigin } = useContext(InputBarContext);
+  const contextOrigin = useClientType();
 
   return useCallback(
     async ({

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -1,4 +1,4 @@
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
 import type {
@@ -10,7 +10,7 @@ import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 
 export function useSubmitMessage({
   owner,
@@ -21,7 +21,7 @@ export function useSubmitMessage({
   user: UserType;
   conversationId: string | null;
 }) {
-  const { origin: contextOrigin } = useContext(InputBarContext);
+  const contextOrigin = useClientType();
 
   return useCallback(
     async (messageData: {

--- a/front/lib/context/clientType.tsx
+++ b/front/lib/context/clientType.tsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export type ClientType = "web" | "extension";
+
+const ClientTypeContext = createContext<ClientType>("web");
+
+export function useClientType(): ClientType {
+  return useContext(ClientTypeContext);
+}
+
+export const ClientTypeProvider = ClientTypeContext.Provider;


### PR DESCRIPTION
## Description

The agent management buttons ("Create" and "Manage agents") are now hidden when running in the extensions by checking `clientType === "web"` in the `AgentBrowser` component. 

Introduces a new ClientTypeProvider context to distinguish between "web" and "extension" environments throughout the app. This distinction used to be in the `InputBarContext`, which didn't make much sense.
This refactoring also removes the origin prop from InputBarContext, replacing it with the `useClientType()` hook in `useCreateConversationWithMessage` and `useSubmitMessage`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
