### PR TITLE
[front] feat: SandboxImage tool manifest

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -450,6 +450,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "sandbox": {
     "bash": "never_ask",
+    "describe_environment": "never_ask",
   },
   "schedules_management": {
     "create_schedule": "high",

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -37,6 +37,21 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       done: "Execute command in sandbox",
     },
   },
+  describe_environment: {
+    description:
+      "Describe the sandbox environment and list available CLI binaries and language libraries.",
+    schema: {
+      format: z
+        .enum(["yaml", "json"])
+        .optional()
+        .describe("Output format (defaults to yaml)"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Describing sandbox environment",
+      done: "Describe sandbox environment",
+    },
+  },
 });
 
 export const SANDBOX_SERVER = {

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -7,6 +7,12 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { generateSandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
+import {
+  createToolManifest,
+  getSandboxImage,
+  toolManifestToJSON,
+  toolManifestToYAML,
+} from "@app/lib/api/sandbox/image";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -107,6 +113,16 @@ export function createSandboxTools(
       }
 
       const output = formatExecOutput(execResult.value);
+
+      return new Ok([{ type: "text" as const, text: output }]);
+    },
+    describe_environment: async ({ format }, { auth }) => {
+      const sandboxImage = getSandboxImage(auth);
+      const manifest = createToolManifest(sandboxImage.tools);
+      const output =
+        format === "json"
+          ? toolManifestToJSON(manifest)
+          : toolManifestToYAML(manifest);
 
       return new Ok([{ type: "text" as const, text: output }]);
     },

--- a/front/lib/api/sandbox/image/dust-base.ts
+++ b/front/lib/api/sandbox/image/dust-base.ts
@@ -5,8 +5,6 @@
  * pre-installed tools and packages using the imperative builder API.
  */
 
-import type { Authenticator } from "@app/lib/auth";
-
 import { SandboxImage } from "./sandbox_image";
 import type { NetworkPolicy } from "./types";
 
@@ -25,10 +23,6 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
     "index.crates.io",
   ],
 };
-
-export function getSandboxImage(_auth?: Authenticator): SandboxImage {
-  return DUST_BASE_IMAGE;
-}
 
 /**
  * The base Dust sandbox image.

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -1,5 +1,17 @@
-export { DUST_BASE_IMAGE, getSandboxImage } from "./dust-base";
+import type { Authenticator } from "@app/lib/auth";
+
+import { DUST_BASE_IMAGE } from "./dust-base";
+import type { SandboxImage } from "./sandbox_image";
+
+export function getSandboxImage(_auth?: Authenticator): SandboxImage {
+  return DUST_BASE_IMAGE;
+}
 export { SandboxImage } from "./sandbox_image";
+export {
+  createToolManifest,
+  toolManifestToJSON,
+  toolManifestToYAML,
+} from "./tool_manifest";
 export type {
   BaseImage,
   NetworkMode,

--- a/front/lib/api/sandbox/image/sandbox_image.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import { SandboxImage } from "./sandbox_image";
 import type { SandboxImageId } from "./types";
 
@@ -148,14 +149,50 @@ describe("SandboxImage.registerTool()", () => {
 });
 
 describe("SandboxImage.copy()", () => {
-  test("adds copy operation", () => {
+  test("accepts string path", () => {
     const image = SandboxImage.fromUbuntu().copy("./src", "/app/src");
 
     expect(image.operations).toHaveLength(1);
     expect(image.operations[0].type).toBe("copy");
     if (image.operations[0].type === "copy") {
-      expect(image.operations[0].src).toBe("./src");
+      expect(image.operations[0].src.type).toBe("path");
+      if (image.operations[0].src.type === "path") {
+        expect(image.operations[0].src.path).toBe("./src");
+      }
       expect(image.operations[0].dest).toBe("/app/src");
+    }
+  });
+
+  test("accepts content generator callback", () => {
+    const image = SandboxImage.fromUbuntu().copy(
+      () => "hello world",
+      "/app/file.txt"
+    );
+
+    expect(image.operations).toHaveLength(1);
+    expect(image.operations[0].type).toBe("copy");
+    if (image.operations[0].type === "copy") {
+      expect(image.operations[0].src.type).toBe("content");
+      if (image.operations[0].src.type === "content") {
+        expect(image.operations[0].src.getContent()).toBe("hello world");
+      }
+      expect(image.operations[0].dest).toBe("/app/file.txt");
+    }
+  });
+
+  test("accepts content generator returning Buffer", () => {
+    const image = SandboxImage.fromUbuntu().copy(
+      () => Buffer.from("binary data"),
+      "/app/data.bin"
+    );
+
+    expect(image.operations).toHaveLength(1);
+    if (image.operations[0].type === "copy") {
+      expect(image.operations[0].src.type).toBe("content");
+      if (image.operations[0].src.type === "content") {
+        const content = image.operations[0].src.getContent();
+        expect(Buffer.isBuffer(content)).toBe(true);
+      }
     }
   });
 });
@@ -228,44 +265,105 @@ describe("SandboxImage immutability", () => {
   });
 });
 
-describe("SandboxImage.toManifest()", () => {
-  test("generates manifest with version 1.0", () => {
-    const image = SandboxImage.fromUbuntu();
-    const manifest = image.toManifest();
+describe("SandboxImage.withToolManifest()", () => {
+  test("adds copy operation with content generator", () => {
+    const image = SandboxImage.fromUbuntu().withToolManifest();
 
-    expect(manifest.version).toBe("1.0");
+    expect(image.operations).toHaveLength(1);
+    expect(image.operations[0].type).toBe("copy");
+    if (image.operations[0].type === "copy") {
+      expect(image.operations[0].src.type).toBe("content");
+      expect(image.operations[0].dest).toBe("/home/user/tool-manifest.yaml");
+      if (image.operations[0].src.type === "content") {
+        const content = image.operations[0].src.getContent();
+        expect(typeof content).toBe("string");
+        expect(content).toContain("version:");
+      }
+    }
   });
 
-  test("includes generatedAt timestamp", () => {
-    const image = SandboxImage.fromUbuntu();
-    const manifest = image.toManifest();
+  test("accepts custom path and format", () => {
+    const image = SandboxImage.fromUbuntu().withToolManifest({
+      path: "/custom/path/manifest.json",
+      format: "json",
+    });
 
-    expect(manifest.generatedAt).toBeDefined();
-    expect(() => new Date(manifest.generatedAt)).not.toThrow();
+    expect(image.operations).toHaveLength(1);
+    if (image.operations[0].type === "copy") {
+      expect(image.operations[0].dest).toBe("/custom/path/manifest.json");
+      if (image.operations[0].src.type === "content") {
+        const content = image.operations[0].src.getContent();
+        expect(content).toContain('"version"');
+      }
+    }
   });
 
-  test("includes all tools", () => {
-    const image = SandboxImage.fromUbuntu()
-      .registerTool(
-        { name: "curl", description: "HTTP client" },
-        { installCmd: "apt-get install -y curl" }
-      )
-      .registerTool(
-        { name: "pandas", description: "Data analysis" },
-        { installCmd: "pip install pandas" }
-      )
-      .registerTool(
-        { name: "custom", description: "Custom tool" },
-        { installCmd: "./setup-custom.sh" }
+  test("uses correct default extension based on format", () => {
+    const jsonImage = SandboxImage.fromUbuntu().withToolManifest({
+      format: "json",
+    });
+
+    if (jsonImage.operations[0].type === "copy") {
+      expect(jsonImage.operations[0].dest).toBe(
+        "/home/user/tool-manifest.json"
       );
+    }
+  });
 
-    const manifest = image.toManifest();
+  test("returns new instance (immutability)", () => {
+    const original = SandboxImage.fromUbuntu();
+    const modified = original.withToolManifest();
 
-    expect(manifest.tools).toHaveLength(3);
-    expect(manifest.tools.map((t) => t.name)).toEqual([
-      "curl",
-      "pandas",
-      "custom",
-    ]);
+    expect(modified).not.toBe(original);
+    expect(original.operations).toHaveLength(0);
+    expect(modified.operations).toHaveLength(1);
+  });
+
+  test("chains with other operations", () => {
+    const image = SandboxImage.fromUbuntu()
+      .registerTool({ name: "curl", description: "HTTP client" })
+      .runCmd("echo hello")
+      .withToolManifest()
+      .runCmd("echo done");
+
+    expect(image.operations).toHaveLength(3);
+    expect(image.operations[0].type).toBe("run");
+    expect(image.operations[1].type).toBe("copy");
+    expect(image.operations[2].type).toBe("run");
+  });
+
+  test("includes registered tools in manifest content", () => {
+    const image = SandboxImage.fromUbuntu()
+      .registerTool({ name: "curl", description: "HTTP client" })
+      .registerTool({ name: "jq", description: "JSON processor" })
+      .withToolManifest();
+
+    if (
+      image.operations[0].type === "copy" &&
+      image.operations[0].src.type === "content"
+    ) {
+      const content = image.operations[0].src.getContent();
+      expect(content).toContain("curl");
+      expect(content).toContain("HTTP client");
+      expect(content).toContain("jq");
+      expect(content).toContain("JSON processor");
+    }
+  });
+
+  test("lazily generates content (captures tools at call time)", () => {
+    const baseImage = SandboxImage.fromUbuntu().registerTool({
+      name: "curl",
+      description: "HTTP client",
+    });
+
+    const imageWithManifest = baseImage.withToolManifest();
+
+    if (
+      imageWithManifest.operations[0].type === "copy" &&
+      imageWithManifest.operations[0].src.type === "content"
+    ) {
+      const content = imageWithManifest.operations[0].src.getContent();
+      expect(content).toContain("curl");
+    }
   });
 });

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -1,11 +1,18 @@
+import {
+  createToolManifest,
+  toolManifestToJSON,
+  toolManifestToYAML,
+} from "./tool_manifest";
 import type {
   BaseImage,
+  ContentGenerator,
+  CopySource,
+  ManifestFormat,
   NetworkPolicy,
   Operation,
   SandboxImageId,
   SandboxResources,
   ToolEntry,
-  ToolManifest,
 } from "./types";
 
 const DEFAULT_RESOURCES: SandboxResources = {
@@ -107,10 +114,17 @@ export class SandboxImage {
     });
   }
 
-  copy(src: string, dest: string): SandboxImage {
+  copy(src: string, dest: string): SandboxImage;
+  copy(src: ContentGenerator, dest: string): SandboxImage;
+  copy(src: string | ContentGenerator, dest: string): SandboxImage {
+    const srcValue: CopySource =
+      typeof src === "string"
+        ? { type: "path", path: src }
+        : { type: "content", getContent: src };
+
     const operation: Operation = {
       type: "copy",
-      src,
+      src: srcValue,
       dest,
     };
 
@@ -150,11 +164,24 @@ export class SandboxImage {
     return this.clone({ network: policy });
   }
 
-  toManifest(): ToolManifest {
-    return {
-      version: "1.0",
-      generatedAt: new Date().toISOString(),
-      tools: this.tools,
+  withToolManifest(options?: {
+    path?: string;
+    format?: ManifestFormat;
+  }): SandboxImage {
+    const format = options?.format ?? "yaml";
+    const extension = format === "yaml" ? "yaml" : "json";
+    const destPath =
+      options?.path ?? `${this.workdir}/tool-manifest.${extension}`;
+
+    // Capture tools at call time, generate content lazily
+    const tools = this.tools;
+    const getContent = (): string => {
+      const manifest = createToolManifest(tools);
+      return format === "yaml"
+        ? toolManifestToYAML(manifest)
+        : toolManifestToJSON(manifest);
     };
+
+    return this.copy(getContent, destPath);
   }
 }

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -1,0 +1,95 @@
+import * as yaml from "js-yaml";
+import { describe, expect, test } from "vitest";
+
+import {
+  createToolManifest,
+  toolManifestToJSON,
+  toolManifestToYAML,
+} from "./tool_manifest";
+import type { ToolManifest } from "./types";
+
+describe("createToolManifest()", () => {
+  test("generates manifest with version 1.0", () => {
+    const manifest = createToolManifest([]);
+
+    expect(manifest.version).toBe("1.0");
+  });
+
+  test("includes generatedAt timestamp", () => {
+    const manifest = createToolManifest([]);
+
+    expect(manifest.generatedAt).toBeDefined();
+    expect(() => new Date(manifest.generatedAt)).not.toThrow();
+  });
+
+  test("includes all tools", () => {
+    const tools = [
+      { name: "curl", description: "HTTP client" },
+      { name: "pandas", description: "Data analysis" },
+      { name: "custom", description: "Custom tool" },
+    ];
+
+    const manifest = createToolManifest(tools);
+
+    expect(manifest.tools).toHaveLength(3);
+    expect(manifest.tools.map((t) => t.name)).toEqual([
+      "curl",
+      "pandas",
+      "custom",
+    ]);
+  });
+});
+
+describe("toolManifestToJSON()", () => {
+  test("generates valid JSON string", () => {
+    const manifest = createToolManifest([
+      { name: "curl", description: "HTTP client" },
+    ]);
+
+    const jsonString = toolManifestToJSON(manifest);
+
+    expect(typeof jsonString).toBe("string");
+    expect(() => JSON.parse(jsonString)).not.toThrow();
+  });
+
+  test("includes all manifest fields", () => {
+    const manifest = createToolManifest([
+      { name: "curl", description: "HTTP client" },
+    ]);
+
+    const jsonString = toolManifestToJSON(manifest);
+    const parsed = JSON.parse(jsonString);
+
+    expect(parsed.version).toBe("1.0");
+    expect(parsed.generatedAt).toBeDefined();
+    expect(parsed.tools).toHaveLength(1);
+  });
+});
+
+describe("toolManifestToYAML()", () => {
+  test("generates valid YAML string", () => {
+    const manifest = createToolManifest([
+      { name: "curl", description: "HTTP client" },
+    ]);
+
+    const yamlString = toolManifestToYAML(manifest);
+
+    expect(typeof yamlString).toBe("string");
+    expect(yamlString).toContain("version:");
+    expect(yamlString).toContain("tools:");
+  });
+
+  test("YAML can be parsed back and matches JSON manifest", () => {
+    const tools = [
+      { name: "curl", description: "HTTP client" },
+      { name: "pandas", description: "Data analysis" },
+    ];
+    const manifest = createToolManifest(tools);
+
+    const yamlString = toolManifestToYAML(manifest);
+    const parsedYaml = yaml.load(yamlString) as ToolManifest;
+
+    expect(parsedYaml.version).toBe(manifest.version);
+    expect(parsedYaml.tools).toEqual(manifest.tools);
+  });
+});

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -1,0 +1,19 @@
+import * as yaml from "js-yaml";
+
+import type { ToolEntry, ToolManifest } from "./types";
+
+export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
+  return {
+    version: "1.0",
+    generatedAt: new Date().toISOString(),
+    tools,
+  };
+}
+
+export function toolManifestToJSON(manifest: ToolManifest): string {
+  return JSON.stringify(manifest, null, 2);
+}
+
+export function toolManifestToYAML(manifest: ToolManifest): string {
+  return yaml.dump(manifest);
+}

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -60,9 +60,17 @@ export interface ToolEntry {
 // Operations
 // ---------------------------------------------------------------------------
 
+export type ManifestFormat = "json" | "yaml";
+
+export type ContentGenerator = () => Buffer | string;
+
+export type CopySource =
+  | { readonly type: "path"; readonly path: string }
+  | { readonly type: "content"; readonly getContent: ContentGenerator };
+
 export type Operation =
   | { readonly type: "run"; readonly command: string }
-  | { readonly type: "copy"; readonly src: string; readonly dest: string }
+  | { readonly type: "copy"; readonly src: CopySource; readonly dest: string }
   | { readonly type: "workdir"; readonly path: string }
   | {
       readonly type: "env";

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -1,7 +1,5 @@
-import {
-  DUST_BASE_IMAGE,
-  type SandboxImageId,
-} from "@app/lib/api/sandbox/image";
+import type { SandboxImageId } from "@app/lib/api/sandbox/image";
+import { DUST_BASE_IMAGE } from "@app/lib/api/sandbox/image/dust-base";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { buildSandboxImage } from "./e2b_template";

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -8,8 +8,10 @@
 import config from "@app/lib/api/config";
 import type { SandboxImage } from "@app/lib/api/sandbox/image";
 import type {
+  ContentGenerator,
   Operation,
   SandboxImageId,
+  SandboxResources,
 } from "@app/lib/api/sandbox/image/types";
 import { formatSandboxImageId } from "@app/lib/api/sandbox/image/types";
 import logger from "@app/logger/logger";
@@ -17,8 +19,11 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { TemplateBuilder, TemplateClass } from "e2b";
+import type { TemplateBuilder } from "e2b";
 import { defaultBuildLogger, Template as E2BTemplate } from "e2b";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 interface E2BBuildConfig {
   apiKey?: string;
@@ -26,45 +31,118 @@ interface E2BBuildConfig {
   skipCache?: boolean;
 }
 
-function applyOperation(e2b: TemplateBuilder, op: Operation): TemplateBuilder {
-  switch (op.type) {
-    case "run":
-      return e2b.runCmd(op.command);
+class ContentMaterializer {
+  private tempDir: string | null = null;
+  private fileCount = 0;
 
-    case "copy":
-      return e2b.copy(op.src, op.dest);
+  materializeToPath(getContent: ContentGenerator): string {
+    if (!this.tempDir) {
+      this.tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-build-"));
+    }
+    const tempFile = path.join(this.tempDir, `content-${this.fileCount++}`);
+    fs.writeFileSync(tempFile, getContent());
+    return tempFile;
+  }
 
-    case "workdir":
-      return e2b.setWorkdir(op.path);
-
-    case "env":
-      return e2b.setEnvs({ ...op.vars });
-
-    default:
-      return assertNever(op);
+  cleanup(): void {
+    if (this.tempDir) {
+      fs.rmSync(this.tempDir, { recursive: true, force: true });
+    }
   }
 }
 
-function toE2BTemplate(image: SandboxImage): TemplateClass {
-  const baseImage = image.baseImage;
-  let e2b: TemplateBuilder;
+interface E2BTemplateBuildOptions {
+  apiKey: string;
+  domain?: string;
+  skipCache?: boolean;
+  resources: SandboxResources;
+}
 
-  switch (baseImage.type) {
-    case "ubuntu":
-      e2b = E2BTemplate().fromUbuntuImage(baseImage.version);
-      break;
-    case "template":
-      e2b = E2BTemplate().fromTemplate(formatSandboxImageId(baseImage.id));
-      break;
-    default:
-      return assertNever(baseImage);
+class E2BTemplateBuilder {
+  private builder: TemplateBuilder;
+  private readonly materializer = new ContentMaterializer();
+
+  private constructor(builder: TemplateBuilder) {
+    this.builder = builder;
   }
 
-  for (const op of image.operations) {
-    e2b = applyOperation(e2b, op);
+  static fromSandboxImage(image: SandboxImage): E2BTemplateBuilder {
+    const baseImage = image.baseImage;
+    let builder: TemplateBuilder;
+
+    switch (baseImage.type) {
+      case "ubuntu":
+        builder = E2BTemplate().fromUbuntuImage(baseImage.version);
+        break;
+      case "template":
+        builder = E2BTemplate().fromTemplate(
+          formatSandboxImageId(baseImage.id)
+        );
+        break;
+      default:
+        return assertNever(baseImage);
+    }
+
+    const e2bBuilder = new E2BTemplateBuilder(builder);
+
+    for (const op of image.operations) {
+      e2bBuilder.applyOperation(op);
+    }
+
+    return e2bBuilder;
   }
 
-  return e2b;
+  private applyOperation(op: Operation): void {
+    switch (op.type) {
+      case "run":
+        this.builder = this.builder.runCmd(op.command);
+        break;
+
+      case "copy":
+        if (op.src.type === "path") {
+          this.builder = this.builder.copy(op.src.path, op.dest);
+        } else {
+          const tempPath = this.materializer.materializeToPath(
+            op.src.getContent
+          );
+          this.builder = this.builder.copy(tempPath, op.dest);
+        }
+        break;
+
+      case "workdir":
+        this.builder = this.builder.setWorkdir(op.path);
+        break;
+
+      case "env":
+        this.builder = this.builder.setEnvs({ ...op.vars });
+        break;
+
+      default:
+        assertNever(op);
+    }
+  }
+
+  async build(
+    imageId: SandboxImageId,
+    options: E2BTemplateBuildOptions
+  ): Promise<{ templateId: string }> {
+    try {
+      return await E2BTemplate.build(
+        this.builder,
+        formatSandboxImageId(imageId),
+        {
+          cpuCount: options.resources.vcpu,
+          memoryMB: options.resources.memoryMb,
+          apiKey: options.apiKey,
+          ...(options.domain ? { domain: options.domain } : {}),
+          ...(options.skipCache ? { skipCache: true } : {}),
+          onBuildLogs: defaultBuildLogger(),
+        }
+      );
+    } finally {
+      this.materializer.cleanup();
+    }
+  }
 }
 
 export async function buildSandboxImage(
@@ -92,20 +170,14 @@ export async function buildSandboxImage(
   );
 
   try {
-    const e2bTemplate = toE2BTemplate(image);
+    const e2bBuilder = E2BTemplateBuilder.fromSandboxImage(image);
 
-    const result = await E2BTemplate.build(
-      e2bTemplate,
-      formatSandboxImageId(imageId),
-      {
-        cpuCount: image.resources.vcpu,
-        memoryMB: image.resources.memoryMb,
-        apiKey,
-        ...(domain ? { domain } : {}),
-        ...(buildConfig?.skipCache ? { skipCache: true } : {}),
-        onBuildLogs: defaultBuildLogger(),
-      }
-    );
+    const result = await e2bBuilder.build(imageId, {
+      apiKey,
+      domain,
+      skipCache: buildConfig?.skipCache,
+      resources: image.resources,
+    });
 
     logger.info(
       {
@@ -115,7 +187,7 @@ export async function buildSandboxImage(
           memoryMB: image.resources.memoryMb,
         },
       },
-      "E2B sandbox image build completed - verify resources in E2B dashboard or use sandbox_image_list.ts"
+      "E2B sandbox image build completed"
     );
 
     return new Ok(result.templateId);


### PR DESCRIPTION
## Description

- Copy now support JIT content generation (useful to write files without buffering the content in memory for no reason). This lead to complexity creep in the e2b template builder factory. To counter that, redesigned it a bit to have a better separation of concerns
- improve tools manifest generation
- dust-base now has a tool manifest file in work-dir
- added a tool `listTools` in sandbox mcp server

Fix https://github.com/dust-tt/tasks/issues/6926

## Tests

- Unit tests
- Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front