### PR TITLE
[Slack MCP] Search_channel optimization

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -17,10 +17,10 @@ import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
 import slackifyMarkdown from "slackify-markdown";
 
 // Constants for Slack API limits and pagination.
-export const MAX_CHANNELS_LIMIT = 500;
 export const MAX_CHANNEL_SEARCH_RESULTS = 20;
 export const MAX_THREAD_MESSAGES = 200;
 export const SLACK_API_PAGE_SIZE = 200; // Slack recommendation 100 to 200 and max 1000 per request.
+export const MAX_PUBLIC_CHANNELS_LIMIT = 1000; // conversations.list is Tier 2 (20 req/min) => max 5 request plus cache TTL.
 export const DEFAULT_THREAD_MESSAGES = 20;
 export const SLACK_THREAD_LISTING_LIMIT = 100;
 export const CHANNEL_CACHE_TTL_MS = 60 * 10 * 1000;
@@ -52,10 +52,9 @@ export const getSlackClient = async (accessToken?: string) => {
   });
 };
 
-type GetChannelsArgs = {
-  slackClient: WebClient;
-  scope: "public" | "joined";
-};
+type GetChannelsArgs =
+  | { slackClient: WebClient; scope: "public"; limit: number }
+  | { slackClient: WebClient; scope: "joined" };
 
 type ChannelWithIdAndName = Omit<Channel, "id" | "name"> & {
   id: string;
@@ -188,10 +187,10 @@ export function cleanUserGroupPayload(
   };
 }
 
-export const getChannels = async ({
-  slackClient,
-  scope,
-}: GetChannelsArgs): Promise<ChannelWithIdAndName[]> => {
+export const getChannels = async (
+  args: GetChannelsArgs
+): Promise<ChannelWithIdAndName[]> => {
+  const { slackClient, scope } = args;
   const channels: Channel[] = [];
   let cursor: string | undefined = undefined;
 
@@ -223,11 +222,9 @@ export const getChannels = async ({
     channels.push(...(response.channels ?? []));
     cursor = response.response_metadata?.next_cursor;
 
-    // We can't handle a huge list of channels, and even if we could, it would be unusable.
-    // So we arbitrarily cap it to MAX_CHANNELS_LIMIT channels.
-    if (channels.length >= MAX_CHANNELS_LIMIT) {
-      logger.warn(
-        `Channel list truncated after reaching over ${MAX_CHANNELS_LIMIT} channels.`
+    if (args.scope === "public" && channels.length >= args.limit) {
+      logger.info(
+        `Channel list capped at ${args.limit} channels (scope: ${scope}).`
       );
       break;
     }
@@ -250,7 +247,11 @@ export const getCachedPublicChannels = cacheWithRedis(
     slackClient: WebClient;
     mcpServerId: string;
   }): Promise<ChannelWithIdAndName[]> => {
-    return getChannels({ slackClient, scope: "public" });
+    return getChannels({
+      slackClient,
+      scope: "public",
+      limit: MAX_PUBLIC_CHANNELS_LIMIT,
+    });
   },
   ({ mcpServerId }: { mcpServerId: string }) => mcpServerId,
   {
@@ -593,30 +594,6 @@ function filterUsers(
   return allMatches.slice(0, limit);
 }
 
-async function searchAndProcessChannels(
-  slackClient: WebClient,
-  scope: "joined" | "public",
-  query: string,
-  contextMessage: string
-): Promise<{
-  result: Ok<Array<{ type: "text"; text: string }>>;
-  count: number;
-}> {
-  const channels = await getChannels({ slackClient, scope });
-  const matched = filterChannels(channels, query);
-  const cleaned = matched.map(cleanChannelPayload);
-  const markdown = cleaned.map(formatChannelAsMarkdown).join("\n");
-  return {
-    result: new Ok([
-      {
-        type: "text" as const,
-        text: `Found ${cleaned.length} channel(s) ${contextMessage}:\n\n${markdown}`,
-      },
-    ]),
-    count: cleaned.length,
-  };
-}
-
 function formatChannelAsMarkdown(c: MinimalChannelInfo): string {
   return [
     `- **#${c.name}**`,
@@ -635,11 +612,13 @@ function formatChannelAsMarkdown(c: MinimalChannelInfo): string {
 // Execute search_channels: automatically detects channel IDs vs text search.
 export async function executeSearchChannels(
   query: string,
-  scope: "auto" | "joined" | "all",
+  searchAll: boolean,
   {
     accessToken,
+    mcpServerId,
   }: {
     accessToken: string;
+    mcpServerId: string;
   }
 ): Promise<Ok<Array<{ type: "text"; text: string }>> | Err<MCPError>> {
   const slackClient = await getSlackClient(accessToken);
@@ -674,49 +653,24 @@ export async function executeSearchChannels(
   }
 
   // Search lookup.
-  // Scope="auto": search in joined channels; if no match fallback in all public channels.
-  if (scope === "auto") {
-    const { result: joinedResult, count: joinedCount } =
-      await searchAndProcessChannels(
-        slackClient,
-        "joined",
-        query,
-        "in your joined channels"
-      );
+  // search_all=true: use workspace-level Redis cache (public channels, TTL 10min)
+  // search_all=false: fetch joined channels (user-specific, no cache)
+  const channels = searchAll
+    ? await getCachedPublicChannels({ slackClient, mcpServerId })
+    : await getChannels({ slackClient, scope: "joined" });
+  const contextMessage = searchAll
+    ? "in public workspace channels"
+    : "in your joined channels";
 
-    if (joinedCount > 0) {
-      return joinedResult;
-    }
-
-    // Fallback to all public channels.
-    const { result: publicResult } = await searchAndProcessChannels(
-      slackClient,
-      "public",
-      query,
-      "in public workspace channels"
-    );
-    return publicResult;
-  }
-
-  // Scope="joined": search all public, private, im and mpim joined channels.
-  if (scope === "joined") {
-    const { result } = await searchAndProcessChannels(
-      slackClient,
-      "joined",
-      query,
-      "in your joined channels"
-    );
-    return result;
-  }
-
-  // Scope="all": search all public channels.
-  const { result } = await searchAndProcessChannels(
-    slackClient,
-    "public",
-    query,
-    "in public workspace channels"
-  );
-  return result;
+  const matched = filterChannels(channels, query);
+  const cleaned = matched.map(cleanChannelPayload);
+  const markdown = cleaned.map(formatChannelAsMarkdown).join("\n");
+  return new Ok([
+    {
+      type: "text" as const,
+      text: `Found ${cleaned.length} channel(s) ${contextMessage}:\n\n${markdown}`,
+    },
+  ]);
 }
 
 // Used by slack_bot

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -201,23 +201,20 @@ Query parameter accepts:
 - Channel ID (e.g., 'C01234ABCD') - instant lookup
 - Channel name or keywords (e.g., 'marketing') - searches channel names, topics, and descriptions, returns top ${MAX_CHANNEL_SEARCH_RESULTS} matches
 
-Scope parameter (applies only to text searches):
-- 'auto' (default) - searches joined channels first, then falls back to all public channels if no results
-- 'joined' - searches only joined channels
-- 'all' - searches only all public channels
-
-Use 'auto' scope by default unless searching for a specific channel subset.`,
+By default, searches only joined channels (public, private, IMs, group DMs).
+Set search_all=true only if the user explicitly requests to search all public workspace channels.`,
     schema: {
       query: z
         .string()
         .describe(
           "Channel ID (e.g., 'C01234ABCD'), channel name, or search keywords. Channel IDs are automatically detected."
         ),
-      scope: z
-        .enum(["auto", "joined", "all"])
-        .default("auto")
+      search_all: z
+        .boolean()
+        .optional()
+        .default(false)
         .describe(
-          "'auto' (default, always use this unless user specifies), 'joined' (only joined channels), 'all' (only public channels). Ignored when query is a channel ID."
+          "Only set to true if the user explicitly requests searching all public workspace channels. By default, searches only joined channels. Ignored when query is a channel ID."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -642,15 +642,16 @@ export function createSlackPersonalTools(
       }
     },
 
-    search_channels: async ({ query, scope }, { authInfo }) => {
+    search_channels: async ({ query, search_all }, { authInfo }) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
       }
 
       try {
-        return await executeSearchChannels(query, scope, {
+        return await executeSearchChannels(query, search_all, {
           accessToken,
+          mcpServerId,
         });
       } catch (error) {
         const authError = handleSlackAuthError(error);


### PR DESCRIPTION
## Description

Simplifies the `search_channels` tool by replacing the `scope` parameter (with values `auto`, `joined`, `all`) with a boolean `search_all` parameter. This fixes the timeout issue reported in #6940 where agents were defaulting to `scope: "all"` on large workspaces, causing slow responses. The new implementation leverages the existing Redis cache (`getCachedPublicChannels`) when `search_all=true` (public channels, 10min TTL, capped at 1000 channels to limit to 5 API calls given Tier 2 rate limits), and fetches joined channels directly (no cache) when `search_all=false`. The tool now defaults to searching only joined channels unless explicitly requested otherwise, and removes the auto-fallback logic that was causing unpredictable performance.
[Front ticket](https://app.frontapp.com/open/cnv_1bvvq6ja?key=V0YV318J17RpqgKN2atKULusjEH8OmGq)

## Risk

Low. Changes API signature of `search_channels` tool (existing agents will adapt to the new schema).

## Tests

Local

## Deploy Plan

Run front