### PR TITLE
[front] - refactor: update styling of `AgentBuilderLeftPanel`

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -53,7 +53,7 @@ export function AgentBuilderLeftPanel({
         }
       />
       <ScrollArea className="flex-1">
-        <div className="w-full space-y-10 px-2 py-8">
+        <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
           <AgentBuilderInstructionsBlock
             agentConfigurationId={agentConfigurationId}
           />


### PR DESCRIPTION
## Description

This PR reverts some style changes introduced by https://github.com/dust-tt/dust/pull/22421 - it centers the main container in the panel and adjust padding for larger screens

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front