### PR TITLE
feat: add memory to the suggestions to improve

### DIFF
--- a/front/lib/butler/analyze_conversation.test.ts
+++ b/front/lib/butler/analyze_conversation.test.ts
@@ -445,6 +445,66 @@ describe("analyzeConversation", () => {
     expect(suggestions).toHaveLength(0);
   });
 
+  it("includes dismissed suggestion history in the prompt", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    // Create a conversation with enough messages for rank distance > cooldown.
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: Array.from({ length: 8 }, () => new Date()),
+    });
+
+    const messages = await MessageModel.findAll({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+      },
+      order: [["rank", "ASC"]],
+    });
+
+    // First call: creates a rename_title suggestion from early message.
+    setupMocksForHighConfidenceRename();
+    await analyzeConversation(authenticator, {
+      conversation,
+      messageId: messages[0].sId,
+    });
+
+    // Manually dismiss the suggestion.
+    await ConversationButlerSuggestionModel.update(
+      { status: "dismissed" },
+      {
+        where: {
+          workspaceId: workspace.id,
+          suggestionType: "rename_title",
+        },
+      }
+    );
+
+    // Second call from a high-rank message (beyond cooldown).
+    const lastMessage = messages[messages.length - 1];
+    expect(lastMessage.rank).toBeGreaterThanOrEqual(10);
+
+    vi.clearAllMocks();
+    mockGetAgentConfigurations.mockResolvedValue([] as never);
+    setupMocksForHighConfidenceRename();
+
+    await analyzeConversation(authenticator, {
+      conversation,
+      messageId: lastMessage.sId,
+    });
+
+    // Verify the prompt passed to renderConversationForModel contains the history.
+    expect(mockRenderConversation).toHaveBeenCalledOnce();
+    const promptArg = mockRenderConversation.mock.calls[0][1].prompt;
+    expect(promptArg).toContain("DISMISSED");
+    expect(promptArg).toContain("Better Title");
+    expect(promptArg).toContain("Do NOT re-suggest titles that were DISMISSED");
+  });
+
   describe("rename_title throttling", () => {
     it("skips rename when a pending suggestion exists within cooldown", async () => {
       const { authenticator, workspace } = await createResourceTest({

--- a/front/lib/butler/analyze_conversation.ts
+++ b/front/lib/butler/analyze_conversation.ts
@@ -14,7 +14,9 @@ import type {
   ButlerSuggestionCreatedEvent,
   ConversationType,
 } from "@app/types/assistant/conversation";
+import type { ButlerSuggestionData } from "@app/types/conversation_butler_suggestion";
 import type { ModelId } from "@app/types/shared/model_id";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const SUGGEST_ACTIONS_FUNCTION_NAME = "suggest_actions";
 
@@ -83,7 +85,8 @@ function buildAnalyzeConversationSpecifications(
 
 function buildPrompt(
   currentTitle: string,
-  agents: LightAgentConfigurationType[]
+  agents: LightAgentConfigurationType[],
+  suggestionHistory: ButlerSuggestionData[]
 ): string {
   const shouldBuildPromptForAgentSuggestion = agents.length > 0;
 
@@ -130,6 +133,35 @@ function buildPrompt(
     prompt +=
       "No agents are available, so set agent_confidence to 0, agent_name to empty string, " +
       "and agent_prompt to empty string.\n\n";
+  }
+
+  if (suggestionHistory.length > 0) {
+    prompt += "Previous suggestion history (most recent first):\n";
+    for (const suggestion of suggestionHistory) {
+      const outcome =
+        suggestion.status === "accepted" ? "ACCEPTED" : "DISMISSED";
+
+      switch (suggestion.suggestionType) {
+        case "rename_title": {
+          const { suggestedTitle } = suggestion.metadata;
+          prompt += `- [${outcome}] Title rename: "${suggestedTitle}"\n`;
+          break;
+        }
+        case "call_agent": {
+          if (!shouldBuildPromptForAgentSuggestion) {
+            break;
+          }
+          const { agentName } = suggestion.metadata;
+          prompt += `- [${outcome}] Agent suggestion: ${agentName}\n`;
+          break;
+        }
+        default:
+          assertNever(suggestion);
+      }
+    }
+    prompt +=
+      "\nDo NOT re-suggest titles that were DISMISSED. " +
+      "Learn from accepted suggestions to understand user preferences.\n\n";
   }
 
   prompt +=
@@ -261,8 +293,14 @@ export async function analyzeConversation(
     .filter((a) => a.scope !== "global" && !participantSIds.has(a.sId))
     .slice(0, MAX_AGENTS_IN_PROMPT);
 
+  const suggestionHistory =
+    await ConversationButlerSuggestionResource.fetchResolvedByConversation(
+      auth,
+      { conversationId: conversation.id, limit: 10 }
+    );
+
   const currentTitle = conversation.title ?? "";
-  const prompt = buildPrompt(currentTitle, availableAgents);
+  const prompt = buildPrompt(currentTitle, availableAgents, suggestionHistory);
 
   const modelConversationRes = await renderConversationForModel(auth, {
     conversation,

--- a/front/lib/resources/conversation_butler_suggestion_resource.ts
+++ b/front/lib/resources/conversation_butler_suggestion_resource.ts
@@ -11,11 +11,12 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type {
-  ButlerSuggestionPublicType,
-  ButlerSuggestionType,
+import {
+  type ButlerSuggestionData,
+  type ButlerSuggestionPublicType,
+  type ButlerSuggestionType,
+  parseButlerSuggestionData,
 } from "@app/types/conversation_butler_suggestion";
-import { parseButlerSuggestionData } from "@app/types/conversation_butler_suggestion";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import type {
@@ -24,6 +25,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
+import { Op } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -179,6 +181,28 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     return results[0] ?? null;
   }
 
+  /**
+   * Fetch resolved (accepted or dismissed) suggestions for a conversation,
+   * ordered by most recent first.
+   */
+  static async fetchResolvedByConversation(
+    auth: Authenticator,
+    { conversationId, limit = 10 }: { conversationId: ModelId; limit?: number }
+  ): Promise<ButlerSuggestionData[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const suggestions = await this.baseFetch(auth, {
+      where: {
+        workspaceId,
+        conversationId,
+        status: { [Op.in]: ["accepted", "dismissed"] },
+      },
+      order: [["createdAt", "DESC"]],
+      limit,
+    });
+
+    return suggestions.map((s) => parseButlerSuggestionData(s));
+  }
+
   private async checkAccess(
     auth: Authenticator,
     transaction?: Transaction
@@ -275,6 +299,7 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     const data = parseButlerSuggestionData({
       suggestionType: this.suggestionType,
       metadata: this.metadata,
+      status: this.status,
     });
 
     return {
@@ -283,7 +308,6 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
       updatedAt: this.updatedAt.getTime(),
       sourceMessageSId: this.sourceMessageSId,
       resultMessageSId: this.resultMessageSId,
-      status: this.status,
       ...data,
     };
   }

--- a/front/types/conversation_butler_suggestion.ts
+++ b/front/types/conversation_butler_suggestion.ts
@@ -34,10 +34,12 @@ export const ButlerSuggestionDataSchema = z.discriminatedUnion(
     z.object({
       suggestionType: z.literal("rename_title"),
       metadata: RenameTitleMetadataSchema,
+      status: z.enum(BUTLER_SUGGESTION_STATUSES),
     }),
     z.object({
       suggestionType: z.literal("call_agent"),
       metadata: CallAgentMetadataSchema,
+      status: z.enum(BUTLER_SUGGESTION_STATUSES),
     }),
   ]
 );


### PR DESCRIPTION
## Description

An idea from @Fraggle was to add "memory" for the suggestions.

This PR adds the previous accepted/dismissed suggestions to improve the output

Fixes: https://github.com/dust-tt/tasks/issues/6909?notification_referrer_id=NT_kwHNQRvaACVSZXBvc2l0b3J5OzY5MzU4MDg3MTtJc3N1ZTs0MDEyODE1MjQ4

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
