### PR TITLE
feat: extension quick actions

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -26,11 +26,9 @@ const state: {
   refreshRequests: ((
     auth: OAuthAuthorizeResponse | AuthBackgroundResponseError
   ) => void)[];
-  lastHandler: (() => void) | undefined;
 } = {
   refreshingToken: false,
   refreshRequests: [],
-  lastHandler: undefined,
 };
 
 /**
@@ -139,7 +137,6 @@ chrome.runtime.onConnect.addListener(async (port) => {
       // This fires when sidepanel closes
       console.log("Sidepanel was closed");
       await platform.storage.set("extensionReady", false);
-      state.lastHandler = undefined;
     });
   }
 });
@@ -198,15 +195,19 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
     return;
   }
 
+  // chrome.sidePanel.open() must be called synchronously within the user gesture
+  // context. Any await before this call would break the gesture chain and throw:
+  // "sidePanel.open() may only be called in response to a user gesture".
+  if (tab) {
+    void chrome.sidePanel.open({ windowId: tab.windowId });
+  }
+
   const isExtensionReady =
     await platform.storage.get<boolean>("extensionReady");
 
-  if (!isExtensionReady && tab) {
-    // Store the handler for later use when the extension is ready.
-    state.lastHandler = handler;
-    void chrome.sidePanel.open({
-      windowId: tab.windowId,
-    });
+  if (!isExtensionReady) {
+    // Store the pending action for later use when the extension is ready.
+    await platform.storage.set("pendingAction", event.menuItemId);
   } else {
     void handler();
   }
@@ -377,11 +378,16 @@ chrome.runtime.onMessage.addListener(
         return true;
 
       case "INPUT_BAR_STATUS":
-        // Enable or disable the context menu items based on the input bar status. Actions are only available when the input bar is visible.
-        if (state.lastHandler && message.available) {
-          state.lastHandler();
-          state.lastHandler = undefined;
-        }
+        void (async () => {
+          if (message.available) {
+            const pendingAction =
+              await platform.storage.get<string>("pendingAction");
+            if (pendingAction) {
+              getActionHandler(pendingAction)?.();
+            }
+          }
+          await platform.storage.delete("pendingAction");
+        })();
         return false;
 
       default:

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -5,9 +5,10 @@ import { InputBarContextProvider } from "@app/components/assistant/conversation/
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
+import type { AttachSelectionMessage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface ConversationContainerProps {
   workspace: LightWorkspaceType;
@@ -72,6 +73,29 @@ export const ConversationContainer = ({
     setPrevConversationId(conversationId);
     fileUploaderService.resetUpload();
   }
+
+  useEffect(() => {
+    void platform.messaging?.sendMessage({
+      type: "INPUT_BAR_STATUS",
+      available: true,
+    });
+
+    const cleanup = platform.messaging?.addMessageListener(
+      async (message: AttachSelectionMessage) => {
+        if (message.type === "EXT_ATTACH_TAB") {
+          void fileUploaderService.uploadContentTab(message);
+        }
+      }
+    );
+
+    return () => {
+      void platform.messaging?.sendMessage({
+        type: "INPUT_BAR_STATUS",
+        available: false,
+      });
+      cleanup?.();
+    };
+  }, [platform.messaging, fileUploaderService.uploadContentTab]);
 
   return (
     <InputBarContextProvider


### PR DESCRIPTION



## Description
Fixes https://github.com/dust-tt/tasks/issues/6755
This PR restores extension quick actions.

- Added `useEffect` in `ConversationContainer` to send `INPUT_BAR_STATUS` signals and listen for `EXT_ATTACH_TAB` messages, replacing logic that was previously in the extension's own `InputBar.tsx` wrapper.
- Open the sidebar when clicking on a quick action
- Replaced in-memory `state.lastHandler` with chrome.storage `pendingAction`. This ensures quick actions work correctly when Chrome restarts the background service worker and in React StrictMode with double-mounts in development.


https://github.com/user-attachments/assets/5a60f470-9734-42a0-ac9a-9ac25a9b338f



## Tests

Manually tested.

## Risks

Low. Changes are isolated to extension-specific messaging flow. The `front` components remain unchanged.

## Deploy Plan

Standard deploy — no additional steps needed.
