### PR TITLE
Add logging to get a clearer view of registry use

### DIFF
--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -737,6 +737,8 @@ impl App {
                 .await?;
 
             info!(
+                project_id = project.project_id(),
+                run_id = run_id.as_str(),
                 block_type = block.block_type().to_string(),
                 block_name = name.as_str(),
                 successes = success,

--- a/core/src/blocks/helpers.rs
+++ b/core/src/blocks/helpers.rs
@@ -6,6 +6,7 @@ use hyper::body::Buf;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::io::prelude::*;
+use tracing::info;
 use url::Url;
 use urlencoding::encode;
 
@@ -48,6 +49,13 @@ pub async fn get_data_source_project_and_view_filter(
         Ok(key) => key,
         Err(_) => Err(anyhow!("Environment variable `DUST_FRONT_API` is not set."))?,
     };
+
+    info!(
+        workspace_id = workspace_id.as_str(),
+        data_source_id = data_source_id.as_str(),
+        is_system_run = is_system_run,
+        "registry lookup"
+    );
 
     let url = format!(
         "{}/api/registry/data_sources/lookup?workspace_id={}&data_source_id={}&is_system_run={}",

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -85,6 +85,15 @@ async function handler(
 
   const allowConversationsDataSources = req.query.is_system_run === "true";
 
+  logger.info(
+    {
+      type: req.query.type,
+      workspaceId: userWorkspaceId,
+      allowConversationsDataSources,
+    },
+    "Received registry lookup request"
+  );
+
   switch (req.method) {
     case "GET":
       switch (req.query.type) {
@@ -185,6 +194,19 @@ async function handleDataSourceView(
   dataSourceViewId: string,
   allowConversationsDataSources: boolean
 ): Promise<Result<LookupDataSourceResponseBody, Error>> {
+  logger.info(
+    {
+      dataSourceView: {
+        id: dataSourceViewId,
+      },
+      workspace: {
+        id: auth.getNonNullableWorkspace().id,
+        sId: auth.getNonNullableWorkspace().sId,
+      },
+    },
+    "Looking up registry with dataSourceView"
+  );
+
   const dataSourceView = await DataSourceViewResource.fetchById(
     auth,
     dataSourceViewId
@@ -233,7 +255,7 @@ async function handleDataSource(
         sId: auth.getNonNullableWorkspace().sId,
       },
     },
-    "Looking up registry with data source id"
+    "Looking up registry with DataSource"
   );
 
   const dataSource = await DataSourceResource.fetchByNameOrId(


### PR DESCRIPTION
## Description

Looks like we have a few DATASOURCE blocks still running but very few: https://app.datadoghq.eu/logs?query=%22Execution%20block%22%20%40block_type%3Adata_source&agg_m=count&agg_m_source=base&agg_q=%40block_type&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1772013711839&to_ts=1772618511839&live=true

The registry lookup logs are not perfectly aligned though: https://app.datadoghq.eu/logs?query=service%3Afront%20%40route%3A%22%2Fapi%2Fregistry%2F%5Btype%5D%2Flookup%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1772019250709&to_ts=1772624050709&live=true

Adding a few logs here and there to better understand the dynamics and use of the registry and attempt to remove it entirely.

## Tests

N/A mostly logging

## Risk

N/A logging

## Deploy Plan

- deploy `front`
- deploy `core`