### PR TITLE
feat: prioritize company data over toolsets for retrieval

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -228,6 +228,10 @@ If you need a capability that is not available in your current tools, first use 
 You may then either:
 - Enable the required toolset on yourself using \`toolsets__enable\` with the provided toolsetId
 - Spawn a sub-agent and pass the required toolset(s) via \`toolsetsToAdd\` so the sub-agent starts with them pre-enabled.
+
+IMPORTANT: For data retrieval, always prefer company data tools over enabling a platform-specific toolset. If the user's company data sources already index data from a platform (e.g. Slack, Notion, Google Drive, GitHub, etc.), use \`semantic_search\` or other company data tools instead of enabling the corresponding toolset. Company data is lower latency, already indexed, and easier to search.
+Only enable a toolset for data retrieval when the needed data is absent from or not indexed in company data sources (e.g. private data, real-time data, or data from a source that isn't connected).
+Toolsets remain valuable for **write operations** (posting a Slack message, creating a Notion page, updating a GitHub issue, etc.) that company data tools cannot perform.
 </additional_tools>
 `
     : "";

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -303,6 +303,12 @@ ${toolsetsList.length > 0 ? toolsetsList : "No additional toolsets are currently
 When encountering any request that might benefit from specialized tools, review the available toolsets above.
 Enable relevant toolsets using \`toolsets__enable\` with the toolsetId (shown in backticks) before attempting to fulfill the request.
 Never assume or reply that you cannot do something before checking if there's a relevant toolset available.
+
+<toolsets_vs_company_data>
+IMPORTANT: If the user's company data sources already index data from a platform (e.g. Slack, Notion, Google Drive, GitHub, etc.), always prefer searching company data over enabling the corresponding toolset for retrieval purposes. Company data is lower latency, already indexed, and easier to search.
+Only enable a toolset for data retrieval when the needed data is absent from or not indexed in company data sources (e.g. private data, real-time data, or data from a source that isn't connected).
+Toolsets remain valuable for **write operations** (posting a Slack message, creating a Notion page, updating a GitHub issue, etc.) that company data tools cannot perform.
+</toolsets_vs_company_data>
 </toolsets_guidelines>`;
 }
 


### PR DESCRIPTION
## Description

Adds explicit instructions to the `@dust` and `deep-dive` global agents to prefer company data sources over enabling platform-specific toolsets when retrieving data.

When data from a platform (Slack, Notion, Google Drive, GitHub, etc.) is already indexed in company data sources, agents should use `semantic_search` and other company data tools rather than enabling the corresponding toolset. Company data is lower latency, already indexed, and easier to search.

Toolsets remain recommended for:
- **Write operations** (posting to Slack, creating Notion pages, updating GitHub issues, etc.)
- **Retrieval of data not in company sources** (private data, real-time data, unconnected sources)

Changes applied in two places:
- `dust.ts` — `<toolsets_vs_company_data>` section in `buildToolsetsContext()` (affects all dust-like agents)
- `deep-dive.ts` — `<additional_tools>` section in `getToolsPrompt()` (affects deep-dive and dust-task sub-agents)

## Tests

Prompt-only change — no functional code modified.

## Risk

Low. Only adds guidance text to agent system prompts. No behavioral code changes.

## Deploy Plan

Standard deploy — changes take effect on next agent invocation.