### PR TITLE
[front] - feat(AgentActionDetails): display enabled tools & skills

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -3,7 +3,13 @@ import { AgentActionSummary } from "@app/components/assistant/conversation/actio
 import { PanelAgentStep } from "@app/components/assistant/conversation/actions/PanelAgentStep";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import {
+  getIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icons";
+import {
   useAgentMessageSkills,
+  useAgentMessageTools,
   useConversationMessage,
 } from "@app/hooks/conversations";
 import { useAgentMessageStreamLegacy } from "@app/hooks/useAgentMessageStreamLegacy";
@@ -58,6 +64,12 @@ function AgentActionsPanelContent({
     messageId,
   });
 
+  const { tools, mutateTools } = useAgentMessageTools({
+    owner,
+    conversation,
+    agentConfigurationId: fullAgentMessage.configuration.sId,
+  });
+
   const { messageStreamState, shouldStream, isFreshMountWithContent } =
     useAgentMessageStreamLegacy({
       message: getLightAgentMessageFromAgentMessage(fullAgentMessage),
@@ -91,8 +103,9 @@ function AgentActionsPanelContent({
       isFreshMountWithContent.current = true;
     } else if (fullAgentMessage.status === "succeeded") {
       void mutateSkills();
+      void mutateTools();
     }
-  }, [fullAgentMessage, isFreshMountWithContent, mutateSkills]);
+  }, [fullAgentMessage, isFreshMountWithContent, mutateSkills, mutateTools]);
 
   const [steps, setSteps] = useState<Record<number, ParsedContentItem[]>>({});
 
@@ -330,18 +343,35 @@ function AgentActionsPanelContent({
           <div>&nbsp;</div>
         </div>
       </div>
-      {skills.length > 0 && (
+      {(skills.length > 0 || tools.length > 0) && (
         <div className="flex flex-col gap-4 border-t border-separator bg-background p-4 dark:border-separator-night dark:bg-background-night">
-          <span className="text-semibold text-sm">Skills used</span>
+          <span className="text-semibold text-sm">Skills & tools enabled</span>
           <div className="flex flex-wrap items-center gap-1">
             {skills.map((skill) => (
               <Chip
                 key={skill.sId}
                 size="xs"
+                color="blue"
                 label={skill.name}
                 icon={getSkillIcon(skill.icon)}
               />
             ))}
+            {tools.map((tool) => {
+              const iconStr = tool.server.icon;
+              const icon =
+                isCustomResourceIconType(iconStr) ||
+                isInternalAllowedIcon(iconStr)
+                  ? getIcon(iconStr)
+                  : undefined;
+              return (
+                <Chip
+                  key={tool.sId}
+                  size="xs"
+                  label={tool.name ?? tool.server.name}
+                  icon={icon}
+                />
+              );
+            })}
           </div>
         </div>
       )}

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -2,11 +2,7 @@ import { AgentActionsPanelHeader } from "@app/components/assistant/conversation/
 import { AgentActionSummary } from "@app/components/assistant/conversation/actions/AgentActionsPanelSummary";
 import { PanelAgentStep } from "@app/components/assistant/conversation/actions/PanelAgentStep";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import {
-  getIcon,
-  isCustomResourceIconType,
-  isInternalAllowedIcon,
-} from "@app/components/resources/resources_icons";
+import { getIcon } from "@app/components/resources/resources_icons";
 import {
   useAgentMessageSkills,
   useAgentMessageTools,
@@ -345,7 +341,7 @@ function AgentActionsPanelContent({
       </div>
       {(skills.length > 0 || tools.length > 0) && (
         <div className="flex flex-col gap-4 border-t border-separator bg-background p-4 dark:border-separator-night dark:bg-background-night">
-          <span className="text-semibold text-sm">Skills & tools enabled</span>
+          <span className="text-semibold text-sm">Enabled capabilities</span>
           <div className="flex flex-wrap items-center gap-1">
             {skills.map((skill) => (
               <Chip
@@ -356,22 +352,14 @@ function AgentActionsPanelContent({
                 icon={getSkillIcon(skill.icon)}
               />
             ))}
-            {tools.map((tool) => {
-              const iconStr = tool.server.icon;
-              const icon =
-                isCustomResourceIconType(iconStr) ||
-                isInternalAllowedIcon(iconStr)
-                  ? getIcon(iconStr)
-                  : undefined;
-              return (
-                <Chip
-                  key={tool.sId}
-                  size="xs"
-                  label={tool.name ?? tool.server.name}
-                  icon={icon}
-                />
-              );
-            })}
+            {tools.map((tool) => (
+              <Chip
+                key={tool.sId}
+                size="xs"
+                label={tool.name ?? tool.server.name}
+                icon={getIcon(tool.server.icon)}
+              />
+            ))}
           </div>
         </div>
       )}

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -1,4 +1,5 @@
 export { useAgentMessageSkills } from "./useAgentMessageSkills";
+export { useAgentMessageTools } from "./useAgentMessageTools";
 export { useCancelMessage } from "./useCancelMessage";
 export { useConversation } from "./useConversation";
 export { useConversationFeedbacks } from "./useConversationFeedbacks";

--- a/front/hooks/conversations/useAgentMessageTools.ts
+++ b/front/hooks/conversations/useAgentMessageTools.ts
@@ -1,0 +1,39 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { FetchConversationToolsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/tools";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UseAgentMessageToolsParams {
+  owner: LightWorkspaceType;
+  conversation: ConversationWithoutContentType | null;
+  agentConfigurationId: string | null;
+  options?: {
+    disabled: boolean;
+  };
+}
+
+export function useAgentMessageTools({
+  owner,
+  conversation,
+  agentConfigurationId,
+  options,
+}: UseAgentMessageToolsParams) {
+  const { fetcher } = useFetcher();
+  const toolsFetcher: Fetcher<FetchConversationToolsResponse> = fetcher;
+
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    conversation && agentConfigurationId
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/tools?agent_configuration_id=${agentConfigurationId}`
+      : null,
+    toolsFetcher,
+    options
+  );
+
+  return {
+    tools: data?.tools ?? emptyArray(),
+    isToolsLoading: !options?.disabled && isLoading,
+    isToolsError: !!error,
+    mutateTools: mutate,
+  };
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -56,12 +56,17 @@ async function handler(
 
   switch (req.method) {
     case "GET":
+      const { agent_configuration_id: agentConfigurationId } = req.query;
+
       // Fetch enabled conversation MCP server views.
       const conversationMCPServerViews =
         await ConversationResource.fetchMCPServerViews(
           auth,
           conversationWithoutContent,
-          { onlyEnabled: true }
+          {
+            onlyEnabled: true,
+            ...(isString(agentConfigurationId) ? { agentConfigurationId } : {}),
+          }
         );
 
       // Batch-fetch all MCP server view details in a single query.


### PR DESCRIPTION
## Description

This PR extends the `AgentActionsPanel` to display both skills and tools enabled for an agent. Previously, only skills were shown in the breakdown panel; now tools (MCP server views) are also displayed alongside skills in a unified section. This improves visibility into all capabilities available to the agent during a conversation. The change introduces a `useAgentMessageTools` hook to fetch and manage tools state, filters the tools API by agent configuration, and ensures proper icon rendering for both skills and tools.

<img width="860" height="1323" alt="Screenshot 2026-03-04 at 13 15 48" src="https://github.com/user-attachments/assets/d775fbe3-ba31-460e-8c5c-b7f1204cd72c" />

## Risk

Low

## Tests

- [x] Locally

## Deploy Plan

Deploy front