### PR TITLE
Add projectId and RunId to registry lookup log

### DIFF
--- a/core/src/blocks/helpers.rs
+++ b/core/src/blocks/helpers.rs
@@ -51,6 +51,8 @@ pub async fn get_data_source_project_and_view_filter(
     };
 
     info!(
+        project_id = env.project.project_id(),
+        run_id = env.run_id.as_str(),
         workspace_id = workspace_id.as_str(),
         data_source_id = data_source_id.as_str(),
         is_system_run = is_system_run,


### PR DESCRIPTION
## Description

This is the log we'll use to retrieve the Dust apps in use that rely on the registry

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `core`