### PR TITLE
feat: improve front build speed

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -479,10 +479,11 @@ const config = {
   },
   webpack(config, { dev, isServer }) {
     if (process.env.BUILD_WITH_SOURCE_MAPS === "true" && !dev) {
-      // Force webpack to generate source maps for both client and server code
-      // This is used in production builds to upload source maps to Datadog for error tracking
-      // Note: Next.js normally only generates source maps for client code in development
-      config.devtool = "source-map";
+      // Generate source maps for Datadog error tracking (uploaded during Docker build).
+      // Client needs full "source-map" for RUM browser error deobfuscation.
+      // Server uses "cheap-module-source-map" (line-level only, no column mapping) which is
+      // significantly faster to generate while still providing useful stack traces in APM.
+      config.devtool = isServer ? "cheap-module-source-map" : "source-map";
     }
 
     if (isServer) {


### PR DESCRIPTION
## Description

Reduce source map built time for server bundles, this should shave ~1-2 min off the Next.js build since server-side compilation no longer pays the cost of full source map generation for all 582 API routes.

  - Client bundles: still use "source-map" (full fidelity for Datadog RUM)                                                                                                                                                               
  - Server bundles: now use "cheap-module-source-map" (line-level mapping, skips column mapping and original source embedding — much faster to generate, still gives useful stack traces in Datadog APM)
                                                                                                                                                                                                                                         
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
