### PR TITLE
Fix conversation page in Frontapp extension

### DIFF
--- a/extension/platforms/front/FrontApp.tsx
+++ b/extension/platforms/front/FrontApp.tsx
@@ -12,7 +12,7 @@ import { createMemoryRouter, RouterProvider } from "react-router-dom";
 // Create a router instance outside the component to avoid recreation.
 // Use memory router to avoid interfering with the parent page.
 const router = createMemoryRouter(routes, {
-  initialEntries: ["/"],
+  initialEntries: [window.location.pathname + window.location.search],
   initialIndex: 0,
 });
 

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -7,6 +7,25 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
+// Suppress ResizeObserver loop warnings. This error is benign: it means a
+// ResizeObserver callback triggered a layout change that couldn't be delivered
+// in the same animation frame. Browsers fire it as a global error event, which
+// webpack-dev-server catches and displays as an overlay. It causes no actual
+// issue in the app, and is especially common in iframe-embedded UIs where the
+// observed element is constrained by the parent page's layout.
+window.addEventListener(
+  "error",
+  (event) => {
+    if (
+      event.message ===
+      "ResizeObserver loop completed with undelivered notifications"
+    ) {
+      event.stopImmediatePropagation();
+    }
+  },
+  true
+);
+
 import { FrontApp } from "@extension/platforms/front/FrontApp";
 import React from "react";
 import ReactDOM from "react-dom/client";


### PR DESCRIPTION
## Description

Fixes conversation page routing in the Frontapp extension. The memory router was always initializing to "/" instead of using the actual URL path and search params from window.location, causing conversation pages to fail to load. 

Additionally, suppresses benign ResizeObserver loop warnings that were appearing in the extension's iframe environment.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
