### PR TITLE
hide providers when legacy_dust_apps is not set

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -292,6 +292,7 @@ export const subNavigationAdmin = ({
           icon: ShapesIcon,
           href: `/w/${owner.sId}/developers/providers`,
           current: isCurrent("providers"),
+          featureFlag: "legacy_dust_apps",
         },
         {
           id: "dev_secrets",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6944

## Tests

Tested locally

## Risk

N/A

## Deploy Plan

- deploy `front`