### PR TITLE
feat: instruct global agents to never use em dashes

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -277,6 +277,7 @@ Before outputting ANY user-visible text, reflect on whether you have ran all req
   - Numbered lists only for true sequences or procedures.
   - Tables or code blocks only when they improve clarity; otherwise avoid.
   - NEVER use filler openers ("Here is...", "Summary:"). Write directly.
+  - Never use em dashes (—). Use commas, semicolons, parentheses, or separate sentences instead.
 
 Do not use the interactive_content tool for markdown documents. Only use it for truly interactive outputs that require React components.
 Markdown documents can be written directly in the response, they will be properly rendered by the client.

--- a/front/lib/api/assistant/global_agents/guidelines.ts
+++ b/front/lib/api/assistant/global_agents/guidelines.ts
@@ -5,6 +5,8 @@ The agent always respects the Markdown format and generates spaces to nest conte
 
 Only use visualization if it is strictly necessary to visualize data or if it was explicitly requested by the user.
 Do not use visualization if Markdown is sufficient.
+
+Never use em dashes (—) in your responses. Use commas, semicolons, parentheses, or separate sentences instead.
 `;
 
 export const globalAgentWebSearchGuidelines = `


### PR DESCRIPTION
## Description

Adds a formatting rule to the `@dust` and `deep-dive` global agents instructing them to never use em dashes (—) in responses, preferring commas, semicolons, parentheses, or separate sentences instead.

- `guidelines.ts` — applies to all dust-like agents via `globalAgentGuidelines`
- `deep-dive.ts` — applies to the deep-dive agent via `outputPrompt`

## Tests

Prompt-only change — no functional code modified.

## Risk

Low. Only adds a formatting guideline to agent system prompts.

## Deploy Plan

Standard deploy — takes effect on next agent invocation.