### PR TITLE
Move dust-hive worktrees inside main tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ AGENTS.local.md
 CLAUDE.local.md
 node_modules
 
+# dust-hive worktrees
+.hives/
+
 # Direnv
 .direnv/
 .envrc

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -1,7 +1,10 @@
 import react from "@vitejs/plugin-react";
+import { createRequire } from "module";
 import path from "path";
 import type { Plugin, PluginOption } from "vite";
 import { defineConfig, loadEnv } from "vite";
+
+const require = createRequire(import.meta.url);
 
 const apps = {
   app: {
@@ -260,15 +263,14 @@ export default defineConfig(({ mode }) => {
         // Resolve SDK dependencies from root node_modules (hoisted by npm workspaces)
         {
           find: "eventsource-parser",
-          replacement: path.resolve(
-            __dirname,
-            "../node_modules/eventsource-parser"
+          replacement: path.dirname(
+            require.resolve("eventsource-parser/package.json")
           ),
         },
         // Handle zod and its subpath imports (e.g., zod/v3)
         {
           find: /^zod(\/.*)?$/,
-          replacement: path.resolve(__dirname, "../node_modules/zod$1"),
+          replacement: path.dirname(require.resolve("zod/package.json")) + "$1",
         },
       ],
       dedupe: ["react", "react-dom"],

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -7,7 +7,10 @@
     "rootDir": "src",
     "paths": {
       "@modelcontextprotocol/sdk/*": [
-        "../../node_modules/@modelcontextprotocol/sdk/dist/esm/*"
+        // Workaround to fix invalid type mapping in @modelcontextprotocol/sdk, see https://github.com/modelcontextprotocol/typescript-sdk/pull/1623
+        "../../node_modules/@modelcontextprotocol/sdk/dist/esm/*",
+        // This path is needed to also support the same issue when using dust-hive under .hives folder
+        "../../../../node_modules/@modelcontextprotocol/sdk/dist/esm/*"
       ]
     },
     "outDir": "dist",

--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -116,7 +116,7 @@ async function destroySingleEnvironment(
   options: DestroyOptions,
   settings: Settings
 ): Promise<Result<void>> {
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
 
   // Check for uncommitted changes (unless --force)
   if (!options.force) {

--- a/x/henry/dust-hive/src/commands/feed.ts
+++ b/x/henry/dust-hive/src/commands/feed.ts
@@ -83,7 +83,7 @@ export async function feedCommand(
   }
 
   // Get front directory path
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const frontPath = path.join(worktreePath, "front");
 
   // Get list of available scenarios

--- a/x/henry/dust-hive/src/commands/flag.ts
+++ b/x/henry/dust-hive/src/commands/flag.ts
@@ -56,7 +56,7 @@ export async function flagCommand(
     );
   }
 
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const frontPath = path.join(worktreePath, "front");
 
   // Resolve flag name — interactive select if not provided

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -1,5 +1,5 @@
 import { setLastActiveEnv } from "../lib/activity";
-import { getEnvironment } from "../lib/environment";
+import { type Environment, getEnvironment } from "../lib/environment";
 import { logger } from "../lib/logger";
 import {
   type LayoutConfig,
@@ -35,7 +35,7 @@ export async function openCommand(
   const env = envResult.value;
 
   const multiplexer = await getConfiguredMultiplexer();
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const envShPath = getEnvFilePath(env.name);
   const sessionName = getSessionName(env.name);
 
@@ -60,7 +60,7 @@ export async function openCommand(
 
 async function resolveEnvironment(
   nameArg: string | undefined
-): Promise<Result<{ name: string }, CommandError>> {
+): Promise<Result<Environment, CommandError>> {
   let envName = nameArg;
   if (!envName) {
     const selected = await selectEnvironmentWithFzf("Select environment to open");

--- a/x/henry/dust-hive/src/commands/refresh.ts
+++ b/x/henry/dust-hive/src/commands/refresh.ts
@@ -1,16 +1,14 @@
 // Refresh command - restore node_modules links in a worktree
 
-import { rm } from "node:fs/promises";
+import { lstat, rm, unlink } from "node:fs/promises";
 import { withEnvironment } from "../lib/commands";
-import { directoryExists } from "../lib/fs";
 import { logger } from "../lib/logger";
 import { getWorktreeDir } from "../lib/paths";
 import { Ok } from "../lib/result";
 import { installAllDependencies } from "../lib/setup";
 
-// Directories that have node_modules to refresh
-const NODE_MODULES_DIRS = [
-  "",
+// Workspace directories that have symlinked node_modules
+const WORKSPACE_DIRS = [
   "sdks/js",
   "front",
   "connectors",
@@ -20,22 +18,38 @@ const NODE_MODULES_DIRS = [
   "viz",
 ];
 
+// Remove a path whether it's a symlink, real directory, or doesn't exist
+async function removePath(path: string): Promise<boolean> {
+  try {
+    const info = await lstat(path);
+    if (info.isSymbolicLink()) {
+      await unlink(path);
+    } else {
+      await rm(path, { recursive: true });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const refreshCommand = withEnvironment("refresh", async (env) => {
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const repoRoot = env.metadata.repoRoot;
 
   logger.info(`Refreshing node_modules for '${env.name}'...`);
   console.log();
 
-  // Remove existing node_modules directories
+  // Remove root node_modules (real dir with @dust-tt overrides)
   logger.step("Removing existing node_modules...");
-  for (const dir of NODE_MODULES_DIRS) {
-    const nodeModulesPath = dir
-      ? `${worktreePath}/${dir}/node_modules`
-      : `${worktreePath}/node_modules`;
-    if (await directoryExists(nodeModulesPath)) {
-      await rm(nodeModulesPath, { recursive: true });
-      logger.info(`  Removed ${dir || "root"}/node_modules`);
+  if (await removePath(`${worktreePath}/node_modules`)) {
+    logger.info("  Removed root/node_modules");
+  }
+
+  // Remove workspace node_modules (symlinks to main repo)
+  for (const dir of WORKSPACE_DIRS) {
+    if (await removePath(`${worktreePath}/${dir}/node_modules`)) {
+      logger.info(`  Removed ${dir}/node_modules`);
     }
   }
   console.log();

--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { setCacheSource } from "../lib/cache";
 import { writeDockerComposeOverride } from "../lib/docker";
@@ -11,7 +12,7 @@ import {
   validateEnvName,
 } from "../lib/environment";
 import { logger } from "../lib/logger";
-import { findRepoRoot, getEnvFilePath, getWorktreeDir } from "../lib/paths";
+import { HIVES_DIR, findRepoRoot, getEnvFilePath, getWorktreeDir } from "../lib/paths";
 import type { PortAllocation } from "../lib/ports";
 import { allocateNextPort, calculatePorts, savePortAllocation } from "../lib/ports";
 import { startService, waitForServiceReady } from "../lib/registry";
@@ -265,7 +266,10 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
   // Always base on main branch
   const baseBranch = "main";
   const workspaceBranch = options.branchName ?? getBranchName(name, settings);
-  const worktreePath = getWorktreeDir(name);
+  const worktreePath = getWorktreeDir(name, mainRepoRoot);
+
+  // Ensure .hives/ directory exists under repo root
+  await mkdir(join(mainRepoRoot, HIVES_DIR), { recursive: true });
 
   logger.info(`Creating environment '${name}' from branch '${baseBranch}'`);
 

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -81,7 +81,7 @@ async function isTemporalRunning(): Promise<boolean> {
 
 async function ensureAllMCPServerViewsCreated(env: Environment): Promise<void> {
   const envShPath = getEnvFilePath(env.name);
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
 
   const command = buildShell({
     sourceEnv: envShPath,

--- a/x/henry/dust-hive/src/lib/config.ts
+++ b/x/henry/dust-hive/src/lib/config.ts
@@ -1,12 +1,12 @@
 import { mkdir } from "node:fs/promises";
-import { CONFIG_ENV_PATH, DUST_HIVE_ENVS, DUST_HIVE_HOME, DUST_HIVE_WORKTREES } from "./paths";
+import { CONFIG_ENV_PATH, DUST_HIVE_ENVS, DUST_HIVE_HOME } from "./paths";
 
 // Ensure all required directories exist
 // Note: Multiplexer layout directories are created by the multiplexer adapter when needed
+// Note: Hives directory (.hives/) is created per-repo at worktree creation time
 export async function ensureDirectories(): Promise<void> {
   await mkdir(DUST_HIVE_HOME, { recursive: true });
   await mkdir(DUST_HIVE_ENVS, { recursive: true });
-  await mkdir(DUST_HIVE_WORKTREES, { recursive: true });
 }
 
 // Check if global config.env exists

--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -304,7 +304,7 @@ async function initAllPostgres(env: Environment): Promise<void> {
 // Initialize Qdrant (runs after qdrant is healthy)
 async function initAllQdrant(env: Environment): Promise<void> {
   const envShPath = getEnvFilePath(env.name);
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const envVars = await loadEnvVars(envShPath);
 
   const result = await initQdrant(worktreePath, envVars);
@@ -317,7 +317,7 @@ async function initAllQdrant(env: Environment): Promise<void> {
 // Initialize Elasticsearch (runs after ES is healthy)
 async function initAllElasticsearch(env: Environment): Promise<void> {
   const envShPath = getEnvFilePath(env.name);
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const envVars = await loadEnvVars(envShPath);
   envVars["__ENV_SH_PATH__"] = envShPath;
 
@@ -339,7 +339,7 @@ async function initAllElasticsearch(env: Environment): Promise<void> {
 // Run core database init
 async function runCoreDbInit(env: Environment): Promise<{ success: boolean; usedCache: boolean }> {
   const envShPath = getEnvFilePath(env.name);
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const envVars = await loadEnvVars(envShPath);
 
   const result = await runBinary("init_db", [], {
@@ -360,7 +360,7 @@ async function runCoreDbInit(env: Environment): Promise<{ success: boolean; used
 // Run front database init
 async function runFrontDbInit(env: Environment): Promise<boolean> {
   const envShPath = getEnvFilePath(env.name);
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
 
   // Commands and their expected completion markers
   // Both init_db.sh and init_plans.sh print "Done" when they complete successfully
@@ -414,7 +414,7 @@ async function runFrontDbInit(env: Environment): Promise<boolean> {
 // Run connectors database init
 async function runConnectorsDbInit(env: Environment): Promise<boolean> {
   const envShPath = getEnvFilePath(env.name);
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
 
   const command = buildShell({
     sourceEnv: envShPath,

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -10,7 +11,9 @@ export const DUST_HIVE_ROOT = resolve(dirname(import.meta.path), "../..");
 export const DUST_HIVE_HOME = join(homedir(), ".dust-hive");
 export const DUST_HIVE_ENVS = join(DUST_HIVE_HOME, "envs");
 export const DUST_HIVE_SCRIPTS = join(DUST_HIVE_HOME, "scripts");
-export const DUST_HIVE_WORKTREES = join(homedir(), "dust-hive");
+
+// Hives directory name (relative to repo root)
+export const HIVES_DIR = ".hives";
 
 // Global config
 export const CONFIG_ENV_PATH = join(DUST_HIVE_HOME, "config.env");
@@ -48,8 +51,21 @@ export function getEnvDir(name: string): string {
   return join(DUST_HIVE_ENVS, name);
 }
 
-export function getWorktreeDir(name: string): string {
-  return join(DUST_HIVE_WORKTREES, name);
+// Old worktree location (pre-migration), kept for backward compatibility
+const OLD_WORKTREES_DIR = join(homedir(), "dust-hive");
+
+// Returns the worktree path for an environment.
+// Falls back to the old ~/dust-hive/{name} location if the new path doesn't
+// exist yet (pre-migration hives). New hives always use {repoRoot}/.hives/{name}.
+export function getWorktreeDir(name: string, repoRoot: string): string {
+  const newPath = join(repoRoot, HIVES_DIR, name);
+  if (!existsSync(newPath)) {
+    const oldPath = join(OLD_WORKTREES_DIR, name);
+    if (existsSync(oldPath)) {
+      return oldPath;
+    }
+  }
+  return newPath;
 }
 
 export function getEnvFilePath(name: string): string {
@@ -143,22 +159,30 @@ export async function findRepoRoot(startPath?: string): Promise<string | null> {
 
 // Detect if current working directory is inside a dust-hive worktree
 // Returns the environment name if found, null otherwise
+// Checks both new (.hives/{name}) and old (~/dust-hive/{name}) locations
 export function detectEnvFromCwd(): string | null {
   const cwd = process.cwd();
-  const worktreesBase = DUST_HIVE_WORKTREES;
 
-  // Check if cwd is under ~/dust-hive/{name}/
-  if (!cwd.startsWith(`${worktreesBase}/`)) {
-    return null;
+  // Check new location: .../.hives/{name}/...
+  const newMarker = `/${HIVES_DIR}/`;
+  const newIdx = cwd.indexOf(newMarker);
+  if (newIdx !== -1) {
+    const afterMarker = cwd.slice(newIdx + newMarker.length);
+    const envName = afterMarker.split("/")[0];
+    if (envName) {
+      return envName;
+    }
   }
 
-  // Extract environment name from path
-  const relativePath = cwd.slice(worktreesBase.length + 1);
-  const envName = relativePath.split("/")[0];
-
-  if (!envName) {
-    return null;
+  // Check old location: ~/dust-hive/{name}/...
+  const oldBase = `${OLD_WORKTREES_DIR}/`;
+  if (cwd.startsWith(oldBase)) {
+    const relativePath = cwd.slice(oldBase.length);
+    const envName = relativePath.split("/")[0];
+    if (envName) {
+      return envName;
+    }
   }
 
-  return envName;
+  return null;
 }

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -39,7 +39,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     buildCommand: () => "npm run watch",
     readinessCheck: {
       type: "file",
-      path: (env) => `${getWorktreeDir(env.name)}/sparkle/dist/esm/index.js`,
+      path: (env) => `${getWorktreeDir(env.name, env.metadata.repoRoot)}/sparkle/dist/esm/index.js`,
     },
   },
   sdk: {
@@ -49,7 +49,8 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     buildCommand: () => "npm run watch",
     readinessCheck: {
       type: "file",
-      path: (env) => `${getWorktreeDir(env.name)}/sdks/js/dist/client.esm.js`,
+      path: (env) =>
+        `${getWorktreeDir(env.name, env.metadata.repoRoot)}/sdks/js/dist/client.esm.js`,
     },
   },
   front: {
@@ -173,7 +174,7 @@ function buildServiceCommand(env: Environment, service: ServiceName): string {
 // Get the working directory for a service
 function getServiceCwd(env: Environment, service: ServiceName): string {
   const config = SERVICE_REGISTRY[service];
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   return `${worktreePath}/${config.cwd}`;
 }
 

--- a/x/henry/dust-hive/src/lib/seed.ts
+++ b/x/henry/dust-hive/src/lib/seed.ts
@@ -193,7 +193,7 @@ export async function runSqlSeed(env: Environment): Promise<boolean> {
   const username = config.username ?? config.email.split("@")[0];
 
   // Read the SQL file from front (single source of truth)
-  const worktreePath = getWorktreeDir(env.name);
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
   const sqlPath = `${worktreePath}/front/lib/dev/dust_hive_seed.sql`;
   const sqlFile = Bun.file(sqlPath);
   if (!(await sqlFile.exists())) {

--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -1,11 +1,14 @@
 // Environment setup operations
-// NOTE: node_modules uses shallow copy from main repo for speed (with SDK override).
-// To run `npm install` in a worktree, first delete node_modules manually.
-// NOTE: cargo target is symlinked to share Rust compilation cache (including linked artifacts).
+// Hives live under {repoRoot}/.hives/{name}/ so Node module resolution
+// naturally walks up to find {repoRoot}/node_modules/. We only need:
+// 1. A small node_modules/@dust-tt/ override so workspace packages resolve
+//    from the hive (not the main repo).
+// 2. Shallow copies of workspace-level node_modules (version overrides).
+// NOTE: cargo target is symlinked to share Rust compilation cache.
 
-import { mkdirSync, readdirSync, symlinkSync } from "node:fs";
+import { mkdirSync, readdirSync, readlinkSync, symlinkSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { ALL_BINARIES, buildBinaries } from "./cache";
 import { directoryExists } from "./fs";
@@ -15,80 +18,40 @@ import { logger } from "./logger";
 // These are personal/local files that aren't tracked in git
 const USER_CONFIG_DIRS = [".claude"];
 
-// @dust-tt packages mapping: npm scope name -> workspace directory relative to repo root
-// These are workspace packages that need to be overridden to point to the worktree
-const DUST_TT_PACKAGES: Record<string, string> = {
-  client: "sdks/js",
-  "dust-cli": "cli",
-  extension: "extension",
-  sparkle: "sparkle",
-};
-
 // Configuration for how to install each dependency type
 export interface DependencyConfig {
   rust: "symlink" | "build";
-  sdks: "symlink" | "install";
-  front: "symlink" | "install";
-  connectors: "symlink" | "install";
-  sparkle: "symlink" | "install";
-  frontspa: "symlink" | "install";
-  extension: "symlink" | "install";
-  viz: "symlink" | "install";
 }
 
-// Symlink node_modules from source to destination
-async function symlinkNodeModules(srcDir: string, destDir: string): Promise<boolean> {
-  const srcNodeModules = `${srcDir}/node_modules`;
-  const destNodeModules = `${destDir}/node_modules`;
-
-  // Check if source node_modules exists
-  if (!(await directoryExists(srcNodeModules))) {
-    return false;
-  }
-
-  // Create symlink
-  const proc = Bun.spawn(["ln", "-s", srcNodeModules, destNodeModules], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-  return proc.exitCode === 0;
-}
-
-// Setup root node_modules with workspace package overrides
-// Creates a real node_modules directory with symlinks to main repo packages,
-// but overrides @dust-tt/* packages to point to the worktree's workspaces.
-// This ensures TypeScript and runtime resolve workspace packages from the worktree,
-// not the main repo (which may have stale types).
-function setupRootNodeModules(mainNodeModules: string, worktreePath: string): void {
-  const target = join(worktreePath, "node_modules");
-
-  // Create target/node_modules/@dust-tt directory
-  mkdirSync(join(target, "@dust-tt"), { recursive: true });
-
-  // Symlink all top-level packages except @dust-tt
-  for (const item of readdirSync(mainNodeModules)) {
-    if (item !== "@dust-tt") {
-      symlinkSync(join(mainNodeModules, item), join(target, item));
-    }
-  }
-
-  // Override @dust-tt packages to point to worktree's workspaces
-  for (const [pkgName, workspaceDir] of Object.entries(DUST_TT_PACKAGES)) {
-    symlinkSync(join(worktreePath, workspaceDir), join(target, "@dust-tt", pkgName));
-  }
-}
-
-// Setup shallow node_modules for workspace packages (front, connectors)
-// Creates a real node_modules directory with symlinks to main repo packages.
-// With npm workspaces, @dust-tt packages are in root node_modules, not here.
-function setupShallowNodeModules(mainNodeModules: string, targetDir: string): void {
-  const target = join(targetDir, "node_modules");
+// Setup a shallow copy of node_modules: a real directory with symlinks to
+// each package from the source. Unlike a direct symlink, this keeps module
+// resolution anchored to the hive path (no symlink target walk-up issues).
+function setupShallowNodeModules(srcNodeModules: string, destDir: string): void {
+  const target = join(destDir, "node_modules");
   mkdirSync(target, { recursive: true });
 
-  // Symlink all packages from main repo
-  for (const item of readdirSync(mainNodeModules)) {
-    symlinkSync(join(mainNodeModules, item), join(target, item));
+  for (const item of readdirSync(srcNodeModules)) {
+    symlinkSync(join(srcNodeModules, item), join(target, item));
+  }
+}
+
+// Setup @dust-tt workspace overrides in hive's node_modules.
+// Since hives are under the repo root, Node resolution walks up to find
+// {repoRoot}/node_modules/ for all packages. But @dust-tt/* packages in
+// the root node_modules point to the main repo's workspaces via relative
+// symlinks. We override them here to point to the hive's workspaces instead,
+// so TypeScript and runtime resolve the hive's types (not the main repo's).
+function setupDustTtOverrides(repoRoot: string, worktreePath: string): void {
+  const mainDustTt = join(repoRoot, "node_modules", "@dust-tt");
+  const hiveDustTt = join(worktreePath, "node_modules", "@dust-tt");
+
+  mkdirSync(hiveDustTt, { recursive: true });
+
+  for (const pkg of readdirSync(mainDustTt)) {
+    const linkTarget = readlinkSync(join(mainDustTt, pkg));
+    const absoluteTarget = resolve(mainDustTt, linkTarget);
+    const workspaceRelative = absoluteTarget.slice(repoRoot.length + 1);
+    symlinkSync(join(worktreePath, workspaceRelative), join(hiveDustTt, pkg));
   }
 }
 
@@ -130,6 +93,9 @@ async function findAgentsFiles(srcDir: string, filename: string): Promise<string
       "-o",
       "-name",
       ".turbo",
+      "-o",
+      "-name",
+      ".hives",
       ")",
       "-prune",
       "-o",
@@ -214,18 +180,49 @@ async function buildRustInWorktree(worktreePath: string): Promise<boolean> {
 // Default config: symlink everything from cache
 const DEFAULT_CONFIG: DependencyConfig = {
   rust: "symlink",
-  sdks: "symlink",
-  front: "symlink",
-  connectors: "symlink",
-  sparkle: "symlink",
-  frontspa: "symlink",
-  extension: "symlink",
-  viz: "symlink",
 };
 
+// Workspace directories that have their own node_modules (version overrides)
+const WORKSPACE_NODE_MODULES = [
+  { name: "sdks/js", dir: "sdks/js" },
+  { name: "front", dir: "front" },
+  { name: "connectors", dir: "connectors" },
+  { name: "sparkle", dir: "sparkle" },
+  { name: "front-spa", dir: "front-spa" },
+  { name: "extension", dir: "extension" },
+  { name: "viz", dir: "viz" },
+];
+
+// Link workspace-level node_modules using shallow copies.
+// Returns names of workspaces that failed.
+async function linkWorkspaceNodeModules(worktreePath: string, repoRoot: string): Promise<string[]> {
+  const failed: string[] = [];
+
+  for (const { name, dir } of WORKSPACE_NODE_MODULES) {
+    const srcNodeModules = `${repoRoot}/${dir}/node_modules`;
+    if (await directoryExists(srcNodeModules)) {
+      logger.step(`${name}: Linking node_modules...`);
+      try {
+        setupShallowNodeModules(srcNodeModules, `${worktreePath}/${dir}`);
+        logger.success(`${name}: Linked`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(`${name}: Failed to link - ${message}`);
+        failed.push(name);
+      }
+    } else {
+      logger.info(`${name}: No node_modules to link (all deps hoisted)`);
+    }
+  }
+
+  return failed;
+}
+
 // Install all dependencies for a worktree
-// With config, can either symlink from cache or install/build in worktree
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: handles multiple dependency types with different modes
+// Since hives are under the repo root, Node module resolution walks up to
+// find {repoRoot}/node_modules/ automatically. We only need to:
+// 1. Override @dust-tt/* packages to point to the hive's workspaces
+// 2. Shallow-copy workspace-level node_modules (version overrides)
 export async function installAllDependencies(
   worktreePath: string,
   repoRoot: string,
@@ -248,102 +245,22 @@ export async function installAllDependencies(
     }
   }
 
-  // Handle root node_modules (npm workspaces hoists deps here)
-  // Override @dust-tt/* packages to point to worktree's workspaces
-  logger.step("root: Linking from cache (with workspace overrides)...");
+  // Setup @dust-tt/* overrides (small node_modules/@dust-tt/ directory).
+  // Everything else resolves by walking up to {repoRoot}/node_modules/.
+  logger.step("Setting up @dust-tt workspace overrides...");
   try {
-    setupRootNodeModules(`${repoRoot}/node_modules`, worktreePath);
-    logger.success("root: Linked");
+    setupDustTtOverrides(repoRoot, worktreePath);
+    logger.success("@dust-tt overrides: Linked");
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.error(`root: Failed to link - ${message}`);
-    failed.push("root");
+    logger.error(`@dust-tt overrides: Failed - ${message}`);
+    failed.push("@dust-tt");
   }
 
-  // Handle node_modules for sdks/js (simple symlink, it IS the SDK)
-  if (config.sdks === "symlink") {
-    logger.step("sdks/js: Linking from cache...");
-    const success = await symlinkNodeModules(`${repoRoot}/sdks/js`, `${worktreePath}/sdks/js`);
-    if (!success) {
-      failed.push("sdks/js");
-    } else {
-      logger.success("sdks/js: Linked");
-    }
-  } else {
-    logger.step("sdks/js: Installing dependencies...");
-    const success = await runNpmInstall(`${worktreePath}/sdks/js`, {
-      preferOffline: true,
-    });
-    if (!success) {
-      failed.push("sdks/js");
-    } else {
-      logger.success("sdks/js: Installed");
-    }
-  }
-
-  // Handle node_modules for front, connectors, sparkle, front-spa, extension, and viz
-  // With npm workspaces, most deps are hoisted to root. These only have local overrides.
-  const workspaceProjects = [
-    {
-      key: "front" as const,
-      name: "front",
-      mainNodeModules: `${repoRoot}/front/node_modules`,
-      dest: `${worktreePath}/front`,
-    },
-    {
-      key: "connectors" as const,
-      name: "connectors",
-      mainNodeModules: `${repoRoot}/connectors/node_modules`,
-      dest: `${worktreePath}/connectors`,
-    },
-    {
-      key: "sparkle" as const, // Uses same config as front
-      name: "sparkle",
-      mainNodeModules: `${repoRoot}/sparkle/node_modules`,
-      dest: `${worktreePath}/sparkle`,
-    },
-    {
-      key: "frontspa" as const, // Uses same config as front
-      name: "front-spa",
-      mainNodeModules: `${repoRoot}/front-spa/node_modules`,
-      dest: `${worktreePath}/front-spa`,
-    },
-    {
-      key: "extension" as const, // Uses same config as front
-      name: "extension",
-      mainNodeModules: `${repoRoot}/extension/node_modules`,
-      dest: `${worktreePath}/extension`,
-    },
-    {
-      key: "viz" as const, // Uses same config as front
-      name: "viz",
-      mainNodeModules: `${repoRoot}/viz/node_modules`,
-      dest: `${worktreePath}/viz`,
-    },
-  ];
-
-  for (const { key, name, mainNodeModules, dest } of workspaceProjects) {
-    const mode = config[key];
-    if (mode === "symlink") {
-      logger.step(`${name}: Linking from cache...`);
-      try {
-        setupShallowNodeModules(mainNodeModules, dest);
-        logger.success(`${name}: Linked`);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.error(`${name}: Failed to link - ${message}`);
-        failed.push(name);
-      }
-    } else {
-      logger.step(`${name}: Installing dependencies...`);
-      const success = await runNpmInstall(dest, { preferOffline: true });
-      if (!success) {
-        failed.push(name);
-      } else {
-        logger.success(`${name}: Installed`);
-      }
-    }
-  }
+  // Shallow-copy workspace-level node_modules (real dirs with per-package symlinks).
+  // This avoids symlink target walk-up issues with TypeScript resolution.
+  const workspaceFailed = await linkWorkspaceNodeModules(worktreePath, repoRoot);
+  failed.push(...workspaceFailed);
 
   if (failed.length > 0) {
     throw new Error(`Failed to install dependencies for: ${failed.join(", ")}`);

--- a/x/henry/dust-hive/tests/lib/paths.test.ts
+++ b/x/henry/dust-hive/tests/lib/paths.test.ts
@@ -6,7 +6,7 @@ import {
   CONFIG_ENV_PATH,
   DUST_HIVE_ENVS,
   DUST_HIVE_HOME,
-  DUST_HIVE_WORKTREES,
+  HIVES_DIR,
   findRepoRoot,
   getDockerOverridePath,
   getEnvDir,
@@ -31,8 +31,8 @@ describe("paths", () => {
       expect(DUST_HIVE_ENVS).toBe(join(home, ".dust-hive", "envs"));
     });
 
-    it("sets DUST_HIVE_WORKTREES to ~/dust-hive", () => {
-      expect(DUST_HIVE_WORKTREES).toBe(join(home, "dust-hive"));
+    it("sets HIVES_DIR to .hives", () => {
+      expect(HIVES_DIR).toBe(".hives");
     });
 
     it("sets CONFIG_ENV_PATH to ~/.dust-hive/config.env", () => {
@@ -51,12 +51,12 @@ describe("paths", () => {
   });
 
   describe("getWorktreeDir", () => {
-    it("returns correct worktree path", () => {
-      expect(getWorktreeDir("test")).toBe(join(home, "dust-hive", "test"));
+    it("returns correct worktree path under repo root", () => {
+      expect(getWorktreeDir("test", "/path/to/repo")).toBe("/path/to/repo/.hives/test");
     });
 
     it("handles environment names with hyphens", () => {
-      expect(getWorktreeDir("auth-v2")).toBe(join(home, "dust-hive", "auth-v2"));
+      expect(getWorktreeDir("auth-v2", "/path/to/repo")).toBe("/path/to/repo/.hives/auth-v2");
     });
   });
 


### PR DESCRIPTION
## Description

Move dust-hive worktrees from `~/dust-hive/{name}/` to `{repoRoot}/.hives/{name}/`.

**Why?** Since hives now live under the main repo tree, Node.js module resolution naturally walks up to find `{repoRoot}/node_modules/`. This eliminates the need for the root-level shallow copy (~1000+ symlinks per hive) — we only need:

1. **`@dust-tt/*` overrides** — a small `node_modules/@dust-tt/` directory in each hive, so workspace packages resolve from the hive's code (not the main repo's).
2. **Workspace-level shallow copies** — for directories with their own `node_modules/` (front, connectors, etc.) that have version overrides.

**Key benefits:**
- **No more broken hives after `npm install`**: Previously, running `npm install` in the main repo would invalidate the shallow-copied root `node_modules/` in every hive, requiring `dust-hive refresh` on all of them. Now, hives inherit the real root `node_modules/` directly — `npm install` in the main repo just works. Also, running `npm install` in a hive was corrupting the main `node_modules/` folder. Now, it will simply make a full install of all packages, without touching the main one.
- **Faster spawn**: Creating ~1000 symlinks for the root node_modules shallow copy is eliminated.
- **Simpler mental model**: Hives are just git worktrees under `.hives/`, module resolution works the standard Node.js way.

**Backward compatibility:** Old hives at `~/dust-hive/{name}/` continue to work — `getWorktreeDir` falls back to the old location if the new path doesn't exist. No migration needed.

## Tests

- Updated `paths.test.ts` for the new `getWorktreeDir(name, repoRoot)` signature and `HIVES_DIR` constant.
- `bun run check` passes (typecheck + lint + tests).

## Risk

Low. Old hives keep working via fallback. New hives use the simplified setup. The only external change is `.hives/` added to `.gitignore`.

## Deploy Plan

N/A — developer tooling only, no deployment needed.