### PR TITLE
feat(poke): add poke MCP server for cross-workspace metadata access

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -424,6 +424,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_events": "never_ask",
     "update_event": "low",
   },
+  "poke": {
+    "get_workspace_metadata": "high",
+  },
   "primitive_types_debugger": {
     "pass_through": "high",
     "tool_without_user_config": "high",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -46,6 +46,7 @@ import { NOTION_SERVER } from "@app/lib/api/actions/servers/notion/metadata";
 import { OPENAI_USAGE_SERVER } from "@app/lib/api/actions/servers/openai_usage/metadata";
 import { OUTLOOK_CALENDAR_SERVER } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
 import { OUTLOOK_MAIL_SERVER } from "@app/lib/api/actions/servers/outlook/mail_metadata";
+import { POKE_SERVER } from "@app/lib/api/actions/servers/poke/metadata";
 import { PRIMITIVE_TYPES_DEBUGGER_SERVER } from "@app/lib/api/actions/servers/primitive_types_debugger/metadata";
 import { PRODUCTBOARD_SERVER } from "@app/lib/api/actions/servers/productboard/metadata";
 import { PROJECT_CONVERSATION_SERVER } from "@app/lib/api/actions/servers/project_conversation/metadata";
@@ -199,6 +200,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "skill_management",
   "schedules_management",
   "project_manager",
+  "poke",
   "project_conversation",
   "sandbox",
 ] as const;
@@ -1087,6 +1089,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: USER_MENTIONS_SERVER,
+  },
+  poke: {
+    id: 1027,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => !featureFlags.includes("poke_mcp"),
+    isPreview: true,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: POKE_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -127,6 +127,7 @@ function createMockAuthenticator(): Authenticator {
     isAdmin: () => true,
     isBuilder: () => true,
     isUser: () => true,
+    isDustSuperUser: () => true,
     role: () => "admin",
     user: () => mockUser,
     groups: () => [],

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -44,6 +44,7 @@ import { default as notionServer } from "@app/lib/api/actions/servers/notion";
 import { default as openaiUsageServer } from "@app/lib/api/actions/servers/openai_usage";
 import { default as outlookCalendarServer } from "@app/lib/api/actions/servers/outlook/calendar_server";
 import { default as outlookMailServer } from "@app/lib/api/actions/servers/outlook/mail_server";
+import { default as pokeServer } from "@app/lib/api/actions/servers/poke";
 import { default as primitiveTypesDebuggerServer } from "@app/lib/api/actions/servers/primitive_types_debugger";
 import { default as productboardServer } from "@app/lib/api/actions/servers/productboard";
 import { default as projectConversationServer } from "@app/lib/api/actions/servers/project_conversation";
@@ -239,6 +240,8 @@ export async function getInternalMCPServer(
       return productboardServer(auth, agentLoopContext);
     case "project_manager":
       return projectManagerServer(auth, agentLoopContext);
+    case "poke":
+      return pokeServer(auth, agentLoopContext);
     case "project_conversation":
       return projectConversationServer(auth, agentLoopContext);
     case "ukg_ready":

--- a/front/lib/api/actions/servers/poke/index.ts
+++ b/front/lib/api/actions/servers/poke/index.ts
@@ -1,0 +1,44 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { POKE_SERVER_NAME } from "@app/lib/api/actions/servers/poke/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/poke/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(POKE_SERVER_NAME);
+
+  // Gate at server creation: if the caller is not a Dust super user, register
+  // a single error tool so the agent gets a clear message.
+  if (!auth.isDustSuperUser()) {
+    server.tool(
+      "poke_not_available",
+      "Poke tools require Dust super user privileges.",
+      {},
+      async () => ({
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Access denied: poke tools require Dust super user privileges.",
+          },
+        ],
+      })
+    );
+    return server;
+  }
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: POKE_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -1,0 +1,47 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const POKE_SERVER_NAME = "poke" as const;
+export const GET_WORKSPACE_METADATA_TOOL_NAME = "get_workspace_metadata";
+
+export const POKE_TOOLS_METADATA = createToolsRecord({
+  [GET_WORKSPACE_METADATA_TOOL_NAME]: {
+    description:
+      "Fetch metadata for a target Dust workspace. Requires Dust super user privileges.",
+    schema: {
+      workspace_id: z
+        .string()
+        .describe("The sId of the target workspace to fetch metadata for."),
+    },
+    stake: "high" as const,
+    displayLabels: {
+      running: "Fetching workspace metadata",
+      done: "Fetched workspace metadata",
+    },
+  },
+});
+
+export const POKE_SERVER = {
+  serverInfo: {
+    name: POKE_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Dust-internal tools for cross-workspace data access (poke). Requires super user privileges.",
+    authorization: null,
+    icon: "ActionLightbulbIcon",
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(POKE_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(POKE_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/poke/tools/index.test.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.test.ts
@@ -1,0 +1,215 @@
+import { Authenticator } from "@app/lib/auth";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it, vi } from "vitest";
+
+import { TOOLS } from ".";
+
+function getToolByName(name: string) {
+  const tool = TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`Tool ${name} not found`);
+  }
+  return tool;
+}
+
+function createTestExtra(auth: Authenticator, agentLoopContext?: unknown) {
+  return {
+    signal: new AbortController().signal,
+    auth,
+    agentLoopContext,
+  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+}
+
+describe("poke tools - security gates", () => {
+  describe("get_workspace_metadata", () => {
+    it("denies access to non-super-user", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const tool = getToolByName("get_workspace_metadata");
+      const result = await tool.handler(
+        { workspace_id: workspace.sId },
+        createTestExtra(auth)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("super user privileges");
+      }
+    });
+
+    it("denies access from non-Dust workspace even for super users", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const superUser = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace, superUser, {
+        role: "admin",
+      });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        superUser.sId,
+        workspace.sId
+      );
+
+      // Sanity: auth IS a super user but the workspace is NOT the Dust workspace.
+      expect(auth.isDustSuperUser()).toBe(true);
+
+      const tool = getToolByName("get_workspace_metadata");
+      const result = await tool.handler(
+        { workspace_id: workspace.sId },
+        createTestExtra(auth)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Dust-internal workspace");
+      }
+    });
+
+    it("denies access when poke_mcp feature flag is disabled", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const superUser = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace, superUser, {
+        role: "admin",
+      });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        superUser.sId,
+        workspace.sId
+      );
+
+      // Make isDustWorkspace return true by setting the env var.
+      vi.stubEnv("PRODUCTION_DUST_WORKSPACE_ID", workspace.sId);
+
+      // Mock getFeatureFlags to return an empty array (no poke_mcp flag).
+      const authModule = await import("@app/lib/auth");
+      vi.spyOn(authModule, "getFeatureFlags").mockResolvedValueOnce([]);
+
+      const tool = getToolByName("get_workspace_metadata");
+      const result = await tool.handler(
+        { workspace_id: workspace.sId },
+        createTestExtra(auth)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("poke_mcp feature flag");
+      }
+
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+
+    it("returns workspace metadata when all security gates pass", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const superUser = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace, superUser, {
+        role: "admin",
+      });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        superUser.sId,
+        workspace.sId
+      );
+
+      // Make isDustWorkspace return true.
+      vi.stubEnv("PRODUCTION_DUST_WORKSPACE_ID", workspace.sId);
+
+      // Mock getFeatureFlags to include poke_mcp.
+      const authModule = await import("@app/lib/auth");
+      vi.spyOn(authModule, "getFeatureFlags").mockResolvedValueOnce([
+        "poke_mcp",
+      ]);
+
+      const tool = getToolByName("get_workspace_metadata");
+      const result = await tool.handler(
+        { workspace_id: workspace.sId },
+        createTestExtra(auth)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          expect(parsed.sId).toBe(workspace.sId);
+          expect(parsed.name).toBe(workspace.name);
+          expect(parsed.plan).toBeDefined();
+        }
+      }
+
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+
+    it("returns error for non-existent target workspace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const superUser = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace, superUser, {
+        role: "admin",
+      });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        superUser.sId,
+        workspace.sId
+      );
+
+      // Make isDustWorkspace return true.
+      vi.stubEnv("PRODUCTION_DUST_WORKSPACE_ID", workspace.sId);
+
+      // Mock getFeatureFlags to include poke_mcp.
+      const authModule = await import("@app/lib/auth");
+      vi.spyOn(authModule, "getFeatureFlags").mockResolvedValueOnce([
+        "poke_mcp",
+      ]);
+
+      const tool = getToolByName("get_workspace_metadata");
+      const result = await tool.handler(
+        { workspace_id: "nonexistent-workspace-id" },
+        createTestExtra(auth)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Workspace not found");
+      }
+
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/front/lib/api/actions/servers/poke/tools/index.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.ts
@@ -1,0 +1,125 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  GET_WORKSPACE_METADATA_TOOL_NAME,
+  POKE_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/poke/metadata";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { isDustWorkspace } from "@app/types/shared/env";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@dust-tt/client/src/error_utils";
+
+const handlers: ToolHandlers<typeof POKE_TOOLS_METADATA> = {
+  [GET_WORKSPACE_METADATA_TOOL_NAME]: async ({ workspace_id }, { auth }) => {
+    const callerWorkspace = auth.getNonNullableWorkspace();
+    const callerUser = auth.user();
+
+    // ──────────────────────────────────────────────────────────────────────
+    // SECURITY GATE 1: Verify the caller is a Dust super user.
+    // This checks both the user's isDustSuperUser flag AND that their email
+    // matches @dust.tt (or we're in development mode).
+    // ──────────────────────────────────────────────────────────────────────
+    if (!auth.isDustSuperUser()) {
+      return new Err(
+        new MCPError(
+          "Access denied: poke tools require Dust super user privileges."
+        )
+      );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // SECURITY GATE 2: Verify the caller's workspace is a Dust-internal
+    // workspace. This prevents a super user whose account is compromised in
+    // a non-Dust workspace from invoking cross-workspace tools.
+    // ──────────────────────────────────────────────────────────────────────
+    if (!isDustWorkspace(callerWorkspace)) {
+      return new Err(
+        new MCPError(
+          "Access denied: poke tools can only be used from a Dust-internal workspace."
+        )
+      );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // SECURITY GATE 3: Re-check the poke_mcp feature flag at execution
+    // time (not just at server configuration time). This ensures that if
+    // the flag is revoked, already-configured agents stop working.
+    // ──────────────────────────────────────────────────────────────────────
+    const featureFlags = await getFeatureFlags(auth);
+    if (!featureFlags.includes("poke_mcp")) {
+      return new Err(
+        new MCPError(
+          "Access denied: the poke_mcp feature flag is not enabled on this workspace."
+        )
+      );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // AUDIT LOG: Structured log entry for cross-workspace access.
+    // Uses a distinct action field so Datadog can alert on it.
+    // Fields: action, callerUserId, callerUserEmail, callerWorkspaceSId,
+    // targetWorkspaceSId, tool.
+    // ──────────────────────────────────────────────────────────────────────
+    logger.info(
+      {
+        action: "poke_cross_workspace_access",
+        callerUserId: callerUser?.id,
+        callerUserEmail: callerUser?.email,
+        callerWorkspaceSId: callerWorkspace.sId,
+        targetWorkspaceSId: workspace_id,
+        tool: GET_WORKSPACE_METADATA_TOOL_NAME,
+      },
+      "Poke MCP: cross-workspace metadata access"
+    );
+
+    // Create an admin authenticator for the target workspace.
+    let targetAuth: Authenticator;
+    try {
+      targetAuth = await Authenticator.internalAdminForWorkspace(workspace_id);
+    } catch (err) {
+      const normalizedErr = normalizeError(err);
+      logger.error(
+        { err: normalizedErr },
+        "Failed to create authenticator for workspace"
+      );
+      return new Err(
+        new MCPError(
+          `Workspace not found: no workspace with sId "${workspace_id}" exists.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const targetWorkspace = targetAuth.getNonNullableWorkspace();
+    const plan = targetAuth.plan();
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            sId: targetWorkspace.sId,
+            name: targetWorkspace.name,
+            segmentation: targetWorkspace.segmentation,
+            ssoEnforced:
+              "ssoEnforced" in targetWorkspace
+                ? targetWorkspace.ssoEnforced
+                : undefined,
+            plan: plan
+              ? {
+                  code: plan.code,
+                  name: plan.name,
+                }
+              : null,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(POKE_TOOLS_METADATA, handlers);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -261,6 +261,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable collapsible messages in conversations",
     stage: "dust_only",
   },
+  poke_mcp: {
+    description: "Enable the Poke MCP server for cross-workspace data access.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -715,6 +715,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
   | "reinforced_agents"
+  | "poke_mcp"
   | "restrict_agents_publishing"
   | "restrict_agents_publishing_to_admins"
   | "salesforce_synced_queries"


### PR DESCRIPTION
## Description

Introduces a Dust-internal-only MCP server that lets agents fetch metadata from any workspace. 
It includes three security gates: 
* super user check
* Dust workspace verification
* runtime feature flag validation. 

All cross-workspace accesses are audit-logged with structured fields.

This PR is the base scaffolding for a MCP that would allow agents (like incidentQ or engRunner) to help support/oncall/runner get better help from agents. 

Next PRs will add read-only tools. 

Down the line, I would like to get a few (high stake of course) write ones (like pausing/resuming connectors, *no* deletion) 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
