### PR TITLE
feat: auto generation of digest

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -168,6 +168,7 @@ export function SpaceConversationsTab({
               owner={owner}
               space={spaceInfo}
               hasConversations={hasHistory}
+              unreadCount={unreadConversationIds.length}
             />
           )}
 

--- a/front/components/assistant/conversation/space/conversations/SpaceUserProjectDigest.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceUserProjectDigest.tsx
@@ -18,17 +18,22 @@ import {
 import { useEffect, useRef, useState } from "react";
 
 const COLLAPSED_MAX_HEIGHT_PX = 200;
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const ACTIVE_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+const UNREAD_THRESHOLD = 5;
 
 interface SpaceUserProjectDigestProps {
   owner: LightWorkspaceType;
   space: SpaceType;
   hasConversations: boolean;
+  unreadCount: number;
 }
 
 export function SpaceUserProjectDigest({
   owner,
   space,
   hasConversations,
+  unreadCount,
 }: SpaceUserProjectDigestProps) {
   const [generationError, setGenerationError] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -86,6 +91,36 @@ export function SpaceUserProjectDigest({
       void mutateGenerationStatus();
     }
   };
+
+  // Auto-trigger digest generation when the digest is stale.
+  const hasAutoTriggeredRef = useRef(false);
+  const handleGenerateRef = useRef(handleGenerate);
+  handleGenerateRef.current = handleGenerate;
+
+  useEffect(() => {
+    if (
+      isDigestsLoading ||
+      isGenerating ||
+      hasAutoTriggeredRef.current ||
+      !hasConversations
+    ) {
+      return;
+    }
+
+    const latestDigest = digests[0];
+    const hasNoDigest = !latestDigest;
+    const ageMs = latestDigest ? Date.now() - latestDigest.createdAt : 0;
+    const isStale = latestDigest && ageMs > STALE_THRESHOLD_MS;
+    const isActiveAndUnread =
+      latestDigest &&
+      ageMs > ACTIVE_THRESHOLD_MS &&
+      unreadCount >= UNREAD_THRESHOLD;
+
+    if (hasNoDigest || isStale || isActiveAndUnread) {
+      hasAutoTriggeredRef.current = true;
+      void handleGenerateRef.current();
+    }
+  }, [isDigestsLoading, isGenerating, digests, hasConversations, unreadCount]);
 
   if (!hasConversations) {
     return null;
@@ -208,11 +243,6 @@ export function SpaceUserProjectDigest({
             </div>
           )}
         </>
-      ) : !isGenerating ? (
-        <div className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
-          No digest yet. Click Generate to create an AI summary of recent
-          project activity.
-        </div>
       ) : (
         <div className="flex items-center gap-3 py-4">
           <Spinner size="sm" variant="color" />

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
@@ -9,9 +9,8 @@ import { launchUserProjectDigestWorkflow } from "@app/temporal/project_user_dige
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-// const COOLDOWN_HOURS = 24;
-// const COOLDOWN_MS = COOLDOWN_HOURS * 60 * 60 * 1000;
-const COOLDOWN_MS = 0;
+const COOLDOWN_MINUTES = 5;
+const COOLDOWN_MS = COOLDOWN_MINUTES * 60 * 1000;
 
 export type PostGenerateUserProjectDigestResponseBody = {
   success: true;
@@ -62,14 +61,14 @@ export async function handler(
         const timeSinceLastDigestMs =
           Date.now() - new Date(latestDigest.createdAt).getTime();
         if (timeSinceLastDigestMs < COOLDOWN_MS) {
-          const remainingHours = Math.ceil(
-            (COOLDOWN_MS - timeSinceLastDigestMs) / (60 * 60 * 1000)
+          const remainingMinutes = Math.ceil(
+            (COOLDOWN_MS - timeSinceLastDigestMs) / (60 * 1000)
           );
           return apiError(req, res, {
             status_code: 429,
             api_error: {
               type: "rate_limit_error",
-              message: `Please wait ${remainingHours} hour${remainingHours > 1 ? "s" : ""} before generating a new digest.`,
+              message: `Please wait ${remainingMinutes} minute${remainingMinutes > 1 ? "s" : ""} before generating a new digest.`,
             },
           });
         }


### PR DESCRIPTION
## Description

Add auto-generation of digest when a user arrives on the project page. So they get fresh summary.

We put back the cooldown so we are not hammered with regeneration.

It's done in the frontend as it required less code (just a few corner cases to handle) 

Fixes: https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=161679814&issue=dust-tt%7Ctasks%7C6921

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
