### PR TITLE
feat: prepare migration to node24

### DIFF
--- a/.github/workflows/build-and-test-connectors.yml
+++ b/.github/workflows/build-and-test-connectors.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
       - name: Typecheck
         run: npm -w connectors run tsgo -- --version && npm -w connectors run tsgo
@@ -30,6 +31,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
       - name: Install Postgres
         uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - name: Install Postgres
@@ -72,6 +73,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - name: Typecheck

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - working-directory: extension
@@ -33,6 +34,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - name: Typecheck

--- a/.github/workflows/build-viz.yml
+++ b/.github/workflows/build-viz.yml
@@ -18,5 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
       - name: Build
         run: npm -w viz run build

--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
 
       - name: Download dist artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -105,6 +105,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: "22.22.0"
           cache: "npm"
           cache-dependency-path: ./package-lock.json
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: "22.22.0"
           cache: "npm"
           cache-dependency-path: ./package-lock.json
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -55,6 +55,7 @@ jobs:
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
 
@@ -100,6 +101,8 @@ jobs:
       - name: Setup Node Dependencies
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}
         uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
 
       - name: Run Danger for connectors
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}

--- a/cli/dust-cli/package.json
+++ b/cli/dust-cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/dust-cli",
   "version": "0.4.4",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -1,6 +1,9 @@
 {
   "name": "connectors",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "scripts": {
     "build": "tsgo --noEmit && tsx esbuild.config.ts",
     "start": "tsx ./src/start.ts -p 3002",

--- a/firebase-functions/slack-webhook-router/package.json
+++ b/firebase-functions/slack-webhook-router/package.json
@@ -1,6 +1,9 @@
 {
   "name": "slack-webhook-router",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "Slack webhook router for multi-region deployment.",
   "type": "module",
   "main": "dist/firebase.js",

--- a/firebase-functions/webhook-router/Dockerfile
+++ b/firebase-functions/webhook-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 
 # Install Java 21 (required for Firebase storage/database emulators)
 # Add Adoptium repo

--- a/firebase-functions/webhook-router/package.json
+++ b/firebase-functions/webhook-router/package.json
@@ -1,6 +1,9 @@
 {
   "name": "webhook-router",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "Webhook router for multi-region deployment.",
   "type": "module",
   "main": "dist/firebase.js",

--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/front-spa",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "type": "module",
   "scripts": {
     "dev:poke": "VITE_APP_NAME=poke VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/front",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "exports": {
     "./components/*": "./components/*",
     "./lib/*": "./lib/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,9 @@
         "dotenv-flow": "^4.1.0",
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "cli/dust-cli/node_modules/@types/node": {
@@ -174,6 +177,9 @@
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "tsx": "^4.21.0",
         "vitest": "^4.0.16"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "connectors/node_modules/@types/express": {
@@ -565,6 +571,9 @@
         "vitest": "^4.0.16",
         "vitest-canvas-mock": "^1.1.3",
         "webpack-stats-plugin": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "front-spa": {
@@ -590,6 +599,9 @@
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
         "vite": "^7.3.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "front/node_modules/@slack/web-api": {
@@ -58085,6 +58097,9 @@
         "npm-watch": "^0.11.0",
         "tslib": "^2.6.2",
         "tsx": "^4.19.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "sdks/js/node_modules/@types/node": {
@@ -58279,6 +58294,9 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "viz/node_modules/@hookform/resolvers": {

--- a/preview-proxy/package.json
+++ b/preview-proxy/package.json
@@ -1,5 +1,8 @@
 {
   "name": "spa-preview-proxy",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -1,6 +1,9 @@
 {
   "name": "dust-sandbox",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "dependencies": {
     "@dust-tt/client": "^1.0.0",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/client",
   "version": "1.2.6",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sparkle/playground/package.json
+++ b/sparkle/playground/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/sparkle-playground",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "type": "module",
   "scripts": {

--- a/tools/datadog-log-exporter/package.json
+++ b/tools/datadog-log-exporter/package.json
@@ -2,6 +2,9 @@
   "name": "datadog-log-exporter",
   "private": true,
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/viz/package.json
+++ b/viz/package.json
@@ -1,6 +1,9 @@
 {
   "name": "viz",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "scripts": {
     "dev": "next dev -p 3007",


### PR DESCRIPTION
## Description

  - Add explicit engines.node: ">=22.22.0" to all 12 workspace package.json files that were missing it (front, connectors, front-spa, sdks/js, cli, viz, extension, sandbox, preview-proxy, firebase-functions, sparkle/playground,
  datadog-log-exporter)
  - Parametrize node-version: "22.22.0" in every GitHub Actions workflow using setup-node-deps, so each workflow can be bumped independently during Node 24 rollout
  - Pin publish-cli and publish-sdk-client workflows from loose 22.x to exact 22.22.0
  - Bump firebase webhook-router Dockerfile from node:20 to node:22

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
