### PR TITLE
feat: prepare migration to node24

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -39,9 +39,9 @@ runs:
           extension/node_modules
           viz/node_modules
           sdks/js/node_modules
-        key: workspaces-node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        key: workspaces-node-modules-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
         restore-keys: |
-          workspaces-node-modules-${{ runner.os }}-
+          workspaces-node-modules-${{ runner.os }}-node${{ inputs.node-version }}-
 
     - name: Install workspaces dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test-connectors.yml
+++ b/.github/workflows/build-and-test-connectors.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
       - name: Typecheck
         run: npm -w connectors run tsgo -- --version && npm -w connectors run tsgo
@@ -35,6 +36,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
       - name: Install Postgres
         uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - name: Install Postgres
@@ -72,6 +73,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - name: Typecheck

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - working-directory: extension
@@ -33,6 +34,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
       - name: Typecheck

--- a/.github/workflows/build-viz.yml
+++ b/.github/workflows/build-viz.yml
@@ -18,5 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
       - name: Build
         run: npm -w viz run build

--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
 
       - name: Download dist artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -105,6 +105,7 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
 

--- a/.github/workflows/node24-compat.yml
+++ b/.github/workflows/node24-compat.yml
@@ -1,0 +1,114 @@
+name: Node 24 Compatibility Check
+
+on:
+  push:
+    paths:
+      - package-lock.json
+      - sdks/js/**
+      - front/**
+      - connectors/**
+      - sparkle/**
+      - .github/workflows/node24-compat.yml
+      - .github/actions/setup-node-deps/**
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  front-tsgo:
+    name: "[Node 24] front typecheck"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "24"
+          build-sdks: "true"
+          build-sparkle: "true"
+      - name: Typecheck
+        run: npm -w front run tsgo -- --version && npm -w front run tsgo
+
+  front-tests:
+    name: "[Node 24] front tests"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      redis:
+        image: redis:7.2.5
+        ports:
+          - 5434:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "24"
+          build-sdks: "true"
+          build-sparkle: "true"
+      - name: Install Postgres
+        uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b
+        with:
+          postgresql docker image: mirror.gcr.io/postgres
+          postgresql version: "14.13"
+          postgresql db: front_test
+          postgresql user: test
+          postgresql password: test
+          postgresql port: 5433
+      - name: Run Tests
+        working-directory: front
+        env:
+          FRONT_DATABASE_URI: "postgres://test:test@localhost:5433/front_test"
+          REDIS_CACHE_URI: "redis://localhost:5434"
+          REDIS_URI: "redis://localhost:5434"
+          NODE_ENV: test
+        run: npx tsx admin/db.ts && npm run test:ci
+
+  connectors-tsgo:
+    name: "[Node 24] connectors typecheck"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "24"
+          build-sdks: "true"
+      - name: Typecheck
+        run: npm -w connectors run tsgo -- --version && npm -w connectors run tsgo
+
+  connectors-tests:
+    name: "[Node 24] connectors tests"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "24"
+          build-sdks: "true"
+      - name: Install Postgres
+        uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b
+        with:
+          postgresql docker image: mirror.gcr.io/postgres
+          postgresql version: "14.13"
+          postgresql db: connectors_test
+          postgresql user: test
+          postgresql password: test
+          postgresql port: 5433
+      - name: Run Tests
+        working-directory: connectors
+        env:
+          CONNECTORS_DATABASE_URI: "postgres://test:test@localhost:5433/connectors_test"
+          NODE_ENV: test
+        run: npx tsx src/admin/db.ts && npm run test:ci

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: "22.22.0"
           cache: "npm"
           cache-dependency-path: ./package-lock.json
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: "22.22.0"
           cache: "npm"
           cache-dependency-path: ./package-lock.json
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -55,6 +55,7 @@ jobs:
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}
         uses: ./.github/actions/setup-node-deps
         with:
+          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
 
@@ -100,6 +101,8 @@ jobs:
       - name: Setup Node Dependencies
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}
         uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
 
       - name: Run Danger for connectors
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}

--- a/cli/dust-cli/package.json
+++ b/cli/dust-cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/dust-cli",
   "version": "0.4.4",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -1,6 +1,9 @@
 {
   "name": "connectors",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "scripts": {
     "build": "tsgo --noEmit && tsx esbuild.config.ts",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",

--- a/firebase-functions/slack-webhook-router/package.json
+++ b/firebase-functions/slack-webhook-router/package.json
@@ -1,6 +1,9 @@
 {
   "name": "slack-webhook-router",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "Slack webhook router for multi-region deployment.",
   "type": "module",
   "main": "dist/firebase.js",

--- a/firebase-functions/webhook-router/Dockerfile
+++ b/firebase-functions/webhook-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 
 # Install Java 21 (required for Firebase storage/database emulators)
 # Add Adoptium repo

--- a/firebase-functions/webhook-router/package.json
+++ b/firebase-functions/webhook-router/package.json
@@ -1,6 +1,9 @@
 {
   "name": "webhook-router",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "Webhook router for multi-region deployment.",
   "type": "module",
   "main": "dist/firebase.js",

--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/front-spa",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "type": "module",
   "scripts": {
     "dev:poke": "VITE_APP_NAME=poke VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/front",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "exports": {
     "./components/*": "./components/*",
     "./lib/*": "./lib/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,9 @@
         "dotenv-flow": "^4.1.0",
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "cli/dust-cli/node_modules/@types/node": {
@@ -174,6 +177,9 @@
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "tsx": "^4.21.0",
         "vitest": "^4.0.16"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "connectors/node_modules/@types/express": {
@@ -564,6 +570,9 @@
         "vitest": "^4.0.16",
         "vitest-canvas-mock": "^1.1.3",
         "webpack-stats-plugin": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "front-spa": {
@@ -589,6 +598,9 @@
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
         "vite": "^7.3.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "front/node_modules/@slack/web-api": {
@@ -58084,6 +58096,9 @@
         "npm-watch": "^0.11.0",
         "tslib": "^2.6.2",
         "tsx": "^4.19.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "sdks/js/node_modules/@types/node": {
@@ -58278,6 +58293,9 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "viz/node_modules/@hookform/resolvers": {

--- a/preview-proxy/package.json
+++ b/preview-proxy/package.json
@@ -1,5 +1,8 @@
 {
   "name": "spa-preview-proxy",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "dust-sandbox",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
+  "private": true,
+  "dependencies": {
+    "@dust-tt/client": "^1.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zod": "^3.22.0",
+    "recharts": "^2.12.0",
+    "d3": "^7.9.0",
+    "lodash": "^4.17.21",
+    "date-fns": "^3.3.0",
+    "axios": "^1.6.0",
+    "node-fetch": "^3.3.0",
+    "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^4.0.0",
+    "exceljs": "^4.4.0",
+    "csv-parse": "^5.5.0",
+    "csv-stringify": "^6.4.0",
+    "cheerio": "^1.0.0",
+    "turndown": "^7.1.2",
+    "uuid": "^9.0.0",
+    "crypto-js": "^4.2.0",
+    "dotenv": "^16.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@types/d3": "^7.4.0",
+    "@types/lodash": "^4.17.0",
+    "@types/node": "^20.11.0",
+    "@types/uuid": "^9.0.0",
+    "@types/crypto-js": "^4.2.0",
+    "@types/turndown": "^5.0.4"
+  }
+}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/client",
   "version": "1.2.6",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sparkle/playground/package.json
+++ b/sparkle/playground/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@dust-tt/sparkle-playground",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "type": "module",
   "scripts": {

--- a/tools/datadog-log-exporter/package.json
+++ b/tools/datadog-log-exporter/package.json
@@ -2,6 +2,9 @@
   "name": "datadog-log-exporter",
   "private": true,
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/viz/package.json
+++ b/viz/package.json
@@ -1,6 +1,9 @@
 {
   "name": "viz",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "private": true,
   "scripts": {
     "dev": "next dev -p 3007",


### PR DESCRIPTION
## Description


  - Add explicit engines.node: ">=22.22.0" to all 12 workspace package.json files that were missing it (front, connectors, front-spa, sdks/js, cli, viz, extension, sandbox, preview-proxy, firebase-functions, sparkle/playground,
  datadog-log-exporter)
  - Parametrize node-version: "22.22.0" in every GitHub Actions workflow using setup-node-deps, so each workflow can be bumped independently during Node 24 rollout
  - Pin publish-cli and publish-sdk-client workflows from loose 22.x to exact 22.22.0
  - Bump firebase webhook-router Dockerfile from node:20 to node:22
  - add an optional node 24 build
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
