### PR TITLE
feat(front): Add Snowflake semantic view support to MCP tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -495,6 +495,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "retrieve_slideshow_file": "never_ask",
   },
   "snowflake": {
+    "describe_semantic_view": "never_ask",
     "describe_table": "never_ask",
     "list_databases": "never_ask",
     "list_schemas": "never_ask",

--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -23,6 +23,11 @@ interface SnowflakeColumn {
   nullable: boolean;
 }
 
+interface SnowflakeSemanticViewInfo {
+  dimensions: Array<{ name: string; dataType: string; tableName: string }>;
+  metrics: Array<{ name: string; dataType: string; tableName: string }>;
+}
+
 interface SnowflakeQueryResult {
   columns: SnowflakeColumn[];
   rows: Record<string, unknown>[];
@@ -380,6 +385,23 @@ export class SnowflakeClient {
       tables.push(...views);
     }
 
+    // Also get semantic views (failure is non-fatal - some schemas may not have semantic views)
+    const semanticViewsResult = await this.executeStatement(
+      `SHOW SEMANTIC VIEWS IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
+    );
+    if (semanticViewsResult.isOk()) {
+      const semanticViews = semanticViewsResult.value.rows
+        .map((row) => {
+          const name = getRowStringMultiKey(row, "name", "NAME");
+          if (!name) {
+            return null;
+          }
+          return { name, kind: "SEMANTIC_VIEW" };
+        })
+        .filter((v): v is { name: string; kind: string } => v !== null);
+      tables.push(...semanticViews);
+    }
+
     return new Ok(tables);
   }
 
@@ -458,6 +480,47 @@ export class SnowflakeClient {
     }
 
     return new Ok(undefined);
+  }
+
+  async describeSemanticView(
+    database: string,
+    schema: string,
+    semanticView: string
+  ): Promise<Result<SnowflakeSemanticViewInfo, Error>> {
+    const escapedName = `"${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"."${escapeSnowflakeIdentifier(semanticView)}"`;
+
+    const dimensionsResult = await this.executeStatement(
+      `SHOW SEMANTIC DIMENSIONS IN ${escapedName}`
+    );
+    if (dimensionsResult.isErr()) {
+      return dimensionsResult;
+    }
+
+    const dimensions = dimensionsResult.value.rows
+      .map((row) => ({
+        name: getRowStringMultiKey(row, "name", "NAME") ?? "",
+        dataType: getRowStringMultiKey(row, "data_type", "DATA_TYPE") ?? "",
+        tableName: getRowStringMultiKey(row, "table_name", "TABLE_NAME") ?? "",
+      }))
+      .filter((d) => d.name !== "");
+
+    // Metrics query is non-fatal - some semantic views may only have dimensions.
+    const metricsResult = await this.executeStatement(
+      `SHOW SEMANTIC METRICS IN ${escapedName}`
+    );
+
+    const metrics = metricsResult.isOk()
+      ? metricsResult.value.rows
+          .map((row) => ({
+            name: getRowStringMultiKey(row, "name", "NAME") ?? "",
+            dataType: getRowStringMultiKey(row, "data_type", "DATA_TYPE") ?? "",
+            tableName:
+              getRowStringMultiKey(row, "table_name", "TABLE_NAME") ?? "",
+          }))
+          .filter((m) => m.name !== "")
+      : [];
+
+    return new Ok({ dimensions, metrics });
   }
 
   async readOnlyQuery(

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -33,7 +33,7 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
   },
   list_tables: {
     description:
-      "List all tables and views within a specified Snowflake schema.",
+      "List all tables, views, and semantic views within a specified Snowflake schema.",
     schema: {
       database: z.string().describe("The name of the database."),
       schema: z
@@ -58,6 +58,22 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Describing Snowflake table",
       done: "Describe Snowflake table",
+    },
+  },
+  describe_semantic_view: {
+    description:
+      "Get the structure (dimensions and metrics) of a Snowflake semantic view. Use this instead of describe_table when the object kind is SEMANTIC_VIEW.",
+    schema: {
+      database: z.string().describe("The name of the database."),
+      schema: z.string().describe("The name of the schema."),
+      semantic_view: z
+        .string()
+        .describe("The name of the semantic view to describe."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Describing Snowflake semantic view",
+      done: "Describe Snowflake semantic view",
     },
   },
   query: {
@@ -114,7 +130,7 @@ export const SNOWFLAKE_SERVER = {
 
     instructions:
       // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
-      "Use list_databases, list_schemas, list_tables, and describe_table to explore the schema before writing queries. Only SELECT queries are allowed.",
+      "Use list_databases, list_schemas, list_tables, and describe_table (or describe_semantic_view for semantic views) to explore the schema before writing queries. Only SELECT queries are allowed.",
   },
   tools: Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -203,7 +203,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: `Found ${tables.length} tables/views in "${database}"."${schema}"`,
+        text: `Found ${tables.length} tables/views/semantic views in "${database}"."${schema}"`,
       },
       {
         type: "text" as const,
@@ -245,6 +245,45 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
             table,
             columns,
           },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+
+  describe_semantic_view: async (
+    { database, schema, semantic_view },
+    { authInfo, agentLoopContext, auth }
+  ) => {
+    const clientRes = await getClientFromAuthInfo(
+      authInfo,
+      agentLoopContext,
+      auth
+    );
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+
+    const result = await clientRes.value.describeSemanticView(
+      database,
+      schema,
+      semantic_view
+    );
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
+
+    const { dimensions, metrics } = result.value;
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Semantic view "${database}"."${schema}"."${semantic_view}" has ${dimensions.length} dimensions and ${metrics.length} metrics`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          { database, schema, semantic_view, dimensions, metrics },
           null,
           2
         ),


### PR DESCRIPTION
## Description

The Snowflake MCP tool currently only discovers standard tables and views. Snowflake semantic views (a newer feature providing a business-focused abstraction layer with dimensions and metrics) are invisible to the tool. This PR adds support for listing and describing semantic views.

Changes:
- **`list_tables`** now also runs `SHOW SEMANTIC VIEWS IN SCHEMA` and returns semantic views with `kind: "SEMANTIC_VIEW"` (non-fatal, same pattern as regular views)
- New **`describe_semantic_view`** tool that exposes dimensions and metrics via `SHOW SEMANTIC DIMENSIONS` / `SHOW SEMANTIC METRICS`
- Updated tool descriptions and server instructions to reference semantic views

## Tests

Manual testing against a Snowflake account with semantic views. No existing tests for the Snowflake MCP tool to update.

## Risk

Low. The semantic views query in `list_tables` is non-fatal (same pattern as the existing views query), so accounts that don't support semantic views are unaffected. The new `describe_semantic_view` tool is purely additive.

## Deploy Plan

Standard deploy — no migrations, no env vars, no dependencies. The new tool is automatically registered via the existing metadata-driven approach.