### PR TITLE
feat: pkce and correct organizationId in chrome extension auth

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -12,6 +12,7 @@ import type { PendingUpdate } from "@extension/platforms/chrome/services/core_pl
 import { ChromeCorePlatformService } from "@extension/platforms/chrome/services/core_platform";
 import { DUST_US_URL } from "@extension/shared/lib/config";
 import { extractPage } from "@extension/shared/lib/extraction";
+import { generatePKCE } from "@extension/shared/lib/utils";
 import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
 import { jwtDecode } from "jwt-decode";
 
@@ -487,23 +488,19 @@ chrome.runtime.onMessageExternal.addListener((request) => {
  * Authenticate the user using WorkOS.
  */
 const authenticate = async (
-  { connection, organizationId }: AuthBackgroundMessage,
+  { organizationId }: AuthBackgroundMessage,
   sendResponse: (
     auth: OAuthAuthorizeResponse | AuthBackgroundResponseError
   ) => void
 ) => {
   // First we call /authorize endpoint to get the authorization code (PKCE flow).
   const redirectUrl = chrome.identity.getRedirectURL();
-
-  // TODO(chris): Remove this condition if no log
-  const workspaceId =
-    connection && connection.startsWith("workspace-")
-      ? connection.split("workspace-")[1]
-      : "";
+  const { codeVerifier, codeChallenge } = await generatePKCE();
 
   const options: Record<string, string> = {
     redirect_uri: redirectUrl,
-    workspaceId: workspaceId,
+    code_challenge_method: "S256",
+    code_challenge: codeChallenge,
     ...(organizationId ? { organizationId } : {}),
   };
 
@@ -547,7 +544,10 @@ const authenticate = async (
       }
 
       if (authorizationCode) {
-        const data = await exchangeCodeForTokens(authorizationCode);
+        const data = await exchangeCodeForTokens(
+          authorizationCode,
+          codeVerifier
+        );
         sendResponse(data);
       } else {
         log(`Missing authorization code: ${redirectUrl}`);
@@ -641,10 +641,12 @@ const refreshToken = async (
  *  Exchange authorization code for tokens
  */
 const exchangeCodeForTokens = async (
-  code: string
+  code: string,
+  codeVerifier: string
 ): Promise<OAuthAuthorizeResponse | AuthBackgroundResponseError> => {
   try {
     const tokenParams: Record<string, string> = {
+      code_verifier: codeVerifier,
       code,
     };
 

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -113,11 +113,9 @@ export class FrontAuthService extends AuthService {
 
     try {
       const options: Record<string, string> = {
-        response_type: "code",
         redirect_uri: FRONT_EXTENSION_URL,
         code_challenge_method: "S256",
         code_challenge: codeChallenge,
-        provider: "authkit",
         connection: forcedConnection ?? "",
         ...(organizationId ? { organizationId } : {}),
       };
@@ -134,10 +132,8 @@ export class FrontAuthService extends AuthService {
       }
 
       const tokenParams = new URLSearchParams({
-        grant_type: "authorization_code",
         code_verifier: storedCodeVerifier,
         code: result.code,
-        redirect_uri: FRONT_EXTENSION_URL,
       });
       const response = await fetch(`${DUST_US_URL}/api/workos/authenticate`, {
         method: "POST",

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -12,7 +12,6 @@ import { getSession } from "@app/lib/auth";
 import { DUST_HAS_SESSION } from "@app/lib/cookies";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
@@ -61,7 +60,6 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       loginHint,
       returnTo,
       redirect_uri,
-      workspaceId,
       code_challenge,
       code_challenge_method,
     } = req.query;
@@ -72,20 +70,6 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
         : `${config.getAuthRedirectBaseUrl()}/api/workos/callback`;
 
     let organizationIdToUse;
-
-    if (workspaceId && isString(workspaceId)) {
-      const workspace = workspaceId
-        ? await WorkspaceResource.fetchById(workspaceId)
-        : null;
-
-      if (!workspace?.workOSOrganizationId) {
-        res.status(400).json({
-          error: "Workspace does not have a WorkOS organization ID",
-        });
-        return;
-      }
-      organizationIdToUse = workspace.workOSOrganizationId;
-    }
 
     if (organizationId && typeof organizationId === "string") {
       organizationIdToUse = organizationId;
@@ -182,15 +166,15 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
   if (!code || !isString(code)) {
     return res.status(400).json({ error: "Invalid code" });
   }
+
+  if (code_verifier && !isString(code_verifier)) {
+    return res.status(400).json({ error: "Invalid code verifier" });
+  }
   try {
-    const authResult =
-      code_verifier && isString(code_verifier)
-        ? await getWorkOS().userManagement.authenticateWithCodeAndVerifier({
-            code,
-            codeVerifier: code_verifier,
-            clientId: config.getWorkOSClientId(),
-          })
-        : await authenticate(code);
+    const authResult = await authenticate({
+      code,
+      codeVerifier: code_verifier,
+    });
 
     const jwtPayload = JSON.parse(
       Buffer.from(authResult.accessToken.split(".")[1], "base64").toString()
@@ -206,10 +190,19 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-async function authenticate(code: string, organizationId?: string) {
+async function authenticate({
+  code,
+  codeVerifier,
+  organizationId,
+}: {
+  code: string;
+  codeVerifier?: string;
+  organizationId?: string;
+}) {
   try {
     return await getWorkOS().userManagement.authenticateWithCode({
       code,
+      codeVerifier,
       clientId: config.getWorkOSClientId(),
       session: {
         sealSession: true,
@@ -263,7 +256,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       authenticationMethod,
       sealedSession,
       accessToken,
-    } = await authenticate(code, stateObj.organizationId);
+    } = await authenticate({ code, organizationId: stateObj.organizationId });
 
     if (!sealedSession) {
       throw new Error("Sealed session not found");


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6931

This PR implements PKCE (Proof Key for Code Exchange) in the Chrome extension authentication flow and fixes organizationId handling.

- Adds PKCE code verifier/challenge generation and verification throughout the auth flow
- Removes deprecated workspaceId lookup logic in favor of directly using organizationId from the extension
- Updates the token exchange to include code_verifier for PKCE validation

## Tests

Manually.

## Risks

Medium High - Changes the authentication flow for the Chrome extension.


## Deploy Plan

Standard deployment