### PR TITLE
[front] feat: expose files in skill versions

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -88,7 +88,7 @@ type SkillResourceConstructorOptions =
       // For global skills, there is no editor group.
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: undefined;
-      fileAttachments?: FileResource[];
+      fileAttachments: FileResource[];
       globalSId: string;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
@@ -96,7 +96,7 @@ type SkillResourceConstructorOptions =
   | {
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: GroupResource;
-      fileAttachments?: FileResource[];
+      fileAttachments: FileResource[];
       globalSId?: undefined;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
@@ -1264,6 +1264,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         dataSourceConfigurations: [],
         globalSId: def.sId,
         mcpServerConfigurations,
+        fileAttachments: [],
       }
     );
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1444,10 +1444,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       allMcpServerViews.map((view) => [view.id, view])
     );
 
+    // Build map to cache FileResource instances.
+    const allFileAttachmentIds = uniq(
+      sortedVersionModels.flatMap((model) => model.fileAttachmentIds)
+    );
+    const allFiles = await FileResource.fetchByModelIdsWithAuth(
+      auth,
+      allFileAttachmentIds
+    );
+    const fileMap = new Map(allFiles.map((file) => [file.id, file]));
+
     // Convert version models to SkillResource instances.
     return sortedVersionModels.map((versionModel) => {
       const mcpServerViews = removeNulls(
         versionModel.mcpServerViewIds.map((id) => mcpServerViewMap.get(id))
+      );
+      const fileAttachments = removeNulls(
+        versionModel.fileAttachmentIds.map((id) => fileMap.get(id))
       );
 
       const skill = new SkillResource(
@@ -1474,6 +1487,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           // As when the user saves we re-compute those from the nodes.
           dataSourceConfigurations: [],
           editorGroup: this.editorGroup ?? undefined,
+          fileAttachments,
           mcpServerConfigurations: mcpServerViews.map((view) => ({
             view,
           })),


### PR DESCRIPTION
## Description

- This PR adds the file attachments in the skill versions exposed to the front-end.
- Also makes `fileAttachments` mandatory in `SkillResource`'s constructor.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
