### PR TITLE
[front] feat: add flow to upload skills from repo

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -1,5 +1,6 @@
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { ImportSkillsDialog } from "@app/components/skills/ImportSkillsDialog";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
 import { SkillsTable } from "@app/components/skills/SkillsTable";
 import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSection";
@@ -9,7 +10,11 @@ import {
   useSetPageTitle,
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
@@ -17,6 +22,7 @@ import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
+  ArrowDownOnSquareIcon,
   Button,
   MagnifyingGlassIcon,
   Page,
@@ -78,9 +84,12 @@ function sortSkillsByName(skills: SkillWithRelationsType[]) {
 export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useHashParam("selectedTab", "active");
   const [skillSearch, setSkillSearch] = useState("");
   const [skillIdParam, setSkillIdParam] = useHashParam("skillId");
@@ -219,6 +228,12 @@ export function ManageSkillsPage() {
         agentId={agentId}
         onClose={() => setAgentId(null)}
       />
+      {isImportDialogOpen && (
+        <ImportSkillsDialog
+          onClose={() => setIsImportDialogOpen(false)}
+          owner={owner}
+        />
+      )}
       <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
         <Page.Header
           title="Manage Skills"
@@ -237,6 +252,15 @@ export function ManageSkillsPage() {
                 setSkillSearch(s);
               }}
             />
+            {hasFeature("sandbox_tools") && (
+              <Button
+                label="Import skill"
+                variant="outline"
+                icon={ArrowDownOnSquareIcon}
+                tooltip="Import skills from a GitHub repository"
+                onClick={() => setIsImportDialogOpen(true)}
+              />
+            )}
             <Button
               label="Create skill"
               href={getSkillBuilderRoute(owner.sId, "new")}

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -169,7 +169,7 @@ export function ImportSkillsDialog({
             disabled: isDetecting || isImporting,
           }}
           rightButtonProps={{
-            label: `Import`,
+            label: "Import",
             disabled: isImporting || selectedCount === 0,
             onClick: handleImport,
           }}

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -1,0 +1,180 @@
+import type { DetectedSkillStatus } from "@app/lib/api/skills/github_detection/import_types";
+import { parseGitHubRepoUrl } from "@app/lib/api/skills/github_detection/parsing";
+import {
+  useDetectSkillsFromRepo,
+  useImportSkills,
+} from "@app/lib/swr/skill_configurations";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Checkbox,
+  Chip,
+  ContextItem,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  PuzzleIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useState } from "react";
+
+interface ImportSkillsDialogProps {
+  onClose: () => void;
+  owner: LightWorkspaceType;
+}
+
+const STATUS_CHIP_LABEL: Record<
+  Exclude<DetectedSkillStatus, "ready">,
+  string
+> = {
+  name_conflict: "Skill name already in use",
+  invalid: "Invalid skill format",
+};
+
+export function ImportSkillsDialog({
+  onClose,
+  owner,
+}: ImportSkillsDialogProps) {
+  const [repoUrl, setRepoUrl] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
+
+  const { detectedSkills, isDetecting, detectError, triggerDetect } =
+    useDetectSkillsFromRepo({ owner });
+  const { importSkills } = useImportSkills({ owner });
+
+  // Pre-select all "ready" skills when detection completes.
+  useEffect(() => {
+    const initial = new Set<string>();
+    for (const skill of detectedSkills) {
+      if (skill.status === "ready") {
+        initial.add(skill.name);
+      }
+    }
+    setSelectedNames(initial);
+  }, [detectedSkills]);
+
+  const handleImport = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (selectedNames.size === 0) {
+        return;
+      }
+
+      setIsImporting(true);
+      await importSkills(repoUrl, [...selectedNames]);
+      setIsImporting(false);
+      onClose();
+    },
+    [repoUrl, selectedNames, importSkills, onClose]
+  );
+
+  const toggleSkill = useCallback((name: string) => {
+    setSelectedNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectedCount = selectedNames.size;
+  const hasDetectedSkills = detectedSkills.length > 0;
+
+  const description = hasDetectedSkills
+    ? `${detectedSkills.length} skill${pluralize(detectedSkills.length)} detected. Select the ones to import.`
+    : "Enter a GitHub repository URL to detect skills.";
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Import skills from GitHub</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <Input
+            placeholder="https://github.com/owner/repo"
+            value={repoUrl}
+            onChange={(e) => {
+              const url = e.target.value;
+              setRepoUrl(url.trim());
+              const trimmed = url.trim();
+              if (trimmed && parseGitHubRepoUrl(trimmed).isOk()) {
+                triggerDetect(trimmed);
+              }
+            }}
+            name="repoUrl"
+            disabled={isDetecting}
+            message={detectError}
+            messageStatus="error"
+            isError={!!detectError}
+          />
+          {isDetecting && (
+            <div className="flex items-center justify-center py-4">
+              <Spinner size="md" />
+            </div>
+          )}
+          {hasDetectedSkills && (
+            <ContextItem.List>
+              {detectedSkills.map((skill) => (
+                <ContextItem
+                  key={skill.name}
+                  title={
+                    <span className="text-sm font-normal">{skill.name}</span>
+                  }
+                  visual={
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        checked={selectedNames.has(skill.name)}
+                        disabled={skill.status === "invalid"}
+                        onCheckedChange={() => toggleSkill(skill.name)}
+                      />
+                      <ContextItem.Visual visual={PuzzleIcon} />
+                    </div>
+                  }
+                  action={
+                    skill.status !== "ready" ? (
+                      <Chip
+                        label={STATUS_CHIP_LABEL[skill.status]}
+                        size="xs"
+                        color="warning"
+                      />
+                    ) : undefined
+                  }
+                />
+              ))}
+            </ContextItem.List>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            disabled: isDetecting || isImporting,
+          }}
+          rightButtonProps={{
+            label: `Import${pluralize(selectedCount)}`,
+            disabled: isImporting || selectedCount === 0,
+            onClick: handleImport,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -120,7 +120,7 @@ export function ImportSkillsDialog({
               }
             }}
             name="repoUrl"
-            disabled={isDetecting}
+            disabled={isImporting}
             message={detectError}
             messageStatus="error"
             isError={!!detectError}
@@ -169,7 +169,7 @@ export function ImportSkillsDialog({
             disabled: isDetecting || isImporting,
           }}
           rightButtonProps={{
-            label: `Import${pluralize(selectedCount)}`,
+            label: `Import`,
             disabled: isImporting || selectedCount === 0,
             onClick: handleImport,
           }}

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -67,8 +67,10 @@ export function ImportSkillsDialog({
         return;
       }
 
-      await importSkills(repoUrl, [...selectedNames]);
-      onClose();
+      const result = await importSkills(repoUrl, [...selectedNames]);
+      if (result.successCount > 0) {
+        onClose();
+      }
     },
     [repoUrl, selectedNames, importSkills, onClose]
   );
@@ -148,7 +150,9 @@ export function ImportSkillsDialog({
                     <div className="flex items-center gap-2">
                       <Checkbox
                         checked={selectedNames.has(skill.name)}
-                        disabled={skill.status === "invalid"}
+                        // TODO(2026-03-04 aubin): allow overriding existing skills with name_conflict status
+                        // (needs to check that it comes from the same source).
+                        disabled={skill.status !== "ready"}
                         onCheckedChange={() => toggleSkill(skill.name)}
                       />
                       <ContextItem.Visual visual={PuzzleIcon} />

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -9,6 +9,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   Checkbox,
   Chip,
+  ContentMessage,
   ContextItem,
   Dialog,
   DialogContainer,
@@ -17,6 +18,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  InformationCircleIcon,
   Input,
   PuzzleIcon,
   Spinner,
@@ -41,12 +43,11 @@ export function ImportSkillsDialog({
   owner,
 }: ImportSkillsDialogProps) {
   const [repoUrl, setRepoUrl] = useState("");
-  const [isImporting, setIsImporting] = useState(false);
   const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
 
   const { detectedSkills, isDetecting, detectError, triggerDetect } =
     useDetectSkillsFromRepo({ owner });
-  const { importSkills } = useImportSkills({ owner });
+  const { importSkills, isImporting } = useImportSkills({ owner });
 
   // Pre-select all "ready" skills when detection completes.
   useEffect(() => {
@@ -66,9 +67,7 @@ export function ImportSkillsDialog({
         return;
       }
 
-      setIsImporting(true);
       await importSkills(repoUrl, [...selectedNames]);
-      setIsImporting(false);
       onClose();
     },
     [repoUrl, selectedNames, importSkills, onClose]
@@ -121,10 +120,17 @@ export function ImportSkillsDialog({
             }}
             name="repoUrl"
             disabled={isImporting}
-            message={detectError}
-            messageStatus="error"
-            isError={!!detectError}
           />
+          {detectError && (
+            <ContentMessage
+              title="Detection failed"
+              icon={InformationCircleIcon}
+              variant="rose"
+              size="lg"
+            >
+              {detectError}
+            </ContentMessage>
+          )}
           {isDetecting && (
             <div className="flex items-center justify-center py-4">
               <Spinner size="md" />

--- a/front/lib/api/skills/github_detection/import_types.ts
+++ b/front/lib/api/skills/github_detection/import_types.ts
@@ -1,0 +1,14 @@
+import type { DetectedSkill } from "@app/lib/api/skills/github_detection/types";
+
+export type DetectedSkillStatus = "ready" | "name_conflict" | "invalid";
+
+export interface DetectedSkillWithStatus extends DetectedSkill {
+  status: DetectedSkillStatus;
+  existingSkillId: string | null;
+}
+
+export interface DetectedSkillSummary {
+  name: string;
+  status: DetectedSkillStatus;
+  existingSkillId: string | null;
+}

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -452,7 +452,7 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
         void mutateActiveSkills();
 
         const successCount = data.imported.length;
-        const errors = data.errors.map((e) => `${e.name}: ${e.message}`);
+        const errors = data.errors.map((e) => e.message);
 
         if (successCount > 0) {
           sendNotification({

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -419,6 +419,7 @@ export function useDetectSkillsFromRepo({
 
 export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
+  const [isImporting, setIsImporting] = useState(false);
   const { mutateSkillsWithRelations: mutateActiveSkills } =
     useSkillsWithRelations({
       owner,
@@ -428,50 +429,55 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
 
   const importSkills = useCallback(
     async (repoUrl: string, names: string[]) => {
-      const res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ repoUrl, names }),
-      });
-
-      if (!res.ok) {
-        const errorData = await getErrorFromResponse(res);
-        sendNotification({
-          type: "error",
-          title: "Import failed",
-          description: errorData.message,
+      setIsImporting(true);
+      try {
+        const res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ repoUrl, names }),
         });
-        return { successCount: 0, errors: [errorData.message] };
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errorData.message,
+          });
+          return { successCount: 0, errors: [errorData.message] };
+        }
+
+        const data: ImportSkillsResponseBody = await res.json();
+
+        void mutateActiveSkills();
+
+        const successCount = data.imported.length;
+        const errors = data.errors.map((e) => `${e.name}: ${e.message}`);
+
+        if (successCount > 0) {
+          sendNotification({
+            type: "success",
+            title: `Imported ${successCount} skill${pluralize(successCount)}`,
+            description:
+              errors.length > 0
+                ? `${errors.length} skill${pluralize(errors.length)} failed to import.`
+                : `All skills were imported successfully.`,
+          });
+        } else {
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errors[0] ?? "Failed to import skills.",
+          });
+        }
+
+        return { successCount, errors };
+      } finally {
+        setIsImporting(false);
       }
-
-      const data: ImportSkillsResponseBody = await res.json();
-
-      void mutateActiveSkills();
-
-      const successCount = data.imported.length;
-      const errors = data.errors.map((e) => `${e.name}: ${e.message}`);
-
-      if (successCount > 0) {
-        sendNotification({
-          type: "success",
-          title: `Imported ${successCount} skill${pluralize(successCount)}`,
-          description:
-            errors.length > 0
-              ? `${errors.length} skill${pluralize(errors.length)} failed to import.`
-              : `All skills were imported successfully.`,
-        });
-      } else {
-        sendNotification({
-          type: "error",
-          title: "Import failed",
-          description: errors[0] ?? "Failed to import skills.",
-        });
-      }
-
-      return { successCount, errors };
     },
     [owner.sId, mutateActiveSkills, sendNotification]
   );
 
-  return { importSkills };
+  return { importSkills, isImporting };
 }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -25,8 +25,8 @@ import type {
   SkillType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
+import { isAPIErrorResponse } from "@app/types/error";
 import { Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
@@ -400,8 +400,9 @@ export function useDetectSkillsFromRepo({
             return;
           }
           setDetectError(
-            normalizeError(err).message ||
-              "Failed to detect skills from this repository."
+            isAPIErrorResponse(err)
+              ? err.error.message
+              : "Failed to detect skills from this repository."
           );
         } finally {
           if (!signal.aborted) {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -1,4 +1,6 @@
+import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { DetectedSkillSummary } from "@app/lib/api/skills/github_detection/import_types";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -15,6 +17,8 @@ import type {
   GetSkillWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills/[sId]";
 import type { GetSkillHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
+import type { DetectSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/detect";
+import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
 import type {
   SkillStatus,
@@ -22,8 +26,10 @@ import type {
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";
 import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
@@ -352,4 +358,120 @@ export function useSkillWithRelations(
     fetchSkillWithRelations: trigger,
     isLoading: isMutating,
   };
+}
+
+const DETECT_SKILLS_DEBOUNCE_MS = 500;
+
+export function useDetectSkillsFromRepo({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const [detectedSkills, setDetectedSkills] = useState<DetectedSkillSummary[]>(
+    []
+  );
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [detectError, setDetectError] = useState<string | null>(null);
+
+  const triggerDetect = useDebounceWithAbort(
+    useCallback(
+      async (repoUrl: string, signal: AbortSignal) => {
+        setIsDetecting(true);
+        setDetectError(null);
+
+        try {
+          const response: DetectSkillsResponseBody = await fetcher(
+            `/api/w/${owner.sId}/skills/detect`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ repoUrl }),
+            }
+          );
+
+          if (signal.aborted) {
+            return;
+          }
+
+          setDetectedSkills(response.skills);
+        } catch (err) {
+          if (signal.aborted) {
+            return;
+          }
+          setDetectError(
+            normalizeError(err).message ||
+              "Failed to detect skills from this repository."
+          );
+        } finally {
+          if (!signal.aborted) {
+            setIsDetecting(false);
+          }
+        }
+      },
+      [owner.sId, fetcher]
+    ),
+    { delayMs: DETECT_SKILLS_DEBOUNCE_MS }
+  );
+
+  return { detectedSkills, isDetecting, detectError, triggerDetect };
+}
+
+export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+      disabled: true,
+    });
+
+  const importSkills = useCallback(
+    async (repoUrl: string, names: string[]) => {
+      const res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoUrl, names }),
+      });
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Import failed",
+          description: errorData.message,
+        });
+        return { successCount: 0, errors: [errorData.message] };
+      }
+
+      const data: ImportSkillsResponseBody = await res.json();
+
+      void mutateActiveSkills();
+
+      const successCount = data.imported.length;
+      const errors = data.errors.map((e) => `${e.name}: ${e.message}`);
+
+      if (successCount > 0) {
+        sendNotification({
+          type: "success",
+          title: `Imported ${successCount} skill${pluralize(successCount)}`,
+          description:
+            errors.length > 0
+              ? `${errors.length} skill${pluralize(errors.length)} failed to import.`
+              : `All skills were imported successfully.`,
+        });
+      } else {
+        sendNotification({
+          type: "error",
+          title: "Import failed",
+          description: errors[0] ?? "Failed to import skills.",
+        });
+      }
+
+      return { successCount, errors };
+    },
+    [owner.sId, mutateActiveSkills, sendNotification]
+  );
+
+  return { importSkills };
 }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -34,6 +34,8 @@ import type { Fetcher } from "swr";
 import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
 
+const DETECT_SKILLS_DEBOUNCE_MS = 1_000;
+
 export function useSkill(options: {
   workspaceId: string;
   skillId: string | null;
@@ -359,8 +361,6 @@ export function useSkillWithRelations(
     isLoading: isMutating,
   };
 }
-
-const DETECT_SKILLS_DEBOUNCE_MS = 500;
 
 export function useDetectSkillsFromRepo({
   owner,

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -74,6 +74,17 @@ async function handler(
 
       const detectedSkills = result.value;
 
+      if (detectedSkills.length === 0) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "No skills found in this repository. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
+          },
+        });
+      }
+
       const skillSummaries = await concurrentExecutor(
         detectedSkills,
         async (skill): Promise<DetectedSkillSummary> => {

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,0 +1,109 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/github_detection/detect_skills";
+import type { DetectedSkillSummary } from "@app/lib/api/skills/github_detection/import_types";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import { isBuilder } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type DetectSkillsResponseBody = {
+  skills: DetectedSkillSummary[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<DetectSkillsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  switch (req.method) {
+    case "POST": {
+      if (!isBuilder(owner)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message: "User is not a builder.",
+          },
+        });
+      }
+
+      const featureFlags = await getFeatureFlags(owner);
+      if (!featureFlags.includes("sandbox_tools")) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Skill import from GitHub is not supported.",
+          },
+        });
+      }
+
+      const { repoUrl } = req.body;
+
+      if (!isString(repoUrl)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "repoUrl is required and must be a string.",
+          },
+        });
+      }
+
+      const result = await detectSkillsFromGitHubRepo({ repoUrl });
+
+      if (result.isErr()) {
+        logger.error(
+          { error: result.error, workspaceId: owner.sId },
+          "Error detecting skills from GitHub repo"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      const detectedSkills = result.value;
+
+      const skillSummaries = await concurrentExecutor(
+        detectedSkills,
+        async (skill): Promise<DetectedSkillSummary> => {
+          const existing = await SkillResource.fetchActiveByName(
+            auth,
+            skill.name
+          );
+
+          return {
+            name: skill.name,
+            status: existing ? "name_conflict" : "ready",
+            existingSkillId: existing ? existing.sId : null,
+          };
+        },
+        { concurrency: 8 }
+      );
+
+      return res.status(200).json({ skills: skillSummaries });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -8,7 +8,6 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import { isBuilder } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type DetectSkillsResponseBody = {
@@ -24,7 +23,7 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      if (!isBuilder(owner)) {
+      if (!auth.isBuilder()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -152,7 +152,12 @@ async function handler(
         { concurrency: IMPORT_CONCURRENCY }
       );
 
-      return res.status(200).json({ imported, errors });
+      return res
+        .status(200)
+        .json({
+          imported: imported.map((skill) => skill.toJSON(auth)),
+          errors,
+        });
     }
 
     default:

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -152,12 +152,10 @@ async function handler(
         { concurrency: IMPORT_CONCURRENCY }
       );
 
-      return res
-        .status(200)
-        .json({
-          imported: imported.map((skill) => skill.toJSON(auth)),
-          errors,
-        });
+      return res.status(200).json({
+        imported: imported.map((skill) => skill.toJSON(auth)),
+        errors,
+      });
     }
 
     default:

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -1,0 +1,170 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/github_detection/detect_skills";
+import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isBuilder } from "@app/types/user";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const IMPORT_CONCURRENCY = 4;
+
+const ImportSkillsRequestBodySchema = t.type({
+  repoUrl: t.string,
+  names: t.array(t.string),
+});
+
+export type ImportSkillsResponseBody = {
+  imported: SkillType[];
+  errors: { name: string; message: string }[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ImportSkillsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  switch (req.method) {
+    case "POST": {
+      if (!isBuilder(owner)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message: "User is not a builder.",
+          },
+        });
+      }
+
+      const featureFlags = await getFeatureFlags(owner);
+      if (!featureFlags.includes("sandbox_tools")) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Skill import from GitHub is not supported.",
+          },
+        });
+      }
+
+      const bodyValidation = ImportSkillsRequestBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const { repoUrl, names } = bodyValidation.right;
+
+      const result = await detectSkillsFromGitHubRepo({ repoUrl });
+      if (result.isErr()) {
+        logger.error(
+          { error: result.error, workspaceId: owner.sId },
+          "Error detecting skills from GitHub repo during import"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      const requestedNames = new Set(names);
+      const selectedSkills = result.value.filter(
+        (skill) =>
+          requestedNames.has(skill.name) &&
+          skill.name &&
+          skill.instructions.trim()
+      );
+
+      const user = auth.getNonNullableUser();
+      const imported: SkillType[] = [];
+      const errors: { name: string; message: string }[] = [];
+
+      await concurrentExecutor(
+        selectedSkills,
+        async (skill) => {
+          const existing = await SkillResource.fetchActiveByName(
+            auth,
+            skill.name
+          );
+          if (existing) {
+            errors.push({
+              name: skill.name,
+              message: `A skill with the name "${skill.name}" already exists.`,
+            });
+            return;
+          }
+
+          let icon: string | null = null;
+          const iconResult = await getSkillIconSuggestion(auth, {
+            name: skill.name,
+            instructions: skill.instructions,
+            agentFacingDescription: skill.description,
+          });
+          if (iconResult.isOk()) {
+            icon = iconResult.value;
+          } else {
+            logger.warn(
+              { error: iconResult.error, skillName: skill.name },
+              "Failed to generate icon suggestion for imported skill"
+            );
+          }
+
+          const skillResource = await SkillResource.makeNew(
+            auth,
+            {
+              status: "active",
+              name: skill.name,
+              agentFacingDescription: skill.description,
+              userFacingDescription: skill.description,
+              instructions: skill.instructions,
+              editedBy: user.id,
+              requestedSpaceIds: [],
+              extendedSkillId: null,
+              icon,
+              source: "github",
+              sourceMetadata: {
+                repoUrl,
+                filePath: skill.skillMdPath,
+              },
+            },
+            { mcpServerViews: [] }
+          );
+
+          imported.push(skillResource.toJSON(auth));
+        },
+        { concurrency: IMPORT_CONCURRENCY }
+      );
+
+      return res.status(200).json({ imported, errors });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -8,7 +8,6 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isBuilder } from "@app/types/user";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -35,7 +34,7 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      if (!isBuilder(owner)) {
+      if (!auth.isBuilder()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -93,7 +93,7 @@ async function handler(
       );
 
       const user = auth.getNonNullableUser();
-      const imported: SkillType[] = [];
+      const imported: SkillResource[] = [];
       const errors: { name: string; message: string }[] = [];
 
       await concurrentExecutor(
@@ -147,7 +147,7 @@ async function handler(
             { mcpServerViews: [] }
           );
 
-          imported.push(skillResource.toJSON(auth));
+          imported.push(skillResource);
         },
         { concurrency: IMPORT_CONCURRENCY }
       );


### PR DESCRIPTION
## Description

- This PR implements the part of the flow designed [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=3681-87980&t=LndAkHsklvDecDIF-0), focusing on the part about import from a GitHub repository and leaving the zip file upload aside for now.
- Implements a very minimalistic version of the flow for now, will little error handling (we only show chips but don't do much with them) and no conflict resolution. Really focuses on the initial import part.
- Only adds one button in the Manage skills part while we're figuring out what the entry will be, what the labels on them will be, etc..

<img width="1174" height="1029" alt="Screenshot 2026-03-05 at 9 54 33 AM" src="https://github.com/user-attachments/assets/b0a58fde-80b9-40d3-b2d7-3dffed7bb215" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
