### PR TITLE
fix: auth connect flow should use full retry to re-execute tool with new credentials

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -909,10 +909,13 @@ function AgentMessageContent({
 
   const retryHandlerWithResetState = useCallback(
     // Conversation and message might be different than the current ones in case of subagents.
-    async (conversationAndMessage: {
-      conversationId: string;
-      messageId: string;
-    }) => {
+    async (
+      conversationAndMessage: {
+        conversationId: string;
+        messageId: string;
+      },
+      { blockedOnly = true }: { blockedOnly?: boolean } = {}
+    ) => {
       methods.data.map((m) =>
         isMessageTemporayState(m) && m.sId === sId
           ? {
@@ -931,7 +934,7 @@ function AgentMessageContent({
       // Retry on the event's conversationId, which may be coming from a subagent.
       if (conversationAndMessage.conversationId !== conversationId) {
         await retryHandler({
-          blockedOnly: true,
+          blockedOnly,
           conversationId: conversationAndMessage.conversationId,
           messageId: conversationAndMessage.messageId,
         });
@@ -939,7 +942,7 @@ function AgentMessageContent({
       // Retry on the main conversation.
       await retryHandler({
         conversationId,
-        blockedOnly: true,
+        blockedOnly,
         messageId: sId,
       });
     },
@@ -1023,11 +1026,18 @@ function AgentMessageContent({
             mcpServerId={blockedAction.metadata.mcpServerId}
             provider={blockedAction.authorizationInfo.provider}
             scope={blockedAction.authorizationInfo.scope}
+            blockedAction={blockedAction}
             retryHandler={() =>
-              retryHandlerWithResetState({
-                conversationId: blockedAction.conversationId,
-                messageId: blockedAction.messageId,
-              })
+              // Auth-blocked workflows have EXITED (unlike validation-blocked
+              // which are PAUSED). A full retry re-runs the message fresh so
+              // the tool picks up the newly connected OAuth credentials.
+              retryHandlerWithResetState(
+                {
+                  conversationId: blockedAction.conversationId,
+                  messageId: blockedAction.messageId,
+                },
+                { blockedOnly: false }
+              )
             }
           />
         );
@@ -1045,6 +1055,7 @@ function AgentMessageContent({
                 messageId: blockedAction.messageId,
               })
             }
+            blockedAction={blockedAction}
           />
         );
     }

--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -1,6 +1,10 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import type { GooglePickerFile } from "@app/hooks/useGooglePicker";
 import { useGooglePicker } from "@app/hooks/useGooglePicker";
-import type { FileAuthorizationInfo } from "@app/lib/actions/mcp";
+import type {
+  BlockedToolExecution,
+  FileAuthorizationInfo,
+} from "@app/lib/actions/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PickerTokenResponseType } from "@app/pages/api/w/[wId]/google_drive/picker_token";
@@ -19,6 +23,7 @@ interface GoogleDriveFileAuthorizationRequiredProps {
   fileAuthorizationInfo: FileAuthorizationInfo;
   mcpServerId: string;
   retryHandler: () => void;
+  blockedAction: BlockedToolExecution;
 }
 
 export function GoogleDriveFileAuthorizationRequired({
@@ -27,6 +32,7 @@ export function GoogleDriveFileAuthorizationRequired({
   fileAuthorizationInfo,
   mcpServerId,
   retryHandler,
+  blockedAction,
 }: GoogleDriveFileAuthorizationRequiredProps) {
   const { user } = useAuth();
   const [isAuthorized, setIsAuthorized] = useState(false);
@@ -38,6 +44,8 @@ export function GoogleDriveFileAuthorizationRequired({
     appId: string;
   } | null>(null);
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
+
+  const { removeCompletedAction } = useBlockedActionsContext();
 
   const isTriggeredByCurrentUser = useMemo(
     () => triggeringUser?.sId === user?.sId,
@@ -85,13 +93,19 @@ export function GoogleDriveFileAuthorizationRequired({
 
       if (targetFileSelected) {
         setIsAuthorized(true);
+        removeCompletedAction(blockedAction.actionId);
         setTimeout(() => {
           retryHandler();
         }, 100);
       }
       // If wrong file selected, user can click the button again
     },
-    [fileAuthorizationInfo.fileId, retryHandler]
+    [
+      fileAuthorizationInfo.fileId,
+      retryHandler,
+      removeCompletedAction,
+      blockedAction.actionId,
+    ]
   );
 
   const handlePickerCancel = useCallback(() => {

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -1,12 +1,13 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import {
   areCredentialOverridesValid,
   PersonalAuthCredentialOverrides,
 } from "@app/components/oauth/PersonalAuthCredentialOverrides";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   useCreatePersonalConnection,
   useMCPServer,
@@ -22,8 +23,9 @@ interface MCPServerPersonalAuthenticationRequiredProps {
   mcpServerId: string;
   owner: LightWorkspaceType;
   provider: OAuthProvider;
-  retryHandler: () => void;
   scope?: string;
+  blockedAction: BlockedToolExecution;
+  retryHandler: () => void;
 }
 
 export function MCPServerPersonalAuthenticationRequired({
@@ -31,8 +33,9 @@ export function MCPServerPersonalAuthenticationRequired({
   mcpServerId,
   owner,
   provider,
-  retryHandler,
   scope,
+  blockedAction,
+  retryHandler,
 }: MCPServerPersonalAuthenticationRequiredProps) {
   const { user } = useAuth();
   const { server: mcpServer } = useMCPServer({
@@ -42,7 +45,7 @@ export function MCPServerPersonalAuthenticationRequired({
 
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
-  const { submit: retry } = useSubmitFunction(async () => retryHandler());
+  const { removeCompletedAction } = useBlockedActionsContext();
 
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
@@ -92,7 +95,8 @@ export function MCPServerPersonalAuthenticationRequired({
         }
       } else {
         setIsConnected(true);
-        await retry();
+        removeCompletedAction(blockedAction.actionId);
+        retryHandler();
       }
     } finally {
       setIsConnecting(false);


### PR DESCRIPTION
## Description

Runner card: https://github.com/dust-tt/tasks/issues/6942

After connecting OAuth via the auth card, the card was stuck. I fixed it, but then when it disappeared but the tool still failed with "requires personal authentication." 

**Root cause:** 
Auth-blocked workflows have exited (unlike validation-blocked which are paused). The connect flow used retryHandlerWithResetState which retries with blockedOnly=true.
This calls retryBlockedActions to resume from the blocked step, but the exited workflow + stale action status meant the tool still couldn't authenticate.

**Fix:** 
Added a blockedOnly param to retryHandlerWithResetState (defaults to true, preserving existing behavior). The auth connect flow now passes blockedOnly: false, which calls retryAgentMessage. Meaning a full retry that creates a new message version and re-runs the agent loop from scratch. The tool re-executes fresh and picks up the newly connected OAuth credentials. This matches what the manual "Retry" button does.

removeCompletedAction is now called to dismiss the auth card on connect, and message state is reset to "created" before retrying to avoid flashing the old error. Same pattern applied to GoogleDriveFileAuthorizationRequired for consistency.

## Tests

Locally this seem to work as expected 🙏🏻 
Tested with Slack and Hubspot. 
Tested with Gdrive list file (to the point it displays the Chip since I don't have all setup locally)

## Risk

Break tool oauth flow in convo? 
Can be rolled back. 

## Deploy Plan

Deploy front. 