### PR TITLE
Do not spot gdrive full sync on WorkflowExecutionAlreadyStartedError

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -545,19 +545,31 @@ export async function googleDriveFullSyncV2({
         folderId
       );
 
-      const handle = await startChild(googleDriveFolderSync, {
-        workflowId: childWorkflowId,
-        searchAttributes: { connectorId: [connectorId] },
-        args: [
-          {
-            connectorId,
-            rootFolderId: folderId,
-            startSyncTs,
-            mimeTypeFilter,
-          },
-        ],
-        memo: workflowInfo().memo,
-      });
+      let handle: ChildWorkflowHandle<typeof googleDriveFolderSync>;
+      try {
+        handle = await startChild(googleDriveFolderSync, {
+          workflowId: childWorkflowId,
+          searchAttributes: { connectorId: [connectorId] },
+          args: [
+            {
+              connectorId,
+              rootFolderId: folderId,
+              startSyncTs,
+              mimeTypeFilter,
+            },
+          ],
+          memo: workflowInfo().memo,
+        });
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          err.name === "WorkflowExecutionAlreadyStartedError"
+        ) {
+          // Workflow already running for this folder, it will be synced by that execution
+          return;
+        }
+        throw err;
+      }
 
       runningFolderWorkflows[folderId] = {
         handle,


### PR DESCRIPTION
## Description

Similar to what has been done in https://github.com/dust-tt/dust/pull/20273
If the full sync tries to sync a folder which is already syncing it fails and stop

## Tests

no

## Risk

low

## Deploy Plan

deploy connector
