### PR TITLE
[Connectors] feat(slack): stream responses via chat.startStream API

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1019,6 +1019,9 @@ async function answerMessage(
       slackTeamId,
       slackUserId,
     });
+    // The stream is invisible until first append (chat.startStream only fires then).
+    // The native "Thinking…" spinner requires the Assistant API's
+    // set_status(), which we don't use, so a task kicks off the stream instead.
     await streamHandler.startTask(`${mention.agentName} is thinking...`);
   } else {
     mainMessage = await slackClient.chat.postMessage({

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -70,7 +70,7 @@ import {
   Ok,
   removeNulls,
 } from "@dust-tt/client";
-import type { WebClient } from "@slack/web-api";
+import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import removeMarkdown from "remove-markdown";
 
@@ -531,10 +531,14 @@ async function processErrorResult(
         ? res.error.message
         : `An error occurred : ${res.error.message}. Our team has been notified and will work on it as soon as possible.`;
 
-    const { slackChatBotMessage, mainMessage } =
+    const { slackChatBotMessage, mainMessage, streamTs } =
       res.error instanceof SlackMessageError
         ? res.error
-        : { mainMessage: undefined, slackChatBotMessage: undefined };
+        : {
+            mainMessage: undefined,
+            streamTs: undefined,
+            slackChatBotMessage: undefined,
+          };
 
     const conversationUrl = makeConversationUrl(
       connector.workspaceId,
@@ -548,14 +552,26 @@ async function processErrorResult(
       connector.workspaceId,
       errorMessage
     );
-    if (mainMessage && mainMessage.ts) {
+
+    const updateTs = streamTs ?? mainMessage?.ts;
+
+    if (updateTs) {
       reportSlackUsage({
         connectorId: connector.id,
         method: "chat.update",
         channelId: slackChannel,
         useCase: "bot",
       });
+    }
 
+    if (streamTs) {
+      // Native streaming path: update the stream message with error.
+      await slackClient.chat.update({
+        ...errorPost,
+        channel: slackChannel,
+        ts: streamTs,
+      });
+    } else if (mainMessage && mainMessage.ts) {
       const mainMessageTs = mainMessage.ts;
 
       await throttleWithRedis(
@@ -621,6 +637,7 @@ async function answerMessage(
     });
   }
 
+  // We start by retrieving the slack user info.
   const slackClient = await getSlackClient(connector.id);
 
   let slackUserInfo: SlackUserInfo | null = null;
@@ -885,6 +902,7 @@ async function answerMessage(
     if (!agentConfig) {
       return new Err(new SlackExternalUserError("Cannot find selected agent."));
     }
+    // Removing all previous mentions.
     if (mentionCandidate) {
       message = message.replace(mentionCandidate, "");
     }
@@ -998,21 +1016,48 @@ async function answerMessage(
     }
   }
 
-  const mainMessage = await slackClient.chat.postMessage({
-    ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
-      assistantName: mention.agentName,
-      agentConfigurations: mostPopularAgentConfigurations,
-      isThinking: true,
-    }),
-    channel: slackChannel,
-    thread_ts: slackMessageTs,
-    metadata: {
-      event_type: "user_message",
-      event_payload: {
-        message_id: slackChatBotMessage.id,
+  const useNativeStreaming = await getNativeStreamingFromFeatureFlag(dustAPI);
+
+  let mainMessage: ChatPostMessageResponse | undefined;
+  let streamer: ReturnType<WebClient["chatStream"]> | undefined;
+  let streamTs: string | undefined;
+
+  if (useNativeStreaming) {
+    streamer = slackClient.chatStream({
+      channel: slackChannel,
+      thread_ts: slackMessageTs,
+      recipient_team_id: slackTeamId,
+      recipient_user_id: slackUserId ?? undefined,
+      buffer_size: 256,
+    });
+    const startRes = await streamer.append({
+      chunks: [
+        {
+          type: "task_update",
+          id: "thinking",
+          title: `${mention.agentName} is thinking...`,
+          status: "in_progress" as const,
+        },
+      ],
+    });
+    streamTs = startRes?.ts;
+  } else {
+    mainMessage = await slackClient.chat.postMessage({
+      ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
+        assistantName: mention.agentName,
+        agentConfigurations: mostPopularAgentConfigurations,
+        isThinking: true,
+      }),
+      channel: slackChannel,
+      thread_ts: slackMessageTs,
+      metadata: {
+        event_type: "user_message",
+        event_payload: {
+          message_id: slackChatBotMessage.id,
+        },
       },
-    },
-  });
+    });
+  }
 
   const buildSlackMessageError = (
     errRes: Err<Error | APIError>,
@@ -1037,7 +1082,8 @@ async function answerMessage(
       new SlackMessageError(
         errRes.error.message,
         slackChatBotMessage.get(),
-        mainMessage
+        mainMessage,
+        streamTs
       )
     );
   };
@@ -1064,6 +1110,7 @@ async function answerMessage(
     skipToolsValidation,
   };
 
+  // Await the promise to get the content fragment.
   const buildContentFragmentRes = await buildContentFragmentPromise;
 
   if (buildContentFragmentRes.isErr()) {
@@ -1148,6 +1195,8 @@ async function answerMessage(
     connector,
     conversation,
     mainMessage,
+    streamer,
+    streamTs,
     slack: {
       slackChannelId: slackChannel,
       slackClient,
@@ -1248,6 +1297,7 @@ async function makeContentFragments(
   if (supportedFiles.length > 0) {
     logger.info({ conversationId }, "Found supported files, uploading them.");
 
+    // Download the files and upload them to the conversation.
     const proxyFetch = createProxyAwareFetch();
     for (const f of supportedFiles) {
       const response = await proxyFetch(f.url_private_download!, {
@@ -1458,35 +1508,70 @@ async function isAgentAccessingRestrictedSpace(
   activeAgentConfigurations: LightAgentConfigurationType[],
   agentId: string
 ): Promise<Result<boolean, Error>> {
-  const agent = activeAgentConfigurations.find((ac) => ac.sId === agentId);
-  if (!agent) {
-    logger.warn(
-      { agentId },
-      "Agent not found when checking for restricted space"
+  try {
+    const agent = activeAgentConfigurations.find((ac) => ac.sId === agentId);
+    if (!agent) {
+      logger.warn(
+        { agentId },
+        "Agent not found when checking for restricted space"
+      );
+      return new Err(new Error(`Agent ${agentId} not found`));
+    }
+
+    // If the agent has no requestedSpaceIds, it's not from a restricted space
+    if (!agent.requestedSpaceIds || agent.requestedSpaceIds.length === 0) {
+      return new Ok(false);
+    }
+
+    const agentSpaceIds = agent.requestedSpaceIds.flat();
+
+    const spacesRes = await dustAPI.getSpaces();
+    if (spacesRes.isErr()) {
+      logger.error(
+        { error: spacesRes.error, agentId },
+        "Error fetching spaces when checking for restricted space"
+      );
+      return new Err(
+        new Error(`Error fetching spaces: ${spacesRes.error.message}`)
+      );
+    }
+
+    // Check if any of the agent's group IDs match with groups from restricted spaces
+    const restrictedSpaces = spacesRes.value.filter(
+      (space) => space.isRestricted
     );
-    return new Err(new Error(`Agent ${agentId} not found`));
-  }
+    const isFromRestrictedSpace = restrictedSpaces.some((space) =>
+      agentSpaceIds.includes(space.sId)
+    );
 
-  if (!agent.requestedSpaceIds || agent.requestedSpaceIds.length === 0) {
-    return new Ok(false);
-  }
+    logger.info(
+      {
+        agentId,
+        isRestricted: isFromRestrictedSpace,
+      },
+      "Checked if agent is from restricted space"
+    );
 
-  const agentSpaceIds = agent.requestedSpaceIds.flat();
-
-  const spacesRes = await dustAPI.getSpaces();
-  if (spacesRes.isErr()) {
+    return new Ok(isFromRestrictedSpace);
+  } catch (error) {
     logger.error(
-      { error: spacesRes.error, agentId },
-      "Error fetching spaces when checking for restricted space"
+      { error, agentId },
+      "Error checking if agent is from restricted space"
     );
     return new Err(
-      new Error(`Error fetching spaces: ${spacesRes.error.message}`)
+      new Error(
+        `Error checking if agent ${agentId} is from restricted space: ${error}`
+      )
     );
   }
+}
 
-  const isFromRestrictedSpace = spacesRes.value
-    .filter((space) => space.isRestricted)
-    .some((space) => agentSpaceIds.includes(space.sId));
-
-  return new Ok(isFromRestrictedSpace);
+async function getNativeStreamingFromFeatureFlag(
+  dustAPI: DustAPI
+): Promise<boolean> {
+  const flagsRes = await dustAPI.getWorkspaceFeatureFlags();
+  if (flagsRes.isErr()) {
+    return false;
+  }
+  return flagsRes.value.includes("slack_native_streaming");
 }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -4,6 +4,7 @@ import {
   makeMessageUpdateBlocksAndText,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/blocks";
+import { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import { streamConversationToSlack } from "@connectors/connectors/slack/chat/stream_conversation_handler";
 import {
@@ -562,17 +563,6 @@ async function processErrorResult(
         channelId: slackChannel,
         useCase: "bot",
       });
-    }
-
-    if (streamTs) {
-      // Native streaming path: update the stream message with error.
-      await slackClient.chat.update({
-        ...errorPost,
-        channel: slackChannel,
-        ts: streamTs,
-      });
-    } else if (mainMessage && mainMessage.ts) {
-      const mainMessageTs = mainMessage.ts;
 
       await throttleWithRedis(
         RATE_LIMITS["chat.update"],
@@ -582,7 +572,7 @@ async function processErrorResult(
           slackClient.chat.update({
             ...errorPost,
             channel: slackChannel,
-            ts: mainMessageTs,
+            ts: updateTs,
           }),
         { source: "processErrorResult" }
       );
@@ -1019,28 +1009,17 @@ async function answerMessage(
   const useNativeStreaming = await getNativeStreamingFromFeatureFlag(dustAPI);
 
   let mainMessage: ChatPostMessageResponse | undefined;
-  let streamer: ReturnType<WebClient["chatStream"]> | undefined;
-  let streamTs: string | undefined;
+  let streamHandler: SlackStreamHandler | undefined;
 
   if (useNativeStreaming) {
-    streamer = slackClient.chatStream({
-      channel: slackChannel,
-      thread_ts: slackMessageTs,
-      recipient_team_id: slackTeamId,
-      recipient_user_id: slackUserId ?? undefined,
-      buffer_size: 256,
+    streamHandler = new SlackStreamHandler(slackClient);
+    streamHandler.start({
+      slackChannel,
+      slackMessageTs,
+      slackTeamId,
+      slackUserId,
     });
-    const startRes = await streamer.append({
-      chunks: [
-        {
-          type: "task_update",
-          id: "thinking",
-          title: `${mention.agentName} is thinking...`,
-          status: "in_progress" as const,
-        },
-      ],
-    });
-    streamTs = startRes?.ts;
+    await streamHandler.startTask(`${mention.agentName} is thinking...`);
   } else {
     mainMessage = await slackClient.chat.postMessage({
       ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
@@ -1083,7 +1062,7 @@ async function answerMessage(
         errRes.error.message,
         slackChatBotMessage.get(),
         mainMessage,
-        streamTs
+        streamHandler?.messageTs
       )
     );
   };
@@ -1195,8 +1174,7 @@ async function answerMessage(
     connector,
     conversation,
     mainMessage,
-    streamer,
-    streamTs,
+    streamHandler,
     slack: {
       slackChannelId: slackChannel,
       slackClient,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -621,7 +621,6 @@ async function answerMessage(
     });
   }
 
-  // We start by retrieving the slack user info.
   const slackClient = await getSlackClient(connector.id);
 
   let slackUserInfo: SlackUserInfo | null = null;
@@ -886,7 +885,6 @@ async function answerMessage(
     if (!agentConfig) {
       return new Err(new SlackExternalUserError("Cannot find selected agent."));
     }
-    // Removing all previous mentions.
     if (mentionCandidate) {
       message = message.replace(mentionCandidate, "");
     }
@@ -1066,7 +1064,6 @@ async function answerMessage(
     skipToolsValidation,
   };
 
-  // Await the promise to get the content fragment.
   const buildContentFragmentRes = await buildContentFragmentPromise;
 
   if (buildContentFragmentRes.isErr()) {
@@ -1155,6 +1152,7 @@ async function answerMessage(
       slackChannelId: slackChannel,
       slackClient,
       slackMessageTs,
+      slackTeamId,
       slackUserInfo,
       slackUserId,
     },
@@ -1250,7 +1248,6 @@ async function makeContentFragments(
   if (supportedFiles.length > 0) {
     logger.info({ conversationId }, "Found supported files, uploading them.");
 
-    // Download the files and upload them to the conversation.
     const proxyFetch = createProxyAwareFetch();
     for (const f of supportedFiles) {
       const response = await proxyFetch(f.url_private_download!, {
@@ -1461,60 +1458,35 @@ async function isAgentAccessingRestrictedSpace(
   activeAgentConfigurations: LightAgentConfigurationType[],
   agentId: string
 ): Promise<Result<boolean, Error>> {
-  try {
-    const agent = activeAgentConfigurations.find((ac) => ac.sId === agentId);
-    if (!agent) {
-      logger.warn(
-        { agentId },
-        "Agent not found when checking for restricted space"
-      );
-      return new Err(new Error(`Agent ${agentId} not found`));
-    }
-
-    // If the agent has no requestedSpaceIds, it's not from a restricted space
-    if (!agent.requestedSpaceIds || agent.requestedSpaceIds.length === 0) {
-      return new Ok(false);
-    }
-
-    const agentSpaceIds = agent.requestedSpaceIds.flat();
-
-    const spacesRes = await dustAPI.getSpaces();
-    if (spacesRes.isErr()) {
-      logger.error(
-        { error: spacesRes.error, agentId },
-        "Error fetching spaces when checking for restricted space"
-      );
-      return new Err(
-        new Error(`Error fetching spaces: ${spacesRes.error.message}`)
-      );
-    }
-
-    // Check if any of the agent's group IDs match with groups from restricted spaces
-    const restrictedSpaces = spacesRes.value.filter(
-      (space) => space.isRestricted
+  const agent = activeAgentConfigurations.find((ac) => ac.sId === agentId);
+  if (!agent) {
+    logger.warn(
+      { agentId },
+      "Agent not found when checking for restricted space"
     );
-    const isFromRestrictedSpace = restrictedSpaces.some((space) =>
-      agentSpaceIds.includes(space.sId)
-    );
+    return new Err(new Error(`Agent ${agentId} not found`));
+  }
 
-    logger.info(
-      {
-        agentId,
-        isRestricted: isFromRestrictedSpace,
-      },
-      "Checked if agent is from restricted space"
-    );
+  if (!agent.requestedSpaceIds || agent.requestedSpaceIds.length === 0) {
+    return new Ok(false);
+  }
 
-    return new Ok(isFromRestrictedSpace);
-  } catch (error) {
+  const agentSpaceIds = agent.requestedSpaceIds.flat();
+
+  const spacesRes = await dustAPI.getSpaces();
+  if (spacesRes.isErr()) {
     logger.error(
-      { error, agentId },
-      "Error checking if agent is from restricted space"
+      { error: spacesRes.error, agentId },
+      "Error fetching spaces when checking for restricted space"
     );
     return new Err(
-      new Error(
-        `Error checking if agent ${agentId} is from restricted space: ${error}`
-      )
+      new Error(`Error fetching spaces: ${spacesRes.error.message}`)
     );
   }
+
+  const isFromRestrictedSpace = spacesRes.value
+    .filter((space) => space.isRestricted)
+    .some((space) => agentSpaceIds.includes(space.sId));
+
+  return new Ok(isFromRestrictedSpace);
 }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1016,13 +1016,15 @@ async function answerMessage(
     streamHandler.start({
       slackChannel,
       slackMessageTs,
+      slackThreadTs,
       slackTeamId,
       slackUserId,
     });
-    // The stream is invisible until first append (chat.startStream only fires then).
-    // The native "Thinking…" spinner requires the Assistant API's
-    // set_status(), which we don't use, so a task kicks off the stream instead.
-    await streamHandler.startTask(`${mention.agentName} is thinking...`);
+    await streamHandler.setThinking(
+      mention.agentName === "dust"
+        ? `is thinking...`
+        : `(${mention.agentName}) is thinking...`
+    );
   } else {
     mainMessage = await slackClient.chat.postMessage({
       ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1012,7 +1012,7 @@ async function answerMessage(
   let streamHandler: SlackStreamHandler | undefined;
 
   if (useNativeStreaming) {
-    streamHandler = new SlackStreamHandler(slackClient);
+    streamHandler = new SlackStreamHandler(slackClient, connector.id);
     streamHandler.start({
       slackChannel,
       slackMessageTs,

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -1,0 +1,75 @@
+import type { ChatStreamer, WebClient } from "@slack/web-api";
+import type { ChatAppendStreamArguments } from "@slack/web-api/dist/types/request/chat";
+
+export class SlackStreamHandler {
+  private streamer: ChatStreamer | undefined;
+  // Single task slot reused for every task — only the latest is visible.
+  // The stream is invisible until first append (chat.startStream only fires
+  // then). The native "Thinking…" spinner requires the Assistant API's
+  // set_status(), which we don't use, so a task kicks off the stream instead.
+  private readonly taskId = "active-step";
+  private hasTask = false;
+  messageTs: string | undefined;
+
+  constructor(private slackClient: WebClient) {}
+
+  public start({
+    slackChannel,
+    slackMessageTs,
+    slackTeamId,
+    slackUserId,
+  }: {
+    slackChannel: string;
+    slackMessageTs: string;
+    slackTeamId: string;
+    slackUserId?: string;
+  }) {
+    this.streamer = this.slackClient.chatStream({
+      channel: slackChannel,
+      thread_ts: slackMessageTs,
+      recipient_team_id: slackTeamId,
+      recipient_user_id: slackUserId ?? undefined,
+      buffer_size: 256,
+    });
+  }
+
+  private async append(
+    payload: Omit<ChatAppendStreamArguments, "channel" | "ts">
+  ) {
+    const res = await this.streamer?.append(payload);
+    if (!this.messageTs && res?.ts) {
+      this.messageTs = res.ts;
+    }
+  }
+
+  async startTask(title: string) {
+    this.hasTask = true;
+    await this.append({
+      chunks: [
+        { type: "task_update", id: this.taskId, title, status: "in_progress" },
+      ],
+    });
+  }
+
+  async appendText(text: string) {
+    if (this.hasTask) {
+      this.hasTask = false;
+      await this.append({
+        chunks: [
+          {
+            type: "task_update",
+            id: this.taskId,
+            title: "Done",
+            status: "complete",
+          },
+        ],
+      });
+    }
+    await this.append({ markdown_text: text });
+  }
+
+  async stop() {
+    this.hasTask = false;
+    await this.streamer?.stop();
+  }
+}

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -9,6 +9,8 @@ const ACTIVE_TASK_ID = "active-task-id";
 export class SlackStreamHandler {
   private streamer: ChatStreamer | undefined;
   private hasTask = false;
+  private channelId: string | undefined;
+  private threadTs: string | undefined;
   messageTs: string | undefined;
 
   constructor(private slackClient: WebClient) {}
@@ -16,20 +18,35 @@ export class SlackStreamHandler {
   public start({
     slackChannel,
     slackMessageTs,
+    slackThreadTs,
     slackTeamId,
     slackUserId,
   }: {
     slackChannel: string;
     slackMessageTs: string;
+    slackThreadTs?: string;
     slackTeamId: string;
     slackUserId?: string;
   }) {
+    this.channelId = slackChannel;
+    this.threadTs = slackThreadTs;
     this.streamer = this.slackClient.chatStream({
       channel: slackChannel,
       thread_ts: slackMessageTs,
       recipient_team_id: slackTeamId,
       recipient_user_id: slackUserId ?? undefined,
       buffer_size: 256,
+    });
+  }
+
+  async setThinking(status: string) {
+    if (!this.channelId || !this.threadTs) {
+      return;
+    }
+    await this.slackClient.assistant.threads.setStatus({
+      channel_id: this.channelId,
+      thread_ts: this.threadTs,
+      status,
     });
   }
 

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -1,13 +1,13 @@
 import type { ChatStreamer, WebClient } from "@slack/web-api";
 import type { ChatAppendStreamArguments } from "@slack/web-api/dist/types/request/chat";
 
+// Single task id reused for every task so only the latest is visible.
+// Later, if we adapt the tool call output a bit further, we can use this
+// to show multiple tasks in a single plan block (see: https://docs.slack.dev/reference/block-kit/blocks/plan-block).
+const ACTIVE_TASK_ID = "active-task-id";
+
 export class SlackStreamHandler {
   private streamer: ChatStreamer | undefined;
-  // Single task slot reused for every task — only the latest is visible.
-  // The stream is invisible until first append (chat.startStream only fires
-  // then). The native "Thinking…" spinner requires the Assistant API's
-  // set_status(), which we don't use, so a task kicks off the stream instead.
-  private readonly taskId = "active-step";
   private hasTask = false;
   messageTs: string | undefined;
 
@@ -46,7 +46,12 @@ export class SlackStreamHandler {
     this.hasTask = true;
     await this.append({
       chunks: [
-        { type: "task_update", id: this.taskId, title, status: "in_progress" },
+        {
+          type: "task_update",
+          id: ACTIVE_TASK_ID,
+          title,
+          status: "in_progress",
+        },
       ],
     });
   }
@@ -58,7 +63,7 @@ export class SlackStreamHandler {
         chunks: [
           {
             type: "task_update",
-            id: this.taskId,
+            id: ACTIVE_TASK_ID,
             title: "Done",
             status: "complete",
           },

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -1,3 +1,5 @@
+import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
+import { throttleWithRedis } from "@connectors/lib/throttle";
 import type { ChatStreamer, WebClient } from "@slack/web-api";
 import type { ChatAppendStreamArguments } from "@slack/web-api/dist/types/request/chat";
 
@@ -13,7 +15,10 @@ export class SlackStreamHandler {
   private threadTs: string | undefined;
   messageTs: string | undefined;
 
-  constructor(private slackClient: WebClient) {}
+  constructor(
+    private readonly slackClient: WebClient,
+    private readonly connectorId: number
+  ) {}
 
   public start({
     slackChannel,
@@ -53,7 +58,13 @@ export class SlackStreamHandler {
   private async append(
     payload: Omit<ChatAppendStreamArguments, "channel" | "ts">
   ) {
-    const res = await this.streamer?.append(payload);
+    const res = await throttleWithRedis(
+      RATE_LIMITS["chat.appendStream"],
+      `${this.connectorId}-chat-appendStream`,
+      { canBeIgnored: true },
+      () => this.streamer?.append(payload) ?? Promise.resolve(undefined),
+      {}
+    );
     if (!this.messageTs && res?.ts) {
       this.messageTs = res.ts;
     }

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -8,6 +8,7 @@ import {
   makeToolValidationBlock,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/blocks";
+import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
 import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
@@ -39,11 +40,8 @@ import {
 } from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import * as t from "io-ts";
-// biome-ignore lint/plugin/noBulkLodash: existing usage
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 import slackifyMarkdown from "slackify-markdown";
-
-type SlackStreamer = ReturnType<WebClient["chatStream"]>;
 
 const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
 const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
@@ -123,8 +121,7 @@ interface StreamConversationToSlackParams {
   connector: ConnectorResource;
   conversation: ConversationPublicType;
   mainMessage?: ChatPostMessageResponse;
-  streamer?: SlackStreamer;
-  streamTs?: string;
+  streamHandler?: SlackStreamHandler;
   slack: {
     slackChannelId: string;
     slackClient: WebClient;
@@ -143,9 +140,10 @@ export async function streamConversationToSlack(
   dustAPI: DustAPI,
   conversationData: StreamConversationToSlackParams
 ): Promise<Result<undefined, Error>> {
-  const { assistantName, agentConfigurations, streamer } = conversationData;
+  const { assistantName, agentConfigurations, streamHandler } =
+    conversationData;
 
-  if (!streamer) {
+  if (!streamHandler) {
     // Old path: update placeholder with thinking state.
     await postSlackMessageUpdate({
       messageUpdate: {
@@ -158,8 +156,6 @@ export async function streamConversationToSlack(
       extraLogs: { source: "streamConversationToSlack" },
     });
   }
-  // Native streaming: thinking already shown via task_update in bot.ts.
-
   return streamAgentAnswerToSlack(dustAPI, conversationData);
 }
 
@@ -209,8 +205,7 @@ async function streamAgentAnswerToSlack(
     serverName: string;
   } | null = null;
 
-  // Native streaming: reuse the streamer from bot.ts.
-  const { streamer, streamTs } = conversationData;
+  const { streamHandler } = conversationData;
 
   // Old path: lodash throttle for chat.update.
   let currentThrottleDelay = SLACK_MESSAGE_UPDATE_THROTTLE_MS;
@@ -223,17 +218,8 @@ async function streamAgentAnswerToSlack(
     switch (event.type) {
       case "tool_params":
       case "tool_notification": {
-        if (streamer) {
-          await streamer.append({
-            chunks: [
-              {
-                type: "task_update",
-                id: `tool-${event.action.id}`,
-                title: getActionRunningLabel(event.action),
-                status: "in_progress" as const,
-              },
-            ],
-          });
+        if (streamHandler) {
+          await streamHandler.startTask(getActionRunningLabel(event.action));
         } else {
           await throttledPostSlackMessageUpdate({
             messageUpdate: {
@@ -274,11 +260,11 @@ async function streamAgentAnswerToSlack(
           conversationId: event.conversationId,
           messageId: event.messageId,
           actionId: event.actionId,
-          slackThreadTs: streamTs
+          slackThreadTs: streamHandler
             ? slackMessageTs
             : mainMessage?.message?.thread_ts,
-          messageTs: streamTs ?? mainMessage?.message?.ts,
-          botId: streamTs ? undefined : mainMessage?.message?.bot_id,
+          messageTs: streamHandler?.messageTs ?? mainMessage?.message?.ts,
+          botId: streamHandler ? undefined : mainMessage?.message?.bot_id,
           slackChatBotMessageId: slackChatBotMessage.id,
         });
 
@@ -330,17 +316,8 @@ async function streamAgentAnswerToSlack(
           };
         }
 
-        if (streamer) {
-          await streamer.append({
-            chunks: [
-              {
-                type: "task_update",
-                id: "auth",
-                title: "Waiting for authentication…",
-                status: "in_progress" as const,
-              },
-            ],
-          });
+        if (streamHandler) {
+          await streamHandler.startTask("Waiting for authentication…");
         } else {
           await throttledPostSlackMessageUpdate({
             messageUpdate: {
@@ -409,8 +386,8 @@ async function streamAgentAnswerToSlack(
 
         answer += event.text;
 
-        if (streamer) {
-          await streamer.append({ markdown_text: event.text });
+        if (streamHandler) {
+          await streamHandler.appendText(event.text);
         } else {
           const { formattedContent, footnotes } = annotateCitations(
             answer,
@@ -479,24 +456,20 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        if (streamer) {
-          await finalizeNativeStreamMessage({
-            streamer,
-            streamTs,
-            messageUpdate: {
-              text: slackContent,
-              assistantName,
-              agentConfigurations,
-              footnotes,
-              conversationId: conversation.sId,
-              messageId,
-            },
-            slack,
-            connector,
-            conversation,
-            filesUploaded,
-          });
-        } else {
+        if (streamHandler) {
+          await streamHandler.stop();
+        }
+
+        {
+          const messageUpdate: SlackMessageUpdate = {
+            text: slackContent,
+            assistantName,
+            agentConfigurations,
+            footnotes,
+            conversationId: conversation.sId,
+            messageId,
+          };
+
           const shouldSplitMessage =
             slackContent.length > MAX_SLACK_MESSAGE_LENGTH
               ? await getMessageSplittingFromFeatureFlag(
@@ -509,30 +482,15 @@ async function streamAgentAnswerToSlack(
 
             throttledPostSlackMessageUpdate.cancel();
 
-            // If we have files, we need to delete and repost the message
             if (filesUploaded.length > 0) {
               await deleteAndRepostMessageWithFiles({
-                messageUpdate: {
-                  text: splitMessages[0],
-                  assistantName,
-                  agentConfigurations,
-                  footnotes,
-                  conversationId: conversation.sId,
-                  messageId,
-                },
+                messageUpdate: { ...messageUpdate, text: splitMessages[0] },
                 ...conversationData,
                 uploadedFiles: filesUploaded,
               });
             } else {
               await postSlackMessageUpdate({
-                messageUpdate: {
-                  text: splitMessages[0],
-                  assistantName,
-                  agentConfigurations,
-                  footnotes,
-                  conversationId: conversation.sId,
-                  messageId,
-                },
+                messageUpdate: { ...messageUpdate, text: splitMessages[0] },
                 ...conversationData,
                 canBeIgnored: false,
                 extraLogs: {
@@ -543,48 +501,29 @@ async function streamAgentAnswerToSlack(
               });
             }
 
-            // Post additional messages as thread replies
             if (splitMessages.length > 1) {
               await postThreadFollowUpMessages(
                 splitMessages.slice(1),
                 conversationData
               );
             }
+          } else if (filesUploaded.length > 0) {
+            await deleteAndRepostMessageWithFiles({
+              messageUpdate,
+              ...conversationData,
+              uploadedFiles: filesUploaded,
+            });
           } else {
-            // If we have files, we need to delete and repost the message
-            if (filesUploaded.length > 0) {
-              await deleteAndRepostMessageWithFiles({
-                messageUpdate: {
-                  text: slackContent,
-                  assistantName,
-                  agentConfigurations,
-                  footnotes,
-                  conversationId: conversation.sId,
-                  messageId,
-                },
-                ...conversationData,
-                uploadedFiles: filesUploaded,
-              });
-            } else {
-              // Use normal single message update (with truncation if needed)
-              await postSlackMessageUpdate({
-                messageUpdate: {
-                  text: slackContent,
-                  assistantName,
-                  agentConfigurations,
-                  footnotes,
-                  conversationId: conversation.sId,
-                  messageId,
-                },
-                ...conversationData,
-                canBeIgnored: false,
-                extraLogs: {
-                  source: "streamAgentAnswerToSlack",
-                  eventType: event.type,
-                  shouldSplitMessage: "false",
-                },
-              });
-            }
+            await postSlackMessageUpdate({
+              messageUpdate,
+              ...conversationData,
+              canBeIgnored: false,
+              extraLogs: {
+                source: "streamAgentAnswerToSlack",
+                eventType: event.type,
+                shouldSplitMessage: "false",
+              },
+            });
           }
         }
 
@@ -596,11 +535,11 @@ async function streamAgentAnswerToSlack(
         ) {
           const blockId = SlackBlockIdStaticAgentConfigSchema.encode({
             slackChatBotMessageId: slackChatBotMessage.id,
-            slackThreadTs: streamTs
+            slackThreadTs: streamHandler
               ? slackMessageTs
               : mainMessage?.message?.thread_ts,
-            messageTs: streamTs ?? mainMessage?.message?.ts,
-            botId: streamTs ? undefined : mainMessage?.message?.bot_id,
+            messageTs: streamHandler?.messageTs ?? mainMessage?.message?.ts,
+            botId: streamHandler ? undefined : mainMessage?.message?.bot_id,
           });
 
           const feedbackParams =
@@ -640,54 +579,33 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
-        // Handle generation cancellation by showing a cancelled message
+        if (streamHandler) {
+          await streamHandler.stop();
+        }
+
         const cancelledMessage = "_Message generation was cancelled._";
-        const { formattedContent, footnotes } = annotateCitations(
-          answer || cancelledMessage,
-          actions
-        );
-        const slackContent = slackifyMarkdown(
-          normalizeContentForSlack(formattedContent)
+        const {
+          formattedContent: cancelledContent,
+          footnotes: cancelledFootnotes,
+        } = annotateCitations(answer || cancelledMessage, actions);
+        const cancelledSlackContent = slackifyMarkdown(
+          normalizeContentForSlack(cancelledContent)
         );
 
-        if (streamer) {
-          await streamer.stop();
-          if (streamTs) {
-            const conversationUrl = makeConversationUrl(
-              connector.workspaceId,
-              conversation.sId
-            );
-            await slackClient.chat.update({
-              ...makeMessageUpdateBlocksAndText(
-                conversationUrl,
-                connector.workspaceId,
-                {
-                  text: slackContent,
-                  assistantName,
-                  agentConfigurations,
-                  footnotes,
-                }
-              ),
-              channel: slackChannelId,
-              ts: streamTs,
-            });
-          }
-        } else {
-          await postSlackMessageUpdate({
-            messageUpdate: {
-              text: slackContent,
-              assistantName,
-              agentConfigurations,
-              footnotes,
-            },
-            ...conversationData,
-            canBeIgnored: false,
-            extraLogs: {
-              source: "streamAgentAnswerToSlack",
-              eventType: event.type,
-            },
-          });
-        }
+        await postSlackMessageUpdate({
+          messageUpdate: {
+            text: cancelledSlackContent,
+            assistantName,
+            agentConfigurations,
+            footnotes: cancelledFootnotes,
+          },
+          ...conversationData,
+          canBeIgnored: false,
+          extraLogs: {
+            source: "streamAgentAnswerToSlack",
+            eventType: event.type,
+          },
+        });
 
         return new Ok(undefined);
       }
@@ -701,13 +619,9 @@ async function streamAgentAnswerToSlack(
     }
   }
 
-  // Clean up stream on early termination (native streaming only).
-  if (streamer) {
-    try {
-      await streamer.stop();
-    } catch (_err) {
-      // Stream might already be stopped.
-    }
+  // Clean up stream if the event stream ended without a terminal event.
+  if (streamHandler) {
+    await streamHandler.stop();
   }
 
   return new Err(
@@ -721,7 +635,7 @@ async function deleteAndRepostMessageWithFiles({
   connector,
   conversation,
   mainMessage,
-  streamTs,
+  streamHandler,
   uploadedFiles,
 }: {
   messageUpdate: SlackMessageUpdate;
@@ -735,7 +649,7 @@ async function deleteAndRepostMessageWithFiles({
   connector: ConnectorResource;
   conversation: ConversationPublicType;
   mainMessage?: ChatPostMessageResponse;
-  streamTs?: string;
+  streamHandler?: SlackStreamHandler;
   uploadedFiles: { file: Buffer; filename: string }[];
 }): Promise<void> {
   const { slackChannelId, slackClient, slackMessageTs } = slack;
@@ -745,7 +659,7 @@ async function deleteAndRepostMessageWithFiles({
   );
 
   const threadTs = mainMessage?.message?.thread_ts ?? slackMessageTs;
-  const deleteTs = streamTs ?? mainMessage?.ts;
+  const deleteTs = streamHandler?.messageTs ?? mainMessage?.ts;
 
   // First post a new message with files
   const response = await slackClient.filesUploadV2({
@@ -798,6 +712,7 @@ async function postSlackMessageUpdate({
   connector,
   conversation,
   mainMessage,
+  streamHandler,
   canBeIgnored,
   extraLogs,
 }: {
@@ -812,10 +727,12 @@ async function postSlackMessageUpdate({
   connector: ConnectorResource;
   conversation: ConversationPublicType;
   mainMessage?: ChatPostMessageResponse;
+  streamHandler?: SlackStreamHandler;
   canBeIgnored: boolean;
   extraLogs: Record<string, string>;
 }): Promise<void> {
-  if (!mainMessage?.ts) {
+  const targetTs = streamHandler?.messageTs ?? mainMessage?.ts;
+  if (!targetTs) {
     return;
   }
 
@@ -838,7 +755,7 @@ async function postSlackMessageUpdate({
             messageUpdate
           ),
           channel: slackChannelId,
-          ts: mainMessage.ts as string,
+          ts: targetTs,
           // Note: file_ids is not supported by chat.update API, so we need to delete and repost the message
         });
       } catch (error) {
@@ -864,94 +781,6 @@ async function postSlackMessageUpdate({
       },
       "Failed to update Slack message."
     );
-  }
-}
-
-/**
- * Stops the native stream and updates the stream message with formatted content.
- * No placeholder to delete — the stream IS the message.
- */
-async function finalizeNativeStreamMessage({
-  streamer,
-  streamTs,
-  messageUpdate,
-  slack,
-  connector,
-  conversation,
-  filesUploaded,
-}: {
-  streamer: SlackStreamer;
-  streamTs: string | undefined;
-  messageUpdate: SlackMessageUpdate;
-  slack: {
-    slackChannelId: string;
-    slackClient: WebClient;
-    slackMessageTs: string;
-    slackUserInfo: SlackUserInfo;
-    slackUserId: string | null;
-  };
-  connector: ConnectorResource;
-  conversation: ConversationPublicType;
-  filesUploaded: { file: Buffer; filename: string }[];
-}): Promise<void> {
-  const { slackChannelId, slackClient, slackMessageTs } = slack;
-  const conversationUrl = makeConversationUrl(
-    connector.workspaceId,
-    conversation.sId
-  );
-
-  try {
-    const stopRes = await streamer.stop();
-    const resolvedStreamTs = streamTs ?? stopRes.ts;
-
-    if (filesUploaded.length > 0) {
-      await slackClient.filesUploadV2({
-        ...makeMessageUpdateBlocksAndText(
-          conversationUrl,
-          connector.workspaceId,
-          messageUpdate
-        ),
-        channel_id: slackChannelId,
-        file_uploads: filesUploaded,
-        thread_ts: slackMessageTs,
-      });
-      if (resolvedStreamTs) {
-        await slackClient.chat.delete({
-          channel: slackChannelId,
-          ts: resolvedStreamTs,
-        });
-      }
-    } else if (resolvedStreamTs) {
-      if (
-        messageUpdate.text &&
-        messageUpdate.text.length <= MAX_SLACK_MESSAGE_LENGTH
-      ) {
-        await slackClient.chat.update({
-          ...makeMessageUpdateBlocksAndText(
-            conversationUrl,
-            connector.workspaceId,
-            messageUpdate
-          ),
-          channel: slackChannelId,
-          ts: resolvedStreamTs,
-        });
-      }
-      // For long messages, the stream message stands as-is.
-    }
-  } catch (err) {
-    logger.error(
-      { err, connectorId: connector.id },
-      "Failed to finalize native stream, falling back to postMessage"
-    );
-    await slackClient.chat.postMessage({
-      ...makeMessageUpdateBlocksAndText(
-        conversationUrl,
-        connector.workspaceId,
-        messageUpdate
-      ),
-      channel: slackChannelId,
-      thread_ts: slackMessageTs,
-    });
   }
 }
 
@@ -1034,10 +863,10 @@ async function postThreadFollowUpMessages(
   followUpMessages: string[],
   conversationData: StreamConversationToSlackParams
 ): Promise<void> {
-  const { slack, connector, conversation, mainMessage, streamTs } =
+  const { slack, connector, conversation, mainMessage, streamHandler } =
     conversationData;
   const { slackChannelId, slackClient } = slack;
-  const threadTs = mainMessage?.ts ?? streamTs;
+  const threadTs = mainMessage?.ts ?? streamHandler?.messageTs;
 
   for (let i = 0; i < followUpMessages.length; i++) {
     const threadResponse = await slackClient.chat.postMessage({

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -39,26 +39,11 @@ import {
 } from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import * as t from "io-ts";
-// biome-ignore lint/plugin/noBulkLodash: existing usage
-import { throttle } from "lodash";
 import slackifyMarkdown from "slackify-markdown";
-
-const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
-const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
-const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 400;
 
 function getActionRunningLabel(action: AgentActionPublicType): string {
   return action.displayLabels?.running ?? TOOL_RUNNING_LABEL;
 }
-
-// Dynamic throttling: longer messages get less frequent updates to reduce UX disruption when the content is expanded.
-// Posting an update on an expanded message will collapse it, frequent updates prevent users from reading the content.
-const getThrottleDelay = (textLength: number): number => {
-  if (textLength >= SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
-    return SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS;
-  }
-  return SLACK_MESSAGE_UPDATE_THROTTLE_MS;
-};
 
 export const SlackBlockIdStaticAgentConfigSchema = t.type({
   slackChatBotMessageId: t.number,
@@ -125,6 +110,7 @@ interface StreamConversationToSlackParams {
     slackChannelId: string;
     slackClient: WebClient;
     slackMessageTs: string;
+    slackTeamId: string;
     slackUserInfo: SlackUserInfo;
     slackUserId: string | null;
   };
@@ -140,7 +126,6 @@ export async function streamConversationToSlack(
 ): Promise<Result<undefined, Error>> {
   const { assistantName, agentConfigurations } = conversationData;
 
-  // Immediately post the conversation URL once available.
   await postSlackMessageUpdate({
     messageUpdate: {
       isThinking: true,
@@ -155,11 +140,7 @@ export async function streamConversationToSlack(
   return streamAgentAnswerToSlack(dustAPI, conversationData);
 }
 
-class SlackAnswerRetryableError extends Error {
-  constructor(message: string) {
-    super(message);
-  }
-}
+class SlackAnswerRetryableError extends Error {}
 
 async function streamAgentAnswerToSlack(
   dustAPI: DustAPI,
@@ -181,6 +162,7 @@ async function streamAgentAnswerToSlack(
     slackChannelId,
     slackClient,
     slackMessageTs,
+    slackTeamId,
     slackUserInfo,
     slackUserId,
   } = slack;
@@ -200,17 +182,21 @@ async function streamAgentAnswerToSlack(
     redisKey: string;
     serverName: string;
   } | null = null;
-  let currentThrottleDelay = SLACK_MESSAGE_UPDATE_THROTTLE_MS;
-  let throttledPostSlackMessageUpdate = throttle(
-    postSlackMessageUpdate,
-    currentThrottleDelay
-  );
+
+  const streamer = slackClient.chatStream({
+    channel: slackChannelId,
+    thread_ts: slackMessageTs,
+    recipient_team_id: slackTeamId,
+    recipient_user_id: slackUserId ?? undefined,
+    buffer_size: 256,
+  });
+  let streamStarted = false;
 
   for await (const event of streamRes.value.eventStream) {
     switch (event.type) {
       case "tool_params":
       case "tool_notification": {
-        await throttledPostSlackMessageUpdate({
+        await postSlackMessageUpdate({
           messageUpdate: {
             isThinking: true,
             assistantName,
@@ -302,7 +288,7 @@ async function streamAgentAnswerToSlack(
           };
         }
 
-        await throttledPostSlackMessageUpdate({
+        await postSlackMessageUpdate({
           messageUpdate: {
             text: "Agent is waiting for authentication…",
             assistantName,
@@ -368,56 +354,18 @@ async function streamAgentAnswerToSlack(
 
         answer += event.text;
 
-        const { formattedContent, footnotes } = annotateCitations(
-          answer,
-          actions
-        );
-        const slackContent = safelyPrepareAnswer(formattedContent);
-        // If the answer cannot be prepared safely, skip processing these tokens.
-        if (!slackContent) {
-          break;
-        }
-        // If the message is too long, we avoid the update entirely (to reduce
-        // rate limiting) the previous update will have shown the "..." and the
-        // link to continue the conversation so this is fine.
-        if (slackContent.length > MAX_SLACK_MESSAGE_LENGTH) {
-          break;
-        }
-
-        const newThrottleDelay = getThrottleDelay(slackContent.length);
-        if (newThrottleDelay !== currentThrottleDelay) {
-          currentThrottleDelay = newThrottleDelay;
-          throttledPostSlackMessageUpdate.cancel();
-          throttledPostSlackMessageUpdate = throttle(
-            postSlackMessageUpdate,
-            currentThrottleDelay
-          );
-        }
-
-        await throttledPostSlackMessageUpdate({
-          messageUpdate: {
-            text: slackContent,
-            assistantName,
-            agentConfigurations,
-            footnotes,
-          },
-          ...conversationData,
-          canBeIgnored: true,
-          extraLogs: {
-            source: "streamAgentAnswerToSlack",
-            eventType: event.type,
-          },
-        });
+        await streamer.append({ markdown_text: event.text });
+        streamStarted = true;
         break;
       }
 
       case "agent_message_success": {
         const finalAnswer = event.message.content ?? "";
-        const actions = event.message.actions;
-        const messageId = event.message.sId; // Get the message ID
+        const messageActions = event.message.actions;
+        const messageId = event.message.sId;
         const { formattedContent, footnotes } = annotateCitations(
           finalAnswer,
-          actions
+          messageActions
         );
 
         const authResult = await slackClient.auth.test();
@@ -426,7 +374,9 @@ async function streamAgentAnswerToSlack(
           authResult.ok &&
           authResult.response_metadata?.scopes?.includes("files:write")
         ) {
-          const files = actions.flatMap((action) => action.generatedFiles);
+          const files = messageActions.flatMap(
+            (action) => action.generatedFiles
+          );
           filesUploaded = await getFilesFromDust(files, dustAPI);
         }
 
@@ -434,96 +384,91 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        const shouldSplitMessage =
-          slackContent.length > MAX_SLACK_MESSAGE_LENGTH
-            ? await getMessageSplittingFromFeatureFlag(
-                conversationData.connector
-              )
-            : false;
+        const messageUpdate: SlackMessageUpdate = {
+          text: slackContent,
+          assistantName,
+          agentConfigurations,
+          footnotes,
+          conversationId: conversation.sId,
+          messageId,
+        };
 
-        if (shouldSplitMessage) {
-          const splitMessages = splitContentForSlack(slackContent);
-
-          throttledPostSlackMessageUpdate.cancel();
-
-          // If we have files, we need to delete and repost the message
-          if (filesUploaded.length > 0) {
-            await deleteAndRepostMessageWithFiles({
-              messageUpdate: {
-                text: splitMessages[0],
-                assistantName,
-                agentConfigurations,
-                footnotes,
-                conversationId: conversation.sId,
-                messageId,
-              },
-              ...conversationData,
-              uploadedFiles: filesUploaded,
-            });
-          } else {
-            await postSlackMessageUpdate({
-              messageUpdate: {
-                text: splitMessages[0],
-                assistantName,
-                agentConfigurations,
-                footnotes,
-                conversationId: conversation.sId,
-                messageId,
-              },
-              ...conversationData,
-              canBeIgnored: false,
-              extraLogs: {
-                source: "streamAgentAnswerToSlack",
-                eventType: event.type,
-                shouldSplitMessage: "true",
-              },
-            });
-          }
-
-          // Post additional messages as thread replies
-          if (splitMessages.length > 1) {
-            await postThreadFollowUpMessages(
-              splitMessages.slice(1),
-              conversationData
-            );
-          }
+        if (streamStarted) {
+          await finalizeStreamMessage({
+            streamer,
+            messageUpdate,
+            slack,
+            connector,
+            conversation,
+            mainMessage,
+            filesUploaded,
+          });
         } else {
-          // If we have files, we need to delete and repost the message
-          if (filesUploaded.length > 0) {
-            await deleteAndRepostMessageWithFiles({
-              messageUpdate: {
-                text: slackContent,
-                assistantName,
-                agentConfigurations,
-                footnotes,
-                conversationId: conversation.sId,
-                messageId,
-              },
-              ...conversationData,
-              uploadedFiles: filesUploaded,
-            });
+          // Fallback: no tokens were streamed, use existing chat.update path.
+          const shouldSplitMessage =
+            slackContent.length > MAX_SLACK_MESSAGE_LENGTH
+              ? await getMessageSplittingFromFeatureFlag(
+                  conversationData.connector
+                )
+              : false;
+
+          if (shouldSplitMessage) {
+            const splitMessages = splitContentForSlack(slackContent);
+
+            if (filesUploaded.length > 0) {
+              await deleteAndRepostMessageWithFiles({
+                messageUpdate: {
+                  ...messageUpdate,
+                  text: splitMessages[0],
+                },
+                ...conversationData,
+                uploadedFiles: filesUploaded,
+              });
+            } else {
+              await postSlackMessageUpdate({
+                messageUpdate: {
+                  ...messageUpdate,
+                  text: splitMessages[0],
+                },
+                ...conversationData,
+                canBeIgnored: false,
+                extraLogs: {
+                  source: "streamAgentAnswerToSlack",
+                  eventType: event.type,
+                  shouldSplitMessage: "true",
+                },
+              });
+            }
+
+            if (splitMessages.length > 1) {
+              await postThreadFollowUpMessages(
+                splitMessages.slice(1),
+                conversationData
+              );
+            }
           } else {
-            // Use normal single message update (with truncation if needed)
-            await postSlackMessageUpdate({
-              messageUpdate: {
-                text: slackContent,
-                assistantName,
-                agentConfigurations,
-                footnotes,
-                conversationId: conversation.sId,
-                messageId,
-              },
-              ...conversationData,
-              canBeIgnored: false,
-              extraLogs: {
-                source: "streamAgentAnswerToSlack",
-                eventType: event.type,
-                shouldSplitMessage: "false",
-              },
-            });
+            if (filesUploaded.length > 0) {
+              await deleteAndRepostMessageWithFiles({
+                messageUpdate,
+                ...conversationData,
+                uploadedFiles: filesUploaded,
+              });
+            } else {
+              await postSlackMessageUpdate({
+                messageUpdate,
+                ...conversationData,
+                canBeIgnored: false,
+                extraLogs: {
+                  source: "streamAgentAnswerToSlack",
+                  eventType: event.type,
+                  shouldSplitMessage: "false",
+                },
+              });
+            }
           }
         }
-        // Post feedback buttons and agent selection (ephemeral or regular message based on setting)
+
+        // Post feedback buttons and agent selection.
         if (
           slackUserId &&
           !slackUserInfo.is_bot &&
@@ -573,7 +518,6 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
-        // Handle generation cancellation by showing a cancelled message
         const cancelledMessage = "_Message generation was cancelled._";
         const { formattedContent, footnotes } = annotateCitations(
           answer || cancelledMessage,
@@ -583,20 +527,28 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        await postSlackMessageUpdate({
-          messageUpdate: {
-            text: slackContent,
-            assistantName,
-            agentConfigurations,
-            footnotes,
-          },
-          ...conversationData,
-          canBeIgnored: false,
-          extraLogs: {
-            source: "streamAgentAnswerToSlack",
-            eventType: event.type,
-          },
-        });
+        if (streamStarted) {
+          await streamer.stop();
+          await slackClient.chat.delete({
+            channel: slackChannelId,
+            ts: mainMessage.ts as string,
+          });
+        } else {
+          await postSlackMessageUpdate({
+            messageUpdate: {
+              text: slackContent,
+              assistantName,
+              agentConfigurations,
+              footnotes,
+            },
+            ...conversationData,
+            canBeIgnored: false,
+            extraLogs: {
+              source: "streamAgentAnswerToSlack",
+              eventType: event.type,
+            },
+          });
+        }
 
         return new Ok(undefined);
       }
@@ -607,6 +559,15 @@ async function streamAgentAnswerToSlack(
 
       default:
         assertNever(event);
+    }
+  }
+
+  // Clean up stream on early termination.
+  if (streamStarted) {
+    try {
+      await streamer.stop();
+    } catch (_err) {
+      // Stream might already be stopped.
     }
   }
 
@@ -642,7 +603,6 @@ async function deleteAndRepostMessageWithFiles({
     conversation.sId
   );
 
-  // First post a new message with files
   const response = await slackClient.filesUploadV2({
     ...makeMessageUpdateBlocksAndText(
       conversationUrl,
@@ -666,7 +626,6 @@ async function deleteAndRepostMessageWithFiles({
     );
   }
 
-  // Then, delete the original message
   try {
     await slackClient.chat.delete({
       channel: slackChannelId,
@@ -757,19 +716,95 @@ async function postSlackMessageUpdate({
 }
 
 /**
- * Safely prepare the answer by normalizing the content for Slack and converting it to Markdown.
- * In streaming mode, partial links might trigger errors in the `slackifyMarkdown` function.
- * This function handles such errors gracefully, ensuring that the full text will be displayed
- * once a valid URL is available.
+ * Stops the Slack stream, deletes the placeholder, and posts the final formatted message.
+ * If the stream or formatting fails, falls back to chat.postMessage.
  */
-function safelyPrepareAnswer(text: string): string | null {
-  const rawAnswer = normalizeContentForSlack(text);
+async function finalizeStreamMessage({
+  streamer,
+  messageUpdate,
+  slack,
+  connector,
+  conversation,
+  mainMessage,
+  filesUploaded,
+}: {
+  streamer: ReturnType<WebClient["chatStream"]>;
+  messageUpdate: SlackMessageUpdate;
+  slack: {
+    slackChannelId: string;
+    slackClient: WebClient;
+    slackMessageTs: string;
+    slackUserInfo: SlackUserInfo;
+    slackUserId: string | null;
+  };
+  connector: ConnectorResource;
+  conversation: ConversationPublicType;
+  mainMessage: ChatPostMessageResponse;
+  filesUploaded: { file: Buffer; filename: string }[];
+}): Promise<void> {
+  const { slackChannelId, slackClient, slackMessageTs } = slack;
+  const conversationUrl = makeConversationUrl(
+    connector.workspaceId,
+    conversation.sId
+  );
 
   try {
-    return slackifyMarkdown(rawAnswer);
-  } catch (_err) {
-    // It's safe to swallow the error as we'll catch up once a valid URL is fully received.
-    return null;
+    const stopRes = await streamer.stop();
+    const streamTs = stopRes.ts;
+
+    await slackClient.chat.delete({
+      channel: slackChannelId,
+      ts: mainMessage.ts as string,
+    });
+
+    if (filesUploaded.length > 0) {
+      // Files require a new message — delete stream message and repost with files.
+      await slackClient.filesUploadV2({
+        ...makeMessageUpdateBlocksAndText(
+          conversationUrl,
+          connector.workspaceId,
+          messageUpdate
+        ),
+        channel_id: slackChannelId,
+        file_uploads: filesUploaded,
+        thread_ts: slackMessageTs,
+      });
+      await slackClient.chat.delete({
+        channel: slackChannelId,
+        ts: streamTs as string,
+      });
+    } else if (
+      messageUpdate.text &&
+      messageUpdate.text.length <= MAX_SLACK_MESSAGE_LENGTH
+    ) {
+      // Update the stream message with properly formatted content (citations, blocks, footer).
+      // For long messages, the stream message stands as-is since the full content
+      // was already delivered via streaming.
+      await slackClient.chat.update({
+        ...makeMessageUpdateBlocksAndText(
+          conversationUrl,
+          connector.workspaceId,
+          messageUpdate
+        ),
+        channel: slackChannelId,
+        ts: streamTs as string,
+      });
+    }
+  } catch (err) {
+    // Stream finalization failed — fall back to posting the full message.
+    logger.error(
+      { err, connectorId: connector.id },
+      "Failed to finalize stream, falling back to postMessage"
+    );
+    await slackClient.chat.postMessage({
+      ...makeMessageUpdateBlocksAndText(
+        conversationUrl,
+        connector.workspaceId,
+        messageUpdate
+      ),
+      channel: slackChannelId,
+      thread_ts: slackMessageTs,
+    });
   }
 }
 
@@ -878,28 +913,19 @@ async function getMessageSplittingFromFeatureFlag(
     const featureFlagsRes = await dustAPI.getWorkspaceFeatureFlags();
     if (featureFlagsRes.isOk()) {
       return featureFlagsRes.value.includes("slack_message_splitting");
-    } else {
-      logger.warn(
-        {
-          error: featureFlagsRes.error,
-          connectorId: connector.id,
-          workspaceId: connector.workspaceId,
-        },
-        "Failed to fetch feature flags, defaulting to message truncation"
-      );
-      return false;
     }
-  } catch (error) {
-    logger.warn(
-      {
-        error,
-        connectorId: connector.id,
-        workspaceId: connector.workspaceId,
-      },
-      "Failed to fetch feature flags, defaulting to message truncation"
-    );
-    return false;
+  } catch {
+    // Fall through to warn + default.
   }
+
+  logger.warn(
+    {
+      connectorId: connector.id,
+      workspaceId: connector.workspaceId,
+    },
+    "Failed to fetch feature flags, defaulting to message truncation"
+  );
+  return false;
 }
 
 async function getFilesFromDust(
@@ -912,7 +938,7 @@ async function getFilesFromDust(
   }>,
   dustAPI: DustAPI
 ): Promise<{ file: Buffer; filename: string }[]> {
-  const visibleFiles = files.filter((file) => !file.hidden); // Skip hidden files
+  const visibleFiles = files.filter((file) => !file.hidden);
   const uploadResults = await concurrentExecutor(
     visibleFiles,
     async (file) => {

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -39,11 +39,28 @@ import {
 } from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import * as t from "io-ts";
+// biome-ignore lint/plugin/noBulkLodash: existing usage
+import { throttle } from "lodash";
 import slackifyMarkdown from "slackify-markdown";
+
+type SlackStreamer = ReturnType<WebClient["chatStream"]>;
+
+const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
+const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
+const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 400;
 
 function getActionRunningLabel(action: AgentActionPublicType): string {
   return action.displayLabels?.running ?? TOOL_RUNNING_LABEL;
 }
+
+// Dynamic throttling: longer messages get less frequent updates to reduce UX disruption when the content is expanded.
+// Posting an update on an expanded message will collapse it, frequent updates prevent users from reading the content.
+const getThrottleDelay = (textLength: number): number => {
+  if (textLength >= SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
+    return SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS;
+  }
+  return SLACK_MESSAGE_UPDATE_THROTTLE_MS;
+};
 
 export const SlackBlockIdStaticAgentConfigSchema = t.type({
   slackChatBotMessageId: t.number,
@@ -105,7 +122,9 @@ interface StreamConversationToSlackParams {
   assistantName: string;
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage: ChatPostMessageResponse;
+  mainMessage?: ChatPostMessageResponse;
+  streamer?: SlackStreamer;
+  streamTs?: string;
   slack: {
     slackChannelId: string;
     slackClient: WebClient;
@@ -124,23 +143,31 @@ export async function streamConversationToSlack(
   dustAPI: DustAPI,
   conversationData: StreamConversationToSlackParams
 ): Promise<Result<undefined, Error>> {
-  const { assistantName, agentConfigurations } = conversationData;
+  const { assistantName, agentConfigurations, streamer } = conversationData;
 
-  await postSlackMessageUpdate({
-    messageUpdate: {
-      isThinking: true,
-      assistantName,
-      agentConfigurations,
-    },
-    ...conversationData,
-    canBeIgnored: false,
-    extraLogs: { source: "streamConversationToSlack" },
-  });
+  if (!streamer) {
+    // Old path: update placeholder with thinking state.
+    await postSlackMessageUpdate({
+      messageUpdate: {
+        isThinking: true,
+        assistantName,
+        agentConfigurations,
+      },
+      ...conversationData,
+      canBeIgnored: false,
+      extraLogs: { source: "streamConversationToSlack" },
+    });
+  }
+  // Native streaming: thinking already shown via task_update in bot.ts.
 
   return streamAgentAnswerToSlack(dustAPI, conversationData);
 }
 
-class SlackAnswerRetryableError extends Error {}
+class SlackAnswerRetryableError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
 
 async function streamAgentAnswerToSlack(
   dustAPI: DustAPI,
@@ -162,7 +189,6 @@ async function streamAgentAnswerToSlack(
     slackChannelId,
     slackClient,
     slackMessageTs,
-    slackTeamId,
     slackUserInfo,
     slackUserId,
   } = slack;
@@ -183,34 +209,48 @@ async function streamAgentAnswerToSlack(
     serverName: string;
   } | null = null;
 
-  const streamer = slackClient.chatStream({
-    channel: slackChannelId,
-    thread_ts: slackMessageTs,
-    recipient_team_id: slackTeamId,
-    recipient_user_id: slackUserId ?? undefined,
-    buffer_size: 256,
-  });
-  let streamStarted = false;
+  // Native streaming: reuse the streamer from bot.ts.
+  const { streamer, streamTs } = conversationData;
+
+  // Old path: lodash throttle for chat.update.
+  let currentThrottleDelay = SLACK_MESSAGE_UPDATE_THROTTLE_MS;
+  let throttledPostSlackMessageUpdate = throttle(
+    postSlackMessageUpdate,
+    currentThrottleDelay
+  );
 
   for await (const event of streamRes.value.eventStream) {
     switch (event.type) {
       case "tool_params":
       case "tool_notification": {
-        await postSlackMessageUpdate({
-          messageUpdate: {
-            isThinking: true,
-            assistantName,
-            agentConfigurations,
-            text: answer,
-            thinkingAction: getActionRunningLabel(event.action),
-          },
-          ...conversationData,
-          canBeIgnored: true,
-          extraLogs: {
-            source: "streamAgentAnswerToSlack",
-            eventType: event.type,
-          },
-        });
+        if (streamer) {
+          await streamer.append({
+            chunks: [
+              {
+                type: "task_update",
+                id: `tool-${event.action.id}`,
+                title: getActionRunningLabel(event.action),
+                status: "in_progress" as const,
+              },
+            ],
+          });
+        } else {
+          await throttledPostSlackMessageUpdate({
+            messageUpdate: {
+              isThinking: true,
+              assistantName,
+              agentConfigurations,
+              text: answer,
+              thinkingAction: getActionRunningLabel(event.action),
+            },
+            ...conversationData,
+            canBeIgnored: true,
+            extraLogs: {
+              source: "streamAgentAnswerToSlack",
+              eventType: event.type,
+            },
+          });
+        }
 
         break;
       }
@@ -234,9 +274,11 @@ async function streamAgentAnswerToSlack(
           conversationId: event.conversationId,
           messageId: event.messageId,
           actionId: event.actionId,
-          slackThreadTs: mainMessage.message?.thread_ts,
-          messageTs: mainMessage.message?.ts,
-          botId: mainMessage.message?.bot_id,
+          slackThreadTs: streamTs
+            ? slackMessageTs
+            : mainMessage?.message?.thread_ts,
+          messageTs: streamTs ?? mainMessage?.message?.ts,
+          botId: streamTs ? undefined : mainMessage?.message?.bot_id,
           slackChatBotMessageId: slackChatBotMessage.id,
         });
 
@@ -288,19 +330,32 @@ async function streamAgentAnswerToSlack(
           };
         }
 
-        await postSlackMessageUpdate({
-          messageUpdate: {
-            text: "Agent is waiting for authentication…",
-            assistantName,
-            agentConfigurations,
-          },
-          ...conversationData,
-          canBeIgnored: false,
-          extraLogs: {
-            source: "streamAgentAnswerToSlack",
-            eventType: event.type,
-          },
-        });
+        if (streamer) {
+          await streamer.append({
+            chunks: [
+              {
+                type: "task_update",
+                id: "auth",
+                title: "Waiting for authentication…",
+                status: "in_progress" as const,
+              },
+            ],
+          });
+        } else {
+          await throttledPostSlackMessageUpdate({
+            messageUpdate: {
+              text: "Agent is waiting for authentication…",
+              assistantName,
+              agentConfigurations,
+            },
+            ...conversationData,
+            canBeIgnored: false,
+            extraLogs: {
+              source: "streamAgentAnswerToSlack",
+              eventType: event.type,
+            },
+          });
+        }
         break;
       }
 
@@ -354,18 +409,60 @@ async function streamAgentAnswerToSlack(
 
         answer += event.text;
 
-        await streamer.append({ markdown_text: event.text });
-        streamStarted = true;
+        if (streamer) {
+          await streamer.append({ markdown_text: event.text });
+        } else {
+          const { formattedContent, footnotes } = annotateCitations(
+            answer,
+            actions
+          );
+          const slackContent = safelyPrepareAnswer(formattedContent);
+          // If the answer cannot be prepared safely, skip processing these tokens.
+          if (!slackContent) {
+            break;
+          }
+          // If the message is too long, we avoid the update entirely (to reduce
+          // rate limiting) the previous update will have shown the "..." and the
+          // link to continue the conversation so this is fine.
+          if (slackContent.length > MAX_SLACK_MESSAGE_LENGTH) {
+            break;
+          }
+
+          const newThrottleDelay = getThrottleDelay(slackContent.length);
+          if (newThrottleDelay !== currentThrottleDelay) {
+            currentThrottleDelay = newThrottleDelay;
+            throttledPostSlackMessageUpdate.cancel();
+            throttledPostSlackMessageUpdate = throttle(
+              postSlackMessageUpdate,
+              currentThrottleDelay
+            );
+          }
+
+          await throttledPostSlackMessageUpdate({
+            messageUpdate: {
+              text: slackContent,
+              assistantName,
+              agentConfigurations,
+              footnotes,
+            },
+            ...conversationData,
+            canBeIgnored: true,
+            extraLogs: {
+              source: "streamAgentAnswerToSlack",
+              eventType: event.type,
+            },
+          });
+        }
         break;
       }
 
       case "agent_message_success": {
         const finalAnswer = event.message.content ?? "";
-        const messageActions = event.message.actions;
-        const messageId = event.message.sId;
+        const actions = event.message.actions;
+        const messageId = event.message.sId; // Get the message ID
         const { formattedContent, footnotes } = annotateCitations(
           finalAnswer,
-          messageActions
+          actions
         );
 
         const authResult = await slackClient.auth.test();
@@ -374,9 +471,7 @@ async function streamAgentAnswerToSlack(
           authResult.ok &&
           authResult.response_metadata?.scopes?.includes("files:write")
         ) {
-          const files = messageActions.flatMap(
-            (action) => action.generatedFiles
-          );
+          const files = actions.flatMap((action) => action.generatedFiles);
           filesUploaded = await getFilesFromDust(files, dustAPI);
         }
 
@@ -384,27 +479,24 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        const messageUpdate: SlackMessageUpdate = {
-          text: slackContent,
-          assistantName,
-          agentConfigurations,
-          footnotes,
-          conversationId: conversation.sId,
-          messageId,
-        };
-
-        if (streamStarted) {
-          await finalizeStreamMessage({
+        if (streamer) {
+          await finalizeNativeStreamMessage({
             streamer,
-            messageUpdate,
+            streamTs,
+            messageUpdate: {
+              text: slackContent,
+              assistantName,
+              agentConfigurations,
+              footnotes,
+              conversationId: conversation.sId,
+              messageId,
+            },
             slack,
             connector,
             conversation,
-            mainMessage,
             filesUploaded,
           });
         } else {
-          // Fallback: no tokens were streamed, use existing chat.update path.
           const shouldSplitMessage =
             slackContent.length > MAX_SLACK_MESSAGE_LENGTH
               ? await getMessageSplittingFromFeatureFlag(
@@ -415,11 +507,18 @@ async function streamAgentAnswerToSlack(
           if (shouldSplitMessage) {
             const splitMessages = splitContentForSlack(slackContent);
 
+            throttledPostSlackMessageUpdate.cancel();
+
+            // If we have files, we need to delete and repost the message
             if (filesUploaded.length > 0) {
               await deleteAndRepostMessageWithFiles({
                 messageUpdate: {
-                  ...messageUpdate,
                   text: splitMessages[0],
+                  assistantName,
+                  agentConfigurations,
+                  footnotes,
+                  conversationId: conversation.sId,
+                  messageId,
                 },
                 ...conversationData,
                 uploadedFiles: filesUploaded,
@@ -427,8 +526,12 @@ async function streamAgentAnswerToSlack(
             } else {
               await postSlackMessageUpdate({
                 messageUpdate: {
-                  ...messageUpdate,
                   text: splitMessages[0],
+                  assistantName,
+                  agentConfigurations,
+                  footnotes,
+                  conversationId: conversation.sId,
+                  messageId,
                 },
                 ...conversationData,
                 canBeIgnored: false,
@@ -440,6 +543,7 @@ async function streamAgentAnswerToSlack(
               });
             }
 
+            // Post additional messages as thread replies
             if (splitMessages.length > 1) {
               await postThreadFollowUpMessages(
                 splitMessages.slice(1),
@@ -447,15 +551,31 @@ async function streamAgentAnswerToSlack(
               );
             }
           } else {
+            // If we have files, we need to delete and repost the message
             if (filesUploaded.length > 0) {
               await deleteAndRepostMessageWithFiles({
-                messageUpdate,
+                messageUpdate: {
+                  text: slackContent,
+                  assistantName,
+                  agentConfigurations,
+                  footnotes,
+                  conversationId: conversation.sId,
+                  messageId,
+                },
                 ...conversationData,
                 uploadedFiles: filesUploaded,
               });
             } else {
+              // Use normal single message update (with truncation if needed)
               await postSlackMessageUpdate({
-                messageUpdate,
+                messageUpdate: {
+                  text: slackContent,
+                  assistantName,
+                  agentConfigurations,
+                  footnotes,
+                  conversationId: conversation.sId,
+                  messageId,
+                },
                 ...conversationData,
                 canBeIgnored: false,
                 extraLogs: {
@@ -468,7 +588,7 @@ async function streamAgentAnswerToSlack(
           }
         }
 
-        // Post feedback buttons and agent selection.
+        // Post feedback buttons and agent selection (ephemeral or regular message based on setting)
         if (
           slackUserId &&
           !slackUserInfo.is_bot &&
@@ -476,9 +596,11 @@ async function streamAgentAnswerToSlack(
         ) {
           const blockId = SlackBlockIdStaticAgentConfigSchema.encode({
             slackChatBotMessageId: slackChatBotMessage.id,
-            slackThreadTs: mainMessage.message?.thread_ts,
-            messageTs: mainMessage.message?.ts,
-            botId: mainMessage.message?.bot_id,
+            slackThreadTs: streamTs
+              ? slackMessageTs
+              : mainMessage?.message?.thread_ts,
+            messageTs: streamTs ?? mainMessage?.message?.ts,
+            botId: streamTs ? undefined : mainMessage?.message?.bot_id,
           });
 
           const feedbackParams =
@@ -518,6 +640,7 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
+        // Handle generation cancellation by showing a cancelled message
         const cancelledMessage = "_Message generation was cancelled._";
         const { formattedContent, footnotes } = annotateCitations(
           answer || cancelledMessage,
@@ -527,12 +650,28 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        if (streamStarted) {
+        if (streamer) {
           await streamer.stop();
-          await slackClient.chat.delete({
-            channel: slackChannelId,
-            ts: mainMessage.ts as string,
-          });
+          if (streamTs) {
+            const conversationUrl = makeConversationUrl(
+              connector.workspaceId,
+              conversation.sId
+            );
+            await slackClient.chat.update({
+              ...makeMessageUpdateBlocksAndText(
+                conversationUrl,
+                connector.workspaceId,
+                {
+                  text: slackContent,
+                  assistantName,
+                  agentConfigurations,
+                  footnotes,
+                }
+              ),
+              channel: slackChannelId,
+              ts: streamTs,
+            });
+          }
         } else {
           await postSlackMessageUpdate({
             messageUpdate: {
@@ -562,8 +701,8 @@ async function streamAgentAnswerToSlack(
     }
   }
 
-  // Clean up stream on early termination.
-  if (streamStarted) {
+  // Clean up stream on early termination (native streaming only).
+  if (streamer) {
     try {
       await streamer.stop();
     } catch (_err) {
@@ -582,6 +721,7 @@ async function deleteAndRepostMessageWithFiles({
   connector,
   conversation,
   mainMessage,
+  streamTs,
   uploadedFiles,
 }: {
   messageUpdate: SlackMessageUpdate;
@@ -594,15 +734,20 @@ async function deleteAndRepostMessageWithFiles({
   };
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage: ChatPostMessageResponse;
+  mainMessage?: ChatPostMessageResponse;
+  streamTs?: string;
   uploadedFiles: { file: Buffer; filename: string }[];
 }): Promise<void> {
-  const { slackChannelId, slackClient } = slack;
+  const { slackChannelId, slackClient, slackMessageTs } = slack;
   const conversationUrl = makeConversationUrl(
     connector.workspaceId,
     conversation.sId
   );
 
+  const threadTs = mainMessage?.message?.thread_ts ?? slackMessageTs;
+  const deleteTs = streamTs ?? mainMessage?.ts;
+
+  // First post a new message with files
   const response = await slackClient.filesUploadV2({
     ...makeMessageUpdateBlocksAndText(
       conversationUrl,
@@ -611,7 +756,7 @@ async function deleteAndRepostMessageWithFiles({
     ),
     channel_id: slackChannelId,
     file_uploads: uploadedFiles,
-    thread_ts: mainMessage.message?.thread_ts, // Preserve thread context if it exists
+    thread_ts: threadTs, // Preserve thread context if it exists
   });
 
   if (response?.error) {
@@ -626,21 +771,24 @@ async function deleteAndRepostMessageWithFiles({
     );
   }
 
-  try {
-    await slackClient.chat.delete({
-      channel: slackChannelId,
-      ts: mainMessage.ts as string,
-    });
-  } catch (error) {
-    logger.error(
-      {
-        provider: "slack",
-        connectorId: connector.id,
-        conversationId: conversation.sId,
-        err: error,
-      },
-      "Failed to delete original Slack message."
-    );
+  // Then, delete the original message
+  if (deleteTs) {
+    try {
+      await slackClient.chat.delete({
+        channel: slackChannelId,
+        ts: deleteTs,
+      });
+    } catch (error) {
+      logger.error(
+        {
+          provider: "slack",
+          connectorId: connector.id,
+          conversationId: conversation.sId,
+          err: error,
+        },
+        "Failed to delete original Slack message."
+      );
+    }
   }
 }
 
@@ -663,10 +811,14 @@ async function postSlackMessageUpdate({
   };
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage: ChatPostMessageResponse;
+  mainMessage?: ChatPostMessageResponse;
   canBeIgnored: boolean;
   extraLogs: Record<string, string>;
 }): Promise<void> {
+  if (!mainMessage?.ts) {
+    return;
+  }
+
   const { slackChannelId, slackClient } = slack;
   const conversationUrl = makeConversationUrl(
     connector.workspaceId,
@@ -716,19 +868,20 @@ async function postSlackMessageUpdate({
 }
 
 /**
- * Stops the Slack stream, deletes the placeholder, and posts the final formatted message.
- * If the stream or formatting fails, falls back to chat.postMessage.
+ * Stops the native stream and updates the stream message with formatted content.
+ * No placeholder to delete — the stream IS the message.
  */
-async function finalizeStreamMessage({
+async function finalizeNativeStreamMessage({
   streamer,
+  streamTs,
   messageUpdate,
   slack,
   connector,
   conversation,
-  mainMessage,
   filesUploaded,
 }: {
-  streamer: ReturnType<WebClient["chatStream"]>;
+  streamer: SlackStreamer;
+  streamTs: string | undefined;
   messageUpdate: SlackMessageUpdate;
   slack: {
     slackChannelId: string;
@@ -739,7 +892,6 @@ async function finalizeStreamMessage({
   };
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage: ChatPostMessageResponse;
   filesUploaded: { file: Buffer; filename: string }[];
 }): Promise<void> {
   const { slackChannelId, slackClient, slackMessageTs } = slack;
@@ -750,15 +902,9 @@ async function finalizeStreamMessage({
 
   try {
     const stopRes = await streamer.stop();
-    const streamTs = stopRes.ts;
-
-    await slackClient.chat.delete({
-      channel: slackChannelId,
-      ts: mainMessage.ts as string,
-    });
+    const resolvedStreamTs = streamTs ?? stopRes.ts;
 
     if (filesUploaded.length > 0) {
-      // Files require a new message — delete stream message and repost with files.
       await slackClient.filesUploadV2({
         ...makeMessageUpdateBlocksAndText(
           conversationUrl,
@@ -769,32 +915,33 @@ async function finalizeStreamMessage({
         file_uploads: filesUploaded,
         thread_ts: slackMessageTs,
       });
-      await slackClient.chat.delete({
-        channel: slackChannelId,
-        ts: streamTs as string,
-      });
-    } else if (
-      messageUpdate.text &&
-      messageUpdate.text.length <= MAX_SLACK_MESSAGE_LENGTH
-    ) {
-      // Update the stream message with properly formatted content (citations, blocks, footer).
-      // For long messages, the stream message stands as-is since the full content
-      // was already delivered via streaming.
-      await slackClient.chat.update({
-        ...makeMessageUpdateBlocksAndText(
-          conversationUrl,
-          connector.workspaceId,
-          messageUpdate
-        ),
-        channel: slackChannelId,
-        ts: streamTs as string,
-      });
+      if (resolvedStreamTs) {
+        await slackClient.chat.delete({
+          channel: slackChannelId,
+          ts: resolvedStreamTs,
+        });
+      }
+    } else if (resolvedStreamTs) {
+      if (
+        messageUpdate.text &&
+        messageUpdate.text.length <= MAX_SLACK_MESSAGE_LENGTH
+      ) {
+        await slackClient.chat.update({
+          ...makeMessageUpdateBlocksAndText(
+            conversationUrl,
+            connector.workspaceId,
+            messageUpdate
+          ),
+          channel: slackChannelId,
+          ts: resolvedStreamTs,
+        });
+      }
+      // For long messages, the stream message stands as-is.
     }
   } catch (err) {
-    // Stream finalization failed — fall back to posting the full message.
     logger.error(
       { err, connectorId: connector.id },
-      "Failed to finalize stream, falling back to postMessage"
+      "Failed to finalize native stream, falling back to postMessage"
     );
     await slackClient.chat.postMessage({
       ...makeMessageUpdateBlocksAndText(
@@ -805,6 +952,23 @@ async function finalizeStreamMessage({
       channel: slackChannelId,
       thread_ts: slackMessageTs,
     });
+  }
+}
+
+/**
+ * Safely prepare the answer by normalizing the content for Slack and converting it to Markdown.
+ * In streaming mode, partial links might trigger errors in the `slackifyMarkdown` function.
+ * This function handles such errors gracefully, ensuring that the full text will be displayed
+ * once a valid URL is available.
+ */
+function safelyPrepareAnswer(text: string): string | null {
+  const rawAnswer = normalizeContentForSlack(text);
+
+  try {
+    return slackifyMarkdown(rawAnswer);
+  } catch (_err) {
+    // It's safe to swallow the error as we'll catch up once a valid URL is fully received.
+    return null;
   }
 }
 
@@ -870,14 +1034,16 @@ async function postThreadFollowUpMessages(
   followUpMessages: string[],
   conversationData: StreamConversationToSlackParams
 ): Promise<void> {
-  const { slack, connector, conversation, mainMessage } = conversationData;
+  const { slack, connector, conversation, mainMessage, streamTs } =
+    conversationData;
   const { slackChannelId, slackClient } = slack;
+  const threadTs = mainMessage?.ts ?? streamTs;
 
   for (let i = 0; i < followUpMessages.length; i++) {
     const threadResponse = await slackClient.chat.postMessage({
       channel: slackChannelId,
       text: followUpMessages[i] || "",
-      thread_ts: mainMessage.ts,
+      thread_ts: threadTs,
     });
 
     if (threadResponse.error) {
@@ -913,19 +1079,28 @@ async function getMessageSplittingFromFeatureFlag(
     const featureFlagsRes = await dustAPI.getWorkspaceFeatureFlags();
     if (featureFlagsRes.isOk()) {
       return featureFlagsRes.value.includes("slack_message_splitting");
+    } else {
+      logger.warn(
+        {
+          error: featureFlagsRes.error,
+          connectorId: connector.id,
+          workspaceId: connector.workspaceId,
+        },
+        "Failed to fetch feature flags, defaulting to message truncation"
+      );
+      return false;
     }
-  } catch {
-    // Fall through to warn + default.
+  } catch (error) {
+    logger.warn(
+      {
+        error,
+        connectorId: connector.id,
+        workspaceId: connector.workspaceId,
+      },
+      "Failed to fetch feature flags, defaulting to message truncation"
+    );
+    return false;
   }
-
-  logger.warn(
-    {
-      connectorId: connector.id,
-      workspaceId: connector.workspaceId,
-    },
-    "Failed to fetch feature flags, defaulting to message truncation"
-  );
-  return false;
 }
 
 async function getFilesFromDust(
@@ -938,7 +1113,7 @@ async function getFilesFromDust(
   }>,
   dustAPI: DustAPI
 ): Promise<{ file: Buffer; filename: string }[]> {
-  const visibleFiles = files.filter((file) => !file.hidden);
+  const visibleFiles = files.filter((file) => !file.hidden); // Skip hidden files
   const uploadResults = await concurrentExecutor(
     visibleFiles,
     async (file) => {

--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -19,7 +19,8 @@ export class SlackMessageError extends Error {
   constructor(
     message: string,
     public slackChatBotMessage: Attributes<SlackChatBotMessageModel>,
-    public mainMessage: ChatPostMessageResponse
+    public mainMessage?: ChatPostMessageResponse,
+    public streamTs?: string
   ) {
     super(message);
   }

--- a/connectors/src/connectors/slack/ratelimits.ts
+++ b/connectors/src/connectors/slack/ratelimits.ts
@@ -26,4 +26,8 @@ export const RATE_LIMITS = {
     limit: 100,
     windowInMs: 60 * 1000,
   },
+  "chat.appendStream": {
+    limit: 100,
+    windowInMs: 60 * 1000,
+  },
 } satisfies Record<string, RateLimit>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -189,6 +189,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
     stage: "dust_only",
   },
+  slack_native_streaming: {
+    description:
+      "Use Slack's native streaming API for bot responses instead of throttled chat.update loop",
+    stage: "dust_only",
+  },
   slack_bot_mcp: {
     description: "Slack bot MCP server for workspace-level Slack integration",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -720,6 +720,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"
+  | "slack_native_streaming"
   | "slideshow"
   | "snowflake_tool"
   | "run_tools_from_prompt"


### PR DESCRIPTION
> [!IMPORTANT]
> Feature is gated behind the feature flag `slack_native_streaming`
> Rollout plan is the following :
> 1. Deploy PR and activate on Dust workspace (~Tue Mar 10. 2026)
> 2. If no particular issues are observed, remove flag and release to all (~Mon Mar 16. 2026)

## Description

Uses Slack's `chat.startStream` / `appendStream` / `stopStream` API to stream text and show tool progress as task cards in real time, instead of posting a placeholder message and throttling `chat.update` calls.

`SlackStreamHandler` wraps `ChatStreamer` from `@slack/web-api`. A single task slot (reused for every step) shows the latest tool as an in-progress card, then marks it complete. Each new task replaces the previous one — only the latest is ever visible. Text tokens stream via `appendText()`. On completion, `chat.update` replaces the streamed message with the final formatted content (citations, footnotes, conversation link).

### Why always chat.update at the end

The existing `chat.update` path already handles citations, footnotes, conversation link, message splitting, and file attachments. Replicating all of that in `stopStream` is unnecessary for a first iteration — `chat.update` gives us the same polished final message while streaming provides real-time feedback during generation.

### Design decisions

- Single task slot with fixed ID (`active-step`) — every `startTask` overwrites the previous card. No history needed since `chat.update` replaces everything at the end anyway
- `SlackMessageError` extended with `streamTs` so error handlers update the correct message regardless of path
- Tool validation and feedback block IDs derive `messageTs` from `streamHandler` in native path vs `mainMessage` in old path

### Native thinking state

Uses `assistant.threads.setStatus` to show Slack's native "Thinking…" spinner before any tool fires. Only requires `chat:write` scope (no assistant scope needed). Only works in threads (needs thread root ts) — silently skipped for top-level messages.

Context: https://www.notion.so/dust-tt/30-Slack-Native-Streaming-31928599d94181ab94fccf8c32d13baf


### Tests

Before (flag off)

![Screen Recording 2026-03-06 at 12 46 29](https://github.com/user-attachments/assets/3c81071b-89d0-40d2-a16d-b1fd29c15b25)


After (flag on)


![Screen Recording 2026-03-09 at 18 27 39](https://github.com/user-attachments/assets/25c5d2e6-b0db-40bf-a568-60b0ed7a9851)

> [!NOTE]
> ### Rate limits
> `startStream`: tier 2 but should be bumped to tier 3 so that would be  60 rpm sustained and 300 burst ([source](https://dust4ai.slack.com/archives/C091X15KN58/p1762538748767529?thread_ts=1762537095.196189&cid=C091X15KN58))
> `appendStream`: tier 4 - 100+ rpm ([source](https://dust4ai.slack.com/archives/C091X15KN58/p1762537987748819?thread_ts=1762537095.196189&cid=C091X15KN58))
> `stopStream`: tier 2 but should be bumped to tier 3 for us
> `setStatus (thinking)`: 600 rpm ([source](https://docs.slack.dev/reference/methods/assistant.threads.setStatus/#rate-limits))