### PR TITLE
Add FF to enable sidekick in workspace if you have builder role

### DIFF
--- a/front/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled.ts
+++ b/front/components/agent_builder/hooks/useIsAgentBuilderCopilotEnabled.ts
@@ -2,7 +2,11 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 
 export function useIsAgentBuilderCopilotEnabled(): boolean {
-  const { isAdmin } = useAgentBuilderContext();
+  const { owner, isAdmin } = useAgentBuilderContext();
   const { hasFeature } = useFeatureFlags();
-  return hasFeature("agent_builder_copilot") && isAdmin;
+  const isBuilder = owner.role === "builder";
+  return (
+    hasFeature("agent_builder_copilot") &&
+    (isAdmin || (hasFeature("agent_builder_copilot_builders") && isBuilder))
+  );
 }

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -124,7 +124,10 @@ export function transformTemplateToFormData(
   hasFeature: (flag: WhitelistableFeature | null | undefined) => boolean
 ): AgentBuilderFormData {
   const hasCopilotAccess =
-    hasFeature("agent_builder_copilot") && owner.role === "admin";
+    hasFeature("agent_builder_copilot") &&
+    (owner.role === "admin" ||
+      (hasFeature("agent_builder_copilot_builders") &&
+        owner.role === "builder"));
   const defaultFormData = getDefaultAgentFormData({
     user,
     owner,

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -55,8 +55,10 @@ export function CreateAgentPage() {
   });
 
   const { hasFeature } = useFeatureFlags();
-  const { isAdmin } = useAuth();
-  const hasCopilot = hasFeature("agent_builder_copilot") && isAdmin;
+  const { isAdmin, isBuilder } = useAuth();
+  const hasCopilot =
+    hasFeature("agent_builder_copilot") &&
+    (isAdmin || (hasFeature("agent_builder_copilot_builders") && isBuilder));
   const { assistantTemplates } = useAssistantTemplates();
 
   const { filteredTemplates, availableTags } = useMemo(() => {

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -50,10 +50,10 @@ export function NewAgentPage() {
     disabled: !duplicateAgentId,
   });
 
-  const shouldPassConversationId =
+  const hasCopilot =
     hasFeature("agent_builder_copilot") &&
-    isAdmin &&
-    agentConfiguration === null;
+    (isAdmin || (hasFeature("agent_builder_copilot_builders") && isBuilder));
+  const shouldPassConversationId = hasCopilot && agentConfiguration === null;
 
   const {
     assistantTemplate,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -31,7 +31,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   agent_builder_copilot: {
-    description: "Enable Sidekick in Agent Builder",
+    description: "Enable Sidekick in Agent Builder (admins only by default)",
+    stage: "dust_only",
+  },
+  agent_builder_copilot_builders: {
+    description: "Allow workspace builders to use Sidekick in Agent Builder",
     stage: "dust_only",
   },
   agent_builder_shrink_wrap: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -668,6 +668,7 @@ export type RetrievalDocumentPublicType = z.infer<
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
   | "agent_builder_copilot"
+  | "agent_builder_copilot_builders"
   | "agent_builder_shrink_wrap"
   | "agent_management_tool"
   | "agent_to_yaml"


### PR DESCRIPTION
## Description

* We have a customer who wants to enable for internal hackathon to all builders. Current FF when enables only makes it visible for the admin role. Intentionally keeping separate feature flags to give us the option to enable for either admin or builder role depending on context. Both of these flags will go away in the near future.

## Tests

* Local testing

## Risk

* Low 

## Deploy Plan

* Deploy front