### PR TITLE
[sparkle] - feat(ActionCard): introduce diff status indicators

### DIFF
--- a/sparkle/src/components/ActionCard.tsx
+++ b/sparkle/src/components/ActionCard.tsx
@@ -37,16 +37,14 @@ const DIFF_CHIP_CONFIG: Record<
   removed: { color: "warning", icon: DashIcon },
 };
 
-export interface ActionCardProps {
+interface ActionCardBaseProps {
   icon: React.ComponentType;
   iconBackgroundColor?: string;
   iconColor?: string;
   label: string;
   description: string | React.ReactNode;
-  isSelected: boolean;
   canAdd: boolean;
   cantAddReason?: string;
-  diffStatus?: ActionCardDiffStatus;
   footer?: { label: string; onClick: () => void };
   onClick?: () => void;
   className?: string;
@@ -55,6 +53,18 @@ export interface ActionCardProps {
   mountPortalContainer?: HTMLElement;
   descriptionLineClamp?: number;
 }
+
+interface ActionCardSelectableProps extends ActionCardBaseProps {
+  isSelected: boolean;
+  diffStatus?: never;
+}
+
+interface ActionCardDiffProps extends ActionCardBaseProps {
+  diffStatus: ActionCardDiffStatus;
+  isSelected?: never;
+}
+
+export type ActionCardProps = ActionCardSelectableProps | ActionCardDiffProps;
 
 export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
   (
@@ -100,7 +110,7 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
                   iconColor={iconColor}
                 />
                 <span className="s-text-sm s-font-medium">{label}</span>
-                {!diffChip && isSelected && (
+                {isSelected && (
                   <Chip
                     size="xs"
                     color="green"

--- a/sparkle/src/components/ActionCard.tsx
+++ b/sparkle/src/components/ActionCard.tsx
@@ -3,12 +3,39 @@ import { Button } from "@sparkle/components/Button";
 import { Card } from "@sparkle/components/Card";
 import { Chip } from "@sparkle/components/Chip";
 import { TruncatedText } from "@sparkle/components/TruncatedText";
-import { PlusIcon } from "@sparkle/icons/app/";
+import { DashIcon, PlusIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";
+import { cva } from "class-variance-authority";
 import React from "react";
 
 const FADE_TRANSITION_CLASSES =
   "s-transition-opacity s-duration-300 s-ease-in-out";
+
+export const ACTION_CARD_DIFF_STATUSES = ["added", "removed"] as const;
+export type ActionCardDiffStatus = (typeof ACTION_CARD_DIFF_STATUSES)[number];
+
+const actionCardDiffVariants = cva("s-p-3", {
+  variants: {
+    diffStatus: {
+      added: cn(
+        "s-bg-success-50 s-border-success-200",
+        "dark:s-bg-success-50-night dark:s-border-success-200-night"
+      ),
+      removed: cn(
+        "s-bg-warning-50 s-border-warning-200",
+        "dark:s-bg-warning-50-night dark:s-border-warning-200-night"
+      ),
+    },
+  },
+});
+
+const DIFF_CHIP_CONFIG: Record<
+  ActionCardDiffStatus,
+  { color: "green" | "warning"; icon: React.ComponentType }
+> = {
+  added: { color: "green", icon: PlusIcon },
+  removed: { color: "warning", icon: DashIcon },
+};
 
 export interface ActionCardProps {
   icon: React.ComponentType;
@@ -19,6 +46,7 @@ export interface ActionCardProps {
   isSelected: boolean;
   canAdd: boolean;
   cantAddReason?: string;
+  diffStatus?: ActionCardDiffStatus;
   footer?: { label: string; onClick: () => void };
   onClick?: () => void;
   className?: string;
@@ -39,6 +67,7 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
       isSelected,
       canAdd,
       cantAddReason,
+      diffStatus,
       footer,
       onClick,
       className,
@@ -49,6 +78,8 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
     },
     ref
   ) => {
+    const diffChip = diffStatus ? DIFF_CHIP_CONFIG[diffStatus] : null;
+
     return (
       <Card
         ref={ref}
@@ -56,7 +87,7 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
         onClick={onClick}
         disabled={!canAdd}
         containerClassName={cardContainerClassName}
-        className={cn("s-p-3", className)}
+        className={cn(actionCardDiffVariants({ diffStatus }), className)}
       >
         <div className="s-flex s-h-full s-w-full s-flex-col s-justify-between">
           <div className="s-flex s-flex-col">
@@ -69,7 +100,7 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
                   iconColor={iconColor}
                 />
                 <span className="s-text-sm s-font-medium">{label}</span>
-                {isSelected && (
+                {!diffChip && isSelected && (
                   <Chip
                     size="xs"
                     color="green"
@@ -79,6 +110,14 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
                 )}
               </div>
               <div className="s-flex s-flex-shrink-0 s-items-center s-gap-2">
+                {diffChip && (
+                  <Chip
+                    size="xs"
+                    color={diffChip.color}
+                    icon={diffChip.icon}
+                    className={cn(FADE_TRANSITION_CLASSES, "s-opacity-100")}
+                  />
+                )}
                 {canAdd && (
                   <Button
                     size="xs"

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -1,4 +1,8 @@
-export { ActionCard } from "./ActionCard";
+export type { ActionCardDiffStatus } from "./ActionCard";
+export {
+  ACTION_CARD_DIFF_STATUSES,
+  ActionCard,
+} from "./ActionCard";
 export { AnimatedText } from "./AnimatedText";
 export { AspectRatio } from "./AspectRatio";
 export {

--- a/sparkle/src/stories/ActionCard.stories.tsx
+++ b/sparkle/src/stories/ActionCard.stories.tsx
@@ -78,7 +78,6 @@ export const DiffStatus = () => (
         cardContainerClassName="s-h-36"
         label="Web Search"
         description="Search & browse the web for up-to-date information."
-        isSelected={false}
         canAdd={false}
         diffStatus="added"
       />
@@ -89,7 +88,6 @@ export const DiffStatus = () => (
         cardContainerClassName="s-h-36"
         label="Code Interpreter"
         description="Run code snippets in a sandboxed environment."
-        isSelected={false}
         canAdd={false}
         diffStatus="removed"
       />

--- a/sparkle/src/stories/ActionCard.stories.tsx
+++ b/sparkle/src/stories/ActionCard.stories.tsx
@@ -2,7 +2,12 @@ import type { Meta } from "@storybook/react";
 import React from "react";
 
 import { ActionCard, Hoverable } from "@sparkle/components";
-import { BookOpenIcon, CommandLineIcon } from "@sparkle/icons/app";
+import {
+  BookOpenIcon,
+  CommandLineIcon,
+  MagnifyingGlassIcon,
+  PlanetIcon,
+} from "@sparkle/icons/app";
 
 const meta: Meta<typeof ActionCard> = {
   title: "Modules/ActionCard",
@@ -60,6 +65,33 @@ export const Examples = () => (
           label: "Click here",
           onClick: () => console.log("Click here"),
         }}
+      />
+    </div>
+  </div>
+);
+
+export const DiffStatus = () => (
+  <div className="s-flex s-gap-3">
+    <div className="s-w-80">
+      <ActionCard
+        icon={MagnifyingGlassIcon}
+        cardContainerClassName="s-h-36"
+        label="Web Search"
+        description="Search & browse the web for up-to-date information."
+        isSelected={false}
+        canAdd={false}
+        diffStatus="added"
+      />
+    </div>
+    <div className="s-w-80">
+      <ActionCard
+        icon={PlanetIcon}
+        cardContainerClassName="s-h-36"
+        label="Code Interpreter"
+        description="Run code snippets in a sandboxed environment."
+        isSelected={false}
+        canAdd={false}
+        diffStatus="removed"
       />
     </div>
   </div>


### PR DESCRIPTION
## Description

Adds diff status indicators to the ActionCard component to visualize added/removed states. The component now accepts an optional `diffStatus` prop (`"added"` | `"removed"`) that displays the card with a colored background (green for added, warning/amber for removed) and a corresponding chip icon (plus for added, dash for removed).

<img width="577" height="172" alt="Screenshot 2026-03-05 at 11 26 47" src="https://github.com/user-attachments/assets/d091ce39-64b7-4d4a-8268-cab4295b4603" />

## Risk

Low - this is an additive change to the Sparkle design system. The `diffStatus` prop is optional and doesn't affect existing ActionCard usage.

## Tests

Added new Storybook story `DiffStatus` demonstrating both added and removed states.

## Deploy Plan

N/A
