### PR TITLE
Mandatory fields for Snowflake tool

### DIFF
--- a/front/components/actions/mcp/MCPServerAuthConnection.tsx
+++ b/front/components/actions/mcp/MCPServerAuthConnection.tsx
@@ -63,10 +63,6 @@ const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
   },
 ] as const;
 
-// Error key used for credential validation errors.
-// Parent components can check formState.errors[AUTH_CREDENTIALS_ERROR_KEY].
-export const AUTH_CREDENTIALS_ERROR_KEY = "authCredentials" as const;
-
 export interface StaticCredentialFormProps {
   owner: LightWorkspaceType;
   onValidityChange: (isValid: boolean) => void;
@@ -103,8 +99,7 @@ export function MCPServerAuthConnection({
   documentationUrl,
   staticCredentialConfig,
 }: MCPServerAuthConnectionProps) {
-  const { setError, clearErrors, setValue, control } =
-    useFormContext<MCPServerOAuthFormValues>();
+  const { setValue, control } = useFormContext<MCPServerOAuthFormValues>();
 
   const { field: useCaseField } = useController({
     name: "useCase",
@@ -171,51 +166,6 @@ export function MCPServerAuthConnection({
       setValue("authCredentials", nextCredentials);
     }
   }, [authorization, useCase, setValue]);
-
-  // Validate credentials based on dynamic requirements.
-  // Runs when credentials or inputs change, uses setError/clearErrors.
-  useEffect(() => {
-    if (!inputs) {
-      clearErrors(AUTH_CREDENTIALS_ERROR_KEY);
-      return;
-    }
-
-    if (!authCredentials) {
-      setError(AUTH_CREDENTIALS_ERROR_KEY, {
-        type: "manual",
-        message: "Credentials required",
-      });
-      return;
-    }
-
-    // Find first invalid credential.
-    let errorMessage: string | null = null;
-    for (const [key, inputData] of Object.entries(inputs)) {
-      if (!isSupportedOAuthCredential(key) || inputData.value) {
-        continue; // Skip unsupported or pre-filled values.
-      }
-
-      const value = authCredentials[key] ?? "";
-      if (inputData.validator) {
-        if (!inputData.validator(value)) {
-          errorMessage = `Invalid ${inputData.label}`;
-          break;
-        }
-      } else if (!value) {
-        errorMessage = `${inputData.label} is required`;
-        break;
-      }
-    }
-
-    if (errorMessage) {
-      setError(AUTH_CREDENTIALS_ERROR_KEY, {
-        type: "manual",
-        message: errorMessage,
-      });
-    } else {
-      clearErrors(AUTH_CREDENTIALS_ERROR_KEY);
-    }
-  }, [authCredentials, inputs, setError, clearErrors]);
 
   const handleCredentialChange = (key: string, value: string) => {
     if (!isSupportedOAuthCredential(key)) {

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -7,10 +7,7 @@ import type {
   StaticCredentialConfig,
   StaticCredentialFormHandle,
 } from "@app/components/actions/mcp/MCPServerAuthConnection";
-import {
-  AUTH_CREDENTIALS_ERROR_KEY,
-  MCPServerAuthConnection,
-} from "@app/components/actions/mcp/MCPServerAuthConnection";
+import { MCPServerAuthConnection } from "@app/components/actions/mcp/MCPServerAuthConnection";
 import type {
   CustomResourceIconType,
   InternalAllowedIconType,
@@ -32,7 +29,10 @@ import {
   useDiscoverOAuthMetadata,
   useUpdateMCPServerView,
 } from "@app/lib/swr/mcp_servers";
-import { OAUTH_PROVIDER_NAMES } from "@app/types/oauth/lib";
+import {
+  OAUTH_PROVIDER_NAMES,
+  validateOAuthCredentials,
+} from "@app/types/oauth/lib";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -72,13 +72,14 @@ export function ConnectMCPServerDialog({
     shouldUnregister: false,
   });
 
-  // Check for credential validation errors set by MCPServerAuthConnection.
-  const hasCredentialErrors =
-    !!form.formState.errors[AUTH_CREDENTIALS_ERROR_KEY];
-
   const useCase = useWatch({
     control: form.control,
     name: "useCase",
+  });
+
+  const authCredentials = useWatch({
+    control: form.control,
+    name: "authCredentials",
   });
 
   const [isLoading, setIsLoading] = useState(false);
@@ -184,8 +185,26 @@ export function ConnectMCPServerDialog({
     setAuthorization(null);
   };
 
+  // Synchronous validation — no race condition with useEffect.
+  const credentialError = useMemo(
+    () =>
+      authorization
+        ? validateOAuthCredentials({
+            provider: authorization.provider,
+            useCase: useCase ?? null,
+            authCredentials: authCredentials ?? null,
+          })
+        : null,
+    [authorization, useCase, authCredentials]
+  );
+
   const handleOAuthSave = async (values: MCPServerOAuthFormValues) => {
     if (!authorization) {
+      return;
+    }
+
+    // Guard: handleSubmit only checks Zod schema errors, not manual setError errors.
+    if (credentialError) {
       return;
     }
 
@@ -238,7 +257,7 @@ export function ConnectMCPServerDialog({
 
   // Form is valid when: use case selected AND either OAuth or static form is valid.
   const isFormValid =
-    !!useCase && (hasStaticForm ? isStaticFormValid : !hasCredentialErrors);
+    !!useCase && (hasStaticForm ? isStaticFormValid : !credentialError);
 
   const handleStaticCredentialSave = async () => {
     if (!authorization || !useCase) {

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -13,10 +13,7 @@ import type {
   StaticCredentialConfig,
   StaticCredentialFormHandle,
 } from "@app/components/actions/mcp/MCPServerAuthConnection";
-import {
-  AUTH_CREDENTIALS_ERROR_KEY,
-  MCPServerAuthConnection,
-} from "@app/components/actions/mcp/MCPServerAuthConnection";
+import { MCPServerAuthConnection } from "@app/components/actions/mcp/MCPServerAuthConnection";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -35,6 +32,7 @@ import {
   useCreateRemoteMCPServer,
   useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
+import { validateOAuthCredentials } from "@app/types/oauth/lib";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -99,13 +97,14 @@ export function CreateMCPServerDialog({
     shouldUnregister: false,
   });
 
-  // Check for credential validation errors set by MCPServerAuthConnection.
-  const hasCredentialErrors =
-    !!form.formState.errors[AUTH_CREDENTIALS_ERROR_KEY];
-
   const useCase = useWatch({
     control: form.control,
     name: "useCase",
+  });
+
+  const authCredentials = useWatch({
+    control: form.control,
+    name: "authCredentials",
   });
 
   const [isLoading, setIsLoading] = useState(false);
@@ -154,6 +153,11 @@ export function CreateMCPServerDialog({
   };
 
   const handleSave = async (values: CreateMCPServerDialogFormValues) => {
+    // Guard: handleSubmit only checks Zod schema errors, not manual setError errors.
+    if (credentialError) {
+      return;
+    }
+
     setIsLoading(true);
 
     const submitRes = await submitCreateMCPServerDialogForm({
@@ -252,6 +256,19 @@ export function CreateMCPServerDialog({
         }
       : undefined;
 
+  // Synchronous validation — no race condition with useEffect.
+  const credentialError = useMemo(
+    () =>
+      authorization
+        ? validateOAuthCredentials({
+            provider: authorization.provider,
+            useCase: useCase ?? null,
+            authCredentials: authCredentials ?? null,
+          })
+        : null,
+    [authorization, useCase, authCredentials]
+  );
+
   const handleCreateServerAndSubmitStaticCredentials = async () => {
     if (!internalMCPServer || !authorization || !useCase) {
       return;
@@ -313,7 +330,7 @@ export function CreateMCPServerDialog({
   // - use case is selected AND either static form or OAuth credentials are valid.
   // When no OAuth needed (no authorization), form is always valid for OAuth fields.
   const isOAuthValid = authorization
-    ? !!useCase && (hasStaticForm ? isStaticFormValid : !hasCredentialErrors)
+    ? !!useCase && (hasStaticForm ? isStaticFormValid : !credentialError)
     : true;
   const isSubmitDisabled = !isOAuthValid || isLoading;
 
@@ -392,7 +409,6 @@ export function CreateMCPServerDialog({
                 if (hasStaticForm) {
                   void handleCreateServerAndSubmitStaticCredentials();
                 } else {
-                  // handleSubmit gates on form validity (including errors set via setError).
                   void form.handleSubmit(handleSave)();
                 }
               },

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -568,6 +568,56 @@ export function isValidSnowflakeWarehouse(s: unknown): s is string {
   );
 }
 
+/**
+ * Pure validation function for OAuth credential inputs.
+ * Returns null if all credentials are valid, or the first error message string.
+ */
+export function validateOAuthCredentials({
+  provider,
+  useCase,
+  authCredentials,
+}: {
+  provider: OAuthProvider;
+  useCase: OAuthUseCase | null;
+  authCredentials: OAuthCredentials | null;
+}): string | null {
+  if (!useCase) {
+    return null;
+  }
+
+  const inputs = getProviderRequiredOAuthCredentialInputs({
+    provider,
+    useCase,
+  });
+
+  if (!inputs) {
+    return null;
+  }
+
+  if (!authCredentials) {
+    return "Credentials required";
+  }
+
+  for (const [key, inputData] of Object.entries(inputs)) {
+    if (!isSupportedOAuthCredential(key) || inputData.value) {
+      continue; // Skip unsupported or pre-filled values.
+    }
+
+    const value = authCredentials[key] ?? "";
+    if (inputData.validator) {
+      if (!inputData.validator(value)) {
+        return value.length === 0
+          ? `${inputData.label} is required`
+          : `Invalid ${inputData.label}`;
+      }
+    } else if (!value) {
+      return `${inputData.label} is required`;
+    }
+  }
+
+  return null;
+}
+
 // Credentials Providers
 
 export const PROVIDERS_WITH_WORKSPACE_CONFIGURATIONS = [


### PR DESCRIPTION
## Description

The MCP OAuth setup form (e.g. Snowflake) allowed submitting with empty required fields due to a race condition. Validation ran in a useEffect that called setError but this only fired on the next render cycle, after a separate useEffect had already set the useCase and enabled the submit button. 

On top of that, react-hook-form's handleSubmit ignores manual setError errors entirely, so even clicking during that window bypassed validation.

Replaced the async useEffect/setError validation with a synchronous useMemo that evaluates in the same render pass so the submit button is never enabled with invalid fields.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
