### PR TITLE
Fix conversation side panel width in extensions

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -111,12 +111,14 @@ export const ConversationContainer = ({
           clientSideMCPServerIds={clientSideMCPServerIds}
         />
       </div>
-      {conversation && (
-        <ConversationSidePanelContent
-          owner={workspace}
-          conversation={conversation}
-          currentPanel={currentPanel}
-        />
+      {conversation && currentPanel && (
+        <div className="flex h-full w-full flex-col">
+          <ConversationSidePanelContent
+            owner={workspace}
+            conversation={conversation}
+            currentPanel={currentPanel}
+          />
+        </div>
       )}
     </InputBarContextProvider>
   );


### PR DESCRIPTION
## Description

Fixes the conversation side panel width display issue in the extension. The side panel content was not taking up the full available width. This wraps `ConversationSidePanelContent` in a `div` with flexbox classes (`flex h-full w-full flex-col`) to ensure proper sizing. Also adds a conditional check to only render the side panel when `currentPanel` is defined.

<img width="221" height="309" alt="image" src="https://github.com/user-attachments/assets/0c42cfea-8a95-4cc3-948c-82356f99d76c" />
<img width="221" height="309" alt="image" src="https://github.com/user-attachments/assets/7cf13a39-954d-4034-8e64-9502a1b3c5f0" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
