### PR TITLE
[front] fix GitHub repository skill frontmatter detection and parsing

### DIFF
--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -1,7 +1,7 @@
 import {
-  extractDescription,
   findSkillDirectories,
   parseGitHubRepoUrl,
+  parseSkillMarkdown,
 } from "@app/lib/api/skills/github_detection/parsing";
 import type {
   DetectedSkill,
@@ -122,10 +122,8 @@ async function fetchBlobContent(
 }
 
 /**
- * Detects skills in a GitHub repository by fetching its tree and looking for
- * directories containing skill.md or SKILL.md files.
- *
- * Uses the GitHub Git Trees API for lightweight access.
+ * Detects Agent Skills (https://agentskills.io/specification) in a GitHub
+ * repository by scanning for SKILL.md files via the Git Trees API.
  */
 export async function detectSkillsFromGitHubRepo({
   repoUrl,
@@ -161,10 +159,17 @@ export async function detectSkillsFromGitHubRepo({
   );
 
   const detectedSkills: DetectedSkill[] = [];
+  const seenNames = new Set<string>();
   for (const result of skills) {
-    if (result.isOk()) {
-      detectedSkills.push(result.value);
+    if (result.isErr()) {
+      continue;
     }
+    const skill = result.value;
+    if (!skill.name || seenNames.has(skill.name)) {
+      continue;
+    }
+    seenNames.add(skill.name);
+    detectedSkills.push(skill);
   }
 
   return new Ok(detectedSkills);
@@ -200,12 +205,11 @@ async function buildDetectedSkill({
     );
     return blobResult;
   }
-  const instructions = blobResult.value;
-
-  const description = extractDescription(instructions);
+  const parsed = parseSkillMarkdown(blobResult.value);
 
   const attachments: DetectedSkillAttachment[] = [];
-  const dirPrefix = skillDir.dirPath ? `${skillDir.dirPath}/` : "";
+  const lastSlash = skillDir.skillMdPath.lastIndexOf("/");
+  const dirPrefix = skillDir.skillMdPath.slice(0, lastSlash + 1);
 
   for (const entry of tree) {
     if (entry.type !== "blob") {
@@ -227,9 +231,10 @@ async function buildDetectedSkill({
   }
 
   return new Ok({
-    dirPath: skillDir.dirPath,
-    description,
-    instructions,
+    name: parsed.name,
+    skillMdPath: skillDir.skillMdPath,
+    description: parsed.description,
+    instructions: parsed.instructions,
     attachments,
   });
 }

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -5,6 +5,8 @@ import type {
 } from "@app/lib/api/skills/github_detection/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import * as yaml from "js-yaml";
+import { z } from "zod";
 
 const SKILL_MD_FILENAME = "skill.md";
 
@@ -62,49 +64,75 @@ export function parseGitHubRepoUrl(
   return new Ok({ owner: segments[0], repo: segments[1] });
 }
 
+const SkillFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+});
+
 /**
- * Extracts the first non-empty paragraph from a markdown string,
- * skipping YAML frontmatter (--- delimited) and headings.
+ * Parses a SKILL.md file per the Agent Skills spec
+ * (https://agentskills.io/specification). Extracts required `name` and
+ * `description` from YAML frontmatter; returns the body as instructions.
+ * Empty `name`/`description` means the frontmatter is missing or invalid.
  */
-export function extractDescription(markdown: string): string {
-  let content = markdown;
+export function parseSkillMarkdown(markdown: string): {
+  name: string;
+  description: string;
+  instructions: string;
+} {
+  const frontmatter = extractFrontmatter(markdown);
 
-  // Strip YAML frontmatter.
-  if (content.startsWith("---")) {
-    const endIndex = content.indexOf("---", 3);
-    if (endIndex !== -1) {
-      content = content.slice(endIndex + 3);
+  if (!frontmatter) {
+    return { name: "", description: "", instructions: markdown };
+  }
+
+  let raw: unknown;
+  try {
+    raw = yaml.load(frontmatter.yaml);
+  } catch {
+    // The lib throws on malformed YAML.
+    return { name: "", description: "", instructions: frontmatter.body };
+  }
+
+  const parsed = SkillFrontmatterSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { name: "", description: "", instructions: frontmatter.body };
+  }
+
+  return {
+    name: parsed.data.name.trim(),
+    description: parsed.data.description.trim(),
+    instructions: frontmatter.body,
+  };
+}
+
+/**
+ * Extracts YAML frontmatter (between `---` markers) and the remaining body.
+ * Returns null if the file doesn't start with a `---` line. The closing `---`
+ * must also be on its own line (not embedded in other content).
+ */
+function extractFrontmatter(
+  markdown: string
+): { yaml: string; body: string } | null {
+  const lines = markdown.split("\n");
+
+  if (!lines[0] || lines[0].trim() !== "---") {
+    return null;
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      return {
+        yaml: lines.slice(1, i).join("\n").trim(),
+        body: lines
+          .slice(i + 1)
+          .join("\n")
+          .trimStart(),
+      };
     }
   }
 
-  const lines = content.split("\n");
-  const paragraphLines: string[] = [];
-  let inParagraph = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Skip empty lines before a paragraph starts.
-    if (!trimmed) {
-      if (inParagraph) {
-        break;
-      }
-      continue;
-    }
-
-    // Skip headings.
-    if (trimmed.startsWith("#")) {
-      if (inParagraph) {
-        break;
-      }
-      continue;
-    }
-
-    inParagraph = true;
-    paragraphLines.push(trimmed);
-  }
-
-  return paragraphLines.join(" ");
+  return null;
 }
 
 /**

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -6,7 +6,8 @@ export interface DetectedSkillAttachment {
 }
 
 export interface DetectedSkill {
-  dirPath: string;
+  name: string;
+  skillMdPath: string;
   description: string;
   instructions: string;
   attachments: DetectedSkillAttachment[];

--- a/front/scripts/detect_github_skills.ts
+++ b/front/scripts/detect_github_skills.ts
@@ -32,7 +32,8 @@ makeScript(
     for (const skill of skills) {
       logger.info(
         {
-          dirPath: skill.dirPath,
+          name: skill.name,
+          skillMdPath: skill.skillMdPath,
           descriptionLength: skill.description.length,
           instructionsLength: skill.instructions.length,
           attachmentCount: skill.attachments.length,


### PR DESCRIPTION
## Description

- This PR fixes the import of skills from a GitHub repository.
- Reference doc: https://agentskills.io/specification
- Extracts the name and description more reliably from the YAML frontmatter.
- Surfaces the `skillMdPath`, which will be useful to add links in the front-end (we need the full path to know if it's `SKILL.md` or `skill.md`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
