### PR TITLE
[front] feat: Add sandbox-bedrock docker img

### DIFF
--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -40,8 +40,11 @@ COPY --from=rust-builder /opt/cargo /opt/cargo
 ARG NODE_VERSION=22.12.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="arm64"; fi && \
-    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
-    | tar -xJ -C /usr/local --strip-components=1
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o SHASUMS256.txt && \
+    grep "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz$" SHASUMS256.txt | sha256sum -c - && \
+    tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+    rm node.tar.xz SHASUMS256.txt
 
 # Bun
 ARG BUN_VERSION=1.3.7
@@ -49,10 +52,13 @@ RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then BUN_ARCH="x64"; else BUN_ARCH="aarch64"; fi && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" \
     -o /tmp/bun.zip && \
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip.sha512" \
+    -o /tmp/bun.zip.sha512 && \
+    echo "$(cat /tmp/bun.zip.sha512)  /tmp/bun.zip" | sha512sum -c - && \
     unzip -q /tmp/bun.zip -d /tmp && \
     mv /tmp/bun-linux-${BUN_ARCH}/bun /usr/local/bin/bun && \
     chmod +x /usr/local/bin/bun && \
-    rm -rf /tmp/bun.zip /tmp/bun-linux-${BUN_ARCH}
+    rm -rf /tmp/bun.zip /tmp/bun.zip.sha512 /tmp/bun-linux-${BUN_ARCH}
 
 WORKDIR /home/user
 

--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -1,0 +1,82 @@
+# Stage 1: rust-builder - compile Rust in isolated stage
+FROM debian:bookworm-slim AS rust-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV PATH="/opt/cargo/bin:$PATH"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain stable --profile minimal
+
+# Stage 2: rootfs - assemble complete filesystem
+FROM debian:bookworm-slim AS rootfs
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git unzip xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python via uv (official Astral approach)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+RUN uv python install 3.14 \
+    && PYTHON_BIN=$(find /opt/python -name "python3" -path "*/bin/*" | head -1) \
+    && ln -s "$PYTHON_BIN" /usr/local/bin/python3 \
+    && ln -s "$PYTHON_BIN" /usr/local/bin/python
+ENV VIRTUAL_ENV=/opt/venv
+RUN uv venv /opt/venv --python 3.14
+
+# Rust from builder stage
+COPY --from=rust-builder /opt/rustup /opt/rustup
+COPY --from=rust-builder /opt/cargo /opt/cargo
+
+# Node.js via official tarball
+ARG NODE_VERSION=22.12.0
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="arm64"; fi && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" \
+    | tar -xJ -C /usr/local --strip-components=1
+
+# Bun
+ARG BUN_VERSION=1.3.7
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then BUN_ARCH="x64"; else BUN_ARCH="aarch64"; fi && \
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" \
+    -o /tmp/bun.zip && \
+    unzip -q /tmp/bun.zip -d /tmp && \
+    mv /tmp/bun-linux-${BUN_ARCH}/bun /usr/local/bin/bun && \
+    chmod +x /usr/local/bin/bun && \
+    rm -rf /tmp/bun.zip /tmp/bun-linux-${BUN_ARCH}
+
+WORKDIR /home/user
+
+# Cleanup unnecessary files to reduce image size
+RUN rm -rf /usr/local/include \
+    && rm -rf /usr/local/lib/node_modules \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
+
+# Persist PATH to /etc/profile.d/ so it's available at runtime in E2B sandbox
+RUN printf '%s\n' \
+    'export PATH="/opt/venv/bin:/opt/cargo/bin:$PATH"' \
+    'export VIRTUAL_ENV="/opt/venv"' \
+    'export RUSTUP_HOME="/opt/rustup"' \
+    'export CARGO_HOME="/opt/cargo"' \
+    > /etc/profile.d/sandbox-env.sh
+
+# Stage 3: final - flatten to single layer
+FROM scratch
+COPY --from=rootfs / /
+
+ENV PATH="/opt/venv/bin:/opt/cargo/bin:/usr/local/bin:/usr/bin:/bin"
+ENV VIRTUAL_ENV="/opt/venv"
+ENV RUSTUP_HOME="/opt/rustup"
+ENV CARGO_HOME="/opt/cargo"
+
+WORKDIR /home/user

--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -7,11 +7,11 @@ ENV CARGO_HOME=/opt/cargo
 ENV PATH="/opt/cargo/bin:$PATH"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates build-essential \
-    && rm -rf /var/lib/apt/lists/*
+  curl ca-certificates build-essential \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --default-toolchain stable --profile minimal
+  sh -s -- -y --default-toolchain stable --profile minimal
 
 # Stage 2: rootfs - assemble complete filesystem
 FROM debian:bookworm-slim AS rootfs
@@ -19,16 +19,16 @@ FROM debian:bookworm-slim AS rootfs
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git unzip xz-utils \
-    && rm -rf /var/lib/apt/lists/*
+  ca-certificates curl git unzip xz-utils \
+  && rm -rf /var/lib/apt/lists/*
 
 # Python via uv (official Astral approach)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 RUN uv python install 3.14 \
-    && PYTHON_BIN=$(find /opt/python -name "python3" -path "*/bin/*" | head -1) \
-    && ln -s "$PYTHON_BIN" /usr/local/bin/python3 \
-    && ln -s "$PYTHON_BIN" /usr/local/bin/python
+  && PYTHON_BIN=$(find /opt/python -name "python3" -path "*/bin/*" | head -1) \
+  && ln -s "$PYTHON_BIN" /usr/local/bin/python3 \
+  && ln -s "$PYTHON_BIN" /usr/local/bin/python
 ENV VIRTUAL_ENV=/opt/venv
 RUN uv venv /opt/venv --python 3.14
 
@@ -39,50 +39,25 @@ COPY --from=rust-builder /opt/cargo /opt/cargo
 # Node.js via official tarball
 ARG NODE_VERSION=22.12.0
 RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="arm64"; fi && \
-    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz && \
-    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o SHASUMS256.txt && \
-    grep "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz$" SHASUMS256.txt | sha256sum -c - && \
-    tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
-    rm node.tar.xz SHASUMS256.txt
+  if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="arm64"; fi && \
+  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz && \
+  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o SHASUMS256.txt && \
+  grep "node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz$" SHASUMS256.txt | awk '{print $1 "  node.tar.xz"}' | sha256sum -c - && \
+  tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+  rm node.tar.xz SHASUMS256.txt
 
 # Bun
 ARG BUN_VERSION=1.3.7
 RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then BUN_ARCH="x64"; else BUN_ARCH="aarch64"; fi && \
-    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" \
-    -o /tmp/bun.zip && \
-    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip.sha512" \
-    -o /tmp/bun.zip.sha512 && \
-    echo "$(cat /tmp/bun.zip.sha512)  /tmp/bun.zip" | sha512sum -c - && \
-    unzip -q /tmp/bun.zip -d /tmp && \
-    mv /tmp/bun-linux-${BUN_ARCH}/bun /usr/local/bin/bun && \
-    chmod +x /usr/local/bin/bun && \
-    rm -rf /tmp/bun.zip /tmp/bun.zip.sha512 /tmp/bun-linux-${BUN_ARCH}
-
-WORKDIR /home/user
-
-# Cleanup unnecessary files to reduce image size
-RUN rm -rf /usr/local/include \
-    && rm -rf /usr/local/lib/node_modules \
-    && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
-    && rm -rf /usr/share/doc /usr/share/man /usr/share/info
-
-# Persist PATH to /etc/profile.d/ so it's available at runtime in E2B sandbox
-RUN printf '%s\n' \
-    'export PATH="/opt/venv/bin:/opt/cargo/bin:$PATH"' \
-    'export VIRTUAL_ENV="/opt/venv"' \
-    'export RUSTUP_HOME="/opt/rustup"' \
-    'export CARGO_HOME="/opt/cargo"' \
-    > /etc/profile.d/sandbox-env.sh
-
-# Stage 3: final - flatten to single layer
-FROM scratch
-COPY --from=rootfs / /
-
-ENV PATH="/opt/venv/bin:/opt/cargo/bin:/usr/local/bin:/usr/bin:/bin"
-ENV VIRTUAL_ENV="/opt/venv"
-ENV RUSTUP_HOME="/opt/rustup"
-ENV CARGO_HOME="/opt/cargo"
+  if [ "$ARCH" = "amd64" ]; then BUN_ARCH="x64"; else BUN_ARCH="aarch64"; fi && \
+  curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" \
+  -o /tmp/bun.zip && \
+  curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" \
+  -o /tmp/SHASUMS256.txt && \
+  grep "bun-linux-${BUN_ARCH}.zip$" /tmp/SHASUMS256.txt | awk '{print $1 "  /tmp/bun.zip"}' | sha256sum -c - && \
+  unzip -q /tmp/bun.zip -d /tmp && \
+  mv /tmp/bun-linux-${BUN_ARCH}/bun /usr/local/bin/bun && \
+  chmod +x /usr/local/bin/bun && \
+  rm -rf /tmp/bun.zip /tmp/SHASUMS256.txt /tmp/bun-linux-${BUN_ARCH}
 
 WORKDIR /home/user

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -489,6 +489,11 @@ const config = {
       domain: EnvironmentConfig.getOptionalEnvVariable("E2B_DOMAIN"),
     };
   },
+  getSandboxGcpArtifactServiceAccountPath: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "SBX_GCP_ARTIFACT_RO_SERVICE_ACCOUNT"
+    );
+  },
 };
 
 export default config;

--- a/front/lib/api/sandbox/image/dust-base.ts
+++ b/front/lib/api/sandbox/image/dust-base.ts
@@ -3,12 +3,20 @@
  *
  * This module defines the standard Dust sandbox image with all
  * pre-installed tools and packages using the imperative builder API.
+ *
+ * The base Docker image (dust-sdbx-bedrock) provides:
+ * - Python 3.14 via uv with venv at /opt/venv
+ * - Node.js 22
+ * - Bun
+ * - Rust toolchain
+ * - Basic system tools (curl, git, ca-certificates)
+ *
+ * This image definition adds additional tools and packages on top.
  */
 
 import { SandboxImage } from "./sandbox_image";
 import type { NetworkPolicy } from "./types";
 
-// TODO(@henry): Change this once S7 is up and running
 export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
   mode: "deny_all",
   allowlist: [
@@ -27,49 +35,24 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
 /**
  * The base Dust sandbox image.
  *
- * Includes common development tools, Python data science packages,
- * Node.js tooling, and the dust sandbox CLI.
+ * Built on top of dust-sdbx-bedrock Docker image, this adds:
+ * - System tools (jq, pandoc, imagemagick, ffmpeg)
+ * - Python data science packages
+ * - Node.js tooling (typescript, tsx)
+ * - Dust sandbox CLI
  */
-export const DUST_BASE_IMAGE = SandboxImage.fromUbuntu("22.04")
-  // Install build essentials (not registered as user-facing tools)
-  // TODO (@jd): build an optimized base docker image that can be pulled
-  // with npm/python/rust bootstrapping
-  .runCmd(
-    "sudo apt-get update && sudo apt-get install -y curl ca-certificates gnupg build-essential"
-  )
+export const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sdbx-bedrock")
+  // Set environment variables (these apply during build operations)
   .setEnv({
     NPM_CONFIG_PREFIX: "/opt/npm-global",
     CARGO_HOME: "/opt/cargo",
     RUSTUP_HOME: "/opt/rustup",
     VIRTUAL_ENV: "/opt/venv",
   })
-  // Install uv, then Python 3.14 via uv (not bound to Ubuntu's old Python)
-  .runCmd("curl -LsSf https://astral.sh/uv/install.sh | sh")
-  .runCmd("uv python install 3.14")
-  // Create venv at user-writable location with uv-managed Python
-  .runCmd(
-    "sudo mkdir -p /opt/venv && sudo chmod -R 777 /opt/venv && " +
-      "uv venv /opt/venv --python 3.14"
-  )
-  // Install Node.js via nodesource
-  .runCmd(
-    "curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - " +
-      "&& sudo apt-get install -y --no-install-recommends nodejs"
-  )
+  // Create npm-global and bin directories for additional package installs
   .runCmd("sudo mkdir -p /opt/npm-global && sudo chmod -R 777 /opt/npm-global")
   .runCmd("sudo mkdir -p /opt/bin && sudo chmod -R 777 /opt/bin")
-  .runCmd(
-    "sudo mkdir -p /opt/cargo /opt/rustup && sudo chmod -R 777 /opt/cargo /opt/rustup"
-  )
-  // Set environment variables for build-time operations (NOT persisted to runtime).
-  // E2B's setEnvs() only applies during build, not in the snapshot.
-  // Install Rust
-  .runCmd(
-    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal " +
-      "&& sudo chmod -R 777 /opt/cargo /opt/rustup"
-  )
-  // Everything above would typically be in a Docker image
-  // Install system tools
+  // Install system tools (git is already in base image)
   .registerTool(
     [
       { name: "git", description: "Version control system" },
@@ -81,10 +64,10 @@ export const DUST_BASE_IMAGE = SandboxImage.fromUbuntu("22.04")
     ],
     {
       installCmd:
-        "sudo apt-get install -y git jq pandoc imagemagick ffmpeg lsb-release",
+        "sudo apt-get update && sudo apt-get install -y jq pandoc imagemagick ffmpeg lsb-release",
     }
   )
-  // Register Python runtime
+  // Register Python runtime (already installed in base image)
   .registerTool({ name: "python", description: "Python interpreter" })
   // Install Python packages
   .registerTool(
@@ -101,14 +84,15 @@ export const DUST_BASE_IMAGE = SandboxImage.fromUbuntu("22.04")
         "uv pip install --python /opt/venv pandas numpy matplotlib requests openpyxl pdfplumber",
     }
   )
+  // Register Bun (already installed in base image)
+  .registerTool({ name: "bun", description: "JavaScript runtime" })
   // Install Node packages
   .registerTool(
     [
       { name: "typescript", description: "TypeScript compiler" },
       { name: "tsx", description: "TypeScript executor" },
-      { name: "bun", description: "JavaScript runtime" },
     ],
-    { installCmd: "npm install -g typescript tsx bun" }
+    { installCmd: "npm install -g typescript tsx" }
   )
   // Install Dust sandbox CLI
   .registerTool(

--- a/front/lib/api/sandbox/image/dust-base.ts
+++ b/front/lib/api/sandbox/image/dust-base.ts
@@ -41,7 +41,9 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
  * - Node.js tooling (typescript, tsx)
  * - Dust sandbox CLI
  */
-export const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sdbx-bedrock")
+export const DUST_BASE_IMAGE = SandboxImage.fromDocker(
+  "dust-sbx-bedrock:latest"
+)
   // Set environment variables (these apply during build operations)
   .setEnv({
     NPM_CONFIG_PREFIX: "/opt/npm-global",

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -84,6 +84,17 @@ export class SandboxImage {
     });
   }
 
+  static fromDocker(imageRef: string): SandboxImage {
+    return new SandboxImage({
+      baseImage: { type: "docker", imageRef },
+      operations: [],
+      tools: [],
+      resources: DEFAULT_RESOURCES,
+      network: DEFAULT_NETWORK,
+      workdir: "/home/user",
+    });
+  }
+
   runCmd(command: string): SandboxImage {
     const operation: Operation = {
       type: "run",

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -114,4 +114,5 @@ export interface ToolManifest {
 
 export type BaseImage =
   | { readonly type: "ubuntu"; readonly version: string }
-  | { readonly type: "template"; readonly id: SandboxImageId };
+  | { readonly type: "template"; readonly id: SandboxImageId }
+  | { readonly type: "docker"; readonly imageRef: string };

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -1,7 +1,9 @@
 import type { SandboxImageId } from "@app/lib/api/sandbox/image";
 import { DUST_BASE_IMAGE } from "@app/lib/api/sandbox/image/dust-base";
+import type { TemplateBuilder } from "e2b";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import type { DockerRegistryFactory } from "./e2b_template";
 import { buildSandboxImage } from "./e2b_template";
 
 const TEST_IMAGE_ID: SandboxImageId = { imageName: "dust-base", tag: "edge" };
@@ -23,19 +25,52 @@ vi.mock("@app/lib/api/config", () => ({
   },
 }));
 
-const mockE2BTemplateBuilder = {
-  fromUbuntuImage: vi.fn().mockReturnThis(),
-  fromTemplate: vi.fn().mockReturnThis(),
-  runCmd: vi.fn().mockReturnThis(),
+// Untyped mock for TemplateBuilder - keeps vi.fn() mock properties accessible
+const mockTemplateBuilder = {
   copy: vi.fn().mockReturnThis(),
+  copyItems: vi.fn().mockReturnThis(),
+  remove: vi.fn().mockReturnThis(),
+  rename: vi.fn().mockReturnThis(),
+  makeDir: vi.fn().mockReturnThis(),
+  makeSymlink: vi.fn().mockReturnThis(),
+  runCmd: vi.fn().mockReturnThis(),
   setWorkdir: vi.fn().mockReturnThis(),
+  setUser: vi.fn().mockReturnThis(),
+  pipInstall: vi.fn().mockReturnThis(),
+  npmInstall: vi.fn().mockReturnThis(),
+  bunInstall: vi.fn().mockReturnThis(),
+  aptInstall: vi.fn().mockReturnThis(),
+  addMcpServer: vi.fn().mockReturnThis(),
+  gitClone: vi.fn().mockReturnThis(),
   setEnvs: vi.fn().mockReturnThis(),
+  skipCache: vi.fn().mockReturnThis(),
+  setStartCmd: vi.fn().mockReturnThis(),
+  setReadyCmd: vi.fn().mockReturnThis(),
+  betaDevContainerPrebuild: vi.fn().mockReturnThis(),
+  betaSetDevContainerStart: vi.fn().mockReturnThis(),
 };
+
+// Mock for Template() factory (has fromUbuntuImage, fromTemplate, etc.)
+const mockE2BTemplateFactory = {
+  fromUbuntuImage: vi.fn().mockReturnValue(mockTemplateBuilder),
+  fromTemplate: vi.fn().mockReturnValue(mockTemplateBuilder),
+  fromGCPRegistry: vi.fn().mockReturnValue(mockTemplateBuilder),
+};
+
+// Type-safe factory wrapper - the runtime mock satisfies TemplateBuilder interface
+function createMockDockerRegistryFactory(): DockerRegistryFactory {
+  return (_imageRef: string): TemplateBuilder => {
+    // The mock has all required methods; return type annotation satisfies TypeScript
+    return mockTemplateBuilder;
+  };
+}
+
+const mockDockerRegistryFactory = vi.fn(createMockDockerRegistryFactory());
 
 const mockBuild = vi.fn();
 
 vi.mock("e2b", () => ({
-  Template: Object.assign(() => mockE2BTemplateBuilder, {
+  Template: Object.assign(() => mockE2BTemplateFactory, {
     build: (...args: unknown[]) => mockBuild(...args),
   }),
   defaultBuildLogger: vi.fn(() => vi.fn()),
@@ -51,15 +86,14 @@ describe("buildSandboxImage()", () => {
 
     const result = await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockE2BTemplateBuilder.fromUbuntuImage).toHaveBeenCalled();
-    expect(mockE2BTemplateBuilder.runCmd).toHaveBeenCalled();
-    expect(mockE2BTemplateBuilder.setEnvs).toHaveBeenCalled();
-    expect(mockE2BTemplateBuilder.setWorkdir).toHaveBeenCalledWith(
-      "/home/user"
-    );
+    expect(mockDockerRegistryFactory).toHaveBeenCalled();
+    expect(mockTemplateBuilder.runCmd).toHaveBeenCalled();
+    expect(mockTemplateBuilder.setEnvs).toHaveBeenCalled();
+    expect(mockTemplateBuilder.setWorkdir).toHaveBeenCalledWith("/home/user");
   });
 
   test("returns templateId from E2B build result", async () => {
@@ -67,6 +101,7 @@ describe("buildSandboxImage()", () => {
 
     const result = await buildSandboxImage(DUST_BASE_IMAGE, STAGING_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
     expect(result.isOk()).toBe(true);
@@ -81,10 +116,11 @@ describe("buildSandboxImage()", () => {
     await buildSandboxImage(DUST_BASE_IMAGE, PRODUCTION_IMAGE_ID, {
       apiKey: "test-api-key",
       domain: "custom.e2b.dev",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
     expect(mockBuild).toHaveBeenCalledWith(
-      mockE2BTemplateBuilder,
+      mockTemplateBuilder,
       "dust-base_production",
       expect.objectContaining({
         apiKey: "test-api-key",
@@ -100,6 +136,7 @@ describe("buildSandboxImage()", () => {
 
     const result = await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
     expect(result.isErr()).toBe(true);
@@ -113,9 +150,10 @@ describe("buildSandboxImage()", () => {
 
     await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
-    const runCmdCalls = mockE2BTemplateBuilder.runCmd.mock.calls;
+    const runCmdCalls = mockTemplateBuilder.runCmd.mock.calls;
     const hasNpmInstall = runCmdCalls.some((call: string[]) =>
       call[0].includes("npm install -g")
     );
@@ -126,15 +164,17 @@ describe("buildSandboxImage()", () => {
     mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
 
     const callOrder: string[] = [];
-    mockE2BTemplateBuilder.fromUbuntuImage.mockImplementation(() => {
-      callOrder.push("fromUbuntuImage");
-      return mockE2BTemplateBuilder;
-    });
-    mockE2BTemplateBuilder.setEnvs.mockImplementation(() => {
+    const trackingDockerRegistryFactory: DockerRegistryFactory = (
+      _imageRef: string
+    ): TemplateBuilder => {
+      callOrder.push("fromDockerRegistry");
+      return mockTemplateBuilder;
+    };
+    mockTemplateBuilder.setEnvs.mockImplementation(() => {
       callOrder.push("setEnvs");
-      return mockE2BTemplateBuilder;
+      return mockTemplateBuilder;
     });
-    mockE2BTemplateBuilder.runCmd.mockImplementation((cmd: string) => {
+    mockTemplateBuilder.runCmd.mockImplementation((cmd: string) => {
       if (cmd.includes("uv pip install")) {
         callOrder.push("runCmd:pip");
       } else if (cmd.includes("npm install")) {
@@ -144,18 +184,19 @@ describe("buildSandboxImage()", () => {
       } else {
         callOrder.push("runCmd");
       }
-      return mockE2BTemplateBuilder;
+      return mockTemplateBuilder;
     });
-    mockE2BTemplateBuilder.setWorkdir.mockImplementation(() => {
+    mockTemplateBuilder.setWorkdir.mockImplementation(() => {
       callOrder.push("setWorkdir");
-      return mockE2BTemplateBuilder;
+      return mockTemplateBuilder;
     });
 
     await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: trackingDockerRegistryFactory,
     });
 
-    expect(callOrder[0]).toBe("fromUbuntuImage");
+    expect(callOrder[0]).toBe("fromDockerRegistry");
     expect(callOrder).toContain("setEnvs");
     expect(callOrder).toContain("runCmd:pip");
     expect(callOrder).toContain("runCmd:npm");
@@ -167,13 +208,13 @@ describe("buildSandboxImage()", () => {
 
     await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
-    const runCmdCalls = mockE2BTemplateBuilder.runCmd.mock.calls;
+    const runCmdCalls = mockTemplateBuilder.runCmd.mock.calls;
     const aptInstallCall = runCmdCalls.find(
       (call: string[]) =>
         call[0].includes("apt-get install") &&
-        call[0].includes("git") &&
         call[0].includes("jq") &&
         call[0].includes("pandoc")
     );
@@ -185,9 +226,10 @@ describe("buildSandboxImage()", () => {
 
     await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
       apiKey: "test-api-key",
+      dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
-    const runCmdCalls = mockE2BTemplateBuilder.runCmd.mock.calls;
+    const runCmdCalls = mockTemplateBuilder.runCmd.mock.calls;
     const pipInstallCall = runCmdCalls.find(
       (call: string[]) =>
         call[0].includes("uv pip install") &&

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -25,10 +25,23 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
+export type DockerRegistryFactory = (imageRef: string) => TemplateBuilder;
+
+export function createGCPRegistryFactory(
+  registry: string,
+  serviceAccountPath: string
+): DockerRegistryFactory {
+  return (imageRef: string) =>
+    E2BTemplate().fromGCPRegistry(`${registry}/${imageRef}`, {
+      serviceAccountJSON: serviceAccountPath,
+    });
+}
+
 interface E2BBuildConfig {
   apiKey?: string;
   domain?: string;
   skipCache?: boolean;
+  dockerRegistryFactory?: DockerRegistryFactory;
 }
 
 class ContentMaterializer {
@@ -66,7 +79,10 @@ class E2BTemplateBuilder {
     this.builder = builder;
   }
 
-  static fromSandboxImage(image: SandboxImage): E2BTemplateBuilder {
+  static fromSandboxImage(
+    image: SandboxImage,
+    options?: { dockerRegistryFactory?: DockerRegistryFactory }
+  ): E2BTemplateBuilder {
     const baseImage = image.baseImage;
     let builder: TemplateBuilder;
 
@@ -78,6 +94,12 @@ class E2BTemplateBuilder {
         builder = E2BTemplate().fromTemplate(
           formatSandboxImageId(baseImage.id)
         );
+        break;
+      case "docker":
+        if (!options?.dockerRegistryFactory) {
+          throw new Error("dockerRegistryFactory is required for docker images");
+        }
+        builder = options.dockerRegistryFactory(baseImage.imageRef);
         break;
       default:
         return assertNever(baseImage);
@@ -170,7 +192,9 @@ export async function buildSandboxImage(
   );
 
   try {
-    const e2bBuilder = E2BTemplateBuilder.fromSandboxImage(image);
+    const e2bBuilder = E2BTemplateBuilder.fromSandboxImage(image, {
+      dockerRegistryFactory: buildConfig?.dockerRegistryFactory,
+    });
 
     const result = await e2bBuilder.build(imageId, {
       apiKey,

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -31,9 +31,16 @@ export function createGCPRegistryFactory(
   registry: string,
   serviceAccountPath: string
 ): DockerRegistryFactory {
+  const absolutePath = path.isAbsolute(serviceAccountPath)
+    ? serviceAccountPath
+    : path.resolve(process.cwd(), serviceAccountPath);
+  // E2B SDK uses path.join internally which breaks absolute paths.
+  // Compute relative path from this file's directory so E2B resolves correctly.
+  const relativePath = path.relative(__dirname, absolutePath);
+
   return (imageRef: string) =>
     E2BTemplate().fromGCPRegistry(`${registry}/${imageRef}`, {
-      serviceAccountJSON: serviceAccountPath,
+      serviceAccountJSON: relativePath,
     });
 }
 
@@ -97,7 +104,9 @@ class E2BTemplateBuilder {
         break;
       case "docker":
         if (!options?.dockerRegistryFactory) {
-          throw new Error("dockerRegistryFactory is required for docker images");
+          throw new Error(
+            "dockerRegistryFactory is required for docker images"
+          );
         }
         builder = options.dockerRegistryFactory(baseImage.imageRef);
         break;

--- a/front/scripts/dev/sandbox_image_build.ts
+++ b/front/scripts/dev/sandbox_image_build.ts
@@ -87,17 +87,9 @@ async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
 
   let dockerRegistryFactory: DockerRegistryFactory | undefined;
   if (dockerRegistry) {
-    const serviceAccountPath = process.env.GCP_ARTIFACT_SERVICE_ACCOUNT;
-    if (!serviceAccountPath) {
-      logger.error(
-        { imageName },
-        "GCP_ARTIFACT_SERVICE_ACCOUNT env var required (path to service account JSON file)"
-      );
-      return;
-    }
     dockerRegistryFactory = createGCPRegistryFactory(
       dockerRegistry,
-      serviceAccountPath
+      config.getSandboxGcpArtifactServiceAccountPath()
     );
   }
 

--- a/front/scripts/dev/sandbox_image_build.ts
+++ b/front/scripts/dev/sandbox_image_build.ts
@@ -7,7 +7,11 @@ import {
   isValidSandboxImageTag,
   type SandboxImageId,
 } from "@app/lib/api/sandbox/image";
-import { buildSandboxImage } from "@app/lib/api/sandbox/providers/e2b_template";
+import {
+  buildSandboxImage,
+  createGCPRegistryFactory,
+  type DockerRegistryFactory,
+} from "@app/lib/api/sandbox/providers/e2b_template";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -16,10 +20,11 @@ interface BuildArgs {
   tag: string;
   execute: boolean;
   skipCache: boolean;
+  dockerRegistry?: string;
 }
 
 async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
-  const { image: imageName, tag, execute, skipCache } = args;
+  const { image: imageName, tag, execute, skipCache, dockerRegistry } = args;
 
   if (!isValidSandboxImageName(imageName)) {
     const available = getSandboxImageNames().join(", ");
@@ -43,8 +48,24 @@ async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
   const { apiKey } = config.getE2BSandboxConfig();
   const sandboxImage = getSandboxImage();
 
+  // Check if the image uses Docker base and registry is required
+  const usesDockerBase = sandboxImage.baseImage.type === "docker";
+  if (usesDockerBase && !dockerRegistry) {
+    logger.error(
+      { imageName },
+      "Image uses Docker base. Please provide --dockerRegistry option (e.g., us-docker.pkg.dev/project/repo)"
+    );
+    return;
+  }
+
   logger.info(
-    { sandboxImage: "DUST_BASE_IMAGE", imageName, tag },
+    {
+      sandboxImage: "DUST_BASE_IMAGE",
+      imageName,
+      tag,
+      usesDockerBase,
+      dockerRegistry: dockerRegistry ?? "N/A",
+    },
     "Using DUST_BASE_IMAGE for build"
   );
 
@@ -57,15 +78,33 @@ async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
         hasApiKey: Boolean(apiKey),
         operationCount: sandboxImage.operations.length,
         toolCount: sandboxImage.tools.length,
+        dockerRegistry: dockerRegistry ?? "N/A",
       },
       "Would build sandbox image via E2B SDK (dry-run)"
     );
     return;
   }
 
+  let dockerRegistryFactory: DockerRegistryFactory | undefined;
+  if (dockerRegistry) {
+    const serviceAccountPath = process.env.GCP_ARTIFACT_SERVICE_ACCOUNT;
+    if (!serviceAccountPath) {
+      logger.error(
+        { imageName },
+        "GCP_ARTIFACT_SERVICE_ACCOUNT env var required (path to service account JSON file)"
+      );
+      return;
+    }
+    dockerRegistryFactory = createGCPRegistryFactory(
+      dockerRegistry,
+      serviceAccountPath
+    );
+  }
+
   const result = await buildSandboxImage(sandboxImage, imageId, {
     ...(apiKey ? { apiKey } : {}),
     skipCache,
+    dockerRegistryFactory,
   });
 
   if (result.isErr()) {
@@ -96,6 +135,11 @@ makeScript(
       default: false,
       describe: "Force rebuild without using cache",
     },
+    "docker-registry": {
+      type: "string" as const,
+      describe:
+        "Docker registry URL for images using Docker base (e.g., us-docker.pkg.dev/project/repo)",
+    },
   },
   async (args, logger) => {
     await buildImage(
@@ -104,6 +148,7 @@ makeScript(
         tag: args.tag,
         execute: args.execute,
         skipCache: args["skip-cache"],
+        dockerRegistry: args["docker-registry"],
       },
       logger
     );


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6925

- Add base docker image to provide runtime + linux utils scaffolding, simplifying the template and providing an optimised image size-wise (compared to Ubuntu + apt-install everything) - currently at 1Gi will get down to ~500Mi once we remove rust compile tools
- Update the e2b builder to handle docker
- It's important to note that at this point the template won't build anymore unless you're on an amd64 machine.
The CI/CD to build the docker image and the template is in #22626

## Tests

- Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front