### PR TITLE
Use the email headers in servers agent_router, run_dust_app and toolsets instead of the group ids

### DIFF
--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -4,12 +4,12 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { AGENT_ROUTER_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_router/metadata";
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
 import apiConfig from "@app/lib/api/config";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { getHeaderFromGroupIds } from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
+import { getHeaderFromUserEmail } from "@app/types/user";
 import { DustAPI } from "@dust-tt/client";
 
 const MAX_INSTRUCTIONS_LENGTH = 1000;
@@ -17,7 +17,7 @@ const MAX_INSTRUCTIONS_LENGTH = 1000;
 const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
   list_all_published_agents: async (_, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
-    const requestedGroupIds = auth.groupIds();
+    const user = auth.user();
 
     const prodCredentials = await prodAPICredentialsForOwner(owner);
     const api = new DustAPI(
@@ -25,7 +25,8 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...getHeaderFromUserEmail(user?.email),
+          ...getApiKeyNameHeader(auth),
         },
       },
       logger
@@ -62,7 +63,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
 
   suggest_agents_for_content: async ({ userMessage }, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
-    const requestedGroupIds = auth.groupIds();
+    const user = auth.user();
 
     const prodCredentials = await prodAPICredentialsForOwner(owner);
     const api = new DustAPI(
@@ -70,7 +71,8 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...getHeaderFromUserEmail(user?.email),
+          ...getApiKeyNameHeader(auth),
         },
       },
       logger

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -20,11 +20,12 @@ import {
 import { RUN_DUST_APP_TOOL_NAME } from "@app/lib/api/actions/servers/run_dust_app/metadata";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import { getHeaderFromGroupIds, getHeaderFromRole } from "@app/types/groups";
+import { getHeaderFromRole } from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
+import { getHeaderFromUserEmail } from "@app/types/user";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
@@ -138,7 +139,7 @@ export default async function createServer(
           auth
         );
 
-        const requestedGroupIds = auth.groupIds();
+        const user = auth.user();
 
         const prodCredentials = await prodAPICredentialsForOwner(owner);
         const apiConfig = config.getDustAPIConfig();
@@ -147,7 +148,8 @@ export default async function createServer(
           {
             ...prodCredentials,
             extraHeaders: {
-              ...getHeaderFromGroupIds(requestedGroupIds),
+              ...getHeaderFromUserEmail(user?.email),
+              ...getApiKeyNameHeader(auth),
               ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
             },
           },

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -9,11 +9,11 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { TOOLSETS_TOOLS_METADATA } from "@app/lib/api/actions/servers/toolsets/metadata";
 import apiConfig from "@app/lib/api/config";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import { getHeaderFromGroupIds } from "@app/types/groups";
 import { Err, Ok } from "@app/types/shared/result";
+import { getHeaderFromUserEmail } from "@app/types/user";
 import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
@@ -24,7 +24,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
         .map((action) => action.mcpServerViewId) ?? [];
 
     const owner = auth.getNonNullableWorkspace();
-    const requestedGroupIds = auth.groupIds();
+    const user = auth.user();
     const prodCredentials = await prodAPICredentialsForOwner(owner, {
       useLocalInDev: true,
     });
@@ -34,7 +34,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
+          ...getHeaderFromUserEmail(user?.email),
+          ...getApiKeyNameHeader(auth),
         },
       },
       logger,
@@ -87,7 +88,6 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       return new Err(new MCPError("User not found", { tracked: false }));
     }
 
-    const requestedGroupIds = auth.groupIds();
     const prodCredentials = await prodAPICredentialsForOwner(owner, {
       useLocalInDev: true,
     });
@@ -98,8 +98,8 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
       {
         ...prodCredentials,
         extraHeaders: {
-          ...getHeaderFromGroupIds(requestedGroupIds),
-          "x-api-user-email": user.email,
+          ...getHeaderFromUserEmail(user.email),
+          ...getApiKeyNameHeader(auth),
         },
       },
       logger,


### PR DESCRIPTION
## Description

Using the group ids may result in too lon headers if there are too many groups.
Using the email header to restrict the auth is already tested by the run_agent server

## Tests


## Risk

may slightly change permissions as the auth will be user and not system, but should not be an issue issue.

## Deploy Plan

deploy front 
