### PR TITLE
Switch to large assistant cards for templates

### DIFF
--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -4,11 +4,7 @@ import type {
   TemplateTagCodeType,
   TemplateTagsType,
 } from "@app/types/assistant/templates";
-import {
-  CardGrid,
-  ContextItem,
-  LargeAssistantCard,
-} from "@dust-tt/sparkle";
+import { CardGrid, ContextItem, LargeAssistantCard } from "@dust-tt/sparkle";
 
 interface AgentTemplateGridProps {
   templates: AssistantTemplateListType[];

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -56,7 +56,7 @@ export function AgentTemplateGrid({
               {hasCopilot ? (
                 <CardGrid>
                   {templatesForTag.map((template) => (
-                    <AssistantCard
+                    <LargeAssistantCard
                       key={template.sId}
                       title={template.handle}
                       pictureUrl={template.pictureUrl}

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -5,7 +5,6 @@ import type {
   TemplateTagsType,
 } from "@app/types/assistant/templates";
 import {
-  AssistantCard,
   CardGrid,
   ContextItem,
   LargeAssistantCard,


### PR DESCRIPTION
## Description

* Keeping grid, but switching to large assistant cards. Too much of the names/description were getting cut off with the smaller cards

## Tests
<img width="1065" height="497" alt="Screenshot 2026-03-04 at 3 50 28 PM" src="https://github.com/user-attachments/assets/adcabc19-8263-4e96-8a53-cb76278f7edb" />

## Risk

* Low

## Deploy Plan

* Deploy front