### PR TITLE
Reenable use of noop provider for copilot new agent from scratch

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -18,6 +18,7 @@ import {
   getSmallWhitelistedModel,
 } from "@app/types/assistant/assistant";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { getCompanyDataAction } from "./shared";
@@ -461,6 +462,8 @@ export function buildCopilotInstructions(
   return parts.join("\n\n");
 }
 
+const COPILOT_NEW_AGENT_STATIC_RESPONSE = "What agent would you like to build?";
+
 export function _getCopilotGlobalAgent(
   auth: Authenticator,
   {
@@ -497,17 +500,24 @@ export function _getCopilotGlobalAgent(
   // (static response without calling a real LLM).
   // Use a fast model for other first turns and the full model for follow-ups.
   const isFirstTurn = globalAgentContext?.userMessageRank === 0;
-  const modelConfiguration = isFirstTurn
-    ? isProviderWhitelisted(owner, "anthropic")
-      ? CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
-      : getSmallWhitelistedModel(owner)
-    : getLargeWhitelistedModel(owner);
+  const isNewAgentFromScratchFirstTurn =
+    isFirstTurn && globalAgentContext?.copilotIsNewAgentFromScratch;
+  const modelConfiguration = isNewAgentFromScratchFirstTurn
+    ? NOOP_MODEL_CONFIG
+    : isFirstTurn
+      ? isProviderWhitelisted(owner, "anthropic")
+        ? CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
+        : getSmallWhitelistedModel(owner)
+      : getLargeWhitelistedModel(owner);
   const model = modelConfiguration
     ? {
         providerId: modelConfiguration.providerId,
         modelId: modelConfiguration.modelId,
         temperature: 0.7,
         reasoningEffort: modelConfiguration.defaultReasoningEffort,
+        ...(isNewAgentFromScratchFirstTurn && {
+          metaData: { staticResponse: COPILOT_NEW_AGENT_STATIC_RESPONSE },
+        }),
       }
     : dummyModelConfiguration;
 

--- a/front/types/assistant/models/providers.test.ts
+++ b/front/types/assistant/models/providers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkspaceType } from "../../user";
+import { isProviderWhitelisted } from "./providers";
+
+function makeWorkspace(
+  whiteListedProviders: WorkspaceType["whiteListedProviders"]
+): WorkspaceType {
+  return {
+    id: 1,
+    sId: "test-workspace",
+    name: "Test",
+    role: "admin",
+    segmentation: null,
+    whiteListedProviders,
+    defaultEmbeddingProvider: null,
+    metadata: {},
+    ssoEnforced: false,
+  };
+}
+
+describe("isProviderWhitelisted", () => {
+  it("treats noop as whitelisted even when workspace restricts providers", () => {
+    const workspace = makeWorkspace(["anthropic", "openai"]);
+    expect(isProviderWhitelisted(workspace, "noop")).toBe(true);
+  });
+
+  it("treats noop as whitelisted when workspace has no restrictions", () => {
+    const workspace = makeWorkspace(null);
+    expect(isProviderWhitelisted(workspace, "noop")).toBe(true);
+  });
+
+  it("allows a provider that is in the whitelist", () => {
+    const workspace = makeWorkspace(["anthropic"]);
+    expect(isProviderWhitelisted(workspace, "anthropic")).toBe(true);
+  });
+
+  it("rejects a provider that is not in the whitelist", () => {
+    const workspace = makeWorkspace(["anthropic"]);
+    expect(isProviderWhitelisted(workspace, "openai")).toBe(false);
+  });
+});

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -55,6 +55,10 @@ export function isProviderWhitelisted(
   owner: WorkspaceType,
   providerId: ModelProviderIdType
 ) {
+  // noop never sees user data, so we always treat it as whitelisted
+  if (providerId === "noop") {
+    return true;
+  }
   const whiteListedProviders = owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
   return whiteListedProviders.includes(providerId);
 }


### PR DESCRIPTION
## Description

Follow up to #22609 to re-enable it.

Having noop as whitelisted is the correct thing to do even when just using the `@noop` agent on a dev machine, as it is broken today if you have a custom provider list.

## Tests

Manual

## Risk

Low.

## Deploy Plan

Front