### PR TITLE
Fix broken /home/* links on app.dust.tt by using absolute URLs

### DIFF
--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -2,6 +2,7 @@ import { BuyCreditDialog } from "@app/components/workspace/BuyCreditDialog";
 import { CreditHistorySheet } from "@app/components/workspace/CreditHistorySheet";
 import { CreditsList, isExpired } from "@app/components/workspace/CreditsList";
 import { ProgrammaticCostChart } from "@app/components/workspace/ProgrammaticCostChart";
+import config from "@app/lib/api/config";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   getBillingCycle,
@@ -361,7 +362,7 @@ export function CreditsUsagePage() {
                 automated workflows, etc.). Usage cost is based on token
                 consumption, according to our{" "}
                 <Hoverable
-                  href="/home/api-pricing"
+                  href={`${config.getStaticWebsiteUrl()}/home/api-pricing`}
                   target="_blank"
                   variant="primary"
                 >

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import {
   getPriceWithCurrency,
   PRO_PLAN_COST_MONTHLY,
@@ -125,7 +126,7 @@ export function SubscriptionPlanCards({
             variant="outline"
             size="md"
             label="Contact sales"
-            href="/home/contact"
+            href={`${config.getStaticWebsiteUrl()}/home/contact`}
             target="_blank"
             disabled={isProcessing}
             className="w-full"


### PR DESCRIPTION
## Description

Since dust.tt no longer redirects to app.dust.tt, relative /home/* URLs in workspace components resolve to app.dust.tt/home/* (404) instead of dust.tt/home/*. Use config.getStaticWebsiteUrl() for correct cross-domain links.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
