### PR TITLE
Use proper byte measurement for tool output and reduce to 20KB

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -2,18 +2,15 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // Size limits for MCP tool outputs
 
-// Approximate baseline context window size we target:
-// 200k tokens * ~4 characters per token * 2 bytes per character.
-const BASELINE_CONTEXT_WINDOW_SIZE = 2 * 4 * 200 * 1000;
-// We don't want to go over 1/4 of the baseline context window size in one tool result.
-export const MAX_TEXT_CONTENT_SIZE = BASELINE_CONTEXT_WINDOW_SIZE / 4;
+// Max bytes for a single text block in a tool result before it gets offloaded to a file.
+export const MAX_TEXT_CONTENT_SIZE_BYTES = 20 * 1024; // 20KB.
 export const MAX_IMAGE_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB.
 export const MAX_RESOURCE_CONTENT_SIZE = 20 * 1024 * 1024; // 20MB.
 
 export const MAXED_OUTPUT_FILE_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 
 export function computeTextByteSize(text: string): number {
-  return text.length * 2; // UTF-8 approximate
+  return Buffer.byteLength(text, "utf8");
 }
 
 export function computeBase64ByteSize(base64: string): number {
@@ -23,11 +20,14 @@ export function computeBase64ByteSize(base64: string): number {
 export function getMaxSize(item: CallToolResult["content"][number]) {
   switch (item.type) {
     case "text":
-      return MAX_TEXT_CONTENT_SIZE;
+      return MAX_TEXT_CONTENT_SIZE_BYTES;
+
     case "image":
       return MAX_IMAGE_CONTENT_SIZE;
+
     case "resource":
       return MAX_RESOURCE_CONTENT_SIZE;
+
     default:
       return 1 * 1024 * 1024; // 1MB default
   }
@@ -39,8 +39,10 @@ export function calculateContentSize(
   switch (item.type) {
     case "text":
       return computeTextByteSize(item.text);
+
     case "image":
       return computeBase64ByteSize(item.data);
+
     case "resource":
       if (
         "blob" in item.resource &&
@@ -53,8 +55,10 @@ export function calculateContentSize(
         return computeTextByteSize(item.resource.text);
       }
       return 0;
+
     case "audio":
       return item.data.length;
+
     default:
       return 0;
   }

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -1,6 +1,6 @@
 import {
   MAX_RESOURCE_CONTENT_SIZE,
-  MAX_TEXT_CONTENT_SIZE,
+  MAX_TEXT_CONTENT_SIZE_BYTES,
   MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
 } from "@app/lib/actions/action_output_limits";
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
@@ -83,12 +83,11 @@ async function setupTest() {
 }
 
 describe("processToolResults", () => {
-  it("should store snippet in DB when text exceeds MAX_TEXT_CONTENT_SIZE", async () => {
+  it("should store snippet in DB when text exceeds MAX_TEXT_CONTENT_SIZE_BYTES", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
-    // Generate text that exceeds MAX_TEXT_CONTENT_SIZE (400KB).
-    // computeTextByteSize uses text.length * 2, so length > MAX_TEXT_CONTENT_SIZE / 2 triggers it.
-    const largeText = "x".repeat(MAX_TEXT_CONTENT_SIZE / 2 + 1);
+    // Generate text that exceeds MAX_TEXT_CONTENT_SIZE_BYTES (20KB).
+    const largeText = "x".repeat(MAX_TEXT_CONTENT_SIZE_BYTES + 1);
 
     const { outputItems } = await processToolResults(auth, {
       action,
@@ -115,8 +114,7 @@ describe("processToolResults", () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
     // Generate resource text that exceeds MAX_RESOURCE_CONTENT_SIZE (20MB).
-    // computeTextByteSize uses text.length * 2, so length > MAX_RESOURCE_CONTENT_SIZE / 2 triggers it.
-    const largeResourceText = "y".repeat(MAX_RESOURCE_CONTENT_SIZE / 2 + 1);
+    const largeResourceText = "y".repeat(MAX_RESOURCE_CONTENT_SIZE + 1);
 
     const { outputItems } = await processToolResults(auth, {
       action,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -5,7 +5,7 @@ import {
 import {
   computeTextByteSize,
   MAX_RESOURCE_CONTENT_SIZE,
-  MAX_TEXT_CONTENT_SIZE,
+  MAX_TEXT_CONTENT_SIZE_BYTES,
   MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
 } from "@app/lib/actions/action_output_limits";
 import type {
@@ -169,7 +169,7 @@ export async function processToolResults(
         case "text": {
           // If the text is too large we create a file and return a resource block that references the file.
           if (
-            computeTextByteSize(block.text) > MAX_TEXT_CONTENT_SIZE &&
+            computeTextByteSize(block.text) > MAX_TEXT_CONTENT_SIZE_BYTES &&
             toolConfiguration.mcpServerName !== "conversation_files"
           ) {
             const fileName = `${toolConfiguration.mcpServerName}_${Date.now()}.txt`;

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -1,6 +1,6 @@
 import {
   computeTextByteSize,
-  MAX_TEXT_CONTENT_SIZE,
+  MAX_TEXT_CONTENT_SIZE_BYTES,
 } from "@app/lib/actions/action_output_limits";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -184,9 +184,9 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
       );
     }
 
-    // Cap to MAX_TEXT_CONTENT_SIZE to avoid storing oversized content in the DB.
-    // computeTextByteSize uses length * 2, so the character cap is MAX_TEXT_CONTENT_SIZE / 2.
-    const maxCharacters = MAX_TEXT_CONTENT_SIZE / 2;
+    // Cap to MAX_TEXT_CONTENT_SIZE_BYTES to avoid storing oversized content in the DB.
+    // For ASCII-dominant text, 1 char ≈ 1 byte, so we use MAX_TEXT_CONTENT_SIZE_BYTES directly.
+    const maxCharacters = MAX_TEXT_CONTENT_SIZE_BYTES;
     const effectiveLimit =
       limit !== undefined ? Math.min(limit, maxCharacters) : maxCharacters;
     const end = start + effectiveLimit;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR replaces the approximate character-based byte estimation (text.length * 2) with actual UTF-8 byte counting using `Buffer.byteLength`, and lowers the text content size limit from `~400KB` (not really actually since we applied a 2x on string length) to `20KB`. 

With this lower threshold, tool outputs will more frequently be offloaded to files, meaning the model will need to use the conversation files server to read and interact with those results rather than having the full content inline in the conversation.

**After this change:**
- Text output items are capped at 20KB (~20k characters, ~5k tokens). Beyond that, the content is offloaded to a
 file.
- When offloaded, an 8k-character snippet (~2k tokens) is kept inline so the model has immediate context to
decide whether to read more via the conversation files server.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
All tool calls that return more than 20KB will require an extra loop to read the file (using pagination). If retrieval is impacted, it's safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
