### PR TITLE
Redirect user to login if token expired

### DIFF
--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -102,6 +102,7 @@ export const useAuthHook = () => {
         new AuthError("not_authenticated", "No access token received.")
       );
       log("Refresh token: No access token received.");
+      setIsLoading(false);
       return;
     }
 

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -50,15 +50,11 @@ async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
   const { query } = req;
 
   let workspaceId = undefined;
-  // TODO(chris): Remove this condition if no log
   if (
     typeof query.organization_id === "string" &&
     query.organization_id.startsWith("workspace-")
   ) {
     workspaceId = query.organization_id.split("workspace-")[1];
-    logger.info(
-      `Received authorize request with organization_id ${query.organization_id} (starting with "workspace-"), extracted workspaceId ${workspaceId}`
-    );
   }
 
   if (typeof query.workspaceId === "string") {


### PR DESCRIPTION
## Description

Fixes the extension loading state when token refresh fails due to an expired token. When `handleRefreshToken()` returns early because no access token was received, the loading state was never cleared, leaving the UI stuck in a loading state. This PR adds `setIsLoading(false)` to properly reset the loading state so the user can be redirected to login. Also removes a TODO comment and associated debug logging in the auth action endpoint.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
