### PR TITLE
Remove 1 scope and add 4 in the Slack tool MCP

### DIFF
--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -60,7 +60,6 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
             "im:read",
             "mpim:read",
             // Semantic search scopes.
-            "search:read",
             "search:read.public",
             "search:read.private",
             "search:read.mpim",
@@ -69,6 +68,11 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
             "users:read.email",
             "users:read",
             "usergroups:read",
+            // The following scopes are needed to use the official Slack MCP, and could be helpful if we switch to that later
+            "canvases:read",
+            "canvases:write",
+            "search:read.files",
+            "search:read.users",
           ];
         default:
           assert(


### PR DESCRIPTION
## Description

This is needed in order to get our published Slack app approved with the right set of scopes.

## Tests

Manual

## Risk

Small potential to affect MCP tool in Prod. Will monitor. Easy to revert.

## Deploy Plan

Front.