### PR TITLE
[front] enh: Improve env on sbx img definition

### DIFF
--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: rust-builder - compile Rust in isolated stage
-FROM debian:bookworm-slim AS rust-builder
+FROM debian:trixie-20260223-slim AS rust-builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUSTUP_HOME=/opt/rustup
@@ -14,7 +14,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
   sh -s -- -y --default-toolchain stable --profile minimal
 
 # Stage 2: rootfs - assemble complete filesystem
-FROM debian:bookworm-slim AS rootfs
+FROM debian:trixie-20260223-slim  AS rootfs
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -37,7 +37,7 @@ COPY --from=rust-builder /opt/rustup /opt/rustup
 COPY --from=rust-builder /opt/cargo /opt/cargo
 
 # Node.js via official tarball
-ARG NODE_VERSION=22.12.0
+ARG NODE_VERSION=24.14.0
 RUN ARCH=$(dpkg --print-architecture) && \
   if [ "$ARCH" = "amd64" ]; then NODE_ARCH="x64"; else NODE_ARCH="arm64"; fi && \
   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz && \

--- a/front/lib/api/sandbox/image/dust-base.ts
+++ b/front/lib/api/sandbox/image/dust-base.ts
@@ -45,7 +45,7 @@ export const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   "dust-sbx-bedrock:latest"
 )
   // Set environment variables (these apply during build operations)
-  .setEnv({
+  .setBuildEnv({
     NPM_CONFIG_PREFIX: "/opt/npm-global",
     CARGO_HOME: "/opt/cargo",
     RUSTUP_HOME: "/opt/rustup",
@@ -114,4 +114,5 @@ export const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   )
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(ALLOWLIST_NETWORK_POLICY)
-  .setWorkdir("/home/user");
+  .setWorkdir("/home/user")
+  .register({ imageName: "dust-base", tag: "production" });

--- a/front/lib/api/sandbox/image/sandbox_image.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.test.ts
@@ -3,66 +3,58 @@ import { describe, expect, test } from "vitest";
 import { SandboxImage } from "./sandbox_image";
 import type { SandboxImageId } from "./types";
 
-describe("SandboxImage.fromUbuntu()", () => {
-  test("creates image with ubuntu base", () => {
-    const image = SandboxImage.fromUbuntu("22.04");
+describe("SandboxImage.fromSandbox()", () => {
+  test("creates image with sandbox base", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromSandbox(id);
 
-    expect(image.baseImage.type).toBe("ubuntu");
-    if (image.baseImage.type === "ubuntu") {
-      expect(image.baseImage.version).toBe("22.04");
-    }
-  });
-
-  test("uses default version when not provided", () => {
-    const image = SandboxImage.fromUbuntu();
-
-    if (image.baseImage.type === "ubuntu") {
-      expect(image.baseImage.version).toBe("22.04");
+    expect(image.baseImage.type).toBe("sandbox");
+    if (image.baseImage.type === "sandbox") {
+      expect(image.baseImage.id).toEqual(id);
     }
   });
 
   test("starts with empty operations and tools", () => {
-    const image = SandboxImage.fromUbuntu();
+    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromSandbox(id);
 
     expect(image.operations).toHaveLength(0);
     expect(image.tools).toHaveLength(0);
   });
 
   test("has default resources", () => {
-    const image = SandboxImage.fromUbuntu();
+    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromSandbox(id);
 
     expect(image.resources.vcpu).toBe(1);
     expect(image.resources.memoryMb).toBe(512);
   });
 
   test("has default network policy", () => {
-    const image = SandboxImage.fromUbuntu();
+    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromSandbox(id);
 
     expect(image.network.mode).toBe("deny_all");
   });
 
   test("has default workdir", () => {
-    const image = SandboxImage.fromUbuntu();
+    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromSandbox(id);
 
     expect(image.workdir).toBe("/home/user");
   });
-});
 
-describe("SandboxImage.fromTemplate()", () => {
-  test("creates image with template reference", () => {
+  test("has empty runEnv by default", () => {
     const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromTemplate(id);
+    const image = SandboxImage.fromSandbox(id);
 
-    expect(image.baseImage.type).toBe("template");
-    if (image.baseImage.type === "template") {
-      expect(image.baseImage.id).toEqual(id);
-    }
+    expect(image.runEnv).toEqual({});
   });
 });
 
 describe("SandboxImage.runCmd()", () => {
   test("adds run operation", () => {
-    const image = SandboxImage.fromUbuntu().runCmd("echo hello");
+    const image = SandboxImage.fromDocker("ubuntu:22.04").runCmd("echo hello");
 
     expect(image.operations).toHaveLength(1);
     expect(image.operations[0].type).toBe("run");
@@ -73,7 +65,7 @@ describe("SandboxImage.runCmd()", () => {
   });
 
   test("returns new image instance", () => {
-    const original = SandboxImage.fromUbuntu();
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
     const modified = original.runCmd("echo hello");
 
     expect(modified).not.toBe(original);
@@ -84,7 +76,7 @@ describe("SandboxImage.runCmd()", () => {
 
 describe("SandboxImage.registerTool()", () => {
   test("registers single tool without installCmd", () => {
-    const image = SandboxImage.fromUbuntu().registerTool({
+    const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool({
       name: "dsbx",
       description: "Dust CLI",
     });
@@ -96,7 +88,7 @@ describe("SandboxImage.registerTool()", () => {
   });
 
   test("registers single tool with installCmd", () => {
-    const image = SandboxImage.fromUbuntu().registerTool(
+    const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool(
       { name: "curl", description: "HTTP client" },
       { installCmd: "apt-get install -y curl" }
     );
@@ -111,7 +103,7 @@ describe("SandboxImage.registerTool()", () => {
   });
 
   test("registers multiple tools with single installCmd", () => {
-    const image = SandboxImage.fromUbuntu().registerTool(
+    const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool(
       [
         { name: "pandas", description: "Data analysis" },
         { name: "numpy", description: "Numerical computing" },
@@ -136,7 +128,7 @@ describe("SandboxImage.registerTool()", () => {
   });
 
   test("returns new image instance", () => {
-    const original = SandboxImage.fromUbuntu();
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
     const modified = original.registerTool({
       name: "curl",
       description: "HTTP client",
@@ -150,7 +142,10 @@ describe("SandboxImage.registerTool()", () => {
 
 describe("SandboxImage.copy()", () => {
   test("accepts string path", () => {
-    const image = SandboxImage.fromUbuntu().copy("./src", "/app/src");
+    const image = SandboxImage.fromDocker("ubuntu:22.04").copy(
+      "./src",
+      "/app/src"
+    );
 
     expect(image.operations).toHaveLength(1);
     expect(image.operations[0].type).toBe("copy");
@@ -164,7 +159,7 @@ describe("SandboxImage.copy()", () => {
   });
 
   test("accepts content generator callback", () => {
-    const image = SandboxImage.fromUbuntu().copy(
+    const image = SandboxImage.fromDocker("ubuntu:22.04").copy(
       () => "hello world",
       "/app/file.txt"
     );
@@ -181,7 +176,7 @@ describe("SandboxImage.copy()", () => {
   });
 
   test("accepts content generator returning Buffer", () => {
-    const image = SandboxImage.fromUbuntu().copy(
+    const image = SandboxImage.fromDocker("ubuntu:22.04").copy(
       () => Buffer.from("binary data"),
       "/app/data.bin"
     );
@@ -199,7 +194,7 @@ describe("SandboxImage.copy()", () => {
 
 describe("SandboxImage.setWorkdir()", () => {
   test("adds workdir operation and updates workdir property", () => {
-    const image = SandboxImage.fromUbuntu().setWorkdir("/app");
+    const image = SandboxImage.fromDocker("ubuntu:22.04").setWorkdir("/app");
 
     expect(image.workdir).toBe("/app");
     expect(image.operations).toHaveLength(1);
@@ -212,7 +207,7 @@ describe("SandboxImage.setWorkdir()", () => {
 
 describe("SandboxImage.withResources()", () => {
   test("updates resources", () => {
-    const image = SandboxImage.fromUbuntu().withResources({
+    const image = SandboxImage.fromDocker("ubuntu:22.04").withResources({
       vcpu: 4,
       memoryMb: 8192,
     });
@@ -222,7 +217,7 @@ describe("SandboxImage.withResources()", () => {
   });
 
   test("returns new image instance", () => {
-    const original = SandboxImage.fromUbuntu();
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
     const modified = original.withResources({ vcpu: 4, memoryMb: 8192 });
 
     expect(modified).not.toBe(original);
@@ -232,7 +227,7 @@ describe("SandboxImage.withResources()", () => {
 
 describe("SandboxImage.withNetwork()", () => {
   test("updates network policy", () => {
-    const image = SandboxImage.fromUbuntu().withNetwork({
+    const image = SandboxImage.fromDocker("ubuntu:22.04").withNetwork({
       mode: "deny_all",
       allowlist: ["example.com", "api.example.com"],
     });
@@ -244,7 +239,7 @@ describe("SandboxImage.withNetwork()", () => {
 
 describe("SandboxImage immutability", () => {
   test("chained operations preserve original instances", () => {
-    const original = SandboxImage.fromUbuntu();
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
     const afterInstall = original.registerTool(
       { name: "curl", description: "HTTP client" },
       { installCmd: "apt-get install -y curl" }
@@ -267,7 +262,7 @@ describe("SandboxImage immutability", () => {
 
 describe("SandboxImage.withToolManifest()", () => {
   test("adds copy operation with content generator", () => {
-    const image = SandboxImage.fromUbuntu().withToolManifest();
+    const image = SandboxImage.fromDocker("ubuntu:22.04").withToolManifest();
 
     expect(image.operations).toHaveLength(1);
     expect(image.operations[0].type).toBe("copy");
@@ -283,7 +278,7 @@ describe("SandboxImage.withToolManifest()", () => {
   });
 
   test("accepts custom path and format", () => {
-    const image = SandboxImage.fromUbuntu().withToolManifest({
+    const image = SandboxImage.fromDocker("ubuntu:22.04").withToolManifest({
       path: "/custom/path/manifest.json",
       format: "json",
     });
@@ -299,7 +294,7 @@ describe("SandboxImage.withToolManifest()", () => {
   });
 
   test("uses correct default extension based on format", () => {
-    const jsonImage = SandboxImage.fromUbuntu().withToolManifest({
+    const jsonImage = SandboxImage.fromDocker("ubuntu:22.04").withToolManifest({
       format: "json",
     });
 
@@ -311,7 +306,7 @@ describe("SandboxImage.withToolManifest()", () => {
   });
 
   test("returns new instance (immutability)", () => {
-    const original = SandboxImage.fromUbuntu();
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
     const modified = original.withToolManifest();
 
     expect(modified).not.toBe(original);
@@ -320,7 +315,7 @@ describe("SandboxImage.withToolManifest()", () => {
   });
 
   test("chains with other operations", () => {
-    const image = SandboxImage.fromUbuntu()
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
       .registerTool({ name: "curl", description: "HTTP client" })
       .runCmd("echo hello")
       .withToolManifest()
@@ -333,7 +328,7 @@ describe("SandboxImage.withToolManifest()", () => {
   });
 
   test("includes registered tools in manifest content", () => {
-    const image = SandboxImage.fromUbuntu()
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
       .registerTool({ name: "curl", description: "HTTP client" })
       .registerTool({ name: "jq", description: "JSON processor" })
       .withToolManifest();
@@ -351,7 +346,7 @@ describe("SandboxImage.withToolManifest()", () => {
   });
 
   test("lazily generates content (captures tools at call time)", () => {
-    const baseImage = SandboxImage.fromUbuntu().registerTool({
+    const baseImage = SandboxImage.fromDocker("ubuntu:22.04").registerTool({
       name: "curl",
       description: "HTTP client",
     });
@@ -365,5 +360,197 @@ describe("SandboxImage.withToolManifest()", () => {
       const content = imageWithManifest.operations[0].src.getContent();
       expect(content).toContain("curl");
     }
+  });
+});
+
+describe("SandboxImage.setBuildEnv()", () => {
+  test("adds env operation", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").setBuildEnv({
+      FOO: "bar",
+      BAZ: "qux",
+    });
+
+    expect(image.operations).toHaveLength(1);
+    expect(image.operations[0].type).toBe("env");
+    if (image.operations[0].type === "env") {
+      expect(image.operations[0].vars).toEqual({ FOO: "bar", BAZ: "qux" });
+    }
+  });
+
+  test("returns new image instance", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const modified = original.setBuildEnv({ FOO: "bar" });
+
+    expect(modified).not.toBe(original);
+    expect(original.operations).toHaveLength(0);
+    expect(modified.operations).toHaveLength(1);
+  });
+});
+
+describe("SandboxImage.setRunEnv()", () => {
+  test("sets runtime environment variables", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
+      API_KEY: "secret",
+      DEBUG: "true",
+    });
+
+    expect(image.runEnv).toEqual({ API_KEY: "secret", DEBUG: "true" });
+  });
+
+  test("merges with existing runEnv", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
+      .setRunEnv({ FOO: "bar" })
+      .setRunEnv({ BAZ: "qux" });
+
+    expect(image.runEnv).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  test("later values override earlier ones", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
+      .setRunEnv({ FOO: "original" })
+      .setRunEnv({ FOO: "updated" });
+
+    expect(image.runEnv).toEqual({ FOO: "updated" });
+  });
+
+  test("does not add operations (runtime-only)", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
+      FOO: "bar",
+    });
+
+    expect(image.operations).toHaveLength(0);
+  });
+
+  test("returns new image instance", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const modified = original.setRunEnv({ FOO: "bar" });
+
+    expect(modified).not.toBe(original);
+    expect(original.runEnv).toEqual({});
+    expect(modified.runEnv).toEqual({ FOO: "bar" });
+  });
+});
+
+describe("SandboxImage.toCreateConfig()", () => {
+  test("returns network and resources from image", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
+      .withResources({ vcpu: 2, memoryMb: 1024 })
+      .withNetwork({ mode: "allow_all" });
+
+    const config = image.toCreateConfig();
+
+    expect(config.network).toEqual({ mode: "allow_all" });
+    expect(config.resources).toEqual({ vcpu: 2, memoryMb: 1024 });
+  });
+
+  test("returns undefined envVars when runEnv is empty", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04");
+
+    const config = image.toCreateConfig();
+
+    expect(config.envVars).toBeUndefined();
+  });
+
+  test("returns envVars when runEnv is non-empty", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
+      FOO: "bar",
+      BAZ: "qux",
+    });
+
+    const config = image.toCreateConfig();
+
+    expect(config.envVars).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  test("returns a copy of runEnv (not the same reference)", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
+      KEY: "value",
+    });
+
+    const config = image.toCreateConfig();
+
+    expect(config.envVars).not.toBe(image.runEnv);
+  });
+
+  test("returns default values for new image", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04");
+
+    const config = image.toCreateConfig();
+
+    expect(config.envVars).toBeUndefined();
+    expect(config.network).toEqual({ mode: "deny_all" });
+    expect(config.resources).toEqual({ vcpu: 1, memoryMb: 512 });
+  });
+
+  test("returns undefined imageId when not registered", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04");
+
+    const config = image.toCreateConfig();
+
+    expect(config.imageId).toBeUndefined();
+  });
+
+  test("returns imageId when registered", () => {
+    const imageId: SandboxImageId = {
+      imageName: "dust-base",
+      tag: "production",
+    };
+    const image = SandboxImage.fromDocker("ubuntu:22.04").register(imageId);
+
+    const config = image.toCreateConfig();
+
+    expect(config.imageId).toEqual(imageId);
+  });
+});
+
+describe("SandboxImage.register()", () => {
+  test("sets imageId", () => {
+    const imageId: SandboxImageId = {
+      imageName: "dust-base",
+      tag: "production",
+    };
+    const image = SandboxImage.fromDocker("ubuntu:22.04").register(imageId);
+
+    expect(image.imageId).toEqual(imageId);
+  });
+
+  test("returns new image instance", () => {
+    const imageId: SandboxImageId = {
+      imageName: "dust-base",
+      tag: "production",
+    };
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const modified = original.register(imageId);
+
+    expect(modified).not.toBe(original);
+    expect(original.imageId).toBeUndefined();
+    expect(modified.imageId).toEqual(imageId);
+  });
+
+  test("chains with other operations", () => {
+    const imageId: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
+      .registerTool({ name: "curl", description: "HTTP client" })
+      .withResources({ vcpu: 2, memoryMb: 1024 })
+      .register(imageId)
+      .setRunEnv({ DEBUG: "true" });
+
+    expect(image.imageId).toEqual(imageId);
+    expect(image.tools).toHaveLength(1);
+    expect(image.resources.vcpu).toBe(2);
+    expect(image.runEnv).toEqual({ DEBUG: "true" });
+  });
+
+  test("has undefined imageId by default", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04");
+
+    expect(image.imageId).toBeUndefined();
+  });
+
+  test("has undefined imageId from sandbox base by default", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
+    const image = SandboxImage.fromSandbox(id);
+
+    expect(image.imageId).toBeUndefined();
   });
 });

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -31,6 +31,8 @@ interface SandboxImageState {
   resources: SandboxResources;
   network: NetworkPolicy;
   workdir: string;
+  runEnv: Readonly<Record<string, string>>;
+  imageId?: SandboxImageId;
 }
 
 export class SandboxImage {
@@ -40,7 +42,9 @@ export class SandboxImage {
   readonly resources: SandboxResources;
   readonly network: NetworkPolicy;
   readonly workdir: string;
+  readonly runEnv: Readonly<Record<string, string>>;
   readonly startupScript?: string;
+  readonly imageId?: SandboxImageId;
 
   private constructor(state: SandboxImageState) {
     this.baseImage = state.baseImage;
@@ -49,6 +53,8 @@ export class SandboxImage {
     this.resources = state.resources;
     this.network = state.network;
     this.workdir = state.workdir;
+    this.runEnv = state.runEnv;
+    this.imageId = state.imageId;
   }
 
   private clone(updates: Partial<SandboxImageState>): SandboxImage {
@@ -59,28 +65,20 @@ export class SandboxImage {
       resources: updates.resources ?? this.resources,
       network: updates.network ?? this.network,
       workdir: updates.workdir ?? this.workdir,
+      runEnv: updates.runEnv ?? this.runEnv,
+      imageId: updates.imageId ?? this.imageId,
     });
   }
 
-  static fromUbuntu(version: string = "22.04"): SandboxImage {
+  static fromSandbox(id: SandboxImageId): SandboxImage {
     return new SandboxImage({
-      baseImage: { type: "ubuntu", version },
+      baseImage: { type: "sandbox", id },
       operations: [],
       tools: [],
       resources: DEFAULT_RESOURCES,
       network: DEFAULT_NETWORK,
       workdir: "/home/user",
-    });
-  }
-
-  static fromTemplate(id: SandboxImageId): SandboxImage {
-    return new SandboxImage({
-      baseImage: { type: "template", id },
-      operations: [],
-      tools: [],
-      resources: DEFAULT_RESOURCES,
-      network: DEFAULT_NETWORK,
-      workdir: "/home/user",
+      runEnv: {},
     });
   }
 
@@ -92,6 +90,7 @@ export class SandboxImage {
       resources: DEFAULT_RESOURCES,
       network: DEFAULT_NETWORK,
       workdir: "/home/user",
+      runEnv: {},
     });
   }
 
@@ -156,7 +155,7 @@ export class SandboxImage {
     });
   }
 
-  setEnv(vars: Record<string, string>): SandboxImage {
+  setBuildEnv(vars: Record<string, string>): SandboxImage {
     const operation: Operation = {
       type: "env",
       vars,
@@ -167,12 +166,22 @@ export class SandboxImage {
     });
   }
 
+  setRunEnv(vars: Record<string, string>): SandboxImage {
+    return this.clone({
+      runEnv: { ...this.runEnv, ...vars },
+    });
+  }
+
   withResources(resources: SandboxResources): SandboxImage {
     return this.clone({ resources });
   }
 
   withNetwork(policy: NetworkPolicy): SandboxImage {
     return this.clone({ network: policy });
+  }
+
+  register(imageId: SandboxImageId): SandboxImage {
+    return this.clone({ imageId });
   }
 
   withToolManifest(options?: {
@@ -194,5 +203,20 @@ export class SandboxImage {
     };
 
     return this.copy(getContent, destPath);
+  }
+
+  toCreateConfig(): {
+    imageId?: SandboxImageId;
+    envVars?: Record<string, string>;
+    network: NetworkPolicy;
+    resources: SandboxResources;
+  } {
+    return {
+      imageId: this.imageId,
+      envVars:
+        Object.keys(this.runEnv).length > 0 ? { ...this.runEnv } : undefined,
+      network: this.network,
+      resources: this.resources,
+    };
   }
 }

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -113,6 +113,5 @@ export interface ToolManifest {
 // ---------------------------------------------------------------------------
 
 export type BaseImage =
-  | { readonly type: "ubuntu"; readonly version: string }
-  | { readonly type: "template"; readonly id: SandboxImageId }
+  | { readonly type: "sandbox"; readonly id: SandboxImageId }
   | { readonly type: "docker"; readonly imageRef: string };

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -10,6 +10,7 @@
 import type {
   NetworkPolicy,
   SandboxImageId,
+  SandboxResources,
 } from "@app/lib/api/sandbox/image/types";
 import type { Result } from "@app/types/shared/result";
 
@@ -27,14 +28,17 @@ export interface SandboxHandle {
 
 /**
  * Configuration for provisioning a new sandbox.
+ * Flat structure derived from SandboxImage.toCreateConfig() with optional overrides.
  */
 export interface SandboxCreateConfig {
-  /** Typed image identifier (name + tag). */
+  /** Typed image identifier (name + tag) override - E2B specific but exposed for overrides. */
   imageId?: SandboxImageId;
-  /** Environment variables injected at creation time. */
+  /** Environment variables for the sandbox runtime. */
   envVars?: Record<string, string>;
-  /** Network egress policy for the sandbox. */
+  /** Network egress policy. */
   network?: NetworkPolicy;
+  /** Resource allocation for the sandbox. */
+  resources?: SandboxResources;
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -85,9 +85,11 @@ export class E2BSandboxProvider implements SandboxProvider {
 
     let sandbox: Sandbox;
     try {
+      const envVars = config.envVars ?? {};
+      const hasEnvVars = Object.keys(envVars).length > 0;
       sandbox = await Sandbox.create(templateId, {
         ...this.connectionOpts(),
-        envs: config.envVars,
+        envs: hasEnvVars ? envVars : undefined,
         timeoutMs: SANDBOX_LIFETIME_MS,
         requestTimeoutMs: REQUEST_TIMEOUT_MS,
         ...(config.network

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -26,7 +26,7 @@ vi.mock("@app/lib/api/config", () => ({
 }));
 
 // Untyped mock for TemplateBuilder - keeps vi.fn() mock properties accessible
-const mockTemplateBuilder = {
+const mockDockerRegistryBuilder = {
   copy: vi.fn().mockReturnThis(),
   copyItems: vi.fn().mockReturnThis(),
   remove: vi.fn().mockReturnThis(),
@@ -50,18 +50,15 @@ const mockTemplateBuilder = {
   betaSetDevContainerStart: vi.fn().mockReturnThis(),
 };
 
-// Mock for Template() factory (has fromUbuntuImage, fromTemplate, etc.)
+// Mock for Template() factory (has fromTemplate, etc.)
 const mockE2BTemplateFactory = {
-  fromUbuntuImage: vi.fn().mockReturnValue(mockTemplateBuilder),
-  fromTemplate: vi.fn().mockReturnValue(mockTemplateBuilder),
-  fromGCPRegistry: vi.fn().mockReturnValue(mockTemplateBuilder),
+  fromTemplate: vi.fn().mockReturnValue(mockDockerRegistryBuilder),
 };
 
 // Type-safe factory wrapper - the runtime mock satisfies TemplateBuilder interface
 function createMockDockerRegistryFactory(): DockerRegistryFactory {
   return (_imageRef: string): TemplateBuilder => {
-    // The mock has all required methods; return type annotation satisfies TypeScript
-    return mockTemplateBuilder;
+    return mockDockerRegistryBuilder;
   };
 }
 
@@ -90,10 +87,14 @@ describe("buildSandboxImage()", () => {
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockDockerRegistryFactory).toHaveBeenCalled();
-    expect(mockTemplateBuilder.runCmd).toHaveBeenCalled();
-    expect(mockTemplateBuilder.setEnvs).toHaveBeenCalled();
-    expect(mockTemplateBuilder.setWorkdir).toHaveBeenCalledWith("/home/user");
+    expect(mockDockerRegistryFactory).toHaveBeenCalledWith(
+      "dust-sbx-bedrock:latest"
+    );
+    expect(mockDockerRegistryBuilder.runCmd).toHaveBeenCalled();
+    expect(mockDockerRegistryBuilder.setEnvs).toHaveBeenCalled();
+    expect(mockDockerRegistryBuilder.setWorkdir).toHaveBeenCalledWith(
+      "/home/user"
+    );
   });
 
   test("returns templateId from E2B build result", async () => {
@@ -120,7 +121,7 @@ describe("buildSandboxImage()", () => {
     });
 
     expect(mockBuild).toHaveBeenCalledWith(
-      mockTemplateBuilder,
+      mockDockerRegistryBuilder,
       "dust-base_production",
       expect.objectContaining({
         apiKey: "test-api-key",
@@ -153,7 +154,7 @@ describe("buildSandboxImage()", () => {
       dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
-    const runCmdCalls = mockTemplateBuilder.runCmd.mock.calls;
+    const runCmdCalls = mockDockerRegistryBuilder.runCmd.mock.calls;
     const hasNpmInstall = runCmdCalls.some((call: string[]) =>
       call[0].includes("npm install -g")
     );
@@ -168,13 +169,13 @@ describe("buildSandboxImage()", () => {
       _imageRef: string
     ): TemplateBuilder => {
       callOrder.push("fromDockerRegistry");
-      return mockTemplateBuilder;
+      return mockDockerRegistryBuilder;
     };
-    mockTemplateBuilder.setEnvs.mockImplementation(() => {
+    mockDockerRegistryBuilder.setEnvs.mockImplementation(() => {
       callOrder.push("setEnvs");
-      return mockTemplateBuilder;
+      return mockDockerRegistryBuilder;
     });
-    mockTemplateBuilder.runCmd.mockImplementation((cmd: string) => {
+    mockDockerRegistryBuilder.runCmd.mockImplementation((cmd: string) => {
       if (cmd.includes("uv pip install")) {
         callOrder.push("runCmd:pip");
       } else if (cmd.includes("npm install")) {
@@ -184,11 +185,11 @@ describe("buildSandboxImage()", () => {
       } else {
         callOrder.push("runCmd");
       }
-      return mockTemplateBuilder;
+      return mockDockerRegistryBuilder;
     });
-    mockTemplateBuilder.setWorkdir.mockImplementation(() => {
+    mockDockerRegistryBuilder.setWorkdir.mockImplementation(() => {
       callOrder.push("setWorkdir");
-      return mockTemplateBuilder;
+      return mockDockerRegistryBuilder;
     });
 
     await buildSandboxImage(DUST_BASE_IMAGE, TEST_IMAGE_ID, {
@@ -211,7 +212,7 @@ describe("buildSandboxImage()", () => {
       dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
-    const runCmdCalls = mockTemplateBuilder.runCmd.mock.calls;
+    const runCmdCalls = mockDockerRegistryBuilder.runCmd.mock.calls;
     const aptInstallCall = runCmdCalls.find(
       (call: string[]) =>
         call[0].includes("apt-get install") &&
@@ -229,7 +230,7 @@ describe("buildSandboxImage()", () => {
       dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
-    const runCmdCalls = mockTemplateBuilder.runCmd.mock.calls;
+    const runCmdCalls = mockDockerRegistryBuilder.runCmd.mock.calls;
     const pipInstallCall = runCmdCalls.find(
       (call: string[]) =>
         call[0].includes("uv pip install") &&

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -94,10 +94,7 @@ class E2BTemplateBuilder {
     let builder: TemplateBuilder;
 
     switch (baseImage.type) {
-      case "ubuntu":
-        builder = E2BTemplate().fromUbuntuImage(baseImage.version);
-        break;
-      case "template":
+      case "sandbox":
         builder = E2BTemplate().fromTemplate(
           formatSandboxImageId(baseImage.id)
         );

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,4 +1,5 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
+import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
   ExecOptions,
   ExecResult,
@@ -286,7 +287,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       );
 
       if (!existing) {
-        const createResult = await provider.create({});
+        const image = getSandboxImage(auth);
+        const createResult = await provider.create(image.toCreateConfig());
         if (createResult.isErr()) {
           return createResult;
         }
@@ -336,7 +338,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         // Falls through to recreation when wake fails.
 
         case "deleted": {
-          const createResult = await provider.create({});
+          const image = getSandboxImage(auth);
+          const createResult = await provider.create(image.toCreateConfig());
           if (createResult.isErr()) {
             return createResult;
           }


### PR DESCRIPTION
## Description

- rename `setEnv` to `setBuildEnv` to avoid noob traps
- implement `setRunEnv`. had to also add `toCreateConfig` to make it work with our current design
- update codepath that create sandboxes to use the new image.toCreateConfig, along with auth-based image retriever.

Fix https://github.com/dust-tt/tasks/issues/6934

## Tests

- Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front