### PR TITLE
[front] enh: reduce GitHub API rate limits during skill import

### DIFF
--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -186,7 +186,7 @@ export function ImportSkillsDialog({
           }}
           rightButtonProps={{
             label: "Import",
-            disabled: selectedCount === 0,
+            disabled: isImporting || selectedCount === 0,
             isLoading: isImporting,
             onClick: handleImport,
           }}

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -186,7 +186,7 @@ export function ImportSkillsDialog({
           }}
           rightButtonProps={{
             label: "Import",
-            disabled: isImporting || selectedCount === 0,
+            disabled: selectedCount === 0,
             isLoading: isImporting,
             onClick: handleImport,
           }}

--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -131,7 +131,7 @@ export async function detectSkillsFromGitHubRepo({
   accessToken,
 }: {
   repoUrl: string;
-  accessToken?: string;
+  accessToken?: string | null;
 }): Promise<Result<DetectedSkill[], SkillDetectionError>> {
   const parseResult = parseGitHubRepoUrl(repoUrl);
   if (parseResult.isErr()) {

--- a/front/lib/api/skills/github_detection/github_auth.ts
+++ b/front/lib/api/skills/github_detection/github_auth.ts
@@ -13,11 +13,13 @@ import logger from "@app/logger/logger";
 export async function getWorkspaceLevelGitHubAccessToken(
   auth: Authenticator
 ): Promise<string | null> {
-  const connection =
-    await MCPServerConnectionResource.findByInternalServerName(auth, {
+  const connection = await MCPServerConnectionResource.findByInternalServerName(
+    auth,
+    {
       serverName: "github",
       connectionType: "workspace",
-    });
+    }
+  );
 
   if (!connection?.connectionId || !connection.internalMCPServerId) {
     return null;

--- a/front/lib/api/skills/github_detection/github_auth.ts
+++ b/front/lib/api/skills/github_detection/github_auth.ts
@@ -8,7 +8,7 @@ import logger from "@app/logger/logger";
  * Attempts to retrieve a GitHub access token from an existing MCP connection
  * (workspace only). Returns null if no connection is available.
  */
-export async function getGitHubAccessToken(
+export async function getWorkspaceLevelGitHubAccessToken(
   auth: Authenticator
 ): Promise<string | null> {
   const connection = await MCPServerConnectionResource.findByInternalServerName(

--- a/front/lib/api/skills/github_detection/github_auth.ts
+++ b/front/lib/api/skills/github_detection/github_auth.ts
@@ -1,0 +1,46 @@
+import apiConfig from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+
+/**
+ * Attempts to retrieve a GitHub access token from an existing MCP connection
+ * (workspace only). Returns null if no connection is available.
+ */
+export async function getGitHubAccessToken(
+  auth: Authenticator
+): Promise<string | null> {
+  const connection = await MCPServerConnectionResource.findByInternalServerName(
+    auth,
+    {
+      serverName: "github",
+      connectionType: "workspace",
+    }
+  );
+
+  if (connection?.connectionId) {
+    const tokenResult = await getOAuthConnectionAccessToken({
+      config: apiConfig.getOAuthAPIConfig(),
+      logger,
+      connectionId: connection.connectionId,
+    });
+    if (tokenResult.isOk()) {
+      return tokenResult.value.access_token;
+    }
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        error: tokenResult.error,
+      },
+      "Failed to get GitHub access token from existing connection."
+    );
+  }
+
+  logger.info(
+    { workspaceId: auth.getNonNullableWorkspace().sId },
+    "No GitHub connection found; falling back to unauthenticated API calls."
+  );
+
+  return null;
+}

--- a/front/lib/api/skills/github_detection/github_auth.ts
+++ b/front/lib/api/skills/github_detection/github_auth.ts
@@ -2,44 +2,50 @@ import apiConfig from "@app/lib/api/config";
 import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import logger from "@app/logger/logger";
 
 /**
  * Attempts to retrieve a GitHub access token from an existing MCP connection
- * (workspace only). Returns null if no connection is available.
+ * (workspace only). Returns null if no connection is available or if the
+ * GitHub server is not on the global space.
  */
 export async function getWorkspaceLevelGitHubAccessToken(
   auth: Authenticator
 ): Promise<string | null> {
-  const connection = await MCPServerConnectionResource.findByInternalServerName(
-    auth,
-    {
+  const connection =
+    await MCPServerConnectionResource.findByInternalServerName(auth, {
       serverName: "github",
       connectionType: "workspace",
-    }
-  );
-
-  if (connection?.connectionId) {
-    const tokenResult = await getOAuthConnectionAccessToken({
-      config: apiConfig.getOAuthAPIConfig(),
-      logger,
-      connectionId: connection.connectionId,
     });
-    if (tokenResult.isOk()) {
-      return tokenResult.value.access_token;
-    }
-    logger.warn(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        error: tokenResult.error,
-      },
-      "Failed to get GitHub access token from existing connection."
-    );
+
+  if (!connection?.connectionId || !connection.internalMCPServerId) {
+    return null;
   }
 
-  logger.info(
-    { workspaceId: auth.getNonNullableWorkspace().sId },
-    "No GitHub connection found; falling back to unauthenticated API calls."
+  const globalView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(
+    auth,
+    connection.internalMCPServerId
+  );
+  if (!globalView) {
+    return null;
+  }
+
+  const tokenResult = await getOAuthConnectionAccessToken({
+    config: apiConfig.getOAuthAPIConfig(),
+    logger,
+    connectionId: connection.connectionId,
+  });
+  if (tokenResult.isOk()) {
+    return tokenResult.value.access_token;
+  }
+
+  logger.warn(
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      error: tokenResult.error,
+    },
+    "Failed to get GitHub access token from existing connection."
   );
 
   return null;

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -2,6 +2,8 @@ import {
   getServerTypeAndIdFromSId,
   remoteMCPServerNameToSId,
 } from "@app/lib/actions/mcp_helper";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { matchesInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
@@ -179,6 +181,34 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
     return connections.length > 0
       ? new Ok(connections[0])
       : new Err(new DustError("connection_not_found", "Connection not found"));
+  }
+
+  static async findByInternalServerName(
+    auth: Authenticator,
+    {
+      serverName,
+      connectionType,
+    }: {
+      serverName: InternalMCPServerNameType;
+      connectionType: MCPServerConnectionConnectionType;
+    }
+  ): Promise<MCPServerConnectionResource | null> {
+    const connections = await this.baseFetch(auth, {
+      where: {
+        serverType: "internal",
+        connectionType,
+        ...(connectionType === "personal"
+          ? { userId: auth.getNonNullableUser().id }
+          : {}),
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return (
+      connections.find((c) =>
+        matchesInternalMCPServerName(c.internalMCPServerId, serverName)
+      ) ?? null
+    );
   }
 
   static async listByMCPServer(

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -379,6 +379,7 @@ export function useDetectSkillsFromRepo({
     useCallback(
       async (repoUrl: string, signal: AbortSignal) => {
         if (repoUrl === lastDetectedUrl.current) {
+          setDetectError(null);
           return;
         }
         setIsDetecting(true);

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -29,7 +29,7 @@ import { isAPIErrorResponse } from "@app/types/error";
 import { Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
@@ -373,10 +373,14 @@ export function useDetectSkillsFromRepo({
   );
   const [isDetecting, setIsDetecting] = useState(false);
   const [detectError, setDetectError] = useState<string | null>(null);
+  const lastDetectedUrl = useRef<string | null>(null);
 
   const triggerDetect = useDebounceWithAbort(
     useCallback(
       async (repoUrl: string, signal: AbortSignal) => {
+        if (repoUrl === lastDetectedUrl.current) {
+          return;
+        }
         setIsDetecting(true);
         setDetectError(null);
 
@@ -387,13 +391,11 @@ export function useDetectSkillsFromRepo({
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ repoUrl }),
+              signal,
             }
           );
 
-          if (signal.aborted) {
-            return;
-          }
-
+          lastDetectedUrl.current = repoUrl;
           setDetectedSkills(response.skills);
         } catch (err) {
           if (signal.aborted) {

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,4 +1,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/github_detection/detect_skills";
+import { getGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
+import type { DetectedSkillSummary } from "@app/lib/api/skills/github_detection/import_types";
 import {
   detectSkillsFromGitHubRepo,
   isSkillFromGitHubRepo,
@@ -59,7 +62,11 @@ async function handler(
         });
       }
 
-      const result = await detectSkillsFromGitHubRepo({ repoUrl });
+      const accessToken = await getGitHubAccessToken(auth);
+      const result = await detectSkillsFromGitHubRepo({
+        repoUrl,
+        accessToken: accessToken ?? undefined,
+      });
 
       if (result.isErr()) {
         logger.error(

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,6 +1,6 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/github_detection/detect_skills";
-import { getGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
+import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
 import type { DetectedSkillSummary } from "@app/lib/api/skills/github_detection/import_types";
 import {
   detectSkillsFromGitHubRepo,
@@ -62,7 +62,7 @@ async function handler(
         });
       }
 
-      const accessToken = await getGitHubAccessToken(auth);
+      const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
       const result = await detectSkillsFromGitHubRepo({
         repoUrl,
         accessToken: accessToken ?? undefined,

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,7 +1,5 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/github_detection/detect_skills";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
-import type { DetectedSkillSummary } from "@app/lib/api/skills/github_detection/import_types";
 import {
   detectSkillsFromGitHubRepo,
   isSkillFromGitHubRepo,

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,9 +1,9 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
 import {
   detectSkillsFromGitHubRepo,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/github_detection/detect_skills";
+import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { DetectedSkillSummary } from "@app/lib/skill";

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -65,7 +65,7 @@ async function handler(
       const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
       const result = await detectSkillsFromGitHubRepo({
         repoUrl,
-        accessToken: accessToken ?? undefined,
+        accessToken,
       });
 
       if (result.isErr()) {

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -3,7 +3,7 @@ import {
   detectSkillsFromGitHubRepo,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/github_detection/detect_skills";
-import { getGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
+import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -74,7 +74,7 @@ async function handler(
 
       const { repoUrl, names } = bodyValidation.right;
 
-      const accessToken = await getGitHubAccessToken(auth);
+      const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
       const result = await detectSkillsFromGitHubRepo({
         repoUrl,
         accessToken: accessToken ?? undefined,

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -77,7 +77,7 @@ async function handler(
       const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
       const result = await detectSkillsFromGitHubRepo({
         repoUrl,
-        accessToken: accessToken ?? undefined,
+        accessToken,
       });
       if (result.isErr()) {
         logger.error(

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -3,6 +3,7 @@ import {
   detectSkillsFromGitHubRepo,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/github_detection/detect_skills";
+import { getGitHubAccessToken } from "@app/lib/api/skills/github_detection/github_auth";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -73,7 +74,11 @@ async function handler(
 
       const { repoUrl, names } = bodyValidation.right;
 
-      const result = await detectSkillsFromGitHubRepo({ repoUrl });
+      const accessToken = await getGitHubAccessToken(auth);
+      const result = await detectSkillsFromGitHubRepo({
+        repoUrl,
+        accessToken: accessToken ?? undefined,
+      });
       if (result.isErr()) {
         logger.error(
           { error: result.error, workspaceId: owner.sId },


### PR DESCRIPTION
## Description

- In the new flow to import skills from a GitHub repository, the calls to the API are not authenticated.
- This leads to frequent rate limit hits.
- This PR allows using a workspace-level GitHub connection on the global space if there's one to make authenticated calls and benefit from more generous rate limits.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
