### PR TITLE
[front] fix tooltip label on Skills detail sheet

### DIFF
--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -49,7 +49,7 @@ export function SkillDetailsButtonBar({
         {skill.canWrite && (
           <Button
             size="sm"
-            tooltip="Edit agent"
+            tooltip="Edit skill"
             href={getSkillBuilderRoute(owner.sId, skill.sId)}
             variant="outline"
             icon={PencilSquareIcon}


### PR DESCRIPTION
## Description

- Fix the tooltip label on the button to edit a skill from the Skills detail sheet.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
