### PR TITLE
[BYOK] Add isByok to plans

### DIFF
--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -36,6 +36,7 @@ export type EditingPlanType = {
   isWebCrawlerAllowed: boolean;
   isSSOAllowed: boolean;
   isSCIMAllowed: boolean;
+  isByok: boolean;
   maxImagesPerWeek: string | number;
   maxMessages: string | number;
   maxMessagesTimeframe: string;
@@ -61,6 +62,7 @@ export const fromPlanType = (plan: PlanType): EditingPlanType => {
     isSalesforceAllowed: plan.limits.connections.isSalesforceAllowed,
     isSSOAllowed: plan.limits.users.isSSOAllowed,
     isSCIMAllowed: plan.limits.users.isSCIMAllowed,
+    isByok: plan.isByok,
     maxMessages: plan.limits.assistant.maxMessages,
     maxMessagesTimeframe: plan.limits.assistant.maxMessagesTimeframe,
     isDeepDiveAllowed: plan.limits.assistant.isDeepDiveAllowed,
@@ -128,6 +130,7 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
       canUseProduct: true,
     },
     trialPeriodDays: parseMaybeNumber(editingPlan.trialPeriodDays),
+    isByok: editingPlan.isByok,
   };
 };
 
@@ -148,6 +151,7 @@ const getEmptyPlan = (): EditingPlanType => ({
   isWebCrawlerAllowed: false,
   isSSOAllowed: false,
   isSCIMAllowed: false,
+  isByok: false,
   maxImagesPerWeek: "",
   maxMessages: "",
   maxMessagesTimeframe: "day",
@@ -301,6 +305,11 @@ export const PLAN_FIELDS = {
     type: "boolean",
     width: "tiny",
     title: "SCIM",
+  },
+  isByok: {
+    type: "boolean",
+    width: "tiny",
+    title: "BYOK",
   },
   maxVaults: {
     type: "number",

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -71,6 +71,7 @@ function createMockPlan(code: string): PlanType {
       },
       canUseProduct: true,
     },
+    isByok: false,
   };
 }
 

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -41,6 +41,7 @@ export class PlanModel extends BaseModel<PlanModel> {
   declare isManagedSalesforceAllowed: boolean;
   declare isSSOAllowed: boolean;
   declare isSCIMAllowed: boolean;
+  declare isByok: boolean;
   declare maxDataSourcesCount: number;
   declare maxDataSourcesDocumentsCount: number;
   declare maxDataSourcesDocumentsSizeMb: number;
@@ -143,6 +144,10 @@ PlanModel.init(
       defaultValue: false,
     },
     isSCIMAllowed: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    isByok: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -52,6 +52,7 @@ export const FREE_NO_PLAN_DATA: PlanAttributes = {
   maxDataSourcesDocumentsSizeMb: 0,
   trialPeriodDays: 0,
   canUseProduct: false,
+  isByok: false,
 };
 
 /**
@@ -84,6 +85,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
     canUseProduct: false,
+    isByok: false,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,
@@ -110,6 +112,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
     canUseProduct: true,
+    isByok: false,
   },
   {
     code: FREE_TRIAL_PHONE_PLAN_CODE,
@@ -136,6 +139,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 0,
     canUseProduct: true,
+    isByok: false,
   },
 ];
 

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -54,6 +54,7 @@ if (isDevelopment() || isTest()) {
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 14,
     canUseProduct: true,
+    isByok: false,
   });
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_39_CODE,
@@ -80,6 +81,7 @@ if (isDevelopment() || isTest()) {
     maxDataSourcesDocumentsSizeMb: 2,
     trialPeriodDays: 14,
     canUseProduct: true,
+    isByok: false,
   });
 }
 

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -51,6 +51,7 @@ export function renderPlanFromModel({
       canUseProduct: plan.canUseProduct,
     },
     trialPeriodDays: plan.trialPeriodDays,
+    isByok: plan.isByok,
   };
 }
 

--- a/front/migrations/db/migration_533.sql
+++ b/front/migrations/db/migration_533.sql
@@ -1,0 +1,2 @@
+-- Migration created on Mar 05, 2026
+ALTER TABLE "public"."plans" ADD COLUMN "isByok" BOOLEAN DEFAULT false;

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -55,6 +55,7 @@ export const PlanTypeSchema = t.type({
     canUseProduct: t.boolean,
   }),
   trialPeriodDays: t.number,
+  isByok: t.boolean,
 });
 
 export type UpsertPokePlanResponseBody = {
@@ -151,6 +152,7 @@ async function handler(
         maxVaultsInWorkspace: body.limits.vaults.maxVaults,
         trialPeriodDays: body.trialPeriodDays,
         canUseProduct: body.limits.canUseProduct,
+        isByok: body.isByok,
       });
       res.status(200).json({
         plan: body,

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -68,6 +68,7 @@ export type PlanType = {
   name: string;
   limits: LimitsType;
   trialPeriodDays: number;
+  isByok: boolean;
 };
 
 export type SubscriptionType = {


### PR DESCRIPTION
## Description

Adds an `isByok` boolean field to the `Plan` model (default `false`) and exposes it end-to-end: DB migration, Sequelize model, plan renderer, type definition, and Poke UI form.

## Tests

Tested manually via the Poke plans form.

## Risk

Low — additive migration with a safe default (`false`). No existing behaviour changes.

## Deploy Plan

> ⚠️ Additive migration (ADD) — run migration BEFORE deploying

1. Block `front` deployment on #deployments (❌)
2. Merge PR on main
3. On Prodbox (US then EU): `psql $FRONT_DATABASE_URI -f ./migrations/db/migration_533.sql`
4. Deploy `main` on `front`
5. Unlock #deployments (✅)
6. Monitor deployment
