### PR TITLE
[Front] enh(copilot): adapt copilot instructions loading to use caching effectively

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -5,7 +5,11 @@ import {
   constructPromptMultiActions,
 } from "@app/lib/api/assistant/generation";
 import { buildMemoriesContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
-import { globalAgentInjectsMemory } from "@app/lib/api/assistant/global_agents/global_agents";
+import {
+  globalAgentInjectsMemory,
+  globalAgentInjectsUserContext,
+  globalAgentInjectsWorkspaceContext,
+} from "@app/lib/api/assistant/global_agents/global_agents";
 import {
   normalizePrompt,
   systemPromptToText,
@@ -337,6 +341,54 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(context.every((s) => s.role === "context")).toBe(true);
   });
 
+  it("should return tuple with user/workspace context in context block for copilot agent", () => {
+    const copilotConfig = {
+      ...agentConfig1,
+      sId: GLOBAL_AGENTS_SID.COPILOT,
+      scope: "global" as const,
+    };
+
+    const userCtx =
+      "<user_context>\n- Job function: Engineering\n- Preferred platforms: Slack\n</user_context>";
+    const workspaceCtx =
+      "<workspace_context>\n## AVAILABLE MODELS\n1 model available.\n</workspace_context>";
+
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: copilotConfig,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      userContext: userCtx,
+      workspaceContext: workspaceCtx,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+
+    const [instructions, context] = normalizePrompt(sections);
+    expect(instructions).toHaveLength(1);
+    expect(instructions[0].role).toBe("instruction");
+    expect(instructions[0].content).toContain("# INSTRUCTIONS");
+    // User/workspace context must NOT be in the cached instructions block.
+    expect(instructions[0].content).not.toContain("<user_context>");
+    expect(instructions[0].content).not.toContain("<workspace_context>");
+
+    // They must appear in the dynamic context block.
+    const userSection = context.find((s) =>
+      s.content.includes("<user_context>")
+    );
+    expect(userSection).toBeDefined();
+    expect(userSection?.content).toContain("Engineering");
+
+    const wsSection = context.find((s) =>
+      s.content.includes("<workspace_context>")
+    );
+    expect(wsSection).toBeDefined();
+    expect(wsSection?.content).toContain("AVAILABLE MODELS");
+  });
+
   it("should include memoriesContext in prompt output when provided", () => {
     const memoriesContext =
       "<existing_memories>\n- User prefers TypeScript (saved Jan 15, 2025).\n</existing_memories>";
@@ -441,6 +493,43 @@ describe("globalAgentInjectsMemory", () => {
     expect(globalAgentInjectsMemory("my-custom-agent")).toBe(false);
     expect(globalAgentInjectsMemory("random-string")).toBe(false);
     expect(globalAgentInjectsMemory("")).toBe(false);
+  });
+});
+
+describe("globalAgentInjectsUserContext", () => {
+  it("should return true for copilot agents", () => {
+    expect(globalAgentInjectsUserContext(GLOBAL_AGENTS_SID.COPILOT)).toBe(true);
+    expect(globalAgentInjectsUserContext(GLOBAL_AGENTS_SID.COPILOT_EDGE)).toBe(
+      true
+    );
+  });
+
+  it("should return false for non-copilot agents", () => {
+    expect(globalAgentInjectsUserContext(GLOBAL_AGENTS_SID.DUST)).toBe(false);
+    expect(globalAgentInjectsUserContext(GLOBAL_AGENTS_SID.DEEP_DIVE)).toBe(
+      false
+    );
+    expect(globalAgentInjectsUserContext(GLOBAL_AGENTS_SID.GPT4)).toBe(false);
+  });
+});
+
+describe("globalAgentInjectsWorkspaceContext", () => {
+  it("should return true for copilot agents", () => {
+    expect(globalAgentInjectsWorkspaceContext(GLOBAL_AGENTS_SID.COPILOT)).toBe(
+      true
+    );
+    expect(
+      globalAgentInjectsWorkspaceContext(GLOBAL_AGENTS_SID.COPILOT_EDGE)
+    ).toBe(true);
+  });
+
+  it("should return false for non-copilot agents", () => {
+    expect(globalAgentInjectsWorkspaceContext(GLOBAL_AGENTS_SID.DUST)).toBe(
+      false
+    );
+    expect(
+      globalAgentInjectsWorkspaceContext(GLOBAL_AGENTS_SID.DEEP_DIVE)
+    ).toBe(false);
   });
 });
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -404,6 +404,8 @@ export function constructPromptMultiActions(
     equippedSkills,
     memoriesContext,
     toolsetsContext,
+    userContext,
+    workspaceContext,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -418,6 +420,8 @@ export function constructPromptMultiActions(
     equippedSkills: SkillResource[];
     memoriesContext?: string;
     toolsetsContext?: string;
+    userContext?: string;
+    workspaceContext?: string;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -429,6 +433,8 @@ export function constructPromptMultiActions(
   // Only enabled for `deep-dive` and `dust(-x)` agents.
   const hasStaticInstructions =
     agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE ||
+    agentConfiguration.sId === GLOBAL_AGENTS_SID.COPILOT ||
+    agentConfiguration.sId === GLOBAL_AGENTS_SID.COPILOT_EDGE ||
     isDustLikeAgent(agentConfiguration.sId);
 
   const instructionsContent = constructInstructionsSection({
@@ -488,6 +494,8 @@ export function constructPromptMultiActions(
       { role: "context" as const, content: projectContextSection },
       { role: "context" as const, content: memoriesContext ?? "" },
       { role: "context" as const, content: toolsetsContext ?? "" },
+      { role: "context" as const, content: userContext ?? "" },
+      { role: "context" as const, content: workspaceContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
 
     return [
@@ -507,6 +515,8 @@ export function constructPromptMultiActions(
     { role: "context" as const, content: pastedContentSection },
     { role: "context" as const, content: guidelinesSection },
     { role: "context" as const, content: memoriesContext ?? "" },
+    { role: "context" as const, content: userContext ?? "" },
+    { role: "context" as const, content: workspaceContext ?? "" },
   ].filter((s) => s.content.trim() !== "");
 
   return allSections;

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -54,10 +54,10 @@ If it is not clear, ALWAYS ask the user for clarification.
 You should NEVER start building a plan until the user has clearly defined what their goal is for the interaction.
 
 Step 4: Build a plan
-Build a plan based on the \`get_agent_config\` output and user intent. Do not make tool calls yet. 
+Build a plan based on the \`get_agent_config\` output and user intent. Do not make tool calls yet.
 Each of these dimensions work in conjunction to define the agent capabilities: instructions, skills, tools, knowledge, model
 
-You will first need to gather information about the workspace to determine what suggestions to make. You MUST refer to <user_context>, <workspace_context>, and <company_data_guidance>.
+You will first need to gather information about the workspace to determine what suggestions to make. You MUST refer to <context_guidance> and <company_data_guidance>.
 
 Dimensions you MUST consider:
 - Review instructions to determine if the agent is meeting the user intent and properly utilizing the configured capabilities: <instructions_guidance>.
@@ -75,7 +75,7 @@ Do not make suggestions in this step. Those will be based on the information you
 If you are running into ambiguity during execution, ask the user for clarification.
 
 Step 6: Make suggestions (assuming this is the user's intent)
-Lead with the changes that will most effect agent behavior. Skip cosmetic fixes until fundamentals are solid. 
+Lead with the changes that will most effect agent behavior. Skip cosmetic fixes until fundamentals are solid.
 You MUST refer to <instruction_suggestion_formatting> and <suggestion_context> when making suggestions.
 
 Step 7: Respond

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -1,5 +1,6 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
 import type { CopilotContext } from "@app/lib/api/assistant/global_agents/copilot_context";
+
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import type {
   MCPServerViewsForGlobalAgentsMap,
@@ -404,24 +405,18 @@ You CANNOT configure triggers or schedules for the agent. When users ask about s
 Do NOT attempt to handle scheduling through instructions or tools — triggers are a separate configuration outside of what you can suggest.
 </triggers_and_schedules>`,
 
-  workspaceContext: (formatted: string) => `<workspace_context>
-The following capabilities are available in this workspace and can be suggested when building agents.
-You DO NOT need to call list_models, list_skills, or list_tools unless explicitly requested by the user.
+  contextGuidance: `<context_guidance>
+The runtime context includes <user_context> and <workspace_context> tags injected separately.
 
-${formatted}
-</workspace_context>`,
-
-  userContext: (formatted: string) => `<user_context>
-The user building this agent has the following profile:
-${formatted}
-
+<user_context> contains the user's job function and preferred platforms.
 Consider their role and platform preferences when suggesting tools and improvements.
-</user_context>`,
+
+<workspace_context> lists all available models, skills, and tools in this workspace.
+You DO NOT need to call list_models, list_skills, or list_tools unless explicitly requested by the user.
+</context_guidance>`,
 };
 
-export function buildCopilotInstructions(
-  copilotContext: CopilotContext | null
-): string {
+export function buildCopilotInstructions(): string {
   const parts: string[] = [
     COPILOT_INSTRUCTION_SECTIONS.primary,
     COPILOT_INSTRUCTION_SECTIONS.agentWorkflow,
@@ -437,27 +432,8 @@ export function buildCopilotInstructions(
     COPILOT_INSTRUCTION_SECTIONS.triggersAndSchedules,
     COPILOT_INSTRUCTION_SECTIONS.workflowVisualization,
     COPILOT_INSTRUCTION_SECTIONS.responseStyle,
+    COPILOT_INSTRUCTION_SECTIONS.contextGuidance,
   ];
-
-  if (!copilotContext) {
-    return parts.join("\n\n");
-  }
-
-  if (copilotContext.formattedUserContext) {
-    parts.push(
-      COPILOT_INSTRUCTION_SECTIONS.userContext(
-        copilotContext.formattedUserContext
-      )
-    );
-  }
-
-  if (copilotContext.formattedWorkspaceContext) {
-    parts.push(
-      COPILOT_INSTRUCTION_SECTIONS.workspaceContext(
-        copilotContext.formattedWorkspaceContext
-      )
-    );
-  }
 
   return parts.join("\n\n");
 }
@@ -523,7 +499,7 @@ export function _getCopilotGlobalAgent(
 
   const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT);
 
-  const instructions = buildCopilotInstructions(copilotContext);
+  const instructions = buildCopilotInstructions();
 
   return {
     id: -1,

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot_edge.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot_edge.ts
@@ -57,7 +57,7 @@ export function _getCopilotEdgeGlobalAgent(
   const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT_EDGE);
 
   const instructions =
-    langfuseConfig?.instructions || buildCopilotInstructions(copilotContext);
+    langfuseConfig?.instructions || buildCopilotInstructions();
 
   return {
     id: -1,

--- a/front/lib/api/assistant/global_agents/copilot_context.ts
+++ b/front/lib/api/assistant/global_agents/copilot_context.ts
@@ -33,8 +33,6 @@ export interface CopilotContext {
   mcpServerViews: {
     context: MCPServerViewResource;
   } | null;
-  formattedUserContext: string | null;
-  formattedWorkspaceContext: string | null;
   langfuseConfig: LangfusePromptConfig | null;
 }
 
@@ -146,6 +144,29 @@ function formatWorkspaceContext(
   ].join("\n\n");
 }
 
+export async function buildUserContext(
+  auth: Authenticator
+): Promise<string | null> {
+  const userMetadata = await fetchCopilotUserMetadata(auth);
+  const formatted = formatUserContext(userMetadata);
+  if (!formatted) {
+    return null;
+  }
+  return `<user_context>\n${formatted}\n</user_context>`;
+}
+
+export async function buildWorkspaceContext(
+  auth: Authenticator
+): Promise<string> {
+  const [models, skills, tools] = await Promise.all([
+    getAvailableModelsForWorkspace(auth),
+    listAvailableSkills(auth),
+    listAvailableTools(auth),
+  ]);
+  const formatted = formatWorkspaceContext(models, skills, tools);
+  return `<workspace_context>\n${formatted}\n</workspace_context>`;
+}
+
 export async function buildCopilotContext(
   auth: Authenticator,
   agentsIdsToFetch: string[]
@@ -157,31 +178,16 @@ export async function buildCopilotContext(
     return null;
   }
 
-  const [context, userMetadata, models, skills, tools] = await Promise.all([
-    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+  const context =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
       AGENT_COPILOT_CONTEXT_TOOL_NAME
-    ),
-    fetchCopilotUserMetadata(auth),
-    getAvailableModelsForWorkspace(auth),
-    listAvailableSkills(auth),
-    listAvailableTools(auth),
-  ]);
-
-  const formattedUserContext = formatUserContext(userMetadata);
-  const formattedWorkspaceContext = formatWorkspaceContext(
-    models,
-    skills,
-    tools
-  );
+    );
 
   let langfuseConfig: LangfusePromptConfig | null = null;
 
   if (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.COPILOT_EDGE)) {
-    const result = await fetchLangfuseSystemPromptConfig("copilot-edge", {
-      userContext: formattedUserContext ?? "",
-      workspaceContext: formattedWorkspaceContext,
-    });
+    const result = await fetchLangfuseSystemPromptConfig("copilot-edge", {});
     if (result.isErr()) {
       logger.error(
         {
@@ -197,8 +203,6 @@ export async function buildCopilotContext(
 
   return {
     mcpServerViews: context ? { context } : null,
-    formattedUserContext,
-    formattedWorkspaceContext,
     langfuseConfig,
   };
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -105,186 +105,361 @@ import { isDevelopment } from "@app/types/shared/env";
 // cache hit rates. Will be properly refactored if we manage to improve cache hit rates.
 const GLOBAL_AGENT_FLAGS: Record<
   GLOBAL_AGENTS_SID,
-  { injectsMemory: boolean; injectsToolsets: boolean }
+  {
+    injectsMemory: boolean;
+    injectsToolsets: boolean;
+    injectsUserContext: boolean;
+    injectsWorkspaceContext: boolean;
+  }
 > = {
-  [GLOBAL_AGENTS_SID.DUST]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_EDGE]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_EDGE]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.DUST_QUICK]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.DUST_OAI]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_OAI]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.DUST_GOOG]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.DUST_ANT]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_ANT]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.DUST_KIMI]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_KIMI]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_KIMI_HIGH]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.DUST_GLM]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_GLM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_GLM_HIGH]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MINIMAX]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_NEXT]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_NEXT_HIGH]: {
     injectsMemory: true,
     injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.HELPER]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.HELPER]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.DEEP_DIVE]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_TASK]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_PLANNING]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.COPILOT]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.COPILOT]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: true,
+    injectsWorkspaceContext: true,
+  },
   [GLOBAL_AGENTS_SID.COPILOT_EDGE]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: true,
+    injectsWorkspaceContext: true,
   },
-  [GLOBAL_AGENTS_SID.SLACK]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.SLACK]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.GOOGLE_DRIVE]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.NOTION]: { injectsMemory: false, injectsToolsets: false },
-  [GLOBAL_AGENTS_SID.GITHUB]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.NOTION]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.GITHUB]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.INTERCOM]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT35_TURBO]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.GPT4]: { injectsMemory: false, injectsToolsets: false },
-  [GLOBAL_AGENTS_SID.GPT5]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.GPT4]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.GPT5]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.GPT5_THINKING]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT5_NANO]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GPT5_MINI]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.O1]: { injectsMemory: false, injectsToolsets: false },
-  [GLOBAL_AGENTS_SID.O1_MINI]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.O1]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.O1_MINI]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.O1_HIGH_REASONING]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.O3_MINI]: { injectsMemory: false, injectsToolsets: false },
-  [GLOBAL_AGENTS_SID.O3]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.O3_MINI]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.O3]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_4_SONNET]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_OPUS]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_SONNET]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.MISTRAL_LARGE]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.MISTRAL_MEDIUM]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.MISTRAL_SMALL]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.GEMINI_PRO]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DEEPSEEK_R1]: {
     injectsMemory: false,
     injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
-  [GLOBAL_AGENTS_SID.NOOP]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.NOOP]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
 };
 
 export function globalAgentInjectsMemory(sId: string): boolean {
@@ -293,6 +468,16 @@ export function globalAgentInjectsMemory(sId: string): boolean {
 
 export function globalAgentInjectsToolsets(sId: string): boolean {
   return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsToolsets;
+}
+
+export function globalAgentInjectsUserContext(sId: string): boolean {
+  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsUserContext;
+}
+
+export function globalAgentInjectsWorkspaceContext(sId: string): boolean {
+  return (
+    isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsWorkspaceContext
+  );
 }
 
 export function isDustLikeAgent(sId: string): boolean {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -17,8 +17,14 @@ import {
   buildToolsetsContext,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import {
+  buildUserContext,
+  buildWorkspaceContext,
+} from "@app/lib/api/assistant/global_agents/copilot_context";
+import {
   globalAgentInjectsMemory,
   globalAgentInjectsToolsets,
+  globalAgentInjectsUserContext,
+  globalAgentInjectsWorkspaceContext,
 } from "@app/lib/api/assistant/global_agents/global_agents";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
@@ -352,6 +358,16 @@ export async function runModel(
     toolsetsContext = buildToolsetsContext(filteredToolsets);
   }
 
+  let userContext: string | undefined;
+  if (globalAgentInjectsUserContext(agentConfiguration.sId) && auth.user()) {
+    userContext = (await buildUserContext(auth)) ?? undefined;
+  }
+
+  let workspaceContext: string | undefined;
+  if (globalAgentInjectsWorkspaceContext(agentConfiguration.sId)) {
+    workspaceContext = await buildWorkspaceContext(auth);
+  }
+
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -366,6 +382,8 @@ export async function runModel(
     equippedSkills,
     memoriesContext,
     toolsetsContext,
+    userContext,
+    workspaceContext,
   });
 
   const specifications: AgentActionSpecification[] = [];

--- a/front/tests/copilot-evals/lib/config.ts
+++ b/front/tests/copilot-evals/lib/config.ts
@@ -52,6 +52,38 @@ function getMockCopilotContext(): CopilotContext {
   };
 }
 
+// In production, run_model.ts injects <user_context> and <workspace_context> into
+// the dynamic context block. The evals bypass run_model.ts and call the LLM directly,
+// so we append mock context to the instructions to simulate runtime injection.
+const MOCK_WORKSPACE_CONTEXT = [
+  "<workspace_context>",
+  "## AVAILABLE MODELS",
+  "4 models available.",
+  "",
+  "### openai",
+  "- **GPT 4 Turbo** (modelId: gpt-4-turbo): OpenAI's fast, intelligent flagship model (no vision)",
+  "- **GPT 5 Mini** (modelId: gpt-5-mini): OpenAI's fastest model. Designed for quick, everyday tasks (no vision)",
+  "### anthropic",
+  "- **Claude Sonnet 4.5** (modelId: claude-sonnet-4-5-20250929): Claude Sonnet 4.5 (no vision)",
+  "- **Claude Opus 4** (modelId: claude-opus-4-20250514): Claude Opus 4 (no vision)",
+  "",
+  "## AVAILABLE SKILLS",
+  "2 skills available.",
+  "",
+  "- **Web Search** (ID: skill_web_search): Search the web for information",
+  "- **Data Analysis** (ID: skill_data_analysis): Analyze data and generate insights",
+  "",
+  "## AVAILABLE TOOLS",
+  "5 tools available.",
+  "",
+  "- **Slack** (ID: mcp_slack): Read and send Slack messages",
+  "- **Notion** (ID: mcp_notion): Search Notion workspace",
+  "- **GitHub** (ID: mcp_github): Access GitHub repositories",
+  "- **Datadog** (ID: mcp_datadog): Search and query Datadog logs and metrics",
+  "- **JIRA** (ID: mcp_jira): Search and manage JIRA issues and projects",
+  "</workspace_context>",
+].join("\n");
+
 const MOCK_MCP_SERVER_VIEWS: MCPServerViewsForGlobalAgentsMap =
   Object.fromEntries(
     MCP_SERVERS_FOR_GLOBAL_AGENTS.map((name) => [name, null])
@@ -134,9 +166,14 @@ export async function getCopilotConfig(): Promise<{
     }
   }
 
+  const instructions = [
+    copilotConfig.instructions ?? "",
+    MOCK_WORKSPACE_CONTEXT,
+  ].join("\n\n");
+
   return {
     config: {
-      instructions: copilotConfig.instructions ?? "",
+      instructions,
       model: copilotConfig.model,
       tools,
     },

--- a/front/tests/copilot-evals/lib/config.ts
+++ b/front/tests/copilot-evals/lib/config.ts
@@ -3,22 +3,12 @@ import { AGENT_COPILOT_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/a
 import { AGENT_COPILOT_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
 import { _getCopilotGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
 import { _getCopilotEdgeGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot_edge";
-import {
-  type CopilotContext,
-  formatAvailableModels,
-  formatAvailableSkills,
-  formatAvailableTools,
-} from "@app/lib/api/assistant/global_agents/copilot_context";
+import type { CopilotContext } from "@app/lib/api/assistant/global_agents/copilot_context";
 import {
   MCP_SERVERS_FOR_GLOBAL_AGENTS,
   type MCPServerViewsForGlobalAgentsMap,
 } from "@app/lib/api/assistant/global_agents/tools";
-import type {
-  AvailableSkill,
-  AvailableTool,
-} from "@app/lib/api/assistant/workspace_capabilities";
 import { Authenticator } from "@app/lib/auth";
-import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { CopilotConfig } from "@app/tests/copilot-evals/lib/types";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
@@ -55,82 +45,9 @@ const GET_AGENT_CONFIG_SPEC: AgentActionSpecification = {
   },
 };
 
-const MOCK_MODEL_IDS = [
-  "gpt-4-turbo",
-  "gpt-5-mini",
-  "claude-sonnet-4-5-20250929",
-  "claude-opus-4-20250514",
-] as const;
-
-const MOCK_WORKSPACE_SKILLS: AvailableSkill[] = [
-  {
-    sId: "skill_web_search",
-    name: "Web Search",
-    userFacingDescription: null,
-    agentFacingDescription: "Search the web for information",
-    icon: null,
-    toolSIds: [],
-  },
-  {
-    sId: "skill_data_analysis",
-    name: "Data Analysis",
-    userFacingDescription: null,
-    agentFacingDescription: "Analyze data and generate insights",
-    icon: null,
-    toolSIds: [],
-  },
-];
-
-const MOCK_WORKSPACE_TOOLS: AvailableTool[] = [
-  {
-    sId: "mcp_slack",
-    name: "Slack",
-    description: "Read and send Slack messages",
-    serverType: "internal",
-    availability: "manual",
-  },
-  {
-    sId: "mcp_notion",
-    name: "Notion",
-    description: "Search Notion workspace",
-    serverType: "internal",
-    availability: "manual",
-  },
-  {
-    sId: "mcp_github",
-    name: "GitHub",
-    description: "Access GitHub repositories",
-    serverType: "internal",
-    availability: "manual",
-  },
-  {
-    sId: "mcp_datadog",
-    name: "Datadog",
-    description: "Search and query Datadog logs and metrics",
-    serverType: "internal",
-    availability: "manual",
-  },
-  {
-    sId: "mcp_jira",
-    name: "JIRA",
-    description: "Search and manage JIRA issues and projects",
-    serverType: "internal",
-    availability: "manual",
-  },
-];
-
 function getMockCopilotContext(): CopilotContext {
-  const models = MOCK_MODEL_IDS.map((id) => getModelConfigByModelId(id)).filter(
-    (m): m is NonNullable<typeof m> => m != null
-  );
   return {
     mcpServerViews: null,
-    formattedUserContext: null,
-    formattedWorkspaceContext: [
-      formatAvailableModels(models),
-      formatAvailableSkills(MOCK_WORKSPACE_SKILLS),
-      formatAvailableTools(MOCK_WORKSPACE_TOOLS),
-    ].join("\n\n"),
     langfuseConfig: null,
   };
 }


### PR DESCRIPTION
## Description

Copilot agents have ~4000+ words of static code-defined instructions but couldn't benefit from Anthropic's extended prompt caching (1h TTL) because dynamic per-user/workspace data was baked into the instructions string. This separates the dynamic parts so copilot agents use the same `[instructions, context]` tuple form as dust-like agents and deep_dive.

### Approach

Add generic `injectsUserContext`/`injectsWorkspaceContext` flags on `GLOBAL_AGENT_FLAGS` (following the existing `injectsMemory`/`injectsToolsets` pattern), then compute user/workspace context at runtime in `run_model.ts` and pass it into the dynamic context block of `constructPromptMultiActions`.

The copilot instructions now include a static `<context_guidance>` section explaining how to interpret the `<user_context>` and `<workspace_context>` tags that arrive at runtime, instead of embedding the actual data in the instructions.

> [!NOTE]
> The Langfuse prompt template for `copilot-edge` needs a separate manual update to remove `{{userContext}}`/`{{workspaceContext}}` template variables and reference the new generic tags injected at runtime.

## Tests

Output system prompt in langfuse :
<img width="3301" height="2260" alt="image" src="https://github.com/user-attachments/assets/cfd7a773-89e5-4bc4-b74d-991c77fd945f" />
