### PR TITLE
Add a return button in the header when we are in a project conversation

### DIFF
--- a/extension/ui/components/conversation/ConversationLayout.tsx
+++ b/extension/ui/components/conversation/ConversationLayout.tsx
@@ -2,6 +2,7 @@ import { AgentSidebarMenu } from "@app/components/assistant/conversation/Sidebar
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import {
+  ArrowLeftIcon,
   BarHeader,
   Button,
   MenuIcon,
@@ -13,20 +14,24 @@ import {
 import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
 import type React from "react";
 import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface ConversationLayoutProps {
   title: string;
+  backHref?: string;
   rightActions?: React.ReactNode;
   children: React.ReactNode;
 }
 
 export const ConversationLayout = ({
   title,
+  backHref,
   rightActions,
   children,
 }: ConversationLayoutProps) => {
   const { workspace: owner } = useAuth();
   const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
+  const navigate = useNavigate();
 
   return (
     <FileDropProvider>
@@ -48,11 +53,21 @@ export const ConversationLayout = ({
         tooltip={title}
         className="justify-between"
         leftActions={
-          <Button
-            variant="ghost"
-            icon={MenuIcon}
-            onClick={() => setSidebarOpen(true)}
-          />
+          <div className="flex flex-row">
+            <Button
+              variant="ghost"
+              icon={MenuIcon}
+              onClick={() => setSidebarOpen(true)}
+            />
+            {backHref && (
+              <Button
+                variant="ghost"
+                icon={ArrowLeftIcon}
+                onClick={() => navigate(backHref)}
+                tooltip="Go back to project homepage"
+              />
+            )}
+          </div>
         }
         rightActions={rightActions}
       />

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -8,6 +8,7 @@ import { GenerationContextProvider } from "@app/components/assistant/conversatio
 import { useConversation } from "@app/hooks/conversations/useConversation";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { getProjectRoute } from "@app/lib/utils/router";
 import { Button, MoreIcon } from "@dust-tt/sparkle";
 import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
@@ -64,6 +65,11 @@ export const MainPage = () => {
   return (
     <ConversationLayout
       title={headerTitle}
+      backHref={
+        conversation?.spaceId
+          ? getProjectRoute(workspace.sId, conversation.spaceId)
+          : undefined
+      }
       rightActions={
         conversationId ? (
           <ConversationMenu


### PR DESCRIPTION
## Description

Adds a return button in the header when we are in a project conversation.
<img width="817" height="1001" alt="image" src="https://github.com/user-attachments/assets/17126030-d5e2-42ef-937a-0ec8c33e1877" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
