### PR TITLE
feat(front): add sandbox tools API endpoint

### DIFF
--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -76,17 +76,25 @@ async function handler(
 
       // Fetch conversation-jitted servers.
       const conversationResult = await getConversation(auth, cId);
-      if (conversationResult.isOk()) {
-        const conversation = conversationResult.value;
-        const attachments = await listAttachments(auth, { conversation });
-        const { servers: jitServers } = await getJITServers(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-          attachments,
+      if (conversationResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: `Conversation ${cId} not found.`,
+          },
         });
-        for (const srv of jitServers) {
-          viewIds.add(srv.mcpServerViewId);
-        }
+      }
+
+      const conversation = conversationResult.value;
+      const attachments = await listAttachments(auth, { conversation });
+      const { servers: jitServers } = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments,
+      });
+      for (const srv of jitServers) {
+        viewIds.add(srv.mcpServerViewId);
       }
 
       if (viewIds.size === 0) {

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -1,0 +1,133 @@
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getJITServers } from "@app/lib/api/assistant/jit_actions";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import {
+  type SandboxExecTokenPayload,
+  verifySandboxExecToken,
+} from "@app/lib/api/sandbox/access_tokens";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+interface GetSandboxToolsResponseType {
+  serverViews: MCPServerViewType[];
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSandboxToolsResponseType>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET": {
+      const token = req.headers.authorization?.replace("Bearer ", "");
+      if (!token) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "not_authenticated",
+            message:
+              "The request does not have valid authentication credentials.",
+          },
+        });
+      }
+
+      const claims: SandboxExecTokenPayload | null =
+        verifySandboxExecToken(token);
+      if (!claims) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_sandbox_token_error",
+            message: "The sandbox token is invalid or expired.",
+          },
+        });
+      }
+
+      const { aId, cId } = claims;
+
+      // Fetch agent accessible servers.
+      const agentConfig = await getAgentConfiguration(auth, {
+        agentId: aId,
+        variant: "full",
+      });
+      if (!agentConfig) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "agent_configuration_not_found",
+            message: `Agent configuration ${aId} not found.`,
+          },
+        });
+      }
+
+      const viewIds = new Set(
+        agentConfig.actions
+          .filter(isServerSideMCPServerConfiguration)
+          .map((action) => action.mcpServerViewId)
+      );
+
+      // Fetch conversation-jitted servers.
+      const conversationResult = await getConversation(auth, cId);
+      if (conversationResult.isOk()) {
+        const conversation = conversationResult.value;
+        const attachments = await listAttachments(auth, { conversation });
+        const { servers: jitServers } = await getJITServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments,
+        });
+        for (const srv of jitServers) {
+          viewIds.add(srv.mcpServerViewId);
+        }
+      }
+
+      if (viewIds.size === 0) {
+        return res.status(200).json({ serverViews: [] });
+      }
+
+      // Fetch the server views with their tools metadata.
+      const views = await MCPServerViewResource.fetchByIds(auth, [...viewIds]);
+
+      const { server, light } = req.query;
+
+      let serverViews = views.map((view) => view.toJSON());
+
+      // Filter by server name if requested.
+      if (isString(server)) {
+        serverViews = serverViews.filter((sv) => sv.server.name === server);
+      }
+
+      // Strip tool inputSchemas in light mode.
+      if (light === "true") {
+        serverViews = serverViews.map((sv) => ({
+          ...sv,
+          server: {
+            ...sv.server,
+            tools: sv.server.tools.map(({ inputSchema, ...rest }) => rest),
+          },
+        }));
+      }
+
+      return res.status(200).json({ serverViews });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

- Adds GET /api/v1/w/:wId/sandbox/tools endpoint
- Verifies sandbox exec token to extract agent/conversation claims
- Returns MCP server views (workspace-level + JIT servers) available to the agent in a given conversation.

The endpoint takes two query parameters :
- server (string, optional) — filters server views by server name
- light ("true", optional) — when "true", strips inputSchema from tools in the response

Those are mainly to filter the result when calling in the CLI so that the result is more digestible.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested end to end.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front