### PR TITLE
feat(sbx-cli): add tools subcommands

### DIFF
--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -1,5 +1,7 @@
 mod status;
+pub mod tools;
 mod version;
 
 pub use status::cmd_status;
+pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools};
 pub use version::cmd_version;

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,0 +1,210 @@
+use anyhow::bail;
+
+use crate::api::DustApiClient;
+
+pub async fn cmd_exec(
+    client: &DustApiClient,
+    server_name: &str,
+    tool_name: &str,
+    raw_args: &[String],
+) -> anyhow::Result<()> {
+    let views = client.list_tools(Some(server_name), false).await?;
+
+    let view = match views.first() {
+        Some(v) => v,
+        None => bail!("server '{server_name}' not found"),
+    };
+
+    // Validate the tool exists on this server.
+    let tool = view.server.tools.iter().find(|t| t.name == tool_name);
+
+    if tool.is_none() {
+        let available: Vec<&str> = view.server.tools.iter().map(|t| t.name.as_str()).collect();
+        bail!(
+            "tool '{tool_name}' not found on server '{server_name}'. Available tools: {}",
+            available.join(", ")
+        );
+    }
+
+    let arguments = parse_args(raw_args)?;
+
+    let resp = client
+        .call_tool(&view.space_id, &view.s_id, tool_name, arguments)
+        .await?;
+
+    for block in &resp.result.content {
+        if let Some(text) = &block.text {
+            println!("{text}");
+        }
+    }
+
+    if resp.result.is_error {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Parse `--key value` pairs into a JSON object.
+/// Auto-detects numbers, booleans, JSON objects/arrays, and falls back to string.
+fn parse_args(raw: &[String]) -> anyhow::Result<Option<serde_json::Value>> {
+    if raw.is_empty() {
+        return Ok(Some(serde_json::Value::Object(serde_json::Map::new())));
+    }
+
+    let mut map = serde_json::Map::new();
+    let mut i = 0;
+
+    while i < raw.len() {
+        let arg = &raw[i];
+        if !arg.starts_with("--") {
+            bail!("expected --key, got '{arg}'");
+        }
+        let key = arg.trim_start_matches('-').to_string();
+        if key.is_empty() {
+            bail!("empty key in '{arg}'");
+        }
+
+        i += 1;
+        if i >= raw.len() {
+            // Flag without value, treat as true.
+            map.insert(key, serde_json::Value::Bool(true));
+            continue;
+        }
+
+        let val = &raw[i];
+        // If next token looks like another flag, treat current as boolean true.
+        if val.starts_with("--") {
+            map.insert(key, serde_json::Value::Bool(true));
+            continue;
+        }
+
+        map.insert(key, coerce_value(val));
+        i += 1;
+    }
+
+    Ok(Some(serde_json::Value::Object(map)))
+}
+
+fn coerce_value(s: &str) -> serde_json::Value {
+    // Booleans
+    if s == "true" {
+        return serde_json::Value::Bool(true);
+    }
+    if s == "false" {
+        return serde_json::Value::Bool(false);
+    }
+    // Numbers (integer or float)
+    if let Ok(n) = s.parse::<i64>() {
+        return serde_json::Value::Number(n.into());
+    }
+    if let Ok(n) = s.parse::<f64>() {
+        if let Some(num) = serde_json::Number::from_f64(n) {
+            return serde_json::Value::Number(num);
+        }
+    }
+    // JSON object or array
+    if (s.starts_with('{') && s.ends_with('}')) || (s.starts_with('[') && s.ends_with(']')) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(s) {
+            return v;
+        }
+    }
+    // Fallback: string
+    serde_json::Value::String(s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_empty_args() {
+        let result = parse_args(&[])
+            .expect("should parse empty")
+            .expect("should have value");
+        assert_eq!(result, serde_json::Value::Object(serde_json::Map::new()));
+    }
+
+    #[test]
+    fn parse_string_args() {
+        let args = vec![
+            "--name".to_string(),
+            "hello".to_string(),
+            "--city".to_string(),
+            "paris".to_string(),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["name"], "hello");
+        assert_eq!(result["city"], "paris");
+    }
+
+    #[test]
+    fn parse_number_args() {
+        let args = vec!["--count".to_string(), "42".to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["count"], 42);
+    }
+
+    #[test]
+    fn parse_bool_args() {
+        let args = vec!["--verbose".to_string(), "true".to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["verbose"], true);
+    }
+
+    #[test]
+    fn parse_flag_without_value() {
+        let args = vec!["--dry-run".to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["dry-run"], true);
+    }
+
+    #[test]
+    fn parse_json_value() {
+        let args = vec!["--filter".to_string(), r#"{"status":"active"}"#.to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["filter"]["status"], "active");
+    }
+
+    #[test]
+    fn parse_float_args() {
+        let args = vec!["--ratio".to_string(), "3.14".to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        let ratio = result["ratio"].as_f64().expect("should be f64");
+        assert!((ratio - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_consecutive_flags() {
+        let args = vec![
+            "--verbose".to_string(),
+            "--debug".to_string(),
+            "--name".to_string(),
+            "foo".to_string(),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["verbose"], true);
+        assert_eq!(result["debug"], true);
+        assert_eq!(result["name"], "foo");
+    }
+
+    #[test]
+    fn parse_missing_dashes_errors() {
+        let args = vec!["name".to_string(), "hello".to_string()];
+        assert!(parse_args(&args).is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/tools/list_servers.rs
+++ b/cli/dust-sandbox/src/commands/tools/list_servers.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use crate::api::DustApiClient;
+
+pub async fn cmd_list_servers(client: &DustApiClient) -> anyhow::Result<()> {
+    let views = client.list_tools(None, true).await?;
+
+    // Dedup by server sId.
+    let mut seen: HashMap<String, (String, usize)> = HashMap::new(); // sId -> (name, tool_count)
+
+    for view in &views {
+        seen.entry(view.server.s_id.clone())
+            .or_insert_with(|| (view.server.name.clone(), view.server.tools.len()));
+    }
+
+    if seen.is_empty() {
+        println!("No MCP servers found.");
+        return Ok(());
+    }
+
+    let mut servers: Vec<_> = seen.into_values().collect();
+    servers.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (name, tool_count) in &servers {
+        println!("{name}  ({tool_count} tools)");
+    }
+
+    Ok(())
+}

--- a/cli/dust-sandbox/src/commands/tools/list_tools.rs
+++ b/cli/dust-sandbox/src/commands/tools/list_tools.rs
@@ -1,0 +1,59 @@
+use anyhow::bail;
+
+use crate::api::DustApiClient;
+
+pub async fn cmd_list_tools(client: &DustApiClient, server_name: &str) -> anyhow::Result<()> {
+    let views = client.list_tools(Some(server_name), false).await?;
+
+    let view = match views.first() {
+        Some(v) => v,
+        None => bail!("server '{server_name}' not found"),
+    };
+
+    if view.server.tools.is_empty() {
+        println!("No tools found on server '{server_name}'.");
+        return Ok(());
+    }
+
+    for tool in &view.server.tools {
+        println!("{}:", tool.name);
+        if !tool.description.is_empty() {
+            println!("  {}", tool.description);
+        }
+        if let Some(schema) = &tool.input_schema {
+            if let Some(props) = schema.get("properties") {
+                if let Some(obj) = props.as_object() {
+                    let required: Vec<&str> = schema
+                        .get("required")
+                        .and_then(|r| r.as_array())
+                        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+                        .unwrap_or_default();
+
+                    for (prop_name, prop_schema) in obj {
+                        let type_str = prop_schema
+                            .get("type")
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("any");
+                        let req_marker = if required.contains(&prop_name.as_str()) {
+                            " (required)"
+                        } else {
+                            ""
+                        };
+                        let desc = prop_schema
+                            .get("description")
+                            .and_then(|d| d.as_str())
+                            .unwrap_or("");
+                        if desc.is_empty() {
+                            println!("  --{prop_name} <{type_str}>{req_marker}");
+                        } else {
+                            println!("  --{prop_name} <{type_str}>{req_marker}  {desc}");
+                        }
+                    }
+                }
+            }
+        }
+        println!();
+    }
+
+    Ok(())
+}

--- a/cli/dust-sandbox/src/commands/tools/mod.rs
+++ b/cli/dust-sandbox/src/commands/tools/mod.rs
@@ -1,0 +1,7 @@
+mod exec;
+mod list_servers;
+mod list_tools;
+
+pub use exec::cmd_exec;
+pub use list_servers::cmd_list_servers;
+pub use list_tools::cmd_list_tools;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -1,3 +1,4 @@
+mod api;
 mod auth;
 mod commands;
 
@@ -16,6 +17,16 @@ enum Commands {
     Version,
     /// Show sandbox login status
     Status,
+    /// Interact with MCP servers and tools
+    Tools {
+        /// Server name (omit to list all servers)
+        server_name: Option<String>,
+        /// Tool name to execute
+        tool_name: Option<String>,
+        /// Tool arguments as --key value pairs
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 #[tokio::main]
@@ -25,6 +36,20 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::Version => commands::cmd_version(),
         Commands::Status => commands::cmd_status()?,
+        Commands::Tools {
+            server_name,
+            tool_name,
+            args,
+        } => {
+            let client = api::DustApiClient::from_env()?;
+            match (server_name, tool_name) {
+                (None, _) => commands::cmd_list_servers(&client).await?,
+                (Some(server), None) => commands::cmd_list_tools(&client, &server).await?,
+                (Some(server), Some(tool)) => {
+                    commands::cmd_exec(&client, &server, &tool, &args).await?
+                }
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Depends on https://github.com/dust-tt/dust/pull/22639 and https://github.com/dust-tt/dust/pull/22640

Adds CLI commands for listing MCP servers, listing tools on a server, and executing a tool call via the Dust API.

  - Adds tools list-servers command to list available MCP servers
  - Adds tools list-tools command to list tools on a specific server
  - Adds tools exec command to execute a tool call with JSON arguments
  - Wires subcommands into main.rs CLI parser

Used as follow : 

`dsbx tools` list available servers
`dsbx tools gmail` list tools on the gmail server
`dsbx tools gmail get_mails --maxResults 3` get the last 3 emails of the user

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

-