### PR TITLE
[front] fix: hide Frame page header on blog post articles

### DIFF
--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -13,6 +13,7 @@ import { useCookies } from "react-cookie";
 interface PublicFrameRendererProps {
   fileId: string;
   fileName?: string;
+  hideHeader?: boolean;
   shareToken: string;
   workspaceId: string;
   vizUrl: string;
@@ -21,6 +22,7 @@ interface PublicFrameRendererProps {
 export function PublicFrameRenderer({
   fileId,
   fileName,
+  hideHeader = false,
   shareToken,
   workspaceId,
   vizUrl,
@@ -58,12 +60,14 @@ export function PublicFrameRenderer({
 
   return (
     <div className="flex h-full flex-col">
-      <PublicInteractiveContentHeader
-        title={formatFilenameForDisplay(fileName ?? "Frame")}
-        user={user}
-        conversationUrl={conversationUrl}
-        projectUrl={projectUrl}
-      />
+      {!hideHeader && (
+        <PublicInteractiveContentHeader
+          title={formatFilenameForDisplay(fileName ?? "Frame")}
+          user={user}
+          conversationUrl={conversationUrl}
+          projectUrl={projectUrl}
+        />
+      )}
 
       {/* Content */}
       <div className="flex-1 overflow-hidden">

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -10,6 +10,7 @@ interface PublicInteractiveContentContainerProps {
   shareToken: string;
   workspaceId: string;
   vizUrl: string;
+  hideHeader?: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ export function PublicInteractiveContentContainer({
   shareToken,
   workspaceId,
   vizUrl,
+  hideHeader = false,
 }: PublicInteractiveContentContainerProps) {
   const { frameMetadata, isFrameLoading, error } = usePublicFrame({
     shareToken,
@@ -49,6 +51,7 @@ export function PublicInteractiveContentContainer({
             shareToken={shareToken}
             workspaceId={workspaceId}
             vizUrl={vizUrl}
+            hideHeader={hideHeader}
           />
         );
 

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -1,15 +1,24 @@
 import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
 import { formatFilenameForDisplay } from "@app/lib/files";
-import { Head, usePathParam, useSearchParam } from "@app/lib/platform";
+import { Head, usePathParam } from "@app/lib/platform";
 import { useShareFrameMetadata } from "@app/lib/swr/share";
 import { getFaviconPath } from "@app/lib/utils";
 import Custom404 from "@app/pages/404";
 import { Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+
+const ALLOWED_EMBED_PREFIXES = ["https://dust.tt/blog/"];
 
 export function SharedFramePage() {
   const token = usePathParam("token");
-  const hideHeader = useSearchParam("embed") === "true";
+
+  const hideHeader = useMemo(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    const referrer = document.referrer;
+    return ALLOWED_EMBED_PREFIXES.some((prefix) => referrer.startsWith(prefix));
+  }, []);
 
   const { shareMetadata, isShareMetadataLoading, shareMetadataError } =
     useShareFrameMetadata({

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -7,18 +7,22 @@ import Custom404 from "@app/pages/404";
 import { Spinner } from "@dust-tt/sparkle";
 import { useEffect, useMemo } from "react";
 
-const ALLOWED_EMBED_PREFIXES = ["https://dust.tt/blog/"];
+function isEmbeddedFromDustBlog(): boolean {
+  if (typeof window === "undefined" || !document.referrer) {
+    return false;
+  }
+  try {
+    const url = new URL(document.referrer);
+    return url.hostname === "dust.tt" && url.pathname.startsWith("/blog/");
+  } catch {
+    return false;
+  }
+}
 
 export function SharedFramePage() {
   const token = usePathParam("token");
 
-  const hideHeader = useMemo(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-    const referrer = document.referrer;
-    return ALLOWED_EMBED_PREFIXES.some((prefix) => referrer.startsWith(prefix));
-  }, []);
+  const hideHeader = useMemo(() => isEmbeddedFromDustBlog(), []);
 
   const { shareMetadata, isShareMetadataLoading, shareMetadataError } =
     useShareFrameMetadata({

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -1,6 +1,6 @@
 import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
 import { formatFilenameForDisplay } from "@app/lib/files";
-import { Head, usePathParam } from "@app/lib/platform";
+import { Head, usePathParam, useSearchParam } from "@app/lib/platform";
 import { useShareFrameMetadata } from "@app/lib/swr/share";
 import { getFaviconPath } from "@app/lib/utils";
 import Custom404 from "@app/pages/404";
@@ -9,6 +9,7 @@ import { useEffect } from "react";
 
 export function SharedFramePage() {
   const token = usePathParam("token");
+  const hideHeader = useSearchParam("embed") === "true";
 
   const { shareMetadata, isShareMetadataLoading, shareMetadataError } =
     useShareFrameMetadata({
@@ -89,6 +90,7 @@ export function SharedFramePage() {
           shareToken={token}
           workspaceId={shareMetadata.workspaceId}
           vizUrl={shareMetadata.vizUrl}
+          hideHeader={hideHeader}
         />
       </div>
     </>

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -7,22 +7,21 @@ import Custom404 from "@app/pages/404";
 import { Spinner } from "@dust-tt/sparkle";
 import { useEffect, useMemo } from "react";
 
-function isEmbeddedFromDustBlog(): boolean {
-  if (typeof window === "undefined" || !document.referrer) {
-    return false;
-  }
-  try {
-    const url = new URL(document.referrer);
-    return url.hostname === "dust.tt" && url.pathname.startsWith("/blog/");
-  } catch {
-    return false;
-  }
-}
+// Origins from which the share frame is considered as embedded.
+// We hide the header for embedded origins.
+const EMBEDDED_ORIGINS = ["https://dust.tt/blog/"];
 
 export function SharedFramePage() {
   const token = usePathParam("token");
 
-  const hideHeader = useMemo(() => isEmbeddedFromDustBlog(), []);
+  const hideHeader = useMemo(() => {
+    if (typeof window === "undefined" || !document.referrer) {
+      return false;
+    }
+    return EMBEDDED_ORIGINS.some((origin) =>
+      document.referrer.toLowerCase().startsWith(origin)
+    );
+  }, []);
 
   const { shareMetadata, isShareMetadataLoading, shareMetadataError } =
     useShareFrameMetadata({

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -72,6 +72,7 @@ interface DustFrameEmbedProps {
 }
 
 function DustFrameEmbed({ frameUrl }: DustFrameEmbedProps) {
+  const embedUrl = `${frameUrl}?embed=true`;
   return (
     <div
       style={{ maxWidth: "1000px" }}
@@ -79,7 +80,7 @@ function DustFrameEmbed({ frameUrl }: DustFrameEmbedProps) {
     >
       <div className="relative aspect-video w-full">
         <iframe
-          src={frameUrl}
+          src={embedUrl}
           title="Dust Frame"
           className="absolute inset-0 h-full w-full border-none"
           allowFullScreen

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -72,7 +72,9 @@ interface DustFrameEmbedProps {
 }
 
 function DustFrameEmbed({ frameUrl }: DustFrameEmbedProps) {
-  const embedUrl = `${frameUrl}?embed=true`;
+  const url = new URL(frameUrl);
+  url.searchParams.set("embed", "true");
+  const embedUrl = url.toString();
   return (
     <div
       style={{ maxWidth: "1000px" }}

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -72,9 +72,6 @@ interface DustFrameEmbedProps {
 }
 
 function DustFrameEmbed({ frameUrl }: DustFrameEmbedProps) {
-  const url = new URL(frameUrl);
-  url.searchParams.set("embed", "true");
-  const embedUrl = url.toString();
   return (
     <div
       style={{ maxWidth: "1000px" }}
@@ -82,7 +79,7 @@ function DustFrameEmbed({ frameUrl }: DustFrameEmbedProps) {
     >
       <div className="relative aspect-video w-full">
         <iframe
-          src={embedUrl}
+          src={frameUrl}
           title="Dust Frame"
           className="absolute inset-0 h-full w-full border-none"
           allowFullScreen


### PR DESCRIPTION
## Description

- In blog articles we can embed Frames to render them as iframes.
- In this context it would be better to not show the header with the button "Try it yourself"/"Go to conversation".
- This PR allows doing that via a query param.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.