### PR TITLE
feat: use raw body for webhook signature verification

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -836,6 +836,7 @@ async function trigger(command: string, args: parseArgs.ParsedArgs) {
             webhookSource,
             headers,
             body,
+            rawBody: JSON.stringify(body),
           });
           if (result.isErr()) {
             localLogger.error(

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -58,14 +58,14 @@ export function checkSignature({
   algorithm,
   secret,
   headers,
-  body,
+  rawBody,
   provider,
 }: {
   headerName: string | null;
   algorithm: "sha1" | "sha256" | "sha512" | null;
   secret: string;
   headers: Record<string, string>;
-  body: unknown;
+  rawBody: string;
   provider: WebhookProvider | null;
 }): Result<
   void,
@@ -75,7 +75,7 @@ export function checkSignature({
     const verifyRes = FathomClient.verifyWebhook({
       secret,
       headers,
-      body: JSON.stringify(body),
+      body: rawBody,
     });
 
     if (verifyRes.isErr()) {
@@ -108,10 +108,8 @@ export function checkSignature({
     });
   }
 
-  const stringifiedBody = JSON.stringify(body);
-
   const isValid = verifySignature({
-    signedContent: stringifiedBody,
+    signedContent: rawBody,
     secret: secret,
     signature,
     algorithm,
@@ -718,11 +716,13 @@ export async function processWebhookRequest(
     webhookRequest,
     headers,
     body,
+    rawBody,
   }: {
     webhookSource: WebhookSourceResource;
     webhookRequest: WebhookRequestResource;
     headers: Record<string, string>;
     body: Record<string, unknown>;
+    rawBody: string;
   }
 ): Promise<Result<void, Error>> {
   const localLogger = logger.child({
@@ -737,7 +737,7 @@ export async function processWebhookRequest(
       algorithm: webhookSource.signatureAlgorithm,
       secret: webhookSource.secret,
       headers,
-      body,
+      rawBody,
       provider: webhookSource.provider,
     });
 

--- a/front/lib/webhookSource.ts
+++ b/front/lib/webhookSource.ts
@@ -62,24 +62,33 @@ export const verifySignature = ({
     return false;
   }
 
-  const expectedSignature = `${algorithm}=${createHmac(algorithm, secret)
+  // Try "{algorithm}={hex}" format first (GitHub-style).
+  const prefixedHex = `${algorithm}=${createHmac(algorithm, secret)
     .update(signedContent, "utf8")
     .digest("hex")}`;
+  if (safeCompare(signature, prefixedHex)) {
+    return true;
+  }
 
-  // timingSafeEqual requires buffers of equal length
-  // Return false immediately if it throws an error
+  // Try raw base64 format (HelpScout, etc.).
+  const rawBase64 = createHmac(algorithm, secret)
+    .update(signedContent, "utf8")
+    .digest("base64");
+  if (safeCompare(signature, rawBase64)) {
+    return true;
+  }
+
+  return false;
+};
+
+function safeCompare(a: string, b: string): boolean {
   try {
-    const isValid = timingSafeEqual(
-      Buffer.from(signature),
-      Buffer.from(expectedSignature)
-    );
-    return isValid;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-  } catch (e) {
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    // Length mismatch.
     return false;
   }
-};
+}
 
 export const buildWebhookUrl = ({
   apiBaseUrl,

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -4,6 +4,14 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
 import { describe, expect, it, vi } from "vitest";
 
+// Mock raw-body to return JSON.stringify(req.body) — the handler disables
+// Next.js body parsing and reads the stream via getRawBody.
+vi.mock("raw-body", () => ({
+  default: vi.fn(async (req: { body: unknown }) =>
+    Buffer.from(JSON.stringify(req.body))
+  ),
+}));
+
 // Shallowly mock file content fragment creation to avoid touching storage.
 vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
   toFileContentFragment: vi.fn(async () => ({
@@ -50,9 +58,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       webhookSourceUrlSecret: webhookSource.urlSecret,
     };
     req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "application/json",
-    };
+    req.headers["content-type"] = "application/json";
 
     await handler(req, res);
 
@@ -77,9 +83,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       webhookSourceUrlSecret: "any-secret",
     };
     req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "application/json",
-    };
+    req.headers["content-type"] = "application/json";
 
     await handler(req, res);
 
@@ -115,10 +119,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       webhookSourceId: "webhook_source/whatever",
       webhookSourceUrlSecret: "any-secret",
     };
-    req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "text/plain",
-    };
+    req.headers["content-type"] = "text/plain";
 
     await handler(req, res);
 
@@ -149,9 +150,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       webhookSourceUrlSecret: "invalid-secret", // Using wrong secret
     };
     req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "application/json",
-    };
+    req.headers["content-type"] = "application/json";
 
     await handler(req, res);
 
@@ -182,9 +181,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       // Missing webhookSourceUrlSecret parameter (it will be undefined)
     };
     req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "application/json",
-    };
+    req.headers["content-type"] = "application/json";
 
     await handler(req, res);
 
@@ -219,9 +216,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       webhookSourceUrlSecret: customUrlSecret, // Using the correct secret
     };
     req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "application/json",
-    };
+    req.headers["content-type"] = "application/json";
 
     await handler(req, res);
 
@@ -240,9 +235,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
       webhookSourceUrlSecret: undefined,
     };
     req.body = { any: "payload" };
-    req.headers = {
-      "content-type": "application/json",
-    };
+    req.headers["content-type"] = "application/json";
 
     await handler(req, res);
 
@@ -293,10 +286,8 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
         login: "octocat",
       },
     };
-    req.headers = {
-      "content-type": "application/json",
-      "x-github-event": "pull_request", // This is the GitHub event header
-    };
+    req.headers["content-type"] = "application/json";
+    req.headers["x-github-event"] = "pull_request"; // This is the GitHub event header
 
     await handler(req, res);
 

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -14,6 +14,7 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { PostWebhookTriggerResponseType } from "@dust-tt/client";
 import type { NextApiResponse } from "next";
+import getRawBody from "raw-body";
 
 /**
  * @swagger
@@ -57,9 +58,7 @@ import type { NextApiResponse } from "next";
 
 export const config = {
   api: {
-    bodyParser: {
-      sizeLimit: "2mb",
-    },
+    bodyParser: false,
   },
 };
 
@@ -68,7 +67,7 @@ async function handler(
 
   res: NextApiResponse<WithAPIErrorResponse<PostWebhookTriggerResponseType>>
 ): Promise<void> {
-  const { method, body, headers, query } = req;
+  const { method, headers, query } = req;
 
   if (method !== "POST") {
     return apiError(req, res, {
@@ -87,6 +86,22 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message: "Content-Type must be application/json.",
+      },
+    });
+  }
+
+  // Read the raw body for signature verification (must match exactly what the
+  // sender signed), then parse JSON for processing.
+  const rawBody = (await getRawBody(req, { limit: "2mb" })).toString("utf8");
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(rawBody) as Record<string, unknown>;
+  } catch {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid JSON body.",
       },
     });
   }
@@ -182,6 +197,7 @@ async function handler(
     webhookRequest,
     headers: filteredHeaders,
     body,
+    rawBody,
   });
 
   if (result.isErr()) {

--- a/front/tests/lib/webhookSource.test.ts
+++ b/front/tests/lib/webhookSource.test.ts
@@ -1,0 +1,129 @@
+import { verifySignature } from "@app/lib/webhookSource";
+import { createHmac } from "crypto";
+import { describe, expect, test } from "vitest";
+
+describe("verifySignature", function () {
+  const secret = "my-webhook-secret";
+  const body = JSON.stringify({ action: "created", id: 42 });
+
+  // A raw body with formatting that differs from JSON.stringify output,
+  // simulating what a real provider like HelpScout would send.
+  const rawBodyWithWhitespace = '{ "action": "created",  "id": 42 }';
+
+  test("accepts prefixed hex signature (GitHub-style)", function () {
+    const sig = `sha256=${createHmac("sha256", secret).update(body, "utf8").digest("hex")}`;
+
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret,
+        signature: sig,
+        algorithm: "sha256",
+      })
+    ).toBe(true);
+  });
+
+  test("accepts raw base64 signature (HelpScout-style, sha1)", function () {
+    const sig = createHmac("sha1", secret)
+      .update(body, "utf8")
+      .digest("base64");
+
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret,
+        signature: sig,
+        algorithm: "sha1",
+      })
+    ).toBe(true);
+  });
+
+  test("accepts raw base64 signature (sha256)", function () {
+    const sig = createHmac("sha256", secret)
+      .update(body, "utf8")
+      .digest("base64");
+
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret,
+        signature: sig,
+        algorithm: "sha256",
+      })
+    ).toBe(true);
+  });
+
+  test("verifies against raw body, not re-serialized JSON", function () {
+    const sig = createHmac("sha1", secret)
+      .update(rawBodyWithWhitespace, "utf8")
+      .digest("base64");
+
+    // Passes when signedContent is the raw body.
+    expect(
+      verifySignature({
+        signedContent: rawBodyWithWhitespace,
+        secret,
+        signature: sig,
+        algorithm: "sha1",
+      })
+    ).toBe(true);
+
+    // Fails when signedContent is the re-serialized body (whitespace differs).
+    expect(
+      verifySignature({
+        signedContent: JSON.stringify(JSON.parse(rawBodyWithWhitespace)),
+        secret,
+        signature: sig,
+        algorithm: "sha1",
+      })
+    ).toBe(false);
+  });
+
+  test("rejects wrong secret", function () {
+    const sig = createHmac("sha256", "wrong-secret")
+      .update(body, "utf8")
+      .digest("base64");
+
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret,
+        signature: sig,
+        algorithm: "sha256",
+      })
+    ).toBe(false);
+  });
+
+  test("rejects empty signature", function () {
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret,
+        signature: "",
+        algorithm: "sha256",
+      })
+    ).toBe(false);
+  });
+
+  test("rejects empty secret", function () {
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret: "",
+        signature: "sha256=abc",
+        algorithm: "sha256",
+      })
+    ).toBe(false);
+  });
+
+  test("rejects garbage signature", function () {
+    expect(
+      verifySignature({
+        signedContent: body,
+        secret,
+        signature: "not-a-valid-signature",
+        algorithm: "sha256",
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/6922

Use the raw HTTP body (instead of re-serialized JSON) for webhook signature verification, fixing providers like HelpScout whose signatures don't survive a `JSON.parse` → `JSON.stringify` round-trip

Add support for raw base64 HMAC signatures (HelpScout-style) alongside the existing `{algorithm}={hex}` format (GitHub-style)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front