### PR TITLE
[LLM] Test omitted thinking display via direct Anthropic API

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -1,6 +1,7 @@
-import Anthropic, { APIError } from "@anthropic-ai/sdk";
+import Anthropic from "@anthropic-ai/sdk";
 import type { MessageCountTokensParams } from "@anthropic-ai/sdk/resources";
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
 
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
@@ -18,7 +19,6 @@ import {
   toMessage,
   toTool,
 } from "@app/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic";
-import { handleError } from "@app/lib/api/llm/clients/anthropic/utils/errors";
 import { LLM } from "@app/lib/api/llm/llm";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -30,8 +30,13 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { untrustedFetch } from "@app/lib/egress/server";
+import logger from "@app/logger/logger";
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import type { WorkspaceType } from "@app/types/user";
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_VERSION = "2023-06-01";
 
 /**
  * Maps prompt sections to Anthropic system blocks.
@@ -70,8 +75,38 @@ function buildSystemBlocks(
   return system;
 }
 
+async function* parseSSEStream(
+  body: AsyncIterable<Uint8Array>
+): AsyncGenerator<BetaRawMessageStreamEvent> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const data = line.slice(6).trim();
+        if (data === "[DONE]") {
+          continue;
+        }
+        const event = JSON.parse(data);
+        // The SDK silently filters non-message events (e.g. "ping") before
+        // yielding them. We must do the same to avoid hitting assertNever.
+        if (event.type === "ping") {
+          continue;
+        }
+        yield event as BetaRawMessageStreamEvent;
+      }
+    }
+  }
+}
+
 export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   private client: Anthropic;
+  private apiKey: string;
   private workspace: WorkspaceType;
 
   constructor(
@@ -87,10 +122,8 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       );
     }
 
-    this.client = new Anthropic({
-      apiKey: ANTHROPIC_API_KEY,
-    });
-
+    this.apiKey = ANTHROPIC_API_KEY;
+    this.client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
     this.workspace = auth.getNonNullableWorkspace();
   }
 
@@ -148,7 +181,34 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     payload: BetaMessageStreamParams
   ): AsyncGenerator<LLMEvent> {
     try {
-      const events = this.client.beta.messages.stream(payload);
+      const { betas, ...body } = payload;
+
+      const response = await untrustedFetch(ANTHROPIC_API_URL, {
+        method: "POST",
+        headers: {
+          "x-api-key": this.apiKey,
+          "anthropic-version": ANTHROPIC_API_VERSION,
+          "content-type": "application/json",
+          ...(betas?.length ? { "anthropic-beta": betas.join(",") } : {}),
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        const message =
+          (errorBody as { error?: { message?: string } })?.error?.message ??
+          `HTTP ${response.status}`;
+        logger.error(
+          { status: response.status, errorBody },
+          "AnthropicLLM: HTTP error from Anthropic API"
+        );
+        throw Object.assign(new Error(message), { status: response.status });
+      }
+
+      if (!response.body) {
+        throw new Error("No response body");
+      }
 
       const shouldCountReasoningTokens =
         this.reasoningEffort !== "none" &&
@@ -160,13 +220,14 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
             this.client.messages.countTokens(body)
         : undefined;
 
-      yield* streamLLMEvents(events, this.metadata, countTokens);
+      yield* streamLLMEvents(
+        parseSSEStream(response.body),
+        this.metadata,
+        countTokens
+      );
     } catch (err) {
-      if (err instanceof APIError) {
-        yield handleError(err, this.metadata);
-      } else {
-        yield handleGenericError(err, this.metadata);
-      }
+      logger.error({ err }, "AnthropicLLM: sendRequest error");
+      yield handleGenericError(err, this.metadata);
     }
   }
 }

--- a/front/lib/api/llm/clients/anthropic/utils/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.test.ts
@@ -69,7 +69,7 @@ describe("toThinkingConfig", () => {
 describe("toAutoThinkingConfig", () => {
   it("returns adaptive thinking when reasoning effort is null", () => {
     expect(toAutoThinkingConfig(null)).toEqual({
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "omitted" },
     });
   });
 
@@ -87,7 +87,7 @@ describe("toAutoThinkingConfig", () => {
 
   it('returns adaptive thinking with output_config for "medium"', () => {
     expect(toAutoThinkingConfig("medium")).toEqual({
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "omitted" },
       output_config: {
         effort: ANTHROPIC_THINKING_EFFORT_MAPPING.medium,
       },
@@ -96,7 +96,7 @@ describe("toAutoThinkingConfig", () => {
 
   it('returns adaptive thinking with output_config for "high"', () => {
     expect(toAutoThinkingConfig("high")).toEqual({
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "omitted" },
       output_config: {
         effort: ANTHROPIC_THINKING_EFFORT_MAPPING.high,
       },

--- a/front/lib/api/llm/clients/anthropic/utils/index.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.ts
@@ -49,7 +49,8 @@ export function toAutoThinkingConfig(
 
   switch (reasoningEffort) {
     case null:
-      return { thinking: { type: "adaptive" } };
+      // @ts-ignore - display: "omitted" is not yet in the SDK types
+      return { thinking: { type: "adaptive", display: "omitted" } };
     case "none":
       return { thinking: { type: "disabled" } };
     case "light":
@@ -58,6 +59,8 @@ export function toAutoThinkingConfig(
       return {
         thinking: {
           type: "adaptive",
+          // @ts-ignore - display: "omitted" is not yet in the SDK types
+          display: "omitted",
         },
         output_config: {
           effort: ANTHROPIC_THINKING_EFFORT_MAPPING[reasoningEffort],


### PR DESCRIPTION
## Description

Experimental spike to test `display: "omitted"` on adaptive thinking, a feature not yet available in the Anthropic SDK types. Bypasses the SDK for the streaming call using `untrustedFetch` directly against the Anthropic messages endpoint, which lets us send the `display: "omitted"` field without SDK type constraints. Adds a raw SSE parser that filters non-message keepalive events before feeding into the existing `streamLLMEvents` pipeline.

**Not intended to be merged.**

## Tests

Tested manually end-to-end: confirmed streaming works and thinking tokens are omitted from the response.

## Risk

Low — changes are scoped to the Anthropic LLM client only.

## Deploy Plan

- Standard deploy, no migration needed