### PR TITLE
[front] enh: refine error codes for skill detection

### DIFF
--- a/front/lib/api/skills/github_detection/detect_skills.ts
+++ b/front/lib/api/skills/github_detection/detect_skills.ts
@@ -58,7 +58,7 @@ async function fetchRepoTree(
       });
     }
     return new Err({
-      type: "api_error",
+      type: "github_api_error",
       message: `Failed to fetch repository tree: ${error.message}`,
     });
   }
@@ -66,7 +66,7 @@ async function fetchRepoTree(
   const parsed = GitHubTreeResponseSchema.safeParse(rawData);
   if (!parsed.success) {
     return new Err({
-      type: "api_error",
+      type: "github_api_error",
       message: `Invalid tree response from GitHub: ${parsed.error.message}`,
     });
   }
@@ -105,7 +105,7 @@ async function fetchBlobContent(
     rawData = response.data;
   } catch (err) {
     return new Err({
-      type: "api_error",
+      type: "github_api_error",
       message: `Failed to fetch blob: ${normalizeError(err).message}`,
     });
   }
@@ -113,7 +113,7 @@ async function fetchBlobContent(
   const parsed = GitHubBlobResponseSchema.safeParse(rawData);
   if (!parsed.success) {
     return new Err({
-      type: "api_error",
+      type: "github_api_error",
       message: `Invalid blob response from GitHub: ${parsed.error.message}`,
     });
   }

--- a/front/lib/api/skills/github_detection/parsing.ts
+++ b/front/lib/api/skills/github_detection/parsing.ts
@@ -36,14 +36,14 @@ export function parseGitHubRepoUrl(
     url = new URL(normalized);
   } catch {
     return new Err({
-      type: "not_found",
+      type: "invalid_url",
       message: `Invalid GitHub repository identifier: "${input}". Expected "owner/repo".`,
     });
   }
 
   if (url.hostname !== "github.com") {
     return new Err({
-      type: "not_found",
+      type: "invalid_url",
       message: `Unsupported hostname "${url.hostname}". Only github.com repositories are supported.`,
     });
   }
@@ -56,7 +56,7 @@ export function parseGitHubRepoUrl(
 
   if (segments.length < 2 || !segments[0] || !segments[1]) {
     return new Err({
-      type: "not_found",
+      type: "invalid_url",
       message: `Invalid GitHub repository identifier: "${input}". Expected "owner/repo".`,
     });
   }

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -14,6 +14,7 @@ export interface DetectedSkill {
 }
 
 export type SkillDetectionError =
+  | { type: "invalid_url"; message: string }
   | { type: "auth_error"; message: string }
   | { type: "not_found"; message: string }
   | { type: "api_error"; message: string };

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -13,10 +13,11 @@ export interface DetectedSkill {
   attachments: DetectedSkillAttachment[];
 }
 
-export type SkillDetectionError = {
-  type: "invalid_url" | "auth_error" | "not_found" | "api_error";
-  message: string;
-};
+export type SkillDetectionError =
+  | { type: "invalid_url"; message: string }
+  | { type: "auth_error"; message: string }
+  | { type: "not_found"; message: string }
+  | { type: "github_api_error"; message: string };
 
 export interface SkillDirectory {
   dirPath: string;

--- a/front/lib/api/skills/github_detection/types.ts
+++ b/front/lib/api/skills/github_detection/types.ts
@@ -13,11 +13,10 @@ export interface DetectedSkill {
   attachments: DetectedSkillAttachment[];
 }
 
-export type SkillDetectionError =
-  | { type: "invalid_url"; message: string }
-  | { type: "auth_error"; message: string }
-  | { type: "not_found"; message: string }
-  | { type: "api_error"; message: string };
+export type SkillDetectionError = {
+  type: "invalid_url" | "auth_error" | "not_found" | "api_error";
+  message: string;
+};
 
 export interface SkillDirectory {
   dirPath: string;

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -60,7 +60,8 @@ async function handler(
       const result = await detectSkillsFromGitHubRepo({ repoUrl });
 
       if (result.isErr()) {
-        const error = result.error;
+        const { error } = result;
+
         switch (error.type) {
           case "invalid_url":
             return apiError(req, res, {
@@ -92,7 +93,7 @@ async function handler(
               "Error detecting skills from GitHub repo"
             );
             return apiError(req, res, {
-              status_code: 400,
+              status_code: 500,
               api_error: {
                 type: "invalid_request_error",
                 message: error.message,

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -87,7 +87,7 @@ async function handler(
                 message: error.message,
               },
             });
-          case "api_error":
+          case "github_api_error":
             logger.error(
               { error, workspaceId: owner.sId },
               "Error detecting skills from GitHub repo"

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -7,6 +7,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -59,17 +60,47 @@ async function handler(
       const result = await detectSkillsFromGitHubRepo({ repoUrl });
 
       if (result.isErr()) {
-        logger.error(
-          { error: result.error, workspaceId: owner.sId },
-          "Error detecting skills from GitHub repo"
-        );
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: result.error.message,
-          },
-        });
+        const error = result.error;
+        switch (error.type) {
+          case "invalid_url":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "auth_error":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "api_error":
+            logger.error(
+              { error, workspaceId: owner.sId },
+              "Error detecting skills from GitHub repo"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: error.message,
+              },
+            });
+          default:
+            assertNever(error);
+        }
       }
 
       const detectedSkills = result.value;

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -80,7 +80,7 @@ async function handler(
             });
           case "auth_error":
             return apiError(req, res, {
-              status_code: 400,
+              status_code: 401,
               api_error: {
                 type: "invalid_request_error",
                 message: error.message,
@@ -92,9 +92,9 @@ async function handler(
               "Error detecting skills from GitHub repo"
             );
             return apiError(req, res, {
-              status_code: 500,
+              status_code: 400,
               api_error: {
-                type: "internal_server_error",
+                type: "invalid_request_error",
                 message: error.message,
               },
             });

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -8,6 +8,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -71,17 +72,47 @@ async function handler(
 
       const result = await detectSkillsFromGitHubRepo({ repoUrl });
       if (result.isErr()) {
-        logger.error(
-          { error: result.error, workspaceId: owner.sId },
-          "Error detecting skills from GitHub repo during import"
-        );
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: result.error.message,
-          },
-        });
+        const error = result.error;
+        switch (error.type) {
+          case "invalid_url":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "auth_error":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "api_error":
+            logger.error(
+              { error, workspaceId: owner.sId },
+              "Error detecting skills from GitHub repo during import"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: error.message,
+              },
+            });
+          default:
+            assertNever(error);
+        }
       }
 
       const requestedNames = new Set(names);

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -92,7 +92,7 @@ async function handler(
             });
           case "auth_error":
             return apiError(req, res, {
-              status_code: 400,
+              status_code: 401,
               api_error: {
                 type: "invalid_request_error",
                 message: error.message,
@@ -104,9 +104,9 @@ async function handler(
               "Error detecting skills from GitHub repo during import"
             );
             return apiError(req, res, {
-              status_code: 500,
+              status_code: 400,
               api_error: {
-                type: "internal_server_error",
+                type: "invalid_request_error",
                 message: error.message,
               },
             });

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -98,13 +98,13 @@ async function handler(
                 message: error.message,
               },
             });
-          case "api_error":
+          case "github_api_error":
             logger.error(
               { error, workspaceId: owner.sId },
               "Error detecting skills from GitHub repo during import"
             );
             return apiError(req, res, {
-              status_code: 400,
+              status_code: 500,
               api_error: {
                 type: "invalid_request_error",
                 message: error.message,


### PR DESCRIPTION
## Description

- This PR improves the error codes of the GitHub skill detection endpoint.
- We used to return 500 on various kinds of error.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
