### PR TITLE
[front] - refactor(SkilBuilder): instructions editor

### DIFF
--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -1,0 +1,96 @@
+import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
+import { cn } from "@dust-tt/sparkle";
+import { Placeholder } from "@tiptap/extensions";
+import type { Transaction } from "@tiptap/pm/state";
+import type { Editor, Extensions } from "@tiptap/react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { useEffect, useMemo, useRef } from "react";
+
+function buildSkillDescriptionExtensions(): Extensions {
+  return [
+    StarterKit.configure({
+      blockquote: false,
+      horizontalRule: false,
+      strike: false,
+      heading: false,
+      bulletList: false,
+      orderedList: false,
+      listItem: false,
+      codeBlock: false,
+      code: false,
+    }),
+    AgentInstructionDiffExtension,
+    Placeholder.configure({
+      placeholder:
+        "When should this skill be used? What is this skill good for?",
+      emptyNodeClass:
+        "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+    }),
+  ];
+}
+
+interface UseSkillDescriptionEditorProps {
+  content: string;
+  onUpdate?: (props: { editor: Editor; transaction: Transaction }) => void;
+  onBlur?: () => void;
+}
+
+export function useSkillDescriptionEditor({
+  content,
+  onUpdate,
+  onBlur,
+}: UseSkillDescriptionEditorProps) {
+  const extensions = useMemo(() => buildSkillDescriptionExtensions(), []);
+
+  const initialContentSetRef = useRef(false);
+
+  const editor = useEditor(
+    {
+      extensions,
+      editable: true,
+      immediatelyRender: false,
+      onUpdate,
+      onBlur,
+    },
+    [extensions]
+  );
+
+  // Set initial content after editor is created.
+  useEffect(() => {
+    if (
+      editor &&
+      content &&
+      !initialContentSetRef.current &&
+      !editor.isDestroyed
+    ) {
+      requestAnimationFrame(() => {
+        if (editor && !editor.isDestroyed) {
+          editor.commands.setContent(`<p>${content}</p>`, {
+            emitUpdate: false,
+          });
+          initialContentSetRef.current = true;
+        }
+      });
+    }
+  }, [editor, content]);
+
+  return { editor };
+}
+
+interface SkillDescriptionEditorContentProps {
+  editor: Editor | null;
+  className?: string;
+}
+
+export function SkillDescriptionEditorContent({
+  editor,
+  className,
+}: SkillDescriptionEditorContentProps) {
+  return (
+    <EditorContent
+      editor={editor}
+      className={cn(className, "leading-7 text-base")}
+    />
+  );
+}

--- a/front/components/editor/editorStyles.ts
+++ b/front/components/editor/editorStyles.ts
@@ -1,0 +1,31 @@
+import { cva } from "class-variance-authority";
+
+export const editorVariants = cva(
+  [
+    "overflow-auto border rounded-xl px-3 pt-2 pb-8 resize-y",
+    "transition-all duration-200",
+    "bg-muted-background dark:bg-muted-background-night",
+  ],
+  {
+    variants: {
+      error: {
+        true: [
+          "border-border-warning/30 dark:border-border-warning-night/60",
+          "ring-warning/0 dark:ring-warning-night/0",
+          "focus-visible:border-border-warning dark:focus-visible:border-border-warning-night",
+          "focus-visible:outline-none focus-visible:ring-2",
+          "focus-visible:ring-warning/10 dark:focus-visible:ring-warning/30",
+        ],
+        false: [
+          "border-border dark:border-border-night",
+          "focus:ring-highlight-300 dark:focus:ring-highlight-300-night",
+          "focus:outline-highlight-200 dark:focus:outline-highlight-200-night",
+          "focus:border-highlight-300 dark:focus:border-highlight-300-night",
+        ],
+      },
+    },
+    defaultVariants: {
+      error: false,
+    },
+  }
+);

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,3 +1,4 @@
+import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import {
@@ -7,9 +8,9 @@ import {
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
-import { cva } from "class-variance-authority";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
@@ -39,35 +40,7 @@ function toAttachedKnowledge(
   }));
 }
 
-const editorVariants = cva(
-  [
-    "overflow-auto border rounded-xl px-3 pt-2 pb-8 resize-y min-h-60 max-h-[1024px]",
-    "transition-all duration-200",
-    "bg-muted-background dark:bg-muted-background-night",
-  ],
-  {
-    variants: {
-      error: {
-        true: [
-          "border-border-warning/30 dark:border-border-warning-night/60",
-          "ring-warning/0 dark:ring-warning-night/0",
-          "focus-visible:border-border-warning dark:focus-visible:border-border-warning-night",
-          "focus-visible:outline-none focus-visible:ring-2",
-          "focus-visible:ring-warning/10 dark:focus-visible:ring-warning/30",
-        ],
-        false: [
-          "border-border dark:border-border-night",
-          "focus:ring-highlight-300 dark:focus:ring-highlight-300-night",
-          "focus:outline-highlight-200 dark:focus:outline-highlight-200-night",
-          "focus:border-highlight-300 dark:focus:border-highlight-300-night",
-        ],
-      },
-    },
-    defaultVariants: {
-      error: false,
-    },
-  }
-);
+const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 
 interface SkillBuilderInstructionsEditorProps {
   compareVersion?: SkillType | null;
@@ -198,7 +171,10 @@ export function SkillBuilderInstructionsEditor({
     editor.setOptions({
       editorProps: {
         attributes: {
-          class: editorVariants({ error: displayError }),
+          class: cn(
+            editorVariants({ error: displayError }),
+            INSTRUCTIONS_EDITOR_SIZE
+          ),
         },
       },
     });


### PR DESCRIPTION
## Description

This PR creates a new `SkillDescriptionEditor` component for editing skill descriptions using Tiptap, and refactors shared editor styling patterns. It extracts the common `editorVariants` CVA styling (border, focus states, error states) into a new `editorStyles.ts` file, which is then reused in `SkillBuilderInstructionsEditor`. The `SkillDescriptionEditor` is a simplified Tiptap editor with `StarterKit` (configured for basic text editing only), Placeholder extension, and `AgentInstructionDiffExtension`.

## Tests

Manually tested locally.

## Risk

Low - adds new component and extracts existing styles without modifying behavior.

## Deploy Plan

Deploy front.