### PR TITLE
Set cache TTL for fetchGcsContent to 15 minutes to cover >80% of messages

### DIFF
--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -12,6 +12,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const GCS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 4;
+const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
 
 type OutputContent = CallToolResult["content"][number];
 
@@ -94,7 +95,7 @@ const fetchGcsContentCached = cacheWithRedis(
   fetchGcsContent,
   (auth, _gcsPath, itemId) =>
     `w:${auth.getNonNullableWorkspace().sId}:mcp_output:${itemId}`,
-  { cacheNullValues: false }
+  { cacheNullValues: false, ttlMs: GCS_CONTENT_CACHE_TTL_MS }
 );
 
 /**


### PR DESCRIPTION
## Description

This is a tentative to clear the cache more agressively to avoid growing until the limit before clearing the objects.

This is the metrics 

Metric | Seconds | Minutes | Hours
-- | -- | -- | --
P25 | 68.000 | 1.133 | 0.019
P50 | 180.000 | 3.000 | 0.050
P75 | 638.000 | 10.633 | 0.177
P80 | 964.000 | 16.067 | 0.268
P85 | 1,725.000 | 28.750 | 0.479
P90 | 4,425.000 | 73.750 | 1.229
P95 | 39,266.800 | 654.447 | 10.907
P99 | 352,923.840 | 5,882.064 | 98.034

So with 15 minutes we will cover at least 80% of the messages
This is a minimum, as the cache is refreshed more often than by ne user message

## Tests

no

## Risk

low, we may invalid to much the cache for MCP output and increase the pressure on GCP requests

## Deploy Plan

deploy front 
