### PR TITLE
Sidekick highlight and dark mode fixes

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -46,14 +46,14 @@ export const SUGGESTION_ID_ATTRIBUTE = "data-suggestion-id";
 
 const CLASSES = {
   remove:
-    "suggestion-deletion rounded line-through bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200 cursor-default",
+    "suggestion-deletion rounded line-through bg-red-100 text-red-800 cursor-default",
   removeDimmed:
-    "suggestion-deletion rounded line-through bg-red-50 dark:bg-red-900/20 text-gray-400 cursor-default",
-  add: "suggestion-addition rounded bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 cursor-default",
+    "suggestion-deletion rounded line-through bg-red-50 text-gray-400 cursor-default",
+  add: "suggestion-addition rounded bg-blue-100 text-blue-800 cursor-default",
   addDimmed:
-    "suggestion-addition rounded bg-blue-50 dark:bg-blue-900/20 text-gray-400 cursor-default",
+    "suggestion-addition rounded bg-blue-50 text-gray-400 cursor-default",
   blockHighlightDimmed:
-    "suggestion-highlight rounded bg-blue-50/50 dark:bg-blue-900/10 cursor-default",
+    "suggestion-highlight rounded bg-gray-100 cursor-default",
 };
 
 export function diffBlockContent(


### PR DESCRIPTION
## Description
Small change to have the block highlight behind a suggestion be a grey variant instead of blue (20% darker than normal instruction background)
Also removed our hard-coded dark mode colors as each of our tailwind colors have a dark mode default, I think we should rely on those instead of passing in different variants
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
<img width="709" height="764" alt="Screenshot 2026-03-05 at 11 38 34 AM" src="https://github.com/user-attachments/assets/ba8828c8-2ad5-4dd6-a628-6e70100fac33" />
<img width="700" height="764" alt="Screenshot 2026-03-05 at 11 38 49 AM" src="https://github.com/user-attachments/assets/f9c82a89-622d-49a0-b53c-f6896ea7c09b" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
