### PR TITLE
Reduce run tool caching

### DIFF
--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -38,6 +38,9 @@ export const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
   "user_message_deleted",
 ] as const;
 
+// Cache for 200 seconds, which maps to P95 execution time of the agent loop.
+const AGENT_CONFIGURATION_CACHE_TTL_MS = 200 * 1000;
+
 export type AgentLoopDataSoftDeleteErrorType =
   (typeof AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES)[number];
 
@@ -296,7 +299,7 @@ export async function getAgentLoopDataWithAuth(
     () =>
       `agentMessageId:${agentMessageId}-agentConfigurationId:${agentId}-agentMessageVersion:${agentMessageVersion}`,
     {
-      ttlMs: 60 * 60 * 1000, // 1 hour
+      ttlMs: AGENT_CONFIGURATION_CACHE_TTL_MS,
     }
   )(auth, {
     agentId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR reduces the cache duration for which agent configuration is cached in the `run_tool` activity to use the P95 values of the agent loop execution time. Knowing that this cache only applied for a given step.

Dashboard with metrics [here](https://app.datadoghq.eu/dashboard/t8g-c26-8w9/agent-loop-execution?fromUser=false&refresh_mode=sliding&from_ts=1772558941457&to_ts=1772731741457&live=true).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
