### PR TITLE
Move registerEditor to a safer call spot

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -305,23 +305,12 @@ function CopilotSuggestionsProviderContent({
   const registerEditor = useCallback((editor: Editor) => {
     if (editorRef.current !== editor) {
       appliedSuggestionsRef.current.clear();
-      setIsEditorReady(false);
     }
 
+    // Called after the editor has fully set its initial content, so it's
+    // immediately ready to have suggestions applied.
     editorRef.current = editor;
-
-    // Wait for the editor content to be set.
-    const checkEditorReady = () => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (editor && !editor.isDestroyed) {
-            setIsEditorReady(true);
-          }
-        });
-      });
-    };
-
-    checkEditorReady();
+    setIsEditorReady(true);
   }, []);
 
   // Dispatch the blur event after a delay so the editor's debounced form sync

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -307,11 +307,6 @@ export function AgentBuilderInstructionsEditor({
     // Mark as set immediately to prevent race conditions
     initialContentSetRef.current = true;
 
-    // Register the editor with the suggestions context if available.
-    if (suggestionsContext) {
-      suggestionsContext.registerEditor(editor);
-    }
-
     // Use requestAnimationFrame to ensure DOM is fully ready
     // This fixes "Applying a mismatched transaction" error in Safari/iOS
     requestAnimationFrame(() => {
@@ -340,6 +335,11 @@ export function AgentBuilderInstructionsEditor({
           // For HTML loads, this preserves existing IDs; for markdown loads, this generates new ones.
           instructionsHtmlField.onChange(stripHtmlAttributes(editor.getHTML()));
           editor.commands.focus("end");
+
+          // Register with the suggestions context now that content is fully set.
+          if (suggestionsContext) {
+            suggestionsContext.registerEditor(editor);
+          }
         }
       });
     });


### PR DESCRIPTION
## Description
Trying to debug a very hard to repro issue where suggestions never appear in the editor, but the accept/reject all buttons appear as do the suggestion cards in the sidekick convo.
Hypothesis is that we're calling `setIsEditor(true)` based on a timing assumption instead of making sure it's actually ready. Moving the point where we call `registerEditor`, which sets this state to true may fix this.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Hard to test if this fixes the bug, but I did test manually to make sure it doesn't create new ones
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->