### PR TITLE
Auto populate agent name for sidekick template use case

### DIFF
--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -142,7 +142,9 @@ export function transformTemplateToFormData(
       : (template.presetInstructions ?? defaultFormData.instructions),
     agentSettings: {
       ...defaultFormData.agentSettings,
-      name: template.handle ?? defaultFormData.agentSettings.name,
+      name: hasCopilotAccess
+        ? defaultFormData.agentSettings.name
+        : (template.handle ?? defaultFormData.agentSettings.name),
       description:
         template.userFacingDescription ??
         defaultFormData.agentSettings.description,


### PR DESCRIPTION
## Description

* Current friction because template names are no longer camel case, which means they do not match the agent name format. I don't think we want static names anymore anyway now that we don't have static templates

## Tests

* Local

## Risk

* Low

## Deploy Plan

* Deploy front