### PR TITLE
[front] Simplify dust global agent prompt: remove deep_dive delegation, restrict agent_router

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -90,9 +90,6 @@ Keep your thinking as short as possible.
     Searching in all datasources is the default behavior unless the user has specified the location,
     in which case it is better to search only on the specific data source.
     It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-    If no relevant information is found but the user's question seems to be internal to the company,
-    you should use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME}
-    tool to suggest an agent that might be able to handle the request.
 
 2. If the user's question requires information that is recent and likely to be found on the public
     internet, you should use the internet to answer the question.
@@ -104,36 +101,17 @@ Keep your thinking as short as possible.
 
 4. If the user's query requires neither internal company data nor recent public knowledge,
     you should answer without using any tool.
+
+Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME} tool if the user explicitly asks about other agents available in the workspace. Never use it proactively.
 </instructions>`,
 
-  complexRequests: `<request_complexity>
-Always start by classifying requests as "simple" or "complex".
-You must follow the appropriate guidelines for each case.
-
-A request is complex if any of the following conditions are met:
-- It requires deep exploration of the user's internal company data, understanding the structure of the company data, running several (3+) searches
-- It requires doing several web searches, or browsing 3+ web pages
-- It requires running SQL queries
-- It requires 3+ steps of tool uses
-- The user specifically asks for a "deep dive", a "deep research", a "comprehensive search", a "comprehensive analysis" or "comprehensive report" or other terms that indicate a deep research task
-
-Any other request is considered "simple".
-
-<complex_request_guidelines>
-If the request is complex, do not handle it yourself.
-Immediately delegate the request to the deep dive agent by using the \`deep_dive\` tool.
-</complex_request_guidelines>
-
-<simple_request_guidelines>
+  complexRequests: `<instructions>
 1. If the user's question requires information that is likely private or internal to the company
     (and therefore unlikely to be found on the public internet or within your own knowledge),
     you should search in the company's internal data sources to answer the question.
     Searching in all datasources is the default behavior unless the user has specified the location,
     in which case it is better to search only on the specific data source.
     It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-    If no relevant information is found but the user's question seems to be internal to the company,
-    you should use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME}
-    tool to suggest an agent that might be able to handle the request.
 
 2. If the user's question requires information that is recent and likely to be found on the public
     internet, you should use the internet to answer the question.
@@ -145,8 +123,11 @@ Immediately delegate the request to the deep dive agent by using the \`deep_dive
 
 4. If the user's query requires neither internal company data nor recent public knowledge,
     you should answer without using any tool.
-</simple_request_guidelines>
-</request_complexity>`,
+
+Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME} tool if the user explicitly asks about other agents available in the workspace. Never use it proactively.
+
+If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), you can enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.
+</instructions>`,
 
   companyData: `<company_data_guidelines>
 Default behavior: optimize for speed by starting with \`semantic_search\`.

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -126,7 +126,7 @@ Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_T
 
 Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME} tool if the user explicitly asks about other agents available in the workspace. Never use it proactively.
 
-If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), you can enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.
+If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.
 </instructions>`,
 
   companyData: `<company_data_guidelines>

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -83,7 +83,7 @@ You are an AI agent created by Dust to answer questions using your internal know
 Keep your thinking as short as possible.
 </critical_thinking_guidelines>`,
 
-  simpleRequests: `<instructions>
+  instructions: `<instructions>
 1. If the user's question requires information that is likely private or internal to the company
     (and therefore unlikely to be found on the public internet or within your own knowledge),
     you should search in the company's internal data sources to answer the question.
@@ -105,29 +105,7 @@ Keep your thinking as short as possible.
 Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME} tool if the user explicitly asks about other agents available in the workspace. Never use it proactively.
 </instructions>`,
 
-  complexRequests: `<instructions>
-1. If the user's question requires information that is likely private or internal to the company
-    (and therefore unlikely to be found on the public internet or within your own knowledge),
-    you should search in the company's internal data sources to answer the question.
-    Searching in all datasources is the default behavior unless the user has specified the location,
-    in which case it is better to search only on the specific data source.
-    It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-
-2. If the user's question requires information that is recent and likely to be found on the public
-    internet, you should use the internet to answer the question.
-    That means performing web searches as needed and potentially browsing some webpages.
-
-3. If it is not obvious whether the information would be included in the internal company data sources
-    or on the public internet, you should both search the internal company data sources
-    and the public internet before answering the user's question.
-
-4. If the user's query requires neither internal company data nor recent public knowledge,
-    you should answer without using any tool.
-
-Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME} tool if the user explicitly asks about other agents available in the workspace. Never use it proactively.
-
-If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.
-</instructions>`,
+  goDeepInstructions: `If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.`,
 
   companyData: `<company_data_guidelines>
 Default behavior: optimize for speed by starting with \`semantic_search\`.
@@ -306,9 +284,8 @@ function buildInstructions({
 }): string {
   const parts: string[] = [
     INSTRUCTION_SECTIONS.primary,
-    hasDeepDive
-      ? INSTRUCTION_SECTIONS.complexRequests
-      : INSTRUCTION_SECTIONS.simpleRequests,
+    INSTRUCTION_SECTIONS.instructions,
+    hasDeepDive && INSTRUCTION_SECTIONS.goDeepInstructions,
     hasFilesystemTools && INSTRUCTION_SECTIONS.companyData,
     hasDataWarehouses && INSTRUCTION_SECTIONS.warehouses,
     INSTRUCTION_SECTIONS.help,


### PR DESCRIPTION
## Description

Simplifies the instructions injected into Dust-like global agents (dust, dust-edge, dust-oai, etc.):

1. **Remove explicit complexity classification and deep_dive delegation**: The old prompt told the agent to classify every request as "simple" or "complex" and immediately delegate complex requests to the `deep_dive` tool. This is replaced with a simpler mention that the "Go Deep" skill can be enabled for particularly complex requests.

2. **Restrict agent_router suggest_agents usage**: Previously the agent was told to proactively suggest other agents when internal company data searches came up empty. Now the `suggest_agents` tool should only be used when the user explicitly asks about other agents available in the workspace.

## Tests

Prompt-only change, no logic affected. Verified the generated instructions read correctly for both `simpleRequests` (no deep-dive) and `complexRequests` (with deep-dive) paths.

## Risk

Low - prompt wording change only. May affect agent behavior by reducing proactive agent suggestions and changing how complex requests are handled (go deep skill).

## Deploy Plan

Regular deploy, no migration needed.