### PR TITLE
Add new column to the Poke MCP Server list that shows the serverid

### DIFF
--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -49,9 +49,9 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
     {
       accessorKey: "server.sId",
       cell: ({ row }) => {
-        const { serverType, server } = row.original;
+        const { server } = row.original;
 
-        return `${serverType}:${server.sId}`;
+        return `${server.sId}`;
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Server ID" />

--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -8,6 +8,7 @@ interface MCPServerView {
   createdAt: number;
   updatedAt: number;
   spaceId: string;
+  serverType: string;
   server: {
     sId: string;
     name: string;
@@ -43,6 +44,17 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Server name" />
+      ),
+    },
+    {
+      accessorKey: "server.sId",
+      cell: ({ row }) => {
+        const { serverType, server } = row.original;
+
+        return `${serverType}:${server.sId}`;
+      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Server ID" />
       ),
     },
     {


### PR DESCRIPTION
## Description

Makes it easier to find the MCP server view given the server id

<img width="739" height="496" alt="Screenshot 2026-03-06 at 11 00 13" src="https://github.com/user-attachments/assets/b5aa2cd7-1d8a-4c49-b872-9bc26f349375" />

## Tests

Manual

## Risk

Poke only

## Deploy Plan

Front