### PR TITLE
[front] enh: Adjust excess credit production check thresholds

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1005,6 +1005,27 @@ export async function getInvoicePaymentUrl(
   return invoice.hosted_invoice_url ?? null;
 }
 
+export function getAnnualizedSubscriptionValueMicroUsd(
+  stripeSubscription: Stripe.Subscription
+): number {
+  let totalMicroUsd = 0;
+  for (const item of stripeSubscription.items.data) {
+    if (item.deleted) {
+      continue;
+    }
+    const unitAmountCents = Number(
+      item.price.unit_amount ?? item.price.unit_amount_decimal ?? 0
+    );
+    const quantity = item.quantity ?? 1;
+    const interval = item.price.recurring?.interval;
+
+    const annualMultiplier = interval === "year" ? 1 : 12;
+    // Convert cents to micro USD: cents * 10_000
+    totalMicroUsd += unitAmountCents * quantity * 10_000 * annualMultiplier;
+  }
+  return totalMicroUsd;
+}
+
 export async function makeAndFinalizeCreditsPAYGInvoice({
   stripeSubscription,
   amountMicroUsd,

--- a/front/lib/production_checks/checks/check_excess_credits.ts
+++ b/front/lib/production_checks/checks/check_excess_credits.ts
@@ -1,19 +1,30 @@
 import { Authenticator } from "@app/lib/auth";
+import {
+  getAnnualizedSubscriptionValueMicroUsd,
+  getStripeSubscription,
+} from "@app/lib/plans/stripe";
 import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
 import { CreditResource } from "@app/lib/resources/credit_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { QueryTypes } from "sequelize";
 
 const EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD = 10_000_000;
 const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
-const EXCESS_PERCENTAGE_THRESHOLD = 2;
+const EXCESS_SUBSCRIPTION_PERCENTAGE_THRESHOLD = 5; // 5% of annual subscription
+const EXCESS_ACTIVE_CREDITS_PERCENTAGE_THRESHOLD = 2; // 2% of active credits (fallback)
 
 interface WorkspaceExcessCredits {
   workspaceId: number;
   workspaceSId: string;
   workspaceName: string;
   totalExcessMicroUsd: number;
+}
+
+interface WorkspaceThresholdData {
+  annualSubscriptionValueMicroUsd: number | null;
+  activeCreditsMicroUsd: number;
 }
 
 export const checkExcessCredits: CheckFunction = async (
@@ -57,38 +68,78 @@ export const checkExcessCredits: CheckFunction = async (
     return;
   }
 
-  // Fetch active credits for workspaces that exceeded the absolute threshold.
-  const activeCreditsByWorkspaceSId = new Map<string, number>();
+  // Fetch subscription and active credits data for workspaces that exceeded the absolute threshold.
+  const thresholdDataByWorkspaceSId = new Map<string, WorkspaceThresholdData>();
   await concurrentExecutor(
     workspacesWithExcessCredits,
     async (workspace) => {
       const auth = await Authenticator.internalAdminForWorkspace(
         workspace.workspaceSId
       );
+
+      // Fetch active credits.
       const activeCredits = await CreditResource.listActive(auth);
-      const totalActiveCreditsMicroUsd = activeCredits.reduce(
+      const activeCreditsMicroUsd = activeCredits.reduce(
         (sum, c) => sum + c.initialAmountMicroUsd,
         0
       );
-      activeCreditsByWorkspaceSId.set(
-        workspace.workspaceSId,
-        totalActiveCreditsMicroUsd
-      );
+
+      // Fetch subscription and calculate annualized value if Stripe subscription exists.
+      let annualSubscriptionValueMicroUsd: number | null = null;
+      const subscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspace.workspaceId
+        );
+
+      if (subscription?.stripeSubscriptionId) {
+        const stripeSubscription = await getStripeSubscription(
+          subscription.stripeSubscriptionId
+        );
+        if (stripeSubscription) {
+          annualSubscriptionValueMicroUsd =
+            getAnnualizedSubscriptionValueMicroUsd(stripeSubscription);
+        }
+      }
+
+      thresholdDataByWorkspaceSId.set(workspace.workspaceSId, {
+        annualSubscriptionValueMicroUsd,
+        activeCreditsMicroUsd,
+      });
     },
     { concurrency: 10 }
   );
 
-  // Filter to only include workspaces where excess exceeds the percentage threshold of active credits.
+  // Filter to only include workspaces where excess exceeds the relative threshold.
+  // For workspaces with Stripe subscription: use 5% of annual subscription value.
+  // For workspaces without Stripe subscription: fallback to 2% of active credits.
   const significantExcessWorkspaces = workspacesWithExcessCredits.filter(
     (w) => {
-      const totalActiveCreditsMicroUsd =
-        activeCreditsByWorkspaceSId.get(w.workspaceSId) ?? 0;
-      if (totalActiveCreditsMicroUsd === 0) {
+      const thresholdData = thresholdDataByWorkspaceSId.get(w.workspaceSId);
+      if (!thresholdData) {
+        return true;
+      }
+
+      const { annualSubscriptionValueMicroUsd, activeCreditsMicroUsd } =
+        thresholdData;
+
+      // If workspace has a Stripe subscription, use subscription-based threshold.
+      if (
+        annualSubscriptionValueMicroUsd !== null &&
+        annualSubscriptionValueMicroUsd > 0
+      ) {
+        const excessPercentage =
+          (Number(w.totalExcessMicroUsd) / annualSubscriptionValueMicroUsd) *
+          100;
+        return excessPercentage > EXCESS_SUBSCRIPTION_PERCENTAGE_THRESHOLD;
+      }
+
+      // Fallback: use active credits threshold.
+      if (activeCreditsMicroUsd === 0) {
         return true;
       }
       const excessPercentage =
-        (Number(w.totalExcessMicroUsd) / totalActiveCreditsMicroUsd) * 100;
-      return excessPercentage > EXCESS_PERCENTAGE_THRESHOLD;
+        (Number(w.totalExcessMicroUsd) / activeCreditsMicroUsd) * 100;
+      return excessPercentage > EXCESS_ACTIVE_CREDITS_PERCENTAGE_THRESHOLD;
     }
   );
 
@@ -107,7 +158,7 @@ export const checkExcessCredits: CheckFunction = async (
     const thresholdDollars = EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD / 1_000_000;
     const message =
       `${significantExcessWorkspaces.length} workspace(s) have excess credits > $${thresholdDollars} ` +
-      `(and > ${EXCESS_PERCENTAGE_THRESHOLD}% of active credits) in the last 30 days`;
+      `(and > ${EXCESS_SUBSCRIPTION_PERCENTAGE_THRESHOLD}% of annual subscription or ${EXCESS_ACTIVE_CREDITS_PERCENTAGE_THRESHOLD}% of active credits) in the last 30 days`;
 
     logger.warn({ workspaces: formattedWorkspaces }, message);
 


### PR DESCRIPTION
## Description

### Context

Currently, we flag workspaces that have excess credits above 2% of active credits over 30D, with a minimal threshold of $10.

We get some noise (e.g a workspace paying hundreds of dollars per year, getting $15 of excess credits) that I think is not really worth engoncall's time as there is nothing to action here.

We can keep tweaking the threshold ($10, maybe $15, maybe $20 ? 🤷 ) but this is brittle, as coming up with the right amount (it there is one) is hard.

In essence, what do we want to monitor ? 

- Trial and Pro accounts exploiting close to 0 boundaries.
- Enterprise accounts leaning heavily on programmatic usage and having a small leak in credits.

### Proposed solution

- Still keep the $10 amount to filter for excess workspace candidate
- But also compare the excess amount to the workspace's ACV (or the proxy we can get), if below 5% => we filter out
- If it is in trial (or free customer), we fall back to 2% of active credits amounts, which means for a trial with $5 you have less than a $1 of allowed excess.

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front