### PR TITLE
fix: show proper error page instead of 404 for invalid invite tokens

### DIFF
--- a/front/components/pages/onboarding/JoinPage.tsx
+++ b/front/components/pages/onboarding/JoinPage.tsx
@@ -12,32 +12,18 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 
-function isRedirectResponse(data: unknown): data is { redirectUrl: string } {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "redirectUrl" in data &&
-    typeof (data as { redirectUrl: unknown }).redirectUrl === "string"
-  );
-}
-
 export function JoinPage() {
   const wId = useRequiredPathParam("wId");
   const token = useSearchParam("t");
   const conversationId = useSearchParam("cId");
 
-  const { joinData, isJoinDataLoading, isJoinDataError } = useJoinData({
+  const { joinData, isJoinDataLoading, redirectUrl } = useJoinData({
     wId,
     token,
     conversationId,
   });
 
-  const errorData = isJoinDataError?.response?.data;
-  const redirectUrl = isRedirectResponse(errorData)
-    ? errorData.redirectUrl
-    : null;
-
-  // Redirect to login-error page when the invite token is invalid.
+  // Redirect when the API returns a redirect URL (e.g. invalid/expired token).
   useEffect(() => {
     if (redirectUrl) {
       window.location.href = redirectUrl;
@@ -45,7 +31,7 @@ export function JoinPage() {
   }, [redirectUrl]);
 
   // Show 404 for unknown workspaces or missing auto-join domains.
-  if (!isJoinDataLoading && !redirectUrl && !joinData) {
+  if (!isJoinDataLoading && !joinData) {
     return <Custom404 />;
   }
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -30,6 +30,7 @@ import type { GetWelcomeResponseBody } from "@app/pages/api/w/[wId]/welcome";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
 import type { GetWorkspaceLookupResponseBody } from "@app/pages/api/workspace-lookup";
 import type { APIErrorResponse, RegionRedirectError } from "@app/types/error";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useEffect, useMemo } from "react";
 import type { Fetcher } from "swr";
@@ -42,6 +43,15 @@ export function isRegionRedirect(data: unknown): data is RegionRedirectError {
     // (data as RegionRedirectError).redirect !== null &&
     // "region" in (data as RegionRedirectError).redirect &&
     // "url" in (data as RegionRedirectError).redirect
+  );
+}
+
+function isRedirectResponse(data: unknown): data is { redirectUrl: string } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "redirectUrl" in data &&
+    typeof data.redirectUrl === "string"
   );
 }
 
@@ -716,10 +726,25 @@ export function useJoinData({
     }
   }, [regionRedirect, mutate, regionContext]);
 
+  // The join API returns { redirectUrl: "..." } (e.g. for invalid/expired
+  // tokens). This is not a standard API error response, so the fetcher wraps
+  // it in new Error(jsonText) — we parse it back out here.
+  const redirectUrl = useMemo(() => {
+    if (!error || isRegionRedirectResponse || !(error instanceof Error)) {
+      return null;
+    }
+    const parsed = safeParseJSON(error.message);
+    if (parsed.isOk() && isRedirectResponse(parsed.value)) {
+      return parsed.value.redirectUrl;
+    }
+    return null;
+  }, [error, isRegionRedirectResponse]);
+
   return {
     joinData: data ?? null,
-    isJoinDataLoading: (!error && !data) || !!isRegionRedirectResponse,
-    isJoinDataError: isRegionRedirectResponse ? undefined : error,
+    isJoinDataLoading:
+      (!error && !data) || !!isRegionRedirectResponse || !!redirectUrl,
+    redirectUrl,
   };
 }
 

--- a/front/pages/api/w/[wId]/join.test.ts
+++ b/front/pages/api/w/[wId]/join.test.ts
@@ -1,5 +1,5 @@
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
-import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
+import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
@@ -66,18 +66,11 @@ describe("GET /api/w/[wId]/join", () => {
   it("returns 200 with join data for a valid invite token", async () => {
     const workspace = await WorkspaceFactory.basic();
 
-    const invitation = await MembershipInvitationModel.create({
-      workspaceId: workspace.id,
+    const invitation = await MembershipInvitationFactory.create(workspace, {
       inviteEmail: "test@example.com",
-      status: "pending",
-      initialRole: "user",
-      sId: `inv-${Date.now()}`,
     });
 
-    const token = getMembershipInvitationToken({
-      id: invitation.id,
-      createdAt: invitation.createdAt.getTime(),
-    } as any);
+    const token = getMembershipInvitationToken(invitation.toJSON());
 
     const { req, res } = createJoinRequest(workspace.sId, { t: token });
 
@@ -115,22 +108,17 @@ describe("GET /api/w/[wId]/join", () => {
     // (7 days) but use a recent createdAt for the JWT so it doesn't fail JWT
     // verification before reaching the expiration check.
     const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
-    const invitation = await MembershipInvitationModel.create({
-      workspaceId: workspace.id,
+    const invitation = await MembershipInvitationFactory.create(workspace, {
       inviteEmail: "expired@example.com",
-      status: "pending",
-      initialRole: "user",
-      sId: `inv-exp-${Date.now()}`,
       createdAt: eightDaysAgo,
     });
 
     // Generate a token with a recent iat/exp so JWT verification passes,
     // but the invitation's createdAt is old enough to trigger expiration.
     const now = Date.now();
-    const token = getMembershipInvitationToken({
-      id: invitation.id,
-      createdAt: now,
-    } as any);
+    const tokenPayload = invitation.toJSON();
+    tokenPayload.createdAt = now;
+    const token = getMembershipInvitationToken(tokenPayload);
 
     const { req, res } = createJoinRequest(workspace.sId, { t: token });
 

--- a/front/pages/api/w/[wId]/join.test.ts
+++ b/front/pages/api/w/[wId]/join.test.ts
@@ -1,0 +1,157 @@
+import { getMembershipInvitationToken } from "@app/lib/api/invitation";
+import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import handler from "./join";
+
+// Mock region redirect to always return null (same region).
+vi.mock("@app/lib/api/regions/lookup", () => ({
+  getWorkspaceRegionRedirect: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock WorkOS user lookup — use importOriginal to preserve other exports
+// (e.g. getWorkOSSession used by withLogging).
+vi.mock(import("@app/lib/api/workos/user"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    fetchUsersFromWorkOSWithEmails: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// Mock getSignInUrl.
+vi.mock("@app/lib/signup", () => ({
+  getSignInUrl: vi.fn().mockReturnValue("https://sign-in-url.test"),
+}));
+
+beforeAll(() => {
+  // Set a test secret for JWT token signing/verification.
+  process.env.DUST_INVITE_TOKEN_SECRET = "test-secret-for-invite-tokens";
+});
+
+function createJoinRequest(wId: string, query: Record<string, string> = {}) {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "GET",
+    query: { wId, ...query },
+    headers: {},
+  });
+  return { req, res };
+}
+
+describe("GET /api/w/[wId]/join", () => {
+  it("returns 405 for non-GET methods", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { wId: workspace.sId },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns 404 for unknown workspace", async () => {
+    const { req, res } = createJoinRequest("nonexistent-workspace-id");
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("workspace_not_found");
+  });
+
+  it("returns 200 with join data for a valid invite token", async () => {
+    const workspace = await WorkspaceFactory.basic();
+
+    const invitation = await MembershipInvitationModel.create({
+      workspaceId: workspace.id,
+      inviteEmail: "test@example.com",
+      status: "pending",
+      initialRole: "user",
+      sId: `inv-${Date.now()}`,
+    });
+
+    const token = getMembershipInvitationToken({
+      id: invitation.id,
+      createdAt: invitation.createdAt.getTime(),
+    } as any);
+
+    const { req, res } = createJoinRequest(workspace.sId, { t: token });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.onboardingType).toBe("email_invite");
+    expect(data.workspace.sId).toBe(workspace.sId);
+    expect(data.signInUrl).toBeDefined();
+  });
+
+  it("returns 400 with redirectUrl for an invalid (mangled) token", async () => {
+    const workspace = await WorkspaceFactory.basic();
+
+    // Simulate a token mangled by corporate email security (not a valid JWT).
+    const mangledToken = "flWucTdvBvWVHmV4AvVfVaE8.flWgMJ4vMKWmbTyjFJ85.xxx";
+
+    const { req, res } = createJoinRequest(workspace.sId, {
+      t: mangledToken,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const data = res._getJSONData();
+    expect(data.redirectUrl).toBeDefined();
+    expect(data.redirectUrl).toContain("reason%3Dinvalid_invitation_token");
+  });
+
+  it("returns 400 with redirectUrl for an expired invitation", async () => {
+    const workspace = await WorkspaceFactory.basic();
+
+    // Create an invitation that is older than INVITATION_EXPIRATION_TIME_SEC
+    // (7 days) but use a recent createdAt for the JWT so it doesn't fail JWT
+    // verification before reaching the expiration check.
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    const invitation = await MembershipInvitationModel.create({
+      workspaceId: workspace.id,
+      inviteEmail: "expired@example.com",
+      status: "pending",
+      initialRole: "user",
+      sId: `inv-exp-${Date.now()}`,
+      createdAt: eightDaysAgo,
+    });
+
+    // Generate a token with a recent iat/exp so JWT verification passes,
+    // but the invitation's createdAt is old enough to trigger expiration.
+    const now = Date.now();
+    const token = getMembershipInvitationToken({
+      id: invitation.id,
+      createdAt: now,
+    } as any);
+
+    const { req, res } = createJoinRequest(workspace.sId, { t: token });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const data = res._getJSONData();
+    expect(data.redirectUrl).toBeDefined();
+    expect(data.redirectUrl).toContain("reason%3Dexpired_invitation");
+  });
+
+  it("returns 404 for domain_invite_link when no auto-join domain", async () => {
+    const workspace = await WorkspaceFactory.basic();
+
+    // No token, no conversationId => domain_invite_link flow.
+    const { req, res } = createJoinRequest(workspace.sId);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("workspace_not_found");
+    expect(res._getJSONData().error.message).toContain("auto-join");
+  });
+});

--- a/front/tests/utils/MembershipInvitationFactory.ts
+++ b/front/tests/utils/MembershipInvitationFactory.ts
@@ -1,0 +1,36 @@
+import { Authenticator } from "@app/lib/auth";
+import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import type { WorkspaceType } from "@app/types/user";
+import { faker } from "@faker-js/faker";
+
+export class MembershipInvitationFactory {
+  static async create(
+    workspace: WorkspaceType,
+    overrides: {
+      inviteEmail?: string;
+      status?: "pending" | "consumed" | "revoked";
+      initialRole?: "user" | "builder" | "admin";
+      createdAt?: Date;
+    } = {}
+  ): Promise<MembershipInvitationResource> {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const resource = await MembershipInvitationResource.makeNew(auth, {
+      inviteEmail: overrides.inviteEmail ?? faker.internet.email(),
+      status: overrides.status ?? "pending",
+      initialRole: overrides.initialRole ?? "user",
+    });
+
+    // If a custom createdAt is needed (e.g. for expiration tests), update it
+    // directly via the model since the Resource doesn't expose createdAt writes.
+    if (overrides.createdAt) {
+      await MembershipInvitationModel.update(
+        { createdAt: overrides.createdAt },
+        { where: { id: resource.id } }
+      );
+    }
+
+    return resource;
+  }
+}


### PR DESCRIPTION
## Description

When a user clicks an invite link with an invalid or expired token, the join API returns a 400 with a redirectUrl pointing to the login-error page. But the frontend never extracted it, so users saw a 404 instead.

The root cause: our SWR fetcher uses fetch, not Axios. On a non-OK response, the fetcher wraps the response body in new Error(jsonText). The old code in JoinPage tried to read the redirect URL via error.response.data, which is an Axios pattern that doesn't exist with fetch. The redirect URL was always null.

The fix moves redirect extraction into useJoinData. It parses error.message (which contains the JSON string from the fetcher), pulls out redirectUrl, and returns it to the page. When a redirect URL is present, isJoinDataLoading stays true so the page shows a spinner until the browser navigates, keeping the 404 guard simple: if loading is done and there's no data, show 404.

This was surfaced by this runner card: https://github.com/dust-tt/tasks/issues/6884


## Tests

Tested manually: invited a user, confirmed a valid token lands on the join page. Hit the same URL with a mangled token. On main it shows a 404. On this branch it redirects to the login-error page.

I added a test for the join route, which is useful as a regression guard for the API contract, but it doesn't prove our frontend fix. Since there are no component tests in the codebase, the frontend fix is only verifiable by manual testing 🙈 ok th

## Risk

Break onboarding flow? 
Can be rolled back. 

## Deploy Plan

Deploy front. 