### PR TITLE
feat: move agent suggestion to a draft

### DIFF
--- a/front/components/assistant/conversation/ButlerSuggestionCard.tsx
+++ b/front/components/assistant/conversation/ButlerSuggestionCard.tsx
@@ -99,6 +99,11 @@ function RenameTitleSuggestionCard({
             {suggestion.metadata.suggestedTitle}
           </span>
         </div>
+        {suggestion.metadata.rationale && (
+          <div className="text-sm text-muted-foreground">
+            {suggestion.metadata.rationale}
+          </div>
+        )}
         <div className="flex flex-row gap-2">
           <Button
             label="Rename"
@@ -159,6 +164,11 @@ function AgentInvocationSuggestionCard({
       className="my-3 w-full max-w-full"
     >
       <div className="flex flex-col gap-3">
+        {suggestion.metadata.rationale && (
+          <div className="text-sm text-muted-foreground">
+            {suggestion.metadata.rationale}
+          </div>
+        )}
         <div className="italic text-sm text-muted-foreground">
           "{suggestion.metadata.prompt}"
         </div>

--- a/front/components/assistant/conversation/ButlerSuggestionCard.tsx
+++ b/front/components/assistant/conversation/ButlerSuggestionCard.tsx
@@ -44,7 +44,7 @@ export function ButlerSuggestionCard({
           onAction={onAction}
           icon={ChatBubbleLeftRightIcon}
           title={`Try asking @${suggestion.metadata.agentName}`}
-          actionLabel="Ask"
+          actionLabel="Draft"
         />
       );
     case "create_frame":
@@ -54,7 +54,7 @@ export function ButlerSuggestionCard({
           onAction={onAction}
           icon={ActionFrameIcon}
           title="Create a Frame?"
-          actionLabel="Create"
+          actionLabel="Draft"
         />
       );
     default:

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1,6 +1,7 @@
 import { ConversationViewerEmptyState } from "@app/components/assistant/ConversationViewerEmptyState";
 import { AgentInputBar } from "@app/components/assistant/conversation/AgentInputBar";
 import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
   createPlaceholderAgentMessage,
   createPlaceholderUserMessage,
@@ -35,7 +36,6 @@ import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types"
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
-import { serializeMention } from "@app/lib/mentions/format";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
@@ -67,6 +67,7 @@ import debounce from "lodash/debounce";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -241,6 +242,8 @@ export const ConversationViewer = ({
   });
   const submitInFlightRef = useRef(false);
 
+  const { setSelectedAgent, setPendingInputText } = useContext(InputBarContext);
+
   const [initialListData, setInitialListData] = useState<
     VirtuosoMessage[] | undefined
   >(undefined);
@@ -375,18 +378,22 @@ export const ConversationViewer = ({
         }
       }
 
-      // If accepting a call_agent or create_frame suggestion, submit the message with the agent mention.
+      // If accepting a call_agent or create_frame suggestion, pre-fill the input bar
+      // with the agent mention and prompt so the user can review/edit before sending.
       if (
         status === "accepted" &&
         (matchedSuggestion?.suggestionType === "call_agent" ||
           matchedSuggestion?.suggestionType === "create_frame")
       ) {
         const { agentSId, agentName, prompt } = matchedSuggestion.metadata;
-        void submitMessage({
-          input: `${serializeMention({ name: agentName, sId: agentSId })} ${prompt}`,
-          mentions: [{ configurationId: agentSId }],
-          contentFragments: { uploaded: [], contentNodes: [] },
+        setSelectedAgent({
+          id: agentSId,
+          type: "agent",
+          label: agentName,
+          pictureUrl: "",
+          description: "",
         });
+        setPendingInputText(prompt);
       }
 
       // Optimistic update: remove the suggestion from local state.
@@ -410,7 +417,13 @@ export const ConversationViewer = ({
         }
       );
     },
-    [conversationId, owner.sId, suggestionsByMessageSId, submitMessage]
+    [
+      conversationId,
+      owner.sId,
+      suggestionsByMessageSId,
+      setSelectedAgent,
+      setPendingInputText,
+    ]
   );
 
   // Hooks related to conversation events streaming.

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -82,8 +82,13 @@ export const InputBar = React.memo(function InputBar({
     DataSourceViewContentNode[]
   >([]);
 
-  const { animate, setAnimate, getAndClearSelectedAgent, fileUploaderService } =
-    useContext(InputBarContext);
+  const {
+    animate,
+    setAnimate,
+    getAndClearSelectedAgent,
+    getAndClearPendingInputText,
+    fileUploaderService,
+  } = useContext(InputBarContext);
 
   // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations } = useUnifiedAgentConfigurations({
@@ -114,6 +119,10 @@ export const InputBar = React.memo(function InputBar({
   const selectedAgent = useMemo(
     () => getAndClearSelectedAgent(),
     [getAndClearSelectedAgent]
+  );
+  const pendingInputText = useMemo(
+    () => getAndClearPendingInputText(),
+    [getAndClearPendingInputText]
   );
   useEffect(() => {
     if (animate && !isAnimating) {
@@ -376,6 +385,7 @@ export const InputBar = React.memo(function InputBar({
             conversation={conversation}
             space={space}
             selectedAgent={selectedAgent}
+            pendingInputText={pendingInputText}
             onEnterKeyDown={handleSubmit}
             stickyMentions={stickyMentions}
             fileUploaderService={fileUploaderService}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -103,6 +103,7 @@ export interface InputBarContainerProps {
   onSkillSelect: (skill: SkillType) => void;
   owner: WorkspaceType;
   saveDraft: (markdown: string) => void;
+  pendingInputText: string | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
   selectedSkills: SkillType[];
@@ -117,6 +118,7 @@ const InputBarContainer = ({
   conversation,
   space,
   selectedAgent,
+  pendingInputText,
   stickyMentions,
   actions,
   disableAutoFocus,
@@ -658,7 +660,8 @@ const InputBarContainer = ({
     editorService,
     stickyMentions,
     selectedAgent,
-    disableAutoFocus
+    disableAutoFocus,
+    pendingInputText
   );
 
   const buttonSize = useMemo(() => {

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -18,6 +18,8 @@ export const InputBarContext = createContext<{
   getAndClearSelectedAgent: () => RichAgentMention | null;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
+  getAndClearPendingInputText: () => string | null;
+  setPendingInputText: (text: string | null) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: {
     onCapture: (type: "text" | "screenshot") => void;
@@ -28,6 +30,8 @@ export const InputBarContext = createContext<{
   getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
+  getAndClearPendingInputText: () => null,
+  setPendingInputText: () => {},
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -62,6 +66,11 @@ export function InputBarContextProvider({
     null
   );
 
+  // Useful when a component needs to pre-fill the input bar with text (e.g. butler suggestions).
+  const [pendingInputText, setPendingInputTextState] = useState<string | null>(
+    null
+  );
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const setSelectedAgentOuter = useCallback(
     (agentMention: RichAgentMention | null) => {
@@ -83,12 +92,24 @@ export function InputBarContextProvider({
     return previousSelectedAgent;
   }, [selectedAgent, setSelectedAgent]);
 
+  const getAndClearPendingInputText = useCallback(() => {
+    const text = pendingInputText;
+    setPendingInputTextState(null);
+    return text;
+  }, [pendingInputText]);
+
+  const setPendingInputText = useCallback((text: string | null) => {
+    setPendingInputTextState(text);
+  }, []);
+
   const value = useMemo(
     () => ({
       animate,
       setAnimate,
       getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
+      getAndClearPendingInputText,
+      setPendingInputText,
       captureActions,
       fileUploaderService,
     }),
@@ -96,6 +117,8 @@ export function InputBarContextProvider({
       animate,
       getAndClearSelectedAgent,
       setSelectedAgentOuter,
+      getAndClearPendingInputText,
+      setPendingInputText,
       captureActions,
       fileUploaderService,
     ]

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -9,7 +9,8 @@ const useHandleMentions = (
   editorService: EditorService,
   stickyMentions: RichMention[] | undefined,
   selectedAgent: RichAgentMention | null,
-  disableAutoFocus: boolean
+  disableAutoFocus: boolean,
+  pendingInputText?: string | null
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
 
@@ -46,10 +47,20 @@ const useHandleMentions = (
     if (selectedAgent) {
       if (!editorService.hasMention(selectedAgent)) {
         // Schedule insertion to avoid synchronous editor updates during React render/effects.
-        queueMicrotask(() => editorService.insertMention(selectedAgent));
+        queueMicrotask(() => {
+          editorService.insertMention(selectedAgent);
+          // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
+          if (pendingInputText) {
+            editorService.insertText(pendingInputText);
+          }
+        });
+      } else if (pendingInputText) {
+        queueMicrotask(() => editorService.insertText(pendingInputText));
       }
+    } else if (pendingInputText) {
+      queueMicrotask(() => editorService.insertText(pendingInputText));
     }
-  }, [selectedAgent, editorService]);
+  }, [selectedAgent, pendingInputText, editorService]);
 
   return { stickyMentionsTextContent };
 };

--- a/front/lib/butler/analyze_conversation.test.ts
+++ b/front/lib/butler/analyze_conversation.test.ts
@@ -83,15 +83,18 @@ function setupMocksForHighConfidenceRename() {
     new Ok({
       actions: [
         {
-          name: "analyze_conversation",
+          name: "suggest_actions",
           arguments: {
             rename_confidence: 85,
             new_title: "Better Title",
+            rename_rationale: "The current title is not descriptive enough.",
             agent_confidence: 0,
             agent_name: "",
             agent_prompt: "",
+            agent_rationale: "",
             frame_confidence: 0,
             frame_prompt: "",
+            frame_rationale: "",
           },
         },
       ],
@@ -150,6 +153,7 @@ describe("analyzeConversation", () => {
     expect(suggestions[0].suggestionType).toBe("rename_title");
     expect(suggestions[0].metadata).toEqual({
       suggestedTitle: "Better Title",
+      rationale: "The current title is not descriptive enough.",
     });
     expect(suggestions[0].status).toBe("pending");
     expect(suggestions[0].sourceMessageId).toBe(message!.id);
@@ -162,7 +166,10 @@ describe("analyzeConversation", () => {
         type: "butler_suggestion_created",
         suggestion: expect.objectContaining({
           suggestionType: "rename_title",
-          metadata: { suggestedTitle: "Better Title" },
+          metadata: {
+            suggestedTitle: "Better Title",
+            rationale: "The current title is not descriptive enough.",
+          },
           sourceMessageSId: message!.sId,
         }),
       }),
@@ -189,15 +196,18 @@ describe("analyzeConversation", () => {
       new Ok({
         actions: [
           {
-            name: "analyze_conversation",
+            name: "suggest_actions",
             arguments: {
               rename_confidence: 40,
               new_title: "Some Title",
+              rename_rationale: "",
               agent_confidence: 0,
               agent_name: "",
               agent_prompt: "",
+              agent_rationale: "",
               frame_confidence: 0,
               frame_prompt: "",
+              frame_rationale: "",
             },
           },
         ],
@@ -235,15 +245,18 @@ describe("analyzeConversation", () => {
       new Ok({
         actions: [
           {
-            name: "analyze_conversation",
+            name: "suggest_actions",
             arguments: {
               rename_confidence: 90,
               new_title: "  test conversation  ",
+              rename_rationale: "",
               agent_confidence: 0,
               agent_name: "",
               agent_prompt: "",
+              agent_rationale: "",
               frame_confidence: 0,
               frame_prompt: "",
+              frame_rationale: "",
             },
           },
         ],
@@ -318,15 +331,18 @@ describe("analyzeConversation", () => {
       new Ok({
         actions: [
           {
-            name: "analyze_conversation",
+            name: "suggest_actions",
             arguments: {
               rename_confidence: 20,
               new_title: "",
+              rename_rationale: "",
               agent_confidence: 85,
               agent_name: "CodeHelper",
               agent_prompt: "Can you help me debug this issue?",
+              agent_rationale: "This agent can help debug the issue.",
               frame_confidence: 0,
               frame_prompt: "",
+              frame_rationale: "",
             },
           },
         ],
@@ -347,6 +363,7 @@ describe("analyzeConversation", () => {
       agentSId: "agent-1",
       agentName: "CodeHelper",
       prompt: "Can you help me debug this issue?",
+      rationale: "This agent can help debug the issue.",
     });
   });
 
@@ -376,15 +393,18 @@ describe("analyzeConversation", () => {
       new Ok({
         actions: [
           {
-            name: "analyze_conversation",
+            name: "suggest_actions",
             arguments: {
               rename_confidence: 85,
               new_title: "Better Title",
+              rename_rationale: "The current title is not descriptive enough.",
               agent_confidence: 80,
               agent_name: "CodeHelper",
               agent_prompt: "Can you help?",
+              agent_rationale: "This agent can help with your question.",
               frame_confidence: 0,
               frame_prompt: "",
+              frame_rationale: "",
             },
           },
         ],
@@ -432,15 +452,18 @@ describe("analyzeConversation", () => {
       new Ok({
         actions: [
           {
-            name: "analyze_conversation",
+            name: "suggest_actions",
             arguments: {
               rename_confidence: 20,
               new_title: "",
+              rename_rationale: "",
               agent_confidence: 90,
               agent_name: "NonExistentAgent",
               agent_prompt: "Help me",
+              agent_rationale: "This agent could help.",
               frame_confidence: 0,
               frame_prompt: "",
+              frame_rationale: "",
             },
           },
         ],

--- a/front/lib/butler/evaluators/call_agent.ts
+++ b/front/lib/butler/evaluators/call_agent.ts
@@ -14,6 +14,7 @@ const AgentResult = z.object({
   agent_confidence: z.number(),
   agent_name: z.string(),
   agent_prompt: z.string(),
+  agent_rationale: z.string().optional(),
 });
 
 export const callAgentEvaluator: ButlerEvaluator = {
@@ -88,8 +89,18 @@ export const callAgentEvaluator: ButlerEvaluator = {
             description:
               "A suggested message to send to the recommended agent, or empty string if none.",
           },
+          agent_rationale: {
+            type: "string",
+            description:
+              "A brief one-sentence explanation of why this agent would help (e.g. 'This agent can search your Jira board for the ticket you mentioned'), or empty string if none.",
+          },
         },
-        required: ["agent_confidence", "agent_name", "agent_prompt"],
+        required: [
+          "agent_confidence",
+          "agent_name",
+          "agent_prompt",
+          "agent_rationale",
+        ],
       },
     };
 
@@ -105,7 +116,8 @@ export const callAgentEvaluator: ButlerEvaluator = {
       return null;
     }
 
-    const { agent_confidence, agent_name, agent_prompt } = parsed.data;
+    const { agent_confidence, agent_name, agent_prompt, agent_rationale } =
+      parsed.data;
 
     if (
       agent_confidence < CONFIDENCE_THRESHOLD ||
@@ -130,6 +142,7 @@ export const callAgentEvaluator: ButlerEvaluator = {
         agentSId: matchedAgent.sId,
         agentName: matchedAgent.name,
         prompt: agent_prompt,
+        rationale: agent_rationale || undefined,
       },
     };
   },

--- a/front/lib/butler/evaluators/create_frame.ts
+++ b/front/lib/butler/evaluators/create_frame.ts
@@ -13,6 +13,7 @@ const CONFIDENCE_THRESHOLD = 70;
 const FrameResult = z.object({
   frame_confidence: z.number(),
   frame_prompt: z.string(),
+  frame_rationale: z.string().optional(),
 });
 
 export const createFrameEvaluator: ButlerEvaluator = {
@@ -63,8 +64,13 @@ export const createFrameEvaluator: ButlerEvaluator = {
             description:
               "A prompt describing the Frame to create, or empty string if none.",
           },
+          frame_rationale: {
+            type: "string",
+            description:
+              "A brief one-sentence explanation of why a Frame would benefit this conversation, or empty string if none.",
+          },
         },
-        required: ["frame_confidence", "frame_prompt"],
+        required: ["frame_confidence", "frame_prompt", "frame_rationale"],
       },
     };
 
@@ -80,7 +86,7 @@ export const createFrameEvaluator: ButlerEvaluator = {
       return null;
     }
 
-    const { frame_confidence, frame_prompt } = parsed.data;
+    const { frame_confidence, frame_prompt, frame_rationale } = parsed.data;
 
     if (frame_confidence < CONFIDENCE_THRESHOLD || !frame_prompt) {
       return null;
@@ -95,6 +101,7 @@ export const createFrameEvaluator: ButlerEvaluator = {
         agentSId: GLOBAL_AGENTS_SID.DUST,
         agentName: "Dust",
         prompt: frame_prompt,
+        rationale: frame_rationale || undefined,
       },
     };
   },

--- a/front/lib/butler/evaluators/rename_title.ts
+++ b/front/lib/butler/evaluators/rename_title.ts
@@ -12,6 +12,7 @@ const CONFIDENCE_THRESHOLD = 70;
 const RenameResult = z.object({
   rename_confidence: z.number(),
   new_title: z.string(),
+  rename_rationale: z.string().optional(),
 });
 
 export const renameTitleEvaluator: ButlerEvaluator = {
@@ -75,8 +76,13 @@ export const renameTitleEvaluator: ButlerEvaluator = {
             type: "string",
             description: "The proposed new title (3-8 words).",
           },
+          rename_rationale: {
+            type: "string",
+            description:
+              "A brief one-sentence explanation of why renaming would help, or empty string if confidence is low.",
+          },
         },
-        required: ["rename_confidence", "new_title"],
+        required: ["rename_confidence", "new_title", "rename_rationale"],
       },
     };
 
@@ -92,7 +98,7 @@ export const renameTitleEvaluator: ButlerEvaluator = {
       return null;
     }
 
-    const { rename_confidence, new_title } = parsed.data;
+    const { rename_confidence, new_title, rename_rationale } = parsed.data;
 
     if (
       rename_confidence < CONFIDENCE_THRESHOLD ||
@@ -105,7 +111,10 @@ export const renameTitleEvaluator: ButlerEvaluator = {
 
     return {
       suggestionType: "rename_title",
-      metadata: { suggestedTitle: new_title },
+      metadata: {
+        suggestedTitle: new_title,
+        rationale: rename_rationale || undefined,
+      },
     };
   },
 };

--- a/front/types/conversation_butler_suggestion.ts
+++ b/front/types/conversation_butler_suggestion.ts
@@ -20,6 +20,7 @@ export type ButlerSuggestionStatus =
 // Per-type metadata schemas (no suggestionType inside — that's the top-level discriminator).
 const RenameTitleMetadataSchema = z.object({
   suggestedTitle: z.string(),
+  rationale: z.string().optional(),
 });
 
 // Shared schema for suggestion types that invoke an agent with a prompt.
@@ -27,6 +28,7 @@ const AgentInvocationMetadataSchema = z.object({
   agentSId: z.string(),
   agentName: z.string(),
   prompt: z.string(),
+  rationale: z.string().optional(),
 });
 
 export type RenameTitleMetadata = z.infer<typeof RenameTitleMetadataSchema>;


### PR DESCRIPTION
## Description

I think it's better to have a suggestion of prompt rather than a direct send. This allows user to edit it and feel more o control: they click on the send button, it's not imposed

So this PR changes that

## Tests

<img width="1023" height="182" alt="image" src="https://github.com/user-attachments/assets/fe72b514-2ca6-442a-97df-a93383a7cac9" />

<img width="983" height="164" alt="image" src="https://github.com/user-attachments/assets/e7bdcef2-eabf-4c0a-8cb2-2e908393499e" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
