### PR TITLE
Redis xadd: increase jitter to avoid conflicts

### DIFF
--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -239,9 +239,11 @@ class RedisHybridManager {
           },
           "Error publishing to Redis, retrying..."
         );
-        // Sleep for ~10ms to avoid flooding the Redis stream with events.
+        // Sleep for at least 5ms to avoid flooding the Redis stream with events.
+        // Add jitter to avoid re-conflicting when restarting
+        // increase jitter for each failure to avoid even more conflicts
         await new Promise((resolve) =>
-          setTimeout(resolve, 5 + Math.floor(Math.random() * 5))
+          setTimeout(resolve, 5 + Math.floor(Math.random() * 5 * (i + 1)))
         );
       }
     }

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -236,6 +236,7 @@ class RedisHybridManager {
             origin,
             attempt: i + 1,
             maxAttempts: MAX_PUBLISH_ATTEMPTS,
+            eventId,
           },
           "Error publishing to Redis, retrying..."
         );


### PR DESCRIPTION
## Description

We are seeing XADD being rejected because the event id is not the lastest one.
This is eitehr a conflict between multiple events happening at the same time, or an issue of `Date.now()` not being monotonic (so we get t2 before t1)
Both issues are reduced by add additional sleep time and additional jitter

## Tests
no

## Risk

low, may slightly delay the operation

## Deploy Plan

deploy front
