### PR TITLE
 Add 3-tier cache structure to system prompt for better Anthropic prefix caching

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -305,15 +305,15 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const sections = constructPromptMultiActions(authenticator1, params);
 
-    // Regular agents return a flat SystemPromptContext[] (no tuple).
-    const [instructions, context] = normalizePrompt(sections);
+    // Regular agents return a flat SystemPromptContext[] (no structured prompt).
+    const { instructions, sharedContext } = normalizePrompt(sections);
     expect(instructions).toHaveLength(0);
-    expect(context.length).toBeGreaterThan(0);
-    expect(context[0].content).toContain("# INSTRUCTIONS");
-    expect(context.every((s) => s.role === "context")).toBe(true);
+    expect(sharedContext.length).toBeGreaterThan(0);
+    expect(sharedContext[0].content).toContain("# INSTRUCTIONS");
+    expect(sharedContext.every((s) => s.role === "context")).toBe(true);
   });
 
-  it("should return tuple with instructions for deep-dive agent", () => {
+  it("should return structured prompt with instructions for deep-dive agent", () => {
     const deepDiveConfig = {
       ...agentConfig1,
       sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
@@ -332,16 +332,19 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const sections = constructPromptMultiActions(authenticator1, params);
 
-    // Deep-dive returns the tuple form [instructions, context].
-    const [instructions, context] = normalizePrompt(sections);
+    // Deep-dive returns the structured form with instructions separated.
+    const { instructions, sharedContext, ephemeralContext } =
+      normalizePrompt(sections);
     expect(instructions).toHaveLength(1);
     expect(instructions[0].role).toBe("instruction");
     expect(instructions[0].content).toContain("# INSTRUCTIONS");
-    expect(context.length).toBeGreaterThan(0);
-    expect(context.every((s) => s.role === "context")).toBe(true);
+    expect(sharedContext.length).toBeGreaterThan(0);
+    expect(sharedContext.every((s) => s.role === "context")).toBe(true);
+    // Deep-dive has no per-user context (no memories/user profile).
+    expect(ephemeralContext).toHaveLength(0);
   });
 
-  it("should return tuple with user/workspace context in context block for copilot agent", () => {
+  it("should place workspace context in shared tier and user context in ephemeral tier for copilot agent", () => {
     const copilotConfig = {
       ...agentConfig1,
       sId: GLOBAL_AGENTS_SID.COPILOT,
@@ -367,7 +370,8 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     const sections = constructPromptMultiActions(authenticator1, params);
 
-    const [instructions, context] = normalizePrompt(sections);
+    const { instructions, sharedContext, ephemeralContext } =
+      normalizePrompt(sections);
     expect(instructions).toHaveLength(1);
     expect(instructions[0].role).toBe("instruction");
     expect(instructions[0].content).toContain("# INSTRUCTIONS");
@@ -375,18 +379,19 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(instructions[0].content).not.toContain("<user_context>");
     expect(instructions[0].content).not.toContain("<workspace_context>");
 
-    // They must appear in the dynamic context block.
-    const userSection = context.find((s) =>
-      s.content.includes("<user_context>")
-    );
-    expect(userSection).toBeDefined();
-    expect(userSection?.content).toContain("Engineering");
-
-    const wsSection = context.find((s) =>
+    // Workspace context belongs in the shared tier (cached across users).
+    const wsSection = sharedContext.find((s) =>
       s.content.includes("<workspace_context>")
     );
     expect(wsSection).toBeDefined();
     expect(wsSection?.content).toContain("AVAILABLE MODELS");
+
+    // User context belongs in the ephemeral tier (per-user).
+    const userSection = ephemeralContext.find((s) =>
+      s.content.includes("<user_context>")
+    );
+    expect(userSection).toBeDefined();
+    expect(userSection?.content).toContain("Engineering");
   });
 
   it("should include memoriesContext in prompt output when provided", () => {
@@ -430,7 +435,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(text).not.toContain("<existing_memories>");
   });
 
-  it("should keep memory_guidelines in instructions but existing_memories in context for dust-like agents", () => {
+  it("should keep memory_guidelines in instructions but existing_memories in ephemeral tier for dust-like agents", () => {
     const dustConfig = {
       ...agentConfig1,
       sId: GLOBAL_AGENTS_SID.DUST,
@@ -453,15 +458,15 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     };
 
     const sections = constructPromptMultiActions(authenticator1, params);
-    const [instructions, context] = normalizePrompt(sections);
+    const { instructions, ephemeralContext } = normalizePrompt(sections);
 
-    // Dust-like agents use the tuple form: memory_guidelines are in instructions.
+    // Dust-like agents: memory_guidelines are in instructions.
     expect(instructions).toHaveLength(1);
     expect(instructions[0].content).toContain("<memory_guidelines>");
     expect(instructions[0].content).not.toContain("<existing_memories>");
 
-    // existing_memories should be in a separate context section.
-    const memoriesSection = context.find((s) =>
+    // existing_memories should be in the ephemeral tier (per-user).
+    const memoriesSection = ephemeralContext.find((s) =>
       s.content.includes("<existing_memories>")
     );
     expect(memoriesSection).toBeDefined();

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -24,6 +24,7 @@ import { PROJECT_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/projec
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import type {
+  StructuredSystemPrompt,
   SystemPromptContext,
   SystemPromptSections,
 } from "@app/lib/api/llm/types/options";
@@ -467,17 +468,16 @@ export function constructPromptMultiActions(
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
 
   if (hasStaticInstructions) {
-    // Tuple form [instructions, context] for prompt caching.
+    // Structured form with 3 cache tiers, ordered from most stable to most volatile.
     //
-    // The instructions block is cached across calls. It contains content that is
-    // stable for a given agent configuration: agent instructions, tools
-    // (directives + server listing), skills, format docs, and guidelines.
-    // Tools and skills can vary when JIT servers or mid-conversation skill
-    // activation occur, but this is uncommon enough that the cache hit rate
-    // is still favorable.
+    // Instructions (long cache): stable per agent config — agent instructions,
+    // tools (directives + server listing), skills, format docs, and guidelines.
     //
-    // The context block contains per-call dynamic content: date, conversation
-    // project, and user memories.
+    // Shared context (short cache): workspace-scoped data shared across users —
+    // date, project context, toolsets, workspace info. A cache breakpoint here
+    // lets different users in the same workspace share this prefix.
+    //
+    // Ephemeral context (no breakpoint): per-user data — memories, user profile.
     const fullInstructions = [
       instructionsContent,
       toolsSection,
@@ -489,19 +489,25 @@ export function constructPromptMultiActions(
       .filter((s) => s.trim() !== "")
       .join("\n");
 
-    const dynamicContext: SystemPromptContext[] = [
+    const sharedContext: SystemPromptContext[] = [
       { role: "context" as const, content: contextSection },
       { role: "context" as const, content: projectContextSection },
-      { role: "context" as const, content: memoriesContext ?? "" },
       { role: "context" as const, content: toolsetsContext ?? "" },
-      { role: "context" as const, content: userContext ?? "" },
       { role: "context" as const, content: workspaceContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
 
-    return [
-      [{ role: "instruction", content: fullInstructions }],
-      dynamicContext,
-    ];
+    const ephemeralContext: SystemPromptContext[] = [
+      { role: "context" as const, content: memoriesContext ?? "" },
+      { role: "context" as const, content: userContext ?? "" },
+    ].filter((s) => s.content.trim() !== "");
+
+    const structured: StructuredSystemPrompt = {
+      instructions: [{ role: "instruction", content: fullInstructions }],
+      sharedContext,
+      ephemeralContext,
+    };
+
+    return structured;
   }
 
   // Flat context-only form: everything goes into context. Original section order.
@@ -514,6 +520,7 @@ export function constructPromptMultiActions(
     { role: "context" as const, content: attachmentsSection },
     { role: "context" as const, content: pastedContentSection },
     { role: "context" as const, content: guidelinesSection },
+    { role: "context" as const, content: toolsetsContext ?? "" },
     { role: "context" as const, content: memoriesContext ?? "" },
     { role: "context" as const, content: userContext ?? "" },
     { role: "context" as const, content: workspaceContext ?? "" },

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -37,9 +37,14 @@ import type { WorkspaceType } from "@app/types/user";
  *
  * Each non-empty tier becomes a separate text block. Cache breakpoints are placed
  * between tiers so that stable prefixes can be reused even when later tiers change:
- *  1. Instructions  – long TTL (1h), stable per agent config.
- *  2. Shared context – default ephemeral (5min), shared across callers.
+ *  1. Instructions      – long TTL (1h), stable per agent config.
+ *  2. Shared context    – default ephemeral (5min), shared across callers.
  *  3. Ephemeral context – no breakpoint needed (last block).
+ *
+ * IMPORTANT: Anthropic allows at most 4 cache breakpoints per request (system + messages combined).
+ * This function uses up to 2 (instructions + shared context).
+ * The remaining budget is for the global + conversation message breakpoints.
+ * /!\ Do not add breakpoints here without auditing total usage across the request.
  */
 function buildSystemBlocks(
   { instructions, sharedContext, ephemeralContext }: StructuredSystemPrompt,

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -25,8 +25,7 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
   LLMStreamParameters,
-  SystemPromptContext,
-  SystemPromptInstruction,
+  StructuredSystemPrompt,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
@@ -34,36 +33,47 @@ import { dustManagedCredentials } from "@app/types/api/credentials";
 import type { WorkspaceType } from "@app/types/user";
 
 /**
- * Maps prompt sections to Anthropic system blocks.
+ * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
  *
- * Each non-empty group in [instructions, context] becomes a separate system block.
- * Both currently use the default 5min cache TTL. Once we remove entropy from
- * instructions, we can use extended-cache-ttl (1h) for better cache savings.
+ * Each non-empty tier becomes a separate text block. Cache breakpoints are placed
+ * between tiers so that stable prefixes can be reused even when later tiers change:
+ *  1. Instructions  – long TTL (1h), stable per agent config.
+ *  2. Shared context – default ephemeral (5min), shared across callers.
+ *  3. Ephemeral context – no breakpoint needed (last block).
  */
 function buildSystemBlocks(
-  [instructions, context]: [SystemPromptInstruction[], SystemPromptContext[]],
+  { instructions, sharedContext, ephemeralContext }: StructuredSystemPrompt,
   { hasConditionalJITTools }: { hasConditionalJITTools?: boolean }
 ) {
   const instructionsText = instructions.map((s) => s.content).join("\n");
-  const contextText = context.map((s) => s.content).join("\n");
+  const sharedText = sharedContext.map((s) => s.content).join("\n");
+  const ephemeralText = ephemeralContext.map((s) => s.content).join("\n");
 
   const system: Anthropic.Beta.Messages.BetaTextBlockParam[] = [];
+
   if (instructionsText) {
     // If we have conditional JIT tools, we expect more variability in the instructions, so we keep
     // the default ephemeral cache. Otherwise, we can set a longer TTL to maximize cache hits.
     const ttl: "1h" | undefined = hasConditionalJITTools ? undefined : "1h";
-
     system.push({
       type: "text",
       text: instructionsText,
       cache_control: { type: "ephemeral", ttl },
     });
   }
-  if (contextText) {
+
+  if (sharedText) {
     system.push({
       type: "text",
-      text: contextText,
+      text: sharedText,
       cache_control: { type: "ephemeral" },
+    });
+  }
+
+  if (ephemeralText) {
+    system.push({
+      type: "text",
+      text: ephemeralText,
     });
   }
 
@@ -148,6 +158,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     payload: BetaMessageStreamParams
   ): AsyncGenerator<LLMEvent> {
     try {
+      console.log(">> payload:", JSON.stringify(payload, null, 2));
       const events = this.client.beta.messages.stream(payload);
 
       const shouldCountReasoningTokens =

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -158,7 +158,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     payload: BetaMessageStreamParams
   ): AsyncGenerator<LLMEvent> {
     try {
-      console.log(">> payload:", JSON.stringify(payload, null, 2));
       const events = this.client.beta.messages.stream(payload);
 
       const shouldCountReasoningTokens =

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -22,17 +22,26 @@ export interface SystemPromptContext {
 }
 
 /**
- * Structured system prompt with type-enforced ordering.
+ * Structured system prompt with cache-tier ordering.
  *
- * - Context-only: `SystemPromptContext[]` - flat array, most common case
- * - With instructions: `[SystemPromptInstruction[], SystemPromptContext[]]` - tuple
- *   guaranteeing instructions come before context
+ * - Context-only: `SystemPromptContext[]` is a flat array, most common case.
+ * - Structured: named tiers ordered from most stable to most volatile. Provider clients might place
+ * cache breakpoints between tiers to maximize prefix cache hits.
  *
- * Provider clients may map each tuple position to a separate system block for caching.
+ *   `instructions`     – stable per agent config (long cache TTL).
+ *   `sharedContext`    – shared across calls with different callers (short cache).
+ *   `ephemeralContext` – per-call data, varies every time (no breakpoint needed since it's the last
+ *                        tier).
  */
+export interface StructuredSystemPrompt {
+  instructions: SystemPromptInstruction[];
+  sharedContext: SystemPromptContext[];
+  ephemeralContext: SystemPromptContext[];
+}
+
 export type SystemPromptSections =
   | SystemPromptContext[]
-  | [SystemPromptInstruction[], SystemPromptContext[]];
+  | StructuredSystemPrompt;
 
 /**
  * Plain strings are treated as context-only. Pass `SystemPromptSections` to
@@ -40,37 +49,47 @@ export type SystemPromptSections =
  */
 export type SystemPromptInput = string | SystemPromptSections;
 
-// Checks whether sections use the [instructions, context] tuple form.
-function isTupleForm(
+function isStructured(
   sections: SystemPromptSections
-): sections is [SystemPromptInstruction[], SystemPromptContext[]] {
-  return sections.length > 0 && Array.isArray(sections[0]);
+): sections is StructuredSystemPrompt {
+  return "instructions" in sections;
 }
 
-// Normalizes prompt input into [instructions, context] tuple form.
+/**
+ * Normalizes any prompt input into a `StructuredSystemPrompt`.
+ *
+ * - Plain string -> single shared-context block.
+ * - Flat `SystemPromptContext[]` -> all items become shared context.
+ * - `StructuredSystemPrompt` -> returned as-is.
+ */
 export function normalizePrompt(
   input: SystemPromptInput
-): [SystemPromptInstruction[], SystemPromptContext[]] {
+): StructuredSystemPrompt {
   if (isString(input)) {
-    return [[], [{ role: "context", content: input }]];
+    return {
+      instructions: [],
+      sharedContext: [{ role: "context", content: input }],
+      ephemeralContext: [],
+    };
   }
 
-  if (isTupleForm(input)) {
+  if (isStructured(input)) {
     return input;
   }
 
-  return [[], input];
+  return { instructions: [], sharedContext: input, ephemeralContext: [] };
 }
 
-// Joins all sections into a flat string.
+// Joins all tiers into a flat string.
 export function systemPromptToText(input: SystemPromptInput): string {
   if (isString(input)) {
     return input;
   }
 
-  const [instructions, context] = normalizePrompt(input);
+  const { instructions, sharedContext, ephemeralContext } =
+    normalizePrompt(input);
 
-  return [...instructions, ...context]
+  return [...instructions, ...sharedContext, ...ephemeralContext]
     .map((s) => s.content.trim())
     .filter(Boolean)
     .join("\n");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The system prompt previously used a 2-tier structure (instructions + context) for Anthropic prompt caching. This meant that per-user data like memories invalidated the cache for workspace-scoped data like toolsets and workspace info, even though that data is shared across all users in the same workspace.

This introduces a `StructuredSystemPrompt` interface with three named tiers ordered by decreasing stability: instructions (stable per agent config, 1h TTL), sharedContext (workspace-scoped, 5min TTL), and ephemeralContext (per-user, 5-min TTL, no breakpoint). The Anthropic client places cache breakpoints between each tier so that two users in the same workspace hitting the same agent share the instructions + workspace prefix even though their memories differ.

Also fixes a pre-existing bug where toolsetsContext was missing from the flat code path used by non-global agents.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
