### PR TITLE
feat: link suggestion to generated message

### DIFF
--- a/front/lib/resources/conversation_butler_suggestion_resource.ts
+++ b/front/lib/resources/conversation_butler_suggestion_resource.ts
@@ -278,6 +278,56 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     await this.update({ status: "dismissed" as const }, transaction);
   }
 
+  /**
+   * Link the agent message that was produced after accepting this suggestion.
+   */
+  async setResultMessage(
+    resultMessageId: ModelId,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.update({ resultMessageId }, transaction);
+  }
+
+  /**
+   * Find an accepted call_agent or create_frame suggestion in a conversation
+   * that has not yet been linked to a result message, matching a specific agent.
+   */
+  static async fetchAcceptedWithoutResult(
+    auth: Authenticator,
+    {
+      conversationId,
+      agentConfigurationSId,
+    }: {
+      conversationId: ModelId;
+      agentConfigurationSId: string;
+    }
+  ): Promise<ConversationButlerSuggestionResource | null> {
+    const results = await this.baseFetch(auth, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId,
+        status: "accepted",
+        resultMessageId: null,
+        suggestionType: { [Op.in]: ["call_agent", "create_frame"] },
+      },
+      order: [["updatedAt", "DESC"]],
+      limit: 1,
+    });
+
+    const suggestion = results[0];
+    if (!suggestion) {
+      return null;
+    }
+
+    // Verify the suggestion's agent matches the one that just responded.
+    const metadata = suggestion.metadata as { agentSId: string };
+    if (metadata.agentSId !== agentConfigurationSId) {
+      return null;
+    }
+
+    return suggestion;
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -7,7 +7,13 @@ import {
   type AuthenticatorType,
   getFeatureFlags,
 } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
@@ -19,6 +25,62 @@ import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/
 import { launchTrackProgrammaticUsage } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { signalButlerComplete } from "@app/temporal/butler/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+/**
+ * Link the completed agent message to an accepted butler suggestion if the
+ * suggestion's agent matches the one that just responded.
+ */
+async function linkButlerSuggestionResult(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  try {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      agentLoopArgs.conversationId
+    );
+    if (!conversation) {
+      return;
+    }
+
+    // Resolve the agent message to get its configurationId and message ModelId.
+    const message = await MessageModel.findOne({
+      where: {
+        sId: agentLoopArgs.agentMessageId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [{ model: AgentMessageModel, as: "agentMessage" }],
+    });
+
+    if (!message?.agentMessage) {
+      return;
+    }
+
+    const suggestion =
+      await ConversationButlerSuggestionResource.fetchAcceptedWithoutResult(
+        auth,
+        {
+          conversationId: conversation.id,
+          agentConfigurationSId: message.agentMessage.agentConfigurationId,
+        }
+      );
+
+    if (suggestion) {
+      // we have an accepted suggestion matching the agent that just responded — link it to the result message
+      await suggestion.setResultMessage(message.id);
+    }
+  } catch (e) {
+    // Non-critical — log and continue.
+    logger.warn(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: e,
+      },
+      "Butler: failed to link suggestion to result message"
+    );
+  }
+}
 
 export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
@@ -54,6 +116,9 @@ export async function finalizeSuccessfulAgentLoopActivity(
           conversationId: agentLoopArgs.conversationId,
           messageId: agentLoopArgs.agentMessageId,
         })
+      : Promise.resolve(),
+    shouldSignalButler
+      ? linkButlerSuggestionResult(auth, agentLoopArgs)
       : Promise.resolve(),
   ]);
 }


### PR DESCRIPTION
## Description

Link a suggestion to a generated message

  How it works end-to-end

  1. User clicks "Draft" on a call_agent suggestion → suggestion marked accepted (no resultMessageId)
  2. User edits prompt in composer, sends → agent loop starts
  3. Agent completes → finalizeSuccessfulAgentLoopActivity runs
  4. linkButlerSuggestionResult finds the accepted suggestion where agentSId matches the responding agent → sets resultMessageId to the agent message's id
  5. If the user changed the agent before sending, the agentSId won't match and no link is made (correct behavior — the suggestion wasn't truly followed)
  
  This adds, yet, another thing in the agent loop, are we ok with that? I think it has a small enough impact
  
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
