### PR TITLE
[LLM] Gate Claude Opus 4.6 behind feature flag for Pro users

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -15,15 +15,15 @@ export function isModelAvailable(
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null
 ) {
-  if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {
-    return false;
-  }
-
   if (
     m.enforceEnterpriseAvailability === true &&
-    (plan === null ||
-      (!isEntreprisePlanPrefix(plan.code) && !isDustCompanyPlan(plan.code)))
+    plan &&
+    (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
   ) {
+    return true;
+  }
+
+  if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {
     return false;
   }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -20,7 +20,7 @@ export function isModelAvailable(
   }
 
   if (
-    m.enterpriseOnly === true &&
+    m.enforceEnterpriseAvailability === true &&
     (plan === null ||
       (!isEntreprisePlanPrefix(plan.code) && !isDustCompanyPlan(plan.code)))
   ) {

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -231,7 +231,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
-  enterpriseOnly: true,
+  enforceEnterpriseAvailability: true,
   customBetas: [
     "auto-thinking-2026-01-12",
     "effort-2025-11-24",

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -231,6 +231,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
+  featureFlag: "claude_4_5_opus_feature",
   enforceEnterpriseAvailability: true,
   customBetas: [
     "auto-thinking-2026-01-12",

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -76,7 +76,7 @@ export type ModelConfigurationType = Omit<
   featureFlag?: WhitelistableFeature;
   customAssistantFeatureFlag?: WhitelistableFeature;
   tokenizer: TokenizerConfig;
-  enterpriseOnly?: boolean;
+  enforceEnterpriseAvailability?: boolean;
 };
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -76,6 +76,7 @@ export type ModelConfigurationType = Omit<
   featureFlag?: WhitelistableFeature;
   customAssistantFeatureFlag?: WhitelistableFeature;
   tokenizer: TokenizerConfig;
+  // When true, enterprise plans bypass the feature flag check (both can coexist).
   enforceEnterpriseAvailability?: boolean;
 };
 


### PR DESCRIPTION
## Description

Renames `enterpriseOnly` to `enforceEnterpriseAvailability` on model configs and updates the `isModelAvailable` logic so that enterprise plans always bypass the feature flag check, while Pro users can still access Claude Opus 4.6 via the `claude_4_5_opus_feature` flag.

## Tests

Not tested.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`