### PR TITLE
fix: run_agent blocking events not bubbling up to parent conversation

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -151,8 +151,11 @@ export function MCPRunAgentActionDetails({
     if (resultResource) {
       return resultResource.resource.uri;
     }
+    if (childStreamIds) {
+      return `/w/${owner.sId}/conversation/${childStreamIds.conversationId}`;
+    }
     return null;
-  }, [resultResource]);
+  }, [resultResource, childStreamIds, owner.sId]);
 
   const references = useMemo(() => {
     if (!resultResource?.resource.refs) {

--- a/front/lib/api/actions/servers/run_agent/types.ts
+++ b/front/lib/api/actions/servers/run_agent/types.ts
@@ -44,6 +44,7 @@ export function makeToolBlockedAwaitingInputResponse(
 ): CallToolResult {
   const agentPauseToolOutputResource = {
     mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+    type: "tool_blocked_awaiting_input" as const,
     text: "Tool requires resume after blocking events",
     uri: "",
     blockingEvents,

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -49,6 +49,7 @@ export async function publishDeferredEventsActivity(
           // This event indicates that personal authentication is required to proceed.
           const newEvent: AgentMessageEvents = {
             ...event,
+            isLastBlockingEventForStep: isLastEvent,
             metadata: {
               ...event.metadata,
               // Override the message id to root the event to the right channel.


### PR DESCRIPTION
## Description

When a sub-agent needs validation (e.g., personal auth for Slack), the blocking event should bubble up to the parent conversation so the user can act on it. Instead, the parent was completing "successfully" with a text response about the auth issue.

The root cause is that https://github.com/dust-tt/dust/pull/21289 accidentally dropped the type: "tool_blocked_awaiting_input" discriminator when extracting the resource into a variable in makeToolBlockedAwaitingInputResponse. This caused BlockedAwaitingInputOutputResourceSchema validation to silently fail, so getExitOrPauseEvents found nothing, the action got marked as succeeded, and the model happily ran another iteration, generating a text response about needing auth instead of actually blocking.

On top of that, publishDeferredEventsActivity wasn't setting isLastBlockingEventForStep on the tool_personal_auth_required event itself (only on the legacy tool_error event). Since the tool_error handler was removed from run_agent in https://github.com/dust-tt/dust/pull/18814, the parent stream  handler could never see the flag and break out of the child stream loop.

Also snuck in a small UX fix: the "View full conversation" link now appears while the sub-agent is still running by falling back to childStreamIds.conversationId, instead of only showing up after the child completes.


## Tests

- Create a conversation using an agent with a sub-agent (run_agent) that requires personal auth (e.g., Slack)
- Verify the parent conversation shows the auth prompt instead of completing with a text response
- Verify the "View full conversation" link appears in the sidebar while the sub-agent is still running
- Verify that approving the auth resumes the sub-agent and parent correctly


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 