### PR TITLE
[Extension] Panels & Overlays improvements

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -2,13 +2,15 @@ import { ConversationContainerVirtuoso } from "@app/components/assistant/convers
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { InputBarContextProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { Button, MenuIcon } from "@dust-tt/sparkle";
 import type { AttachSelectionMessage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 interface ConversationContainerProps {
   workspace: LightWorkspaceType;
@@ -29,6 +31,7 @@ export const ConversationContainer = ({
 }: ConversationContainerProps) => {
   const platform = usePlatform();
   const { currentPanel } = useConversationSidePanelContext();
+  const { setSidebarOpen } = useContext(SidebarContext);
   const fileUploaderService = useFileUploaderService(
     platform.capture,
     conversationId
@@ -112,7 +115,15 @@ export const ConversationContainer = ({
         />
       </div>
       {conversation && currentPanel && (
-        <div className="flex h-full w-full flex-col">
+        <div className="fixed inset-0 z-50 flex flex-col bg-background dark:bg-background-night">
+          {/* Hamburger button overlaid in the pl-14 area of AppLayoutTitle header */}
+          <div className="absolute left-0 top-0 z-10 flex h-[58px] shrink-0 items-center px-2">
+            <Button
+              variant="ghost"
+              icon={MenuIcon}
+              onClick={() => setSidebarOpen(true)}
+            />
+          </div>
           <ConversationSidePanelContent
             owner={workspace}
             conversation={conversation}

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -11,6 +11,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
@@ -552,21 +553,24 @@ function PreviewActionButtons({
   exitFullScreen,
   reloadFile,
 }: PreviewActionButtonsProps) {
+  const clientType = useClientType();
   return (
     <div className="fixed bottom-4 right-3 flex flex-col gap-1 rounded-lg bg-white p-1 shadow-md dark:bg-gray-900">
-      <Tooltip
-        label={`${isFullScreen ? "Exit" : "Go to"} full screen mode`}
-        side="left"
-        tooltipTriggerAsChild
-        trigger={
-          <Button
-            icon={isFullScreen ? FullscreenExitIcon : FullscreenIcon}
-            variant="ghost"
-            size="xs"
-            onClick={isFullScreen ? exitFullScreen : enterFullScreen}
-          />
-        }
-      />
+      {clientType !== "extension" && (
+        <Tooltip
+          label={`${isFullScreen ? "Exit" : "Go to"} full screen mode`}
+          side="left"
+          tooltipTriggerAsChild
+          trigger={
+            <Button
+              icon={isFullScreen ? FullscreenExitIcon : FullscreenIcon}
+              variant="ghost"
+              size="xs"
+              onClick={isFullScreen ? exitFullScreen : enterFullScreen}
+            />
+          }
+        />
+      )}
       {lastEditedByAgentConfigurationId && (
         <Tooltip
           label={


### PR DESCRIPTION
## Description

Improves the conversation side panel UX in the extension by addressing two issues from #6983:

1. **Side panel now renders as a full overlay**: When opening message breakdowns or frames, the panel now covers the entire screen with a fixed overlay (`fixed inset-0 z-50`) instead of being constrained to a resizable panel. A hamburger button is added to access the sidebar when the panel is open.
<img width="293" height="465" alt="image" src="https://github.com/user-attachments/assets/8b6808c8-de59-4890-8e26-2eac4a1b2de1" />
<img width="293" height="465" alt="image" src="https://github.com/user-attachments/assets/e00cd7ae-b421-4919-99f2-4e1a10a27f33" />



2. **Fullscreen button hidden in extension**: The fullscreen toggle button in frame previews is now hidden for extension clients (via `clientType !== "extension"` check) since fullscreen mode doesn't work properly in the extension context.

## Tests

Manually tested in the extension.

## Risk

Low. Changes are isolated to the extension's conversation side panel rendering.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
