### PR TITLE
refactor: butler with multiple calls

### DIFF
--- a/front/lib/butler/analyze_conversation.test.ts
+++ b/front/lib/butler/analyze_conversation.test.ts
@@ -510,12 +510,17 @@ describe("analyzeConversation", () => {
       messageId: lastMessage.sId,
     });
 
-    // Verify the prompt passed to renderConversationForModel contains the history.
-    expect(mockRenderConversation).toHaveBeenCalledOnce();
-    const promptArg = mockRenderConversation.mock.calls[0][1].prompt;
-    expect(promptArg).toContain("DISMISSED");
-    expect(promptArg).toContain("Better Title");
-    expect(promptArg).toContain("Do NOT re-suggest titles that were DISMISSED");
+    // Verify that at least one of the prompts passed to renderConversationForModel
+    // contains the dismissed suggestion history (from the rename evaluator).
+    const allPrompts = mockRenderConversation.mock.calls.map(
+      (call) => call[1].prompt
+    );
+    const renamePrompt = allPrompts.find((p) => p.includes("DISMISSED"));
+    expect(renamePrompt).toBeDefined();
+    expect(renamePrompt).toContain("Better Title");
+    expect(renamePrompt).toContain(
+      "Do NOT re-suggest titles that were DISMISSED"
+    );
   });
 
   describe("rename_title throttling", () => {

--- a/front/lib/butler/analyze_conversation.ts
+++ b/front/lib/butler/analyze_conversation.ts
@@ -1,17 +1,22 @@
-import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  getAllEvaluators,
+  getEvaluatorForPass,
+} from "@app/lib/butler/evaluator_registry";
+import type {
+  ButlerEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+} from "@app/lib/butler/evaluators/types";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import {
-  GLOBAL_AGENTS_SID,
-  getFastestWhitelistedModel,
-} from "@app/types/assistant/assistant";
+import { getFastestWhitelistedModel } from "@app/types/assistant/assistant";
 import type {
   ButlerDoneEvent,
   ButlerSuggestionCreatedEvent,
@@ -19,227 +24,12 @@ import type {
   ConversationType,
 } from "@app/types/assistant/conversation";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
-import type { ButlerSuggestionData } from "@app/types/conversation_butler_suggestion";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { ButlerSuggestionType } from "@app/types/conversation_butler_suggestion";
 import type { ModelId } from "@app/types/shared/model_id";
-import { assertNever } from "@app/types/shared/utils/assert_never";
-import { z } from "zod";
-
-const SUGGEST_ACTIONS_FUNCTION_NAME = "suggest_actions";
-
-const MAX_AGENTS_IN_PROMPT = 50;
-const RENAME_CONFIDENCE_THRESHOLD = 70;
-const AGENT_CONFIDENCE_THRESHOLD = 70;
-const FRAME_CONFIDENCE_THRESHOLD = 70;
 
 // Minimum number of messages (by rank distance) between two suggestions of the same type.
 const SUGGESTION_COOLDOWN_MESSAGES = 10;
-
-const SuggestActionsResult = z.object({
-  rename_confidence: z.number(),
-  new_title: z.string(),
-  agent_confidence: z.number(),
-  agent_name: z.string(),
-  agent_prompt: z.string(),
-  frame_confidence: z.number(),
-  frame_prompt: z.string(),
-});
-
-function buildAnalyzeConversationSpecifications({
-  hasAgents,
-  shouldSuggestFrame,
-}: {
-  hasAgents: boolean;
-  shouldSuggestFrame: boolean;
-}): AgentActionSpecification[] {
-  const properties: Record<string, object> = {
-    rename_confidence: {
-      type: "number",
-      description:
-        "Confidence from 0 to 100 that renaming the conversation title would improve it. " +
-        "Use 0 if the current title is already adequate.",
-    },
-    new_title: {
-      type: "string",
-      description: "The proposed new title (3-8 words).",
-    },
-    agent_confidence: {
-      type: "number",
-      description: hasAgents
-        ? "Confidence from 0 to 100 that one of the listed agents would help the user. " +
-          "Use 0 if the conversation doesn't need agent help or no agents are relevant."
-        : "Always set to 0 when no agents are available.",
-    },
-    agent_name: {
-      type: "string",
-      description: hasAgents
-        ? "The exact name of the recommended agent from the provided list, or empty string if none."
-        : "Always set to empty string when no agents are available.",
-    },
-    agent_prompt: {
-      type: "string",
-      description: hasAgents
-        ? "A suggested message to send to the recommended agent, or empty string if none."
-        : "Always set to empty string when no agents are available.",
-    },
-    frame_confidence: {
-      type: "number",
-      description: shouldSuggestFrame
-        ? "Confidence from 0 to 100 that creating a visual Frame would benefit the conversation. " +
-          "Use 0 if the conversation does not have content that would benefit from visual output."
-        : "Always set to 0 when frame suggestions are not available.",
-    },
-    frame_prompt: {
-      type: "string",
-      description: shouldSuggestFrame
-        ? "A prompt describing the Frame to create (e.g. 'Create a dashboard summarizing the sales data we discussed'), or empty string if none."
-        : "Always set to empty string when frame suggestions are not available.",
-    },
-  };
-
-  return [
-    {
-      name: SUGGEST_ACTIONS_FUNCTION_NAME,
-      description:
-        "Suggested one or many actions to the user to evaluate whether the title should be updated, " +
-        "whether an available agent could help, and whether a visual Frame should be created.",
-      inputSchema: {
-        type: "object",
-        properties,
-        required: [
-          "rename_confidence",
-          "new_title",
-          "agent_confidence",
-          "agent_name",
-          "agent_prompt",
-          "frame_confidence",
-          "frame_prompt",
-        ],
-      },
-    },
-  ];
-}
-
-function buildPrompt(
-  currentTitle: string,
-  agents: LightAgentConfigurationType[],
-  suggestionHistory: ButlerSuggestionData[],
-  shouldSuggestFrame: boolean
-): string {
-  const shouldBuildPromptForAgentSuggestion = agents.length > 0;
-
-  let prompt = "You are a conversation analyst. Your job is to:\n";
-
-  const tasks: string[] = [
-    "Score how much the conversation title would benefit from being updated.",
-  ];
-  if (shouldBuildPromptForAgentSuggestion) {
-    tasks.push("Determine if one of the available agents could help the user.");
-  }
-  if (shouldSuggestFrame) {
-    tasks.push(
-      "Determine if creating a visual Frame would benefit the conversation."
-    );
-  }
-
-  for (let i = 0; i < tasks.length; i++) {
-    prompt += `${i + 1}. ${tasks[i]}\n`;
-  }
-  prompt += "\n";
-
-  prompt +=
-    "Title evaluation guidelines:\n" +
-    "- The current title was auto-generated early in the conversation and may no longer reflect the main topic.\n" +
-    "- A good title is 3-8 words, specific, and captures the main intent.\n" +
-    "- Set rename_confidence HIGH (>75) only when the current title is clearly wrong, misleading, " +
-    "or the conversation has shifted to a completely different topic.\n" +
-    "- Set rename_confidence LOW (<30) when the current title is already a reasonable summary, " +
-    "or the difference is just stylistic.\n" +
-    "- Be conservative — most auto-generated titles are adequate.\n\n";
-
-  if (shouldBuildPromptForAgentSuggestion) {
-    prompt +=
-      "Agent suggestion guidelines:\n" +
-      "- Review the list of available agents below and determine if one could help with the user's current question or task.\n" +
-      "- Set agent_confidence HIGH (>75) only when an agent clearly matches the user's need " +
-      "and hasn't already been involved in the conversation.\n" +
-      "- Set agent_confidence LOW (<30) when the user's need is already being addressed " +
-      "or no agent is a strong match.\n" +
-      "- The agent_name MUST exactly match one of the names from the list below.\n" +
-      "- The agent_prompt should be a natural message the user would send to that agent.\n\n" +
-      "Available agents:\n";
-
-    for (const agent of agents) {
-      const description = agent.description ? `: ${agent.description}` : "";
-      prompt += `- ${agent.name}${description}\n`;
-    }
-
-    prompt += "\n";
-  } else {
-    prompt +=
-      "No agents are available, so set agent_confidence to 0, agent_name to empty string, " +
-      "and agent_prompt to empty string.\n\n";
-  }
-
-  if (shouldSuggestFrame) {
-    prompt +=
-      "Frame creation guidelines:\n" +
-      "- Frames are interactive visual components (dashboards, charts, presentations, formatted documents).\n" +
-      "- Set frame_confidence HIGH (>75) only when the conversation contains content that would clearly " +
-      "benefit from visual presentation: data analysis results, document iterations, structured reports, " +
-      "comparisons, or summaries that deserve a polished visual output.\n" +
-      "- Set frame_confidence LOW (<30) when the conversation is purely Q&A, has no structured data " +
-      "or document content, or the user hasn't reached a point where a visual output would add value.\n" +
-      '- The frame_prompt should start with "Use the Create Frames skill to" followed by a description of the Frame to create ' +
-      'based on the conversation content (e.g. "Use the Create Frames skill to build a dashboard summarizing the quarterly sales data", ' +
-      '"Use the Create Frames skill to turn this report into an interactive presentation").\n' +
-      "- Be conservative — only suggest frames when there is clear value in a visual output.\n\n";
-  } else {
-    prompt +=
-      "Frame creation is not available, so set frame_confidence to 0 and frame_prompt to empty string.\n\n";
-  }
-
-  if (suggestionHistory.length > 0) {
-    prompt += "Previous suggestion history (most recent first):\n";
-    for (const suggestion of suggestionHistory) {
-      const outcome =
-        suggestion.status === "accepted" ? "ACCEPTED" : "DISMISSED";
-
-      switch (suggestion.suggestionType) {
-        case "rename_title": {
-          const { suggestedTitle } = suggestion.metadata;
-          prompt += `- [${outcome}] Title rename: "${suggestedTitle}"\n`;
-          break;
-        }
-        case "call_agent": {
-          if (!shouldBuildPromptForAgentSuggestion) {
-            break;
-          }
-          const { agentName } = suggestion.metadata;
-          prompt += `- [${outcome}] Agent suggestion: ${agentName}\n`;
-          break;
-        }
-        case "create_frame": {
-          if (!shouldSuggestFrame) {
-            break;
-          }
-          prompt += `- [${outcome}] Frame creation suggestion\n`;
-          break;
-        }
-        default:
-          assertNever(suggestion);
-      }
-    }
-    prompt +=
-      "\nDo NOT re-suggest titles that were DISMISSED. " +
-      "Learn from accepted suggestions to understand user preferences.\n\n";
-  }
-
-  prompt +=
-    "You MUST call the tool. Always call it.\n\n" +
-    `The current conversation title is: "${currentTitle}"`;
-
-  return prompt;
-}
 
 /**
  * Single pass over conversation content to extract:
@@ -258,7 +48,9 @@ function analyzeConversationContent(conversation: ConversationType): {
         participantIds.add(message.configuration.sId);
         if (!hasFrame) {
           for (const action of message.actions) {
-            if (action.internalMCPServerName === "interactive_content") {
+            if (
+              action.internalMCPServerName === INTERACTIVE_CONTENT_SERVER_NAME
+            ) {
               hasFrame = true;
               break;
             }
@@ -275,14 +67,14 @@ function analyzeConversationContent(conversation: ConversationType): {
  *
  * Rules:
  * - If the most recent suggestion of this type is still pending and was
- *   created within the last SUGGESTION_COOLDOWN_MESSAGES messages → skip
+ *   created within the last SUGGESTION_COOLDOWN_MESSAGES messages -> skip
  *   (the user can still see it).
  * - If the most recent suggestion is still pending but is older than
- *   SUGGESTION_COOLDOWN_MESSAGES messages → auto-dismiss it (it's scrolled
+ *   SUGGESTION_COOLDOWN_MESSAGES messages -> auto-dismiss it (it's scrolled
  *   off-screen) and allow a new one.
  * - If the most recent suggestion was dismissed/accepted within the last
- *   SUGGESTION_COOLDOWN_MESSAGES messages → skip (respect cooldown).
- * - Otherwise → allow.
+ *   SUGGESTION_COOLDOWN_MESSAGES messages -> skip (respect cooldown).
+ * - Otherwise -> allow.
  */
 async function shouldProposeSuggestion(
   auth: Authenticator,
@@ -293,7 +85,7 @@ async function shouldProposeSuggestion(
   }: {
     conversationId: ModelId;
     currentMessageRank: number;
-    suggestionType: "rename_title" | "call_agent" | "create_frame";
+    suggestionType: ButlerSuggestionType;
   }
 ): Promise<boolean> {
   const latest =
@@ -339,18 +131,183 @@ async function shouldProposeSuggestion(
 }
 
 /**
- * Analyze a conversation with a single LLM call to evaluate both title rename
- * and agent suggestion. Creates suggestions for each evaluation that passes
- * the confidence threshold.
+ * Run a single evaluator: build prompt, call LLM, parse result.
+ */
+async function runEvaluator(
+  auth: Authenticator,
+  evaluator: ButlerEvaluator,
+  context: EvaluatorContext,
+  model: ModelConfigurationType
+): Promise<EvaluatorResult | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const { prompt, specification } = evaluator.getPromptAndSpec(context);
+
+  const modelConversationRes = await renderConversationForModel(auth, {
+    conversation: context.conversation,
+    model,
+    prompt,
+    tools: "",
+    allowedTokenCount: model.contextSize - model.generationTokensCount,
+    excludeActions: true,
+    excludeImages: true,
+  });
+
+  if (modelConversationRes.isErr()) {
+    logger.error(
+      {
+        conversationId: context.conversation.id,
+        evaluator: evaluator.type,
+        error: modelConversationRes.error,
+      },
+      "Butler: failed to render conversation for evaluator"
+    );
+    return null;
+  }
+
+  const { modelConversation: conv } = modelConversationRes.value;
+  if (conv.messages.length === 0) {
+    return null;
+  }
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: specification.name,
+      useCache: false,
+    },
+    {
+      conversation: conv,
+      prompt,
+      specifications: [specification],
+      forceToolCall: specification.name,
+    },
+    {
+      context: {
+        operationType: "butler_analyze_conversation",
+        conversationId: context.conversation.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    logger.error(
+      {
+        conversationId: context.conversation.id,
+        evaluator: evaluator.type,
+        error: res.error,
+      },
+      "Butler: LLM call failed for evaluator"
+    );
+    return null;
+  }
+
+  const action = res.value.actions?.[0];
+  if (!action?.arguments) {
+    logger.warn(
+      { conversationId: context.conversation.id, evaluator: evaluator.type },
+      "Butler: no tool call in LLM response for evaluator"
+    );
+    return null;
+  }
+
+  return evaluator.parseResult(action.arguments, context);
+}
+
+/**
+ * Given an evaluator result, check throttling and create the suggestion.
+ */
+async function createSuggestionFromResult(
+  auth: Authenticator,
+  result: EvaluatorResult,
+  context: EvaluatorContext
+): Promise<void> {
+  const shouldPropose = await shouldProposeSuggestion(auth, {
+    conversationId: context.conversation.id,
+    currentMessageRank: context.sourceMessageRank,
+    suggestionType: result.suggestionType,
+  });
+
+  if (!shouldPropose) {
+    return;
+  }
+
+  const suggestion = await ConversationButlerSuggestionResource.makeNew(auth, {
+    conversationId: context.conversation.id,
+    sourceMessageId: context.sourceMessageId,
+    suggestionType: result.suggestionType,
+    metadata: result.metadata,
+    status: "pending",
+  });
+
+  const event: ButlerSuggestionCreatedEvent = {
+    type: "butler_suggestion_created",
+    created: Date.now(),
+    suggestion: suggestion.toJSON(),
+  };
+
+  await publishConversationEvent(event, {
+    conversationId: context.conversation.sId,
+  });
+}
+
+/**
+ * Build the shared EvaluatorContext from the conversation state.
+ */
+async function buildEvaluatorContext(
+  auth: Authenticator,
+  conversation: ConversationType,
+  sourceMessage: { id: ModelId; rank: number }
+): Promise<EvaluatorContext> {
+  const { participantIds, hasFrame } = analyzeConversationContent(conversation);
+
+  const allAgents = await getAgentConfigurationsForView({
+    auth,
+    agentsGetView: "list",
+    variant: "extra_light",
+    sort: "priority",
+  });
+
+  const availableAgents = allAgents.filter(
+    (a) => a.scope !== "global" && !participantIds.has(a.sId)
+  );
+
+  const suggestionHistory =
+    await ConversationButlerSuggestionResource.fetchResolvedByConversation(
+      auth,
+      { conversationId: conversation.id, limit: 10 }
+    );
+
+  return {
+    conversation,
+    currentTitle: conversation.title ?? "",
+    availableAgents,
+    hasFrame,
+    sourceMessageId: sourceMessage.id,
+    sourceMessageRank: sourceMessage.rank,
+    suggestionHistory,
+  };
+}
+
+/**
+ * Analyze a conversation by running evaluators and creating suggestions.
+ *
+ * When `passIndex` is provided, only the evaluator selected by rotation runs
+ * (stagger mode -- reduces suggestion fatigue). When omitted or -1, all
+ * evaluators run (used for the final/complete pass after butler_complete signal).
  */
 export async function analyzeConversation(
   auth: Authenticator,
   {
     conversation,
     messageId,
+    passIndex = -1,
   }: {
     conversation: ConversationType;
     messageId: string;
+    passIndex?: number;
   }
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
@@ -373,130 +330,6 @@ export async function analyzeConversation(
       return;
     }
 
-    // Single pass to extract participant agents and frame presence.
-    const { participantIds, hasFrame } =
-      analyzeConversationContent(conversation);
-
-    // Fetch available agents, filtering out global (platform-provided) agents
-    // and those already participating in the conversation.
-    const allAgents = await getAgentConfigurationsForView({
-      auth,
-      agentsGetView: "list",
-      variant: "extra_light",
-      sort: "priority",
-    });
-    const availableAgents = allAgents
-      .filter((a) => a.scope !== "global" && !participantIds.has(a.sId))
-      .slice(0, MAX_AGENTS_IN_PROMPT);
-
-    // Only suggest frames if no frame has already been created in this conversation.
-    const shouldSuggestFrame = !hasFrame;
-
-    const suggestionHistory =
-      await ConversationButlerSuggestionResource.fetchResolvedByConversation(
-        auth,
-        { conversationId: conversation.id, limit: 10 }
-      );
-
-    const currentTitle = conversation.title ?? "";
-    const prompt = buildPrompt(
-      currentTitle,
-      availableAgents,
-      suggestionHistory,
-      shouldSuggestFrame
-    );
-
-    const modelConversationRes = await renderConversationForModel(auth, {
-      conversation,
-      model,
-      prompt,
-      tools: "",
-      allowedTokenCount: model.contextSize - model.generationTokensCount,
-      excludeActions: true,
-      excludeImages: true,
-    });
-
-    if (modelConversationRes.isErr()) {
-      logger.error(
-        {
-          conversationId: conversation.id,
-          error: modelConversationRes.error,
-        },
-        "Butler: failed to render conversation for analysis"
-      );
-      return;
-    }
-
-    const { modelConversation: conv } = modelConversationRes.value;
-    if (conv.messages.length === 0) {
-      return;
-    }
-
-    const res = await runMultiActionsAgent(
-      auth,
-      {
-        providerId: model.providerId,
-        modelId: model.modelId,
-        functionCall: SUGGEST_ACTIONS_FUNCTION_NAME,
-        useCache: false,
-      },
-      {
-        conversation: conv,
-        prompt,
-        specifications: buildAnalyzeConversationSpecifications({
-          hasAgents: availableAgents.length > 0,
-          shouldSuggestFrame,
-        }),
-        forceToolCall: SUGGEST_ACTIONS_FUNCTION_NAME,
-      },
-      {
-        context: {
-          operationType: "butler_analyze_conversation",
-          conversationId: conversation.sId,
-          workspaceId: owner.sId,
-        },
-      }
-    );
-
-    if (res.isErr()) {
-      logger.error(
-        { conversationId: conversation.id, error: res.error },
-        "Butler: LLM call failed for conversation analysis"
-      );
-      return;
-    }
-
-    const action = res.value.actions?.[0];
-    if (!action?.arguments) {
-      logger.warn(
-        { conversationId: conversation.id },
-        "Butler: no tool call in LLM response for conversation analysis. Hint: improve the prompt"
-      );
-      return;
-    }
-
-    const parseResult = SuggestActionsResult.safeParse(action.arguments);
-    if (parseResult.success === false) {
-      logger.error(
-        {
-          conversationId: conversation.id,
-          error: parseResult.error,
-        },
-        "Butler: failed to parse LLM response for conversation analysis"
-      );
-      return;
-    }
-
-    const {
-      rename_confidence,
-      new_title,
-      agent_confidence,
-      agent_name,
-      agent_prompt,
-      frame_confidence,
-      frame_prompt,
-    } = parseResult.data;
-
     // Find the source message that triggered this analysis.
     const sourceMessage = await MessageModel.findOne({
       where: {
@@ -510,171 +343,29 @@ export async function analyzeConversation(
       return;
     }
 
-    // Process rename title suggestion with throttling.
-    if (
-      rename_confidence >= RENAME_CONFIDENCE_THRESHOLD &&
-      new_title &&
-      new_title.trim().toLowerCase() !== currentTitle.trim().toLowerCase()
-    ) {
-      const shouldPropose = await shouldProposeSuggestion(auth, {
-        conversationId: conversation.id,
-        currentMessageRank: sourceMessage.rank,
-        suggestionType: "rename_title",
-      });
+    const context = await buildEvaluatorContext(auth, conversation, {
+      id: sourceMessage.id,
+      rank: sourceMessage.rank,
+    });
 
-      if (shouldPropose) {
-        const suggestion = await ConversationButlerSuggestionResource.makeNew(
-          auth,
-          {
-            conversationId: conversation.id,
-            sourceMessageId: sourceMessage.id,
-            suggestionType: "rename_title",
-            metadata: { suggestedTitle: new_title },
-            status: "pending",
-          }
-        );
-
-        const event: ButlerSuggestionCreatedEvent = {
-          type: "butler_suggestion_created",
-          created: Date.now(),
-          suggestion: suggestion.toJSON(),
-        };
-
-        await publishConversationEvent(event, {
-          conversationId: conversation.sId,
-        });
-
-        logger.info(
-          {
-            conversationId: conversation.id,
-            suggestedTitle: new_title,
-            confidence: rename_confidence,
-          },
-          "Butler: created rename_title suggestion"
-        );
-      }
+    // Select evaluators based on pass mode.
+    let evaluatorsToRun: ButlerEvaluator[];
+    if (passIndex >= 0) {
+      // Stagger mode: pick one evaluator from the rotation.
+      const selected = getEvaluatorForPass(passIndex);
+      evaluatorsToRun = [selected];
+    } else {
+      // Complete mode: run all evaluators.
+      evaluatorsToRun = getAllEvaluators();
     }
 
-    // Process agent suggestion with throttling.
-    if (
-      agent_confidence >= AGENT_CONFIDENCE_THRESHOLD &&
-      agent_name &&
-      agent_prompt
-    ) {
-      // Validate that the agent name matches an available agent (case-insensitive).
-      const matchedAgent = availableAgents.find(
-        (a) => a.name.toLowerCase() === agent_name.toLowerCase()
-      );
+    // Filter to evaluators that should actually run.
+    evaluatorsToRun = evaluatorsToRun.filter((e) => e.shouldRun(context));
 
-      if (matchedAgent) {
-        const shouldPropose = await shouldProposeSuggestion(auth, {
-          conversationId: conversation.id,
-          currentMessageRank: sourceMessage.rank,
-          suggestionType: "call_agent",
-        });
-
-        if (shouldPropose) {
-          const suggestion = await ConversationButlerSuggestionResource.makeNew(
-            auth,
-            {
-              conversationId: conversation.id,
-              sourceMessageId: sourceMessage.id,
-              suggestionType: "call_agent",
-              metadata: {
-                agentSId: matchedAgent.sId,
-                agentName: matchedAgent.name,
-                prompt: agent_prompt,
-              },
-              status: "pending",
-            }
-          );
-
-          const event: ButlerSuggestionCreatedEvent = {
-            type: "butler_suggestion_created",
-            created: Date.now(),
-            suggestion: suggestion.toJSON(),
-          };
-
-          await publishConversationEvent(event, {
-            conversationId: conversation.sId,
-          });
-
-          logger.info(
-            {
-              conversationId: conversation.id,
-              agentName: matchedAgent.name,
-              agentSId: matchedAgent.sId,
-              confidence: agent_confidence,
-            },
-            "Butler: created call_agent suggestion"
-          );
-        } else {
-          logger.info(
-            {
-              conversationId: conversation.id,
-              agentName: matchedAgent.name,
-              confidence: agent_confidence,
-            },
-            "Butler: skipped call_agent suggestion (throttled)"
-          );
-        }
-      }
-    }
-
-    // Process frame creation suggestion with throttling.
-    if (
-      shouldSuggestFrame &&
-      frame_confidence >= FRAME_CONFIDENCE_THRESHOLD &&
-      frame_prompt
-    ) {
-      const dustAgent = allAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST);
-
-      if (!dustAgent) {
-        logger.debug(
-          { conversationId: conversation.id },
-          "Butler: @dust agent not found, skipping create_frame suggestion"
-        );
-      } else {
-        const shouldPropose = await shouldProposeSuggestion(auth, {
-          conversationId: conversation.id,
-          currentMessageRank: sourceMessage.rank,
-          suggestionType: "create_frame",
-        });
-
-        if (shouldPropose) {
-          const suggestion = await ConversationButlerSuggestionResource.makeNew(
-            auth,
-            {
-              conversationId: conversation.id,
-              sourceMessageId: sourceMessage.id,
-              suggestionType: "create_frame",
-              metadata: {
-                agentSId: dustAgent.sId,
-                agentName: dustAgent.name,
-                prompt: frame_prompt,
-              },
-              status: "pending",
-            }
-          );
-
-          const event: ButlerSuggestionCreatedEvent = {
-            type: "butler_suggestion_created",
-            created: Date.now(),
-            suggestion: suggestion.toJSON(),
-          };
-
-          await publishConversationEvent(event, {
-            conversationId: conversation.sId,
-          });
-
-          logger.info(
-            {
-              conversationId: conversation.id,
-              confidence: frame_confidence,
-            },
-            "Butler: created create_frame suggestion"
-          );
-        }
+    for (const evaluator of evaluatorsToRun) {
+      const result = await runEvaluator(auth, evaluator, context, model);
+      if (result) {
+        await createSuggestionFromResult(auth, result, context);
       }
     }
   } finally {

--- a/front/lib/butler/evaluator_registry.ts
+++ b/front/lib/butler/evaluator_registry.ts
@@ -1,0 +1,45 @@
+import { callAgentEvaluator } from "@app/lib/butler/evaluators/call_agent";
+import { createFrameEvaluator } from "@app/lib/butler/evaluators/create_frame";
+import { renameTitleEvaluator } from "@app/lib/butler/evaluators/rename_title";
+import type { ButlerEvaluator } from "@app/lib/butler/evaluators/types";
+
+// All registered evaluators.
+const ALL_EVALUATORS: ButlerEvaluator[] = [
+  renameTitleEvaluator,
+  callAgentEvaluator,
+  createFrameEvaluator,
+];
+
+// Weighted rotation sequence: agent gets ~50%, frame ~30%, rename ~20%.
+// Each pass picks one evaluator from this cycle based on passIndex.
+const ROTATION_SEQUENCE: ButlerEvaluator[] = [
+  callAgentEvaluator, // 0
+  createFrameEvaluator, // 1
+  callAgentEvaluator, // 2
+  renameTitleEvaluator, // 3
+  createFrameEvaluator, // 4
+  callAgentEvaluator, // 5
+  renameTitleEvaluator, // 6
+  callAgentEvaluator, // 7
+  createFrameEvaluator, // 8
+  callAgentEvaluator, // 9
+];
+
+/**
+ * Select the evaluator to run for this pass.
+ *
+ * Uses a weighted rotation: the passIndex selects from ROTATION_SEQUENCE.
+ * If the selected evaluator's shouldRun returns false, we try the next ones
+ * in the sequence until we find one that can run (or exhaust options).
+ */
+export function getEvaluatorForPass(passIndex: number): ButlerEvaluator {
+  const idx = passIndex % ROTATION_SEQUENCE.length;
+  return ROTATION_SEQUENCE[idx];
+}
+
+/**
+ * Get all evaluators (used when running the final/complete pass).
+ */
+export function getAllEvaluators(): ButlerEvaluator[] {
+  return ALL_EVALUATORS;
+}

--- a/front/lib/butler/evaluators/call_agent.ts
+++ b/front/lib/butler/evaluators/call_agent.ts
@@ -1,0 +1,136 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type {
+  ButlerEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+} from "@app/lib/butler/evaluators/types";
+import { z } from "zod";
+
+const FUNCTION_NAME = "evaluate_agent";
+const CONFIDENCE_THRESHOLD = 70;
+const MAX_AGENTS_IN_PROMPT = 50;
+
+const AgentResult = z.object({
+  agent_confidence: z.number(),
+  agent_name: z.string(),
+  agent_prompt: z.string(),
+});
+
+export const callAgentEvaluator: ButlerEvaluator = {
+  type: "call_agent",
+
+  shouldRun(context: EvaluatorContext): boolean {
+    return context.availableAgents.length > 0;
+  },
+
+  getPromptAndSpec(context: EvaluatorContext): {
+    prompt: string;
+    specification: AgentActionSpecification;
+  } {
+    const agents = context.availableAgents.slice(0, MAX_AGENTS_IN_PROMPT);
+
+    let prompt =
+      "You are a conversation analyst. Your job is to determine if one of the available agents could help the user.\n\n";
+
+    prompt +=
+      "Agent suggestion guidelines:\n" +
+      "- Review the list of available agents below and determine if one could help with the user's current question or task.\n" +
+      "- Set agent_confidence HIGH (>75) only when an agent clearly matches the user's need " +
+      "and hasn't already been involved in the conversation.\n" +
+      "- Set agent_confidence LOW (<30) when the user's need is already being addressed " +
+      "or no agent is a strong match.\n" +
+      "- The agent_name MUST exactly match one of the names from the list below.\n" +
+      "- The agent_prompt should be a natural message the user would send to that agent.\n\n" +
+      "Available agents:\n";
+
+    for (const agent of agents) {
+      const description = agent.description ? `: ${agent.description}` : "";
+      prompt += `- ${agent.name}${description}\n`;
+    }
+    prompt += "\n";
+
+    const agentHistory = context.suggestionHistory.filter(
+      (s) => s.suggestionType === "call_agent"
+    );
+    if (agentHistory.length > 0) {
+      prompt += "Previous agent suggestion history (most recent first):\n";
+      for (const suggestion of agentHistory) {
+        const outcome =
+          suggestion.status === "accepted" ? "ACCEPTED" : "DISMISSED";
+        const { agentName } = suggestion.metadata;
+        prompt += `- [${outcome}] Agent suggestion: ${agentName}\n`;
+      }
+      prompt += "\n";
+    }
+
+    prompt += "You MUST call the tool. Always call it.";
+
+    const specification: AgentActionSpecification = {
+      name: FUNCTION_NAME,
+      description:
+        "Evaluate whether one of the available agents could help the user.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          agent_confidence: {
+            type: "number",
+            description:
+              "Confidence from 0 to 100 that one of the listed agents would help the user. " +
+              "Use 0 if the conversation doesn't need agent help or no agents are relevant.",
+          },
+          agent_name: {
+            type: "string",
+            description:
+              "The exact name of the recommended agent from the provided list, or empty string if none.",
+          },
+          agent_prompt: {
+            type: "string",
+            description:
+              "A suggested message to send to the recommended agent, or empty string if none.",
+          },
+        },
+        required: ["agent_confidence", "agent_name", "agent_prompt"],
+      },
+    };
+
+    return { prompt, specification };
+  },
+
+  parseResult(
+    toolArguments: Record<string, unknown>,
+    context: EvaluatorContext
+  ): EvaluatorResult | null {
+    const parsed = AgentResult.safeParse(toolArguments);
+    if (!parsed.success) {
+      return null;
+    }
+
+    const { agent_confidence, agent_name, agent_prompt } = parsed.data;
+
+    if (
+      agent_confidence < CONFIDENCE_THRESHOLD ||
+      !agent_name ||
+      !agent_prompt
+    ) {
+      return null;
+    }
+
+    // Validate that the agent name matches an available agent (case-insensitive).
+    const matchedAgent = context.availableAgents.find(
+      (a) => a.name.toLowerCase() === agent_name.toLowerCase()
+    );
+
+    if (!matchedAgent) {
+      return null;
+    }
+
+    return {
+      suggestionType: "call_agent",
+      metadata: {
+        agentSId: matchedAgent.sId,
+        agentName: matchedAgent.name,
+        prompt: agent_prompt,
+      },
+    };
+  },
+};

--- a/front/lib/butler/evaluators/create_frame.ts
+++ b/front/lib/butler/evaluators/create_frame.ts
@@ -1,0 +1,101 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type {
+  ButlerEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+} from "@app/lib/butler/evaluators/types";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { z } from "zod";
+
+const FUNCTION_NAME = "evaluate_frame";
+const CONFIDENCE_THRESHOLD = 70;
+
+const FrameResult = z.object({
+  frame_confidence: z.number(),
+  frame_prompt: z.string(),
+});
+
+export const createFrameEvaluator: ButlerEvaluator = {
+  type: "create_frame",
+
+  shouldRun(context: EvaluatorContext): boolean {
+    // Skip if a frame already exists in this conversation.
+    return !context.hasFrame;
+  },
+
+  getPromptAndSpec(_context: EvaluatorContext): {
+    prompt: string;
+    specification: AgentActionSpecification;
+  } {
+    let prompt =
+      "You are a conversation analyst. Your job is to determine if creating a visual Frame would benefit the conversation.\n\n";
+
+    prompt +=
+      "Frame creation guidelines:\n" +
+      "- Frames are interactive visual components (dashboards, charts, presentations, formatted documents).\n" +
+      "- Set frame_confidence HIGH (>75) only when the conversation contains content that would clearly " +
+      "benefit from visual presentation: data analysis results, document iterations, structured reports, " +
+      "comparisons, or summaries that deserve a polished visual output.\n" +
+      "- Set frame_confidence LOW (<30) when the conversation is purely Q&A, has no structured data " +
+      "or document content, or the user hasn't reached a point where a visual output would add value.\n" +
+      '- The frame_prompt should start with "Use the Create Frames skill to" followed by a description of the Frame to create ' +
+      'based on the conversation content (e.g. "Use the Create Frames skill to build a dashboard summarizing the quarterly sales data", ' +
+      '"Use the Create Frames skill to turn this report into an interactive presentation").\n' +
+      "- Be conservative -- only suggest frames when there is clear value in a visual output.\n\n";
+
+    prompt += "You MUST call the tool. Always call it.";
+
+    const specification: AgentActionSpecification = {
+      name: FUNCTION_NAME,
+      description:
+        "Evaluate whether creating a visual Frame would benefit the conversation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          frame_confidence: {
+            type: "number",
+            description:
+              "Confidence from 0 to 100 that creating a visual Frame would benefit the conversation. " +
+              "Use 0 if the conversation does not have content that would benefit from visual output.",
+          },
+          frame_prompt: {
+            type: "string",
+            description:
+              "A prompt describing the Frame to create, or empty string if none.",
+          },
+        },
+        required: ["frame_confidence", "frame_prompt"],
+      },
+    };
+
+    return { prompt, specification };
+  },
+
+  parseResult(
+    toolArguments: Record<string, unknown>,
+    context: EvaluatorContext
+  ): EvaluatorResult | null {
+    const parsed = FrameResult.safeParse(toolArguments);
+    if (!parsed.success) {
+      return null;
+    }
+
+    const { frame_confidence, frame_prompt } = parsed.data;
+
+    if (frame_confidence < CONFIDENCE_THRESHOLD || !frame_prompt) {
+      return null;
+    }
+
+    // Find the @dust agent to use for frame creation.
+    // We search all agents (not just availableAgents which filters out globals).
+    // The dust agent sId is a well-known constant.
+    return {
+      suggestionType: "create_frame",
+      metadata: {
+        agentSId: GLOBAL_AGENTS_SID.DUST,
+        agentName: "Dust",
+        prompt: frame_prompt,
+      },
+    };
+  },
+};

--- a/front/lib/butler/evaluators/rename_title.ts
+++ b/front/lib/butler/evaluators/rename_title.ts
@@ -1,0 +1,111 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type {
+  ButlerEvaluator,
+  EvaluatorContext,
+  EvaluatorResult,
+} from "@app/lib/butler/evaluators/types";
+import { z } from "zod";
+
+const FUNCTION_NAME = "evaluate_rename";
+const CONFIDENCE_THRESHOLD = 70;
+
+const RenameResult = z.object({
+  rename_confidence: z.number(),
+  new_title: z.string(),
+});
+
+export const renameTitleEvaluator: ButlerEvaluator = {
+  type: "rename_title",
+
+  shouldRun(): boolean {
+    // Title rename is always worth evaluating.
+    return true;
+  },
+
+  getPromptAndSpec(context: EvaluatorContext): {
+    prompt: string;
+    specification: AgentActionSpecification;
+  } {
+    let prompt =
+      "You are a conversation analyst. Your job is to score how much the conversation title would benefit from being updated.\n\n";
+
+    prompt +=
+      "Title evaluation guidelines:\n" +
+      "- The current title was auto-generated early in the conversation and may no longer reflect the main topic.\n" +
+      "- A good title is 3-8 words, specific, and captures the main intent.\n" +
+      "- Set rename_confidence HIGH (>75) only when the current title is clearly wrong, misleading, " +
+      "or the conversation has shifted to a completely different topic.\n" +
+      "- Set rename_confidence LOW (<30) when the current title is already a reasonable summary, " +
+      "or the difference is just stylistic.\n" +
+      "- Be conservative -- most auto-generated titles are adequate.\n\n";
+
+    const renameHistory = context.suggestionHistory.filter(
+      (s) => s.suggestionType === "rename_title"
+    );
+    if (renameHistory.length > 0) {
+      prompt += "Previous rename suggestion history (most recent first):\n";
+      for (const suggestion of renameHistory) {
+        const outcome =
+          suggestion.status === "accepted" ? "ACCEPTED" : "DISMISSED";
+        const { suggestedTitle } = suggestion.metadata;
+        prompt += `- [${outcome}] Title rename: "${suggestedTitle}"\n`;
+      }
+      prompt +=
+        "\nDo NOT re-suggest titles that were DISMISSED. " +
+        "Learn from accepted suggestions to understand user preferences.\n\n";
+    }
+
+    prompt +=
+      "You MUST call the tool. Always call it.\n\n" +
+      `The current conversation title is: "${context.currentTitle}"`;
+
+    const specification: AgentActionSpecification = {
+      name: FUNCTION_NAME,
+      description: "Evaluate whether the conversation title should be updated.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          rename_confidence: {
+            type: "number",
+            description:
+              "Confidence from 0 to 100 that renaming the conversation title would improve it. " +
+              "Use 0 if the current title is already adequate.",
+          },
+          new_title: {
+            type: "string",
+            description: "The proposed new title (3-8 words).",
+          },
+        },
+        required: ["rename_confidence", "new_title"],
+      },
+    };
+
+    return { prompt, specification };
+  },
+
+  parseResult(
+    toolArguments: Record<string, unknown>,
+    context: EvaluatorContext
+  ): EvaluatorResult | null {
+    const parsed = RenameResult.safeParse(toolArguments);
+    if (!parsed.success) {
+      return null;
+    }
+
+    const { rename_confidence, new_title } = parsed.data;
+
+    if (
+      rename_confidence < CONFIDENCE_THRESHOLD ||
+      !new_title ||
+      new_title.trim().toLowerCase() ===
+        context.currentTitle.trim().toLowerCase()
+    ) {
+      return null;
+    }
+
+    return {
+      suggestionType: "rename_title",
+      metadata: { suggestedTitle: new_title },
+    };
+  },
+};

--- a/front/lib/butler/evaluators/types.ts
+++ b/front/lib/butler/evaluators/types.ts
@@ -1,0 +1,50 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type {
+  ButlerSuggestionData,
+  ButlerSuggestionMetadata,
+  ButlerSuggestionType,
+} from "@app/types/conversation_butler_suggestion";
+import type { ModelId } from "@app/types/shared/model_id";
+
+// What every evaluator receives.
+export interface EvaluatorContext {
+  conversation: ConversationType;
+  currentTitle: string;
+  availableAgents: LightAgentConfigurationType[];
+  hasFrame: boolean;
+  sourceMessageId: ModelId;
+  sourceMessageRank: number;
+  suggestionHistory: ButlerSuggestionData[];
+}
+
+// What an evaluator returns when it has a suggestion to propose.
+export interface EvaluatorResult {
+  suggestionType: ButlerSuggestionType;
+  metadata: ButlerSuggestionMetadata;
+}
+
+// The evaluator contract.
+export interface ButlerEvaluator {
+  // Which suggestion type this evaluator produces.
+  type: ButlerSuggestionType;
+
+  // Whether this evaluator should run given the current conversation state.
+  // Cheap check -- no LLM call. Used to skip evaluators that can't possibly
+  // produce a result (e.g. frame evaluator when a frame already exists).
+  shouldRun(context: EvaluatorContext): boolean;
+
+  // Build the prompt and tool specification for the LLM call.
+  getPromptAndSpec(context: EvaluatorContext): {
+    prompt: string;
+    specification: AgentActionSpecification;
+  };
+
+  // Parse the LLM tool call result and return a suggestion if confidence passes.
+  // Returns null if nothing to suggest.
+  parseResult(
+    toolArguments: Record<string, unknown>,
+    context: EvaluatorContext
+  ): EvaluatorResult | null;
+}

--- a/front/lib/resources/conversation_butler_suggestion_resource.ts
+++ b/front/lib/resources/conversation_butler_suggestion_resource.ts
@@ -278,6 +278,56 @@ export class ConversationButlerSuggestionResource extends BaseResource<Conversat
     await this.update({ status: "dismissed" as const }, transaction);
   }
 
+  /**
+   * Link the agent message that was produced after accepting this suggestion.
+   */
+  async setResultMessage(
+    resultMessageId: ModelId,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.update({ resultMessageId }, transaction);
+  }
+
+  /**
+   * Find an accepted call_agent or create_frame suggestion in a conversation
+   * that has not yet been linked to a result message, matching a specific agent.
+   */
+  static async fetchAcceptedWithoutResult(
+    auth: Authenticator,
+    {
+      conversationId,
+      agentConfigurationSId,
+    }: {
+      conversationId: ModelId;
+      agentConfigurationSId: string;
+    }
+  ): Promise<ConversationButlerSuggestionResource | null> {
+    const results = await this.baseFetch(auth, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId,
+        status: "accepted",
+        resultMessageId: null,
+        suggestionType: { [Op.in]: ["call_agent", "create_frame"] },
+      },
+      order: [["updatedAt", "DESC"]],
+      limit: 1,
+    });
+
+    const suggestion = results[0];
+    if (!suggestion) {
+      return null;
+    }
+
+    // Verify the suggestion's agent matches the one that just responded.
+    const metadata = suggestion.metadata as { agentSId: string };
+    if (metadata.agentSId !== agentConfigurationSId) {
+      return null;
+    }
+
+    return suggestion;
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -7,7 +7,13 @@ import {
   type AuthenticatorType,
   getFeatureFlags,
 } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
@@ -19,6 +25,62 @@ import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/
 import { launchTrackProgrammaticUsage } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { signalButlerComplete } from "@app/temporal/butler/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+/**
+ * Link the completed agent message to an accepted butler suggestion if the
+ * suggestion's agent matches the one that just responded.
+ */
+async function linkButlerSuggestionResult(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  try {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      agentLoopArgs.conversationId
+    );
+    if (!conversation) {
+      return;
+    }
+
+    // Resolve the agent message to get its configurationId and message ModelId.
+    const message = await MessageModel.findOne({
+      where: {
+        sId: agentLoopArgs.agentMessageId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [{ model: AgentMessageModel, as: "agentMessage" }],
+    });
+
+    if (!message?.agentMessage) {
+      return;
+    }
+
+    const suggestion =
+      await ConversationButlerSuggestionResource.fetchAcceptedWithoutResult(
+        auth,
+        {
+          conversationId: conversation.id,
+          agentConfigurationSId: message.agentMessage.agentConfigurationId,
+        }
+      );
+
+    if (suggestion) {
+      // we have an accepted suggestion matching the agent that just responded — link it to the result message
+      await suggestion.setResultMessage(message.id);
+    }
+  } catch (e) {
+    // Non-critical — log and continue.
+    logger.warn(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: e,
+      },
+      "Butler: failed to link suggestion to result message"
+    );
+  }
+}
 
 export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
@@ -54,6 +116,9 @@ export async function finalizeSuccessfulAgentLoopActivity(
           conversationId: agentLoopArgs.conversationId,
           messageId: agentLoopArgs.agentMessageId,
         })
+      : Promise.resolve(),
+    shouldSignalButler
+      ? linkButlerSuggestionResult(auth, agentLoopArgs)
       : Promise.resolve(),
   ]);
 }

--- a/front/temporal/butler/activities.test.ts
+++ b/front/temporal/butler/activities.test.ts
@@ -44,6 +44,7 @@ describe("analyzeConversationActivity", () => {
       authType: authenticator.toJSON(),
       conversationId: conversation.sId,
       messageId: "any-msg-id",
+      passIndex: 0,
     });
 
     const suggestions = await ConversationButlerSuggestionModel.findAll({
@@ -77,6 +78,7 @@ describe("analyzeConversationActivity", () => {
       authType: authenticator.toJSON(),
       conversationId: conversation.sId,
       messageId: "any-msg-id",
+      passIndex: 0,
     });
 
     const suggestions = await ConversationButlerSuggestionModel.findAll({

--- a/front/temporal/butler/activities.ts
+++ b/front/temporal/butler/activities.ts
@@ -7,10 +7,12 @@ export async function analyzeConversationActivity({
   authType,
   conversationId,
   messageId,
+  passIndex,
 }: {
   authType: AuthenticatorType;
   conversationId: string;
   messageId: string;
+  passIndex: number;
 }): Promise<void> {
   const authResult = await Authenticator.fromJSON(authType);
   if (authResult.isErr()) {
@@ -47,5 +49,6 @@ export async function analyzeConversationActivity({
   await analyzeConversation(auth, {
     conversation,
     messageId,
+    passIndex,
   });
 }

--- a/front/temporal/butler/workflows.ts
+++ b/front/temporal/butler/workflows.ts
@@ -25,6 +25,7 @@ export async function butlerWorkflow({
   let needsAnalysis = true;
   let complete = false;
   let latestMessageId: string | null = null;
+  let passIndex = 0;
 
   setHandler(butlerRefreshSignal, (messageId: string) => {
     needsAnalysis = true;
@@ -52,16 +53,19 @@ export async function butlerWorkflow({
         conversationId,
         authType,
         messageId,
+        passIndex,
       });
+      passIndex++;
     }
   }
 
-  // Final analysis after completion signal.
+  // Final analysis after completion signal: run all evaluators (passIndex = -1).
   if (latestMessageId) {
     await analyzeConversationActivity({
       conversationId,
       authType,
       messageId: latestMessageId,
+      passIndex: -1,
     });
   }
 }


### PR DESCRIPTION
## Description

Refactor monolithic analyzer into "evaluator" architecture

  The single-LLM-call analyzeConversation function that evaluated all 3 suggestion types (rename_title, call_agent, create_frame) simultaneously has been split into independent evaluators with a weighted

  Each evaluator owns its prompt, tool spec, result parsing, and shouldRun gate. The orchestrator selects which evaluator to run based on a passIndex:

  Tradeoffs

  Pros:
  - Reduces suggestion fatigue: In stagger mode, at most 1 suggestion per analysis pass instead of up to 3
  - Focused prompts: Each evaluator gets a purpose-built prompt rather than a multi-objective one — should improve suggestion quality
  - Independent shouldRun: Evaluators can cheaply skip themselves (e.g. frame evaluator skips when a frame exists) without bloating a shared prompt

  Cons:
  - More LLM calls in complete mode: When all evaluators run (final pass), it makes multiple separate renderConversationForModel + runMultiActionsAgent calls instead of 1. Each re-renders the conversation
  independently. This is offset by the fact that complete mode only runs once per conversation (on butler_complete signal), and stagger mode (the hot path) makes only 1 call.
  - Conversation rendering not shared across evaluators: Each evaluator's prompt differs, so the tokenized conversation is rendered separately per evaluator in complete mode. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
