### PR TITLE
fix(mcp): fallback to cached tools if admin is disconnected

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -80,6 +80,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
@@ -1097,12 +1098,26 @@ export async function listToolsForServerSideMCPServer(
     return new Ok(serverSideToolConfigs);
   }
 
+  return buildToolConfigurationsFromRawTools(
+    auth,
+    connectionParams.mcpServerId,
+    config,
+    allToolsRaw
+  );
+}
+
+async function buildToolConfigurationsFromRawTools(
+  auth: Authenticator,
+  mcpServerId: string,
+  config: ServerSideMCPServerConfigurationType,
+  allToolsRaw: MCPToolType[]
+): Promise<Result<ServerSideMCPToolConfigurationType[], Error>> {
   const metadata = await RemoteMCPServerToolMetadataResource.fetchByServerId(
     auth,
-    connectionParams.mcpServerId
+    mcpServerId
   );
 
-  const r = getToolExtraFields(connectionParams.mcpServerId, metadata);
+  const r = getToolExtraFields(mcpServerId, metadata);
   if (r.isErr()) {
     return r;
   }
@@ -1114,9 +1129,7 @@ export async function listToolsForServerSideMCPServer(
     toolsArgumentsRequiringApproval,
   } = r.value;
 
-  const availability = getAvailabilityOfInternalMCPServerById(
-    connectionParams.mcpServerId
-  );
+  const availability = getAvailabilityOfInternalMCPServerById(mcpServerId);
 
   const toolsWithStakesRetryPoliciesAndTimeout = allToolsRaw
     .filter(({ name }) => !(toolsEnabled[name] === false)) // Include tools that are enabled (true) or not explicitly disabled (undefined).
@@ -1128,7 +1141,7 @@ export async function listToolsForServerSideMCPServer(
           ? FALLBACK_MCP_TOOL_STAKE_LEVEL
           : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL),
       availability,
-      toolServerId: connectionParams.mcpServerId,
+      toolServerId: mcpServerId,
       ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
       retryPolicy:
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -1164,6 +1177,40 @@ async function listMCPServerToolsAndServerInstructions(
       agentLoopContext: { listToolsContext: agentLoopListToolsContext },
     });
     if (r.isErr()) {
+      // When the workspace connection is broken (admin token revoked/expired),
+      // fall back to cached tools so users are not blocked.
+      if (
+        MCPServerRequiresAdminAuthenticationError.is(r.error) &&
+        isConnectViaMCPServerId(connectionParams) &&
+        isServerSideMCPServerConfiguration(config)
+      ) {
+        const remoteMCPServer = await RemoteMCPServerResource.fetchById(
+          auth,
+          connectionParams.mcpServerId
+        );
+        if (remoteMCPServer?.cachedTools?.length) {
+          logger.warn(
+            {
+              workspaceId: owner.sId,
+              mcpServerId: connectionParams.mcpServerId,
+              cachedToolCount: remoteMCPServer.cachedTools.length,
+            },
+            "Workspace connection broken for remote MCP server, falling back to cached tools"
+          );
+          const cachedToolsRes = await buildToolConfigurationsFromRawTools(
+            auth,
+            connectionParams.mcpServerId,
+            config,
+            remoteMCPServer.cachedTools
+          );
+          if (cachedToolsRes.isOk()) {
+            return new Ok({
+              instructions: undefined,
+              tools: cachedToolsRes.value,
+            });
+          }
+        }
+      }
       return r;
     }
     mcpClient = r.value;

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -146,6 +146,151 @@ async function createMCPProxyConfig(auth: Authenticator, host: string) {
   };
 }
 
+/**
+ * Resolve the OAuth token for a remote MCP server.
+ *
+ * For personal_actions servers:
+ *   - Tool execution: use the user's personal token.
+ *   - Listing tools (user session): try personal token first, fall back to workspace.
+ *   - Listing tools (sync / no user): use workspace token.
+ * For platform_actions or servers without auth: use workspace token or shared secret.
+ */
+async function resolveRemoteServerOAuthToken(
+  auth: Authenticator,
+  {
+    mcpServerId,
+    oAuthUseCase,
+    remoteMCPServer,
+    isToolExecution,
+  }: {
+    mcpServerId: string;
+    oAuthUseCase: MCPOAuthUseCase | null;
+    remoteMCPServer: RemoteMCPServerResource;
+    isToolExecution: boolean;
+  }
+): Promise<
+  Result<
+    {
+      token: OAuthTokens | undefined;
+      oauthConnectionType: "personal" | "workspace" | undefined;
+      oauthConnectionId: string | undefined;
+    },
+    Error | MCPServerPersonalAuthenticationRequiredError
+  >
+> {
+  // Shared secret: no OAuth needed.
+  if (remoteMCPServer.sharedSecret) {
+    return new Ok({
+      token: {
+        access_token: remoteMCPServer.sharedSecret,
+        token_type: "bearer",
+        expires_in: undefined,
+        scope: "",
+      },
+      oauthConnectionType: undefined,
+      oauthConnectionId: undefined,
+    });
+  }
+
+  // No authorization required.
+  if (!remoteMCPServer.authorization) {
+    return new Ok({
+      token: undefined,
+      oauthConnectionType: undefined,
+      oauthConnectionId: undefined,
+    });
+  }
+
+  // Determine which connection type to try.
+  let connectionType: "personal" | "workspace";
+  if (oAuthUseCase === "personal_actions" && isToolExecution) {
+    connectionType = "personal";
+  } else if (oAuthUseCase === "personal_actions" && auth.user()) {
+    // Listing tools with a user session: try personal first.
+    const personalConnection = await getConnectionForMCPServer(auth, {
+      mcpServerId,
+      connectionType: "personal",
+    });
+    if (personalConnection.isOk()) {
+      return new Ok({
+        token: {
+          access_token: personalConnection.value.access_token,
+          token_type: "bearer",
+          expires_in: personalConnection.value.access_token_expiry ?? undefined,
+          scope: personalConnection.value.connection.metadata.scope,
+        },
+        oauthConnectionType: "personal",
+        oauthConnectionId: personalConnection.value.connection.connection_id,
+      });
+    }
+    // Personal connection not found — fall back to workspace.
+    connectionType = "workspace";
+  } else {
+    connectionType = "workspace";
+  }
+
+  // Fetch connection token.
+  const c = await getConnectionForMCPServer(auth, {
+    mcpServerId,
+    connectionType,
+  });
+  if (c.isOk()) {
+    return new Ok({
+      token: {
+        access_token: c.value.access_token,
+        token_type: "bearer",
+        expires_in: c.value.access_token_expiry ?? undefined,
+        scope: c.value.connection.metadata.scope,
+      },
+      oauthConnectionType: connectionType,
+      oauthConnectionId: c.value.connection.connection_id,
+    });
+  }
+
+  // Connection failed — return the appropriate error.
+  const { provider, scope } = remoteMCPServer.authorization;
+
+  switch (connectionType) {
+    case "personal": {
+      // Check if admin has set up the workspace connection.
+      const adminConnectionRes =
+        await MCPServerConnectionResource.findByMCPServer(auth, {
+          mcpServerId,
+          connectionType: "workspace",
+        });
+      if (
+        adminConnectionRes.isErr() &&
+        adminConnectionRes.error.code === "connection_not_found"
+      ) {
+        return new Err(
+          new MCPServerRequiresAdminAuthenticationError(
+            mcpServerId,
+            provider,
+            scope
+          )
+        );
+      }
+      return new Err(
+        new MCPServerPersonalAuthenticationRequiredError(
+          mcpServerId,
+          provider,
+          scope
+        )
+      );
+    }
+    case "workspace":
+      return new Err(
+        new MCPServerRequiresAdminAuthenticationError(
+          mcpServerId,
+          provider,
+          scope
+        )
+      );
+    default:
+      assertNever(connectionType);
+  }
+}
+
 export async function connectToMCPServer(
   auth: Authenticator,
   {
@@ -349,86 +494,19 @@ export async function connectToMCPServer(
 
           const url = new URL(remoteMCPServer.url);
 
-          let token: OAuthTokens | undefined;
-          let oauthConnectionType: "personal" | "workspace" | undefined;
-          let oauthConnectionId: string | undefined;
-
-          // If the server has a shared secret, we use it to authenticate.
-          if (remoteMCPServer.sharedSecret) {
-            token = {
-              access_token: remoteMCPServer.sharedSecret,
-              token_type: "bearer",
-              expires_in: undefined,
-              scope: "",
-            };
+          const tokenRes = await resolveRemoteServerOAuthToken(auth, {
+            mcpServerId: params.mcpServerId,
+            oAuthUseCase: params.oAuthUseCase,
+            remoteMCPServer,
+            isToolExecution: !!(
+              agentLoopContext?.runContext || allowDirectToolExecution
+            ),
+          });
+          if (tokenRes.isErr()) {
+            return tokenRes;
           }
-          // The server requires authentication.
-          else if (remoteMCPServer.authorization) {
-            // We only fetch the personal token if we are running a tool.
-            // Otherwise, for listing tools etc.., we use the workspace token.
-            oauthConnectionType =
-              params.oAuthUseCase === "personal_actions" &&
-              (agentLoopContext?.runContext || allowDirectToolExecution)
-                ? "personal"
-                : "workspace";
-
-            const c = await getConnectionForMCPServer(auth, {
-              mcpServerId: params.mcpServerId,
-              connectionType: oauthConnectionType,
-            });
-            if (c.isOk()) {
-              oauthConnectionId = c.value.connection.connection_id;
-              token = {
-                access_token: c.value.access_token,
-                token_type: "bearer",
-                expires_in: c.value.access_token_expiry ?? undefined,
-                scope: c.value.connection.metadata.scope,
-              };
-            } else {
-              const scope = remoteMCPServer.authorization.scope;
-
-              if (oauthConnectionType === "personal") {
-                // Check if admin connection exists for the server.
-                // We only check if the connection resource exists (not if the token is valid)
-                // because for personal_actions we just need to know if admin setup is done.
-                const adminConnectionRes =
-                  await MCPServerConnectionResource.findByMCPServer(auth, {
-                    mcpServerId: params.mcpServerId,
-                    connectionType: "workspace",
-                  });
-                if (
-                  adminConnectionRes.isErr() &&
-                  adminConnectionRes.error.code === "connection_not_found"
-                ) {
-                  return new Err(
-                    new MCPServerRequiresAdminAuthenticationError(
-                      params.mcpServerId,
-                      remoteMCPServer.authorization.provider,
-                      scope
-                    )
-                  );
-                }
-                return new Err(
-                  new MCPServerPersonalAuthenticationRequiredError(
-                    params.mcpServerId,
-                    remoteMCPServer.authorization.provider,
-                    scope
-                  )
-                );
-              } else if (oauthConnectionType === "workspace") {
-                // Workspace connection required — admin must set up or reconnect.
-                return new Err(
-                  new MCPServerRequiresAdminAuthenticationError(
-                    params.mcpServerId,
-                    remoteMCPServer.authorization.provider,
-                    scope
-                  )
-                );
-              } else {
-                assertNever(oauthConnectionType);
-              }
-            }
-          }
+          const { token, oauthConnectionType, oauthConnectionId } =
+            tokenRes.value;
 
           try {
             const { dispatcher, fetch: proxyFetch } =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  For personal_actions MCP servers, the workspace connection serves two purposes:
  1. Credential store (client_id/secret) — prerequisite for personal OAuth flows
  2. Admin's OAuth token — used for metadata operations (listing tools, sync)

  When the admin's refresh token becomes invalid (e.g. the remote server returns invalid_grant), the token refresh fails with TokenRevokedError. This cascades into MCPServerRequiresAdminAuthenticationError for every user trying to use the server, because tool listing always went through the workspace connection, even when the user had their own valid personal connection.

This PR 
- Fixes : Remote MCP servers with personal authentication (personal_actions) become completely unusable when the admin's workspace OAuth refresh token expires or is revoked by the remote server (invalid_grant). This blocks all users, even those with valid personal connections, because tool listing always used the workspace token.
- Fixes: When no connection works at all, fall back to cached tools from the last successful sync instead of failing with an error.
- Refactors: Extract resolveRemoteServerOAuthToken helper from connectToMCPServer to clarify the token resolution logic for remote servers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

In front-edge, before the changes, the model said "tool not available". With the changes, it asks me to connect the tool.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low-ish, should help, probably, i hope

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy frony