### PR TITLE
[LLM] Fix Claude Opus 4.6 unavailable in enterprise workspaces

### DIFF
--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -231,7 +231,6 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
-  featureFlag: "claude_4_5_opus_feature",
   enforceEnterpriseAvailability: true,
   customBetas: [
     "auto-thinking-2026-01-12",


### PR DESCRIPTION
## Description

Removes the `featureFlag: "claude_4_5_opus_feature"` from `CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG`, which was incorrectly gating Claude Opus 4.6 behind a feature flag and causing enterprise workspaces to see "model is not supported" errors.

## Tests

Tested manually — enterprise workspaces should now be able to select and use Claude Opus 4.6.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`