### PR TITLE
[front] Improve typing for sub agent tool output

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -17,6 +17,15 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
+export type SingleResourceToolOutput<
+  T extends {
+    uri: string;
+    mimeType?: string;
+  },
+> = {
+  content: [{ type: "resource"; resource: T }];
+};
+
 export function isBlobResource(
   outputBlock: CallToolResult["content"][number]
 ): outputBlock is {
@@ -1029,6 +1038,25 @@ export const AuthRequiredOutputResourceSchema = z.object({
   uri: z.string(),
 });
 
+export type AuthRequiredOutputResourceType = z.infer<
+  typeof AuthRequiredOutputResourceSchema
+>;
+
+export const FileAuthRequiredOutputResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
+  type: z.literal("tool_file_auth_required"),
+  fileId: z.string(),
+  fileName: z.string(),
+  connectionId: z.string(),
+  mimeType_file: z.string(),
+  text: z.string(),
+  uri: z.string(),
+});
+
+export type FileAuthRequiredOutputResourceType = z.infer<
+  typeof FileAuthRequiredOutputResourceSchema
+>;
+
 export const BlockedAwaitingInputOutputResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
   type: z.literal("tool_blocked_awaiting_input"),
@@ -1038,6 +1066,10 @@ export const BlockedAwaitingInputOutputResourceSchema = z.object({
   state: z.any(),
 });
 
+export type BlockedAwaitingInputOutputResourceType = z.infer<
+  typeof BlockedAwaitingInputOutputResourceSchema
+>;
+
 export const EarlyExitOutputResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
   type: z.literal("tool_early_exit"),
@@ -1046,10 +1078,15 @@ export const EarlyExitOutputResourceSchema = z.object({
   uri: z.string(),
 });
 
+export type EarlyExitOutputResourceType = z.infer<
+  typeof EarlyExitOutputResourceSchema
+>;
+
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,
   BlockedAwaitingInputOutputResourceSchema,
   EarlyExitOutputResourceSchema,
+  FileAuthRequiredOutputResourceSchema,
 ]);
 
 export type AgentPauseOutputResourceType = z.infer<

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -4,6 +4,12 @@ import {
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type {
+  AuthRequiredOutputResourceType,
+  EarlyExitOutputResourceType,
+  FileAuthRequiredOutputResourceType,
+  SingleResourceToolOutput,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -22,7 +28,7 @@ export function makeInternalMCPServer(
 export function makePersonalAuthenticationError(
   provider: OAuthProvider,
   scope?: string
-) {
+): SingleResourceToolOutput<AuthRequiredOutputResourceType> {
   return {
     content: [
       {
@@ -50,7 +56,7 @@ export function makeFileAuthorizationError({
   fileName: string;
   connectionId: string;
   mimeType: string;
-}) {
+}): SingleResourceToolOutput<FileAuthRequiredOutputResourceType> {
   return {
     content: [
       {
@@ -76,7 +82,7 @@ export function makeMCPToolExit({
 }: {
   message: string;
   isError: boolean;
-}) {
+}): SingleResourceToolOutput<EarlyExitOutputResourceType> {
   return {
     content: [
       {

--- a/front/lib/api/actions/servers/run_agent/types.ts
+++ b/front/lib/api/actions/servers/run_agent/types.ts
@@ -1,7 +1,10 @@
 import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type {
+  BlockedAwaitingInputOutputResourceType,
+  SingleResourceToolOutput,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { MCPApproveExecutionEvent } from "@dust-tt/client";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 export interface ChildAgentBlob {
   name: string;
@@ -41,7 +44,7 @@ export type RunAgentBlockingEvent =
 export function makeToolBlockedAwaitingInputResponse(
   blockingEvents: RunAgentBlockingEvent[],
   state: RunAgentResumeState
-): CallToolResult {
+): SingleResourceToolOutput<BlockedAwaitingInputOutputResourceType> {
   const agentPauseToolOutputResource = {
     mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
     type: "tool_blocked_awaiting_input" as const,


### PR DESCRIPTION
## Description

- This PR adds stronger constraints on tool output
- Goal is to avoid issues such as the one fixed in https://github.com/dust-tt/dust/pull/22698 (`type` field accidentally removed without any type error).

## Tests

- Tested locally.

## Risk

- None, no runtime change.

## Deploy Plan

- Deploy front.
