### PR TITLE
[LLM] Refactor model availability to availableIfUnion/customAvailableIf

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -5,7 +5,7 @@ import {
 } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { isModelAvailable } from "@app/lib/assistant";
+import { isModelCustomAvailable } from "@app/lib/assistant";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useWorkspace } from "@app/lib/swr/workspaces";
@@ -81,7 +81,8 @@ export function ProviderManagementModal({
     [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
     (m) => m.modelId
   ).filter(
-    (model) => !model.isLegacy && isModelAvailable(model, featureFlags, plan)
+    (model) =>
+      !model.isLegacy && isModelCustomAvailable(model, featureFlags, plan)
   );
 
   const modelProviders = filteredModels.reduce(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -36,6 +36,7 @@ import {
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
+import { isEnforcedByEnterpriseAvailability } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -642,7 +643,8 @@ export async function postUserMessage(
     const supportedModelConfig = getSupportedModelConfig(agentConfig.model);
     if (
       supportedModelConfig?.featureFlag &&
-      !featureFlags.includes(supportedModelConfig.featureFlag)
+      !featureFlags.includes(supportedModelConfig.featureFlag) &&
+      !isEnforcedByEnterpriseAvailability(supportedModelConfig, plan)
     ) {
       return new Err({
         status_code: 400,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -36,7 +36,7 @@ import {
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
-import { isEnforcedByEnterpriseAvailability } from "@app/lib/assistant";
+import { isModelAvailable } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -642,9 +642,8 @@ export async function postUserMessage(
 
     const supportedModelConfig = getSupportedModelConfig(agentConfig.model);
     if (
-      supportedModelConfig?.featureFlag &&
-      !featureFlags.includes(supportedModelConfig.featureFlag) &&
-      !isEnforcedByEnterpriseAvailability(supportedModelConfig, plan)
+      supportedModelConfig &&
+      !isModelAvailable(supportedModelConfig, featureFlags, plan)
     ) {
       return new Err({
         status_code: 400,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1086,7 +1086,8 @@ export async function getGlobalAgents(
     );
   }
   // Also hide dust-next variants if the custom model's own feature flag isn't enabled.
-  const customModelFlag = CUSTOM_MODEL_CONFIGS[0]?.featureFlag;
+  const customModelFlag =
+    CUSTOM_MODEL_CONFIGS[0]?.availableIfUnion?.featureFlag;
   if (customModelFlag && !flags.includes(customModelFlag)) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) =>

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1087,7 +1087,7 @@ export async function getGlobalAgents(
   }
   // Also hide dust-next variants if the custom model's own feature flag isn't enabled.
   const customModelFlag =
-    CUSTOM_MODEL_CONFIGS[0]?.availableIfUnion?.featureFlag;
+    CUSTOM_MODEL_CONFIGS[0]?.availableIfOneOf?.featureFlag;
   if (customModelFlag && !flags.includes(customModelFlag)) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) =>

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -5,7 +5,7 @@ import {
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { isModelAvailableAndWhitelisted } from "@app/lib/assistant";
+import { isModelCustomAvailableAndWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -45,7 +45,7 @@ export async function getAvailableModelsForWorkspace(
 
   const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
   return allUsedModels.filter((m) =>
-    isModelAvailableAndWhitelisted(m, featureFlags, plan, owner)
+    isModelCustomAvailableAndWhitelisted(m, featureFlags, plan, owner)
   );
 }
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,6 +1,6 @@
 import {
-  isModelAvailable,
-  isModelAvailableAndWhitelisted,
+  isModelCustomAvailable,
+  isModelCustomAvailableAndWhitelisted,
 } from "@app/lib/assistant";
 import {
   FREE_NO_PLAN_CODE,
@@ -75,131 +75,119 @@ function createMockPlan(code: string): PlanType {
   };
 }
 
-describe("isModelAvailable", () => {
+describe("isModelCustomAvailable", () => {
   it("should return true for a basic model without restrictions", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(true);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
   });
 
   it("should return true when featureFlag is enabled", () => {
     const model = createMockModel({
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: undefined,
+      availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(true);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
   });
 
   it("should return false when featureFlag is not enabled", () => {
     const model = createMockModel({
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: undefined,
+      availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(false);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
   });
 
   it("should return true when customAssistantFeatureFlag is enabled", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: "openai_o1_feature",
+      customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["openai_o1_feature"];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(true);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
   });
 
   it("should return false when customAssistantFeatureFlag is not enabled", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: "openai_o1_feature",
+      customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(false);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
   });
 
   it("should return true for large model with upgraded plan", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: true,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(true);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
   });
 
   it("should return true for large model with free upgraded plan", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: true,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(FREE_UPGRADED_PLAN_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(true);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
   });
 
   it("should return false for large model without upgraded plan", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: true,
+      availableIfUnion: { enterprise: true },
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(FREE_NO_PLAN_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(false);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
   });
 
   it("should return false for large model with null plan", () => {
     const model = createMockModel({
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: true,
+      availableIfUnion: { enterprise: true },
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = null;
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(false);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
   });
 
   it("should return false when both featureFlag and customAssistantFeatureFlag are required but only one is enabled", () => {
     const model = createMockModel({
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: "openai_o1_feature",
+      availableIfUnion: { featureFlag: "deepseek_feature" },
+      customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(false);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
   });
 
   it("should return true when both featureFlag and customAssistantFeatureFlag are required and both are enabled", () => {
     const model = createMockModel({
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: "openai_o1_feature",
+      availableIfUnion: { featureFlag: "deepseek_feature" },
+      customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [
@@ -208,23 +196,22 @@ describe("isModelAvailable", () => {
     ];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(true);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
   });
 
   it("should return false when large model requires upgraded plan but featureFlag is missing", () => {
     const model = createMockModel({
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: undefined,
+      availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: true,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
-    expect(isModelAvailable(model, featureFlags, plan)).toBe(false);
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
   });
 });
 
-describe("isModelAvailableAndWhitelisted", () => {
+describe("isModelCustomAvailableAndWhitelisted", () => {
   let workspace: WorkspaceType;
   const upgradedPlan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
   const nonUpgradedPlan = createMockPlan(FREE_NO_PLAN_CODE);
@@ -236,15 +223,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return true when model is available and provider is whitelisted", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
 
     // WorkspaceFactory.basic() creates a workspace with PRO_PLAN_SEAT_29_CODE which should have all providers whitelisted by default
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -256,8 +241,6 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return false when model is available but provider is not whitelisted", async () => {
     const model = createMockModel({
       providerId: "deepseek",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -269,7 +252,7 @@ describe("isModelAvailableAndWhitelisted", () => {
     };
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -281,14 +264,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return false when model is not available even if provider is whitelisted", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: undefined,
+      availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = []; // featureFlag not enabled
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -300,14 +282,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return false when large model is not available due to plan", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: true,
+      availableIfUnion: { enterprise: true },
     });
     const featureFlags: WhitelistableFeature[] = [];
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         nonUpgradedPlan,
@@ -319,14 +300,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return false when model requires featureFlag that is not enabled", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: undefined,
+      availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = []; // featureFlag not enabled
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -338,14 +318,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return true when model requires featureFlag that is enabled and provider is whitelisted", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: "deepseek_feature",
-      customAssistantFeatureFlag: undefined,
+      availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -357,14 +336,12 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return true for large model with upgraded plan and whitelisted provider", async () => {
     const model = createMockModel({
       providerId: "anthropic",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: true,
     });
     const featureFlags: WhitelistableFeature[] = [];
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -376,8 +353,6 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return false when provider is not whitelisted even if model is available", async () => {
     const model = createMockModel({
       providerId: "xai",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -389,7 +364,7 @@ describe("isModelAvailableAndWhitelisted", () => {
     };
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -401,15 +376,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return true when workspace has all providers whitelisted (default)", async () => {
     const model = createMockModel({
       providerId: "mistral",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
 
     // WorkspaceFactory.basic() should have all providers whitelisted by default
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -421,8 +394,6 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return true when whiteListedProviders is null (defaults to all providers)", async () => {
     const model = createMockModel({
       providerId: "togetherai",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: undefined,
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -433,7 +404,7 @@ describe("isModelAvailableAndWhitelisted", () => {
     };
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -445,14 +416,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return false when model requires customAssistantFeatureFlag that is not enabled", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: "openai_o1_feature",
+      customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = []; // customAssistantFeatureFlag not enabled
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,
@@ -464,14 +434,13 @@ describe("isModelAvailableAndWhitelisted", () => {
   it("should return true when model requires customAssistantFeatureFlag that is enabled and provider is whitelisted", async () => {
     const model = createMockModel({
       providerId: "openai",
-      featureFlag: undefined,
-      customAssistantFeatureFlag: "openai_o1_feature",
+      customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["openai_o1_feature"];
 
     expect(
-      isModelAvailableAndWhitelisted(
+      isModelCustomAvailableAndWhitelisted(
         model,
         featureFlags,
         upgradedPlan,

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -89,7 +89,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return true when featureFlag is enabled", () => {
     const model = createMockModel({
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];
@@ -100,7 +100,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return false when featureFlag is not enabled", () => {
     const model = createMockModel({
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -154,7 +154,7 @@ describe("isModelCustomAvailable", () => {
   it("should return false for large model without upgraded plan", () => {
     const model = createMockModel({
       largeModel: true,
-      availableIfUnion: { enterprise: true },
+      availableIfOneOf: { enterprise: true },
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(FREE_NO_PLAN_CODE);
@@ -165,7 +165,7 @@ describe("isModelCustomAvailable", () => {
   it("should return false for large model with null plan", () => {
     const model = createMockModel({
       largeModel: true,
-      availableIfUnion: { enterprise: true },
+      availableIfOneOf: { enterprise: true },
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = null;
@@ -175,7 +175,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return false when both featureFlag and customAssistantFeatureFlag are required but only one is enabled", () => {
     const model = createMockModel({
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
@@ -187,7 +187,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return true when both featureFlag and customAssistantFeatureFlag are required and both are enabled", () => {
     const model = createMockModel({
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       customAvailableIf: { featureFlag: "openai_o1_feature" },
       largeModel: false,
     });
@@ -202,7 +202,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return false when large model requires upgraded plan but featureFlag is missing", () => {
     const model = createMockModel({
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       largeModel: true,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -214,7 +214,7 @@ describe("isModelCustomAvailable", () => {
   // enterprise availability tests
   it("should return true when enterprise is set and plan is an enterprise plan", () => {
     const model = createMockModel({
-      availableIfUnion: { enterprise: true },
+      availableIfOneOf: { enterprise: true },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -225,7 +225,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return true when enterprise is set and plan has ENT_ prefix", () => {
     const model = createMockModel({
-      availableIfUnion: { enterprise: true },
+      availableIfOneOf: { enterprise: true },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -236,7 +236,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return true when both enterprise and featureFlag are set, with enterprise plan (no featureFlag needed)", () => {
     const model = createMockModel({
-      availableIfUnion: { enterprise: true, featureFlag: "deepseek_feature" },
+      availableIfOneOf: { enterprise: true, featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -247,7 +247,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return true when both enterprise and featureFlag are set, with featureFlag enabled (no enterprise plan needed)", () => {
     const model = createMockModel({
-      availableIfUnion: { enterprise: true, featureFlag: "deepseek_feature" },
+      availableIfOneOf: { enterprise: true, featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];
@@ -258,7 +258,7 @@ describe("isModelCustomAvailable", () => {
 
   it("should return false when both enterprise and featureFlag are set but neither condition is met", () => {
     const model = createMockModel({
-      availableIfUnion: { enterprise: true, featureFlag: "deepseek_feature" },
+      availableIfOneOf: { enterprise: true, featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
@@ -321,7 +321,7 @@ describe("isModelCustomAvailableAndWhitelisted", () => {
   it("should return false when model is not available even if provider is whitelisted", async () => {
     const model = createMockModel({
       providerId: "openai",
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = []; // featureFlag not enabled
@@ -340,7 +340,7 @@ describe("isModelCustomAvailableAndWhitelisted", () => {
     const model = createMockModel({
       providerId: "openai",
       largeModel: true,
-      availableIfUnion: { enterprise: true },
+      availableIfOneOf: { enterprise: true },
     });
     const featureFlags: WhitelistableFeature[] = [];
 
@@ -357,7 +357,7 @@ describe("isModelCustomAvailableAndWhitelisted", () => {
   it("should return false when model requires featureFlag that is not enabled", async () => {
     const model = createMockModel({
       providerId: "openai",
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = []; // featureFlag not enabled
@@ -375,7 +375,7 @@ describe("isModelCustomAvailableAndWhitelisted", () => {
   it("should return true when model requires featureFlag that is enabled and provider is whitelisted", async () => {
     const model = createMockModel({
       providerId: "openai",
-      availableIfUnion: { featureFlag: "deepseek_feature" },
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
       largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -3,6 +3,7 @@ import {
   isModelCustomAvailableAndWhitelisted,
 } from "@app/lib/assistant";
 import {
+  DUST_COMPANY_PLAN_CODE,
   FREE_NO_PLAN_CODE,
   FREE_UPGRADED_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
@@ -203,6 +204,62 @@ describe("isModelCustomAvailable", () => {
     const model = createMockModel({
       availableIfUnion: { featureFlag: "deepseek_feature" },
       largeModel: true,
+    });
+    const featureFlags: WhitelistableFeature[] = [];
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
+
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(false);
+  });
+
+  // enterprise availability tests
+  it("should return true when enterprise is set and plan is an enterprise plan", () => {
+    const model = createMockModel({
+      availableIfUnion: { enterprise: true },
+      largeModel: false,
+    });
+    const featureFlags: WhitelistableFeature[] = [];
+    const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
+
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
+  });
+
+  it("should return true when enterprise is set and plan has ENT_ prefix", () => {
+    const model = createMockModel({
+      availableIfUnion: { enterprise: true },
+      largeModel: false,
+    });
+    const featureFlags: WhitelistableFeature[] = [];
+    const plan = createMockPlan("ENT_CUSTOM_PLAN");
+
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
+  });
+
+  it("should return true when both enterprise and featureFlag are set, with enterprise plan (no featureFlag needed)", () => {
+    const model = createMockModel({
+      availableIfUnion: { enterprise: true, featureFlag: "deepseek_feature" },
+      largeModel: false,
+    });
+    const featureFlags: WhitelistableFeature[] = [];
+    const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
+
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
+  });
+
+  it("should return true when both enterprise and featureFlag are set, with featureFlag enabled (no enterprise plan needed)", () => {
+    const model = createMockModel({
+      availableIfUnion: { enterprise: true, featureFlag: "deepseek_feature" },
+      largeModel: false,
+    });
+    const featureFlags: WhitelistableFeature[] = ["deepseek_feature"];
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
+
+    expect(isModelCustomAvailable(model, featureFlags, plan)).toBe(true);
+  });
+
+  it("should return false when both enterprise and featureFlag are set but neither condition is met", () => {
+    const model = createMockModel({
+      availableIfUnion: { enterprise: true, featureFlag: "deepseek_feature" },
+      largeModel: false,
     });
     const featureFlags: WhitelistableFeature[] = [];
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,7 +1,6 @@
 import {
   isDustCompanyPlan,
   isEntreprisePlanPrefix,
-  isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -9,55 +8,70 @@ import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
 
-export function isEnforcedByEnterpriseAvailability(
-  m: ModelConfigurationType,
-  plan: PlanType | null
-): boolean {
+export function passEnterpriseAvalability(plan: PlanType | null): boolean {
   return (
-    m.enforceEnterpriseAvailability === true &&
     plan !== null &&
     (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
   );
 }
 
-// Returns true if the model is available to the workspace, regardless of whether it is whitelisted or not.
+// Returns true if the model is available to the workspace for use.
 export function isModelAvailable(
   m: ModelConfigurationType,
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null
 ) {
-  if (m.enforceEnterpriseAvailability === true) {
-    return (
-      plan &&
-      (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
-    );
+  if (!m.availableIfUnion) {
+    return true;
   }
 
-  if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {
+  const { enterprise, featureFlag } = m.availableIfUnion;
+
+  if (enterprise === true && passEnterpriseAvalability(plan)) {
+    return true;
+  }
+
+  if (featureFlag && featureFlags.includes(featureFlag)) {
+    return true;
+  }
+
+  return false;
+}
+
+// Returns true if the model is available to the workspace for build.
+export function isModelCustomAvailable(
+  m: ModelConfigurationType,
+  featureFlags: WhitelistableFeature[],
+  plan: PlanType | null
+) {
+  if (!isModelAvailable(m, featureFlags, plan)) {
     return false;
   }
+
+  if (!m.customAvailableIf) {
+    return true;
+  }
+
+  const { featureFlag: customAssistantFeatureFlag } = m.customAvailableIf;
 
   if (
-    m.customAssistantFeatureFlag &&
-    !featureFlags.includes(m.customAssistantFeatureFlag)
+    customAssistantFeatureFlag &&
+    featureFlags.includes(customAssistantFeatureFlag)
   ) {
-    return false;
+    return true;
   }
 
-  if (m.largeModel && !isUpgraded(plan)) {
-    return false;
-  }
-  return true;
+  return false;
 }
 
 // Returns true if the model is available to the workspace and is whitelisted.
-export function isModelAvailableAndWhitelisted(
+export function isModelCustomAvailableAndWhitelisted(
   m: ModelConfigurationType,
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null,
   owner: WorkspaceType
 ) {
-  if (!isModelAvailable(m, featureFlags, plan)) {
+  if (!isModelCustomAvailable(m, featureFlags, plan)) {
     return false;
   }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -9,7 +9,7 @@ import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
 
-export function passEnterpriseAvailability(plan: PlanType | null): boolean {
+export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   return (
     plan !== null &&
     (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
@@ -22,13 +22,13 @@ export function isModelAvailable(
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null
 ) {
-  if (!m.availableIfUnion) {
+  if (!m.availableIfOneOf) {
     return true;
   }
 
-  const { enterprise, featureFlag } = m.availableIfUnion;
+  const { enterprise, featureFlag } = m.availableIfOneOf;
 
-  if (enterprise === true && passEnterpriseAvailability(plan)) {
+  if (enterprise === true && isEnterpriseOrDust(plan)) {
     return true;
   }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,6 +1,7 @@
 import {
   isDustCompanyPlan,
   isEntreprisePlanPrefix,
+  isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -48,20 +49,18 @@ export function isModelCustomAvailable(
     return false;
   }
 
-  if (!m.customAvailableIf) {
-    return true;
+  if (m.customAvailableIf) {
+    return (
+      m.customAvailableIf.featureFlag &&
+      featureFlags.includes(m.customAvailableIf.featureFlag)
+    );
   }
 
-  const { featureFlag: customAssistantFeatureFlag } = m.customAvailableIf;
-
-  if (
-    customAssistantFeatureFlag &&
-    featureFlags.includes(customAssistantFeatureFlag)
-  ) {
-    return true;
+  if (m.largeModel && !isUpgraded(plan)) {
+    return false;
   }
 
-  return false;
+  return true;
 }
 
 // Returns true if the model is available to the workspace and is whitelisted.

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -9,7 +9,7 @@ import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
 
-export function passEnterpriseAvalability(plan: PlanType | null): boolean {
+export function passEnterpriseAvailability(plan: PlanType | null): boolean {
   return (
     plan !== null &&
     (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
@@ -28,7 +28,7 @@ export function isModelAvailable(
 
   const { enterprise, featureFlag } = m.availableIfUnion;
 
-  if (enterprise === true && passEnterpriseAvalability(plan)) {
+  if (enterprise === true && passEnterpriseAvailability(plan)) {
     return true;
   }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -9,6 +9,17 @@ import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
 
+export function isEnforcedByEnterpriseAvailability(
+  m: ModelConfigurationType,
+  plan: PlanType | null
+): boolean {
+  return (
+    m.enforceEnterpriseAvailability === true &&
+    plan !== null &&
+    (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
+  );
+}
+
 // Returns true if the model is available to the workspace, regardless of whether it is whitelisted or not.
 export function isModelAvailable(
   m: ModelConfigurationType,

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -3,7 +3,7 @@ import {
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/types";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { isModelAvailableAndWhitelisted } from "@app/lib/assistant";
+import { isModelCustomAvailableAndWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -31,11 +31,11 @@ async function handler(
       // Include both standard models and custom models (from GCS at build time)
       const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
       const models: ModelConfigurationType[] = allUsedModels.filter((m) =>
-        isModelAvailableAndWhitelisted(m, featureFlags, plan, owner)
+        isModelCustomAvailableAndWhitelisted(m, featureFlags, plan, owner)
       );
       const reasoningModels: ModelConfigurationType[] =
         REASONING_MODEL_CONFIGS.filter((m) =>
-          isModelAvailableAndWhitelisted(m, featureFlags, plan, owner)
+          isModelCustomAvailableAndWhitelisted(m, featureFlags, plan, owner)
         );
 
       return res.status(200).json({ models, reasoningModels });

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -69,7 +69,7 @@ export const CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "claude_4_opus_feature",
   },
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
@@ -206,7 +206,7 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "claude_4_5_opus_feature",
   },
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
@@ -235,7 +235,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
-  availableIfUnion: {
+  availableIfOneOf: {
     enterprise: true,
     featureFlag: "claude_4_5_opus_feature",
   },

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -231,6 +231,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
+  featureFlag: "claude_4_5_opus_feature",
   enforceEnterpriseAvailability: true,
   customBetas: [
     "auto-thinking-2026-01-12",

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -69,7 +69,9 @@ export const CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
-  featureFlag: "claude_4_opus_feature",
+  availableIfUnion: {
+    featureFlag: "claude_4_opus_feature",
+  },
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -204,7 +206,9 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
-  featureFlag: "claude_4_5_opus_feature",
+  availableIfUnion: {
+    featureFlag: "claude_4_5_opus_feature",
+  },
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -231,8 +235,9 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
-  featureFlag: "claude_4_5_opus_feature",
-  enforceEnterpriseAvailability: true,
+  availableIfUnion: {
+    enterprise: true,
+  },
   customBetas: [
     "auto-thinking-2026-01-12",
     "effort-2025-11-24",

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -237,6 +237,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   customThinkingType: "auto",
   availableIfUnion: {
     enterprise: true,
+    featureFlag: "claude_4_5_opus_feature",
   },
   customBetas: [
     "auto-thinking-2026-01-12",

--- a/front/types/assistant/models/deepseek.ts
+++ b/front/types/assistant/models/deepseek.ts
@@ -19,7 +19,9 @@ export const DEEPSEEK_CHAT_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  featureFlag: "deepseek_feature",
+  availableIfUnion: {
+    featureFlag: "deepseek_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
@@ -39,6 +41,8 @@ export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  featureFlag: "deepseek_feature",
+  availableIfUnion: {
+    featureFlag: "deepseek_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/deepseek.ts
+++ b/front/types/assistant/models/deepseek.ts
@@ -19,7 +19,7 @@ export const DEEPSEEK_CHAT_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "deepseek_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -41,7 +41,7 @@ export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "deepseek_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -53,7 +53,7 @@ export const FIREWORKS_DEEPSEEK_V3P2_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -97,7 +97,7 @@ export const FIREWORKS_KIMI_K2P5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
   },
 };
@@ -121,7 +121,7 @@ export const FIREWORKS_MINIMAX_M2P5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
   },
 };
@@ -145,7 +145,7 @@ export const FIREWORKS_GLM_5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
   },
 };

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -53,7 +53,9 @@ export const FIREWORKS_DEEPSEEK_V3P2_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
-  featureFlag: "fireworks_new_model_feature",
+  availableIfUnion: {
+    featureFlag: "fireworks_new_model_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_CONFIG: ModelConfigurationType = {
@@ -95,7 +97,9 @@ export const FIREWORKS_KIMI_K2P5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  featureFlag: "fireworks_new_model_feature",
+  availableIfUnion: {
+    featureFlag: "fireworks_new_model_feature",
+  },
 };
 export const FIREWORKS_MINIMAX_M2P5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -117,7 +121,9 @@ export const FIREWORKS_MINIMAX_M2P5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  featureFlag: "fireworks_new_model_feature",
+  availableIfUnion: {
+    featureFlag: "fireworks_new_model_feature",
+  },
 };
 export const FIREWORKS_GLM_5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -139,5 +145,7 @@ export const FIREWORKS_GLM_5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  featureFlag: "fireworks_new_model_feature",
+  availableIfUnion: {
+    featureFlag: "fireworks_new_model_feature",
+  },
 };

--- a/front/types/assistant/models/noop.ts
+++ b/front/types/assistant/models/noop.ts
@@ -19,7 +19,7 @@ export const NOOP_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "noop_model_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },

--- a/front/types/assistant/models/noop.ts
+++ b/front/types/assistant/models/noop.ts
@@ -19,6 +19,8 @@ export const NOOP_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "noop_model_feature",
+  availableIfUnion: {
+    featureFlag: "noop_model_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -356,8 +356,12 @@ export const O1_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  featureFlag: "openai_o1_feature",
-  customAssistantFeatureFlag: "openai_o1_custom_assistants_feature",
+  availableIfUnion: {
+    featureFlag: "openai_o1_feature",
+  },
+  customAvailableIf: {
+    featureFlag: "openai_o1_custom_assistants_feature",
+  },
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
@@ -379,7 +383,9 @@ export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  customAssistantFeatureFlag: "openai_o1_custom_assistants_feature",
+  customAvailableIf: {
+    featureFlag: "openai_o1_custom_assistants_feature",
+  },
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -356,7 +356,7 @@ export const O1_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "openai_o1_feature",
   },
   customAvailableIf: {

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -73,15 +73,17 @@ export type ModelConfigurationType = Omit<
   minimumReasoningEffort: AgentReasoningEffort;
   maximumReasoningEffort: AgentReasoningEffort;
   defaultReasoningEffort: AgentReasoningEffort;
-  // If undefined, model is enabled.
-  // If object is empty, model is disabled.
-  // If defined, model must satisfy at least one of the conditions in the union to be enabled.
-  availableIfUnion?: {
-    // If set to true and workspace is enterprise, model is enabled.
+  // If undefined, model is available.
+  // If object is empty, model is not available.
+  // If defined, model must satisfy one of the conditions to be available.
+  availableIfOneOf?: {
+    // If set to true and workspace is enterprise, model is available.
     enterprise?: boolean;
-    // If set, model is enabled for use only if feature flag is enabled.
+    // If set, model is available if feature flag is enabled.
     featureFlag?: WhitelistableFeature;
   };
+  // Pre-requisite: must be available.
+  // If object is empty, model is not custom available.
   customAvailableIf?: {
     featureFlag?: WhitelistableFeature;
   };

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -73,11 +73,19 @@ export type ModelConfigurationType = Omit<
   minimumReasoningEffort: AgentReasoningEffort;
   maximumReasoningEffort: AgentReasoningEffort;
   defaultReasoningEffort: AgentReasoningEffort;
-  featureFlag?: WhitelistableFeature;
-  customAssistantFeatureFlag?: WhitelistableFeature;
+  // If undefined, model is enabled.
+  // If object is empty, model is disabled.
+  // If defined, model must satisfy at least one of the conditions in the union to be enabled.
+  availableIfUnion?: {
+    // If set to true and workspace is enterprise, model is enabled.
+    enterprise?: boolean;
+    // If set, model is enabled for use only if feature flag is enabled.
+    featureFlag?: WhitelistableFeature;
+  };
+  customAvailableIf?: {
+    featureFlag?: WhitelistableFeature;
+  };
   tokenizer: TokenizerConfig;
-  // When true, enterprise plans bypass the feature flag check (both can coexist).
-  enforceEnterpriseAvailability?: boolean;
 };
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];

--- a/front/types/assistant/models/xai.ts
+++ b/front/types/assistant/models/xai.ts
@@ -30,7 +30,7 @@ export const GROK_3_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -53,7 +53,7 @@ export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -77,7 +77,7 @@ export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -100,7 +100,7 @@ export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -123,7 +123,7 @@ export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -146,7 +146,7 @@ export const GROK_4_1_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  availableIfUnion: {
+  availableIfOneOf: {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
@@ -171,7 +171,7 @@ export const GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType =
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
     supportsResponseFormat: false,
-    availableIfUnion: {
+    availableIfOneOf: {
       featureFlag: "xai_feature",
     },
     tokenizer: { type: "tiktoken", base: "o200k_base" },

--- a/front/types/assistant/models/xai.ts
+++ b/front/types/assistant/models/xai.ts
@@ -30,7 +30,9 @@ export const GROK_3_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "xai_feature",
+  availableIfUnion: {
+    featureFlag: "xai_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
@@ -51,7 +53,9 @@ export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "xai_feature",
+  availableIfUnion: {
+    featureFlag: "xai_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 
@@ -73,7 +77,9 @@ export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "xai_feature",
+  availableIfUnion: {
+    featureFlag: "xai_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
@@ -94,7 +100,9 @@ export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "xai_feature",
+  availableIfUnion: {
+    featureFlag: "xai_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
@@ -115,7 +123,9 @@ export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "xai_feature",
+  availableIfUnion: {
+    featureFlag: "xai_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_4_1_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
@@ -136,7 +146,9 @@ export const GROK_4_1_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
-  featureFlag: "xai_feature",
+  availableIfUnion: {
+    featureFlag: "xai_feature",
+  },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType =
@@ -159,6 +171,8 @@ export const GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType =
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
     supportsResponseFormat: false,
-    featureFlag: "xai_feature",
+    availableIfUnion: {
+      featureFlag: "xai_feature",
+    },
     tokenizer: { type: "tiktoken", base: "o200k_base" },
   };


### PR DESCRIPTION
## Description

Replaces the flat `featureFlag`, `customAssistantFeatureFlag`, and `enforceEnterpriseAvailability` fields on `ModelConfigurationType` with two structured objects: `availableIfUnion` (OR-semantics gate for runtime use: enterprise plan or feature flag) and `customAvailableIf` (additional gate for the custom-assistant builder). Introduces `isModelAvailable` / `isModelCustomAvailable` / `isModelCustomAvailableAndWhitelisted` helpers that read the new shape, and migrates all provider configs and callsites to use them. As the immediate motivating fix, `claude-opus-4-6` is now accessible to enterprise workspaces **and** to workspaces with the `claude_4_5_opus_feature` flag.

## Tests

Unit tests updated to cover the new OR-gate logic across `isModelAvailable` and `isModelCustomAvailable`; tested manually that enterprise workspaces can use Claude Opus 4.6 and non-enterprise workspaces without the flag cannot.

## Risk

Low — pure refactor of availability logic with equivalent semantics for all existing models; no schema changes.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`