### PR TITLE
[front] Optimize prompt caching wrt conditional JIT tools

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -786,19 +786,22 @@ function deduplicateMCPServerConfigurations({
   agentActions,
   clientSideActions,
   skillServers,
-  jitServers,
+  stableJITServers,
+  conditionalJITServers,
 }: {
   agentActions: MCPServerConfigurationType[];
   clientSideActions: MCPServerConfigurationType[];
   skillServers: MCPServerConfigurationType[];
-  jitServers: MCPServerConfigurationType[];
+  stableJITServers: MCPServerConfigurationType[];
+  conditionalJITServers: MCPServerConfigurationType[];
 }): MCPServerConfigurationType[] {
   const seen = new Set<string>();
   return [
     ...agentActions,
     ...clientSideActions,
     ...skillServers,
-    ...jitServers,
+    ...stableJITServers,
+    ...conditionalJITServers,
   ].filter((config) => {
     const viewId = isServerSideMCPServerConfiguration(config)
       ? config.mcpServerViewId
@@ -822,10 +825,12 @@ export async function tryListMCPTools(
   auth: Authenticator,
   agentLoopListToolsContext: AgentLoopListToolsContextWithoutConfigurationType,
   {
-    jitServers,
+    stableJITServers,
+    conditionalJITServers,
     skillServers,
   }: {
-    jitServers: MCPServerConfigurationType[];
+    stableJITServers: MCPServerConfigurationType[];
+    conditionalJITServers: MCPServerConfigurationType[];
     skillServers: MCPServerConfigurationType[];
   }
 ): Promise<{

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -726,10 +726,21 @@ type AgentLoopListToolsContextWithoutConfigurationType = Omit<
  */
 async function disambiguateServerNamesBySpace(
   auth: Authenticator,
-  configs: MCPServerConfigurationType[]
-): Promise<MCPServerConfigurationType[]> {
+  {
+    stableConfigs,
+    conditionalJITConfigs,
+  }: {
+    stableConfigs: MCPServerConfigurationType[];
+    conditionalJITConfigs: MCPServerConfigurationType[];
+  }
+): Promise<{
+  stableConfigs: MCPServerConfigurationType[];
+  conditionalJITConfigs: MCPServerConfigurationType[];
+}> {
+  const allConfigs = [...stableConfigs, ...conditionalJITConfigs];
+
   // Build a map of name -> unique viewIds for server-side configs.
-  const viewIdsByName = configs
+  const viewIdsByName = allConfigs
     .filter(isServerSideMCPServerConfiguration)
     .reduce((map, config) => {
       const viewIds = map.get(config.name) ?? new Set<string>();
@@ -748,7 +759,7 @@ async function disambiguateServerNamesBySpace(
   }
 
   if (viewIdsToFetch.length === 0) {
-    return configs;
+    return { stableConfigs, conditionalJITConfigs };
   }
 
   // We fetch the views to get the space names.
@@ -761,7 +772,9 @@ async function disambiguateServerNamesBySpace(
   );
 
   // Apply space prefix to colliding server-side configs.
-  return configs.map((config) => {
+  const disambiguate = (
+    config: MCPServerConfigurationType
+  ): MCPServerConfigurationType => {
     if (
       isServerSideMCPServerConfiguration(config) &&
       collidingNames.has(config.name)
@@ -775,12 +788,17 @@ async function disambiguateServerNamesBySpace(
       }
     }
     return config;
-  });
+  };
+
+  return {
+    stableConfigs: stableConfigs.map(disambiguate),
+    conditionalJITConfigs: conditionalJITConfigs.map(disambiguate),
+  };
 }
 
 /**
  * Deduplicates MCP server configurations by view ID and name.
- * Priority order: agent actions > client-side > skill servers > JIT servers.
+ * Priority order: agent > client-side > skill > stable JIT > conditional JIT.
  */
 function deduplicateMCPServerConfigurations({
   agentActions,
@@ -794,27 +812,218 @@ function deduplicateMCPServerConfigurations({
   skillServers: MCPServerConfigurationType[];
   stableJITServers: MCPServerConfigurationType[];
   conditionalJITServers: MCPServerConfigurationType[];
-}): MCPServerConfigurationType[] {
+}): {
+  stableConfigs: MCPServerConfigurationType[];
+  conditionalJITConfigs: MCPServerConfigurationType[];
+} {
+  // Reference identity is safe here: dedup runs before disambiguation (which
+  // copies objects via .map()), so the original references are preserved.
+  const conditionalJITSet = new Set<MCPServerConfigurationType>(
+    conditionalJITServers
+  );
   const seen = new Set<string>();
-  return [
+
+  const stableConfigs: MCPServerConfigurationType[] = [];
+  const conditionalJITConfigs: MCPServerConfigurationType[] = [];
+
+  for (const config of [
     ...agentActions,
     ...clientSideActions,
     ...skillServers,
     ...stableJITServers,
     ...conditionalJITServers,
-  ].filter((config) => {
+  ]) {
     const viewId = isServerSideMCPServerConfiguration(config)
       ? config.mcpServerViewId
       : config.clientSideMcpServerId;
     const key = `${viewId}:${slugify(config.name)}`;
 
     if (seen.has(key)) {
-      return false;
+      continue;
     }
 
     seen.add(key);
-    return true;
+
+    if (conditionalJITSet.has(config)) {
+      conditionalJITConfigs.push(config);
+    } else {
+      stableConfigs.push(config);
+    }
+  }
+
+  return { stableConfigs, conditionalJITConfigs };
+}
+
+async function listToolsForAction(
+  auth: Authenticator,
+  agentLoopListToolsContext: AgentLoopListToolsContextWithoutConfigurationType,
+  preFetchedMcpServerViews: Map<string, MCPServerViewResource>,
+  action: MCPServerConfigurationType
+): Promise<Result<ServerToolsAndInstructions, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  let connectionParams: MCPConnectionParams;
+  if (isServerSideMCPServerConfiguration(action)) {
+    const mcpServerView = preFetchedMcpServerViews.get(action.mcpServerViewId);
+    if (!mcpServerView) {
+      return new Err(new Error(`MCP server view not found for ${action.name}`));
+    }
+    connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
+  } else {
+    connectionParams = makeClientSideMCPConnectionParams(action, {
+      conversationId: agentLoopListToolsContext.conversation.sId,
+      messageId: agentLoopListToolsContext.agentMessage.sId,
+    });
+  }
+
+  const toolsAndInstructionsRes = await listMCPServerToolsAndServerInstructions(
+    auth,
+    action,
+    {
+      ...agentLoopListToolsContext,
+      agentActionConfiguration: action,
+    },
+    connectionParams
+  );
+
+  if (toolsAndInstructionsRes.isErr()) {
+    logger.error(
+      {
+        workspaceId: owner.sId,
+        conversationId: agentLoopListToolsContext.conversation.sId,
+        messageId: agentLoopListToolsContext.agentMessage.sId,
+        actionId: action.sId,
+        mcpServerName: action.name,
+        error: toolsAndInstructionsRes.error,
+      },
+      `Error listing tools from MCP server: ${normalizeError(
+        toolsAndInstructionsRes.error
+      )}`
+    );
+    return new Err(
+      new Error(
+        `An error occurred while listing the available tools for ${action.name}. ` +
+          "Tools from this server are not available for this message. " +
+          "Inform the user of this issue."
+      )
+    );
+  }
+
+  const { instructions, tools: rawToolsFromServer } =
+    toolsAndInstructionsRes.value;
+
+  const processedTools: MCPToolConfigurationType[] = [];
+
+  for (const toolConfig of rawToolsFromServer) {
+    let toolName: string;
+    // Fix the tool name to be valid for the model.
+    try {
+      toolName = getPrefixedToolName(action.name, toolConfig.name);
+    } catch (error) {
+      logger.warn(
+        {
+          workspaceId: owner.sId,
+          conversationId: agentLoopListToolsContext.conversation.sId,
+          messageId: agentLoopListToolsContext.agentMessage.sId,
+          actionId: action.sId,
+          mcpServerName: action.name,
+          toolName: toolConfig.name,
+          error: error,
+        },
+        `Invalid tool name, skipping the tool.`
+      );
+      continue;
+    }
+
+    // Check that all tools arguments names are valid for the model (a-zA-Z0-9_.-).
+    const toolArgumentsNames = Object.keys(
+      toolConfig.inputSchema?.properties ?? {}
+    );
+
+    const invalidArgumentNames = toolArgumentsNames.filter(
+      (argumentName) => !/^[a-zA-Z0-9_.-]+$/.test(argumentName)
+    );
+    if (invalidArgumentNames.length > 0) {
+      logger.warn(
+        {
+          workspaceId: owner.sId,
+          conversationId: agentLoopListToolsContext.conversation.sId,
+          messageId: agentLoopListToolsContext.agentMessage.sId,
+          actionId: action.sId,
+          mcpServerName: action.name,
+          toolName: toolConfig.name,
+          invalidArgumentNames,
+        },
+        `Invalid argument name(s), skipping the tool.`
+      );
+      continue;
+    }
+
+    // This handles the case where the MCP server configuration is using pre-configured
+    // data sources or tables. We add the description to the tool description so that the
+    // model has more information to make the right choice.
+    let extraDescription: string = "";
+    if (action.description) {
+      const hasDataSourceConfiguration =
+        Object.keys(
+          findMatchingSubSchemas(
+            toolConfig.inputSchema,
+            INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+          )
+        ).length > 0;
+
+      const hasTableConfiguration =
+        Object.keys(
+          findMatchingSubSchemas(
+            toolConfig.inputSchema,
+            INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
+          )
+        ).length > 0;
+
+      if (hasDataSourceConfiguration && hasTableConfiguration) {
+        // Might be confusing for the model if we end up in this situation,
+        // which is not a use case we have now.
+        extraDescription += `\nDescription of the data sources and tables:\n${action.description}`;
+      } else if (hasDataSourceConfiguration) {
+        extraDescription += `\nDescription of the data sources:\n${action.description}`;
+      } else if (hasTableConfiguration) {
+        extraDescription += `\nDescription of the tables:\n${action.description}`;
+      }
+    }
+
+    processedTools.push({
+      ...toolConfig,
+      originalName: toolConfig.name,
+      mcpServerName: action.name,
+      name: toolName,
+      description: (toolConfig.description ?? "") + extraDescription,
+    });
+  }
+
+  return new Ok<ServerToolsAndInstructions>({
+    serverName: action.name,
+    instructions,
+    tools: processedTools,
   });
+}
+
+function aggregateToolListingResults(
+  results: Result<ServerToolsAndInstructions, Error>[]
+): { toolsAndInstructions: ServerToolsAndInstructions[]; errors: string[] } {
+  return results.reduce<{
+    toolsAndInstructions: ServerToolsAndInstructions[];
+    errors: string[];
+  }>(
+    (acc, result) => {
+      if (result.isOk()) {
+        acc.toolsAndInstructions.push(result.value);
+      } else {
+        acc.errors.push(result.error.message);
+      }
+      return acc;
+    },
+    { toolsAndInstructions: [], errors: [] }
+  );
 }
 
 /**
@@ -838,225 +1047,69 @@ export async function tryListMCPTools(
   conditionalJITServerToolsAndInstructions: ServerToolsAndInstructions[];
   error?: string;
 }> {
-  const owner = auth.getNonNullableWorkspace();
+  const { stableConfigs, conditionalJITConfigs } =
+    deduplicateMCPServerConfigurations({
+      agentActions: agentLoopListToolsContext.agentConfiguration.actions,
+      clientSideActions:
+        agentLoopListToolsContext.clientSideActionConfigurations ?? [],
+      skillServers,
+      stableJITServers,
+      conditionalJITServers,
+    });
 
-  const conditionalJITServerNames = new Set(
-    conditionalJITServers.map((s) => s.name)
-  );
-
-  const deduplicatedConfigs = deduplicateMCPServerConfigurations({
-    agentActions: agentLoopListToolsContext.agentConfiguration.actions,
-    clientSideActions:
-      agentLoopListToolsContext.clientSideActionConfigurations ?? [],
-    skillServers,
-    stableJITServers,
-    conditionalJITServers,
+  // Disambiguate across both groups so cross-group name collisions are detected.
+  const {
+    stableConfigs: stableActions,
+    conditionalJITConfigs: conditionalJITActions,
+  } = await disambiguateServerNamesBySpace(auth, {
+    stableConfigs,
+    conditionalJITConfigs,
   });
 
-  const mcpServerActions = await disambiguateServerNamesBySpace(
-    auth,
-    deduplicatedConfigs
-  );
-
   // Pre-fetch all MCPServerViews for server-side configs to avoid N+1 queries.
-  const serverSideViewIds = mcpServerActions
-    .filter((config) => isServerSideMCPServerConfiguration(config))
-    .map((config) => config.mcpServerViewId);
+  const allActions = [...stableActions, ...conditionalJITActions];
   const preFetchedViews = await MCPServerViewResource.fetchByIds(
     auth,
-    serverSideViewIds
+    allActions
+      .filter((config) => isServerSideMCPServerConfiguration(config))
+      .map((config) => config.mcpServerViewId)
   );
   const preFetchedMcpServerViews = new Map(
     preFetchedViews.map((view) => [view.sId, view])
   );
 
-  // Discover all tools exposed by all available MCP servers.
-  const results = await concurrentExecutor(
-    mcpServerActions,
-    async (action) => {
-      let connectionParams: MCPConnectionParams;
-      if (isServerSideMCPServerConfiguration(action)) {
-        const mcpServerView = preFetchedMcpServerViews.get(
-          action.mcpServerViewId
-        );
-        if (!mcpServerView) {
-          return new Err(
-            new Error(`MCP server view not found for ${action.name}`)
-          );
-        }
-        connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
-      } else {
-        connectionParams = makeClientSideMCPConnectionParams(action, {
-          conversationId: agentLoopListToolsContext.conversation.sId,
-          messageId: agentLoopListToolsContext.agentMessage.sId,
-        });
-      }
-
-      const toolsAndInstructionsRes =
-        await listMCPServerToolsAndServerInstructions(
-          auth,
-          action,
-          {
-            ...agentLoopListToolsContext,
-            agentActionConfiguration: action,
-          },
-          connectionParams
-        );
-
-      if (toolsAndInstructionsRes.isErr()) {
-        logger.error(
-          {
-            workspaceId: owner.sId,
-            conversationId: agentLoopListToolsContext.conversation.sId,
-            messageId: agentLoopListToolsContext.agentMessage.sId,
-            actionId: action.sId,
-            mcpServerName: action.name,
-            error: toolsAndInstructionsRes.error,
-          },
-          `Error listing tools from MCP server: ${normalizeError(
-            toolsAndInstructionsRes.error
-          )}`
-        );
-        return new Err(
-          new Error(
-            `An error occurred while listing the available tools for ${action.name}. ` +
-              "Tools from this server are not available for this message. " +
-              "Inform the user of this issue."
-          )
-        );
-      }
-
-      const { instructions, tools: rawToolsFromServer } =
-        toolsAndInstructionsRes.value;
-
-      const processedTools: MCPToolConfigurationType[] = [];
-
-      for (const toolConfig of rawToolsFromServer) {
-        let toolName: string;
-        // Fix the tool name to be valid for the model.
-        try {
-          toolName = getPrefixedToolName(action.name, toolConfig.name);
-        } catch (error) {
-          logger.warn(
-            {
-              workspaceId: owner.sId,
-              conversationId: agentLoopListToolsContext.conversation.sId,
-              messageId: agentLoopListToolsContext.agentMessage.sId,
-              actionId: action.sId,
-              mcpServerName: action.name,
-              toolName: toolConfig.name,
-              error: error,
-            },
-            `Invalid tool name, skipping the tool.`
-          );
-          continue;
-        }
-
-        // Check that all tools arguments names are valid for the model (a-zA-Z0-9_.-).
-        const toolArgumentsNames = Object.keys(
-          toolConfig.inputSchema?.properties ?? {}
-        );
-
-        const invalidArgumentNames = toolArgumentsNames.filter(
-          (argumentName) => !/^[a-zA-Z0-9_.-]+$/.test(argumentName)
-        );
-        if (invalidArgumentNames.length > 0) {
-          logger.warn(
-            {
-              workspaceId: owner.sId,
-              conversationId: agentLoopListToolsContext.conversation.sId,
-              messageId: agentLoopListToolsContext.agentMessage.sId,
-              actionId: action.sId,
-              mcpServerName: action.name,
-              toolName: toolConfig.name,
-              invalidArgumentNames,
-            },
-            `Invalid argument name(s), skipping the tool.`
-          );
-          continue;
-        }
-
-        // This handles the case where the MCP server configuration is using pre-configured data sources
-        // or tables.
-        // We add the description of the data sources or tables to the tool description so that the model
-        // has more information to make the right choice.
-        // This replicates the current behavior of the Retrieval action for example.
-        let extraDescription: string = "";
-        if (action.description) {
-          const hasDataSourceConfiguration =
-            Object.keys(
-              findMatchingSubSchemas(
-                toolConfig.inputSchema,
-                INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-              )
-            ).length > 0;
-
-          const hasTableConfiguration =
-            Object.keys(
-              findMatchingSubSchemas(
-                toolConfig.inputSchema,
-                INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
-              )
-            ).length > 0;
-
-          if (hasDataSourceConfiguration && hasTableConfiguration) {
-            // Might be confusing for the model if we end up in this situation,
-            // which is not a use case we have now.
-            extraDescription += `\nDescription of the data sources and tables:\n${action.description}`;
-          } else if (hasDataSourceConfiguration) {
-            extraDescription += `\nDescription of the data sources:\n${action.description}`;
-          } else if (hasTableConfiguration) {
-            extraDescription += `\nDescription of the tables:\n${action.description}`;
-          }
-        }
-
-        processedTools.push({
-          ...toolConfig,
-          originalName: toolConfig.name,
-          mcpServerName: action.name,
-          name: toolName,
-          description: (toolConfig.description ?? "") + extraDescription,
-        });
-      }
-
-      // Return the server's instructions and its processed tools.
-      return new Ok<ServerToolsAndInstructions>({
-        serverName: action.name,
-        instructions,
-        tools: processedTools,
-      });
-    },
+  // Discover tools from stable and conditional JIT servers separately.
+  const stableResults = await concurrentExecutor(
+    stableActions,
+    (action) =>
+      listToolsForAction(
+        auth,
+        agentLoopListToolsContext,
+        preFetchedMcpServerViews,
+        action
+      ),
+    { concurrency: 10 }
+  );
+  const conditionalJITResults = await concurrentExecutor(
+    conditionalJITActions,
+    (action) =>
+      listToolsForAction(
+        auth,
+        agentLoopListToolsContext,
+        preFetchedMcpServerViews,
+        action
+      ),
     { concurrency: 10 }
   );
 
-  // Aggregate results
-  const { serverToolsAndInstructions, errors } = results.reduce<{
-    serverToolsAndInstructions: ServerToolsAndInstructions[];
-    errors: string[];
-  }>(
-    (acc, result) => {
-      if (result.isOk()) {
-        acc.serverToolsAndInstructions.push(result.value);
-      } else {
-        acc.errors.push(result.error.message);
-      }
-      return acc;
-    },
-    { serverToolsAndInstructions: [], errors: [] }
-  );
-
-  const stableServerToolsAndInstructions = serverToolsAndInstructions.filter(
-    (s) => !conditionalJITServerNames.has(s.serverName)
-  );
-  const conditionalJITServerToolsAndInstructions =
-    serverToolsAndInstructions.filter((s) =>
-      conditionalJITServerNames.has(s.serverName)
-    );
+  const stable = aggregateToolListingResults(stableResults);
+  const conditional = aggregateToolListingResults(conditionalJITResults);
+  const allErrors = [...stable.errors, ...conditional.errors];
 
   return {
-    stableServerToolsAndInstructions,
-    conditionalJITServerToolsAndInstructions,
-    error: errors.length > 0 ? errors.join("\n") : undefined,
+    stableServerToolsAndInstructions: stable.toolsAndInstructions,
+    conditionalJITServerToolsAndInstructions: conditional.toolsAndInstructions,
+    error: allErrors.length > 0 ? allErrors.join("\n") : undefined,
   };
 }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -844,7 +844,8 @@ export async function tryListMCPTools(
     clientSideActions:
       agentLoopListToolsContext.clientSideActionConfigurations ?? [],
     skillServers,
-    jitServers,
+    stableJITServers,
+    conditionalJITServers,
   });
 
   const mcpServerActions = await disambiguateServerNamesBySpace(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1048,9 +1048,10 @@ export async function tryListMCPTools(
   const stableServerToolsAndInstructions = serverToolsAndInstructions.filter(
     (s) => !conditionalJITServerNames.has(s.serverName)
   );
-  const conditionalJITServerToolsAndInstructions = serverToolsAndInstructions.filter(
-    (s) => conditionalJITServerNames.has(s.serverName)
-  );
+  const conditionalJITServerToolsAndInstructions =
+    serverToolsAndInstructions.filter((s) =>
+      conditionalJITServerNames.has(s.serverName)
+    );
 
   return {
     stableServerToolsAndInstructions,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -796,6 +796,14 @@ async function disambiguateServerNamesBySpace(
   };
 }
 
+function getDeduplicationKey(config: MCPServerConfigurationType): string {
+  const viewId = isServerSideMCPServerConfiguration(config)
+    ? config.mcpServerViewId
+    : config.clientSideMcpServerId;
+
+  return `${viewId}:${slugify(config.name)}`;
+}
+
 /**
  * Deduplicates MCP server configurations by view ID and name.
  * Priority order: agent > client-side > skill > stable JIT > conditional JIT.
@@ -816,38 +824,30 @@ function deduplicateMCPServerConfigurations({
   stableConfigs: MCPServerConfigurationType[];
   conditionalJITConfigs: MCPServerConfigurationType[];
 } {
-  // Reference identity is safe here: dedup runs before disambiguation (which
-  // copies objects via .map()), so the original references are preserved.
-  const conditionalJITSet = new Set<MCPServerConfigurationType>(
-    conditionalJITServers
-  );
   const seen = new Set<string>();
-
   const stableConfigs: MCPServerConfigurationType[] = [];
   const conditionalJITConfigs: MCPServerConfigurationType[] = [];
 
+  // Process stable configs first (higher priority).
   for (const config of [
     ...agentActions,
     ...clientSideActions,
     ...skillServers,
     ...stableJITServers,
-    ...conditionalJITServers,
   ]) {
-    const viewId = isServerSideMCPServerConfiguration(config)
-      ? config.mcpServerViewId
-      : config.clientSideMcpServerId;
-    const key = `${viewId}:${slugify(config.name)}`;
-
-    if (seen.has(key)) {
-      continue;
-    }
-
-    seen.add(key);
-
-    if (conditionalJITSet.has(config)) {
-      conditionalJITConfigs.push(config);
-    } else {
+    const key = getDeduplicationKey(config);
+    if (!seen.has(key)) {
+      seen.add(key);
       stableConfigs.push(config);
+    }
+  }
+
+  // Then conditional JIT configs (lower priority).
+  for (const config of conditionalJITServers) {
+    const key = getDeduplicationKey(config);
+    if (!seen.has(key)) {
+      seen.add(key);
+      conditionalJITConfigs.push(config);
     }
   }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -772,28 +772,34 @@ async function disambiguateServerNamesBySpace(
   );
 
   // Apply space prefix to colliding server-side configs.
-  const disambiguate = (
-    config: MCPServerConfigurationType
-  ): MCPServerConfigurationType => {
-    if (
-      isServerSideMCPServerConfiguration(config) &&
-      collidingNames.has(config.name)
-    ) {
-      const spaceName = viewIdToSpaceName.get(config.mcpServerViewId);
-      if (spaceName) {
-        return {
-          ...config,
-          name: `${slugify(spaceName)}${TOOL_NAME_SEPARATOR}${config.name}`,
-        };
-      }
-    }
-    return config;
-  };
-
   return {
-    stableConfigs: stableConfigs.map(disambiguate),
-    conditionalJITConfigs: conditionalJITConfigs.map(disambiguate),
+    stableConfigs: stableConfigs.map((c) =>
+      disambiguateConfig(c, collidingNames, viewIdToSpaceName)
+    ),
+    conditionalJITConfigs: conditionalJITConfigs.map((c) =>
+      disambiguateConfig(c, collidingNames, viewIdToSpaceName)
+    ),
   };
+}
+
+function disambiguateConfig(
+  config: MCPServerConfigurationType,
+  collidingNames: Set<string>,
+  viewIdToSpaceName: Map<string, string>
+): MCPServerConfigurationType {
+  if (
+    isServerSideMCPServerConfiguration(config) &&
+    collidingNames.has(config.name)
+  ) {
+    const spaceName = viewIdToSpaceName.get(config.mcpServerViewId);
+    if (spaceName) {
+      return {
+        ...config,
+        name: `${slugify(spaceName)}${TOOL_NAME_SEPARATOR}${config.name}`,
+      };
+    }
+  }
+  return config;
 }
 
 function getDeduplicationKey(config: MCPServerConfigurationType): string {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -834,10 +834,15 @@ export async function tryListMCPTools(
     skillServers: MCPServerConfigurationType[];
   }
 ): Promise<{
-  serverToolsAndInstructions: ServerToolsAndInstructions[];
+  stableServerToolsAndInstructions: ServerToolsAndInstructions[];
+  conditionalJITServerToolsAndInstructions: ServerToolsAndInstructions[];
   error?: string;
 }> {
   const owner = auth.getNonNullableWorkspace();
+
+  const conditionalJITServerNames = new Set(
+    conditionalJITServers.map((s) => s.name)
+  );
 
   const deduplicatedConfigs = deduplicateMCPServerConfigurations({
     agentActions: agentLoopListToolsContext.agentConfiguration.actions,
@@ -1040,8 +1045,16 @@ export async function tryListMCPTools(
     { serverToolsAndInstructions: [], errors: [] }
   );
 
+  const stableServerToolsAndInstructions = serverToolsAndInstructions.filter(
+    (s) => !conditionalJITServerNames.has(s.serverName)
+  );
+  const conditionalJITServerToolsAndInstructions = serverToolsAndInstructions.filter(
+    (s) => conditionalJITServerNames.has(s.serverName)
+  );
+
   return {
-    serverToolsAndInstructions,
+    stableServerToolsAndInstructions,
+    conditionalJITServerToolsAndInstructions,
     error: errors.length > 0 ? errors.join("\n") : undefined,
   };
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -197,18 +197,18 @@ function constructToolsSection({
   return toolsSection;
 }
 
-function constructConditionalJitToolsSection({
-  conditionalJitServerToolsAndInstructions,
+function constructConditionalJITToolsSection({
+  conditionalJITServerToolsAndInstructions,
 }: {
-  conditionalJitServerToolsAndInstructions?: ServerToolsAndInstructions[];
+  conditionalJITServerToolsAndInstructions?: ServerToolsAndInstructions[];
 }): string {
-  if (!conditionalJitServerToolsAndInstructions?.length) {
+  if (!conditionalJITServerToolsAndInstructions?.length) {
     return "";
   }
 
   let section = "\n## CONDITIONAL TOOL SERVERS\n";
   section += "The following tool servers are also available.\n";
-  section += formatToolServerListing(conditionalJitServerToolsAndInstructions);
+  section += formatToolServerListing(conditionalJITServerToolsAndInstructions);
   section += "\n";
   return section;
 }
@@ -421,7 +421,7 @@ export function constructPromptMultiActions(
     agentsList,
     conversation,
     stableServerToolsAndInstructions,
-    conditionalJitServerToolsAndInstructions,
+    conditionalJITServerToolsAndInstructions,
     enabledSkills,
     equippedSkills,
     memoriesContext,
@@ -438,7 +438,7 @@ export function constructPromptMultiActions(
     agentsList: LightAgentConfigurationType[] | null;
     conversation?: ConversationWithoutContentType;
     stableServerToolsAndInstructions?: ServerToolsAndInstructions[];
-    conditionalJitServerToolsAndInstructions?: ServerToolsAndInstructions[];
+    conditionalJITServerToolsAndInstructions?: ServerToolsAndInstructions[];
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
     memoriesContext?: string;
@@ -487,8 +487,8 @@ export function constructPromptMultiActions(
   const attachmentsSection = constructAttachmentsSection();
   const pastedContentSection = constructPastedContentSection();
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
-  const conditionalJitToolsSection = constructConditionalJitToolsSection({
-    conditionalJitServerToolsAndInstructions,
+  const conditionalJITToolsSection = constructConditionalJITToolsSection({
+    conditionalJITServerToolsAndInstructions,
   });
 
   if (hasStaticInstructions) {
@@ -517,7 +517,7 @@ export function constructPromptMultiActions(
       { role: "context" as const, content: contextSection },
       { role: "context" as const, content: projectContextSection },
       { role: "context" as const, content: toolsetsContext ?? "" },
-      { role: "context" as const, content: conditionalJitToolsSection },
+      { role: "context" as const, content: conditionalJITToolsSection },
       { role: "context" as const, content: workspaceContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
 
@@ -546,7 +546,7 @@ export function constructPromptMultiActions(
     { role: "context" as const, content: pastedContentSection },
     { role: "context" as const, content: guidelinesSection },
     { role: "context" as const, content: toolsetsContext ?? "" },
-    { role: "context" as const, content: conditionalJitToolsSection },
+    { role: "context" as const, content: conditionalJITToolsSection },
     { role: "context" as const, content: memoriesContext ?? "" },
     { role: "context" as const, content: userContext ?? "" },
     { role: "context" as const, content: workspaceContext ?? "" },

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -122,6 +122,28 @@ When information should be preserved for future conversations or context, add it
 `;
 }
 
+function formatToolServerListing(
+  servers: ServerToolsAndInstructions[]
+): string {
+  let prompt = "";
+  for (const serverData of servers) {
+    prompt += `\n### SERVER NAME: ${serverData.serverName}\n`;
+    if (serverData.instructions) {
+      prompt += `Server instructions: ${serverData.instructions}\n`;
+    }
+    if (serverData.tools && serverData.tools.length > 0) {
+      prompt += "Tools available on this server (names only):\n";
+      for (const tool of serverData.tools) {
+        prompt += `  - ${tool.name}\n`;
+      }
+    } else {
+      prompt +=
+        "  (No tools reported by this server or tool listing failed.)\n";
+    }
+  }
+  return prompt;
+}
+
 function constructToolsSection({
   hasAvailableActions,
   model,
@@ -165,32 +187,31 @@ function constructToolsSection({
   // is determined by the comprehensive tool specifications provided to the model separately.
   // All discovered tools from all servers are made available for the agent to call, regardless of
   // whether their server has explicit instructions or is detailed in this specific prompt overview.
-  let toolServersPrompt = "";
-
   if (serverToolsAndInstructions && serverToolsAndInstructions.length > 0) {
-    toolServersPrompt = "\n## AVAILABLE TOOL SERVERS\n";
-    toolServersPrompt +=
+    toolsSection += "\n## AVAILABLE TOOL SERVERS\n";
+    toolsSection +=
       "Each server provides a list of tools made available to the agent.\n";
-    for (const serverData of serverToolsAndInstructions) {
-      toolServersPrompt += `\n### SERVER NAME: ${serverData.serverName}\n`;
-      if (serverData.instructions) {
-        toolServersPrompt += `Server instructions: ${serverData.instructions}\n`;
-      }
-      if (serverData.tools && serverData.tools.length > 0) {
-        toolServersPrompt += `Tools available on this server (names only):\n`;
-        for (const tool of serverData.tools) {
-          toolServersPrompt += `  - ${tool.name}\n`;
-        }
-      } else {
-        toolServersPrompt += `  (No tools reported by this server or tool listing failed.)\n`;
-      }
-    }
-    toolServersPrompt += "\n";
+    toolsSection += formatToolServerListing(serverToolsAndInstructions);
+    toolsSection += "\n";
   }
 
-  toolsSection += toolServersPrompt;
-
   return toolsSection;
+}
+
+function constructConditionalJitToolsSection({
+  serverToolsAndInstructions,
+}: {
+  serverToolsAndInstructions: ServerToolsAndInstructions[];
+}): string {
+  if (!serverToolsAndInstructions.length) {
+    return "";
+  }
+
+  let section = "\n## CONDITIONAL TOOL SERVERS\n";
+  section += "The following tool servers are also available.\n";
+  section += formatToolServerListing(serverToolsAndInstructions);
+  section += "\n";
+  return section;
 }
 
 /**
@@ -401,6 +422,7 @@ export function constructPromptMultiActions(
     agentsList,
     conversation,
     serverToolsAndInstructions,
+    conditionalJitServerToolsAndInstructions,
     enabledSkills,
     equippedSkills,
     memoriesContext,
@@ -417,6 +439,7 @@ export function constructPromptMultiActions(
     agentsList: LightAgentConfigurationType[] | null;
     conversation?: ConversationWithoutContentType;
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
+    conditionalJitServerToolsAndInstructions?: ServerToolsAndInstructions[];
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
     memoriesContext?: string;
@@ -465,6 +488,9 @@ export function constructPromptMultiActions(
   const attachmentsSection = constructAttachmentsSection();
   const pastedContentSection = constructPastedContentSection();
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
+  const conditionalJitToolsSection = constructConditionalJitToolsSection({
+    serverToolsAndInstructions: conditionalJitServerToolsAndInstructions ?? [],
+  });
 
   if (hasStaticInstructions) {
     // Structured form with 3 cache tiers, ordered from most stable to most volatile.
@@ -492,6 +518,7 @@ export function constructPromptMultiActions(
       { role: "context" as const, content: contextSection },
       { role: "context" as const, content: projectContextSection },
       { role: "context" as const, content: toolsetsContext ?? "" },
+      { role: "context" as const, content: conditionalJitToolsSection },
       { role: "context" as const, content: workspaceContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
 
@@ -520,6 +547,7 @@ export function constructPromptMultiActions(
     { role: "context" as const, content: pastedContentSection },
     { role: "context" as const, content: guidelinesSection },
     { role: "context" as const, content: toolsetsContext ?? "" },
+    { role: "context" as const, content: conditionalJitToolsSection },
     { role: "context" as const, content: memoriesContext ?? "" },
     { role: "context" as const, content: userContext ?? "" },
     { role: "context" as const, content: workspaceContext ?? "" },

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -207,7 +207,8 @@ function constructConditionalJITToolsSection({
   }
 
   let section = "\n## CONDITIONAL TOOL SERVERS\n";
-  section += "The following tool servers are also available.\n";
+  section +=
+    "The following tool servers were made available based on the conversation context.\n";
   section += formatToolServerListing(conditionalJITServerToolsAndInstructions);
   section += "\n";
   return section;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -421,7 +421,7 @@ export function constructPromptMultiActions(
     errorContext,
     agentsList,
     conversation,
-    serverToolsAndInstructions,
+    stableServerToolsAndInstructions,
     conditionalJitServerToolsAndInstructions,
     enabledSkills,
     equippedSkills,
@@ -438,7 +438,7 @@ export function constructPromptMultiActions(
     errorContext?: string;
     agentsList: LightAgentConfigurationType[] | null;
     conversation?: ConversationWithoutContentType;
-    serverToolsAndInstructions?: ServerToolsAndInstructions[];
+    stableServerToolsAndInstructions?: ServerToolsAndInstructions[];
     conditionalJitServerToolsAndInstructions?: ServerToolsAndInstructions[];
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
@@ -479,7 +479,7 @@ export function constructPromptMultiActions(
     hasAvailableActions,
     model,
     agentConfiguration,
-    serverToolsAndInstructions,
+    serverToolsAndInstructions: stableServerToolsAndInstructions,
   });
   const skillsSection = constructSkillsSection({
     enabledSkills,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -192,24 +192,23 @@ function constructToolsSection({
     toolsSection +=
       "Each server provides a list of tools made available to the agent.\n";
     toolsSection += formatToolServerListing(serverToolsAndInstructions);
-    toolsSection += "\n";
   }
 
   return toolsSection;
 }
 
 function constructConditionalJitToolsSection({
-  serverToolsAndInstructions,
+  conditionalJitServerToolsAndInstructions,
 }: {
-  serverToolsAndInstructions: ServerToolsAndInstructions[];
+  conditionalJitServerToolsAndInstructions?: ServerToolsAndInstructions[];
 }): string {
-  if (!serverToolsAndInstructions.length) {
+  if (!conditionalJitServerToolsAndInstructions?.length) {
     return "";
   }
 
   let section = "\n## CONDITIONAL TOOL SERVERS\n";
   section += "The following tool servers are also available.\n";
-  section += formatToolServerListing(serverToolsAndInstructions);
+  section += formatToolServerListing(conditionalJitServerToolsAndInstructions);
   section += "\n";
   return section;
 }
@@ -489,7 +488,7 @@ export function constructPromptMultiActions(
   const pastedContentSection = constructPastedContentSection();
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
   const conditionalJitToolsSection = constructConditionalJitToolsSection({
-    serverToolsAndInstructions: conditionalJitServerToolsAndInstructions ?? [],
+    conditionalJitServerToolsAndInstructions,
   });
 
   if (hasStaticInstructions) {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -268,7 +268,7 @@ IMPORTANT: If the user's company data sources already index data from a platform
 Only enable a toolset for data retrieval when the needed data is absent from or not indexed in company data sources (e.g. private data, real-time data, or data from a source that isn't connected).
 Toolsets remain valuable for **write operations** (posting a Slack message, creating a Notion page, updating a GitHub issue, etc.) that company data tools cannot perform.
 </toolsets_vs_company_data>
-</toolsets_guidelines>\n`;
+</toolsets_guidelines>`;
 }
 
 function buildInstructions({

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -268,7 +268,7 @@ IMPORTANT: If the user's company data sources already index data from a platform
 Only enable a toolset for data retrieval when the needed data is absent from or not indexed in company data sources (e.g. private data, real-time data, or data from a source that isn't connected).
 Toolsets remain valuable for **write operations** (posting a Slack message, creating a Notion page, updating a GitHub issue, etc.) that company data tools cannot perform.
 </toolsets_vs_company_data>
-</toolsets_guidelines>`;
+</toolsets_guidelines>\n`;
 }
 
 function buildInstructions({

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -19,13 +19,26 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
-async function getAllJITServers(...args: Parameters<typeof getJITServers>) {
-  const { stableServers, conditionalServers } = await getJITServers(...args);
-  return [...stableServers, ...conditionalServers];
+async function getAllJITServers(
+  auth: Authenticator,
+  params: {
+    agentConfiguration: AgentConfigurationType;
+    conversation: ConversationWithoutContentType;
+    attachments: ConversationAttachmentType[];
+  }
+) {
+  const { stableJITServers, conditionalJITServers } = await getJITServers(
+    auth,
+    params
+  );
+  return [...stableJITServers, ...conditionalJITServers];
 }
 
 describe("getJITServers", () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -23,11 +23,8 @@ import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
-async function getAllJITServers(
-  ...args: Parameters<typeof getJITServers>
-) {
-  const { stableServers, conditionalServers } =
-    await getJITServers(...args);
+async function getAllJITServers(...args: Parameters<typeof getJITServers>) {
+  const { stableServers, conditionalServers } = await getJITServers(...args);
   return [...stableServers, ...conditionalServers];
 }
 

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -23,6 +23,14 @@ import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
+async function getAllJITServers(
+  ...args: Parameters<typeof getJITServers>
+) {
+  const { stableServers, conditionalServers } =
+    await getJITServers(...args);
+  return [...stableServers, ...conditionalServers];
+}
+
 describe("getJITServers", () => {
   let auth: Authenticator;
   let workspace: WorkspaceType;
@@ -52,7 +60,7 @@ describe("getJITServers", () => {
 
   describe("basic MCP servers", () => {
     it("should return common_utilities MCP server when no attachments", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -94,7 +102,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -125,7 +133,7 @@ describe("getJITServers", () => {
         agentConfigurationId: agentConfig.id,
       });
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -145,7 +153,7 @@ describe("getJITServers", () => {
     it("should not include skill_management server when agent has no skills", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -180,7 +188,7 @@ describe("getJITServers", () => {
 
       expect(projectDatasourceView).toBeDefined();
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: conversationWithSpace,
         attachments: [],
@@ -206,7 +214,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include project search server when feature flag is disabled", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -224,7 +232,7 @@ describe("getJITServers", () => {
       await FeatureFlagFactory.basic("projects", workspace);
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: {
           ...conversation,
@@ -246,7 +254,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include project_manager server when feature flag is disabled", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: {
           ...conversation,
@@ -266,7 +274,7 @@ describe("getJITServers", () => {
       // Enable projects feature flag.
       await FeatureFlagFactory.basic("projects", workspace);
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -291,7 +299,7 @@ describe("getJITServers", () => {
         workspace.id
       );
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -309,7 +317,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include schedules_management server for non-onboarding conversations", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -351,7 +359,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -405,7 +413,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -455,7 +463,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -496,7 +504,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -540,7 +548,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -592,7 +600,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -613,7 +621,7 @@ describe("getJITServers", () => {
 
   describe("server structure", () => {
     it("should return servers with correct structure", async () => {
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -672,7 +680,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const { servers: jitServers } = await getJITServers(auth, {
+      const jitServers = await getAllJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -136,10 +136,10 @@ export async function getJITServers(
     attachments: ConversationAttachmentType[];
   }
 ): Promise<{
-  servers: ServerSideMCPServerConfigurationType[];
-  hasConditionalJITTools: boolean;
+  stableServers: ServerSideMCPServerConfigurationType[];
+  conditionalServers: ServerSideMCPServerConfigurationType[];
 }> {
-  const [baseServers, conditionalServers] = await Promise.all([
+  const [stableServers, conditionalServers] = await Promise.all([
     getUnconditionalJITServers(auth, { agentConfiguration, conversation }),
     getConditionalJITServers(auth, {
       agentConfiguration,
@@ -149,7 +149,7 @@ export async function getJITServers(
   ]);
 
   return {
-    servers: [...baseServers, ...conditionalServers],
-    hasConditionalJITTools: conditionalServers.length > 0,
+    stableServers,
+    conditionalServers,
   };
 }

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -20,7 +20,7 @@ import { removeNulls } from "@app/types/shared/utils/general";
 /**
  * Servers whose tool specifications are mostly always added or never added.
  */
-async function getUnconditionalJITServers(
+async function getStableJITServers(
   auth: Authenticator,
   {
     agentConfiguration,
@@ -45,23 +45,6 @@ async function getUnconditionalJITServers(
     conversation
   );
   servers.push(skillManagementServer);
-
-  // Add the three project servers if the conversation belongs to a project.
-
-  const projectSearchServer = await getProjectSearchServer(auth, conversation);
-  servers.push(projectSearchServer);
-
-  const projectManagerServer = await getProjectManagerServer(
-    auth,
-    conversation
-  );
-  servers.push(projectManagerServer);
-
-  const projectConversationServer = await getProjectConversationServer(
-    auth,
-    conversation
-  );
-  servers.push(projectConversationServer);
 
   return removeNulls(servers);
 }
@@ -90,6 +73,23 @@ async function getConditionalJITServers(
     agentConfiguration.sId
   );
   servers.push(...conversationServers);
+
+  // Add the three project servers if the conversation belongs to a project.
+
+  const projectSearchServer = await getProjectSearchServer(auth, conversation);
+  servers.push(projectSearchServer);
+
+  const projectManagerServer = await getProjectManagerServer(
+    auth,
+    conversation
+  );
+  servers.push(projectManagerServer);
+
+  const projectConversationServer = await getProjectConversationServer(
+    auth,
+    conversation
+  );
+  servers.push(projectConversationServer);
 
   // Add the schedules_management server, only applies to the onboarding conversation.
   const schedulesManagementServer = await getSchedulesManagementServer(
@@ -136,11 +136,11 @@ export async function getJITServers(
     attachments: ConversationAttachmentType[];
   }
 ): Promise<{
-  stableServers: ServerSideMCPServerConfigurationType[];
-  conditionalServers: ServerSideMCPServerConfigurationType[];
+  stableJITServers: ServerSideMCPServerConfigurationType[];
+  conditionalJITServers: ServerSideMCPServerConfigurationType[];
 }> {
-  const [stableServers, conditionalServers] = await Promise.all([
-    getUnconditionalJITServers(auth, { agentConfiguration, conversation }),
+  const [stableJITServers, conditionalJITServers] = await Promise.all([
+    getStableJITServers(auth, { agentConfiguration, conversation }),
     getConditionalJITServers(auth, {
       agentConfiguration,
       conversation,
@@ -149,7 +149,7 @@ export async function getJITServers(
   ]);
 
   return {
-    stableServers,
-    conditionalServers,
+    stableJITServers,
+    conditionalJITServers,
   };
 }

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -216,22 +216,36 @@ async function handler(
         reactions: [],
       };
 
-      const { serverToolsAndInstructions, error: mcpToolsListingError } =
-        await tryListMCPTools(
-          auth,
-          {
-            agentConfiguration,
-            conversation,
-            agentMessage: placeholderAgentMessage,
-            clientSideActionConfigurations: clientSideMCPActionConfigurations,
-          },
-          {
-            jitServers,
-            skillServers,
-          }
+      const {
+        serverToolsAndInstructions: allServerToolsAndInstructions,
+        error: mcpToolsListingError,
+      } = await tryListMCPTools(
+        auth,
+        {
+          agentConfiguration,
+          conversation,
+          agentMessage: placeholderAgentMessage,
+          clientSideActionConfigurations: clientSideMCPActionConfigurations,
+        },
+        {
+          jitServers,
+          skillServers,
+        }
+      );
+
+      const conditionalJitServerNames = new Set(
+        conditionalServers.map((s) => s.name)
+      );
+      const stableServerToolsAndInstructions =
+        allServerToolsAndInstructions.filter(
+          (a) => !conditionalJitServerNames.has(a.serverName)
+        );
+      const conditionalJitServerToolsAndInstructions =
+        allServerToolsAndInstructions.filter((a) =>
+          conditionalJitServerNames.has(a.serverName)
         );
 
-      const availableActions = serverToolsAndInstructions.flatMap(
+      const availableActions = allServerToolsAndInstructions.flatMap(
         (s) => s.tools
       );
 
@@ -261,7 +275,8 @@ async function handler(
         errorContext: mcpToolsListingError,
         agentsList,
         conversation,
-        stableServerToolsAndInstructions: serverToolsAndInstructions,
+        stableServerToolsAndInstructions,
+        conditionalJitServerToolsAndInstructions,
         enabledSkills,
         equippedSkills,
       });

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -240,8 +240,7 @@ async function handler(
       const availableActions = [
         ...stableServerToolsAndInstructions,
         ...conditionalJITServerToolsAndInstructions,
-      ].flatMap((s) => s.tools
-      );
+      ].flatMap((s) => s.tools);
 
       let fallbackPrompt = "You are a conversational agent";
       if (agentConfiguration.actions.length || availableActions.length > 0) {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -163,12 +163,11 @@ async function handler(
 
       // Build tools list and prompt similar to the agent loop.
       const attachments = await listAttachments(auth, { conversation });
-      const { stableServers, conditionalServers } =
-        await getJITServers(auth, {
-          agentConfiguration,
-          conversation,
-          attachments,
-        });
+      const { stableServers, conditionalServers } = await getJITServers(auth, {
+        agentConfiguration,
+        conversation,
+        attachments,
+      });
       const jitServers = [...stableServers, ...conditionalServers];
 
       const { enabledSkills, equippedSkills } =
@@ -262,7 +261,7 @@ async function handler(
         errorContext: mcpToolsListingError,
         agentsList,
         conversation,
-        serverToolsAndInstructions,
+        stableServerToolsAndInstructions: serverToolsAndInstructions,
         enabledSkills,
         equippedSkills,
       });

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -219,7 +219,8 @@ async function handler(
       };
 
       const {
-        serverToolsAndInstructions: allServerToolsAndInstructions,
+        stableServerToolsAndInstructions,
+        conditionalJITServerToolsAndInstructions,
         error: mcpToolsListingError,
       } = await tryListMCPTools(
         auth,
@@ -236,20 +237,10 @@ async function handler(
         }
       );
 
-      const conditionalJITServerNames = new Set(
-        conditionalJITServers.map((s) => s.name)
-      );
-      const stableServerToolsAndInstructions =
-        allServerToolsAndInstructions.filter(
-          (a) => !conditionalJITServerNames.has(a.serverName)
-        );
-      const conditionalJITServerToolsAndInstructions =
-        allServerToolsAndInstructions.filter((a) =>
-          conditionalJITServerNames.has(a.serverName)
-        );
-
-      const availableActions = allServerToolsAndInstructions.flatMap(
-        (s) => s.tools
+      const availableActions = [
+        ...stableServerToolsAndInstructions,
+        ...conditionalJITServerToolsAndInstructions,
+      ].flatMap((s) => s.tools
       );
 
       let fallbackPrompt = "You are a conversational agent";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -233,16 +233,16 @@ async function handler(
         }
       );
 
-      const conditionalJitServerNames = new Set(
+      const conditionalJITServerNames = new Set(
         conditionalServers.map((s) => s.name)
       );
       const stableServerToolsAndInstructions =
         allServerToolsAndInstructions.filter(
-          (a) => !conditionalJitServerNames.has(a.serverName)
+          (a) => !conditionalJITServerNames.has(a.serverName)
         );
-      const conditionalJitServerToolsAndInstructions =
+      const conditionalJITServerToolsAndInstructions =
         allServerToolsAndInstructions.filter((a) =>
-          conditionalJitServerNames.has(a.serverName)
+          conditionalJITServerNames.has(a.serverName)
         );
 
       const availableActions = allServerToolsAndInstructions.flatMap(
@@ -276,7 +276,7 @@ async function handler(
         agentsList,
         conversation,
         stableServerToolsAndInstructions,
-        conditionalJitServerToolsAndInstructions,
+        conditionalJITServerToolsAndInstructions,
         enabledSkills,
         equippedSkills,
       });

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -237,7 +237,7 @@ async function handler(
       );
 
       const conditionalJITServerNames = new Set(
-        conditionalServers.map((s) => s.name)
+        conditionalJITServers.map((s) => s.name)
       );
       const stableServerToolsAndInstructions =
         allServerToolsAndInstructions.filter(

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -163,12 +163,14 @@ async function handler(
 
       // Build tools list and prompt similar to the agent loop.
       const attachments = await listAttachments(auth, { conversation });
-      const { stableServers, conditionalServers } = await getJITServers(auth, {
-        agentConfiguration,
-        conversation,
-        attachments,
-      });
-      const jitServers = [...stableServers, ...conditionalServers];
+      const { stableJITServers, conditionalJITServers } = await getJITServers(
+        auth,
+        {
+          agentConfiguration,
+          conversation,
+          attachments,
+        }
+      );
 
       const { enabledSkills, equippedSkills } =
         await SkillResource.listForAgentLoop(auth, {
@@ -228,7 +230,8 @@ async function handler(
           clientSideActionConfigurations: clientSideMCPActionConfigurations,
         },
         {
-          jitServers,
+          stableJITServers,
+          conditionalJITServers,
           skillServers,
         }
       );

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -163,11 +163,13 @@ async function handler(
 
       // Build tools list and prompt similar to the agent loop.
       const attachments = await listAttachments(auth, { conversation });
-      const { servers: jitServers } = await getJITServers(auth, {
-        agentConfiguration,
-        conversation,
-        attachments,
-      });
+      const { stableServers, conditionalServers } =
+        await getJITServers(auth, {
+          agentConfiguration,
+          conversation,
+          attachments,
+        });
+      const jitServers = [...stableServers, ...conditionalServers];
 
       const { enabledSkills, equippedSkills } =
         await SkillResource.listForAgentLoop(auth, {

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -93,12 +93,11 @@ async function handler(
 
       const conversation = conversationResult.value;
       const attachments = await listAttachments(auth, { conversation });
-      const { stableServers, conditionalServers } =
-        await getJITServers(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-          attachments,
-        });
+      const { stableServers, conditionalServers } = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments,
+      });
       const jitServers = [...stableServers, ...conditionalServers];
       for (const srv of jitServers) {
         viewIds.add(srv.mcpServerViewId);

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -94,11 +94,14 @@ async function handler(
       const conversation = conversationResult.value;
       const attachments = await listAttachments(auth, { conversation });
 
-      const { stableJITServers, conditionalJITServers } = await getJITServers(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-        attachments,
-      });
+      const { stableJITServers, conditionalJITServers } = await getJITServers(
+        auth,
+        {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments,
+        }
+      );
 
       for (const srv of [...stableJITServers, ...conditionalJITServers]) {
         viewIds.add(srv.mcpServerViewId);

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -93,11 +93,13 @@ async function handler(
 
       const conversation = conversationResult.value;
       const attachments = await listAttachments(auth, { conversation });
-      const { servers: jitServers } = await getJITServers(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-        attachments,
-      });
+      const { stableServers, conditionalServers } =
+        await getJITServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments,
+        });
+      const jitServers = [...stableServers, ...conditionalServers];
       for (const srv of jitServers) {
         viewIds.add(srv.mcpServerViewId);
       }

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -93,13 +93,14 @@ async function handler(
 
       const conversation = conversationResult.value;
       const attachments = await listAttachments(auth, { conversation });
-      const { stableServers, conditionalServers } = await getJITServers(auth, {
+
+      const { stableJITServers, conditionalJITServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
       });
-      const jitServers = [...stableServers, ...conditionalServers];
-      for (const srv of jitServers) {
+
+      for (const srv of [...stableJITServers, ...conditionalJITServers]) {
         viewIds.add(srv.mcpServerViewId);
       }
 

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -161,11 +161,15 @@ async function listAvailableTools(
     });
 
   const attachments = await listAttachments(auth, { conversation });
-  const { servers: jitServers } = await getJITServers(auth, {
-    agentConfiguration,
-    conversation,
-    attachments,
-  });
+  const { stableServers, conditionalServers } = await getJITServers(
+    auth,
+    {
+      agentConfiguration,
+      conversation,
+      attachments,
+    }
+  );
+  const jitServers = [...stableServers, ...conditionalServers];
 
   const clientSideMCPActionConfigurations =
     await createClientSideMCPServerConfigurations(

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -161,14 +161,11 @@ async function listAvailableTools(
     });
 
   const attachments = await listAttachments(auth, { conversation });
-  const { stableServers, conditionalServers } = await getJITServers(
-    auth,
-    {
-      agentConfiguration,
-      conversation,
-      attachments,
-    }
-  );
+  const { stableServers, conditionalServers } = await getJITServers(auth, {
+    agentConfiguration,
+    conversation,
+    attachments,
+  });
   const jitServers = [...stableServers, ...conditionalServers];
 
   const clientSideMCPActionConfigurations =

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -161,12 +161,14 @@ async function listAvailableTools(
     });
 
   const attachments = await listAttachments(auth, { conversation });
-  const { stableServers, conditionalServers } = await getJITServers(auth, {
+  const {
+    stableJITServers,
+    conditionalJITServers,
+  } = await getJITServers(auth, {
     agentConfiguration,
     conversation,
     attachments,
   });
-  const jitServers = [...stableServers, ...conditionalServers];
 
   const clientSideMCPActionConfigurations =
     await createClientSideMCPServerConfigurations(
@@ -214,7 +216,8 @@ async function listAvailableTools(
       clientSideActionConfigurations: clientSideMCPActionConfigurations,
     },
     {
-      jitServers,
+      stableJITServers,
+      conditionalJITServers,
       skillServers,
     }
   );

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -161,14 +161,14 @@ async function listAvailableTools(
     });
 
   const attachments = await listAttachments(auth, { conversation });
-  const {
-    stableJITServers,
-    conditionalJITServers,
-  } = await getJITServers(auth, {
-    agentConfiguration,
-    conversation,
-    attachments,
-  });
+  const { stableJITServers, conditionalJITServers } = await getJITServers(
+    auth,
+    {
+      agentConfiguration,
+      conversation,
+      attachments,
+    }
+  );
 
   const clientSideMCPActionConfigurations =
     await createClientSideMCPServerConfigurations(

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -207,7 +207,10 @@ async function listAvailableTools(
     skillServers.push(dataWarehouseServer);
   }
 
-  const { serverToolsAndInstructions: mcpActions } = await tryListMCPTools(
+  const {
+    stableServerToolsAndInstructions,
+    conditionalJITServerToolsAndInstructions,
+  } = await tryListMCPTools(
     auth,
     {
       agentConfiguration,
@@ -222,7 +225,10 @@ async function listAvailableTools(
     }
   );
 
-  return mcpActions.flatMap((s) => s.tools);
+  return [
+    ...stableServerToolsAndInstructions,
+    ...conditionalJITServerToolsAndInstructions,
+  ].flatMap((s) => s.tools);
 }
 
 /**

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -229,10 +229,7 @@ export async function runModel(
       attachments,
     });
     const hasConditionalJITTools = conditionalJitServers.length > 0;
-    const jitServers = [
-      ...stableJitServers,
-      ...conditionalJitServers,
-    ];
+    const jitServers = [...stableJitServers, ...conditionalJitServers];
 
     const clientSideMCPActionConfigurations =
       await createClientSideMCPServerConfigurations(
@@ -396,7 +393,7 @@ export async function runModel(
     errorContext: mcpToolsListingError,
     agentsList,
     conversation,
-    serverToolsAndInstructions: stableServerToolsAndInstructions,
+    stableServerToolsAndInstructions,
     conditionalJitServerToolsAndInstructions,
     enabledSkills,
     equippedSkills,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -216,17 +216,23 @@ export async function runModel(
     equippedSkills,
     hasConditionalJITTools,
     mcpActions,
+    conditionalJitServerNames,
     mcpToolsListingError,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
-    const { servers: jitServers, hasConditionalJITTools } = await getJITServers(
-      auth,
-      {
-        agentConfiguration,
-        conversation,
-        attachments,
-      }
-    );
+    const {
+      stableServers: stableJitServers,
+      conditionalServers: conditionalJitServers,
+    } = await getJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      attachments,
+    });
+    const hasConditionalJITTools = conditionalJitServers.length > 0;
+    const jitServers = [
+      ...stableJitServers,
+      ...conditionalJitServers,
+    ];
 
     const clientSideMCPActionConfigurations =
       await createClientSideMCPServerConfigurations(
@@ -282,11 +288,16 @@ export async function runModel(
       )
     );
 
+    const conditionalJitServerNames = new Set(
+      conditionalJitServers.map((s) => s.name)
+    );
+
     return {
       hasConditionalJITTools,
       enabledSkills,
       equippedSkills,
       mcpActions,
+      conditionalJitServerNames,
       mcpToolsListingError,
     };
   });
@@ -369,6 +380,13 @@ export async function runModel(
     workspaceContext = await buildWorkspaceContext(auth);
   }
 
+  const stableServerToolsAndInstructions = mcpActions.filter(
+    (a) => !conditionalJitServerNames.has(a.serverName)
+  );
+  const conditionalJitServerToolsAndInstructions = mcpActions.filter((a) =>
+    conditionalJitServerNames.has(a.serverName)
+  );
+
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -378,7 +396,8 @@ export async function runModel(
     errorContext: mcpToolsListingError,
     agentsList,
     conversation,
-    serverToolsAndInstructions: mcpActions,
+    serverToolsAndInstructions: stableServerToolsAndInstructions,
+    conditionalJitServerToolsAndInstructions,
     enabledSkills,
     equippedSkills,
     memoriesContext,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -216,20 +216,20 @@ export async function runModel(
     equippedSkills,
     hasConditionalJITTools,
     mcpActions,
-    conditionalJitServerNames,
+    conditionalJITServerNames,
     mcpToolsListingError,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
     const {
-      stableServers: stableJitServers,
-      conditionalServers: conditionalJitServers,
+      stableServers: stableJITServers,
+      conditionalServers: conditionalJITServers,
     } = await getJITServers(auth, {
       agentConfiguration,
       conversation,
       attachments,
     });
-    const hasConditionalJITTools = conditionalJitServers.length > 0;
-    const jitServers = [...stableJitServers, ...conditionalJitServers];
+    const hasConditionalJITTools = conditionalJITServers.length > 0;
+    const jitServers = [...stableJITServers, ...conditionalJITServers];
 
     const clientSideMCPActionConfigurations =
       await createClientSideMCPServerConfigurations(
@@ -285,8 +285,8 @@ export async function runModel(
       )
     );
 
-    const conditionalJitServerNames = new Set(
-      conditionalJitServers.map((s) => s.name)
+    const conditionalJITServerNames = new Set(
+      conditionalJITServers.map((s) => s.name)
     );
 
     return {
@@ -294,7 +294,7 @@ export async function runModel(
       enabledSkills,
       equippedSkills,
       mcpActions,
-      conditionalJitServerNames,
+      conditionalJITServerNames,
       mcpToolsListingError,
     };
   });
@@ -378,10 +378,10 @@ export async function runModel(
   }
 
   const stableServerToolsAndInstructions = mcpActions.filter(
-    (a) => !conditionalJitServerNames.has(a.serverName)
+    (a) => !conditionalJITServerNames.has(a.serverName)
   );
-  const conditionalJitServerToolsAndInstructions = mcpActions.filter((a) =>
-    conditionalJitServerNames.has(a.serverName)
+  const conditionalJITServerToolsAndInstructions = mcpActions.filter((a) =>
+    conditionalJITServerNames.has(a.serverName)
   );
 
   const prompt = constructPromptMultiActions(auth, {
@@ -394,7 +394,7 @@ export async function runModel(
     agentsList,
     conversation,
     stableServerToolsAndInstructions,
-    conditionalJitServerToolsAndInstructions,
+    conditionalJITServerToolsAndInstructions,
     enabledSkills,
     equippedSkills,
     memoriesContext,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -221,15 +221,14 @@ export async function runModel(
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
     const {
-      stableServers: stableJITServers,
-      conditionalServers: conditionalJITServers,
+      stableJITServers,
+      conditionalJITServers,
     } = await getJITServers(auth, {
       agentConfiguration,
       conversation,
       attachments,
     });
     const hasConditionalJITTools = conditionalJITServers.length > 0;
-    const jitServers = [...stableJITServers, ...conditionalJITServers];
 
     const clientSideMCPActionConfigurations =
       await createClientSideMCPServerConfigurations(
@@ -281,7 +280,7 @@ export async function runModel(
           agentMessage,
           clientSideActionConfigurations: clientSideMCPActionConfigurations,
         },
-        { jitServers, skillServers }
+        { stableJITServers, conditionalJITServers, skillServers }
       )
     );
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -220,14 +220,14 @@ export async function runModel(
     mcpToolsListingError,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
-    const {
-      stableJITServers,
-      conditionalJITServers,
-    } = await getJITServers(auth, {
-      agentConfiguration,
-      conversation,
-      attachments,
-    });
+    const { stableJITServers, conditionalJITServers } = await getJITServers(
+      auth,
+      {
+        agentConfiguration,
+        conversation,
+        attachments,
+      }
+    );
     const hasConditionalJITTools = conditionalJITServers.length > 0;
 
     const clientSideMCPActionConfigurations =

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -588,8 +588,7 @@ export async function runModel(
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,
-    hasConditionalJITTools:
-      conditionalJITServerToolsAndInstructions.length > 0,
+    hasConditionalJITTools: conditionalJITServerToolsAndInstructions.length > 0,
     userMessage,
     specifications,
     flushParserTokens,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -214,9 +214,8 @@ export async function runModel(
   const {
     enabledSkills,
     equippedSkills,
-    hasConditionalJITTools,
-    mcpActions,
-    conditionalJITServerNames,
+    stableServerToolsAndInstructions,
+    conditionalJITServerToolsAndInstructions,
     mcpToolsListingError,
   } = await startActiveObservation("resolve-tools", async () => {
     const attachments = await listAttachments(auth, { conversation });
@@ -228,7 +227,6 @@ export async function runModel(
         attachments,
       }
     );
-    const hasConditionalJITTools = conditionalJITServers.length > 0;
 
     const clientSideMCPActionConfigurations =
       await createClientSideMCPServerConfigurations(
@@ -269,7 +267,8 @@ export async function runModel(
     }
 
     const {
-      serverToolsAndInstructions: mcpActions,
+      stableServerToolsAndInstructions,
+      conditionalJITServerToolsAndInstructions,
       error: mcpToolsListingError,
     } = await startActiveObservation("list-mcp-tools", () =>
       tryListMCPTools(
@@ -284,16 +283,11 @@ export async function runModel(
       )
     );
 
-    const conditionalJITServerNames = new Set(
-      conditionalJITServers.map((s) => s.name)
-    );
-
     return {
-      hasConditionalJITTools,
       enabledSkills,
       equippedSkills,
-      mcpActions,
-      conditionalJITServerNames,
+      stableServerToolsAndInstructions,
+      conditionalJITServerToolsAndInstructions,
       mcpToolsListingError,
     };
   });
@@ -311,7 +305,13 @@ export async function runModel(
 
   // If we are on the last step, we don't show any action.
   // This will force the agent to run the generation.
-  const availableActions = isLastStep ? [] : mcpActions.flatMap((s) => s.tools);
+  const allServerToolsAndInstructions = [
+    ...stableServerToolsAndInstructions,
+    ...conditionalJITServerToolsAndInstructions,
+  ];
+  const availableActions = isLastStep
+    ? []
+    : allServerToolsAndInstructions.flatMap((s) => s.tools);
 
   let fallbackPrompt = "You are a conversational agent";
   if (agentConfiguration.actions.length || availableActions.length > 0) {
@@ -375,13 +375,6 @@ export async function runModel(
   if (globalAgentInjectsWorkspaceContext(agentConfiguration.sId)) {
     workspaceContext = await buildWorkspaceContext(auth);
   }
-
-  const stableServerToolsAndInstructions = mcpActions.filter(
-    (a) => !conditionalJITServerNames.has(a.serverName)
-  );
-  const conditionalJITServerToolsAndInstructions = mcpActions.filter((a) =>
-    conditionalJITServerNames.has(a.serverName)
-  );
 
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
@@ -595,7 +588,8 @@ export async function runModel(
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,
-    hasConditionalJITTools,
+    hasConditionalJITTools:
+      conditionalJITServerToolsAndInstructions.length > 0,
     userMessage,
     specifications,
     flushParserTokens,


### PR DESCRIPTION
## Description

- We have observed examples where adding a JIT tool conditionally (e.g. file in the conversation) busts a significant part of the cache due to the list of tools changing.
- This PR reorganizes the way the system prompt blocks are structured to separate the conditional JIT tools (e.g. conversation file) from the tools that are always there (e.g company data semantic search) and move them down.
- Note: `mcp_actions.ts` should be moved in `lib/api` and split in several files. This can be tackled in a follow up PR.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.