### PR TITLE
feat: disable opus for non enterprise

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -15,12 +15,11 @@ export function isModelAvailable(
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null
 ) {
-  if (
-    m.enforceEnterpriseAvailability === true &&
-    plan &&
-    (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
-  ) {
-    return true;
+  if (m.enforceEnterpriseAvailability === true) {
+    return (
+      plan &&
+      (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
+    );
   }
 
   if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {


### PR DESCRIPTION
## Description

This is a quickfix that works while there is no model with both enterprise AND feature flags
the real fix will come with https://github.com/dust-tt/dust/pull/22706

Because currently all non enterprise have access to opus

## Tests

no

## Risk

low

## Deploy Plan

front
