### PR TITLE
fix: give right necessary permissions to use child workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,9 @@ concurrency:
 jobs:
   ensure-sandbox-images:
     if: inputs.component == 'front' || inputs.component == 'front-edge'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/sandbox-img-registry.yml
     secrets: inherit
 


### PR DESCRIPTION
## Description

Deploy front is failing because of parent workflow having the permissions of the child workflow
cf https://github.com/dust-tt/dust/actions/runs/22778148242

## Tests

no

## Risk

low

## Deploy Plan

front
