### PR TITLE
Fix ensure-sandbox-image permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,9 @@ jobs:
     if: inputs.component == 'front' || inputs.component == 'front-edge'
     uses: ./.github/workflows/sandbox-img-registry.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
 
   check-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

* Fixing  permission issue that is prevent pipeline deployments from running: `The workflow is not valid. .github/workflows/deploy.yml (Line: 67, Col: 3): Error calling workflow 'dust-tt/dust/.github/workflows/sandbox-img-registry.yml@42e42aaa9b344883d8813d5cde87a1d7cfcabfb0'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.`