### PR TITLE
Surface read-only access error for google drive tools

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -326,6 +326,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     schema: {
       fileId: z.string().describe("The ID of the file to comment on."),
       content: z.string().describe("The text content of the comment."),
+      canEdit: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -340,6 +346,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       fileId: z.string().describe("The ID of the file containing the comment."),
       commentId: z.string().describe("The ID of the comment to reply to."),
       content: z.string().describe("The plain text content of the reply."),
+      canEdit: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -358,6 +370,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       "Text must be inserted within paragraph bounds, not at structural element boundaries (e.g., insert at startIndex + 1 for table cells).",
     schema: {
       documentId: z.string().describe("The ID of the document to update."),
+      canEdit: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+        ),
       requests: GoogleDocsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the document. Include multiple operations in a single call to minimize requests. " +
           "Each request is an object with optional properties for each request type (only one should be set per request). " +
@@ -378,6 +396,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       "For more complex operations like formatting, merging cells, or updating existing data, use update_spreadsheet instead.",
     schema: {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
+      canEdit: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+        ),
       range: z
         .string()
         .describe(
@@ -418,6 +442,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       spreadsheetId: z
         .string()
         .describe("The ID of the spreadsheet to update."),
+      canEdit: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+        ),
       requests: GoogleSheetsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the spreadsheet. Include multiple operations in a single call to minimize requests. " +
           "Each request is an object with optional properties for each request type (only one should be set per request). " +
@@ -441,6 +471,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       presentationId: z
         .string()
         .describe("The ID of the presentation to update."),
+      canEdit: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+        ),
       requests: GoogleSlidesRequestsArraySchema.describe(
         "An array of batch update requests to apply to the presentation. Include multiple operations in a single call to minimize requests. " +
           "Each request is an object with optional properties for each request type (only one should be set per request). " +

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -330,7 +330,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
         ),
     },
     stake: "low",
@@ -350,7 +350,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
         ),
     },
     stake: "low",
@@ -374,7 +374,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
         ),
       requests: GoogleDocsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the document. Include multiple operations in a single call to minimize requests. " +
@@ -400,7 +400,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
         ),
       range: z
         .string()
@@ -446,7 +446,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
         ),
       requests: GoogleSheetsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the spreadsheet. Include multiple operations in a single call to minimize requests. " +
@@ -475,7 +475,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available. If false, the edit will be rejected."
+          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
         ),
       requests: GoogleSlidesRequestsArraySchema.describe(
         "An array of batch update requests to apply to the presentation. Include multiple operations in a single call to minimize requests. " +

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -178,6 +178,41 @@ function addAgentAttribution(
   return content;
 }
 
+/**
+ * Pre-flight check to verify write access to a file the LLM already knows about.
+ * Called when `canEdit` was not passed by the LLM, to catch view-only files before
+ * triggering the auth loop.
+ *
+ * Uses the drive.readonly scope (present on the token) to read file capabilities —
+ * this works for any file the user can see, regardless of file picker authorization.
+ *
+ * Returns { canEdit, fileName } if capabilities could be determined, or null if the
+ * file is inaccessible or the check fails — in both cases the caller should proceed
+ * and let the existing error flow handle it.
+ */
+async function checkWriteAccess(
+  drive: NonNullable<Awaited<ReturnType<typeof getDriveClient>>>,
+  fileId: string
+): Promise<{ canEdit: boolean; fileName: string } | null> {
+  try {
+    const res = await drive.files.get({
+      fileId,
+      fields: "capabilities(canEdit),name",
+    });
+    const { capabilities, name } = res.data;
+    if (!capabilities) {
+      return null;
+    }
+    return {
+      canEdit: capabilities.canEdit ?? true,
+      fileName: name ?? fileId,
+    };
+  } catch {
+    // File inaccessible or unexpected error — proceed and let the existing error flow handle it.
+    return null;
+  }
+}
+
 const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   list_drives: async ({ pageToken }, { authInfo }) => {
     const drive = await getDriveClient(authInfo);
@@ -656,6 +691,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
+    if (canEdit === undefined) {
+      const accessCheck = await checkWriteAccess(drive, fileId);
+      if (accessCheck !== null && !accessCheck.canEdit) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+          },
+        ]);
+      }
+    }
 
     const finalContent = addAgentAttribution(content, { agentLoopContext });
 
@@ -702,6 +748,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
+    if (canEdit === undefined) {
+      const accessCheck = await checkWriteAccess(drive, fileId);
+      if (accessCheck !== null && !accessCheck.canEdit) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+          },
+        ]);
+      }
+    }
 
     const finalContent = addAgentAttribution(content, { agentLoopContext });
 
@@ -746,6 +803,20 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
         },
       ]);
+    }
+    if (canEdit === undefined) {
+      const drive = await getDriveClient(authInfo);
+      if (drive) {
+        const accessCheck = await checkWriteAccess(drive, documentId);
+        if (accessCheck !== null && !accessCheck.canEdit) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+            },
+          ]);
+        }
+      }
     }
     const docs = await getDocsClient(authInfo);
     if (!docs) {
@@ -808,6 +879,20 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     }
+    if (canEdit === undefined) {
+      const drive = await getDriveClient(authInfo);
+      if (drive) {
+        const accessCheck = await checkWriteAccess(drive, spreadsheetId);
+        if (accessCheck !== null && !accessCheck.canEdit) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+            },
+          ]);
+        }
+      }
+    }
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
@@ -852,6 +937,20 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
         },
       ]);
+    }
+    if (canEdit === undefined) {
+      const drive = await getDriveClient(authInfo);
+      if (drive) {
+        const accessCheck = await checkWriteAccess(drive, spreadsheetId);
+        if (accessCheck !== null && !accessCheck.canEdit) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+            },
+          ]);
+        }
+      }
     }
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
@@ -905,6 +1004,20 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
         },
       ]);
+    }
+    if (canEdit === undefined) {
+      const drive = await getDriveClient(authInfo);
+      if (drive) {
+        const accessCheck = await checkWriteAccess(drive, presentationId);
+        if (accessCheck !== null && !accessCheck.canEdit) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+            },
+          ]);
+        }
+      }
     }
     const slides = await getSlidesClient(authInfo);
     if (!slides) {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -227,7 +227,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         pageToken,
         pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
         fields:
-          "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared)",
+          "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared, capabilities(canEdit))",
         orderBy,
       };
 
@@ -274,7 +274,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       const fileMetadata = await drive.files.get({
         fileId,
         supportsAllDrives: true,
-        fields: "id, name, mimeType, size",
+        fields: "id, name, mimeType, size, capabilities(canEdit)",
       });
       const file = fileMetadata.data;
 
@@ -359,6 +359,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
               fileId,
               fileName: file.name,
               mimeType: file.mimeType,
+              canEdit: file.capabilities?.canEdit ?? null,
               content: truncatedContent,
               returnedContentLength: truncatedContent.length,
               totalContentLength,
@@ -640,9 +641,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   create_comment: async (
-    { fileId, content },
+    { fileId, content, canEdit },
     { authInfo, agentLoopContext }
   ) => {
+    if (canEdit === false) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+        },
+      ]);
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
@@ -678,9 +687,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   create_reply: async (
-    { fileId, commentId, content },
+    { fileId, commentId, content, canEdit },
     { authInfo, agentLoopContext }
   ) => {
+    if (canEdit === false) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+        },
+      ]);
+    }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
@@ -719,9 +736,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   update_document: async (
-    { documentId, requests },
+    { documentId, requests, canEdit },
     { authInfo, agentLoopContext }
   ) => {
+    if (canEdit === false) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+        },
+      ]);
+    }
     const docs = await getDocsClient(authInfo);
     if (!docs) {
       return new Err(new MCPError("Failed to authenticate with Google Docs"));
@@ -771,9 +796,18 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       majorDimension = "ROWS",
       valueInputOption = "USER_ENTERED",
       insertDataOption = "INSERT_ROWS",
+      canEdit,
     },
     { authInfo, agentLoopContext }
   ) => {
+    if (canEdit === false) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+        },
+      ]);
+    }
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
@@ -808,9 +842,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   update_spreadsheet: async (
-    { spreadsheetId, requests },
+    { spreadsheetId, requests, canEdit },
     { authInfo, agentLoopContext }
   ) => {
+    if (canEdit === false) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+        },
+      ]);
+    }
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
@@ -853,9 +895,17 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
   },
 
   update_presentation: async (
-    { presentationId, requests },
+    { presentationId, requests, canEdit },
     { authInfo, agentLoopContext }
   ) => {
+    if (canEdit === false) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+        },
+      ]);
+    }
     const slides = await getSlidesClient(authInfo);
     if (!slides) {
       return new Err(new MCPError("Failed to authenticate with Google Slides"));

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -683,7 +683,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
+          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
         },
       ]);
     }
@@ -697,7 +697,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text" as const,
-            text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
+            text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
           },
         ]);
       }
@@ -740,7 +740,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
+          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
         },
       ]);
     }
@@ -754,7 +754,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text" as const,
-            text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
+            text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
           },
         ]);
       }
@@ -800,7 +800,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
+          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
         },
       ]);
     }
@@ -812,7 +812,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
+              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
             },
           ]);
         }
@@ -875,7 +875,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
+          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
         },
       ]);
     }
@@ -887,7 +887,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
+              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
             },
           ]);
         }
@@ -934,7 +934,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
+          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
         },
       ]);
     }
@@ -946,7 +946,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
+              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
             },
           ]);
         }
@@ -1001,7 +1001,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
+          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
         },
       ]);
     }
@@ -1013,7 +1013,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
+              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
             },
           ]);
         }

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -683,7 +683,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
         },
       ]);
     }
@@ -697,7 +697,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text" as const,
-            text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+            text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
           },
         ]);
       }
@@ -740,7 +740,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
         },
       ]);
     }
@@ -754,7 +754,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text" as const,
-            text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+            text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
           },
         ]);
       }
@@ -800,7 +800,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
         },
       ]);
     }
@@ -812,7 +812,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
             },
           ]);
         }
@@ -875,7 +875,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
         },
       ]);
     }
@@ -887,7 +887,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
             },
           ]);
         }
@@ -934,7 +934,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
         },
       ]);
     }
@@ -946,7 +946,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
             },
           ]);
         }
@@ -1001,7 +1001,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text" as const,
-          text: "You only have view access to this file. To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.",
+          text: "You only have view access to this file. To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.",
         },
       ]);
     }
@@ -1013,7 +1013,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
           return new Ok([
             {
               type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". To edit it, ask the file owner to grant you edit permissions, or use a different file that you have edit access to.`,
+              text: `You only have view access to "${accessCheck.fileName}". To make changes, ask the file owner to grant you edit permissions, or offer to use copy_file to create an editable copy.`,
             },
           ]);
         }

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -213,6 +213,40 @@ async function checkWriteAccess(
   }
 }
 
+/**
+ * Checks whether the caller has write access to a file before attempting a write operation.
+ * Returns an early Ok result with a view-only message when access is denied, or null to proceed.
+ */
+async function ensureWriteAccess(
+  canEdit: boolean | undefined,
+  fileId: string,
+  authInfo: ToolHandlerExtra["authInfo"]
+): Promise<ToolHandlerResult | null> {
+  if (canEdit === false) {
+    return new Ok([
+      {
+        type: "text" as const,
+        text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
+      },
+    ]);
+  }
+  if (canEdit === undefined) {
+    const drive = await getDriveClient(authInfo);
+    if (drive) {
+      const accessCheck = await checkWriteAccess(drive, fileId);
+      if (accessCheck !== null && !accessCheck.canEdit) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
+          },
+        ]);
+      }
+    }
+  }
+  return null;
+}
+
 const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   list_drives: async ({ pageToken }, { authInfo }) => {
     const drive = await getDriveClient(authInfo);
@@ -679,28 +713,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { fileId, content, canEdit },
     { authInfo, agentLoopContext }
   ) => {
-    if (canEdit === false) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
-        },
-      ]);
+    const accessError = await ensureWriteAccess(canEdit, fileId, authInfo);
+    if (accessError) {
+      return accessError;
     }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
-    }
-    if (canEdit === undefined) {
-      const accessCheck = await checkWriteAccess(drive, fileId);
-      if (accessCheck !== null && !accessCheck.canEdit) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
-          },
-        ]);
-      }
     }
 
     const finalContent = addAgentAttribution(content, { agentLoopContext });
@@ -736,28 +755,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { fileId, commentId, content, canEdit },
     { authInfo, agentLoopContext }
   ) => {
-    if (canEdit === false) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
-        },
-      ]);
+    const accessError = await ensureWriteAccess(canEdit, fileId, authInfo);
+    if (accessError) {
+      return accessError;
     }
     const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
-    }
-    if (canEdit === undefined) {
-      const accessCheck = await checkWriteAccess(drive, fileId);
-      if (accessCheck !== null && !accessCheck.canEdit) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
-          },
-        ]);
-      }
     }
 
     const finalContent = addAgentAttribution(content, { agentLoopContext });
@@ -796,27 +800,9 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { documentId, requests, canEdit },
     { authInfo, agentLoopContext }
   ) => {
-    if (canEdit === false) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
-        },
-      ]);
-    }
-    if (canEdit === undefined) {
-      const drive = await getDriveClient(authInfo);
-      if (drive) {
-        const accessCheck = await checkWriteAccess(drive, documentId);
-        if (accessCheck !== null && !accessCheck.canEdit) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
-            },
-          ]);
-        }
-      }
+    const accessError = await ensureWriteAccess(canEdit, documentId, authInfo);
+    if (accessError) {
+      return accessError;
     }
     const docs = await getDocsClient(authInfo);
     if (!docs) {
@@ -871,27 +857,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     },
     { authInfo, agentLoopContext }
   ) => {
-    if (canEdit === false) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
-        },
-      ]);
-    }
-    if (canEdit === undefined) {
-      const drive = await getDriveClient(authInfo);
-      if (drive) {
-        const accessCheck = await checkWriteAccess(drive, spreadsheetId);
-        if (accessCheck !== null && !accessCheck.canEdit) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
-            },
-          ]);
-        }
-      }
+    const accessError = await ensureWriteAccess(
+      canEdit,
+      spreadsheetId,
+      authInfo
+    );
+    if (accessError) {
+      return accessError;
     }
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
@@ -930,27 +902,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { spreadsheetId, requests, canEdit },
     { authInfo, agentLoopContext }
   ) => {
-    if (canEdit === false) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
-        },
-      ]);
-    }
-    if (canEdit === undefined) {
-      const drive = await getDriveClient(authInfo);
-      if (drive) {
-        const accessCheck = await checkWriteAccess(drive, spreadsheetId);
-        if (accessCheck !== null && !accessCheck.canEdit) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
-            },
-          ]);
-        }
-      }
+    const accessError = await ensureWriteAccess(
+      canEdit,
+      spreadsheetId,
+      authInfo
+    );
+    if (accessError) {
+      return accessError;
     }
     const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
@@ -997,27 +955,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     { presentationId, requests, canEdit },
     { authInfo, agentLoopContext }
   ) => {
-    if (canEdit === false) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "You only have view access to this file. The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.",
-        },
-      ]);
-    }
-    if (canEdit === undefined) {
-      const drive = await getDriveClient(authInfo);
-      if (drive) {
-        const accessCheck = await checkWriteAccess(drive, presentationId);
-        if (accessCheck !== null && !accessCheck.canEdit) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `You only have view access to "${accessCheck.fileName}". The user can request edit access from the file owner, or you can ask if they'd like you to call copy_file to create an editable copy.`,
-            },
-          ]);
-        }
-      }
+    const accessError = await ensureWriteAccess(
+      canEdit,
+      presentationId,
+      authInfo
+    );
+    if (accessError) {
+      return accessError;
     }
     const slides = await getSlidesClient(authInfo);
     if (!slides) {


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/6876
## Description
Currently if you ask an agent to edit a google drive file you only have read access to, we don't catch it since the errors google sends match those for auth errors. This results in a looping auth request flow and unclear user instructions. Fixing that by checking the `canEdit` field on file metadata for gdrive files and checking this before making any api calls. If field is null at the time the request is made, making an api call to retrieve it before attempting to write so the user won't see the file picker for this. Also surfacing relevant info and work-arounds to the user, like the ability to clone an edit a file

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="949" height="394" alt="Screenshot 2026-03-06 at 4 37 30 PM" src="https://github.com/user-attachments/assets/d83d2511-cc83-4138-84a7-c54832bf2ee8" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
