### PR TITLE
[front] Improve extended skill SB view

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -176,7 +176,7 @@ export default function SkillBuilder({
                     size="lg"
                   >
                     A customized version of {extendedSkill.name} with your own
-                    instructions and preferences
+                    instructions and preferences.
                   </ContentMessage>
                 )}
                 {skill?.status === "suggested" && (

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -15,12 +15,12 @@ import {
   transformSkillTypeToFormData,
 } from "@app/components/skill_builder/skillFormData";
 import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkillBuilderForm";
-import { ExtendedSkillBadge } from "@app/components/skills/ExtendedSkillBadge";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
+import { getSkillIcon } from "@app/lib/skill";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -161,14 +161,6 @@ export default function SkillBuilder({
               variant="default"
               className="mx-4"
               title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
-              description={
-                extendedSkill ? (
-                  <ExtendedSkillBadge
-                    extendedSkill={extendedSkill}
-                    className="text-sm"
-                  />
-                ) : undefined
-              }
               rightActions={
                 <BarHeader.ButtonBar variant="close" onClose={handleCancel} />
               }
@@ -176,6 +168,17 @@ export default function SkillBuilder({
 
             <ScrollArea className="flex-1">
               <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
+                {extendedSkill && (
+                  <ContentMessage
+                    title={`Built on ${extendedSkill.name}`}
+                    variant="highlight"
+                    icon={getSkillIcon(extendedSkill.icon)}
+                    size="lg"
+                  >
+                    A customized version of {extendedSkill.name} with your own
+                    instructions and preferences
+                  </ContentMessage>
+                )}
                 {skill?.status === "suggested" && (
                   <ContentMessage
                     title="This is a generated skill suggestion"
@@ -192,7 +195,7 @@ export default function SkillBuilder({
                 <SkillBuilderAgentFacingDescriptionSection />
                 <SkillBuilderInstructionsSection skill={skill} />
                 {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
-                <SkillBuilderToolsSection />
+                <SkillBuilderToolsSection extendedSkill={extendedSkill} />
                 <SkillBuilderSettingsSection />
               </div>
             </ScrollArea>

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -79,7 +79,7 @@ export function SkillBuilderToolsSection({
               color="highlight"
               size="xs"
               icon={getSkillIcon(extendedSkill.icon)}
-              label={`Already includes ${extendedSkill.name}`}
+              label={`Already includes tools from ${extendedSkill.name}`}
             />
           )}
         </div>

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -6,9 +6,12 @@ import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MC
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getSkillIcon } from "@app/lib/skill";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
   Button,
   CardGrid,
+  Chip,
   EmptyCTA,
   Spinner,
   ToolsIcon,
@@ -17,7 +20,13 @@ import {
 import React, { useCallback, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
-export function SkillBuilderToolsSection() {
+interface SkillBuilderToolsSectionProps {
+  extendedSkill?: SkillType;
+}
+
+export function SkillBuilderToolsSection({
+  extendedSkill,
+}: SkillBuilderToolsSectionProps) {
   const { getValues } = useFormContext<SkillBuilderFormData>();
   const { fields, remove, append } = useFieldArray<
     SkillBuilderFormData,
@@ -61,9 +70,19 @@ export function SkillBuilderToolsSection() {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          Tools
-        </h3>
+        <div className="flex items-center gap-2">
+          <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+            Tools
+          </h3>
+          {extendedSkill && (
+            <Chip
+              color="highlight"
+              size="xs"
+              icon={getSkillIcon(extendedSkill.icon)}
+              label={`Already includes ${extendedSkill.name}`}
+            />
+          )}
+        </div>
         {headerActions}
       </div>
 


### PR DESCRIPTION
## Description

- Implements the design discussed in Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=3557-34285&t=LndAkHsklvDecDIF-0).
- Goal is to improve the visual feedback on extending a skill in Skill Builder.
- Adds a content message at the top that makes it more obvious that a skill is being extended, and adds a chip that specifies that the tools of the extended skill are already included.

<img width="919" height="922" alt="Screenshot 2026-03-08 at 10 34 58 PM" src="https://github.com/user-attachments/assets/a504e3cc-5d97-407e-b26d-40370bc1bde2" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
