### PR TITLE
[front] feat: add tools to update and list job postings in Ashby

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -49,7 +49,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_interview_feedback": "never_ask",
     "get_referral_form": "never_ask",
     "get_report_data": "never_ask",
+    "list_job_postings": "never_ask",
     "search_candidates": "never_ask",
+    "update_job_posting": "high",
   },
   "common_utilities": {
     "generate_random_float": "never_ask",

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -9,6 +9,7 @@ import type {
   AshbyCandidateSearchRequest,
   AshbyFeedbackSubmission,
   AshbyJob,
+  AshbyJobPostingListRequest,
   AshbyJobPostingUpdateRequest,
   AshbyReferralCreateRequest,
   AshbyReportSynchronousRequest,
@@ -21,6 +22,7 @@ import {
   AshbyCandidateListNotesResponseSchema,
   AshbyCandidateSearchResponseSchema,
   AshbyJobListResponseSchema,
+  AshbyJobPostingListResponseSchema,
   AshbyJobPostingUpdateResponseSchema,
   AshbyReferralCreateResponseSchema,
   AshbyReferralFormInfoResponseSchema,
@@ -192,6 +194,14 @@ export class AshbyClient {
       "referral.create",
       request,
       AshbyReferralCreateResponseSchema
+    );
+  }
+
+  async listJobPostings(request: AshbyJobPostingListRequest) {
+    return this.postRequest(
+      "jobPosting.list",
+      request,
+      AshbyJobPostingListResponseSchema
     );
   }
 

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -9,6 +9,7 @@ import type {
   AshbyCandidateSearchRequest,
   AshbyFeedbackSubmission,
   AshbyJob,
+  AshbyJobPostingUpdateRequest,
   AshbyReferralCreateRequest,
   AshbyReportSynchronousRequest,
   AshbyUserSearchRequest,
@@ -20,6 +21,7 @@ import {
   AshbyCandidateListNotesResponseSchema,
   AshbyCandidateSearchResponseSchema,
   AshbyJobListResponseSchema,
+  AshbyJobPostingUpdateResponseSchema,
   AshbyReferralCreateResponseSchema,
   AshbyReferralFormInfoResponseSchema,
   AshbyReportSynchronousResponseSchema,
@@ -190,6 +192,14 @@ export class AshbyClient {
       "referral.create",
       request,
       AshbyReferralCreateResponseSchema
+    );
+  }
+
+  async updateJobPosting(request: AshbyJobPostingUpdateRequest) {
+    return this.postRequest(
+      "jobPosting.update",
+      request,
+      AshbyJobPostingUpdateResponseSchema
     );
   }
 

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -152,13 +152,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       "descriptionBody part is modifiable. To fully customize the description, " +
       "set both suppressDescriptionOpening and suppressDescriptionClosing to true.",
     schema: {
-      jobPostingId: z
-        .string()
-        .describe("The ID of the job posting to update."),
-      title: z
-        .string()
-        .optional()
-        .describe("A new title for the job posting."),
+      jobPostingId: z.string().describe("The ID of the job posting to update."),
+      title: z.string().optional().describe("A new title for the job posting."),
       descriptionHtml: z
         .string()
         .optional()

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -115,8 +115,9 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
   update_job_posting: {
     description:
       "Update an existing job posting in Ashby. " +
-      "You can update the title and/or the description of the job posting. " +
-      "The description must be in HTML format. " +
+      "You can update the title, description, and/or workplace type. " +
+      "The description must be in HTML format " +
+      "(supported tags: h1-h6, b, i, u, a, ul, ol, li, code, pre). " +
       "When description openings and closings are not suppressed, only the " +
       "descriptionBody part is modifiable. To fully customize the description, " +
       "set both suppressDescriptionOpening and suppressDescriptionClosing to true.",
@@ -127,7 +128,7 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       title: z
         .string()
         .optional()
-        .describe("New title for the job posting."),
+        .describe("A new title for the job posting."),
       descriptionHtml: z
         .string()
         .optional()
@@ -136,17 +137,26 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
             "Only the descriptionBody part is modifiable unless " +
             "both suppressDescriptionOpening and suppressDescriptionClosing are true."
         ),
+      workplaceType: z
+        .enum(["OnSite", "Hybrid", "Remote"])
+        .optional()
+        .describe(
+          "The type of workplace for the job posting: " +
+            "OnSite, Hybrid, or Remote."
+        ),
       suppressDescriptionOpening: z
         .boolean()
         .optional()
         .describe(
-          "Set to true to suppress the system-generated description opening."
+          "When true, the job description opening from the brand " +
+            "will be suppressed."
         ),
       suppressDescriptionClosing: z
         .boolean()
         .optional()
         .describe(
-          "Set to true to suppress the system-generated description closing."
+          "When true, the job description closing from the brand " +
+            "will be suppressed."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -112,6 +112,49 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       done: "Create referral on Ashby",
     },
   },
+  update_job_posting: {
+    description:
+      "Update an existing job posting in Ashby. " +
+      "You can update the title and/or the description of the job posting. " +
+      "The description must be in HTML format. " +
+      "When description openings and closings are not suppressed, only the " +
+      "descriptionBody part is modifiable. To fully customize the description, " +
+      "set both suppressDescriptionOpening and suppressDescriptionClosing to true.",
+    schema: {
+      jobPostingId: z
+        .string()
+        .describe("The ID of the job posting to update."),
+      title: z
+        .string()
+        .optional()
+        .describe("New title for the job posting."),
+      descriptionHtml: z
+        .string()
+        .optional()
+        .describe(
+          "Updated HTML description for the job posting. " +
+            "Only the descriptionBody part is modifiable unless " +
+            "both suppressDescriptionOpening and suppressDescriptionClosing are true."
+        ),
+      suppressDescriptionOpening: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set to true to suppress the system-generated description opening."
+        ),
+      suppressDescriptionClosing: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set to true to suppress the system-generated description closing."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Updating job posting on Ashby",
+      done: "Update job posting on Ashby",
+    },
+  },
 });
 
 export const ASHBY_SERVER = {

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -112,6 +112,36 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       done: "Create referral on Ashby",
     },
   },
+  list_job_postings: {
+    description:
+      "List all published job postings in Ashby. " +
+      "Returns job postings with their title, department, team, location, " +
+      "employment type, workplace type, and other details. " +
+      "By default includes both listed and unlisted postings. " +
+      "Set listedOnly to true to only return publicly listed postings.",
+    schema: {
+      location: z
+        .string()
+        .optional()
+        .describe("Filter by location name (case sensitive)."),
+      department: z
+        .string()
+        .optional()
+        .describe("Filter by department name (case sensitive)."),
+      listedOnly: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, only return publicly listed job postings. " +
+            "Defaults to false."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing job postings from Ashby",
+      done: "List job postings from Ashby",
+    },
+  },
   update_job_posting: {
     description:
       "Update an existing job posting in Ashby. " +

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -5,6 +5,7 @@ import type {
   AshbyCandidateNote,
   AshbyFeedbackSubmission,
   AshbyJob,
+  AshbyJobPosting,
   AshbyReferralFormInfo,
   AshbyReportSynchronousResponse,
 } from "@app/lib/api/actions/servers/ashby/types";
@@ -207,6 +208,24 @@ export function renderCandidateNotes(
   const noteTexts = notes.map((note) => renderSingleNote(note));
 
   return header.join("\n") + noteTexts.join(`\n\n${delimiterLine}\n\n`);
+}
+
+export function renderJobPostingList(postings: AshbyJobPosting[]): string {
+  return postings
+    .map(
+      (p) =>
+        `- **${p.title}** (ID: ${p.id})\n` +
+        `  Department: ${p.departmentName} | Team: ${p.teamName}\n` +
+        `  Location: ${p.locationName}` +
+        (p.workplaceType ? ` (${p.workplaceType})` : "") +
+        `\n` +
+        `  Employment: ${p.employmentType} | Listed: ${p.isListed}\n` +
+        `  Published: ${p.publishedDate}` +
+        (p.compensationTierSummary
+          ? `\n  Compensation: ${p.compensationTierSummary}`
+          : "")
+    )
+    .join("\n\n");
 }
 
 export function renderReferralForm(

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -397,6 +397,76 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     ]);
   },
 
+  update_job_posting: async (
+    {
+      jobPostingId,
+      title,
+      descriptionHtml,
+      suppressDescriptionOpening,
+      suppressDescriptionClosing,
+    },
+    extra
+  ) => {
+    if (!title && !descriptionHtml) {
+      return new Err(
+        new MCPError(
+          "At least one of title or descriptionHtml must be provided.",
+          { tracked: false }
+        )
+      );
+    }
+
+    const clientResult = getAshbyClient(extra);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+
+    const client = clientResult.value;
+
+    const updateResult = await client.updateJobPosting({
+      jobPostingId,
+      title,
+      descriptionHtml,
+      suppressDescriptionOpening,
+      suppressDescriptionClosing,
+    });
+
+    if (updateResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to update job posting: ${updateResult.error.message}`
+        )
+      );
+    }
+
+    if (!updateResult.value.success || !updateResult.value.results) {
+      const errorMessage =
+        updateResult.value.errorInfo?.message ??
+        updateResult.value.errors?.join(", ") ??
+        "Unknown error";
+      return new Err(
+        new MCPError(`Failed to update job posting: ${errorMessage}`)
+      );
+    }
+
+    const updatedFields = [
+      title ? "title" : null,
+      descriptionHtml ? "description" : null,
+    ]
+      .filter(Boolean)
+      .join(" and ");
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Successfully updated job posting ${updatedFields}.\n\n` +
+          `Job Posting ID: ${updateResult.value.results.id}\n` +
+          `Title: ${updateResult.value.results.title}`,
+      },
+    ]);
+  },
+
   [CREATE_REFERRAL_TOOL_NAME]: async ({ fieldSubmissions }, extra) => {
     const clientResult = await getAshbyClient(extra);
     if (clientResult.isErr()) {

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -414,16 +414,12 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     if (result.isErr()) {
       return new Err(
-        new MCPError(
-          `Failed to list job postings: ${result.error.message}`
-        )
+        new MCPError(`Failed to list job postings: ${result.error.message}`)
       );
     }
 
     if (!result.value.success) {
-      return new Err(
-        new MCPError("Failed to list job postings from Ashby.")
-      );
+      return new Err(new MCPError("Failed to list job postings from Ashby."));
     }
 
     const postings = result.value.results;

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -397,6 +397,69 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     ]);
   },
 
+  list_job_postings: async ({ location, department, listedOnly }, extra) => {
+    const clientResult = getAshbyClient(extra);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+
+    const client = clientResult.value;
+
+    const result = await client.listJobPostings({
+      location,
+      department,
+      listedOnly,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to list job postings: ${result.error.message}`
+        )
+      );
+    }
+
+    if (!result.value.success) {
+      return new Err(
+        new MCPError("Failed to list job postings from Ashby.")
+      );
+    }
+
+    const postings = result.value.results;
+
+    if (postings.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "No job postings found matching the criteria.",
+        },
+      ]);
+    }
+
+    const postingsText = postings
+      .map(
+        (p) =>
+          `- **${p.title}** (ID: ${p.id})\n` +
+          `  Department: ${p.departmentName} | Team: ${p.teamName}\n` +
+          `  Location: ${p.locationName}` +
+          (p.workplaceType ? ` (${p.workplaceType})` : "") +
+          `\n` +
+          `  Employment: ${p.employmentType} | Listed: ${p.isListed}\n` +
+          `  Published: ${p.publishedDate}` +
+          (p.compensationTierSummary
+            ? `\n  Compensation: ${p.compensationTierSummary}`
+            : "")
+      )
+      .join("\n\n");
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Found ${postings.length} job posting(s):\n\n${postingsText}`,
+      },
+    ]);
+  },
+
   update_job_posting: async (
     {
       jobPostingId,

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -402,15 +402,17 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       jobPostingId,
       title,
       descriptionHtml,
+      workplaceType,
       suppressDescriptionOpening,
       suppressDescriptionClosing,
     },
     extra
   ) => {
-    if (!title && !descriptionHtml) {
+    if (!title && !descriptionHtml && !workplaceType) {
       return new Err(
         new MCPError(
-          "At least one of title or descriptionHtml must be provided.",
+          "At least one of title, descriptionHtml, or workplaceType " +
+            "must be provided.",
           { tracked: false }
         )
       );
@@ -426,7 +428,10 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const updateResult = await client.updateJobPosting({
       jobPostingId,
       title,
-      descriptionHtml,
+      description: descriptionHtml
+        ? { type: "text/html", content: sanitizeHtml(descriptionHtml) }
+        : undefined,
+      workplaceType,
       suppressDescriptionOpening,
       suppressDescriptionClosing,
     });
@@ -452,9 +457,10 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const updatedFields = [
       title ? "title" : null,
       descriptionHtml ? "description" : null,
+      workplaceType ? "workplace type" : null,
     ]
       .filter(Boolean)
-      .join(" and ");
+      .join(", ");
 
     return new Ok([
       {

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -19,6 +19,7 @@ import {
   renderCandidateList,
   renderCandidateNotes,
   renderInterviewFeedbackRecap,
+  renderJobPostingList,
   renderReferralForm,
   renderReport,
 } from "@app/lib/api/actions/servers/ashby/rendering";
@@ -436,21 +437,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       ]);
     }
 
-    const postingsText = postings
-      .map(
-        (p) =>
-          `- **${p.title}** (ID: ${p.id})\n` +
-          `  Department: ${p.departmentName} | Team: ${p.teamName}\n` +
-          `  Location: ${p.locationName}` +
-          (p.workplaceType ? ` (${p.workplaceType})` : "") +
-          `\n` +
-          `  Employment: ${p.employmentType} | Listed: ${p.isListed}\n` +
-          `  Published: ${p.publishedDate}` +
-          (p.compensationTierSummary
-            ? `\n  Compensation: ${p.compensationTierSummary}`
-            : "")
-      )
-      .join("\n\n");
+    const postingsText = renderJobPostingList(postings);
 
     return new Ok([
       {

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -444,3 +444,40 @@ export const AshbyReferralCreateResponseSchema = z.object({
 export type AshbyReferralCreateResponse = z.infer<
   typeof AshbyReferralCreateResponseSchema
 >;
+
+// Job posting update
+
+export const AshbyJobPostingUpdateRequestSchema = z.object({
+  jobPostingId: z.string(),
+  title: z.string().optional(),
+  descriptionHtml: z.string().optional(),
+  suppressDescriptionOpening: z.boolean().optional(),
+  suppressDescriptionClosing: z.boolean().optional(),
+});
+
+export type AshbyJobPostingUpdateRequest = z.infer<
+  typeof AshbyJobPostingUpdateRequestSchema
+>;
+
+export const AshbyJobPostingUpdateResponseSchema = z.object({
+  success: z.boolean(),
+  results: z
+    .object({
+      id: z.string(),
+      title: z.string(),
+    })
+    .passthrough()
+    .optional(),
+  errors: z.array(z.string()).optional(),
+  errorInfo: z
+    .object({
+      code: z.string().optional(),
+      message: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+export type AshbyJobPostingUpdateResponse = z.infer<
+  typeof AshbyJobPostingUpdateResponseSchema
+>;

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -447,10 +447,26 @@ export type AshbyReferralCreateResponse = z.infer<
 
 // Job posting update
 
+export const AshbyJobPostingWorkplaceTypeSchema = z.enum([
+  "OnSite",
+  "Hybrid",
+  "Remote",
+]);
+
+export type AshbyJobPostingWorkplaceType = z.infer<
+  typeof AshbyJobPostingWorkplaceTypeSchema
+>;
+
 export const AshbyJobPostingUpdateRequestSchema = z.object({
   jobPostingId: z.string(),
   title: z.string().optional(),
-  descriptionHtml: z.string().optional(),
+  description: z
+    .object({
+      type: z.literal("text/html"),
+      content: z.string(),
+    })
+    .optional(),
+  workplaceType: AshbyJobPostingWorkplaceTypeSchema.optional(),
   suppressDescriptionOpening: z.boolean().optional(),
   suppressDescriptionClosing: z.boolean().optional(),
 });

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -445,6 +445,69 @@ export type AshbyReferralCreateResponse = z.infer<
   typeof AshbyReferralCreateResponseSchema
 >;
 
+// Job posting list
+
+export const AshbyJobPostingEmploymentTypeSchema = z.enum([
+  "FullTime",
+  "PartTime",
+  "Intern",
+  "Contract",
+  "Temporary",
+]);
+
+export type AshbyJobPostingEmploymentType = z.infer<
+  typeof AshbyJobPostingEmploymentTypeSchema
+>;
+
+export const AshbyJobPostingSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    jobId: z.string(),
+    departmentName: z.string(),
+    teamName: z.string(),
+    locationName: z.string(),
+    locationIds: z
+      .object({
+        primaryLocationId: z.string(),
+        secondaryLocationIds: z.array(z.string()),
+      })
+      .optional(),
+    workplaceType: z.string().optional(),
+    employmentType: z.string(),
+    isListed: z.boolean(),
+    publishedDate: z.string(),
+    applicationDeadline: z.string().optional().nullable(),
+    externalLink: z.string().optional().nullable(),
+    applyLink: z.string(),
+    compensationTierSummary: z.string().optional().nullable(),
+    shouldDisplayCompensationOnJobBoard: z.boolean(),
+    updatedAt: z.string(),
+  })
+  .passthrough();
+
+export type AshbyJobPosting = z.infer<typeof AshbyJobPostingSchema>;
+
+export const AshbyJobPostingListRequestSchema = z.object({
+  location: z.string().optional(),
+  department: z.string().optional(),
+  listedOnly: z.boolean().optional(),
+  jobBoardId: z.string().optional(),
+});
+
+export type AshbyJobPostingListRequest = z.infer<
+  typeof AshbyJobPostingListRequestSchema
+>;
+
+export const AshbyJobPostingListResponseSchema = z.object({
+  success: z.boolean(),
+  results: z.array(AshbyJobPostingSchema),
+});
+
+export type AshbyJobPostingListResponse = z.infer<
+  typeof AshbyJobPostingListResponseSchema
+>;
+
 // Job posting update
 
 export const AshbyJobPostingWorkplaceTypeSchema = z.enum([


### PR DESCRIPTION
## Description

- This PR adds two tools to the Ashby MCP server, one that lists existing job postings and one that updates an existing job posting.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
