### PR TITLE
Fix duplicated sections

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,9 +71,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/sandbox-img-registry.yml
     secrets: inherit
-    permissions:
-      contents: read
-      id-token: write
 
   check-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Remove deplucated sections introduced by https://github.com/dust-tt/dust/pull/22710 and https://github.com/dust-tt/dust/pull/22711 both making the same change, breaking the CI with:

```
[Invalid workflow file: .github/workflows/deploy.yml#L1](https://github.com/dust-tt/dust/actions/runs/22797171791/workflow)
(Line: 74, Col: 5): 'permissions' is already defined
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
