### PR TITLE
[connectors] add CLI command to delete Gong call transcripts

### DIFF
--- a/connectors/src/connectors/gong/lib/cli.ts
+++ b/connectors/src/connectors/gong/lib/cli.ts
@@ -1,21 +1,28 @@
 import { makeGongForceResyncWorkflowId } from "@connectors/connectors/gong";
+import { makeGongTranscriptInternalId } from "@connectors/connectors/gong/lib/internal_ids";
 import {
   fetchGongConfiguration,
   fetchGongConnector,
 } from "@connectors/connectors/gong/lib/utils";
 import { QUEUE_NAME } from "@connectors/connectors/gong/temporal/config";
 import { gongSyncTranscriptsWorkflow } from "@connectors/connectors/gong/temporal/workflows";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
+import { GongTranscriptResource } from "@connectors/resources/gong_resources";
 import type {
   GongCommandType,
+  GongDeleteTranscriptResponseType,
   GongForceResyncResponseType,
 } from "@connectors/types";
 
 export const gong = async ({
   command,
   args,
-}: GongCommandType): Promise<GongForceResyncResponseType> => {
+}: GongCommandType): Promise<
+  GongForceResyncResponseType | GongDeleteTranscriptResponseType
+> => {
   const logger = topLogger.child({ majorCommand: "gong", command, args });
   switch (command) {
     case "force-resync": {
@@ -65,6 +72,52 @@ export const gong = async ({
           ? `https://cloud.temporal.io/namespaces/${temporalNamespace}/workflows/${workflowId}`
           : undefined,
       };
+    }
+
+    case "delete-transcript": {
+      const { connectorId, callId } = args;
+      if (!connectorId) {
+        throw new Error("Missing --connectorId argument");
+      }
+      if (!callId) {
+        throw new Error("Missing --callId argument");
+      }
+
+      const connector = await fetchGongConnector({ connectorId });
+      if (connector.type !== "gong") {
+        throw new Error("Connector is not a Gong connector.");
+      }
+
+      const transcript = await GongTranscriptResource.fetchByCallId(
+        callId,
+        connector
+      );
+      if (!transcript) {
+        throw new Error(
+          `Transcript with callId ${callId} not found for connector ${connectorId}.`
+        );
+      }
+
+      const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+      await deleteDataSourceDocument(
+        dataSourceConfig,
+        makeGongTranscriptInternalId(connector, callId),
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          dataSourceId: dataSourceConfig.dataSourceId,
+          provider: "gong",
+          callId,
+        }
+      );
+
+      await GongTranscriptResource.batchDelete(connector, [transcript]);
+
+      logger.info(
+        { connectorId, callId },
+        "[Admin] Transcript deleted successfully."
+      );
+      return { callId };
     }
 
     default:

--- a/connectors/src/connectors/gong/lib/cli.ts
+++ b/connectors/src/connectors/gong/lib/cli.ts
@@ -111,7 +111,7 @@ export const gong = async ({
         }
       );
 
-      await GongTranscriptResource.batchDelete(connector, [transcript]);
+      await transcript.delete();
 
       logger.info(
         { connectorId, callId },

--- a/connectors/src/connectors/gong/lib/cli.ts
+++ b/connectors/src/connectors/gong/lib/cli.ts
@@ -75,13 +75,15 @@ export const gong = async ({
     }
 
     case "delete-transcript": {
-      const { connectorId, callId } = args;
+      const { connectorId, callId: callIdArg } = args;
       if (!connectorId) {
         throw new Error("Missing --connectorId argument");
       }
-      if (!callId) {
+      if (!callIdArg) {
         throw new Error("Missing --callId argument");
       }
+
+      const callId = callIdArg.toString();
 
       const connector = await fetchGongConnector({ connectorId });
       if (connector.type !== "gong") {

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -367,6 +367,7 @@ export class GongTranscriptResource extends BaseResource<GongTranscriptModel> {
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await this.model.destroy({
       where: {
+        id: this.id,
         connectorId: this.connectorId,
       },
       transaction,

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -200,10 +200,10 @@ export type GithubCommandType = t.TypeOf<typeof GithubCommandSchema>;
 export const GongCommandSchema = t.type({
   majorCommand: t.literal("gong"),
   command: t.union([t.literal("force-resync"), t.literal("delete-transcript")]),
-  args: t.type({
-    connectorId: t.union([t.number, t.undefined]),
-    fromTs: t.union([t.number, t.undefined]),
-    callId: t.union([t.string, t.undefined]),
+  args: t.partial({
+    connectorId: t.number,
+    fromTs: t.number,
+    callId: t.number,
   }),
 });
 export type GongCommandType = t.TypeOf<typeof GongCommandSchema>;

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -197,24 +197,15 @@ export type GithubCommandType = t.TypeOf<typeof GithubCommandSchema>;
 /**
  * <Gong>
  */
-export const GongCommandSchema = t.union([
-  t.type({
-    majorCommand: t.literal("gong"),
-    command: t.literal("force-resync"),
-    args: t.type({
-      connectorId: t.union([t.number, t.undefined]),
-      fromTs: t.union([t.number, t.undefined]),
-    }),
+export const GongCommandSchema = t.type({
+  majorCommand: t.literal("gong"),
+  command: t.union([t.literal("force-resync"), t.literal("delete-transcript")]),
+  args: t.type({
+    connectorId: t.union([t.number, t.undefined]),
+    fromTs: t.union([t.number, t.undefined]),
+    callId: t.union([t.string, t.undefined]),
   }),
-  t.type({
-    majorCommand: t.literal("gong"),
-    command: t.literal("delete-transcript"),
-    args: t.type({
-      connectorId: t.union([t.number, t.undefined]),
-      callId: t.union([t.string, t.undefined]),
-    }),
-  }),
-]);
+});
 export type GongCommandType = t.TypeOf<typeof GongCommandSchema>;
 
 export const GongForceResyncResponseSchema = t.type({

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -197,14 +197,24 @@ export type GithubCommandType = t.TypeOf<typeof GithubCommandSchema>;
 /**
  * <Gong>
  */
-export const GongCommandSchema = t.type({
-  majorCommand: t.literal("gong"),
-  command: t.literal("force-resync"),
-  args: t.type({
-    connectorId: t.union([t.number, t.undefined]),
-    fromTs: t.union([t.number, t.undefined]),
+export const GongCommandSchema = t.union([
+  t.type({
+    majorCommand: t.literal("gong"),
+    command: t.literal("force-resync"),
+    args: t.type({
+      connectorId: t.union([t.number, t.undefined]),
+      fromTs: t.union([t.number, t.undefined]),
+    }),
   }),
-});
+  t.type({
+    majorCommand: t.literal("gong"),
+    command: t.literal("delete-transcript"),
+    args: t.type({
+      connectorId: t.union([t.number, t.undefined]),
+      callId: t.union([t.string, t.undefined]),
+    }),
+  }),
+]);
 export type GongCommandType = t.TypeOf<typeof GongCommandSchema>;
 
 export const GongForceResyncResponseSchema = t.type({
@@ -213,6 +223,13 @@ export const GongForceResyncResponseSchema = t.type({
 });
 export type GongForceResyncResponseType = t.TypeOf<
   typeof GongForceResyncResponseSchema
+>;
+
+export const GongDeleteTranscriptResponseSchema = t.type({
+  callId: t.string,
+});
+export type GongDeleteTranscriptResponseType = t.TypeOf<
+  typeof GongDeleteTranscriptResponseSchema
 >;
 /**
  * </Gong>
@@ -890,6 +907,7 @@ export const AdminResponseSchema = t.union([
   ConfluenceResolveSpaceFromUrlResponseSchema,
   ConfluenceSkipPageResponseSchema,
   ConfluenceUpsertPageResponseSchema,
+  GongDeleteTranscriptResponseSchema,
   GongForceResyncResponseSchema,
   IntercomCheckConversationResponseSchema,
   IntercomCheckMissingConversationsResponseSchema,

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -200,10 +200,10 @@ export type GithubCommandType = t.TypeOf<typeof GithubCommandSchema>;
 export const GongCommandSchema = t.type({
   majorCommand: t.literal("gong"),
   command: t.union([t.literal("force-resync"), t.literal("delete-transcript")]),
-  args: t.type({
-    connectorId: t.union([t.number, t.undefined]),
-    fromTs: t.union([t.number, t.undefined]),
-    callId: t.union([t.string, t.undefined]),
+  args: t.partial({
+    connectorId: t.number,
+    fromTs: t.number,
+    callId: t.number,
   }),
 });
 export type GongCommandType = t.TypeOf<typeof GongCommandSchema>;

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -199,10 +199,11 @@ export type GithubCommandType = t.TypeOf<typeof GithubCommandSchema>;
  */
 export const GongCommandSchema = t.type({
   majorCommand: t.literal("gong"),
-  command: t.literal("force-resync"),
+  command: t.union([t.literal("force-resync"), t.literal("delete-transcript")]),
   args: t.type({
     connectorId: t.union([t.number, t.undefined]),
     fromTs: t.union([t.number, t.undefined]),
+    callId: t.union([t.string, t.undefined]),
   }),
 });
 export type GongCommandType = t.TypeOf<typeof GongCommandSchema>;


### PR DESCRIPTION
## Description

- This PR adds a CLI command for Gong to delete a call transcript.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
