### PR TITLE
[Front] feat(byok): add ProviderCredential model and migration

### DIFF
--- a/front/lib/models/provider_credential.ts
+++ b/front/lib/models/provider_credential.ts
@@ -1,0 +1,65 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class ProviderCredentialModel extends WorkspaceAwareModel<ProviderCredentialModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare providerId: ModelProviderIdType;
+  declare credentialId: string;
+  declare isHealthy: boolean;
+  declare placeholder: string;
+
+  declare editedByUserId: ForeignKey<UserModel["id"]> | null;
+  declare editedByUser: NonAttribute<UserModel>;
+}
+
+ProviderCredentialModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    providerId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    credentialId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    placeholder: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    isHealthy: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: frontSequelize,
+    modelName: "provider_credential",
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "providerId"],
+      },
+    ],
+  }
+);
+
+ProviderCredentialModel.belongsTo(UserModel, {
+  as: "editedByUser",
+  foreignKey: { name: "editedByUserId", allowNull: true },
+});

--- a/front/migrations/db/migration_535.sql
+++ b/front/migrations/db/migration_535.sql
@@ -1,0 +1,14 @@
+-- Migration created on Mar 09, 2026
+CREATE TABLE IF NOT EXISTS "provider_credentials" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "providerId" VARCHAR(255) NOT NULL,
+    "credentialId" VARCHAR(255) NOT NULL,
+    "placeholder" VARCHAR(255) NOT NULL,
+    "isHealthy" BOOLEAN NOT NULL,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "editedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "provider_credentials_workspace_id_provider_id" ON "provider_credentials" ("workspaceId", "providerId");


### PR DESCRIPTION
## Description

Add `ProviderCredential` model to store workspace-level BYOK provider credentials. Each workspace can have one credential per provider (unique index on `workspaceId, providerId`). The credential references the oauth credential table via `credentialId` and tracks health status and a display placeholder.

No separate `workspaceId` index needed — the unique composite index already covers `workspaceId`-only queries via [leftmost prefix](https://www.postgresql.org/docs/current/indexes-unique.html#:~:text=PostgreSQL%20automatically%20creates%20a%20unique,mechanism%20that%20enforces%20the%20constraint.).

Part of https://github.com/dust-tt/tasks/issues/6962

## Deploy Plan

1. Merge this PR on main
2. Execute migration on both regions
3. Deploy front