### PR TITLE
Add assertNeverAndIgnore for backward-compatible API data handling

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -58,11 +58,25 @@ When branching on a discriminated union or string union, prefer an exhaustive `s
 ternaries. This keeps the code readable and ensures TypeScript enforces exhaustiveness when cases
 are added.
 
+Two variants are available:
+
+- **`assertNever`**: Throws at runtime. Use when missing a case is a bug (server-side code,
+  internal client logic, client-created data).
+- **`assertNeverAndIgnore`**: Does NOT throw at runtime. Use in client-side code that processes
+  API data (event streams, API responses, connector types, etc.) where the server may add new
+  enum values before the client is updated. The unknown value is silently ignored instead of
+  crashing the app.
+
+Both provide the same compile-time exhaustiveness checking. Using the wrong variant is a bug:
+using `assertNever` on API data can crash the app when the server adds a new value, and using
+`assertNeverAndIgnore` on internal logic can silently swallow programming errors.
+
 Example:
 
 ```
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNever, assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 
+// Internal logic: use assertNever (crash on missing case)
 type Status = "approved" | "rejected" | "expired";
 
 function titleForStatus(status: Status): string {
@@ -75,6 +89,19 @@ function titleForStatus(status: Status): string {
       return "Expired";
     default:
       return assertNever(status);
+  }
+}
+
+// Processing API data: use assertNeverAndIgnore (gracefully ignore unknown values)
+function handleStreamEvent(event: AgentMessageEvent): State {
+  switch (event.type) {
+    case "generation_tokens":
+      return { ...state, content: state.content + event.text };
+    case "agent_error":
+      return { ...state, status: "error" };
+    default:
+      assertNeverAndIgnore(event);
+      return state;
   }
 }
 ```

--- a/front/components/agent_builder/shared/tables.ts
+++ b/front/components/agent_builder/shared/tables.ts
@@ -8,7 +8,7 @@ import type {
 import type { LightContentNode } from "@app/types/api/public/spaces";
 import type { DataSourceType } from "@app/types/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -48,7 +48,10 @@ export function getTableIdForContentNode(
       );
 
     default:
-      assertNever(dataSource.connectorProvider);
+      assertNeverAndIgnore(dataSource.connectorProvider);
+      throw new Error(
+        `Provider ${dataSource.connectorProvider} is not supported`
+      );
   }
 }
 

--- a/front/components/agent_builder/sidekick/SidekickSuggestionsContext.tsx
+++ b/front/components/agent_builder/sidekick/SidekickSuggestionsContext.tsx
@@ -19,7 +19,7 @@ import {
   usePatchAgentSuggestions,
 } from "@app/lib/swr/agent_suggestions";
 import type { DataSourceViewType } from "@app/types/data_source_view";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   AgentInstructionsSuggestionType,
   AgentSuggestionType,
@@ -261,7 +261,8 @@ function CopilotSuggestionsProviderContent({
           return { ...suggestion, relations: null };
 
         default:
-          assertNever(suggestion);
+          assertNeverAndIgnore(suggestion);
+          return null;
       }
     },
     [

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -3,7 +3,7 @@ import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -172,7 +172,8 @@ function getLimitPromptForCode(
     }
 
     default:
-      assertNever(code);
+      assertNeverAndIgnore(code);
+      return undefined;
   }
 }
 
@@ -194,7 +195,7 @@ export function ReachedLimitPopup({
   const [isFairUsageModalOpened, setIsFairUsageModalOpened] = useState(false);
 
   const router = useAppRouter();
-  const { title, children, validateLabel, onValidate } = getLimitPromptForCode(
+  const limitPrompt = getLimitPromptForCode(
     router,
     owner,
     code,
@@ -202,6 +203,12 @@ export function ReachedLimitPopup({
     () => setIsFairUsageModalOpened(true),
     isAdmin
   );
+
+  if (!limitPrompt) {
+    return null;
+  }
+
+  const { title, children, validateLabel, onValidate } = limitPrompt;
 
   return (
     <>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -66,7 +66,7 @@ import {
   isSupportedImageContentType,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   LightWorkspaceType,
   UserType,
@@ -295,7 +295,7 @@ export function AgentMessage({
             // Do nothing
             break;
           default:
-            assertNever(eventPayload.data);
+            assertNeverAndIgnore(eventPayload.data);
         }
       },
       [

--- a/front/components/assistant/conversation/ButlerSuggestionCard.tsx
+++ b/front/components/assistant/conversation/ButlerSuggestionCard.tsx
@@ -4,7 +4,7 @@ import type {
   CreateFrameButlerSuggestion,
   RenameTitleButlerSuggestion,
 } from "@app/types/conversation_butler_suggestion";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ActionFrameIcon,
   Button,
@@ -58,7 +58,7 @@ export function ButlerSuggestionCard({
         />
       );
     default:
-      assertNever(suggestion);
+      assertNeverAndIgnore(suggestion);
   }
 }
 

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
@@ -23,7 +23,7 @@ import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -306,6 +306,7 @@ function renderOtherAction(
       order: 3,
     };
   } else {
-    return assertNever(action);
+    assertNeverAndIgnore(action);
+    return null;
   }
 }

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -48,7 +48,7 @@ import type {
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { APIError } from "@app/types/error";
 import { isOAuthProvider } from "@app/types/oauth/lib";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import type { NotificationType } from "@dust-tt/sparkle";
 import {
@@ -1145,7 +1145,7 @@ export function ConnectorPermissionsModal({
           case "dust_project":
             return null;
           default:
-            assertNever(c.type);
+            assertNeverAndIgnore(c.type);
         }
       })}
 

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -3,7 +3,7 @@ import { DATASOURCE_QUOTA_PER_SEAT } from "@app/lib/plans/usage/types";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConnectorType } from "@app/types/data_source";
 import { fileSizeToHumanReadable } from "@app/types/files";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { Chip, Tooltip } from "@dust-tt/sparkle";
 
 interface ConnectorSyncingChipProps {
@@ -112,7 +112,7 @@ export default function ConnectorSyncingChip({
           />
         );
       default:
-        assertNever(connector.errorType);
+        assertNeverAndIgnore(connector.errorType);
     }
   } else if (connector.pausedAt) {
     return (

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -44,7 +44,7 @@ import type {
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import { defaultSelectionConfiguration } from "@app/types/data_source_view";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -691,7 +691,7 @@ function LimitedSearchContentMessage({
       };
 
     default:
-      assertNever(warningCode);
+      assertNeverAndIgnore(warningCode);
   }
 }
 

--- a/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
@@ -15,7 +15,7 @@ import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   AgentInstructionsSuggestionType,
   AgentKnowledgeSuggestionWithRelationsType,
@@ -54,7 +54,8 @@ function mapSuggestionStateToCardState(
     case "outdated":
       return "disabled";
     default:
-      assertNever(state);
+      assertNeverAndIgnore(state);
+      return "disabled";
   }
 }
 
@@ -580,7 +581,8 @@ export function CopilotSuggestionCard({
     case "knowledge":
       return <KnowledgeSuggestionCard agentSuggestion={agentSuggestion} />;
     default:
-      assertNever(agentSuggestion);
+      assertNeverAndIgnore(agentSuggestion);
+      return null;
   }
 }
 

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -10,7 +10,7 @@ import type { UserMessageType } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isFileContentFragment } from "@app/types/content_fragment";
 import type { PokeAgentMessageType } from "@app/types/poke";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -622,7 +622,7 @@ export function ConversationPage() {
                         );
                       }
                       default:
-                        assertNever(m);
+                        assertNeverAndIgnore(m);
                     }
                   })}
                 </div>

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -36,7 +36,7 @@ import { isOAuthProvider } from "@app/types/oauth/lib";
 import type { PlanType } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import {
@@ -489,7 +489,7 @@ export const AddConnectionMenu = ({
             case undefined:
               return null;
             default:
-              assertNever(c);
+              assertNeverAndIgnore(c);
           }
         })}
 

--- a/front/components/spaces/FilePreviewSheet.tsx
+++ b/front/components/spaces/FilePreviewSheet.tsx
@@ -17,7 +17,7 @@ import {
   isMarkdownContentType,
   isPdfContentType,
 } from "@app/types/files";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ArrowDownOnSquareIcon,
@@ -269,7 +269,7 @@ function FileContentRenderer({
       }
       return null;
     default:
-      assertNever(previewConfig.category);
+      assertNeverAndIgnore(previewConfig.category);
   }
 }
 

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -44,7 +44,7 @@ import type {
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -230,7 +230,8 @@ const getSpaceSectionDetails = (
       return { label: "Administration", displayCreateSpaceButton: false };
 
     default:
-      assertNever(kind);
+      assertNeverAndIgnore(kind);
+      return { label: kind, displayCreateSpaceButton: false };
   }
 };
 

--- a/front/components/workspace/DirectorySync.tsx
+++ b/front/components/workspace/DirectorySync.tsx
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/swr/workos";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import type { PlanType } from "@app/types/plan";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -179,7 +179,7 @@ function DirectorySyncStatus({
       );
 
     default:
-      assertNever(dsyncStatus.status);
+      assertNeverAndIgnore(dsyncStatus.status);
   }
 }
 

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -14,7 +14,7 @@ import {
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { LightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
@@ -359,7 +359,7 @@ export function useAgentMessageStream({
           break;
 
         default:
-          assertNever(eventType);
+          assertNeverAndIgnore(eventType);
       }
 
       if (customOnEventCallback) {

--- a/front/hooks/useAgentMessageStreamLegacy.ts
+++ b/front/hooks/useAgentMessageStreamLegacy.ts
@@ -17,7 +17,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useMemo, useReducer, useRef } from "react";
 
@@ -251,7 +251,7 @@ function messageReducer(
           newState.agentState = "thinking";
           break;
         default:
-          assertNever(event);
+          assertNeverAndIgnore(event);
       }
       return newState;
     }
@@ -272,7 +272,8 @@ function messageReducer(
       };
 
     default:
-      assertNever(event);
+      assertNeverAndIgnore(event);
+      return state;
   }
 }
 
@@ -351,7 +352,7 @@ export function useAgentMessageStreamLegacy({
       case "created":
         return true;
       default:
-        assertNever(messageStreamState.message.status);
+        assertNeverAndIgnore(messageStreamState.message.status);
     }
   }, [message.status, messageStreamState.message.status]);
 

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -1,6 +1,6 @@
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useReducer } from "react";
 
@@ -77,7 +77,8 @@ function childAgentStreamReducer(
       return state;
 
     default:
-      assertNever(event);
+      assertNeverAndIgnore(event);
+      return state;
   }
 }
 

--- a/front/types/shared/utils/assert_never.ts
+++ b/front/types/shared/utils/assert_never.ts
@@ -1,7 +1,24 @@
+/**
+ * Compile-time exhaustiveness checking that throws at runtime.
+ * Use this when missing a case is a bug (internal logic, client-created data).
+ * For client-side code processing API data where unknown values should be
+ * safely ignored, use assertNeverAndIgnore instead.
+ */
 export function assertNever(x: never): never {
   throw new Error(
     `${
       typeof x === "object" ? JSON.stringify(x) : x
     } is not of type never. This should never happen.`
   );
+}
+
+/**
+ * Like assertNever, provides compile-time exhaustiveness checking on switch statements,
+ * but does NOT crash at runtime. Use this in client-side code that processes API data
+ * (event streams, API responses) where new enum values or event types may be added
+ * server-side before the client is updated.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function assertNeverAndIgnore(_x: never): void {
+  // Intentionally empty.
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2896,12 +2896,29 @@ export function isAgentMention(arg: MentionType): arg is AgentMentionType {
   return (arg as AgentMentionType).configurationId !== undefined;
 }
 
+/**
+ * Compile-time exhaustiveness checking that throws at runtime.
+ * Use this when missing a case is a bug (internal logic, client-created data).
+ * For client-side code processing API data where unknown values should be
+ * safely ignored, use assertNeverAndIgnore instead.
+ */
 export function assertNever(x: never): never {
   throw new Error(
     `${
       typeof x === "object" ? JSON.stringify(x) : x
     } is not of type never. This should never happen.`
   );
+}
+
+/**
+ * Like assertNever, provides compile-time exhaustiveness checking on switch statements,
+ * but does NOT crash at runtime. Use this in client-side code that processes API data
+ * (event streams, API responses) where new enum values or event types may be added
+ * server-side before the client is updated.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function assertNeverAndIgnore(_x: never): void {
+  // Intentionally empty.
 }
 
 export function removeNulls<T>(arr: (T | null | undefined)[]): T[] {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/6957


## Description

Introduces `assertNeverAndIgnore` alongside the existing `assertNever` to support backward compatibility with API changes.

**Problem:** Client-side code uses `assertNever` in switch statements on types coming from the API (event streams, connector types, suggestion types, etc.). When the server adds a new enum value, older clients crash because `assertNever` throws on the unhandled case.

**Solution:** `assertNeverAndIgnore` provides the same **compile-time exhaustiveness checking** as `assertNever`, but does **not throw at runtime** — it silently ignores unknown values. This was how it was handled in extension custom code, since now we share the same code everywhere we need to handled that properly in front code.

### What changed

- Added `assertNeverAndIgnore` to `front/types/shared/utils/assert_never.ts` and `sdks/js/src/types.ts`
- Added JSDoc comments to both functions explaining when to use each
- Updated coding rules to explain which variant should be used
- Replaced `assertNever` → `assertNeverAndIgnore` in ~20 client-side files that process API data:
  - **Event streaming hooks** (`useAgentMessageStream`, `useAgentMessageStreamLegacy`, `useChildAgentStream`)
  - **Components processing API responses** (connector types, suggestion types, message types, space kinds, error types, limit codes, sync statuses, etc.)
- Kept `assertNever` in:
  - All **server-side code** (`front/lib/`, `front/pages/api/`, `front/temporal/`, `connectors/`)
  - Client code switching on **internal state** (UI state, reducer actions, RPC messages, client-created items)

### Rule of thumb
- `assertNever`: missing a case is a bug (internal logic, client-created data)
- `assertNeverAndIgnore`: the API might send new values the client doesn't know about yet

## Tests

Type-checked with `npx tsgo --noEmit` (front) and `npx tsc --noEmit` (CLI). No errors.

## Risk

Low. `assertNeverAndIgnore` only affects runtime behavior for values that are currently impossible (typed as `never`). If the API adds a new value, the client will now gracefully ignore it instead of crashing.

## Deploy Plan

No special deploy order needed. Safe to deploy at any time.