### PR TITLE
Fix check_membership_active_users_consistency to not consider revoked users

### DIFF
--- a/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
+++ b/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
@@ -51,11 +51,15 @@ export const checkMembershipActiveUsersConsistency: CheckFunction = async (
           COUNT(DISTINCT um."userId")::int as "activeUsersByMessagesCount"
         FROM messages msg
         JOIN user_messages um ON msg."userMessageId" = um.id
+        JOIN memberships m ON m."userId" = um."userId"
+          AND m."workspaceId" = msg."workspaceId"
+          AND m."firstUsedAt" IS NOT NULL
+          AND m."endAt" IS NULL
         GROUP BY msg."workspaceId"
       )
       SELECT
-        w.id as "workspaceId",
-        w."sId" as "workspaceSId",
+        w.id as "workspaceModelId",
+        w."sId" as "workspaceId",
         w."name" as "workspaceName",
         p."code" as "planCode",
         s."stripeSubscriptionId",


### PR DESCRIPTION
## Description

The check currently reports more than 150 workspaces but the ones I have checked just have revoked users 

## Tests

no

## Risk
low

## Deploy Plan

deploy front