### PR TITLE
[front] enh(Ashby): add job info call before update

### DIFF
--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -9,6 +9,7 @@ import type {
   AshbyCandidateSearchRequest,
   AshbyFeedbackSubmission,
   AshbyJob,
+  AshbyJobPostingInfoRequest,
   AshbyJobPostingListRequest,
   AshbyJobPostingUpdateRequest,
   AshbyReferralCreateRequest,
@@ -22,6 +23,7 @@ import {
   AshbyCandidateListNotesResponseSchema,
   AshbyCandidateSearchResponseSchema,
   AshbyJobListResponseSchema,
+  AshbyJobPostingInfoResponseSchema,
   AshbyJobPostingListResponseSchema,
   AshbyJobPostingUpdateResponseSchema,
   AshbyReferralCreateResponseSchema,
@@ -194,6 +196,14 @@ export class AshbyClient {
       "referral.create",
       request,
       AshbyReferralCreateResponseSchema
+    );
+  }
+
+  async getJobPostingInfo(request: AshbyJobPostingInfoRequest) {
+    return this.postRequest(
+      "jobPosting.info",
+      request,
+      AshbyJobPostingInfoResponseSchema
     );
   }
 

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -471,6 +471,24 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     const client = clientResult.value;
 
+    // Fetch current job posting info before updating.
+    const infoResult = await client.getJobPostingInfo({ jobPostingId });
+    if (infoResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to fetch job posting info: ${infoResult.error.message}`
+        )
+      );
+    }
+
+    if (!infoResult.value.success || !infoResult.value.results) {
+      return new Err(
+        new MCPError("Failed to fetch job posting info from Ashby.")
+      );
+    }
+
+    const previousPosting = infoResult.value.results;
+
     const updateResult = await client.updateJobPosting({
       jobPostingId,
       title,
@@ -508,13 +526,21 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       .filter(Boolean)
       .join(", ");
 
+    const lines = [
+      `Successfully updated job posting ${updatedFields}.`,
+      "",
+      `Job Posting ID: ${updateResult.value.results.id}`,
+      `Title: ${updateResult.value.results.title}`,
+    ];
+
+    if (previousPosting.descriptionHtml) {
+      lines.push("", "Previous description:", previousPosting.descriptionHtml);
+    }
+
     return new Ok([
       {
         type: "text" as const,
-        text:
-          `Successfully updated job posting ${updatedFields}.\n\n` +
-          `Job Posting ID: ${updateResult.value.results.id}\n` +
-          `Title: ${updateResult.value.results.title}`,
+        text: lines.join("\n"),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -508,6 +508,48 @@ export type AshbyJobPostingListResponse = z.infer<
   typeof AshbyJobPostingListResponseSchema
 >;
 
+// Job posting info
+
+const AshbyDescriptionPartSchema = z.object({
+  html: z.string(),
+  plain: z.string(),
+});
+
+export const AshbyJobPostingInfoRequestSchema = z.object({
+  jobPostingId: z.string(),
+});
+
+export type AshbyJobPostingInfoRequest = z.infer<
+  typeof AshbyJobPostingInfoRequestSchema
+>;
+
+export const AshbyJobPostingInfoSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    descriptionPlain: z.string().optional(),
+    descriptionHtml: z.string().optional(),
+    descriptionParts: z
+      .object({
+        descriptionOpening: AshbyDescriptionPartSchema.optional().nullable(),
+        descriptionBody: AshbyDescriptionPartSchema.optional().nullable(),
+        descriptionClosing: AshbyDescriptionPartSchema.optional().nullable(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export type AshbyJobPostingInfo = z.infer<typeof AshbyJobPostingInfoSchema>;
+
+export const AshbyJobPostingInfoResponseSchema = z.object({
+  success: z.boolean(),
+  results: AshbyJobPostingInfoSchema.optional(),
+});
+
+export type AshbyJobPostingInfoResponse = z.infer<
+  typeof AshbyJobPostingInfoResponseSchema
+>;
+
 // Job posting update
 
 export const AshbyJobPostingWorkplaceTypeSchema = z.enum([


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/22714
- This PR improves the tool to update a job posting in Ashby by exposing what the old description was to the model.
- This allows rolling back the changes if needed.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
