### PR TITLE
[sparkle] move props to context in markdown

### DIFF
--- a/front/components/markdown/InstructionBlock.tsx
+++ b/front/components/markdown/InstructionBlock.tsx
@@ -3,10 +3,10 @@ import { ChevronDownIcon, Chip, cn } from "@dust-tt/sparkle";
 import type React from "react";
 import { visit } from "unist-util-visit";
 
-type InstructionBlockProps = {
+interface InstructionBlockProps {
   tagName: string;
   children: React.ReactNode;
-};
+}
 
 /**
  * Renders an instruction block with styled tag chips in readonly markdown display.

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -16,10 +16,10 @@ export type CustomRenderers = {
   ) => React.JSX.Element;
 };
 
-type VisualizationBlockProps = {
+interface VisualizationBlockProps {
   position: PositionType;
   customRenderer?: CustomRenderers;
-};
+}
 export function VisualizationBlock({
   position,
   customRenderer,

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -1,4 +1,5 @@
 import { ContentBlockWrapper } from "@sparkle/components/markdown/ContentBlockWrapper";
+import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { cva } from "class-variance-authority";
 import React from "react";
 
@@ -26,17 +27,16 @@ export const blockquoteVariants = cva(
   }
 );
 
-interface BlockquoteBlockProps {
-  children: React.ReactNode;
-  variant?: "surface";
-  buttonDisplay?: "inside" | "outside" | null; // null to hide buttons
-}
-
 export function BlockquoteBlock({
   children,
   variant = "surface",
-  buttonDisplay = "inside",
-}: BlockquoteBlockProps) {
+}: {
+  children: React.ReactNode;
+  variant?: "surface";
+}) {
+  const { canCopyQuotes } = useMarkdownStyle();
+  const buttonDisplay = canCopyQuotes ? "inside" : null;
+
   const elementAt1 = React.Children.toArray(children)[1];
   const childrenContent =
     elementAt1 && React.isValidElement(elementAt1)

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -27,13 +27,15 @@ export const blockquoteVariants = cva(
   }
 );
 
+interface BlockquoteBlockProps {
+  children: React.ReactNode;
+  variant?: "surface";
+}
+
 export function BlockquoteBlock({
   children,
   variant = "surface",
-}: {
-  children: React.ReactNode;
-  variant?: "surface";
-}) {
+}: BlockquoteBlockProps) {
   const { canCopyQuotes } = useMarkdownStyle();
   const buttonDisplay = canCopyQuotes ? "inside" : null;
 

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -45,14 +45,14 @@ export const codeBlockVariants = cva(
   }
 );
 
-type CodeBlockProps = {
+interface CodeBlockProps {
   children?: React.ReactNode;
   className?: string;
   inline?: boolean;
   variant?: "surface";
   wrapLongLines?: boolean;
   showLineNumber?: boolean;
-};
+}
 
 export function CodeBlock({
   children,

--- a/sparkle/src/components/markdown/HeadingBlock.tsx
+++ b/sparkle/src/components/markdown/HeadingBlock.tsx
@@ -1,0 +1,107 @@
+import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
+import { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
+import { cn } from "@sparkle/lib/utils";
+import React from "react";
+
+const headingSpacing: Record<number, string> = {
+  1: "s-pb-2 s-pt-4",
+  2: "s-pb-2 s-pt-4",
+  3: "s-pb-2 s-pt-4",
+  4: "s-pb-2 s-pt-3",
+  5: "s-pb-1.5 s-pt-2.5",
+  6: "s-pb-1.5 s-pt-2.5",
+};
+
+interface HeadingBlockProps {
+  children?: React.ReactNode;
+}
+
+export function H1Block({ children }: HeadingBlockProps) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  return (
+    <h1
+      className={cn(
+        headingSpacing[1],
+        forcedTextSize ?? markdownHeaderClasses.h1,
+        textColor
+      )}
+    >
+      {children}
+    </h1>
+  );
+}
+
+export function H2Block({ children }: HeadingBlockProps) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  return (
+    <h2
+      className={cn(
+        headingSpacing[2],
+        forcedTextSize ?? markdownHeaderClasses.h2,
+        textColor
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function H3Block({ children }: HeadingBlockProps) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  return (
+    <h3
+      className={cn(
+        headingSpacing[3],
+        forcedTextSize ?? markdownHeaderClasses.h3,
+        textColor
+      )}
+    >
+      {children}
+    </h3>
+  );
+}
+
+export function H4Block({ children }: HeadingBlockProps) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  return (
+    <h4
+      className={cn(
+        headingSpacing[4],
+        forcedTextSize ?? markdownHeaderClasses.h4,
+        textColor
+      )}
+    >
+      {children}
+    </h4>
+  );
+}
+
+export function H5Block({ children }: HeadingBlockProps) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  return (
+    <h5
+      className={cn(
+        headingSpacing[5],
+        forcedTextSize ?? markdownHeaderClasses.h5,
+        textColor
+      )}
+    >
+      {children}
+    </h5>
+  );
+}
+
+export function H6Block({ children }: HeadingBlockProps) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  return (
+    <h6
+      className={cn(
+        headingSpacing[6],
+        forcedTextSize ?? markdownHeaderClasses.h6,
+        textColor
+      )}
+    >
+      {children}
+    </h6>
+  );
+}

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -25,10 +25,7 @@ interface OlBlockProps {
   start?: number;
 }
 
-export function OlBlock({
-  children,
-  start,
-}: OlBlockProps) {
+export function OlBlock({ children, start }: OlBlockProps) {
   const { textColor, forcedTextSize } = useMarkdownStyle();
   const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
@@ -45,10 +42,7 @@ interface LiBlockProps {
   className?: string;
 }
 
-export function LiBlock({
-  children,
-  className,
-}: LiBlockProps) {
+export function LiBlock({ children, className }: LiBlockProps) {
   const { textColor, forcedTextSize } = useMarkdownStyle();
   const textSize = forcedTextSize ?? markdownParagraphSize;
   return (

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -1,16 +1,14 @@
+import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
+import { markdownParagraphSize } from "@sparkle/components/markdown/markdownSizes";
 import { cn } from "@sparkle/lib";
 import { cva } from "class-variance-authority";
 import React from "react";
 
 export const ulBlockVariants = cva(["s-list-disc s-pb-2 s-pl-6"]);
 
-interface UlBlockProps {
-  children: React.ReactNode;
-  textColor: string;
-  textSize: string;
-}
-
-export function UlBlock({ children, textColor, textSize }: UlBlockProps) {
+export function UlBlock({ children }: { children: React.ReactNode }) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
     <ul className={cn(ulBlockVariants(), textColor, textSize)}>{children}</ul>
   );
@@ -18,19 +16,15 @@ export function UlBlock({ children, textColor, textSize }: UlBlockProps) {
 
 export const olBlockVariants = cva(["s-list-decimal s-pb-2 s-pl-6"]);
 
-interface OlBlockProps {
-  children: React.ReactNode;
-  start?: number;
-  textColor: string;
-  textSize: string;
-}
-
 export function OlBlock({
   children,
   start,
-  textColor,
-  textSize,
-}: OlBlockProps) {
+}: {
+  children: React.ReactNode;
+  start?: number;
+}) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
     <ol start={start} className={cn(olBlockVariants(), textColor, textSize)}>
       {children}
@@ -40,19 +34,15 @@ export function OlBlock({
 
 export const liBlockVariants = cva(["s-break-words"]);
 
-interface LiBlockProps {
-  children: React.ReactNode;
-  className?: string;
-  textColor: string;
-  textSize: string;
-}
-
 export function LiBlock({
   children,
   className,
-  textColor,
-  textSize,
-}: LiBlockProps) {
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { textColor, forcedTextSize } = useMarkdownStyle();
+  const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
     <li className={cn(liBlockVariants(), textColor, textSize, className)}>
       {children}

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -6,7 +6,11 @@ import React from "react";
 
 export const ulBlockVariants = cva(["s-list-disc s-pb-2 s-pl-6"]);
 
-export function UlBlock({ children }: { children: React.ReactNode }) {
+interface UlBlockProps {
+  children: React.ReactNode;
+}
+
+export function UlBlock({ children }: UlBlockProps) {
   const { textColor, forcedTextSize } = useMarkdownStyle();
   const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
@@ -16,13 +20,15 @@ export function UlBlock({ children }: { children: React.ReactNode }) {
 
 export const olBlockVariants = cva(["s-list-decimal s-pb-2 s-pl-6"]);
 
+interface OlBlockProps {
+  children: React.ReactNode;
+  start?: number;
+}
+
 export function OlBlock({
   children,
   start,
-}: {
-  children: React.ReactNode;
-  start?: number;
-}) {
+}: OlBlockProps) {
   const { textColor, forcedTextSize } = useMarkdownStyle();
   const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
@@ -34,13 +40,15 @@ export function OlBlock({
 
 export const liBlockVariants = cva(["s-break-words"]);
 
+interface LiBlockProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
 export function LiBlock({
   children,
   className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+}: LiBlockProps) {
   const { textColor, forcedTextSize } = useMarkdownStyle();
   const textSize = forcedTextSize ?? markdownParagraphSize;
   return (

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -55,7 +55,7 @@ function showUnsupportedDirective() {
 export function Markdown({
   content,
   isStreaming = false,
-  textColor,
+  textColor = "s-text-foreground dark:s-text-foreground-night",
   forcedTextSize,
   isLastMessage = false,
   compactSpacing = false,

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -161,9 +161,10 @@ export function Markdown({
     [additionalMarkdownPlugins]
   );
 
-  const rehypePlugins = [
-    [safeRehypeKatex, { output: "mathml" }],
-  ] as PluggableList;
+  const rehypePlugins = useMemo(
+    () => [[safeRehypeKatex, { output: "mathml" }]] as PluggableList,
+    []
+  );
 
   try {
     return (

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -55,7 +55,7 @@ function showUnsupportedDirective() {
 export function Markdown({
   content,
   isStreaming = false,
-  textColor = "s-text-foreground dark:s-text-foreground-night",
+  textColor,
   forcedTextSize,
   isLastMessage = false,
   compactSpacing = false,

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -2,8 +2,17 @@ import { Checkbox } from "@sparkle/components/Checkbox";
 import { Chip } from "@sparkle/components/Chip";
 import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
 import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
+import {
+  H1Block,
+  H2Block,
+  H3Block,
+  H4Block,
+  H5Block,
+  H6Block,
+} from "@sparkle/components/markdown/HeadingBlock";
 import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
+import { MarkdownStyleContext } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { ParagraphBlock } from "@sparkle/components/markdown/ParagraphBlock";
 import { PreBlock } from "@sparkle/components/markdown/PreBlock";
 import { safeRehypeKatex } from "@sparkle/components/markdown/safeRehypeKatex";
@@ -29,19 +38,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 
-export const markdownHeaderClasses = {
-  h1: "s-heading-2xl",
-  h2: "s-heading-xl",
-  h3: "s-heading-lg",
-  h4: "s-text-base s-font-semibold",
-  h5: "s-text-sm s-font-semibold",
-  h6: "s-text-sm s-font-regular s-italic",
-};
-
-const sizes = {
-  p: "s-text-base s-leading-7",
-  ...markdownHeaderClasses,
-};
+export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
 
 function showUnsupportedDirective() {
   return (tree: any) => {
@@ -84,6 +81,16 @@ export function Markdown({
     return sanitized;
   }, [content, compactSpacing]);
 
+  const styleContextValue = useMemo(
+    () => ({
+      textColor,
+      forcedTextSize,
+      compactSpacing,
+      canCopyQuotes,
+    }),
+    [textColor, forcedTextSize, compactSpacing, canCopyQuotes]
+  );
+
   // Note on re-renderings. A lot of effort has been put into preventing rerendering across markdown
   // AST parsing rounds (happening at each token being streamed).
   //
@@ -98,141 +105,43 @@ export function Markdown({
   // Minimal test whenever editing this code: ensure that code block content of a streaming message
   // can be selected without blinking.
 
-  // Memoized separately from additionalMarkdownComponents so that base component references
-  // (p, pre, ul, etc.) stay stable across re-renders. ReactMarkdown compares component types
-  // by reference — a new function would remount the entire subtree, destroying stateful children.
+  // Style props flow through MarkdownStyleContext so base component references stay stable
+  // across re-renders. ReactMarkdown compares component types by reference — a new function
+  // would remount the entire subtree, destroying stateful children.
   const baseMarkdownComponents: Components = useMemo(() => {
     return {
       pre: ({ children }) => <PreBlock>{children}</PreBlock>,
       a: LinkBlock,
-      ul: ({ children }) => (
-        <UlBlock
-          textSize={forcedTextSize ? forcedTextSize : sizes.p}
-          textColor={textColor}
-        >
-          {children}
-        </UlBlock>
-      ),
-      ol: ({ children, start }) => (
-        <OlBlock
-          start={start}
-          textColor={textColor}
-          textSize={forcedTextSize ? forcedTextSize : sizes.p}
-        >
-          {children}
-        </OlBlock>
-      ),
-      li: ({ children }) => (
-        <LiBlock
-          textColor={textColor}
-          textSize={forcedTextSize ? forcedTextSize : sizes.p}
-        >
-          {children}
-        </LiBlock>
-      ),
-      p: ({ children }) => (
-        <ParagraphBlock
-          textColor={textColor}
-          textSize={forcedTextSize ? forcedTextSize : sizes.p}
-          compactSpacing={compactSpacing}
-        >
-          {children}
-        </ParagraphBlock>
-      ),
+      ul: UlBlock,
+      ol: OlBlock,
+      li: LiBlock,
+      p: ParagraphBlock,
+      h1: H1Block,
+      h2: H2Block,
+      h3: H3Block,
+      h4: H4Block,
+      h5: H5Block,
+      h6: H6Block,
       table: TableBlock,
       thead: TableHeadBlock,
       tbody: TableBodyBlock,
       th: TableHeaderBlock,
       td: TableDataBlock,
-      h1: ({ children }) => (
-        <h1
-          className={cn(
-            "s-pb-2 s-pt-4",
-            forcedTextSize ? forcedTextSize : sizes.h1,
-            textColor
-          )}
-        >
-          {children}
-        </h1>
-      ),
-      h2: ({ children }) => (
-        <h2
-          className={cn(
-            "s-pb-2 s-pt-4",
-            forcedTextSize ? forcedTextSize : sizes.h2,
-            textColor
-          )}
-        >
-          {children}
-        </h2>
-      ),
-      h3: ({ children }) => (
-        <h3
-          className={cn(
-            "s-pb-2 s-pt-4",
-            forcedTextSize ? forcedTextSize : sizes.h3,
-            textColor
-          )}
-        >
-          {children}
-        </h3>
-      ),
-      h4: ({ children }) => (
-        <h4
-          className={cn(
-            "s-pb-2 s-pt-3",
-            forcedTextSize ? forcedTextSize : sizes.h4,
-            textColor
-          )}
-        >
-          {children}
-        </h4>
-      ),
-      h5: ({ children }) => (
-        <h5
-          className={cn(
-            "s-pb-1.5 s-pt-2.5",
-            forcedTextSize ? forcedTextSize : sizes.h5,
-            textColor
-          )}
-        >
-          {children}
-        </h5>
-      ),
-      h6: ({ children }) => (
-        <h6
-          className={cn(
-            "s-pb-1.5 s-pt-2.5",
-            forcedTextSize ? forcedTextSize : sizes.h6,
-            textColor
-          )}
-        >
-          {children}
-        </h6>
-      ),
       strong: ({ children }) => (
         <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
           {children}
         </strong>
       ),
       input: Input,
-      blockquote: ({ children }) => (
-        <BlockquoteBlock buttonDisplay={canCopyQuotes ? "inside" : null}>
-          {children}
-        </BlockquoteBlock>
-      ),
+      blockquote: BlockquoteBlock,
       hr: () => (
         <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
       ),
       code: CodeBlockWithExtendedSupport,
     };
-  }, [textColor, compactSpacing, forcedTextSize, canCopyQuotes]);
+  }, []);
 
   // Merge base components with additional directive components.
-  // Even though this creates a new object when additionalMarkdownComponents changes,
-  // the spread copies the same function references from baseMarkdownComponents —
-  // it doesn't re-execute the arrow functions that define them.
-  // So base elements (p, pre, ul…) keep stable identities and won't remount.
   const markdownComponents: Components = useMemo(
     () => ({
       ...baseMarkdownComponents,
@@ -259,22 +168,24 @@ export function Markdown({
   try {
     return (
       <div className="s-w-full">
-        <MarkdownContentContext.Provider
-          value={{
-            content: processedContent,
-            isStreaming,
-            isLastMessage,
-          }}
-        >
-          <ReactMarkdown
-            linkTarget="_blank"
-            components={markdownComponents}
-            remarkPlugins={markdownPlugins}
-            rehypePlugins={rehypePlugins}
+        <MarkdownStyleContext.Provider value={styleContextValue}>
+          <MarkdownContentContext.Provider
+            value={{
+              content: processedContent,
+              isStreaming,
+              isLastMessage,
+            }}
           >
-            {processedContent}
-          </ReactMarkdown>
-        </MarkdownContentContext.Provider>
+            <ReactMarkdown
+              linkTarget="_blank"
+              components={markdownComponents}
+              remarkPlugins={markdownPlugins}
+              rehypePlugins={rehypePlugins}
+            >
+              {processedContent}
+            </ReactMarkdown>
+          </MarkdownContentContext.Provider>
+        </MarkdownStyleContext.Provider>
       </div>
     );
   } catch (_error) {

--- a/sparkle/src/components/markdown/MarkdownStyleContext.tsx
+++ b/sparkle/src/components/markdown/MarkdownStyleContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+interface MarkdownStyleContextType {
+  textColor: string;
+  forcedTextSize?: string;
+  compactSpacing: boolean;
+  canCopyQuotes: boolean;
+}
+
+export const MarkdownStyleContext = createContext<MarkdownStyleContextType>({
+  textColor: "s-text-foreground dark:s-text-foreground-night",
+  compactSpacing: false,
+  canCopyQuotes: true,
+});
+
+export function useMarkdownStyle() {
+  return useContext(MarkdownStyleContext);
+}

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -1,3 +1,5 @@
+import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
+import { markdownParagraphSize } from "@sparkle/components/markdown/markdownSizes";
 import { cn } from "@sparkle/lib";
 import { cva } from "class-variance-authority";
 import React from "react";
@@ -16,19 +18,13 @@ export const paragraphBlockVariants = cva(
   }
 );
 
-interface ParagraphBlockProps {
-  children: React.ReactNode;
-  textColor: string;
-  textSize: string;
-  compactSpacing?: boolean;
-}
-
 export function ParagraphBlock({
   children,
-  textColor,
-  textSize,
-  compactSpacing = false,
-}: ParagraphBlockProps) {
+}: {
+  children: React.ReactNode;
+}) {
+  const { textColor, forcedTextSize, compactSpacing } = useMarkdownStyle();
+  const textSize = forcedTextSize ?? markdownParagraphSize;
   return (
     <div
       className={cn(

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -18,11 +18,11 @@ export const paragraphBlockVariants = cva(
   }
 );
 
-export function ParagraphBlock({
-  children,
-}: {
+interface ParagraphBlockProps {
   children: React.ReactNode;
-}) {
+}
+
+export function ParagraphBlock({ children }: ParagraphBlockProps) {
   const { textColor, forcedTextSize, compactSpacing } = useMarkdownStyle();
   const textSize = forcedTextSize ?? markdownParagraphSize;
   return (

--- a/sparkle/src/components/markdown/index.ts
+++ b/sparkle/src/components/markdown/index.ts
@@ -4,6 +4,7 @@ export * from "./CodeBlockWithExtendedSupport";
 export * from "./ContentBlockWrapper";
 export * from "./Markdown";
 export * from "./MarkdownContentContext";
+export * from "./MarkdownStyleContext";
 export * from "./PrettyJsonViewer";
 export * from "./QuickReplyBlock";
 export * from "./TableBlock";

--- a/sparkle/src/components/markdown/markdownSizes.ts
+++ b/sparkle/src/components/markdown/markdownSizes.ts
@@ -1,0 +1,10 @@
+export const markdownHeaderClasses = {
+  h1: "s-heading-2xl",
+  h2: "s-heading-xl",
+  h3: "s-heading-lg",
+  h4: "s-text-base s-font-semibold",
+  h5: "s-text-sm s-font-semibold",
+  h6: "s-text-sm s-font-regular s-italic",
+};
+
+export const markdownParagraphSize = "s-text-base s-leading-7";


### PR DESCRIPTION
## Description
This PR is moving all the props we pass to markdown components to a context, it should not change anything but I need this change for adding streaming animation and memoizing each markdown component. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
