### PR TITLE
[sparkle] memo markdown components with custom comparison + add streaming animation

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -18,7 +18,7 @@ import {
   userMentionDirective,
 } from "@app/lib/mentions/markdown/plugin";
 import type { WorkspaceType } from "@app/types/user";
-import { Markdown } from "@dust-tt/sparkle";
+import { Markdown, type StreamingState } from "@dust-tt/sparkle";
 import React from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
@@ -30,6 +30,7 @@ export const AgentMessageMarkdown = ({
   additionalMarkdownPlugins = [] as PluggableList,
   isLastMessage = false,
   isStreaming = false,
+  streamingState,
   isInstructions = false,
   textColor,
   compactSpacing,
@@ -40,6 +41,7 @@ export const AgentMessageMarkdown = ({
   content: string;
   isLastMessage?: boolean;
   isStreaming?: boolean;
+  streamingState?: StreamingState;
   isInstructions?: boolean;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
@@ -90,6 +92,8 @@ export const AgentMessageMarkdown = ({
       additionalMarkdownPlugins={markdownPlugins}
       isLastMessage={isLastMessage}
       isStreaming={isStreaming}
+      streamingState={streamingState}
+      enableAnimation
       textColor={textColor}
       compactSpacing={compactSpacing}
       forcedTextSize={forcedTextSize}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -72,7 +72,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types/user";
-import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
+import type { DropdownMenuItemProps, StreamingState } from "@dust-tt/sparkle";
 import {
   ArrowPathIcon,
   Button,
@@ -1137,6 +1137,10 @@ function AgentMessageContent({
               content={sanitizeVisualizationContent(agentMessage.content)}
               owner={owner}
               isStreaming={streaming && lastTokenClassification === "tokens"}
+              streamingState={getStreamingState(
+                streaming && lastTokenClassification === "tokens",
+                agentMessage.status
+              )}
               isLastMessage={isLastMessage}
               additionalMarkdownComponents={additionalMarkdownComponents}
               additionalMarkdownPlugins={additionalMarkdownPlugins}
@@ -1196,6 +1200,19 @@ function AgentMessageContent({
       )}
     </div>
   );
+}
+
+function getStreamingState(
+  isStreaming: boolean,
+  messageStatus: string
+): StreamingState {
+  if (isStreaming) {
+    return "streaming";
+  }
+  if (messageStatus === "cancelled") {
+    return "cancelled";
+  }
+  return "none";
 }
 
 function getCitations({

--- a/package-lock.json
+++ b/package-lock.json
@@ -58138,6 +58138,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "emoji-mart": "^5.5.2",
+        "framer-motion": "^11.18.2",
         "lottie-react": "^2.4.0",
         "lottie-web": "^5.12.2",
         "mermaid": "^11.4.1",
@@ -58207,6 +58208,48 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       }
+    },
+    "sparkle/node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "sparkle/node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "sparkle/node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "sparkle/node_modules/unist-util-visit": {
       "version": "5.1.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -125,6 +125,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "emoji-mart": "^5.5.2",
+    "framer-motion": "^11.18.2",
     "lottie-react": "^2.4.0",
     "lottie-web": "^5.12.2",
     "mermaid": "^11.4.1",

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -1,7 +1,11 @@
 import { ContentBlockWrapper } from "@sparkle/components/markdown/ContentBlockWrapper";
 import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { cva } from "class-variance-authority";
-import React from "react";
+import React, { memo } from "react";
 
 export const blockquoteVariants = cva(
   [
@@ -27,43 +31,47 @@ export const blockquoteVariants = cva(
   }
 );
 
-interface BlockquoteBlockProps {
-  children: React.ReactNode;
-  variant?: "surface";
-}
+export const BlockquoteBlock = memo(
+  ({
+    children,
+    variant = "surface",
+  }: {
+    children: React.ReactNode;
+    variant?: "surface";
+    node?: MarkdownNode;
+  }) => {
+    const { canCopyQuotes } = useMarkdownStyle();
+    const buttonDisplay = canCopyQuotes ? "inside" : null;
 
-export function BlockquoteBlock({
-  children,
-  variant = "surface",
-}: BlockquoteBlockProps) {
-  const { canCopyQuotes } = useMarkdownStyle();
-  const buttonDisplay = canCopyQuotes ? "inside" : null;
+    const elementAt1 = React.Children.toArray(children)[1];
+    const childrenContent =
+      elementAt1 && React.isValidElement(elementAt1)
+        ? elementAt1.props.children
+        : null;
 
-  const elementAt1 = React.Children.toArray(children)[1];
-  const childrenContent =
-    elementAt1 && React.isValidElement(elementAt1)
-      ? elementAt1.props.children
-      : null;
+    // Convert array content to string if necessary
+    const contentAsString = Array.isArray(childrenContent)
+      ? childrenContent.filter((c) => typeof c === "string").join("")
+      : childrenContent;
 
-  // Convert array content to string if necessary
-  const contentAsString = Array.isArray(childrenContent)
-    ? childrenContent.filter((c) => typeof c === "string").join("")
-    : childrenContent;
+    // Only pass content if it exists
+    const clipboardContent = contentAsString
+      ? { "text/plain": contentAsString }
+      : undefined;
 
-  // Only pass content if it exists
-  const clipboardContent = contentAsString
-    ? { "text/plain": contentAsString }
-    : undefined;
-
-  return (
-    <ContentBlockWrapper
-      content={clipboardContent}
-      className="s-my-2"
-      buttonDisplay={buttonDisplay}
-    >
-      <blockquote className={blockquoteVariants({ variant, buttonDisplay })}>
-        {children}
-      </blockquote>
-    </ContentBlockWrapper>
-  );
-}
+    return (
+      <ContentBlockWrapper
+        content={clipboardContent}
+        className="s-my-2"
+        buttonDisplay={buttonDisplay}
+      >
+        <blockquote className={blockquoteVariants({ variant, buttonDisplay })}>
+          {children}
+        </blockquote>
+      </ContentBlockWrapper>
+    );
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.variant === next.variant
+);
+BlockquoteBlock.displayName = "BlockquoteBlock";

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -31,15 +31,14 @@ export const blockquoteVariants = cva(
   }
 );
 
+interface BlockquoteBlockProps {
+  children: React.ReactNode;
+  variant?: "surface";
+  node?: MarkdownNode;
+}
+
 export const BlockquoteBlock = memo(
-  ({
-    children,
-    variant = "surface",
-  }: {
-    children: React.ReactNode;
-    variant?: "surface";
-    node?: MarkdownNode;
-  }) => {
+  ({ children, variant = "surface" }: BlockquoteBlockProps) => {
     const { canCopyQuotes } = useMarkdownStyle();
     const buttonDisplay = canCopyQuotes ? "inside" : null;
 

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -45,6 +45,103 @@ export const codeBlockVariants = cva(
   }
 );
 
+const codeStyle = {
+  hljs: {
+    display: "block",
+    overflowX: "auto",
+    padding: "1em",
+    color: "var(--s-foreground)",
+    backgroundColor: "transparent",
+    fontSize: "0.875rem",
+  },
+  "hljs-ln": {
+    color: "var(--s-muted-foreground)",
+    fontSize: "0.75rem",
+    paddingRight: "1em",
+    textAlign: "right",
+    userSelect: "none",
+  },
+  "hljs-keyword": {
+    // function, const, let, if, return
+    color: violet[500],
+  },
+  "hljs-function": {
+    color: customColors.blue[600],
+  },
+  "hljs-title": {
+    // Function names
+    color: customColors.blue[600],
+  },
+  "hljs-built_in": {
+    // document, console, Date
+    color: customColors.golden[500],
+  },
+  "hljs-string": {
+    // Regular strings
+    color: customColors.green[500],
+  },
+  "hljs-variable": {
+    // Regular variables
+    color: "var(--s-foreground)",
+  },
+  "hljs-literal": {
+    // true, false, null
+    color: customColors.golden[500],
+  },
+  "hljs-number": {
+    // Numeric values
+    color: customColors.golden[500],
+  },
+  "hljs-comment": {
+    // Comments
+    color: customColors.golden[700],
+  },
+  "hljs-template-variable": {
+    // Template literal variables ${...}
+    color: customColors.rose[500],
+  },
+  "hljs-property": {
+    // Object properties
+    color: "var(--s-foreground)",
+  },
+  "hljs-punctuation": {
+    // Brackets, dots, etc
+    color: "var(--s-foreground)",
+  },
+  "hljs-operator": {
+    // =, +, -, etc
+    color: violet[500],
+  },
+  "hljs-method": {
+    // Method calls
+    color: customColors.blue[600],
+  },
+  "hljs-tag": {
+    // HTML tags
+    color: customColors.rose[500],
+  },
+  "hljs-name": {
+    // Tag names
+    color: customColors.rose[500],
+  },
+  "hljs-attr": {
+    // HTML attributes
+    color: customColors.golden[500],
+  },
+  "hljs-params": {
+    // Function parameters
+    color: "var(--s-foreground)",
+  },
+  // Typography styles
+  "hljs-emphasis": {
+    fontStyle: "italic",
+  },
+  "hljs-strong": {
+    fontWeight: "bold",
+  },
+};
+
+
 interface CodeBlockProps {
   children?: React.ReactNode;
   className?: string;
@@ -70,104 +167,7 @@ export function CodeBlock({
     tsx: "typescript",
     py: "python",
   };
-
   const languageToUse = languageOverrides[language] || language;
-
-  const codeStyle = {
-    hljs: {
-      display: "block",
-      overflowX: "auto",
-      padding: "1em",
-      color: "var(--s-foreground)",
-      backgroundColor: "transparent",
-      fontSize: "0.875rem",
-    },
-    "hljs-ln": {
-      color: "var(--s-muted-foreground)",
-      fontSize: "0.75rem",
-      paddingRight: "1em",
-      textAlign: "right",
-      userSelect: "none",
-    },
-    "hljs-keyword": {
-      // function, const, let, if, return
-      color: violet[500],
-    },
-    "hljs-function": {
-      color: customColors.blue[600],
-    },
-    "hljs-title": {
-      // Function names
-      color: customColors.blue[600],
-    },
-    "hljs-built_in": {
-      // document, console, Date
-      color: customColors.golden[500],
-    },
-    "hljs-string": {
-      // Regular strings
-      color: customColors.green[500],
-    },
-    "hljs-variable": {
-      // Regular variables
-      color: "var(--s-foreground)",
-    },
-    "hljs-literal": {
-      // true, false, null
-      color: customColors.golden[500],
-    },
-    "hljs-number": {
-      // Numeric values
-      color: customColors.golden[500],
-    },
-    "hljs-comment": {
-      // Comments
-      color: customColors.golden[700],
-    },
-    "hljs-template-variable": {
-      // Template literal variables ${...}
-      color: customColors.rose[500],
-    },
-    "hljs-property": {
-      // Object properties
-      color: "var(--s-foreground)",
-    },
-    "hljs-punctuation": {
-      // Brackets, dots, etc
-      color: "var(--s-foreground)",
-    },
-    "hljs-operator": {
-      // =, +, -, etc
-      color: violet[500],
-    },
-    "hljs-method": {
-      // Method calls
-      color: customColors.blue[600],
-    },
-    "hljs-tag": {
-      // HTML tags
-      color: customColors.rose[500],
-    },
-    "hljs-name": {
-      // Tag names
-      color: customColors.rose[500],
-    },
-    "hljs-attr": {
-      // HTML attributes
-      color: customColors.golden[500],
-    },
-    "hljs-params": {
-      // Function parameters
-      color: "var(--s-foreground)",
-    },
-    // Typography styles
-    "hljs-emphasis": {
-      fontStyle: "italic",
-    },
-    "hljs-strong": {
-      fontWeight: "bold",
-    },
-  };
 
   return !inline ? (
     <Suspense fallback={<div />}>

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -141,7 +141,6 @@ const codeStyle = {
   },
 };
 
-
 interface CodeBlockProps {
   children?: React.ReactNode;
   className?: string;

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -9,9 +9,13 @@ import {
   type JsonValueType,
   PrettyJsonViewer,
 } from "@sparkle/components/markdown/PrettyJsonViewer";
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { CommandLineIcon, SparklesIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { memo, useContext, useEffect, useRef, useState } from "react";
 import {
   amber,
   blue,
@@ -136,13 +140,13 @@ const mermaidStyles = `
     background: ${palette.gray[100]};
     cursor: default;
   }
-    
+
   .mermaid text,
   .mermaid .nodeLabel,
   .mermaid .edgeLabel,
   .mermaid .label {
     cursor: text;
-     
+
   /* Cluster styles */
   .mermaid .cluster rect {
     rx: 8px;
@@ -319,157 +323,165 @@ export function StyledMermaidGraph({
   );
 }
 
-export function CodeBlockWithExtendedSupport({
-  children,
-  className,
-  inline,
-}: {
-  children?: React.ReactNode;
-  className?: string;
-  inline?: boolean;
-}) {
-  const validChildrenContent = String(children).trim();
-  const [showMermaid, setShowMermaid] = useState<boolean>(false);
-  const [isValidMermaid, setIsValidMermaid] = useState<boolean>(false);
-  const [showPrettyJson, setShowPrettyJson] = useState<boolean>(false);
-  const [parsedJson, setParsedJson] = useState<JsonValueType | null>(null);
-  const { isStreaming } = useContext(MarkdownContentContext);
+export const CodeBlockWithExtendedSupport = memo(
+  ({
+    children,
+    className,
+    inline,
+  }: {
+    children?: React.ReactNode;
+    className?: string;
+    inline?: boolean;
+    node?: MarkdownNode;
+  }) => {
+    const validChildrenContent = String(children).trim();
+    const [showMermaid, setShowMermaid] = useState<boolean>(false);
+    const [isValidMermaid, setIsValidMermaid] = useState<boolean>(false);
+    const [showPrettyJson, setShowPrettyJson] = useState<boolean>(false);
+    const [parsedJson, setParsedJson] = useState<JsonValueType | null>(null);
+    const { isStreaming } = useContext(MarkdownContentContext);
 
-  // Detect language from className
-  const language = className?.split("-")[1];
+    // Detect language from className
+    const language = className?.split("-")[1];
 
-  // Only create getContentToDownload when we actually want to enable downloads
-  const getContentToDownload: GetContentToDownloadFunction | undefined =
-    !inline &&
-    validChildrenContent &&
-    (language === "csv" || language === "json")
-      ? async () => ({
-          content: validChildrenContent,
-          filename: `dust_output_${Date.now()}`,
-          type: language === "csv" ? "text/csv" : "application/json",
-        })
-      : undefined;
+    // Only create getContentToDownload when we actually want to enable downloads
+    const getContentToDownload: GetContentToDownloadFunction | undefined =
+      !inline &&
+      validChildrenContent &&
+      (language === "csv" || language === "json")
+        ? async () => ({
+            content: validChildrenContent,
+            filename: `dust_output_${Date.now()}`,
+            type: language === "csv" ? "text/csv" : "application/json",
+          })
+        : undefined;
 
-  // Check for valid Mermaid and JSON.
-  useEffect(() => {
-    if (isStreaming || !validChildrenContent) {
-      return;
-    }
-    if (language === "mermaid") {
-      const checkValidMermaid = async () => {
-        try {
-          const mermaid = (await import("mermaid")).default;
-          await mermaid.parse(validChildrenContent);
-          setIsValidMermaid(true);
-          setShowMermaid(true);
-        } catch (_e) {
-          setIsValidMermaid(false);
-          setShowMermaid(false);
-        }
-      };
-      void checkValidMermaid();
-    }
-    if (language === "json") {
-      try {
-        const parsed = JSON.parse(validChildrenContent);
-        setParsedJson(parsed);
-        const prettyJsonPreference = getPrettyJsonPreference();
-        setShowPrettyJson(prettyJsonPreference);
-      } catch (_e) {
-        setParsedJson(null);
-        setShowPrettyJson(false);
+    // Check for valid Mermaid and JSON.
+    useEffect(() => {
+      if (isStreaming || !validChildrenContent) {
+        return;
       }
+      if (language === "mermaid") {
+        const checkValidMermaid = async () => {
+          try {
+            const mermaid = (await import("mermaid")).default;
+            await mermaid.parse(validChildrenContent);
+            setIsValidMermaid(true);
+            setShowMermaid(true);
+          } catch (_e) {
+            setIsValidMermaid(false);
+            setShowMermaid(false);
+          }
+        };
+        void checkValidMermaid();
+      }
+      if (language === "json") {
+        try {
+          const parsed = JSON.parse(validChildrenContent);
+          setParsedJson(parsed);
+          const prettyJsonPreference = getPrettyJsonPreference();
+          setShowPrettyJson(prettyJsonPreference);
+        } catch (_e) {
+          setParsedJson(null);
+          setShowPrettyJson(false);
+        }
+      }
+    }, [isStreaming, language, validChildrenContent]);
+
+    if (inline) {
+      return (
+        <CodeBlock className={className} inline={inline}>
+          {children}
+        </CodeBlock>
+      );
     }
-  }, [isStreaming, language, validChildrenContent]);
 
-  if (inline) {
-    return (
-      <CodeBlock className={className} inline={inline}>
-        {children}
-      </CodeBlock>
-    );
-  }
+    if (isValidMermaid) {
+      return (
+        <ContentBlockWrapper
+          content={validChildrenContent}
+          getContentToDownload={getContentToDownload}
+          actions={
+            <Button
+              className="s-font-sans"
+              size="xs"
+              variant={"outline"}
+              label={showMermaid ? "Markdown" : "Mermaid"}
+              icon={showMermaid ? CommandLineIcon : SparklesIcon}
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setShowMermaid(!showMermaid);
+              }}
+              tooltip={showMermaid ? "Switch to Markdown" : "Switch to Mermaid"}
+            />
+          }
+        >
+          {showMermaid ? (
+            <MermaidGraph chart={validChildrenContent} />
+          ) : (
+            <CodeBlock className={className} inline={inline}>
+              {children}
+            </CodeBlock>
+          )}
+        </ContentBlockWrapper>
+      );
+    }
 
-  if (isValidMermaid) {
+    if (parsedJson !== null) {
+      return (
+        <ContentBlockWrapper
+          content={validChildrenContent}
+          getContentToDownload={getContentToDownload}
+          actions={
+            <Button
+              className="s-font-sans"
+              size="xs"
+              variant={"outline"}
+              label={showPrettyJson ? "Raw JSON" : "Pretty JSON"}
+              icon={showPrettyJson ? CommandLineIcon : SparklesIcon}
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const newValue = !showPrettyJson;
+                setShowPrettyJson(newValue);
+                setPrettyJsonPreference(newValue);
+              }}
+              tooltip={
+                showPrettyJson ? "Switch to Raw JSON" : "Switch to Pretty View"
+              }
+            />
+          }
+          displayActions="hover"
+          buttonDisplay="inside"
+        >
+          {showPrettyJson ? (
+            <PrettyJsonViewer data={parsedJson} />
+          ) : (
+            <CodeBlock className={className} inline={inline} wrapLongLines>
+              {children}
+            </CodeBlock>
+          )}
+        </ContentBlockWrapper>
+      );
+    }
+
     return (
       <ContentBlockWrapper
         content={validChildrenContent}
         getContentToDownload={getContentToDownload}
-        actions={
-          <Button
-            className="s-font-sans"
-            size="xs"
-            variant={"outline"}
-            label={showMermaid ? "Markdown" : "Mermaid"}
-            icon={showMermaid ? CommandLineIcon : SparklesIcon}
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setShowMermaid(!showMermaid);
-            }}
-            tooltip={showMermaid ? "Switch to Markdown" : "Switch to Mermaid"}
-          />
-        }
-      >
-        {showMermaid ? (
-          <MermaidGraph chart={validChildrenContent} />
-        ) : (
-          <CodeBlock className={className} inline={inline}>
-            {children}
-          </CodeBlock>
-        )}
-      </ContentBlockWrapper>
-    );
-  }
-
-  if (parsedJson !== null) {
-    return (
-      <ContentBlockWrapper
-        content={validChildrenContent}
-        getContentToDownload={getContentToDownload}
-        actions={
-          <Button
-            className="s-font-sans"
-            size="xs"
-            variant={"outline"}
-            label={showPrettyJson ? "Raw JSON" : "Pretty JSON"}
-            icon={showPrettyJson ? CommandLineIcon : SparklesIcon}
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const newValue = !showPrettyJson;
-              setShowPrettyJson(newValue);
-              setPrettyJsonPreference(newValue);
-            }}
-            tooltip={
-              showPrettyJson ? "Switch to Raw JSON" : "Switch to Pretty View"
-            }
-          />
-        }
-        displayActions="hover"
         buttonDisplay="inside"
+        displayActions="hover"
       >
-        {showPrettyJson ? (
-          <PrettyJsonViewer data={parsedJson} />
-        ) : (
-          <CodeBlock className={className} inline={inline} wrapLongLines>
-            {children}
-          </CodeBlock>
-        )}
+        <CodeBlock className={className} inline={inline}>
+          {children}
+        </CodeBlock>
       </ContentBlockWrapper>
     );
-  }
-
-  return (
-    <ContentBlockWrapper
-      content={validChildrenContent}
-      getContentToDownload={getContentToDownload}
-      buttonDisplay="inside"
-      displayActions="hover"
-    >
-      <CodeBlock className={className} inline={inline}>
-        {children}
-      </CodeBlock>
-    </ContentBlockWrapper>
-  );
-}
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) &&
+    prev.className === next.className &&
+    prev.inline === next.inline
+);
+CodeBlockWithExtendedSupport.displayName = "CodeBlockWithExtendedSupport";

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -307,13 +307,15 @@ const MermaidGraph: React.FC<{ chart: string }> = ({ chart }) => {
   );
 };
 
+interface StyledMermaidGraphProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
 export function StyledMermaidGraph({
   children,
   className,
-}: {
-  children?: React.ReactNode;
-  className?: string;
-}) {
+}: StyledMermaidGraphProps) {
   const validChildrenContent = String(children).trim();
 
   return (
@@ -323,17 +325,15 @@ export function StyledMermaidGraph({
   );
 }
 
+interface CodeBlockWithExtendedSupportProps {
+  children?: React.ReactNode;
+  className?: string;
+  inline?: boolean;
+  node?: MarkdownNode;
+}
+
 export const CodeBlockWithExtendedSupport = memo(
-  ({
-    children,
-    className,
-    inline,
-  }: {
-    children?: React.ReactNode;
-    className?: string;
-    inline?: boolean;
-    node?: MarkdownNode;
-  }) => {
+  ({ children, className, inline }: CodeBlockWithExtendedSupportProps) => {
     const validChildrenContent = String(children).trim();
     const [showMermaid, setShowMermaid] = useState<boolean>(false);
     const [isValidMermaid, setIsValidMermaid] = useState<boolean>(false);

--- a/sparkle/src/components/markdown/HeadingBlock.tsx
+++ b/sparkle/src/components/markdown/HeadingBlock.tsx
@@ -1,7 +1,11 @@
 import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib/utils";
-import React from "react";
+import React, { memo } from "react";
 
 const headingSpacing: Record<number, string> = {
   1: "s-pb-2 s-pt-4",
@@ -14,94 +18,119 @@ const headingSpacing: Record<number, string> = {
 
 interface HeadingBlockProps {
   children?: React.ReactNode;
+  node?: MarkdownNode;
 }
 
-export function H1Block({ children }: HeadingBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  return (
-    <h1
-      className={cn(
-        headingSpacing[1],
-        forcedTextSize ?? markdownHeaderClasses.h1,
-        textColor
-      )}
-    >
-      {children}
-    </h1>
-  );
-}
+export const H1Block = memo(
+  ({ children }: HeadingBlockProps) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    return (
+      <h1
+        className={cn(
+          headingSpacing[1],
+          forcedTextSize ?? markdownHeaderClasses.h1,
+          textColor
+        )}
+      >
+        {children}
+      </h1>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+H1Block.displayName = "H1Block";
 
-export function H2Block({ children }: HeadingBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  return (
-    <h2
-      className={cn(
-        headingSpacing[2],
-        forcedTextSize ?? markdownHeaderClasses.h2,
-        textColor
-      )}
-    >
-      {children}
-    </h2>
-  );
-}
+export const H2Block = memo(
+  ({ children }: HeadingBlockProps) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    return (
+      <h2
+        className={cn(
+          headingSpacing[2],
+          forcedTextSize ?? markdownHeaderClasses.h2,
+          textColor
+        )}
+      >
+        {children}
+      </h2>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+H2Block.displayName = "H2Block";
 
-export function H3Block({ children }: HeadingBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  return (
-    <h3
-      className={cn(
-        headingSpacing[3],
-        forcedTextSize ?? markdownHeaderClasses.h3,
-        textColor
-      )}
-    >
-      {children}
-    </h3>
-  );
-}
+export const H3Block = memo(
+  ({ children }: HeadingBlockProps) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    return (
+      <h3
+        className={cn(
+          headingSpacing[3],
+          forcedTextSize ?? markdownHeaderClasses.h3,
+          textColor
+        )}
+      >
+        {children}
+      </h3>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+H3Block.displayName = "H3Block";
 
-export function H4Block({ children }: HeadingBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  return (
-    <h4
-      className={cn(
-        headingSpacing[4],
-        forcedTextSize ?? markdownHeaderClasses.h4,
-        textColor
-      )}
-    >
-      {children}
-    </h4>
-  );
-}
+export const H4Block = memo(
+  ({ children }: HeadingBlockProps) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    return (
+      <h4
+        className={cn(
+          headingSpacing[4],
+          forcedTextSize ?? markdownHeaderClasses.h4,
+          textColor
+        )}
+      >
+        {children}
+      </h4>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+H4Block.displayName = "H4Block";
 
-export function H5Block({ children }: HeadingBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  return (
-    <h5
-      className={cn(
-        headingSpacing[5],
-        forcedTextSize ?? markdownHeaderClasses.h5,
-        textColor
-      )}
-    >
-      {children}
-    </h5>
-  );
-}
+export const H5Block = memo(
+  ({ children }: HeadingBlockProps) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    return (
+      <h5
+        className={cn(
+          headingSpacing[5],
+          forcedTextSize ?? markdownHeaderClasses.h5,
+          textColor
+        )}
+      >
+        {children}
+      </h5>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+H5Block.displayName = "H5Block";
 
-export function H6Block({ children }: HeadingBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  return (
-    <h6
-      className={cn(
-        headingSpacing[6],
-        forcedTextSize ?? markdownHeaderClasses.h6,
-        textColor
-      )}
-    >
-      {children}
-    </h6>
-  );
-}
+export const H6Block = memo(
+  ({ children }: HeadingBlockProps) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    return (
+      <h6
+        className={cn(
+          headingSpacing[6],
+          forcedTextSize ?? markdownHeaderClasses.h6,
+          textColor
+        )}
+      >
+        {children}
+      </h6>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+H6Block.displayName = "H6Block";

--- a/sparkle/src/components/markdown/HrBlock.tsx
+++ b/sparkle/src/components/markdown/HrBlock.tsx
@@ -2,7 +2,7 @@ import {
   type MarkdownNode,
   sameNodePosition,
 } from "@sparkle/components/markdown/utils";
-import { memo } from "react";
+import React, { memo } from "react";
 
 export const HrBlock = memo(
   (_props: { node?: MarkdownNode }) => (

--- a/sparkle/src/components/markdown/HrBlock.tsx
+++ b/sparkle/src/components/markdown/HrBlock.tsx
@@ -1,0 +1,13 @@
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
+import { memo } from "react";
+
+export const HrBlock = memo(
+  (_props: { node?: MarkdownNode }) => (
+    <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
+  ),
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+HrBlock.displayName = "HrBlock";

--- a/sparkle/src/components/markdown/HrBlock.tsx
+++ b/sparkle/src/components/markdown/HrBlock.tsx
@@ -4,8 +4,12 @@ import {
 } from "@sparkle/components/markdown/utils";
 import React, { memo } from "react";
 
+interface HrBlockProps {
+  node?: MarkdownNode;
+}
+
 export const HrBlock = memo(
-  (_props: { node?: MarkdownNode }) => (
+  (_props: HrBlockProps) => (
     <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
   ),
   (prev, next) => sameNodePosition(prev.node, next.node)

--- a/sparkle/src/components/markdown/InputBlock.tsx
+++ b/sparkle/src/components/markdown/InputBlock.tsx
@@ -8,7 +8,7 @@ type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
     ref?: React.Ref<HTMLInputElement>;
   };
 
-export const MemoInput = memo(
+export const InputBlock = memo(
   ({ type, checked, className, onChange, ref, ...props }: InputProps) => {
     const inputRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => inputRef.current!);
@@ -49,4 +49,4 @@ export const MemoInput = memo(
     prev.checked === next.checked &&
     prev.className === next.className
 );
-MemoInput.displayName = "MemoInput";
+InputBlock.displayName = "InputBlock";

--- a/sparkle/src/components/markdown/InputBlock.tsx
+++ b/sparkle/src/components/markdown/InputBlock.tsx
@@ -1,0 +1,52 @@
+import { Checkbox } from "@sparkle/components/Checkbox";
+import { sameNodePosition } from "@sparkle/components/markdown/utils";
+import React, { memo } from "react";
+import type { ReactMarkdownProps } from "react-markdown/lib/ast-to-react";
+
+type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
+  ReactMarkdownProps & {
+    ref?: React.Ref<HTMLInputElement>;
+  };
+
+export const MemoInput = memo(
+  ({ type, checked, className, onChange, ref, ...props }: InputProps) => {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    React.useImperativeHandle(ref, () => inputRef.current!);
+
+    if (type !== "checkbox") {
+      return (
+        <input
+          ref={inputRef}
+          type={type}
+          checked={checked}
+          className={className}
+          {...props}
+        />
+      );
+    }
+
+    const handleCheckedChange = (isChecked: boolean) => {
+      onChange?.({
+        target: { type: "checkbox", checked: isChecked },
+      } as React.ChangeEvent<HTMLInputElement>);
+    };
+
+    return (
+      <div className="s-inline-flex s-items-center">
+        <Checkbox
+          ref={inputRef as unknown as React.Ref<HTMLButtonElement>}
+          size="xs"
+          checked={checked}
+          className="s-translate-y-[3px]"
+          onCheckedChange={handleCheckedChange}
+        />
+      </div>
+    );
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) &&
+    prev.type === next.type &&
+    prev.checked === next.checked &&
+    prev.className === next.className
+);
+MemoInput.displayName = "MemoInput";

--- a/sparkle/src/components/markdown/LinkBlock.tsx
+++ b/sparkle/src/components/markdown/LinkBlock.tsx
@@ -5,15 +5,14 @@ import {
 import { cn } from "@sparkle/lib";
 import React, { memo } from "react";
 
+interface LinkBlockProps {
+  href?: string;
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const LinkBlock = memo(
-  ({
-    href,
-    children,
-  }: {
-    href?: string;
-    children: React.ReactNode;
-    node?: MarkdownNode;
-  }) => (
+  ({ href, children }: LinkBlockProps) => (
     <a
       href={href}
       title={href}

--- a/sparkle/src/components/markdown/LinkBlock.tsx
+++ b/sparkle/src/components/markdown/LinkBlock.tsx
@@ -1,0 +1,35 @@
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
+import { cn } from "@sparkle/lib";
+import React, { memo } from "react";
+
+export const LinkBlock = memo(
+  ({
+    href,
+    children,
+  }: {
+    href?: string;
+    children: React.ReactNode;
+    node?: MarkdownNode;
+  }) => (
+    <a
+      href={href}
+      title={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
+        "s-text-highlight dark:s-text-highlight-night",
+        "hover:s-text-highlight-400 dark:hover:s-text-highlight-400-night",
+        "active:s-text-highlight-dark dark:active:s-text-highlight-dark-night"
+      )}
+    >
+      {children}
+    </a>
+  ),
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.href === next.href
+);
+LinkBlock.displayName = "LinkBlock";

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -10,8 +10,13 @@ import React, { memo } from "react";
 
 export const ulBlockVariants = cva(["s-list-disc s-pb-2 s-pl-6"]);
 
+interface UlBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const UlBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: UlBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
     return (
@@ -24,15 +29,14 @@ UlBlock.displayName = "UlBlock";
 
 export const olBlockVariants = cva(["s-list-decimal s-pb-2 s-pl-6"]);
 
+interface OlBlockProps {
+  children: React.ReactNode;
+  start?: number;
+  node?: MarkdownNode;
+}
+
 export const OlBlock = memo(
-  ({
-    children,
-    start,
-  }: {
-    children: React.ReactNode;
-    start?: number;
-    node?: MarkdownNode;
-  }) => {
+  ({ children, start }: OlBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
     return (
@@ -48,15 +52,14 @@ OlBlock.displayName = "OlBlock";
 
 export const liBlockVariants = cva(["s-break-words"]);
 
+interface LiBlockProps {
+  children: React.ReactNode;
+  className?: string;
+  node?: MarkdownNode;
+}
+
 export const LiBlock = memo(
-  ({
-    children,
-    className,
-  }: {
-    children: React.ReactNode;
-    className?: string;
-    node?: MarkdownNode;
-  }) => {
+  ({ children, className }: LiBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
     return (

--- a/sparkle/src/components/markdown/List.tsx
+++ b/sparkle/src/components/markdown/List.tsx
@@ -1,53 +1,71 @@
 import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { markdownParagraphSize } from "@sparkle/components/markdown/markdownSizes";
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib";
 import { cva } from "class-variance-authority";
-import React from "react";
+import React, { memo } from "react";
 
 export const ulBlockVariants = cva(["s-list-disc s-pb-2 s-pl-6"]);
 
-interface UlBlockProps {
-  children: React.ReactNode;
-}
-
-export function UlBlock({ children }: UlBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  const textSize = forcedTextSize ?? markdownParagraphSize;
-  return (
-    <ul className={cn(ulBlockVariants(), textColor, textSize)}>{children}</ul>
-  );
-}
+export const UlBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    const textSize = forcedTextSize ?? markdownParagraphSize;
+    return (
+      <ul className={cn(ulBlockVariants(), textColor, textSize)}>{children}</ul>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+UlBlock.displayName = "UlBlock";
 
 export const olBlockVariants = cva(["s-list-decimal s-pb-2 s-pl-6"]);
 
-interface OlBlockProps {
-  children: React.ReactNode;
-  start?: number;
-}
-
-export function OlBlock({ children, start }: OlBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  const textSize = forcedTextSize ?? markdownParagraphSize;
-  return (
-    <ol start={start} className={cn(olBlockVariants(), textColor, textSize)}>
-      {children}
-    </ol>
-  );
-}
+export const OlBlock = memo(
+  ({
+    children,
+    start,
+  }: {
+    children: React.ReactNode;
+    start?: number;
+    node?: MarkdownNode;
+  }) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    const textSize = forcedTextSize ?? markdownParagraphSize;
+    return (
+      <ol start={start} className={cn(olBlockVariants(), textColor, textSize)}>
+        {children}
+      </ol>
+    );
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.start === next.start
+);
+OlBlock.displayName = "OlBlock";
 
 export const liBlockVariants = cva(["s-break-words"]);
 
-interface LiBlockProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-export function LiBlock({ children, className }: LiBlockProps) {
-  const { textColor, forcedTextSize } = useMarkdownStyle();
-  const textSize = forcedTextSize ?? markdownParagraphSize;
-  return (
-    <li className={cn(liBlockVariants(), textColor, textSize, className)}>
-      {children}
-    </li>
-  );
-}
+export const LiBlock = memo(
+  ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    node?: MarkdownNode;
+  }) => {
+    const { textColor, forcedTextSize } = useMarkdownStyle();
+    const textSize = forcedTextSize ?? markdownParagraphSize;
+    return (
+      <li className={cn(liBlockVariants(), textColor, textSize, className)}>
+        {children}
+      </li>
+    );
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.className === next.className
+);
+LiBlock.displayName = "LiBlock";

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -10,7 +10,7 @@ import {
   H6Block,
 } from "@sparkle/components/markdown/HeadingBlock";
 import { HrBlock } from "@sparkle/components/markdown/HrBlock";
-import { MemoInput } from "@sparkle/components/markdown/InputBlock";
+import { InputBlock } from "@sparkle/components/markdown/InputBlock";
 import { LinkBlock } from "@sparkle/components/markdown/LinkBlock";
 import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
@@ -126,7 +126,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
       th: TableHeaderBlock,
       td: TableDataBlock,
       strong: StrongBlock,
-      input: MemoInput,
+      input: InputBlock,
       blockquote: BlockquoteBlock,
       hr: HrBlock,
       code: CodeBlockWithExtendedSupport,

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -1,4 +1,3 @@
-import { Checkbox } from "@sparkle/components/Checkbox";
 import { Chip } from "@sparkle/components/Chip";
 import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
 import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
@@ -10,11 +9,15 @@ import {
   H5Block,
   H6Block,
 } from "@sparkle/components/markdown/HeadingBlock";
+import { HrBlock } from "@sparkle/components/markdown/HrBlock";
+import { MemoInput } from "@sparkle/components/markdown/InputBlock";
+import { LinkBlock } from "@sparkle/components/markdown/LinkBlock";
 import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
 import { MarkdownStyleContext } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { ParagraphBlock } from "@sparkle/components/markdown/ParagraphBlock";
 import { PreBlock } from "@sparkle/components/markdown/PreBlock";
+import { StrongBlock } from "@sparkle/components/markdown/StrongBlock";
 import { safeRehypeKatex } from "@sparkle/components/markdown/safeRehypeKatex";
 import {
   TableBlock,
@@ -24,16 +27,12 @@ import {
   TableHeaderBlock,
 } from "@sparkle/components/markdown/TableBlock";
 import {
-  type MarkdownNode,
   preserveLineBreaks,
-  sameNodePosition,
   sanitizeContent,
 } from "@sparkle/components/markdown/utils";
-import { cn } from "@sparkle/lib/utils";
-import React, { memo, useMemo } from "react";
+import React, { useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
-import type { ReactMarkdownProps } from "react-markdown/lib/ast-to-react";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
@@ -41,103 +40,6 @@ import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 
 export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
-
-// Module-level memo'd components that don't need context.
-
-const StrongBlock = memo(
-  ({ children }: { children?: React.ReactNode; node?: MarkdownNode }) => (
-    <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
-      {children}
-    </strong>
-  ),
-  (prev, next) => sameNodePosition(prev.node, next.node)
-);
-StrongBlock.displayName = "StrongBlock";
-
-const HrBlock = memo(
-  (_props: { node?: MarkdownNode }) => (
-    <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
-  ),
-  (prev, next) => sameNodePosition(prev.node, next.node)
-);
-HrBlock.displayName = "HrBlock";
-
-const LinkBlock = memo(
-  ({
-    href,
-    children,
-  }: {
-    href?: string;
-    children: React.ReactNode;
-    node?: MarkdownNode;
-  }) => (
-    <a
-      href={href}
-      title={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
-        "s-text-highlight dark:s-text-highlight-night",
-        "hover:s-text-highlight-400 dark:hover:s-text-highlight-400-night",
-        "active:s-text-highlight-dark dark:active:s-text-highlight-dark-night"
-      )}
-    >
-      {children}
-    </a>
-  ),
-  (prev, next) =>
-    sameNodePosition(prev.node, next.node) && prev.href === next.href
-);
-LinkBlock.displayName = "LinkBlock";
-
-type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
-  ReactMarkdownProps & {
-    ref?: React.Ref<HTMLInputElement>;
-  };
-
-const MemoInput = memo(
-  ({ type, checked, className, onChange, ref, ...props }: InputProps) => {
-    const inputRef = React.useRef<HTMLInputElement>(null);
-    React.useImperativeHandle(ref, () => inputRef.current!);
-
-    if (type !== "checkbox") {
-      return (
-        <input
-          ref={inputRef}
-          type={type}
-          checked={checked}
-          className={className}
-          {...props}
-        />
-      );
-    }
-
-    const handleCheckedChange = (isChecked: boolean) => {
-      onChange?.({
-        target: { type: "checkbox", checked: isChecked },
-      } as React.ChangeEvent<HTMLInputElement>);
-    };
-
-    return (
-      <div className="s-inline-flex s-items-center">
-        <Checkbox
-          ref={inputRef as unknown as React.Ref<HTMLButtonElement>}
-          size="xs"
-          checked={checked}
-          className="s-translate-y-[3px]"
-          onCheckedChange={handleCheckedChange}
-        />
-      </div>
-    );
-  },
-  (prev, next) =>
-    sameNodePosition(prev.node, next.node) &&
-    prev.type === next.type &&
-    prev.checked === next.checked &&
-    prev.className === next.className
-);
-MemoInput.displayName = "MemoInput";
 
 function showUnsupportedDirective() {
   return (tree: any) => {
@@ -151,17 +53,7 @@ function showUnsupportedDirective() {
   };
 }
 
-export function Markdown({
-  content,
-  isStreaming = false,
-  textColor = "s-text-foreground dark:s-text-foreground-night",
-  forcedTextSize,
-  isLastMessage = false,
-  compactSpacing = false,
-  additionalMarkdownComponents,
-  additionalMarkdownPlugins,
-  canCopyQuotes = true,
-}: {
+interface MarkdownProps {
   content: string;
   isStreaming?: boolean;
   textColor?: string;
@@ -171,7 +63,19 @@ export function Markdown({
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   canCopyQuotes?: boolean;
-}) {
+}
+
+export const Markdown: React.FC<MarkdownProps> = ({
+  content,
+  isStreaming = false,
+  textColor = "s-text-foreground dark:s-text-foreground-night",
+  forcedTextSize,
+  isLastMessage = false,
+  compactSpacing = false,
+  additionalMarkdownComponents,
+  additionalMarkdownPlugins,
+  canCopyQuotes = true,
+}) => {
   const processedContent = useMemo(() => {
     let sanitized = sanitizeContent(content);
     if (compactSpacing) {
@@ -288,4 +192,4 @@ export function Markdown({
       </div>
     );
   }
-}
+};

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -53,7 +53,7 @@ function showUnsupportedDirective() {
   };
 }
 
-interface MarkdownProps {
+export interface MarkdownProps {
   content: string;
   isStreaming?: boolean;
   textColor?: string;

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -24,11 +24,13 @@ import {
   TableHeaderBlock,
 } from "@sparkle/components/markdown/TableBlock";
 import {
+  type MarkdownNode,
   preserveLineBreaks,
+  sameNodePosition,
   sanitizeContent,
 } from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib/utils";
-import React, { useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import type { ReactMarkdownProps } from "react-markdown/lib/ast-to-react";
@@ -39,6 +41,103 @@ import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 
 export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
+
+// Module-level memo'd components that don't need context.
+
+const StrongBlock = memo(
+  ({ children }: { children?: React.ReactNode; node?: MarkdownNode }) => (
+    <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
+      {children}
+    </strong>
+  ),
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+StrongBlock.displayName = "StrongBlock";
+
+const HrBlock = memo(
+  (_props: { node?: MarkdownNode }) => (
+    <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
+  ),
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+HrBlock.displayName = "HrBlock";
+
+const LinkBlock = memo(
+  ({
+    href,
+    children,
+  }: {
+    href?: string;
+    children: React.ReactNode;
+    node?: MarkdownNode;
+  }) => (
+    <a
+      href={href}
+      title={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
+        "s-text-highlight dark:s-text-highlight-night",
+        "hover:s-text-highlight-400 dark:hover:s-text-highlight-400-night",
+        "active:s-text-highlight-dark dark:active:s-text-highlight-dark-night"
+      )}
+    >
+      {children}
+    </a>
+  ),
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.href === next.href
+);
+LinkBlock.displayName = "LinkBlock";
+
+type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
+  ReactMarkdownProps & {
+    ref?: React.Ref<HTMLInputElement>;
+  };
+
+const MemoInput = memo(
+  ({ type, checked, className, onChange, ref, ...props }: InputProps) => {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    React.useImperativeHandle(ref, () => inputRef.current!);
+
+    if (type !== "checkbox") {
+      return (
+        <input
+          ref={inputRef}
+          type={type}
+          checked={checked}
+          className={className}
+          {...props}
+        />
+      );
+    }
+
+    const handleCheckedChange = (isChecked: boolean) => {
+      onChange?.({
+        target: { type: "checkbox", checked: isChecked },
+      } as React.ChangeEvent<HTMLInputElement>);
+    };
+
+    return (
+      <div className="s-inline-flex s-items-center">
+        <Checkbox
+          ref={inputRef as unknown as React.Ref<HTMLButtonElement>}
+          size="xs"
+          checked={checked}
+          className="s-translate-y-[3px]"
+          onCheckedChange={handleCheckedChange}
+        />
+      </div>
+    );
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) &&
+    prev.type === next.type &&
+    prev.checked === next.checked &&
+    prev.className === next.className
+);
+MemoInput.displayName = "MemoInput";
 
 function showUnsupportedDirective() {
   return (tree: any) => {
@@ -94,23 +193,18 @@ export function Markdown({
   // Note on re-renderings. A lot of effort has been put into preventing rerendering across markdown
   // AST parsing rounds (happening at each token being streamed).
   //
-  // When adding a new directive and associated component that depends on external data (eg
-  // workspace or message), you can use the customRenderer.visualization pattern. It is essential
-  // for the customRenderer argument to be memoized to avoid re-renderings through the
-  // markdownComponents memoization dependency on `customRenderer`.
-  //
-  // Make sure to spend some time understanding the re-rendering or lack thereof through the parser
-  // rounds.
+  // All base components are React.memo'd with sameNodePosition custom comparison.
+  // During streaming, unchanged nodes (same AST position) skip re-rendering entirely.
+  // Style props flow through MarkdownStyleContext, which bypasses memo when values change.
   //
   // Minimal test whenever editing this code: ensure that code block content of a streaming message
   // can be selected without blinking.
 
-  // Style props flow through MarkdownStyleContext so base component references stay stable
-  // across re-renders. ReactMarkdown compares component types by reference — a new function
-  // would remount the entire subtree, destroying stateful children.
-  const baseMarkdownComponents: Components = useMemo(() => {
-    return {
-      pre: ({ children }) => <PreBlock>{children}</PreBlock>,
+  // All base components are memo'd and read style props from MarkdownStyleContext,
+  // so this object never needs to be recreated.
+  const baseMarkdownComponents: Components = useMemo(
+    () => ({
+      pre: PreBlock,
       a: LinkBlock,
       ul: UlBlock,
       ol: OlBlock,
@@ -127,19 +221,14 @@ export function Markdown({
       tbody: TableBodyBlock,
       th: TableHeaderBlock,
       td: TableDataBlock,
-      strong: ({ children }) => (
-        <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
-          {children}
-        </strong>
-      ),
-      input: Input,
+      strong: StrongBlock,
+      input: MemoInput,
       blockquote: BlockquoteBlock,
-      hr: () => (
-        <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
-      ),
+      hr: HrBlock,
       code: CodeBlockWithExtendedSupport,
-    };
-  }, []);
+    }),
+    []
+  );
 
   // Merge base components with additional directive components.
   const markdownComponents: Components = useMemo(
@@ -199,76 +288,4 @@ export function Markdown({
       </div>
     );
   }
-}
-
-function LinkBlock({
-  href,
-  children,
-}: {
-  href?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <a
-      href={href}
-      title={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
-        "s-text-highlight dark:s-text-highlight-night",
-        "hover:s-text-highlight-400 dark:hover:s-text-highlight-400-night",
-        "active:s-text-highlight-dark dark:active:s-text-highlight-dark-night"
-      )}
-    >
-      {children}
-    </a>
-  );
-}
-
-type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "ref"> &
-  ReactMarkdownProps & {
-    ref?: React.Ref<HTMLInputElement>;
-  };
-
-function Input({
-  type,
-  checked,
-  className,
-  onChange,
-  ref,
-  ...props
-}: InputProps) {
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  React.useImperativeHandle(ref, () => inputRef.current!);
-
-  if (type !== "checkbox") {
-    return (
-      <input
-        ref={inputRef}
-        type={type}
-        checked={checked}
-        className={className}
-        {...props}
-      />
-    );
-  }
-
-  const handleCheckedChange = (isChecked: boolean) => {
-    onChange?.({
-      target: { type: "checkbox", checked: isChecked },
-    } as React.ChangeEvent<HTMLInputElement>);
-  };
-
-  return (
-    <div className="s-inline-flex s-items-center">
-      <Checkbox
-        ref={inputRef as unknown as React.Ref<HTMLButtonElement>}
-        size="xs"
-        checked={checked}
-        className="s-translate-y-[3px]"
-        onCheckedChange={handleCheckedChange}
-      />
-    </div>
-  );
 }

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -27,6 +27,10 @@ import {
   TableHeaderBlock,
 } from "@sparkle/components/markdown/TableBlock";
 import {
+  type StreamingState,
+  useAnimatedText,
+} from "@sparkle/components/markdown/useAnimatedText";
+import {
   preserveLineBreaks,
   sanitizeContent,
 } from "@sparkle/components/markdown/utils";
@@ -40,6 +44,9 @@ import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 
 export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
+
+const DEFAULT_ANIMATION_DURATION_SECONDS = 1;
+const DEFAULT_DELIMITER = "";
 
 function showUnsupportedDirective() {
   return (tree: any) => {
@@ -56,6 +63,7 @@ function showUnsupportedDirective() {
 export interface MarkdownProps {
   content: string;
   isStreaming?: boolean;
+  streamingState?: StreamingState;
   textColor?: string;
   isLastMessage?: boolean;
   compactSpacing?: boolean; // When true, removes vertical padding from paragraph blocks for tighter spacing
@@ -63,11 +71,15 @@ export interface MarkdownProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   canCopyQuotes?: boolean;
+  enableAnimation?: boolean;
+  animationDurationSeconds?: number;
+  delimiter?: string;
 }
 
 export const Markdown: React.FC<MarkdownProps> = ({
   content,
   isStreaming = false,
+  streamingState,
   textColor = "s-text-foreground dark:s-text-foreground-night",
   forcedTextSize,
   isLastMessage = false,
@@ -75,7 +87,15 @@ export const Markdown: React.FC<MarkdownProps> = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   canCopyQuotes = true,
+  enableAnimation = false,
+  animationDurationSeconds = DEFAULT_ANIMATION_DURATION_SECONDS,
+  delimiter = DEFAULT_DELIMITER,
 }) => {
+  // Derive streaming state: explicit prop takes priority, otherwise derive from isStreaming boolean.
+  // @TODO: remove isStreaming prop and use streamingState prop only
+  const effectiveStreamingState: StreamingState =
+    streamingState ?? (isStreaming ? "streaming" : "none");
+
   const processedContent = useMemo(() => {
     let sanitized = sanitizeContent(content);
     if (compactSpacing) {
@@ -83,6 +103,14 @@ export const Markdown: React.FC<MarkdownProps> = ({
     }
     return sanitized;
   }, [content, compactSpacing]);
+
+  // Animate text during streaming for a smooth reveal effect.
+  const animatedContent = useAnimatedText(
+    processedContent,
+    enableAnimation ? effectiveStreamingState : "none",
+    animationDurationSeconds,
+    delimiter
+  );
 
   const styleContextValue = useMemo(
     () => ({
@@ -166,7 +194,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
           <MarkdownContentContext.Provider
             value={{
               content: processedContent,
-              isStreaming,
+              isStreaming: effectiveStreamingState === "streaming",
               isLastMessage,
             }}
           >
@@ -176,7 +204,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
               remarkPlugins={markdownPlugins}
               rehypePlugins={rehypePlugins}
             >
-              {processedContent}
+              {animatedContent}
             </ReactMarkdown>
           </MarkdownContentContext.Provider>
         </MarkdownStyleContext.Provider>

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -1,8 +1,12 @@
 import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import { markdownParagraphSize } from "@sparkle/components/markdown/markdownSizes";
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib";
 import { cva } from "class-variance-authority";
-import React from "react";
+import React, { memo } from "react";
 
 export const paragraphBlockVariants = cva(
   [
@@ -18,22 +22,22 @@ export const paragraphBlockVariants = cva(
   }
 );
 
-interface ParagraphBlockProps {
-  children: React.ReactNode;
-}
-
-export function ParagraphBlock({ children }: ParagraphBlockProps) {
-  const { textColor, forcedTextSize, compactSpacing } = useMarkdownStyle();
-  const textSize = forcedTextSize ?? markdownParagraphSize;
-  return (
-    <div
-      className={cn(
-        paragraphBlockVariants({ compactSpacing }),
-        textSize,
-        textColor
-      )}
-    >
-      {children}
-    </div>
-  );
-}
+export const ParagraphBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    const { textColor, forcedTextSize, compactSpacing } = useMarkdownStyle();
+    const textSize = forcedTextSize ?? markdownParagraphSize;
+    return (
+      <div
+        className={cn(
+          paragraphBlockVariants({ compactSpacing }),
+          textSize,
+          textColor
+        )}
+      >
+        {children}
+      </div>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+ParagraphBlock.displayName = "ParagraphBlock";

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -22,8 +22,13 @@ export const paragraphBlockVariants = cva(
   }
 );
 
+interface ParagraphBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const ParagraphBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: ParagraphBlockProps) => {
     const { textColor, forcedTextSize, compactSpacing } = useMarkdownStyle();
     const textSize = forcedTextSize ?? markdownParagraphSize;
     return (

--- a/sparkle/src/components/markdown/PreBlock.tsx
+++ b/sparkle/src/components/markdown/PreBlock.tsx
@@ -19,15 +19,14 @@ export const preBlockVariants = cva(
   }
 );
 
+interface PreBlockProps {
+  children: React.ReactNode;
+  variant?: "surface";
+  node?: MarkdownNode;
+}
+
 export const PreBlock = memo(
-  ({
-    children,
-    variant = "surface",
-  }: {
-    children: React.ReactNode;
-    variant?: "surface";
-    node?: MarkdownNode;
-  }) => {
+  ({ children, variant = "surface" }: PreBlockProps) => {
     const validChildrenContent =
       Array.isArray(children) && children[0]
         ? children[0].props.children[0]

--- a/sparkle/src/components/markdown/PreBlock.tsx
+++ b/sparkle/src/components/markdown/PreBlock.tsx
@@ -1,5 +1,9 @@
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { cva } from "class-variance-authority";
-import React from "react";
+import React, { memo } from "react";
 
 export const preBlockVariants = cva(
   [
@@ -15,28 +19,35 @@ export const preBlockVariants = cva(
   }
 );
 
-interface PreBlockProps {
-  children: React.ReactNode;
-  variant?: "surface";
-}
-
-export function PreBlock({ children, variant = "surface" }: PreBlockProps) {
-  const validChildrenContent =
-    Array.isArray(children) && children[0]
-      ? children[0].props.children[0]
-      : null;
-
-  let fallbackData: string | null = null;
-  if (!validChildrenContent) {
-    fallbackData =
+export const PreBlock = memo(
+  ({
+    children,
+    variant = "surface",
+  }: {
+    children: React.ReactNode;
+    variant?: "surface";
+    node?: MarkdownNode;
+  }) => {
+    const validChildrenContent =
       Array.isArray(children) && children[0]
-        ? children[0].props?.node?.data?.meta
+        ? children[0].props.children[0]
         : null;
-  }
 
-  return (
-    <pre className={preBlockVariants({ variant })}>
-      {validChildrenContent ? children : fallbackData || children}
-    </pre>
-  );
-}
+    let fallbackData: string | null = null;
+    if (!validChildrenContent) {
+      fallbackData =
+        Array.isArray(children) && children[0]
+          ? children[0].props?.node?.data?.meta
+          : null;
+    }
+
+    return (
+      <pre className={preBlockVariants({ variant })}>
+        {validChildrenContent ? children : fallbackData || children}
+      </pre>
+    );
+  },
+  (prev, next) =>
+    sameNodePosition(prev.node, next.node) && prev.variant === next.variant
+);
+PreBlock.displayName = "PreBlock";

--- a/sparkle/src/components/markdown/StrongBlock.tsx
+++ b/sparkle/src/components/markdown/StrongBlock.tsx
@@ -4,8 +4,13 @@ import {
 } from "@sparkle/components/markdown/utils";
 import React, { memo } from "react";
 
+interface StrongBlockProps {
+  children?: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const StrongBlock = memo(
-  ({ children }: { children?: React.ReactNode; node?: MarkdownNode }) => (
+  ({ children }: StrongBlockProps) => (
     <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
       {children}
     </strong>

--- a/sparkle/src/components/markdown/StrongBlock.tsx
+++ b/sparkle/src/components/markdown/StrongBlock.tsx
@@ -1,0 +1,15 @@
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
+import React, { memo } from "react";
+
+export const StrongBlock = memo(
+  ({ children }: { children?: React.ReactNode; node?: MarkdownNode }) => (
+    <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
+      {children}
+    </strong>
+  ),
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+StrongBlock.displayName = "StrongBlock";

--- a/sparkle/src/components/markdown/TableBlock.tsx
+++ b/sparkle/src/components/markdown/TableBlock.tsx
@@ -1,6 +1,10 @@
 import { ContentBlockWrapper } from "@sparkle/components/markdown/ContentBlockWrapper";
+import {
+  type MarkdownNode,
+  sameNodePosition,
+} from "@sparkle/components/markdown/utils";
 import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
-import React, { type ReactNode, useMemo } from "react";
+import React, { memo, type ReactNode, useMemo } from "react";
 
 const getNodeText = (node: ReactNode): string => {
   if (["string", "number"].includes(typeof node)) {
@@ -16,100 +20,122 @@ const getNodeText = (node: ReactNode): string => {
   return "";
 };
 
-export function TableBlock({ children }: { children: React.ReactNode }) {
-  const tableData = useMemo(() => {
-    const [headNode, bodyNode] = Array.from(children as [any, any]);
-    if (
-      !headNode ||
-      !bodyNode ||
-      !("props" in headNode) ||
-      !("props" in bodyNode)
-    ) {
-      return;
-    }
+export const TableBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    const tableData = useMemo(() => {
+      const [headNode, bodyNode] = Array.from(children as [any, any]);
+      if (
+        !headNode ||
+        !bodyNode ||
+        !("props" in headNode) ||
+        !("props" in bodyNode)
+      ) {
+        return;
+      }
 
-    const headCells = headNode.props.children[0].props.children.map((c: any) =>
-      getNodeText(c.props.children)
-    );
+      const headCells = headNode.props.children[0].props.children.map(
+        (c: any) => getNodeText(c.props.children)
+      );
 
-    const headHtml = `<thead><tr>${headCells
-      .map((c: any) => `<th><b>${c}</b></th>`)
-      .join("")}</tr></thead>`;
-    const headPlain = headCells.join("\t");
+      const headHtml = `<thead><tr>${headCells
+        .map((c: any) => `<th><b>${c}</b></th>`)
+        .join("")}</tr></thead>`;
+      const headPlain = headCells.join("\t");
 
-    const bodyRows = bodyNode.props.children.map((row: any) =>
-      row.props.children.map((cell: any) => {
-        const children = cell.props.children;
-        return (Array.isArray(children) ? children : [children])
-          .map((child: any) =>
-            child?.type?.name === "CiteBlock" ? "" : getNodeText(child)
-          )
-          .join("");
-      })
-    );
-    const bodyHtml = `<tbody>${bodyRows
-      .map((row: any) => {
-        return `<tr>${row
-          .map((cell: any) => `<td>${cell}</td>`)
-          .join("")}</tr>`;
-      })
-      .join("")}</tbody>`;
-    const bodyPlain = bodyRows.map((row: any) => row.join("\t")).join("\n");
-
-    return {
-      "text/html": `<table>${headHtml}${bodyHtml}</table>`,
-      "text/plain": headPlain + "\n" + bodyPlain,
-    };
-  }, [children]);
-
-  return (
-    <ContentBlockWrapper
-      innerClassName="s-relative s-my-2 s-w-full s-border s-border-border dark:s-border-border-night s-rounded-2xl"
-      content={tableData}
-    >
-      <ScrollArea className="s-w-full s-rounded-2xl">
-        <table className="s-w-full">{children}</table>
-        <ScrollBar orientation="horizontal" />
-      </ScrollArea>
-    </ContentBlockWrapper>
-  );
-}
-
-export function TableHeadBlock({ children }: { children: React.ReactNode }) {
-  return (
-    <thead className="s-bg-muted-background s-px-2 s-py-2 dark:s-bg-muted-background-night">
-      {children}
-    </thead>
-  );
-}
-
-export function TableBodyBlock({ children }: { children: React.ReactNode }) {
-  return (
-    <tbody className="s-bg-white dark:s-bg-background-night">{children}</tbody>
-  );
-}
-
-export function TableHeaderBlock({ children }: { children: React.ReactNode }) {
-  return (
-    <th className="s-truncate s-whitespace-nowrap s-break-words s-py-3.5 s-pl-4 s-text-left s-text-xs s-font-semibold s-text-muted-foreground dark:s-text-muted-foreground-night">
-      {children}
-    </th>
-  );
-}
-
-export function TableDataBlock({ children }: { children: React.ReactNode }) {
-  return (
-    <td className="s-px-4 s-py-3 s-text-sm s-text-foreground dark:s-text-foreground-night">
-      {Array.isArray(children) ? (
-        children.map((child: any, i) => {
-          if (child === "<br>") {
-            return <br key={i} />;
-          }
-          return <React.Fragment key={i}>{child}</React.Fragment>;
+      const bodyRows = bodyNode.props.children.map((row: any) =>
+        row.props.children.map((cell: any) => {
+          const children = cell.props.children;
+          return (Array.isArray(children) ? children : [children])
+            .map((child: any) =>
+              child?.type?.name === "CiteBlock" ? "" : getNodeText(child)
+            )
+            .join("");
         })
-      ) : (
-        <>{children}</>
-      )}
-    </td>
-  );
-}
+      );
+      const bodyHtml = `<tbody>${bodyRows
+        .map((row: any) => {
+          return `<tr>${row
+            .map((cell: any) => `<td>${cell}</td>`)
+            .join("")}</tr>`;
+        })
+        .join("")}</tbody>`;
+      const bodyPlain = bodyRows.map((row: any) => row.join("\t")).join("\n");
+
+      return {
+        "text/html": `<table>${headHtml}${bodyHtml}</table>`,
+        "text/plain": headPlain + "\n" + bodyPlain,
+      };
+    }, [children]);
+
+    return (
+      <ContentBlockWrapper
+        innerClassName="s-relative s-my-2 s-w-full s-border s-border-border dark:s-border-border-night s-rounded-2xl"
+        content={tableData}
+      >
+        <ScrollArea className="s-w-full s-rounded-2xl">
+          <table className="s-w-full">{children}</table>
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
+      </ContentBlockWrapper>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+TableBlock.displayName = "TableBlock";
+
+export const TableHeadBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    return (
+      <thead className="s-bg-muted-background s-px-2 s-py-2 dark:s-bg-muted-background-night">
+        {children}
+      </thead>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+TableHeadBlock.displayName = "TableHeadBlock";
+
+export const TableBodyBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    return (
+      <tbody className="s-bg-white dark:s-bg-background-night">
+        {children}
+      </tbody>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+TableBodyBlock.displayName = "TableBodyBlock";
+
+export const TableHeaderBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    return (
+      <th className="s-truncate s-whitespace-nowrap s-break-words s-py-3.5 s-pl-4 s-text-left s-text-xs s-font-semibold s-text-muted-foreground dark:s-text-muted-foreground-night">
+        {children}
+      </th>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+TableHeaderBlock.displayName = "TableHeaderBlock";
+
+export const TableDataBlock = memo(
+  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+    return (
+      <td className="s-px-4 s-py-3 s-text-sm s-text-foreground dark:s-text-foreground-night">
+        {Array.isArray(children) ? (
+          children.map((child: any, i) => {
+            if (child === "<br>") {
+              return <br key={i} />;
+            }
+            return <React.Fragment key={i}>{child}</React.Fragment>;
+          })
+        ) : (
+          <>{children}</>
+        )}
+      </td>
+    );
+  },
+  (prev, next) => sameNodePosition(prev.node, next.node)
+);
+TableDataBlock.displayName = "TableDataBlock";

--- a/sparkle/src/components/markdown/TableBlock.tsx
+++ b/sparkle/src/components/markdown/TableBlock.tsx
@@ -20,8 +20,13 @@ const getNodeText = (node: ReactNode): string => {
   return "";
 };
 
+interface TableBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const TableBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: TableBlockProps) => {
     const tableData = useMemo(() => {
       const [headNode, bodyNode] = Array.from(children as [any, any]);
       if (
@@ -83,8 +88,13 @@ export const TableBlock = memo(
 );
 TableBlock.displayName = "TableBlock";
 
+interface TableHeadBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const TableHeadBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: TableHeadBlockProps) => {
     return (
       <thead className="s-bg-muted-background s-px-2 s-py-2 dark:s-bg-muted-background-night">
         {children}
@@ -95,8 +105,13 @@ export const TableHeadBlock = memo(
 );
 TableHeadBlock.displayName = "TableHeadBlock";
 
+interface TableBodyBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const TableBodyBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: TableBodyBlockProps) => {
     return (
       <tbody className="s-bg-white dark:s-bg-background-night">
         {children}
@@ -107,8 +122,13 @@ export const TableBodyBlock = memo(
 );
 TableBodyBlock.displayName = "TableBodyBlock";
 
+interface TableHeaderBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const TableHeaderBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: TableHeaderBlockProps) => {
     return (
       <th className="s-truncate s-whitespace-nowrap s-break-words s-py-3.5 s-pl-4 s-text-left s-text-xs s-font-semibold s-text-muted-foreground dark:s-text-muted-foreground-night">
         {children}
@@ -119,8 +139,13 @@ export const TableHeaderBlock = memo(
 );
 TableHeaderBlock.displayName = "TableHeaderBlock";
 
+interface TableDataBlockProps {
+  children: React.ReactNode;
+  node?: MarkdownNode;
+}
+
 export const TableDataBlock = memo(
-  ({ children }: { children: React.ReactNode; node?: MarkdownNode }) => {
+  ({ children }: TableDataBlockProps) => {
     return (
       <td className="s-px-4 s-py-3 s-text-sm s-text-foreground dark:s-text-foreground-night">
         {Array.isArray(children) ? (

--- a/sparkle/src/components/markdown/index.ts
+++ b/sparkle/src/components/markdown/index.ts
@@ -8,4 +8,5 @@ export * from "./MarkdownStyleContext";
 export * from "./PrettyJsonViewer";
 export * from "./QuickReplyBlock";
 export * from "./TableBlock";
+export type { StreamingState } from "./useAnimatedText";
 export * from "./utils";

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -1,0 +1,76 @@
+import { animate } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+export type StreamingState = "streaming" | "none" | "cancelled";
+
+export function useAnimatedText(
+  text: string,
+  streamingState: StreamingState,
+  animationDurationSeconds: number,
+  delimiter: string
+) {
+  const [cursor, setCursor] = useState(0);
+  const [startingCursor, setStartingCursor] = useState(0);
+  const [prevText, setPrevText] = useState(text);
+  const [disableAnimation, setDisableAnimation] = useState(true);
+
+  const controlsRef = useRef<ReturnType<typeof animate> | null>(null);
+  const streamingStateRef = useRef(streamingState);
+  streamingStateRef.current = streamingState;
+
+  // if the new chunks of text have arrived, reset the starting cursor to the current cursor
+  if (prevText !== text) {
+    setPrevText(text);
+    setStartingCursor(cursor);
+  }
+
+  useEffect(() => {
+    if (streamingStateRef.current !== "streaming") {
+      return;
+    }
+
+    setDisableAnimation(false);
+    const textParts = text.split(delimiter);
+
+    // Animates from startingCursor to textParts.length over animationDurationSeconds seconds.
+    // Each time new text arrives, the animation restarts from the current cursor.
+    // The duration is fixed, so the reveal speed depends on the gap (target - cursor):
+    //   - First chunk: small gap (e.g. 29 chars / 1s = ~29 chars/sec) → feels slow/throttled.
+    //   - Later chunks: larger gap (e.g. 131 chars / 1s = ~131 chars/sec) → feels smooth
+    //     because more chars are crammed into the same duration.
+    controlsRef.current = animate(startingCursor, textParts.length, {
+      duration: animationDurationSeconds,
+      ease: "easeOut",
+      // latest is the interpolated cursor position (number of visible characters).
+      onUpdate(latest: number) {
+        setCursor(Math.floor(latest));
+      },
+      onComplete() {
+        setDisableAnimation(true);
+        controlsRef.current = null;
+      },
+    });
+
+    return () => {
+      controlsRef.current?.stop();
+    };
+  }, [startingCursor, text, delimiter, animationDurationSeconds]);
+
+  useEffect(() => {
+    // stop animation if streaming is cancelled.
+    if (streamingState === "cancelled") {
+      controlsRef.current?.stop();
+      controlsRef.current = null;
+    }
+  }, [streamingState]);
+
+  // Return full text immediately if cancelled or none (and animation is finished if streaming before)
+  if (
+    streamingState === "cancelled" ||
+    (streamingState === "none" && disableAnimation)
+  ) {
+    return text;
+  }
+
+  return text.split(delimiter).slice(0, cursor).join(delimiter);
+}

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -6,9 +6,11 @@ export function sameNodePosition(
   prev?: MarkdownNode,
   next?: MarkdownNode
 ): boolean {
+  // Neither has position — nothing to compare, treat as equal.
   if (!(prev?.position || next?.position)) {
     return true;
   }
+  // Only one has position — they differ.
   if (!(prev?.position && next?.position)) {
     return false;
   }

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -1,3 +1,32 @@
+// Minimal type matching ReactMarkdown's AST node position.
+type MarkdownPoint = { line?: number; column?: number };
+type MarkdownPosition = { start?: MarkdownPoint; end?: MarkdownPoint };
+export type MarkdownNode = { position?: MarkdownPosition };
+
+export function sameNodePosition(
+  prev?: MarkdownNode,
+  next?: MarkdownNode
+): boolean {
+  if (!(prev?.position || next?.position)) {
+    return true;
+  }
+  if (!(prev?.position && next?.position)) {
+    return false;
+  }
+
+  const prevStart = prev.position.start;
+  const nextStart = next.position.start;
+  const prevEnd = prev.position.end;
+  const nextEnd = next.position.end;
+
+  return (
+    prevStart?.line === nextStart?.line &&
+    prevStart?.column === nextStart?.column &&
+    prevEnd?.line === nextEnd?.line &&
+    prevEnd?.column === nextEnd?.column
+  );
+}
+
 export function sanitizeContent(str: string): string {
   // (1) Add closing backticks if they are missing such that we render a code block or inline
   // element during streaming.

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -1,7 +1,6 @@
-// Minimal type matching ReactMarkdown's AST node position.
-type MarkdownPoint = { line?: number; column?: number };
-type MarkdownPosition = { start?: MarkdownPoint; end?: MarkdownPoint };
-export type MarkdownNode = { position?: MarkdownPosition };
+import type { Element } from "hast";
+
+export type MarkdownNode = Element;
 
 export function sameNodePosition(
   prev?: MarkdownNode,


### PR DESCRIPTION
## Description
This PR contains https://github.com/dust-tt/dust/pull/22733 too, since if something goes wrong we need to revert them together 

This PR is to memoize markdown components with custom comparison to avoid unnecessary re-renders (this is a requirement for adding streaming animation since streaming animation will re-render markdown a lot). Inspiration came from Vercel's streaming markdown repository [here](https://github.com/vercel/streamdown/blob/c0d45ca15aa3e3de4daf889fb1da050028b23318/packages/streamdown/lib/components.tsx#L60).

There are lots of changes but basically I wrap everything with memo with custom comparison (most of them compare node position from previous render, some of them also compare additional props). The idea is to avoid re-render as long as the node position is the same. 

If you don't know about a custom comparison, you can read more [in the react doc](https://react.dev/reference/react/memo#specifying-a-custom-comparison-function).  

before:

https://github.com/user-attachments/assets/0b1175dc-2f51-4c8c-8e90-1f1f9b28a50f



after:

https://github.com/user-attachments/assets/a94dbfbf-c9ff-4b43-92e9-108db18404aa




<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
