### PR TITLE
Add streaming animation

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -18,7 +18,7 @@ import {
   userMentionDirective,
 } from "@app/lib/mentions/markdown/plugin";
 import type { WorkspaceType } from "@app/types/user";
-import { Markdown } from "@dust-tt/sparkle";
+import { Markdown, type StreamingState } from "@dust-tt/sparkle";
 import React from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
@@ -30,6 +30,7 @@ export const AgentMessageMarkdown = ({
   additionalMarkdownPlugins = [] as PluggableList,
   isLastMessage = false,
   isStreaming = false,
+  streamingState,
   isInstructions = false,
   textColor,
   compactSpacing,
@@ -40,6 +41,7 @@ export const AgentMessageMarkdown = ({
   content: string;
   isLastMessage?: boolean;
   isStreaming?: boolean;
+  streamingState?: StreamingState;
   isInstructions?: boolean;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
@@ -90,6 +92,7 @@ export const AgentMessageMarkdown = ({
       additionalMarkdownPlugins={markdownPlugins}
       isLastMessage={isLastMessage}
       isStreaming={isStreaming}
+      streamingState={streamingState}
       textColor={textColor}
       compactSpacing={compactSpacing}
       forcedTextSize={forcedTextSize}

--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -93,6 +93,7 @@ export const AgentMessageMarkdown = ({
       isLastMessage={isLastMessage}
       isStreaming={isStreaming}
       streamingState={streamingState}
+      enableAnimation
       textColor={textColor}
       compactSpacing={compactSpacing}
       forcedTextSize={forcedTextSize}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -72,7 +72,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types/user";
-import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
+import type { DropdownMenuItemProps, StreamingState } from "@dust-tt/sparkle";
 import {
   ArrowPathIcon,
   Button,
@@ -1137,6 +1137,10 @@ function AgentMessageContent({
               content={sanitizeVisualizationContent(agentMessage.content)}
               owner={owner}
               isStreaming={streaming && lastTokenClassification === "tokens"}
+              streamingState={getStreamingState(
+                streaming && lastTokenClassification === "tokens",
+                agentMessage.status
+              )}
               isLastMessage={isLastMessage}
               additionalMarkdownComponents={additionalMarkdownComponents}
               additionalMarkdownPlugins={additionalMarkdownPlugins}
@@ -1196,6 +1200,19 @@ function AgentMessageContent({
       )}
     </div>
   );
+}
+
+function getStreamingState(
+  isStreaming: boolean,
+  messageStatus: string
+): StreamingState {
+  if (isStreaming) {
+    return "streaming";
+  }
+  if (messageStatus === "cancelled") {
+    return "cancelled";
+  }
+  return "none";
 }
 
 function getCitations({

--- a/package-lock.json
+++ b/package-lock.json
@@ -58138,6 +58138,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "emoji-mart": "^5.5.2",
+        "framer-motion": "^11.18.2",
         "lottie-react": "^2.4.0",
         "lottie-web": "^5.12.2",
         "mermaid": "^11.4.1",
@@ -58207,6 +58208,48 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       }
+    },
+    "sparkle/node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "sparkle/node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "sparkle/node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "sparkle/node_modules/unist-util-visit": {
       "version": "5.1.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -125,6 +125,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "emoji-mart": "^5.5.2",
+    "framer-motion": "^11.18.2",
     "lottie-react": "^2.4.0",
     "lottie-web": "^5.12.2",
     "mermaid": "^11.4.1",

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -27,6 +27,10 @@ import {
   TableHeaderBlock,
 } from "@sparkle/components/markdown/TableBlock";
 import {
+  type StreamingState,
+  useAnimatedText,
+} from "@sparkle/components/markdown/useAnimatedText";
+import {
   preserveLineBreaks,
   sanitizeContent,
 } from "@sparkle/components/markdown/utils";
@@ -40,6 +44,9 @@ import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 
 export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
+
+const DEFAULT_ANIMATION_DURATION = 2;
+const DEFAULT_DELIMITER = "";
 
 function showUnsupportedDirective() {
   return (tree: any) => {
@@ -56,6 +63,7 @@ function showUnsupportedDirective() {
 export interface MarkdownProps {
   content: string;
   isStreaming?: boolean;
+  streamingState?: StreamingState;
   textColor?: string;
   isLastMessage?: boolean;
   compactSpacing?: boolean; // When true, removes vertical padding from paragraph blocks for tighter spacing
@@ -63,11 +71,14 @@ export interface MarkdownProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   canCopyQuotes?: boolean;
+  animationDuration?: number;
+  delimiter?: string;
 }
 
 export const Markdown: React.FC<MarkdownProps> = ({
   content,
   isStreaming = false,
+  streamingState,
   textColor = "s-text-foreground dark:s-text-foreground-night",
   forcedTextSize,
   isLastMessage = false,
@@ -75,7 +86,14 @@ export const Markdown: React.FC<MarkdownProps> = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   canCopyQuotes = true,
+  animationDuration = DEFAULT_ANIMATION_DURATION,
+  delimiter = DEFAULT_DELIMITER,
 }) => {
+  // Derive streaming state: explicit prop takes priority, otherwise derive from isStreaming boolean.
+  // @TODO: remove isStreaming prop and use streamingState prop only
+  const effectiveStreamingState: StreamingState =
+    streamingState ?? (isStreaming ? "streaming" : "none");
+
   const processedContent = useMemo(() => {
     let sanitized = sanitizeContent(content);
     if (compactSpacing) {
@@ -83,6 +101,14 @@ export const Markdown: React.FC<MarkdownProps> = ({
     }
     return sanitized;
   }, [content, compactSpacing]);
+
+  // Animate text during streaming for a smooth reveal effect.
+  const animatedContent = useAnimatedText(
+    processedContent,
+    effectiveStreamingState,
+    animationDuration,
+    delimiter
+  );
 
   const styleContextValue = useMemo(
     () => ({
@@ -166,7 +192,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
           <MarkdownContentContext.Provider
             value={{
               content: processedContent,
-              isStreaming,
+              isStreaming: effectiveStreamingState === "streaming",
               isLastMessage,
             }}
           >
@@ -176,7 +202,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
               remarkPlugins={markdownPlugins}
               rehypePlugins={rehypePlugins}
             >
-              {processedContent}
+              {animatedContent}
             </ReactMarkdown>
           </MarkdownContentContext.Provider>
         </MarkdownStyleContext.Provider>

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -71,6 +71,7 @@ export interface MarkdownProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   canCopyQuotes?: boolean;
+  enableAnimation?: boolean;
   animationDuration?: number;
   delimiter?: string;
 }
@@ -86,6 +87,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   canCopyQuotes = true,
+  enableAnimation = false,
   animationDuration = DEFAULT_ANIMATION_DURATION,
   delimiter = DEFAULT_DELIMITER,
 }) => {
@@ -105,7 +107,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   // Animate text during streaming for a smooth reveal effect.
   const animatedContent = useAnimatedText(
     processedContent,
-    effectiveStreamingState,
+    enableAnimation ? effectiveStreamingState : "none",
     animationDuration,
     delimiter
   );

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -45,7 +45,7 @@ import { visit } from "unist-util-visit";
 
 export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
 
-const DEFAULT_ANIMATION_DURATION = 2;
+const DEFAULT_ANIMATION_DURATION = 1;
 const DEFAULT_DELIMITER = "";
 
 function showUnsupportedDirective() {

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -45,7 +45,7 @@ import { visit } from "unist-util-visit";
 
 export { markdownHeaderClasses } from "@sparkle/components/markdown/markdownSizes";
 
-const DEFAULT_ANIMATION_DURATION = 1;
+const DEFAULT_ANIMATION_DURATION_SECONDS = 1;
 const DEFAULT_DELIMITER = "";
 
 function showUnsupportedDirective() {
@@ -88,7 +88,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   additionalMarkdownPlugins,
   canCopyQuotes = true,
   enableAnimation = false,
-  animationDuration = DEFAULT_ANIMATION_DURATION,
+  animationDuration = DEFAULT_ANIMATION_DURATION_SECONDS,
   delimiter = DEFAULT_DELIMITER,
 }) => {
   // Derive streaming state: explicit prop takes priority, otherwise derive from isStreaming boolean.

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -72,7 +72,7 @@ export interface MarkdownProps {
   additionalMarkdownPlugins?: PluggableList;
   canCopyQuotes?: boolean;
   enableAnimation?: boolean;
-  animationDuration?: number;
+  animationDurationSeconds?: number;
   delimiter?: string;
 }
 
@@ -88,7 +88,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   additionalMarkdownPlugins,
   canCopyQuotes = true,
   enableAnimation = false,
-  animationDuration = DEFAULT_ANIMATION_DURATION_SECONDS,
+  animationDurationSeconds = DEFAULT_ANIMATION_DURATION_SECONDS,
   delimiter = DEFAULT_DELIMITER,
 }) => {
   // Derive streaming state: explicit prop takes priority, otherwise derive from isStreaming boolean.
@@ -108,7 +108,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   const animatedContent = useAnimatedText(
     processedContent,
     enableAnimation ? effectiveStreamingState : "none",
-    animationDuration,
+    animationDurationSeconds,
     delimiter
   );
 

--- a/sparkle/src/components/markdown/index.ts
+++ b/sparkle/src/components/markdown/index.ts
@@ -8,4 +8,5 @@ export * from "./MarkdownStyleContext";
 export * from "./PrettyJsonViewer";
 export * from "./QuickReplyBlock";
 export * from "./TableBlock";
+export type { StreamingState } from "./useAnimatedText";
 export * from "./utils";

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -16,7 +16,6 @@ export function useAnimatedText(
 
   const controlsRef = useRef<ReturnType<typeof animate> | null>(null);
   const streamingStateRef = useRef(streamingState);
-  const hasMultipleChunksRef = useRef(false);
   streamingStateRef.current = streamingState;
 
   // if the new chunks of text have arrived, reset the starting cursor to the current cursor
@@ -65,7 +64,7 @@ export function useAnimatedText(
     }
   }, [streamingState]);
 
-  // Return full text immediately if cancelled or none (and animation is finished)
+  // Return full text immediately if cancelled or none (and animation is finished if streaming before)
   if (
     streamingState === "cancelled" ||
     (streamingState === "none" && disableAnimation)

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -1,0 +1,81 @@
+import { animate } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+export type StreamingState = "streaming" | "none" | "cancelled";
+
+export function useAnimatedText(
+  text: string,
+  streamingState: StreamingState,
+  animationDuration: number,
+  delimiter: string
+) {
+  const [cursor, setCursor] = useState(0);
+  const [startingCursor, setStartingCursor] = useState(0);
+  const [prevText, setPrevText] = useState(text);
+  const [animationDone, setAnimationDone] = useState(true);
+
+  const controlsRef = useRef<ReturnType<typeof animate> | null>(null);
+  const streamingStateRef = useRef(streamingState);
+  const hasMultipleChunksRef = useRef(false);
+  streamingStateRef.current = streamingState;
+
+  if (prevText !== text) {
+    setPrevText(text);
+    setStartingCursor(cursor);
+    if (streamingStateRef.current === "streaming" && startingCursor > 0) {
+      hasMultipleChunksRef.current = true;
+    }
+  }
+
+  useEffect(() => {
+    if (streamingStateRef.current !== "streaming") {
+      return;
+    }
+
+    setAnimationDone(false);
+    const textParts = text.split(delimiter);
+
+    controlsRef.current = animate(startingCursor, textParts.length, {
+      duration: animationDuration,
+      ease: "easeOut",
+      onUpdate(latest: number) {
+        setCursor(Math.floor(latest));
+      },
+      onComplete() {
+        setAnimationDone(true);
+        controlsRef.current = null;
+      },
+    });
+
+    return () => {
+      controlsRef.current?.stop();
+    };
+  }, [startingCursor, text, delimiter, animationDuration]);
+
+  useEffect(() => {
+    if (streamingState === "cancelled") {
+      controlsRef.current?.stop();
+      controlsRef.current = null;
+    }
+    if (streamingState === "none" && !hasMultipleChunksRef.current) {
+      // Text arrived in a single chunk — skip animation.
+      controlsRef.current?.stop();
+      controlsRef.current = null;
+      setAnimationDone(true);
+    }
+    if (streamingState === "streaming") {
+      hasMultipleChunksRef.current = false;
+    }
+  }, [streamingState]);
+
+  // Return full text immediately if cancelled
+  // Return full text if ended and animation is done
+  if (
+    streamingState === "cancelled" ||
+    (streamingState === "none" && animationDone)
+  ) {
+    return text;
+  }
+
+  return text.split(delimiter).slice(0, cursor).join(delimiter);
+}

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -12,19 +12,17 @@ export function useAnimatedText(
   const [cursor, setCursor] = useState(0);
   const [startingCursor, setStartingCursor] = useState(0);
   const [prevText, setPrevText] = useState(text);
-  const [animationDone, setAnimationDone] = useState(true);
+  const [disableAnimation, setDisableAnimation] = useState(true);
 
   const controlsRef = useRef<ReturnType<typeof animate> | null>(null);
   const streamingStateRef = useRef(streamingState);
   const hasMultipleChunksRef = useRef(false);
   streamingStateRef.current = streamingState;
 
+  // if the new chunks of text have arrived, reset the starting cursor to the current cursor
   if (prevText !== text) {
     setPrevText(text);
     setStartingCursor(cursor);
-    if (streamingStateRef.current === "streaming" && startingCursor > 0) {
-      hasMultipleChunksRef.current = true;
-    }
   }
 
   useEffect(() => {
@@ -32,17 +30,24 @@ export function useAnimatedText(
       return;
     }
 
-    setAnimationDone(false);
+    setDisableAnimation(false);
     const textParts = text.split(delimiter);
 
+    // Animates from startingCursor to textParts.length over animationDuration seconds.
+    // Each time new text arrives, the animation restarts from the current cursor.
+    // The duration is fixed, so the reveal speed depends on the gap (target - cursor):
+    //   - First chunk: small gap (e.g. 29 chars / 1s = ~29 chars/sec) → feels slow/throttled.
+    //   - Later chunks: larger gap (e.g. 131 chars / 1s = ~131 chars/sec) → feels smooth
+    //     because more chars are crammed into the same duration.
     controlsRef.current = animate(startingCursor, textParts.length, {
       duration: animationDuration,
       ease: "easeOut",
+      // latest is the interpolated cursor position (number of visible characters).
       onUpdate(latest: number) {
         setCursor(Math.floor(latest));
       },
       onComplete() {
-        setAnimationDone(true);
+        setDisableAnimation(true);
         controlsRef.current = null;
       },
     });
@@ -53,26 +58,17 @@ export function useAnimatedText(
   }, [startingCursor, text, delimiter, animationDuration]);
 
   useEffect(() => {
+    // stop animation if streaming is cancelled.
     if (streamingState === "cancelled") {
       controlsRef.current?.stop();
       controlsRef.current = null;
     }
-    if (streamingState === "none" && !hasMultipleChunksRef.current) {
-      // Text arrived in a single chunk — skip animation.
-      controlsRef.current?.stop();
-      controlsRef.current = null;
-      setAnimationDone(true);
-    }
-    if (streamingState === "streaming") {
-      hasMultipleChunksRef.current = false;
-    }
   }, [streamingState]);
 
-  // Return full text immediately if cancelled
-  // Return full text if ended and animation is done
+  // Return full text immediately if cancelled or none (and animation is finished)
   if (
     streamingState === "cancelled" ||
-    (streamingState === "none" && animationDone)
+    (streamingState === "none" && disableAnimation)
   ) {
     return text;
   }

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -6,7 +6,7 @@ export type StreamingState = "streaming" | "none" | "cancelled";
 export function useAnimatedText(
   text: string,
   streamingState: StreamingState,
-  animationDuration: number,
+  animationDurationSeconds: number,
   delimiter: string
 ) {
   const [cursor, setCursor] = useState(0);
@@ -32,14 +32,14 @@ export function useAnimatedText(
     setDisableAnimation(false);
     const textParts = text.split(delimiter);
 
-    // Animates from startingCursor to textParts.length over animationDuration seconds.
+    // Animates from startingCursor to textParts.length over animationDurationSeconds seconds.
     // Each time new text arrives, the animation restarts from the current cursor.
     // The duration is fixed, so the reveal speed depends on the gap (target - cursor):
     //   - First chunk: small gap (e.g. 29 chars / 1s = ~29 chars/sec) → feels slow/throttled.
     //   - Later chunks: larger gap (e.g. 131 chars / 1s = ~131 chars/sec) → feels smooth
     //     because more chars are crammed into the same duration.
     controlsRef.current = animate(startingCursor, textParts.length, {
-      duration: animationDuration,
+      duration: animationDurationSeconds,
       ease: "easeOut",
       // latest is the interpolated cursor position (number of visible characters).
       onUpdate(latest: number) {
@@ -54,7 +54,7 @@ export function useAnimatedText(
     return () => {
       controlsRef.current?.stop();
     };
-  }, [startingCursor, text, delimiter, animationDuration]);
+  }, [startingCursor, text, delimiter, animationDurationSeconds]);
 
   useEffect(() => {
     // stop animation if streaming is cancelled.


### PR DESCRIPTION
## Description
This PR is to add streaming animation to AgentMessage. You can test it here: https://a4f786fd--app.preview.dust.tt/w/0ec9852c2f

Base animation implementation came from [here](https://buildui.com/recipes/use-animated-text) (there is a tutorial video too). 

Each markdown component has been memoized so it won't be re-rendered unless its position changes (done in [this PR](https://github.com/dust-tt/dust/pull/22732))

Some notes:
- It doesn't feel nice when a response is ultra short since it feels a bit slow (like when you just say "Hello"), I will see if I can tweak it.
- I didn't add it to the thinking tokens display since it didn't really feel nice (probably we should do line by line animation but I know we are redesigning it so I would not touch for now). 
- I tried but it's a bit too complex to avoid showing incomplete (?) markdown (e.g. `**AB`). Since it's already better than the current one I think it's okay to start with it. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
I'm not sure how it performs on low end machines. I tested it on my phone and everything feels okay 

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
