### PR TITLE
[front] Update "Trusted by" count from 2,000+ to 5,000+

### DIFF
--- a/front/components/home/TrustedBy.tsx
+++ b/front/components/home/TrustedBy.tsx
@@ -245,7 +245,7 @@ export default function TrustedBy({
     >
       {showTitle && (
         <H4 className="mb-6 w-full text-center text-foreground">
-          Trusted by <span className="text-blue-500">2,000+</span> organizations
+          Trusted by <span className="text-blue-500">5,000+</span> organizations
         </H4>
       )}
 

--- a/front/components/home/content/Skip/config/skipConfig.tsx
+++ b/front/components/home/content/Skip/config/skipConfig.tsx
@@ -95,7 +95,7 @@ export const skipConfig: SkipConfig = {
         embedUrl: "https://www.youtube.com/embed/38vCIR2yHoA",
       },
     ],
-    usersCount: "2,000+ teams already using Dust",
+    usersCount: "5,000+ teams already using Dust",
   },
 
   trustedByTitle: "TRUSTED BY AMBITIOUS TEAMS AT:",

--- a/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
+++ b/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
@@ -106,7 +106,7 @@ export const sqAgentConfig: SqAgentConfig = {
         embedUrl: "https://www.youtube.com/embed/38vCIR2yHoA",
       },
     ],
-    usersCount: "2,000+ teams already using Dust",
+    usersCount: "5,000+ teams already using Dust",
   },
 
   trustedByTitle: "TRUSTED BY LEADING B2B SAAS COMPANIES",


### PR DESCRIPTION
## Description

Updates the "Trusted by" count from 2,000+ to 5,000+ teams across the homepage and landing pages to reflect current user growth. Changes are applied to the main `TrustedBy` component and the Skip and SqAgent landing page configurations.

## Tests

Manual verification of the updated text on the homepage and relevant landing pages.

## Risk

None - text-only change with no functional impact.