### PR TITLE
Title: Fix Poké reinvite to generate fresh invitation with new 7-day token

### DIFF
--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -1,17 +1,46 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
 import {
   ClipboardIcon,
   IconButton,
   MovingMailIcon,
+  Tooltip,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+const INVITATION_EXPIRATION_TIME_MS = INVITATION_EXPIRATION_TIME_SEC * 1000;
+
+function formatExpiresIn(createdAt: number): {
+  label: string;
+  isExpired: boolean;
+  exactDate: string;
+} {
+  const expiresAtMs =
+    new Date(createdAt).getTime() + INVITATION_EXPIRATION_TIME_MS;
+  const nowMs = Date.now();
+  const diffMs = expiresAtMs - nowMs;
+  const exactDate = new Date(expiresAtMs).toLocaleString();
+
+  if (diffMs <= 0) {
+    const agoMs = Math.abs(diffMs);
+    const agoHours = Math.floor(agoMs / (1000 * 60 * 60));
+    const agoDays = Math.floor(agoHours / 24);
+    const label = agoDays > 0 ? `${agoDays}d ago` : `${agoHours}h ago`;
+    return { label, isExpired: true, exactDate };
+  }
+
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+  const label = days > 0 ? `in ${days}d` : `in ${hours}h`;
+  return { label, isExpired: false, exactDate };
+}
+
 export function makeColumnsForInvitations(
   onRevokeInvitation: (email: string) => Promise<void>,
-  onResendInvitation: (invitationId: string) => Promise<void>
+  onReinvite: (invitationId: string) => Promise<void>
 ): ColumnDef<MembershipInvitationTypeWithLink>[] {
   return [
     {
@@ -33,10 +62,20 @@ export function makeColumnsForInvitations(
       ),
     },
     {
-      accessorKey: "isExpired",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Expired" />
-      ),
+      id: "expires",
+      header: "Expires",
+      cell: ({ row }) => {
+        const createdAt: number = row.original.createdAt;
+        const { label, isExpired, exactDate } = formatExpiresIn(createdAt);
+        return (
+          <Tooltip
+            label={exactDate}
+            trigger={
+              <span className={isExpired ? "text-red-500" : ""}>{label}</span>
+            }
+          />
+        );
+      },
     },
     {
       accessorKey: "inviteLink",
@@ -67,8 +106,8 @@ export function makeColumnsForInvitations(
       },
     },
     {
-      id: "resend",
-      header: "Resend",
+      id: "reinvite",
+      header: "Reinvite",
       cell: ({ row }) => {
         const invitation = row.original;
 
@@ -77,9 +116,9 @@ export function makeColumnsForInvitations(
             icon={MovingMailIcon}
             size="xs"
             variant="outline"
-            tooltip="Resend invitation email"
+            tooltip="Reinvite (revokes current and sends a new invitation)"
             onClick={async () => {
-              await onResendInvitation(invitation.sId);
+              await onReinvite(invitation.sId);
             }}
           />
         );

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -16,8 +16,12 @@ export function InvitationsDataTable({
   invitations,
 }: InvitationsDataTableProps) {
   const router = useAppRouter();
-  async function onResendInvitation(invitationId: string): Promise<void> {
-    if (!window.confirm("Are you sure you want to resend this invitation?")) {
+  async function onReinvite(invitationId: string): Promise<void> {
+    if (
+      !window.confirm(
+        "This will revoke the current invitation and send a new one with a fresh 7-day validity. Continue?"
+      )
+    ) {
       return;
     }
 
@@ -29,14 +33,16 @@ export function InvitationsDataTable({
         }
       );
       if (!r.ok) {
-        throw new Error(`Failed to resend invitation: ${r.statusText}`);
+        throw new Error(`Failed to reinvite: ${r.statusText}`);
       }
       const response = await r.json();
-      window.alert("Invitation resent successfully to " + response.email + ".");
+      window.alert(
+        "New invitation sent successfully to " + response.email + "."
+      );
       router.reload();
     } catch (e) {
       console.error(e);
-      window.alert("An error occurred while resending the invitation.");
+      window.alert("An error occurred while reinviting.");
     }
   }
 
@@ -75,10 +81,7 @@ export function InvitationsDataTable({
           <h2 className="text-md mb-4 font-bold">Pending Invitations:</h2>
         </div>
         <PokeDataTable
-          columns={makeColumnsForInvitations(
-            onRevokeInvitation,
-            onResendInvitation
-          )}
+          columns={makeColumnsForInvitations(onRevokeInvitation, onReinvite)}
           data={invitations}
           defaultFilterColumn="inviteEmail"
         />

--- a/front/pages/api/poke/workspaces/[wId]/invitations/[iId].test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/[iId].test.ts
@@ -1,0 +1,90 @@
+import { Authenticator } from "@app/lib/auth";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
+import sgMail from "@sendgrid/mail";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./[iId]";
+
+// Mock SendGrid so no real emails are sent.
+vi.spyOn(sgMail, "setApiKey").mockImplementation(() => {});
+vi.spyOn(sgMail, "send").mockResolvedValue([
+  { statusCode: 202, headers: {}, body: {} },
+  {},
+] as never);
+
+// Mock config to provide required values for invitation emails.
+vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      getSendgridApiKey: vi.fn().mockReturnValue("SG.test"),
+      getInvitationEmailTemplate: vi.fn().mockReturnValue("d-test"),
+      getSupportEmailAddress: vi.fn().mockReturnValue("test@dust.tt"),
+      getAppUrl: vi.fn().mockReturnValue("http://localhost:3000"),
+      getDustInviteTokenSecret: vi
+        .fn()
+        .mockReturnValue("test-invite-secret-32chars!!!!!"),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PATCH /api/poke/workspaces/[wId]/invitations/[iId]", () => {
+  it("revokes the old invitation and creates a new one with a fresh createdAt", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    // Create a pending invitation that was created 5 days ago.
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    const invitation = await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: "test-reinvite@example.com",
+      status: "pending",
+      initialRole: "user",
+      createdAt: fiveDaysAgo,
+    });
+
+    req.query.iId = invitation.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.success).toBe(true);
+    expect(data.email).toBe("test-reinvite@example.com");
+
+    // The original invitation should now be revoked.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const oldInvitation = await MembershipInvitationResource.fetchById(
+      adminAuth,
+      invitation.sId
+    );
+    expect(oldInvitation).not.toBeNull();
+    expect(oldInvitation!.status).toBe("revoked");
+
+    // A new pending invitation should exist for the same email.
+    const newInvitations =
+      await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+        email: "test-reinvite@example.com",
+        workspace,
+        includeExpired: false,
+      });
+    expect(newInvitations).not.toBeNull();
+    expect(newInvitations!.sId).not.toBe(invitation.sId);
+
+    // The new invitation should have a recent createdAt (within the last minute).
+    const newCreatedAtMs = newInvitations!.createdAt.getTime();
+    expect(newCreatedAtMs).toBeGreaterThan(Date.now() - 60_000);
+  });
+});

--- a/front/pages/api/poke/workspaces/[wId]/invitations/[iId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/[iId].ts
@@ -73,6 +73,10 @@ async function handler(
 
   switch (req.method) {
     case "PATCH": {
+      // Revoke the existing invitation so that a brand new one is created
+      // with a fresh createdAt (and therefore a fresh 7-day token).
+      await invitation.revoke();
+
       const invitationRes = await handleMembershipInvitations(
         workspaceAdminAuth,
         {


### PR DESCRIPTION
## Description

The "Resend" button on Poké's Pending Invitations list had a subtle "issue": it re-sent the invitation email, but the JWT token's expiry was always computed from the original createdAt timestamp. This meant resending an invitation created 5 days ago would produce a token valid for only 2 more days and not the full 7-day window the recipient expects.

This change makes the Poké action revoke the existing invitation and create a brand new one, giving the recipient a fresh 7-day validity window. The button is renamed from "Resend" to "Reinvite" to reflect this behavior, and a confirmation dialog explains what will happen.

One trade-off: since the old invitation is revoked, any previously sent link becomes invalid and the user must use the link from the latest email. This feels worth it though, as it solves the many cases where users struggle to sign up, the GTM team resends the invite, and it still doesn't work because the token is about to expire, generating runner cards for nothing.

On the list view in Poké the isExpired boolean column is replaced with an "Expires" column showing relative time (e.g. "in 3d", "5h ago") with the exact expiry date available on hover via a tooltip. Expired invitations are highlighted in red.

## Tests

A functional test verifies that the PATCH endpoint correctly revokes the old invitation and creates a new one with a fresh createdAt.

Also tested locally. 

## Risk

Poké only. 

## Deploy Plan

Deploy front. 