### PR TITLE
Add tooltip to Project Settings tab icon

### DIFF
--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -333,7 +333,7 @@ export function SpaceConversationsPage() {
                 />
               </>
             )}
-            <TabsTrigger value="settings" icon={Cog6ToothIcon} />
+            <TabsTrigger value="settings" icon={Cog6ToothIcon} tooltip="Settings" />
             <TabsTrigger
               value="alpha"
               label="Alpha"

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -333,7 +333,11 @@ export function SpaceConversationsPage() {
                 />
               </>
             )}
-            <TabsTrigger value="settings" icon={Cog6ToothIcon} tooltip="Settings" />
+            <TabsTrigger
+              value="settings"
+              icon={Cog6ToothIcon}
+              tooltip="Settings"
+            />
             <TabsTrigger
               value="alpha"
               label="Alpha"


### PR DESCRIPTION
## Summary
- Add a "Settings" tooltip to the Project view's Settings tab, which only displays a cog icon without a label
- Uses the existing `tooltip` prop on `TabsTrigger` — no component changes needed

## Test plan
- [x] Navigate to a Project view
- [x] Hover over the Settings (cog) icon tab
- [x] Verify a "Settings" tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)