### PR TITLE
Login/logout consistency

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -628,7 +628,7 @@ const refreshToken = async (
         });
       });
     } catch (error) {
-      log("Token refresh failed: unknown error", error);
+      log("Token refresh failed", error);
       const handlers = state.refreshRequests;
       state.refreshRequests = [];
       handlers.forEach((sendResponse) => {
@@ -693,39 +693,47 @@ const logout = async (
     response: AuthBackgroundResponseSuccess | AuthBackgroundResponseError
   ) => void
 ) => {
-  const redirectUri = chrome.identity.getRedirectURL();
-  const queryParams: Record<string, string> = {
-    returnTo: redirectUri,
-  };
-  // We need to get the session to log out the user from WorkOS.
   const accessToken = await platform.auth.getAccessToken();
-  if (accessToken) {
-    const decodedPayload = jwtDecode<Record<string, string>>(accessToken);
-    if (decodedPayload) {
-      queryParams.session_id = decodedPayload.sid || "";
-    }
-  } else {
+  if (!accessToken) {
     log("No access token found for WorkOS logout.");
     sendResponse({ success: false, error: "No access token found." });
     return;
   }
 
-  const logoutUrl = `${DUST_US_URL}/api/workos/logout-url?${new URLSearchParams(
-    queryParams
-  )}`;
+  const decodedPayload = jwtDecode<Record<string, string>>(accessToken);
+  const sessionId = decodedPayload?.sid;
+  if (!sessionId) {
+    log("No session ID found in access token.");
+    sendResponse({ success: false, error: "No session ID found." });
+    return;
+  }
 
-  chrome.identity.launchWebAuthFlow(
-    { url: logoutUrl, interactive: false },
-    () => {
-      if (chrome.runtime.lastError) {
-        log("Logout failed:", chrome.runtime.lastError.message);
-        sendResponse({
-          success: false,
-          error: `Logout failed: ${chrome.runtime.lastError.message}`,
-        });
-      } else {
-        sendResponse({ success: true });
-      }
+  try {
+    const response = await fetch(`${DUST_US_URL}/api/workos/revoke-session`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      credentials: "omit",
+      body: JSON.stringify({ session_id: sessionId }),
+    });
+
+    if (!response.ok) {
+      log("Revoke session failed:", response.status);
+      sendResponse({
+        success: false,
+        error: `Revoke session failed: ${response.status}`,
+      });
+      return;
     }
-  );
+
+    sendResponse({ success: true });
+  } catch (error) {
+    log("Revoke session failed:", error);
+    sendResponse({
+      success: false,
+      error: `Revoke session failed: ${error}`,
+    });
+  }
 };

--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -51,8 +51,9 @@ export class ChromeAuthService extends AuthService {
       const storedTokens = await this.saveTokens(response);
       return new Ok(storedTokens);
     } catch (error) {
-      log("Refresh token: unknown error.", error);
-      return new Err(new AuthError("not_authenticated", error?.toString()));
+      return new Err(
+        new AuthError("invalid_oauth_token_error", error?.toString())
+      );
     }
   }
 

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -180,16 +180,15 @@ export class FrontAuthService extends AuthService {
   }
 
   async logout(): Promise<boolean> {
-    const queryParams: Record<string, string> = {
-      returnTo: FRONT_EXTENSION_URL,
-    };
-
     const accessToken = await this.getAccessToken();
-    if (accessToken) {
-      const decodedPayload = jwtDecode<Record<string, string>>(accessToken);
-      if (decodedPayload) {
-        queryParams.session_id = decodedPayload.sid || "";
-      }
+    if (!accessToken) {
+      return true;
+    }
+
+    const decodedPayload = jwtDecode<Record<string, string>>(accessToken);
+    const sessionId = decodedPayload?.sid;
+    if (!sessionId) {
+      return true;
     }
 
     const regionInfo = await this.getRegionInfoFromStorage();
@@ -197,23 +196,21 @@ export class FrontAuthService extends AuthService {
       return true;
     }
 
-    const logoutUrl = `${regionInfo.url}/api/workos/logout?${new URLSearchParams(
-      queryParams
-    )}`;
-
-    const result = await openAndWaitForPopup<void>(
-      logoutUrl,
-      "Logout",
-      (popup) => {
-        const popupUrl = popup.location.href;
-        return popupUrl.includes(FRONT_EXTENSION_URL)
-          ? { data: undefined }
-          : null;
+    const response = await fetch(
+      `${regionInfo.url}/api/workos/revoke-session`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        credentials: "omit",
+        body: JSON.stringify({ session_id: sessionId }),
       }
     );
 
-    if (result.error) {
-      throw result.error;
+    if (!response.ok) {
+      throw new Error(`Revoke session failed: ${response.status}`);
     }
 
     return true;
@@ -227,7 +224,7 @@ export class FrontAuthService extends AuthService {
       tokens.expiresAt < Date.now() ||
       forceRefresh
     ) {
-      const refreshRes = await this.refreshToken();
+      const refreshRes = await this.refreshToken(tokens);
       if (refreshRes.isOk()) {
         tokens = refreshRes.value;
       } else {
@@ -238,18 +235,19 @@ export class FrontAuthService extends AuthService {
     return tokens?.accessToken ?? null;
   }
 
-  async refreshToken(): Promise<Result<StoredTokens, AuthError>> {
+  async refreshToken(
+    tokens: StoredTokens | null
+  ): Promise<Result<StoredTokens, AuthError>> {
     try {
+      tokens = tokens ?? (await this.getStoredTokens());
+      if (!tokens) {
+        return new Err(new AuthError("not_authenticated", "No tokens found."));
+      }
+
       const tokenParams: Record<string, string> = {
         grant_type: "refresh_token",
-        refresh_token: (await this.getStoredTokens())?.refreshToken || "",
+        refresh_token: tokens.refreshToken ?? "",
       };
-
-      if (!tokenParams.refresh_token) {
-        return new Err(
-          new AuthError("invalid_oauth_token_error", "No refresh token")
-        );
-      }
 
       const regionInfo = await this.getRegionInfoFromStorage();
       if (!regionInfo) {

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -99,9 +99,11 @@ export const useAuthHook = () => {
     const newAccessToken = await platform.auth.getAccessToken(true);
     if (!newAccessToken) {
       setAuthError(
-        new AuthError("not_authenticated", "No access token received.")
+        new AuthError(
+          "not_authenticated",
+          "Session expired. Please sign in again."
+        )
       );
-      log("Refresh token: No access token received.");
       setIsLoading(false);
       return;
     }

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -18,7 +18,7 @@ import { statsDClient } from "@app/logger/statsDClient";
 import { isDevelopment } from "@app/types/shared/env";
 import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
-import { GenericServerException } from "@workos-inc/node";
+import { GenericServerException, OauthException } from "@workos-inc/node";
 import { sealData } from "iron-session";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -45,8 +45,8 @@ export default async function handler(
       return handleAuthenticate(req, res);
     case "logout":
       return handleLogout(req, res);
-    case "logout-url":
-      return handleLogoutUrl(req, res);
+    case "revoke-session":
+      return handleRevokeSession(req, res);
     default:
       return res.status(400).json({ error: "Invalid action" });
   }
@@ -143,12 +143,17 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
   const { code, grant_type, refresh_token, code_verifier } = req.body;
 
   if (grant_type && !isString(grant_type)) {
-    return res.status(400).json({ error: "Invalid grant_type" });
+    return res
+      .status(400)
+      .json({ error: "Invalid grant_type", type: "invalid_request_error" });
   }
 
   if (grant_type === "refresh_token") {
     if (!refresh_token || !isString(refresh_token)) {
-      return res.status(400).json({ error: "Invalid refresh token" });
+      return res.status(400).json({
+        error: "Invalid refresh token",
+        type: "invalid_request_error",
+      });
     }
     try {
       const result =
@@ -158,8 +163,17 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
         });
       return res.status(200).json(result);
     } catch (error) {
-      logger.error({ error }, "Error during WorkOS token refresh");
-      return res.status(500).json({ error: "Authentication failed" });
+      if (error instanceof OauthException) {
+        return res
+          .status(error.status)
+          .json({ error: error.errorDescription, type: error.error });
+      } else {
+        logger.error({ error }, "Error during WorkOS token refresh");
+        return res.status(500).json({
+          error: "Authentication failed",
+          type: "internal_server_error",
+        });
+      }
     }
   }
 
@@ -185,8 +199,17 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
 
     return res.status(200).json({ ...authResult, expiresIn });
   } catch (error) {
-    logger.error({ error }, "Error during WorkOS authentication");
-    return res.status(500).json({ error: "Authentication failed" });
+    if (error instanceof OauthException) {
+      return res
+        .status(error.status)
+        .json({ error: error.errorDescription, type: error.error });
+    } else {
+      logger.error({ error }, "Error during WorkOS authentication");
+      return res.status(500).json({
+        error: "Authentication failed",
+        type: "internal_server_error",
+      });
+    }
   }
 }
 
@@ -483,18 +506,31 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
   redirectTo(res, sanitizedReturnTo);
 }
 
-async function handleLogoutUrl(req: NextApiRequest, res: NextApiResponse) {
-  const { session_id, returnTo } = req.query;
+/**
+ * Revoke a specific WorkOS session via API (same as handleLogout but accepts
+ * session_id from request body instead of reading from cookie).
+ * Used by the Chrome extension which authenticates with Bearer tokens.
+ */
+async function handleRevokeSession(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { session_id } = req.body;
 
   if (!session_id || !isString(session_id)) {
     return res.status(400).json({ error: "Invalid session_id" });
   }
-  const logoutUrl = getWorkOS().userManagement.getLogoutUrl({
-    sessionId: session_id,
-    returnTo: isString(returnTo) ? returnTo : undefined,
-  });
 
-  return res.redirect(logoutUrl);
+  try {
+    await getWorkOS().userManagement.revokeSession({
+      sessionId: session_id,
+    });
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    logger.error({ error }, "Error during WorkOS session revocation");
+    return res.status(500).json({ error: "Session revocation failed" });
+  }
 }
 
 function redirectTo(res: NextApiResponse, sanitizedReturnTo: string) {


### PR DESCRIPTION
## Description

Standardize extension logout to use `revokeSession` (same as the webapp) instead of `getLogoutUrl` which was doing a full AuthKit logout redirect. Remove the now-unused `logout-url` endpoint.

### Changes

**Backend (`front/pages/api/workos/[action].ts`)**:
- Add new `revoke-session` action: accepts a POST with `session_id` in the body, calls `revokeSession({ sessionId })` server-side. Used by the extension which authenticates with Bearer tokens (no cookies).
- Remove `logout-url` action and `handleLogoutUrl` function: no longer used by any client.
- Improve error handling in `handleAuthenticate`: surface `OauthException` errors with proper status codes and error types instead of generic 500s.

**Chrome extension (`extension/platforms/chrome/background.ts`)**:
- Replace `launchWebAuthFlow` + `logout-url` (full AuthKit logout) with a POST to `revoke-session` (session revocation only). This is consistent with how the webapp handles logout.

**Front extension (`extension/platforms/front/services/auth.ts`)**:
- Replace popup-based logout (opening `/api/workos/logout`) with a POST to `revoke-session`, matching the Chrome extension behavior.
- Align `refreshToken` signature with Chrome platform (accept `tokens` parameter).

**Auth error handling (`extension/ui/components/auth/useAuth.ts`, `extension/platforms/chrome/services/auth.ts`)**:
- Improve error messages on session expiry.

### Context

The extension and webapp share the same WorkOS AuthKit session (single client ID, `launchWebAuthFlow` shares browser cookies). Previously the extension used `getLogoutUrl` which destroyed the AuthKit session entirely — a more aggressive logout than needed. Now all logout flows (webapp, Chrome extension, front extension) consistently use `revokeSession`, which invalidates the session server-side without the redirect dance.

## Tests

Manual testing of login/logout flows on both extension and webapp.

## Risk

Low. `revokeSession` is already used by the webapp logout. The new `revoke-session` endpoint is additive. The removed `logout-url` endpoint had no remaining callers. Extension logout behavior changes from redirect-based to API-based but the end result (session invalidated) is the same.

## Deploy Plan

Deploy front first (adds the `revoke-session` endpoint), then deploy the extension.