### PR TITLE
[front] feat: add `discover_skills` skill

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -258,7 +258,6 @@ function constructSkillsSection({
 
     skillsSection += skillInstructions.join("\n");
   }
-  skillsSection += "\n";
 
   // Equipped but not yet enabled skills - show name and description only
   if (equippedSkills && equippedSkills.length > 0) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -258,6 +258,7 @@ function constructSkillsSection({
 
     skillsSection += skillInstructions.join("\n");
   }
+  skillsSection += "\n";
 
   // Equipped but not yet enabled skills - show name and description only
   if (equippedSkills && equippedSkills.length > 0) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -271,7 +271,7 @@ function constructSkillsSection({
           `- **${name}**: ${agentFacingDescription}`
       )
       .join("\n");
-    skillsSection += skillList + "\n";
+    skillsSection += skillList + "\n\n";
   }
 
   return skillsSection;

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -482,7 +482,7 @@ function _getDustLikeGlobalAgent(
     ...dustAgent,
     status: "active",
     actions,
-    skills: ["frames", "go-deep", "mention_users"],
+    skills: ["discover_skills", "frames", "go-deep", "mention_users"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -122,6 +122,10 @@ SkillConfigurationModel.init(SKILL_MODEL_ATTRIBUTES, {
       concurrently: true,
     },
     {
+      fields: ["workspaceId", "status", "isDefault"],
+      concurrently: true,
+    },
+    {
       fields: ["workspaceId", "editedBy"],
       concurrently: true,
     },

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -1,0 +1,57 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import type {
+  FetchInstructionsContext,
+  GlobalSkillDefinition,
+} from "@app/lib/resources/skill/global/registry";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+
+function buildDiscoverSkillsInstructions(
+  defaultSkills: SkillResource[]
+): string {
+  if (defaultSkills.length === 0) {
+    return "No workspace skills are currently available for discovery.";
+  }
+
+  const skillList = defaultSkills
+    .map(
+      ({ name, agentFacingDescription }) =>
+        `- **${name}**: ${agentFacingDescription}`
+    )
+    .join("\n");
+
+  return `<discover_skills_guidelines>
+The following workspace skills are available to enable for this conversation.
+Enable relevant skills using the \`enable_skill\` tool when a user's request matches a skill's purpose.
+
+<available_workspace_skills>
+${skillList}
+</available_workspace_skills>
+</discover_skills_guidelines>`;
+}
+
+export const discoverSkillsSkill = {
+  sId: "discover_skills",
+  name: "Discover Skills",
+  userFacingDescription:
+    "Automatically discover and activate workspace skills as needed.",
+  agentFacingDescription:
+    "List available workspace skills and enable them for the current conversation.",
+  fetchInstructions: async (
+    _auth: Authenticator,
+    _spaceIds: string[],
+    { listDefaultSkills }: FetchInstructionsContext
+  ) => {
+    const defaultSkills = await listDefaultSkills();
+
+    return buildDiscoverSkillsInstructions(defaultSkills);
+  },
+  version: 1,
+  icon: "PuzzleIcon",
+  isAutoEnabled: true,
+  isRestricted: async (auth: Authenticator) => {
+    const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
+    return !flags.includes("discover_skills");
+  },
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -13,7 +13,8 @@ function buildDiscoverSkillsInstructions(
     return "No workspace skills are currently available for discovery.";
   }
 
-  const skillList = discoverableSkills
+  const skillList = [...discoverableSkills]
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map(
       ({ name, agentFacingDescription }) =>
         `- **${name}**: ${agentFacingDescription}`

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -2,6 +2,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 
+// This skill allows discovering skills from the workspace. When equipped on an
+// agent, it causes `listForAgentLoop` to include discoverable skills (custom
+// default skills + non-auto-enabled global skills) in the equipped skills list.
 export const discoverSkillsSkill = {
   sId: "discover_skills",
   name: "Discover Skills",

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -40,9 +40,9 @@ export const discoverSkillsSkill = {
   fetchInstructions: async (
     _auth: Authenticator,
     _spaceIds: string[],
-    { listDefaultSkills }: FetchInstructionsContext
+    { listDiscoverable }: FetchInstructionsContext
   ) => {
-    const defaultSkills = await listDefaultSkills();
+    const defaultSkills = await listDiscoverable();
 
     return buildDiscoverSkillsInstructions(defaultSkills);
   },

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -1,35 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import type {
-  FetchInstructionsContext,
-  GlobalSkillDefinition,
-} from "@app/lib/resources/skill/global/registry";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
-
-function buildDiscoverSkillsInstructions(
-  discoverableSkills: SkillResource[]
-): string {
-  if (discoverableSkills.length === 0) {
-    return "No workspace skills are currently available for discovery.";
-  }
-
-  const skillList = [...discoverableSkills]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map(
-      ({ name, agentFacingDescription }) =>
-        `- **${name}**: ${agentFacingDescription}`
-    )
-    .join("\n");
-
-  return `<discover_skills_guidelines>
-The following workspace skills are available to enable for this conversation.
-Enable relevant skills using the \`enable_skill\` tool when a user's request matches a skill's purpose.
-
-<available_workspace_skills>
-${skillList}
-</available_workspace_skills>
-</discover_skills_guidelines>`;
-}
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 
 export const discoverSkillsSkill = {
   sId: "discover_skills",
@@ -38,15 +9,9 @@ export const discoverSkillsSkill = {
     "Automatically discover and activate workspace skills as needed.",
   agentFacingDescription:
     "List available workspace skills and enable them for the current conversation.",
-  fetchInstructions: async (
-    _auth: Authenticator,
-    _spaceIds: string[],
-    { listDiscoverableSkills }: FetchInstructionsContext
-  ) => {
-    const discoverableSkills = await listDiscoverableSkills();
-
-    return buildDiscoverSkillsInstructions(discoverableSkills);
-  },
+  instructions:
+    "Workspace skills marked as available will appear alongside agent-configured skills. " +
+    "Enable them the same way you would any other available skill.",
   version: 1,
   icon: "PuzzleIcon",
   isAutoEnabled: true,

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -7,13 +7,13 @@ import type {
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 
 function buildDiscoverSkillsInstructions(
-  defaultSkills: SkillResource[]
+  discoverableSkills: SkillResource[]
 ): string {
-  if (defaultSkills.length === 0) {
+  if (discoverableSkills.length === 0) {
     return "No workspace skills are currently available for discovery.";
   }
 
-  const skillList = defaultSkills
+  const skillList = discoverableSkills
     .map(
       ({ name, agentFacingDescription }) =>
         `- **${name}**: ${agentFacingDescription}`
@@ -40,11 +40,11 @@ export const discoverSkillsSkill = {
   fetchInstructions: async (
     _auth: Authenticator,
     _spaceIds: string[],
-    { listDiscoverable }: FetchInstructionsContext
+    { listDiscoverableSkills }: FetchInstructionsContext
   ) => {
-    const defaultSkills = await listDiscoverable();
+    const discoverableSkills = await listDiscoverableSkills();
 
-    return buildDiscoverSkillsInstructions(defaultSkills);
+    return buildDiscoverSkillsInstructions(discoverableSkills);
   },
   version: 1,
   icon: "PuzzleIcon",

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -13,8 +13,8 @@ export const discoverSkillsSkill = {
   agentFacingDescription:
     "List available workspace skills and enable them for the current conversation.",
   instructions:
-    "Workspace skills marked as available will appear alongside agent-configured skills. " +
-    "Enable them the same way you would any other available skill.",
+    "Some of the available skills listed below come from the workspace rather than " +
+    "this agent's configuration. They can be enabled exactly like any other available skill.",
   version: 1,
   icon: "PuzzleIcon",
   isAutoEnabled: true,

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -42,7 +42,7 @@ type WithStaticInstructions<T extends BaseGlobalSkillDefinition> = T & {
 };
 
 export type FetchInstructionsContext = {
-  listDiscoverable: () => Promise<SkillResource[]>;
+  listDiscoverableSkills: () => Promise<SkillResource[]>;
 };
 
 type WithDynamicInstructions<T extends BaseGlobalSkillDefinition> = T & {

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -143,6 +143,16 @@ export class GlobalSkillsRegistry {
             return false; // Global skills are always active.
           }
 
+          // Global skills are default discoverable except if they are auto enabled,
+          // in which case discoverability does not really haved a meaning.
+          if (where.isDefault !== undefined) {
+            const isDefault =
+              !("isAutoEnabled" in skill) || !skill.isAutoEnabled;
+            if (isDefault !== where.isDefault) {
+              return false;
+            }
+          }
+
           return true;
         })
       : [...GLOBAL_SKILLS_ARRAY];

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -6,7 +6,6 @@ import { discoverToolsSkill } from "@app/lib/resources/skill/global/discover_too
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/global/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/global/mention_users";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -41,16 +40,11 @@ type WithStaticInstructions<T extends BaseGlobalSkillDefinition> = T & {
   readonly fetchInstructions?: never;
 };
 
-export type FetchInstructionsContext = {
-  listDiscoverableSkills: () => Promise<SkillResource[]>;
-};
-
 type WithDynamicInstructions<T extends BaseGlobalSkillDefinition> = T & {
   readonly instructions?: never;
   readonly fetchInstructions: (
     auth: Authenticator,
-    spaceIds: string[],
-    context: FetchInstructionsContext
+    spaceIds: string[]
   ) => Promise<string>;
 };
 

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -42,7 +42,7 @@ type WithStaticInstructions<T extends BaseGlobalSkillDefinition> = T & {
 };
 
 export type FetchInstructionsContext = {
-  listDefaultSkills: () => Promise<SkillResource[]>;
+  listDiscoverable: () => Promise<SkillResource[]>;
 };
 
 type WithDynamicInstructions<T extends BaseGlobalSkillDefinition> = T & {

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -138,7 +138,7 @@ export class GlobalSkillsRegistry {
           }
 
           // Global skills are default discoverable except if they are auto enabled,
-          // in which case discoverability does not really haved a meaning.
+          // in which case discoverability does not really have a meaning.
           if (where.isDefault !== undefined) {
             const isDefault =
               !("isAutoEnabled" in skill) || !skill.isAutoEnabled;

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -1,10 +1,12 @@
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { discoverKnowledgeSkill } from "@app/lib/resources/skill/global/discover_knowledge";
+import { discoverSkillsSkill } from "@app/lib/resources/skill/global/discover_skills";
 import { discoverToolsSkill } from "@app/lib/resources/skill/global/discover_tools";
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/global/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/global/mention_users";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -39,11 +41,16 @@ type WithStaticInstructions<T extends BaseGlobalSkillDefinition> = T & {
   readonly fetchInstructions?: never;
 };
 
+export type FetchInstructionsContext = {
+  listDefaultSkills: () => Promise<SkillResource[]>;
+};
+
 type WithDynamicInstructions<T extends BaseGlobalSkillDefinition> = T & {
   readonly instructions?: never;
   readonly fetchInstructions: (
     auth: Authenticator,
-    spaceIds: string[]
+    spaceIds: string[],
+    context: FetchInstructionsContext
   ) => Promise<string>;
 };
 
@@ -81,6 +88,7 @@ function ensureUniqueSIds<T extends readonly GlobalSkillDefinition[]>(
 // Registry is a simple array.
 const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   discoverKnowledgeSkill,
+  discoverSkillsSkill,
   discoverToolsSkill,
   framesSkill,
   goDeepSkill,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -489,7 +489,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     options: SkillConfigurationFindOptions = {},
     context: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillIds?: Set<string>;
     } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
@@ -796,11 +795,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }[],
     {
       agentLoopData,
-      enabledSkillIds,
       status,
     }: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillIds?: Set<string>;
       status?: SkillStatus | SkillStatus[];
     } = {}
   ): Promise<SkillResource[]> {
@@ -816,7 +813,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
         },
       },
-      { agentLoopData, enabledSkillIds }
+      { agentLoopData }
     );
   }
 
@@ -834,13 +831,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async listByAgentConfiguration(
     auth: Authenticator,
     agentConfiguration: AgentConfigurationType,
-    {
-      agentLoopData,
-      enabledSkillIds,
-    }: {
-      agentLoopData?: AgentLoopExecutionData;
-      enabledSkillIds?: Set<string>;
-    } = {}
+    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
       auth,
@@ -853,7 +844,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchBySkillReferences(auth, refs, {
       agentLoopData,
-      enabledSkillIds,
     });
   }
 
@@ -944,22 +934,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   /**
    * List discoverable skills: custom default skills + non-auto-enabled global
-   * skills, excluding already-enabled skills.
+   * skills.
    */
   static async listDiscoverable(
-    auth: Authenticator,
-    { enabledSkillIds }: { enabledSkillIds?: Set<string> } = {}
+    auth: Authenticator
   ): Promise<SkillResource[]> {
-    const skills = await this.baseFetch(auth, {
+    return this.baseFetch(auth, {
       where: {
         status: "active",
         isDefault: true,
       },
     });
-
-    return enabledSkillIds
-      ? skills.filter((s) => !enabledSkillIds.has(s.sId))
-      : skills;
   }
 
   /**
@@ -1110,21 +1095,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
-      {
-        agentLoopData,
-        enabledSkillIds: new Set(conversationEnabledSkills.map((s) => s.sId)),
-      }
+      { agentLoopData }
     );
+    const discoverableSkills = await this.listDiscoverable(auth);
 
     // Auto-enabled skills are always treated as enabled when present in the agent configuration. Only possible for global skills for now.
     const autoEnabledSkills = allAgentSkills.filter((s) => s.isAutoEnabled);
 
     const enabledSkills = [...conversationEnabledSkills, ...autoEnabledSkills];
-    // Skills that are already enabled are not equipped.
+    // Skills that are already enabled or equipped are not discoverable.
     const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
-    const equippedSkills = allAgentSkills.filter(
-      (s) => !enabledSkillIds.has(s.sId)
-    );
+    const agentSkillIds = new Set(allAgentSkills.map((s) => s.sId));
+    const equippedSkills = [
+      ...allAgentSkills.filter((s) => !enabledSkillIds.has(s.sId)),
+      ...discoverableSkills.filter(
+        (s) => !enabledSkillIds.has(s.sId) && !agentSkillIds.has(s.sId)
+      ),
+    ];
 
     const augmentedEnabledSkills = await this.augmentSkillsWithExtendedSkills(
       auth,
@@ -1237,10 +1224,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     def: GlobalSkillDefinition,
     {
       agentLoopData,
-      enabledSkillIds,
     }: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillIds?: Set<string>;
     } = {}
   ): Promise<SkillResource> {
     const { agentConfiguration } = agentLoopData ?? {};
@@ -1272,15 +1257,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerConfigurations = mcpServerConfigurationsByName.flat();
     }
 
-    let instructions;
-    if (def.fetchInstructions) {
-      instructions = await def.fetchInstructions(auth, requestedSpaceIds, {
-        listDiscoverableSkills: () =>
-          this.listDiscoverable(auth, { enabledSkillIds }),
-      });
-    } else {
-      instructions = def.instructions;
-    }
+    const instructions = def.fetchInstructions
+      ? await def.fetchInstructions(auth, requestedSpaceIds)
+      : def.instructions;
 
     return new SkillResource(
       this.model,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1272,12 +1272,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerConfigurations = mcpServerConfigurationsByName.flat();
     }
 
-    const instructions = def.fetchInstructions
-      ? await def.fetchInstructions(auth, requestedSpaceIds, {
-          listDiscoverableSkills: () =>
-            this.listDiscoverable(auth, { excludeNames: enabledSkillNames }),
-        })
-      : def.instructions;
+    let instructions;
+    if (def.fetchInstructions) {
+      instructions = await def.fetchInstructions(auth, requestedSpaceIds, {
+        listDiscoverableSkills: () =>
+          this.listDiscoverable(auth, { excludeNames: enabledSkillNames }),
+      });
+    } else {
+      instructions = def.instructions;
+    }
 
     return new SkillResource(
       this.model,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1274,7 +1274,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const instructions = def.fetchInstructions
       ? await def.fetchInstructions(auth, requestedSpaceIds, {
-          listDiscoverable: () =>
+          listDiscoverableSkills: () =>
             this.listDiscoverable(auth, { excludeNames: enabledSkillNames }),
         })
       : def.instructions;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -27,7 +27,7 @@ import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
-import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
+import type { GlobalSkillDefinition, GlobalSkillId } from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -194,7 +194,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   readonly editorGroup: GroupResource | null = null;
   readonly version: number | null = null;
 
-  private readonly globalSId: string | null;
+  private readonly globalSId: GlobalSkillId | null;
 
   private _mcpServerConfigurations: SkillMCPServerConfiguration[];
 
@@ -1095,7 +1095,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentConfiguration,
       { agentLoopData }
     );
-    const discoverableSkills = await this.listDiscoverable(auth);
+
+    let discoverableSkills: SkillResource[] = [];
+    if (allAgentSkills.some((s) => s.globalSId === "discover_skills")) {
+      discoverableSkills = await this.listDiscoverable(auth);
+    }
 
     // Auto-enabled skills are always treated as enabled when present in the agent configuration. Only possible for global skills for now.
     const autoEnabledSkills = allAgentSkills.filter((s) => s.isAutoEnabled);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -943,7 +943,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List active custom skills marked as default, excluding already-enabled skills.
+   * List discoverable skills: custom default skills + non-auto-enabled global
+   * skills, excluding already-enabled skills.
    */
   static async listDiscoverable(
     auth: Authenticator,
@@ -956,9 +957,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    return enabledSkillNames
-      ? skills.filter((s) => !enabledSkillNames.has(s.name))
-      : skills;
+    return skills.filter(
+      (s) =>
+        !s.isAutoEnabled &&
+        (!enabledSkillNames || !enabledSkillNames.has(s.name))
+    );
   }
 
   /**

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1251,7 +1251,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     const instructions = def.fetchInstructions
-      ? await def.fetchInstructions(auth, requestedSpaceIds)
+      ? await def.fetchInstructions(auth, requestedSpaceIds, {
+          listDefaultSkills: () => this.listDefault(auth),
+        })
       : def.instructions;
 
     return new SkillResource(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1303,7 +1303,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         extendedSkillId: null,
         source: null,
         sourceMetadata: null,
-        isDefault: false,
+        isDefault: def.isAutoEnabled !== true,
       },
       {
         // Global skills do not have data source configurations.
@@ -2100,8 +2100,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         (ref.customSkillId !== null && ref.customSkillId === this.id)
     );
 
-    // Allow enabling default skills even if not equipped (discovered via discover_skills).
-    if (!hasSkill && !this.isDefault) {
+    // Allow enabling default skills if the agent has the discover_skills skill.
+    const hasDiscoverSkills =
+      this.isDefault &&
+      refs.some((ref) => ref.globalSkillId === "discover_skills");
+
+    if (!hasSkill && !hasDiscoverSkills) {
       return new Err(
         new Error(
           `Skill ${this.name} is not equipped by agent ${agentConfiguration.name}.`

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1117,14 +1117,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // Compute the equipped skills: agent skills not already enabled +
     // discoverable skills not already enabled or equipped.
     const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
-    const agentEquippedSkills = allAgentSkills
-      .filter((s) => !enabledSkillIds.has(s.sId));
+    const agentEquippedSkills = allAgentSkills.filter(
+      (s) => !enabledSkillIds.has(s.sId)
+    );
 
-    const agentEquippedSkillIds = new Set(agentEquippedSkills.map((s) => s.sId));
-    const discoveredSkills = discoverableSkills
-      .filter(
-        (s) => !enabledSkillIds.has(s.sId) && !agentEquippedSkillIds.has(s.sId)
-      );
+    const agentEquippedSkillIds = new Set(
+      agentEquippedSkills.map((s) => s.sId)
+    );
+    const discoveredSkills = discoverableSkills.filter(
+      (s) => !enabledSkillIds.has(s.sId) && !agentEquippedSkillIds.has(s.sId)
+    );
 
     const equippedSkills = [
       ...agentEquippedSkills.sort(sortByName),

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -947,18 +947,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listDiscoverable(
     auth: Authenticator,
-    { excludeNames }: { excludeNames?: Set<string> } = {}
+    { enabledSkillNames }: { enabledSkillNames?: Set<string> } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
       where: {
         status: "active",
         isDefault: true,
       },
-      onlyCustom: true,
     });
 
-    return excludeNames
-      ? skills.filter((s) => !excludeNames.has(s.name))
+    return enabledSkillNames
+      ? skills.filter((s) => !enabledSkillNames.has(s.name))
       : skills;
   }
 
@@ -1276,7 +1275,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (def.fetchInstructions) {
       instructions = await def.fetchInstructions(auth, requestedSpaceIds, {
         listDiscoverableSkills: () =>
-          this.listDiscoverable(auth, { excludeNames: enabledSkillNames }),
+          this.listDiscoverable(auth, { enabledSkillNames }),
       });
     } else {
       instructions = def.instructions;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1107,13 +1107,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         agentLoopData,
       }
     );
-    const enabledSkillIds = new Set(
-      conversationEnabledSkills.map((s) => s.sId)
-    );
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
-      { agentLoopData, enabledSkillIds }
+      {
+        agentLoopData,
+        enabledSkillIds: new Set(conversationEnabledSkills.map((s) => s.sId)),
+      }
     );
 
     // Auto-enabled skills are always treated as enabled when present in the agent configuration. Only possible for global skills for now.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -936,9 +936,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    * List discoverable skills: custom default skills + non-auto-enabled global
    * skills.
    */
-  static async listDiscoverable(
-    auth: Authenticator
-  ): Promise<SkillResource[]> {
+  static async listDiscoverable(auth: Authenticator): Promise<SkillResource[]> {
     return this.baseFetch(auth, {
       where: {
         status: "active",
@@ -1102,21 +1100,36 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // Auto-enabled skills are always treated as enabled when present in the agent configuration. Only possible for global skills for now.
     const autoEnabledSkills = allAgentSkills.filter((s) => s.isAutoEnabled);
 
-    const enabledSkills = [...conversationEnabledSkills, ...autoEnabledSkills];
-    // Skills that are already enabled or equipped are not discoverable.
-    const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
-    const agentSkillIds = new Set(allAgentSkills.map((s) => s.sId));
-    const equippedSkills = [
-      ...allAgentSkills.filter((s) => !enabledSkillIds.has(s.sId)),
-      ...discoverableSkills.filter(
-        (s) => !enabledSkillIds.has(s.sId) && !agentSkillIds.has(s.sId)
-      ),
+    const sortByName = (a: SkillResource, b: SkillResource) =>
+      a.name.localeCompare(b.name);
+
+    // Compute the enabled skills: auto-enabled skills + conversation-enabled skills.
+    const enabledSkills = [
+      ...autoEnabledSkills.sort(sortByName),
+      ...conversationEnabledSkills.sort(sortByName),
     ];
 
     const augmentedEnabledSkills = await this.augmentSkillsWithExtendedSkills(
       auth,
       enabledSkills
     );
+
+    // Compute the equipped skills: agent skills not already enabled +
+    // discoverable skills not already enabled or equipped.
+    const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
+    const agentEquippedSkills = allAgentSkills
+      .filter((s) => !enabledSkillIds.has(s.sId));
+
+    const agentEquippedSkillIds = new Set(agentEquippedSkills.map((s) => s.sId));
+    const discoveredSkills = discoverableSkills
+      .filter(
+        (s) => !enabledSkillIds.has(s.sId) && !agentEquippedSkillIds.has(s.sId)
+      );
+
+    const equippedSkills = [
+      ...agentEquippedSkills.sort(sortByName),
+      ...discoveredSkills.sort(sortByName),
+    ];
 
     return {
       enabledSkills: augmentedEnabledSkills,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -489,6 +489,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     options: SkillConfigurationFindOptions = {},
     context: {
       agentLoopData?: AgentLoopExecutionData;
+      enabledSkillNames?: Set<string>;
     } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
@@ -795,9 +796,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }[],
     {
       agentLoopData,
+      enabledSkillNames,
       status,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      enabledSkillNames?: Set<string>;
       status?: SkillStatus | SkillStatus[];
     } = {}
   ): Promise<SkillResource[]> {
@@ -813,7 +816,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
         },
       },
-      { agentLoopData }
+      { agentLoopData, enabledSkillNames }
     );
   }
 
@@ -831,7 +834,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async listByAgentConfiguration(
     auth: Authenticator,
     agentConfiguration: AgentConfigurationType,
-    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
+    {
+      agentLoopData,
+      enabledSkillNames,
+    }: {
+      agentLoopData?: AgentLoopExecutionData;
+      enabledSkillNames?: Set<string>;
+    } = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
       auth,
@@ -844,6 +853,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchBySkillReferences(auth, refs, {
       agentLoopData,
+      enabledSkillNames,
     });
   }
 
@@ -933,16 +943,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List active custom skills marked as default.
+   * List active custom skills marked as default, excluding already-enabled skills.
    */
-  static async listDefault(auth: Authenticator): Promise<SkillResource[]> {
-    return this.baseFetch(auth, {
+  static async listDiscoverable(
+    auth: Authenticator,
+    { excludeNames }: { excludeNames?: Set<string> } = {}
+  ): Promise<SkillResource[]> {
+    const skills = await this.baseFetch(auth, {
       where: {
         status: "active",
         isDefault: true,
       },
       onlyCustom: true,
     });
+
+    return excludeNames
+      ? skills.filter((s) => !excludeNames.has(s.name))
+      : skills;
   }
 
   /**
@@ -1090,10 +1107,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         agentLoopData,
       }
     );
+    const enabledSkillNames = new Set(
+      conversationEnabledSkills.map((s) => s.name)
+    );
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
-      { agentLoopData }
+      { agentLoopData, enabledSkillNames }
     );
 
     // Auto-enabled skills are always treated as enabled when present in the agent configuration. Only possible for global skills for now.
@@ -1217,8 +1237,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     def: GlobalSkillDefinition,
     {
       agentLoopData,
+      enabledSkillNames,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      enabledSkillNames?: Set<string>;
     } = {}
   ): Promise<SkillResource> {
     const { agentConfiguration } = agentLoopData ?? {};
@@ -1252,7 +1274,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const instructions = def.fetchInstructions
       ? await def.fetchInstructions(auth, requestedSpaceIds, {
-          listDefaultSkills: () => this.listDefault(auth),
+          listDiscoverable: () =>
+            this.listDiscoverable(auth, { excludeNames: enabledSkillNames }),
         })
       : def.instructions;
 
@@ -2072,7 +2095,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         (ref.customSkillId !== null && ref.customSkillId === this.id)
     );
 
-    if (!hasSkill) {
+    // Allow enabling default skills even if not equipped (discovered via discover_skills).
+    if (!hasSkill && !this.isDefault) {
       return new Err(
         new Error(
           `Skill ${this.name} is not equipped by agent ${agentConfiguration.name}.`

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -489,7 +489,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     options: SkillConfigurationFindOptions = {},
     context: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillNames?: Set<string>;
+      enabledSkillIds?: Set<string>;
     } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
@@ -796,11 +796,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }[],
     {
       agentLoopData,
-      enabledSkillNames,
+      enabledSkillIds,
       status,
     }: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillNames?: Set<string>;
+      enabledSkillIds?: Set<string>;
       status?: SkillStatus | SkillStatus[];
     } = {}
   ): Promise<SkillResource[]> {
@@ -816,7 +816,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
         },
       },
-      { agentLoopData, enabledSkillNames }
+      { agentLoopData, enabledSkillIds }
     );
   }
 
@@ -836,10 +836,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     agentConfiguration: AgentConfigurationType,
     {
       agentLoopData,
-      enabledSkillNames,
+      enabledSkillIds,
     }: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillNames?: Set<string>;
+      enabledSkillIds?: Set<string>;
     } = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
@@ -853,7 +853,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchBySkillReferences(auth, refs, {
       agentLoopData,
-      enabledSkillNames,
+      enabledSkillIds,
     });
   }
 
@@ -948,7 +948,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listDiscoverable(
     auth: Authenticator,
-    { enabledSkillNames }: { enabledSkillNames?: Set<string> } = {}
+    { enabledSkillIds }: { enabledSkillIds?: Set<string> } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
       where: {
@@ -957,11 +957,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    return skills.filter(
-      (s) =>
-        !s.isAutoEnabled &&
-        (!enabledSkillNames || !enabledSkillNames.has(s.name))
-    );
+    return enabledSkillIds
+      ? skills.filter((s) => !enabledSkillIds.has(s.sId))
+      : skills;
   }
 
   /**
@@ -1109,13 +1107,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         agentLoopData,
       }
     );
-    const enabledSkillNames = new Set(
-      conversationEnabledSkills.map((s) => s.name)
+    const enabledSkillIds = new Set(
+      conversationEnabledSkills.map((s) => s.sId)
     );
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
-      { agentLoopData, enabledSkillNames }
+      { agentLoopData, enabledSkillIds }
     );
 
     // Auto-enabled skills are always treated as enabled when present in the agent configuration. Only possible for global skills for now.
@@ -1239,10 +1237,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     def: GlobalSkillDefinition,
     {
       agentLoopData,
-      enabledSkillNames,
+      enabledSkillIds,
     }: {
       agentLoopData?: AgentLoopExecutionData;
-      enabledSkillNames?: Set<string>;
+      enabledSkillIds?: Set<string>;
     } = {}
   ): Promise<SkillResource> {
     const { agentConfiguration } = agentLoopData ?? {};
@@ -1278,7 +1276,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (def.fetchInstructions) {
       instructions = await def.fetchInstructions(auth, requestedSpaceIds, {
         listDiscoverableSkills: () =>
-          this.listDiscoverable(auth, { enabledSkillNames }),
+          this.listDiscoverable(auth, { enabledSkillIds }),
       });
     } else {
       instructions = def.instructions;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -197,7 +197,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   readonly editorGroup: GroupResource | null = null;
   readonly version: number | null = null;
 
-  private readonly globalSId: GlobalSkillId | null;
+  private readonly globalSId: string | null;
 
   private _mcpServerConfigurations: SkillMCPServerConfiguration[];
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -27,10 +27,7 @@ import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
-import type {
-  GlobalSkillDefinition,
-  GlobalSkillId,
-} from "@app/lib/resources/skill/global/registry";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -27,7 +27,10 @@ import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
-import type { GlobalSkillDefinition, GlobalSkillId } from "@app/lib/resources/skill/global/registry";
+import type {
+  GlobalSkillDefinition,
+  GlobalSkillId,
+} from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -12,6 +12,7 @@ export type AllSkillConfigurationFindOptions = Omit<
     sId?: string | string[];
     id?: number | number[];
     status?: SkillStatus | SkillStatus[];
+    isDefault?: boolean;
   };
   onlyCustom?: false; // Default: include global skills.
 };

--- a/front/migrations/db/migration_536.sql
+++ b/front/migrations/db/migration_536.sql
@@ -1,0 +1,3 @@
+-- Script to run before deployment of copilot->sidekick rename
+ALTER TABLE "public"."templates" ADD COLUMN "sidekickInstructions" TEXT;
+UPDATE templates SET "sidekickInstructions" = "copilotInstructions";

--- a/front/migrations/db/migration_536.sql
+++ b/front/migrations/db/migration_536.sql
@@ -1,3 +1,0 @@
--- Script to run before deployment of copilot->sidekick rename
-ALTER TABLE "public"."templates" ADD COLUMN "sidekickInstructions" TEXT;
-UPDATE templates SET "sidekickInstructions" = "copilotInstructions";

--- a/front/migrations/db/migration_538.sql
+++ b/front/migrations/db/migration_538.sql
@@ -1,0 +1,4 @@
+-- Migration created on Mar 09, 2026
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "skill_configurations_workspace_id_status_is_default"
+  ON "skill_configurations" ("workspaceId", "status", "isDefault");

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -251,6 +251,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable reinforced agents: background analysis of conversations to suggest agent improvements",
     stage: "dust_only",
   },
+  discover_skills: {
+    description: "Enable default skills discovery on global agents",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -252,7 +252,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   discover_skills: {
-    description: "Enable default skills discovery on global agents",
+    description: "Enable default skills discovery on global agents (do not enable for customers)",
     stage: "dust_only",
   },
 } as const satisfies Record<string, FeatureFlag>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -252,7 +252,8 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   discover_skills: {
-    description: "Enable default skills discovery on global agents (do not enable for customers)",
+    description:
+      "Enable default skills discovery on global agents (do not enable for customers)",
     stage: "dust_only",
   },
 } as const satisfies Record<string, FeatureFlag>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,6 +690,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
   | "discord_bot"
+  | "discover_skills"
   | "email_agents"
   | "dust_academy"
   | "dust_internal_global_agents"


### PR DESCRIPTION
## Description

- This PR adds a `discover_skills` skill that allows discovering skills on the workspace and enabling them on the fly.
- Having the skills extends the list of equipped skills.
- Main use case is for the dust global agent.
- Next step is to implement the UI to make a skill discoverable/view the list of discoverable skills.


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy front.
