### PR TITLE
Add fallback values in AgentMCPActionResource.toJSON()

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -951,7 +951,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     // Extract the unprefixed tool name from the function call name (e.g. "server__tool" -> "tool").
     const toolName =
       this.toolConfiguration.originalName ??
-      this.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
+      this.functionCallName.split(TOOL_NAME_SEPARATOR).at(-1) ??
       this.functionCallName;
     const mcpServerId = this.metadata.mcpServerId ?? null;
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1,3 +1,4 @@
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -104,7 +105,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     >,
     readonly metadata: {
       internalMCPServerName: InternalMCPServerNameType | null;
-      mcpServerId: string;
+      // Can be undefined for old actions created before toolServerId was added to the toolConfiguration JSONB.
+      mcpServerId: string | undefined;
     }
   ) {
     super(model, blob);
@@ -945,7 +947,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
 
     const internalMCPServerName = this.metadata.internalMCPServerName;
-    const toolName = this.toolConfiguration.originalName;
+    // Fallback for old actions created before these fields were added to the toolConfiguration JSONB.
+    // Extract the unprefixed tool name from the function call name (e.g. "server__tool" -> "tool").
+    const toolName =
+      this.toolConfiguration.originalName ??
+      this.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
+      this.functionCallName;
+    const mcpServerId = this.metadata.mcpServerId ?? null;
 
     const displayLabels = internalMCPServerName
       ? (getInternalMCPServerToolDisplayLabels(internalMCPServerName)?.[
@@ -967,7 +975,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       functionCallId: this.stepContent.value.value.id,
       internalMCPServerName,
       toolName,
-      mcpServerId: this.metadata.mcpServerId,
+      mcpServerId,
       params: this.augmentedInputs,
       status: this.status,
       step: this.stepContent.step,


### PR DESCRIPTION
## Description

Fix dust-project-full-sync Temporal activity failures caused by Zod validation errors when fetching conversations containing old agent MCP actions
Add fallback values in AgentMCPActionResource.toJSON() for toolName and mcpServerId when the underlying toolConfiguration JSONB is empty

### Context:
The dust-project-full-sync Temporal workflow (activity dust-project-full-sync-XXXX) is failing for some workspaces with a Zod validation error:
```
Failed to fetch conversations: Unexpected response format from DustAPI [...]:
  actions[0].mcpServerId - Required
  actions[0].toolName - Required
```

### Root cause:
The toolConfiguration JSONB column on agent_mcp_actions was added in migration_332 with DEFAULT '{}'. This means all rows that existed before the migration got an empty {} as their toolConfiguration. No backfill migration was ever created to populate originalName or toolServerId for these pre-existing rows.

When the conversations API serializes these old actions via AgentMCPActionResource.toJSON(), it returns toolName: undefined and mcpServerId: undefined. The JS SDK's Zod schema (AgentActionTypeSchema) requires toolName: z.string() and mcpServerId: z.string().nullable(), so validation fails and the entire sync activity crashes.

### Fix
toolName falls back to the tool name from this.functionCallName when originalName is missing from the JSONB, this is the closest equivalent already stored on the action


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
