### PR TITLE
Add flag to restrict builder agent publishing

### DIFF
--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -4,8 +4,8 @@ import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSou
 import { SlackSettingsSheet } from "@app/components/agent_builder/settings/SlackSettingsSheet";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
+import { getPublishingRestrictionForOwner } from "@app/lib/api/assistant/publishing_restrictions";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { isBuilder } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -48,11 +48,10 @@ export function AccessSection() {
   const { owner } = useAgentBuilderContext();
   const { featureFlags } = useFeatureFlags();
 
-  const restrictAgentsPublishing = featureFlags.includes(
-    "restrict_agents_publishing"
-  );
-  const publishingToggleDisabled =
-    restrictAgentsPublishing && !isBuilder(owner);
+  const {
+    disabled: publishingToggleDisabled,
+    tooltip: publishingToggleTooltip,
+  } = getPublishingRestrictionForOwner(featureFlags, owner);
 
   const getDisplayValue = () => {
     return scope.value === "visible" ? "Published" : "Unpublished";
@@ -97,11 +96,7 @@ export function AccessSection() {
               isSelect
               type="button"
               disabled={publishingToggleDisabled}
-              tooltip={
-                publishingToggleDisabled
-                  ? "Publishing agents is restricted to builders and admins"
-                  : undefined
-              }
+              tooltip={publishingToggleTooltip}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">

--- a/front/components/pages/workspace/WorkspaceSettingsPage.tsx
+++ b/front/components/pages/workspace/WorkspaceSettingsPage.tsx
@@ -2,6 +2,7 @@ import { CapabilitiesSection } from "@app/components/workspace/settings/Capabili
 import { IntegrationsSection } from "@app/components/workspace/settings/IntegrationsSection";
 import { ModelSelectionSection } from "@app/components/workspace/settings/ModelSelectionSection";
 import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
+import { getPublishingRestrictionMessage } from "@app/lib/api/assistant/publishing_restrictions";
 import {
   useAuth,
   useFeatureFlags,
@@ -46,8 +47,8 @@ export function WorkspaceSettingsPage() {
       <ModelSelectionSection owner={owner} plan={subscription.plan} />
       <CapabilitiesSection
         owner={owner}
-        showRestrictAgentsPublishing={featureFlags.includes(
-          "restrict_agents_publishing"
+        publishingRestrictionMessage={getPublishingRestrictionMessage(
+          featureFlags
         )}
       />
       <IntegrationsSection

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -6,10 +6,10 @@ import { ContextItem, Page } from "@dust-tt/sparkle";
 
 export function CapabilitiesSection({
   owner,
-  showRestrictAgentsPublishing,
+  publishingRestrictionMessage,
 }: {
   owner: WorkspaceType;
-  showRestrictAgentsPublishing: boolean;
+  publishingRestrictionMessage: string | null;
 }) {
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -18,7 +18,11 @@ export function CapabilitiesSection({
         <div className="h-full border-b border-border dark:border-border-night" />
         <InteractiveContentSharingToggle owner={owner} />
         <VoiceTranscriptionToggle owner={owner} />
-        {showRestrictAgentsPublishing && <RestrictAgentsPublishingCapability />}
+        {publishingRestrictionMessage && (
+          <RestrictAgentsPublishingCapability
+            subElement={publishingRestrictionMessage}
+          />
+        )}
       </ContextItem.List>
     </Page.Vertical>
   );

--- a/front/components/workspace/settings/RestrictAgentsPublishingCapability.tsx
+++ b/front/components/workspace/settings/RestrictAgentsPublishingCapability.tsx
@@ -1,10 +1,14 @@
 import { ContextItem, LockIcon, SliderToggle } from "@dust-tt/sparkle";
 
-export function RestrictAgentsPublishingCapability() {
+export function RestrictAgentsPublishingCapability({
+  subElement,
+}: {
+  subElement: string;
+}) {
   return (
     <ContextItem
       title="Restricted agents publication"
-      subElement="Publishing agents is restricted to builders and admins"
+      subElement={subElement}
       visual={<LockIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -10,6 +10,11 @@ import {
 } from "@app/lib/api/assistant/configuration/helpers";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import {
+  canPublishForAuth,
+  getPublishingRestrictionLevel,
+  PUBLISHING_RESTRICTIONS,
+} from "@app/lib/api/assistant/publishing_restrictions";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import config from "@app/lib/api/config";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
@@ -477,25 +482,15 @@ export async function createAgentConfiguration(
       }
     }
     if (existingAgent && existingAgent.scope !== "visible") {
-      if (
-        !(await canPublishAgent(auth)) &&
-        scope === "visible" &&
-        status === "active"
-      ) {
-        return new Err(
-          new Error("Publishing agents is restricted to builders and admins.")
-        );
+      const { canPublish, message } = await canPublishAgent(auth);
+      if (!canPublish && scope === "visible" && status === "active") {
+        return new Err(new Error(message!));
       }
     }
   } else {
-    if (
-      !(await canPublishAgent(auth)) &&
-      scope === "visible" &&
-      status === "active"
-    ) {
-      return new Err(
-        new Error("Publishing agents is restricted to builders and admins.")
-      );
+    const { canPublish, message } = await canPublishAgent(auth);
+    if (!canPublish && scope === "visible" && status === "active") {
+      return new Err(new Error(message!));
     }
   }
 
@@ -1585,16 +1580,16 @@ export async function updateAgentPermissions(
   }
 }
 
-async function canPublishAgent(auth: Authenticator): Promise<boolean> {
+async function canPublishAgent(auth: Authenticator): Promise<{
+  canPublish: boolean;
+  message: string | null;
+}> {
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-
-  if (
-    featureFlags.includes("restrict_agents_publishing") &&
-    !auth.isBuilder()
-  ) {
-    return false;
+  const level = getPublishingRestrictionLevel(featureFlags);
+  if (!level || canPublishForAuth(auth, level)) {
+    return { canPublish: true, message: null };
   }
-  return true;
+  return { canPublish: false, message: PUBLISHING_RESTRICTIONS[level].message };
 }
 
 export async function updateAgentConfigurationScope(
@@ -1611,15 +1606,14 @@ export async function updateAgentConfigurationScope(
     return new Err(new Error(`Could not find agent ${agentConfigurationId}`));
   }
 
+  const { canPublish, message } = await canPublishAgent(auth);
   if (
-    !(await canPublishAgent(auth)) &&
+    !canPublish &&
     agentConfig.scope !== "visible" &&
     scope === "visible" &&
     agentConfig.status === "active"
   ) {
-    return new Err(
-      new Error("Publishing agents is restricted to builders and admins.")
-    );
+    return new Err(new Error(message!));
   }
 
   const previousScope = agentConfig.scope;

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -490,7 +490,7 @@ export async function createAgentConfiguration(
   } else {
     const { canPublish, message } = await canPublishAgent(auth);
     if (!canPublish && scope === "visible" && status === "active") {
-      return new Err(new Error(message!));
+      return new Err(new Error(message ?? "Publishing agents is restricted."));
     }
   }
 
@@ -1613,7 +1613,7 @@ export async function updateAgentConfigurationScope(
     scope === "visible" &&
     agentConfig.status === "active"
   ) {
-    return new Err(new Error(message!));
+    return new Err(new Error(message ?? "Publishing agents is restricted."));
   }
 
   const previousScope = agentConfig.scope;

--- a/front/lib/api/assistant/publishing_restrictions.ts
+++ b/front/lib/api/assistant/publishing_restrictions.ts
@@ -1,0 +1,78 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { WorkspaceType } from "@app/types/user";
+import { isAdmin, isBuilder } from "@app/types/user";
+
+export const PUBLISHING_RESTRICTIONS = {
+  builders_and_admins: {
+    message: "Publishing agents is restricted to builders and admins.",
+    requiredRole: "builder" as const,
+  },
+  admins_only: {
+    message: "Publishing agents is restricted to admins.",
+    requiredRole: "admin" as const,
+  },
+} as const;
+
+export type PublishingRestriction = keyof typeof PUBLISHING_RESTRICTIONS;
+
+export function getPublishingRestrictionLevel(
+  featureFlags: readonly string[]
+): PublishingRestriction | null {
+  if (featureFlags.includes("restrict_agents_publishing_to_admins")) {
+    return "admins_only";
+  }
+  if (featureFlags.includes("restrict_agents_publishing")) {
+    return "builders_and_admins";
+  }
+  return null;
+}
+
+export function getPublishingRestrictionMessage(
+  featureFlags: readonly string[]
+): string | null {
+  const level = getPublishingRestrictionLevel(featureFlags);
+  return level ? PUBLISHING_RESTRICTIONS[level].message : null;
+}
+
+function canPublishForRole(
+  role: "admin" | "builder",
+  check: { isAdmin: boolean; isBuilder: boolean }
+): boolean {
+  return role === "admin" ? check.isAdmin : check.isBuilder;
+}
+
+export function canPublishForOwner(
+  owner: WorkspaceType | null,
+  level: PublishingRestriction
+): boolean {
+  return canPublishForRole(PUBLISHING_RESTRICTIONS[level].requiredRole, {
+    isAdmin: isAdmin(owner),
+    isBuilder: isBuilder(owner),
+  });
+}
+
+export function canPublishForAuth(
+  auth: Authenticator,
+  level: PublishingRestriction
+): boolean {
+  return canPublishForRole(PUBLISHING_RESTRICTIONS[level].requiredRole, {
+    isAdmin: auth.isAdmin(),
+    isBuilder: auth.isBuilder(),
+  });
+}
+
+export function getPublishingRestrictionForOwner(
+  featureFlags: readonly string[],
+  owner: WorkspaceType | null
+): { disabled: boolean; tooltip: string | undefined } {
+  const level = getPublishingRestrictionLevel(featureFlags);
+  if (!level) {
+    return { disabled: false, tooltip: undefined };
+  }
+  const restriction = PUBLISHING_RESTRICTIONS[level];
+  const disabled = !canPublishForOwner(owner, level);
+  return {
+    disabled,
+    tooltip: disabled ? restriction.message : undefined,
+  };
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -84,6 +84,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Restrict publishing agents to builders and admins",
     stage: "on_demand",
   },
+  restrict_agents_publishing_to_admins: {
+    description: "Restrict publishing agents to admins only",
+    stage: "on_demand",
+  },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -711,6 +711,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
   | "restrict_agents_publishing"
+  | "restrict_agents_publishing_to_admins"
   | "salesforce_synced_queries"
   | "salesforce_tool_write"
   | "salesforce_tool"


### PR DESCRIPTION
## Description

* As requested by enterprise customer, adding flag to restrict publishing for builder role. We already have this flag to restrict for user role, so leveraging/consolidating same logic

## Tests

<img width="871" height="514" alt="Screenshot 2026-03-09 at 11 36 33 AM" src="https://github.com/user-attachments/assets/5382a2d4-f35f-48f3-9a9f-caaea3f5c87d" />


## Risk

* Unintentional publishing permissions change

## Deploy Plan

* Deploy front