### PR TITLE
Fix Stripe webhook: skip payment failing status for enterprise credit purchase invoices

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -498,39 +498,39 @@ async function handler(
             stripeSubscription &&
             isCreditPurchaseInvoice(invoice) &&
             !isEnterpriseSubscription(stripeSubscription);
-          // When we received a failed payment for a pro credit purchase,
-          // We do NOT want to send an email to the admin telling them
-          // their subscription is going to be cancelled
-          // This is because credits have not been provisioned yet, and we
-          // will end-up voiding the invoice if it continues failing
-          if (isProCreditPurchaseInvoice) {
-            const result = await voidFailedProCreditPurchaseInvoice({
-              auth,
-              invoice,
-            });
-            if (result.isErr()) {
-              // For eng-oncall
-              // This case is supposed to be extremely rare, as there are not a lot of things that can fail
-              // during an invoice void, you will need to inspect the invoice directly in stripe to see what
-              // happened, and invoice it by hand, with the added metadata put in `voidFailedProCreditPurchase`
-              // contact Stripe owners in case of doubt
-              logger.error(
-                {
-                  error: result.error,
-                  panic: true,
-                  stripeError: true,
-                  invoiceId: invoice.id,
-                },
-                "[Stripe Webhook] Error handling failed credit purchase"
-              );
-            } else if (result.value.voided) {
-              logger.warn(
-                { invoiceId: invoice.id },
-                "[Stripe Webhook] Voided Pro credit purchase invoice after 3 failures"
-              );
+          // When we received a failed payment for a credit purchase (pro or enterprise),
+          // we do NOT want to set the payment failing status or send an email to the admin
+          // telling them their subscription is going to be cancelled.
+          // Credits have not been provisioned yet — for pro, we void the invoice after
+          // repeated failures; for enterprise, they are paid in arrears or with a 30-day notice.
+          if (isCreditPurchaseInvoice(invoice)) {
+            if (isProCreditPurchaseInvoice) {
+              const result = await voidFailedProCreditPurchaseInvoice({
+                auth,
+                invoice,
+              });
+              if (result.isErr()) {
+                // For eng-oncall
+                // This case is supposed to be extremely rare, as there are not a lot of things that can fail
+                // during an invoice void, you will need to inspect the invoice directly in stripe to see what
+                // happened, and invoice it by hand, with the added metadata put in `voidFailedProCreditPurchase`
+                // contact Stripe owners in case of doubt
+                logger.error(
+                  {
+                    error: result.error,
+                    panic: true,
+                    stripeError: true,
+                    invoiceId: invoice.id,
+                  },
+                  "[Stripe Webhook] Error handling failed credit purchase"
+                );
+              } else if (result.value.voided) {
+                logger.warn(
+                  { invoiceId: invoice.id },
+                  "[Stripe Webhook] Voided Pro credit purchase invoice after 3 failures"
+                );
+              }
             }
-            // On the other hand credit purchase from enterprise are paid in arrears or with a 30days notice
-            // Either way, we want to go through the usual flow for payment failures
           } else {
             const owner = auth.workspace();
             const subscriptionType = auth.subscription();


### PR DESCRIPTION
## Description

Fix for this runner card: https://github.com/dust-tt/tasks/issues/6999

When an enterprise credit purchase invoice failed payment, the invoice.payment_failed handler was setting paymentFailingSince because the guard only excluded pro credit purchases. Then when invoice.paid fired, the status was not cleared because that handler correctly skipped credit purchase invoices. This asymmetry left enterprise workspaces stuck with a payment failing banner that could never be resolved by a successful payment.

The fix moves the outer condition in invoice.payment_failed to check isCreditPurchaseInvoice(invoice) first, so all credit purchase invoices (pro and enterprise) skip the payment failing logic entirely. Pro credit purchases still get voided after repeated failures as before. Enterprise credit purchases are paid in arrears or with a 30-day notice, so setting a payment failing status on them was incorrect.

## Tests

Quite long to test and fix straightforward so did not took time to test locally. 
Review with hidden whitespaces makes the diff a 2-liner. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 