### PR TITLE
[Front] feat(byok): add ProviderCredentialResource with plan-gated access

### DIFF
--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -12,6 +12,9 @@ export const PRO_PLAN_SEAT_29_CODE = "PRO_PLAN_SEAT_29";
 export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
 export const PRO_PLAN_SEAT_39_CODE = "PRO_PLAN_SEAT_39";
 
+// BYOK plan:
+export const FREE_BYOK_PLAN_CODE = "FREE_BYOK";
+
 /**
  * ENT_PLAN_FAKE is not subscribable and is only used to display the Enterprise plan in the UI (hence it's not stored on the db).
  */

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -1,5 +1,6 @@
 import { PlanModel } from "@app/lib/models/plan";
 import {
+  FREE_BYOK_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
@@ -82,6 +83,33 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
+  });
+  PRO_PLANS_DATA.push({
+    code: FREE_BYOK_PLAN_CODE,
+    name: "Free (BYOK)",
+    maxMessages: -1,
+    maxMessagesTimeframe: "lifetime",
+    isDeepDiveAllowed: true,
+    maxImagesPerWeek: 50,
+    maxUsersInWorkspace: -1,
+    maxVaultsInWorkspace: -1,
+    isSlackbotAllowed: true,
+    isManagedSlackAllowed: true,
+    isManagedConfluenceAllowed: true,
+    isManagedNotionAllowed: true,
+    isManagedGoogleDriveAllowed: true,
+    isManagedGithubAllowed: true,
+    isManagedIntercomAllowed: true,
+    isManagedWebCrawlerAllowed: true,
+    isManagedSalesforceAllowed: true,
+    isSSOAllowed: true,
+    isSCIMAllowed: false,
+    maxDataSourcesCount: -1,
+    maxDataSourcesDocumentsCount: -1,
+    maxDataSourcesDocumentsSizeMb: 2,
+    trialPeriodDays: 0,
+    canUseProduct: true,
+    isByok: true,
   });
 }
 

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -1,0 +1,131 @@
+import { Authenticator } from "@app/lib/auth";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * Enable isByok on the workspace's plan and return a fresh authenticator
+ * that reflects the updated plan.
+ *
+ * Uses SubscriptionModel/PlanModel directly: SubscriptionResource goes through
+ * Redis cache which drops planId, and no PlanResource exists for plan mutations.
+ */
+async function enableByokAndRefreshAuth(
+  workspace: LightWorkspaceType,
+  userId: string
+): Promise<Authenticator> {
+  const subscription = await SubscriptionModel.findOne({
+    where: { workspaceId: workspace.id, status: "active" },
+  });
+  if (!subscription) {
+    throw new Error("No active subscription found");
+  }
+  await PlanModel.update(
+    { isByok: true },
+    { where: { id: subscription.planId } }
+  );
+
+  // Re-create authenticator so it picks up the updated plan.
+  return Authenticator.fromUserIdAndWorkspaceId(userId, workspace.sId);
+}
+
+describe("ProviderCredentialResource", () => {
+  let auth: Authenticator;
+  let userId: string;
+
+  beforeEach(async () => {
+    const testSetup = await createResourceTest({ role: "admin" });
+    auth = testSetup.authenticator;
+    userId = testSetup.user.sId;
+  });
+
+  describe("listByWorkspace", () => {
+    it("throws when plan does not have isByok enabled", async () => {
+      await expect(
+        ProviderCredentialResource.listByWorkspace(auth)
+      ).rejects.toThrow("BYOK is not enabled");
+    });
+
+    it("returns empty array when no credentials exist", async () => {
+      const workspace = auth.getNonNullableWorkspace();
+      auth = await enableByokAndRefreshAuth(workspace, userId);
+
+      const credentials =
+        await ProviderCredentialResource.listByWorkspace(auth);
+
+      expect(credentials).toEqual([]);
+    });
+
+    it("returns all credentials for the workspace", async () => {
+      const workspace = auth.getNonNullableWorkspace();
+      auth = await enableByokAndRefreshAuth(workspace, userId);
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+      await ProviderCredentialFactory.basic(workspace, "anthropic");
+
+      const credentials =
+        await ProviderCredentialResource.listByWorkspace(auth);
+
+      expect(credentials).toHaveLength(2);
+      expect(credentials.map((c) => c.providerId).sort()).toEqual([
+        "anthropic",
+        "openai",
+      ]);
+    });
+  });
+
+  describe("toJSON", () => {
+    it("returns a valid ProviderCredentialType", async () => {
+      const workspace = auth.getNonNullableWorkspace();
+      auth = await enableByokAndRefreshAuth(workspace, userId);
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      const [credential] =
+        await ProviderCredentialResource.listByWorkspace(auth);
+
+      const json = credential.toJSON();
+
+      expect(json.sId).toMatch(/^pcr_/);
+      expect(json.providerId).toBe("openai");
+      expect(json.credentialId).toBe("cred-openai");
+      expect(json.isHealthy).toBe(true);
+      expect(json.placeholder).toBe("sk-...abc");
+      expect(json.editedByUserId).toBeNull();
+      expect(typeof json.createdAt).toBe("number");
+      expect(typeof json.updatedAt).toBe("number");
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the credential", async () => {
+      const workspace = auth.getNonNullableWorkspace();
+      auth = await enableByokAndRefreshAuth(workspace, userId);
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      const [credential] =
+        await ProviderCredentialResource.listByWorkspace(auth);
+      await credential.delete(auth);
+
+      const remaining = await ProviderCredentialResource.listByWorkspace(auth);
+      expect(remaining).toHaveLength(0);
+    });
+  });
+
+  describe("deleteAllForWorkspace", () => {
+    it("removes all credentials for the workspace", async () => {
+      const workspace = auth.getNonNullableWorkspace();
+      auth = await enableByokAndRefreshAuth(workspace, userId);
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+      await ProviderCredentialFactory.basic(workspace, "anthropic");
+
+      await ProviderCredentialResource.deleteAllForWorkspace(auth);
+
+      const remaining = await ProviderCredentialResource.listByWorkspace(auth);
+      expect(remaining).toHaveLength(0);
+    });
+  });
+});

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -1,73 +1,44 @@
-import { Authenticator } from "@app/lib/auth";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
 import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
-/**
- * Enable isByok on the workspace's plan and return a fresh authenticator
- * that reflects the updated plan.
- *
- * Uses SubscriptionModel/PlanModel directly: SubscriptionResource goes through
- * Redis cache which drops planId, and no PlanResource exists for plan mutations.
- */
-async function enableByokAndRefreshAuth(
-  workspace: LightWorkspaceType,
-  userId: string
-): Promise<Authenticator> {
-  const subscription = await SubscriptionModel.findOne({
-    where: { workspaceId: workspace.id, status: "active" },
-  });
-  if (!subscription) {
-    throw new Error("No active subscription found");
-  }
-  await PlanModel.update(
-    { isByok: true },
-    { where: { id: subscription.planId } }
-  );
-
-  // Re-create authenticator so it picks up the updated plan.
-  return Authenticator.fromUserIdAndWorkspaceId(userId, workspace.sId);
-}
-
 describe("ProviderCredentialResource", () => {
-  let auth: Authenticator;
-  let userId: string;
-
-  beforeEach(async () => {
-    const testSetup = await createResourceTest({ role: "admin" });
-    auth = testSetup.authenticator;
-    userId = testSetup.user.sId;
-  });
-
   describe("listByWorkspace", () => {
     it("throws when plan does not have isByok enabled", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
       await expect(
-        ProviderCredentialResource.listByWorkspace(auth)
+        ProviderCredentialResource.listByWorkspace(authenticator)
       ).rejects.toThrow("BYOK is not enabled");
     });
 
     it("returns empty array when no credentials exist", async () => {
-      const workspace = auth.getNonNullableWorkspace();
-      auth = await enableByokAndRefreshAuth(workspace, userId);
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
 
       const credentials =
-        await ProviderCredentialResource.listByWorkspace(auth);
+        await ProviderCredentialResource.listByWorkspace(authenticator);
 
       expect(credentials).toEqual([]);
     });
 
     it("returns all credentials for the workspace", async () => {
-      const workspace = auth.getNonNullableWorkspace();
-      auth = await enableByokAndRefreshAuth(workspace, userId);
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
       await ProviderCredentialFactory.basic(workspace, "anthropic");
 
       const credentials =
-        await ProviderCredentialResource.listByWorkspace(auth);
+        await ProviderCredentialResource.listByWorkspace(authenticator);
 
       expect(credentials).toHaveLength(2);
       expect(credentials.map((c) => c.providerId).sort()).toEqual([
@@ -79,12 +50,15 @@ describe("ProviderCredentialResource", () => {
 
   describe("toJSON", () => {
     it("returns a valid ProviderCredentialType", async () => {
-      const workspace = auth.getNonNullableWorkspace();
-      auth = await enableByokAndRefreshAuth(workspace, userId);
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
       await ProviderCredentialFactory.basic(workspace, "openai");
 
       const [credential] =
-        await ProviderCredentialResource.listByWorkspace(auth);
+        await ProviderCredentialResource.listByWorkspace(authenticator);
 
       const json = credential.toJSON();
 
@@ -100,9 +74,19 @@ describe("ProviderCredentialResource", () => {
   });
 
   describe("delete", () => {
+    let auth: Authenticator;
+    let workspace: LightWorkspaceType;
+
+    beforeEach(async () => {
+      const testSetup = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      auth = testSetup.authenticator;
+      workspace = auth.getNonNullableWorkspace();
+    });
+
     it("removes the credential", async () => {
-      const workspace = auth.getNonNullableWorkspace();
-      auth = await enableByokAndRefreshAuth(workspace, userId);
       await ProviderCredentialFactory.basic(workspace, "openai");
 
       const [credential] =
@@ -116,15 +100,19 @@ describe("ProviderCredentialResource", () => {
 
   describe("deleteAllForWorkspace", () => {
     it("removes all credentials for the workspace", async () => {
-      const workspace = auth.getNonNullableWorkspace();
-      auth = await enableByokAndRefreshAuth(workspace, userId);
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
       await ProviderCredentialFactory.basic(workspace, "anthropic");
 
-      await ProviderCredentialResource.deleteAllForWorkspace(auth);
+      await ProviderCredentialResource.deleteAllForWorkspace(authenticator);
 
-      const remaining = await ProviderCredentialResource.listByWorkspace(auth);
+      const remaining =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
       expect(remaining).toHaveLength(0);
     });
   });

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -1,9 +1,7 @@
-import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
-import type { LightWorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("ProviderCredentialResource", () => {
   describe("listByWorkspace", () => {
@@ -74,26 +72,21 @@ describe("ProviderCredentialResource", () => {
   });
 
   describe("delete", () => {
-    let auth: Authenticator;
-    let workspace: LightWorkspaceType;
-
-    beforeEach(async () => {
-      const testSetup = await createResourceTest({
+    it("removes the credential", async () => {
+      const { authenticator } = await createResourceTest({
         role: "admin",
         isByok: true,
       });
-      auth = testSetup.authenticator;
-      workspace = auth.getNonNullableWorkspace();
-    });
+      const workspace = authenticator.getNonNullableWorkspace();
 
-    it("removes the credential", async () => {
       await ProviderCredentialFactory.basic(workspace, "openai");
 
       const [credential] =
-        await ProviderCredentialResource.listByWorkspace(auth);
-      await credential.delete(auth);
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+      await credential.delete(authenticator);
 
-      const remaining = await ProviderCredentialResource.listByWorkspace(auth);
+      const remaining =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
       expect(remaining).toHaveLength(0);
     });
   });

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -43,7 +43,6 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
 
     const models = await this.model.findAll({
       where: { workspaceId: workspace.id },
-      order: [["createdAt", "DESC"]],
     });
 
     return models.map(
@@ -85,7 +84,6 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   toJSON(): ProviderCredentialType {
     return {
       sId: this.sId,
-      id: this.id,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
       providerId: this.providerId,

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -1,0 +1,98 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ProviderCredentialModel } from "@app/lib/models/provider_credential";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { ProviderCredentialType } from "@app/types/provider_credential";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
+import type { Attributes, ModelStatic } from "sequelize";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+export interface ProviderCredentialResource
+  extends ReadonlyAttributesType<ProviderCredentialModel> {}
+export class ProviderCredentialResource extends BaseResource<ProviderCredentialModel> {
+  static model: ModelStaticWorkspaceAware<ProviderCredentialModel> =
+    ProviderCredentialModel;
+
+  constructor(
+    model: ModelStatic<ProviderCredentialModel>,
+    blob: Attributes<ProviderCredentialModel>
+  ) {
+    super(ProviderCredentialModel, blob);
+  }
+
+  get sId(): string {
+    return makeSId("provider_credential", {
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  private static async baseFetch(
+    auth: Authenticator
+  ): Promise<ProviderCredentialResource[]> {
+    const plan = auth.getNonNullablePlan();
+    assert(plan.isByok, "BYOK is not enabled on this workspace's plan.");
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const models = await this.model.findAll({
+      where: { workspaceId: workspace.id },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return models.map(
+      (m) => new ProviderCredentialResource(ProviderCredentialModel, m.get())
+    );
+  }
+
+  static async listByWorkspace(
+    auth: Authenticator
+  ): Promise<ProviderCredentialResource[]> {
+    return this.baseFetch(auth);
+  }
+
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    await ProviderCredentialModel.destroy({
+      where: { workspaceId: workspace.id },
+    });
+  }
+
+  async delete(
+    auth: Authenticator
+  ): Promise<Result<number | undefined, Error>> {
+    try {
+      const affectedCount = await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      });
+
+      return new Ok(affectedCount);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  toJSON(): ProviderCredentialType {
+    return {
+      sId: this.sId,
+      id: this.id,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      providerId: this.providerId,
+      credentialId: this.credentialId,
+      isHealthy: this.isHealthy,
+      placeholder: this.placeholder,
+      editedByUserId: this.editedByUserId,
+    };
+  }
+}

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -81,6 +81,9 @@ export const RESOURCES_PREFIX = {
 
   // Conversation branches.
   conversation_branch: "cbr",
+
+  // Provider credentials (BYOK).
+  provider_credential: "pcr",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -43,6 +43,7 @@ import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resou
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -706,6 +707,7 @@ export async function deleteWorkspaceActivity({
     where: { workspaceId: workspace.id },
   });
   await ExtensionConfigurationResource.deleteForWorkspace(auth, {});
+  await ProviderCredentialResource.deleteAllForWorkspace(auth);
   await DustAppSecretModel.destroy({
     where: {
       workspaceId: workspace.id,

--- a/front/tests/utils/ProviderCredentialFactory.ts
+++ b/front/tests/utils/ProviderCredentialFactory.ts
@@ -1,0 +1,18 @@
+import { ProviderCredentialModel } from "@app/lib/models/provider_credential";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { LightWorkspaceType } from "@app/types/user";
+
+export class ProviderCredentialFactory {
+  static async basic(
+    workspace: LightWorkspaceType,
+    providerId: ModelProviderIdType = "openai"
+  ) {
+    return ProviderCredentialModel.create({
+      workspaceId: workspace.id,
+      providerId,
+      credentialId: `cred-${providerId}`,
+      isHealthy: true,
+      placeholder: "sk-...abc",
+    });
+  }
+}

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,5 +1,8 @@
 import { PlanModel } from "@app/lib/models/plan";
-import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import {
+  FREE_BYOK_PLAN_CODE,
+  PRO_PLAN_SEAT_29_CODE,
+} from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -12,8 +15,16 @@ import { expect } from "vitest";
 
 export class WorkspaceFactory {
   static async basic(): Promise<WorkspaceType> {
-    // Plans are seeded by the DB init script (admin/db.ts) to avoid deadlocks
-    // from concurrent upserts in parallel test workers.
+    return this.create(PRO_PLAN_SEAT_29_CODE);
+  }
+
+  static async byok(): Promise<WorkspaceType> {
+    return this.create(FREE_BYOK_PLAN_CODE);
+  }
+
+  // Plans are seeded by the DB init script (admin/db.ts) to avoid deadlocks
+  // from concurrent upserts in parallel test workers.
+  private static async create(planCode: string): Promise<WorkspaceType> {
     const workspace = await WorkspaceModel.create({
       sId: generateRandomModelSId(),
       name: faker.company.name(),
@@ -21,25 +32,22 @@ export class WorkspaceFactory {
       workOSOrganizationId: faker.string.alpha(10),
     });
 
-    const newPlan = await PlanModel.findOne({
-      where: { code: PRO_PLAN_SEAT_29_CODE },
-    });
-    if (!newPlan) {
-      throw new Error(`Plan ${PRO_PLAN_SEAT_29_CODE} not found`);
+    const plan = await PlanModel.findOne({ where: { code: planCode } });
+    if (!plan) {
+      throw new Error(`Plan ${planCode} not found`);
     }
-    const now = new Date();
 
     await SubscriptionResource.makeNew(
       {
         sId: generateRandomModelSId(),
         workspaceId: workspace.id,
-        planId: newPlan.id,
+        planId: plan.id,
         status: "active",
-        startDate: now,
+        startDate: new Date(),
         stripeSubscriptionId: null,
         endDate: null,
       },
-      renderPlanFromModel({ plan: newPlan })
+      renderPlanFromModel({ plan })
     );
 
     const workspaceType: WorkspaceType = {

--- a/front/tests/utils/generic_resource_tests.ts
+++ b/front/tests/utils/generic_resource_tests.ts
@@ -16,9 +16,11 @@ import type { LightWorkspaceType } from "@app/types/user";
 export const createResourceTest: ({
   role,
   isSuperUser,
+  isByok,
 }: {
   role?: MembershipRoleType;
   isSuperUser?: boolean;
+  isByok?: boolean;
 }) => Promise<{
   workspace: LightWorkspaceType;
   user: UserResource;
@@ -32,11 +34,15 @@ export const createResourceTest: ({
 }> = async ({
   role = "user",
   isSuperUser = false,
+  isByok = false,
 }: {
   role?: MembershipRoleType;
   isSuperUser?: boolean;
+  isByok?: boolean;
 }) => {
-  const workspace = await WorkspaceFactory.basic();
+  const workspace = isByok
+    ? await WorkspaceFactory.byok()
+    : await WorkspaceFactory.basic();
   const user: UserResource = await (isSuperUser
     ? UserFactory.superUser()
     : UserFactory.basic());

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -3,7 +3,6 @@ import type { ModelId } from "@app/types/shared/model_id";
 
 export type ProviderCredentialType = {
   sId: string;
-  id: ModelId;
   createdAt: number;
   updatedAt: number;
   providerId: ModelProviderIdType;

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -1,0 +1,14 @@
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ModelId } from "@app/types/shared/model_id";
+
+export type ProviderCredentialType = {
+  sId: string;
+  id: ModelId;
+  createdAt: number;
+  updatedAt: number;
+  providerId: ModelProviderIdType;
+  credentialId: string;
+  isHealthy: boolean;
+  placeholder: string;
+  editedByUserId: ModelId | null;
+};


### PR DESCRIPTION
## Description

Add `ProviderCredentialResource` to wrap the `ProviderCredentialModel` behind `isByok` plan gating. The resource asserts `plan.isByok` in `baseFetch` so all read paths are gated. Registered in workspace deletion workflow via `deleteAllForWorkspace`.

`listByWorkspace` will be used by a future `getCredentials(auth)` entry point for credential resolution of BYOK workspaces

Part of https://github.com/dust-tt/tasks/issues/6962