### PR TITLE
MCP: allow version field of size 2K and check it

### DIFF
--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -51,7 +51,7 @@ RemoteMCPServerModel.init(
       allowNull: false,
     },
     version: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
       defaultValue: DEFAULT_MCP_ACTION_VERSION,
     },

--- a/front/migrations/db/migration_540.sql
+++ b/front/migrations/db/migration_540.sql
@@ -1,0 +1,6 @@
+-- Migration created on Mar 09, 2026
+-- Change version column on remote_mcp_servers to TEXT to avoid
+-- "value too long for type character varying(255)" errors when remote
+-- MCP servers return long version strings.
+ALTER TABLE "remote_mcp_servers"
+  ALTER COLUMN "version" TYPE TEXT;


### PR DESCRIPTION
## Description

Trying to fix this error we are seeing in datadog:

```
Object: value too long for type character varying(255)
```

I'm 99% certain it is due to version field, I'm seeing version field with 90 characters in db like these:
 - `v0.78.1 (build commit: cb4fc724b57892442b12aba6a59c83eca5975d61 date: 2026-01-07T09:04:53)`
 - `github-mcp-server/remote-58032d03b8d04b1f2f066c743970d036e09df41e`

So more than 255 characters is possible


## Risk

low

## Deploy Plan

 - lock front
 - merge
 - apply migration
 - deploy
 - unlock front 
