### PR TITLE
[Agent Email] Replace hardcoded gating with feature flag

### DIFF
--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -11,14 +11,17 @@ import {
   storeEmailReplyContext,
 } from "@app/lib/api/assistant/email/email_trigger";
 import config from "@app/lib/api/config";
-import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
+import {
+  Authenticator,
+  type AuthenticatorType,
+  getFeatureFlags,
+} from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
-import { isDevelopment } from "@app/types/shared/env";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 
@@ -48,37 +51,19 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
 }
 
 /**
- * Check security gating for email replies.
- * Returns true if the reply should be sent, false otherwise.
- *
- * Defense-in-depth: duplicates the webhook handler checks as a second layer
- * of protection in case Redis data is manipulated or context is stored incorrectly.
+ * Check feature flag for email replies (defense-in-depth, duplicates webhook check).
  */
-function checkEmailReplyGating(
-  context: EmailReplyContext,
-  agentMessageId: string
-): boolean {
-  // Security gating: only allow replies to dust.tt emails in the Dust workspace.
-  if (!context.fromEmail.endsWith("@dust.tt")) {
-    logger.warn(
-      { agentMessageId, fromEmail: context.fromEmail },
-      "[email] Sender email not in @dust.tt domain, skipping reply"
-    );
+async function isEmailReplyEnabled(
+  authType: AuthenticatorType
+): Promise<boolean> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
     return false;
   }
-  const productionDustWorkspaceId = config.getProductionDustWorkspaceId();
-  if (
-    !isDevelopment() &&
-    productionDustWorkspaceId &&
-    context.workspaceId !== productionDustWorkspaceId
-  ) {
-    logger.warn(
-      { agentMessageId, workspaceId: context.workspaceId },
-      "[email] Workspace not gated for email replies, skipping reply"
-    );
-    return false;
-  }
-  return true;
+  const featureFlags = await getFeatureFlags(
+    authResult.value.getNonNullableWorkspace()
+  );
+  return featureFlags.includes("email_agents");
 }
 
 /**
@@ -190,7 +175,11 @@ export async function sendEmailReplyOnCompletion(
       return;
     }
 
-    if (!checkEmailReplyGating(context, agentLoopArgs.agentMessageId)) {
+    if (!(await isEmailReplyEnabled(authType))) {
+      await deleteEmailReplyContext(
+        authType.workspaceId,
+        agentLoopArgs.agentMessageId
+      );
       return;
     }
 
@@ -311,7 +300,7 @@ export async function sendEmailReplyOnError(
       agentLoopArgs.agentMessageId
     );
 
-    if (!checkEmailReplyGating(context, agentLoopArgs.agentMessageId)) {
+    if (!(await isEmailReplyEnabled(authType))) {
       return;
     }
 

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -60,7 +60,9 @@ async function isEmailAgentsEnabled(
 ): Promise<boolean> {
   const authResult = await Authenticator.fromJSON(authType);
   if (authResult.isErr()) {
-    logger.warn("[email] Failed to create authenticator for feature flag check");
+    logger.warn(
+      "[email] Failed to create authenticator for feature flag check"
+    );
     return false;
   }
   const featureFlags = await getFeatureFlags(

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -51,6 +51,32 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
 }
 
 /**
+ * Defense-in-depth: check feature flag before sending email replies.
+ * Duplicates the webhook handler check in case Redis data is manipulated
+ * or context is stored incorrectly.
+ */
+async function isEmailAgentsEnabled(
+  authType: AuthenticatorType
+): Promise<boolean> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.warn("[email] Failed to create authenticator for feature flag check");
+    return false;
+  }
+  const featureFlags = await getFeatureFlags(
+    authResult.value.getNonNullableWorkspace()
+  );
+  if (!featureFlags.includes("email_agents")) {
+    logger.info(
+      { workspaceId: authType.workspaceId },
+      "[email] email_agents feature flag not enabled, skipping reply"
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
  * Check if the agent is blocked on tool validation.
  * If so, send a validation email and re-store the context with fresh TTL.
  * Returns true if blocked (validation email sent), false otherwise.
@@ -174,11 +200,7 @@ export async function sendEmailReplyOnCompletion(
 
     const { auth, agentMessage, conversation } = dataRes.value;
 
-    // Defense-in-depth: check feature flag before sending reply.
-    const featureFlags = await getFeatureFlags(
-      auth.getNonNullableWorkspace()
-    );
-    if (!featureFlags.includes("email_agents")) {
+    if (!(await isEmailAgentsEnabled(authType))) {
       await deleteEmailReplyContext(
         authType.workspaceId,
         agentLoopArgs.agentMessageId
@@ -288,15 +310,7 @@ export async function sendEmailReplyOnError(
       agentLoopArgs.agentMessageId
     );
 
-    // Defense-in-depth: check feature flag before sending reply.
-    const authResult = await Authenticator.fromJSON(authType);
-    if (authResult.isErr()) {
-      return;
-    }
-    const featureFlags = await getFeatureFlags(
-      authResult.value.getNonNullableWorkspace()
-    );
-    if (!featureFlags.includes("email_agents")) {
+    if (!(await isEmailAgentsEnabled(authType))) {
       return;
     }
 

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -51,22 +51,6 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
 }
 
 /**
- * Check feature flag for email replies (defense-in-depth, duplicates webhook check).
- */
-async function isEmailReplyEnabled(
-  authType: AuthenticatorType
-): Promise<boolean> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return false;
-  }
-  const featureFlags = await getFeatureFlags(
-    authResult.value.getNonNullableWorkspace()
-  );
-  return featureFlags.includes("email_agents");
-}
-
-/**
  * Check if the agent is blocked on tool validation.
  * If so, send a validation email and re-store the context with fresh TTL.
  * Returns true if blocked (validation email sent), false otherwise.
@@ -175,14 +159,6 @@ export async function sendEmailReplyOnCompletion(
       return;
     }
 
-    if (!(await isEmailReplyEnabled(authType))) {
-      await deleteEmailReplyContext(
-        authType.workspaceId,
-        agentLoopArgs.agentMessageId
-      );
-      return;
-    }
-
     // Get the completed agent message data.
     const dataRes = await getAgentLoopData(authType, agentLoopArgs);
     if (dataRes.isErr()) {
@@ -197,6 +173,18 @@ export async function sendEmailReplyOnCompletion(
     }
 
     const { auth, agentMessage, conversation } = dataRes.value;
+
+    // Defense-in-depth: check feature flag before sending reply.
+    const featureFlags = await getFeatureFlags(
+      auth.getNonNullableWorkspace()
+    );
+    if (!featureFlags.includes("email_agents")) {
+      await deleteEmailReplyContext(
+        authType.workspaceId,
+        agentLoopArgs.agentMessageId
+      );
+      return;
+    }
 
     // Check if blocked on tool validation — send validation email instead.
     const blocked = await handleBlockedValidation(
@@ -300,7 +288,15 @@ export async function sendEmailReplyOnError(
       agentLoopArgs.agentMessageId
     );
 
-    if (!(await isEmailReplyEnabled(authType))) {
+    // Defense-in-depth: check feature flag before sending reply.
+    const authResult = await Authenticator.fromJSON(authType);
+    if (authResult.isErr()) {
+      return;
+    }
+    const featureFlags = await getFeatureFlags(
+      authResult.value.getNonNullableWorkspace()
+    );
+    if (!featureFlags.includes("email_agents")) {
       return;
     }
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -12,7 +12,7 @@ import { generateValidationToken } from "@app/lib/api/email/validation_token";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -376,25 +376,43 @@ export async function userAndWorkspaceFromEmail({
     });
   }
 
+  // Filter to workspaces with the email_agents feature flag enabled.
+  const eligibleWorkspaceModels: typeof workspaceModels = [];
+  for (const w of workspaceModels) {
+    const lightWorkspace = renderLightWorkspaceType({ workspace: w });
+    const flags = await getFeatureFlags(lightWorkspace);
+    if (flags.includes("email_agents")) {
+      eligibleWorkspaceModels.push(w);
+    }
+  }
+
+  if (eligibleWorkspaceModels.length === 0) {
+    return new Err({
+      type: "workspace_not_found",
+      message:
+        "Email interactions with agents are not enabled for any of your workspaces.",
+    });
+  }
+
   // Pick the best workspace: prefer paying plans, then upgraded free plans,
   // then fall back to the most recently created workspace.
   const subscriptionsByWorkspaceId =
     await SubscriptionResource.fetchActiveByWorkspacesModelId(
-      workspaceModels.map((w) => w.id)
+      eligibleWorkspaceModels.map((w) => w.id)
     );
 
-  const payingWorkspace = workspaceModels.find((w) => {
+  const payingWorkspace = eligibleWorkspaceModels.find((w) => {
     const sub = subscriptionsByWorkspaceId[w.id];
     return sub && !isFreePlan(sub.getPlan().code);
   });
 
-  const upgradedWorkspace = workspaceModels.find((w) => {
+  const upgradedWorkspace = eligibleWorkspaceModels.find((w) => {
     const sub = subscriptionsByWorkspaceId[w.id];
     return sub && isUpgraded(sub.getPlan());
   });
 
   // Ordered by id DESC, so first = most recently created.
-  const mostRecentWorkspace = workspaceModels[0];
+  const mostRecentWorkspace = eligibleWorkspaceModels[0];
 
   const selectedWorkspace =
     payingWorkspace ?? upgradedWorkspace ?? mostRecentWorkspace;

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -11,7 +11,7 @@ import {
   userAndWorkspaceFromEmail,
 } from "@app/lib/api/assistant/email/email_trigger";
 import apiConfig from "@app/lib/api/config";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -220,20 +220,6 @@ async function handler(
 
       const email = emailRes.value;
 
-      // Gating: only dust.tt emails are allowed to trigger the agent
-      // WARNING: DO NOT UNGATE. Todo before ungating:
-      // - ! check security, including but not limited to SPF dkim approach thorough review
-      // - review from https://github.com/dust-tt/dust/pull/5365 for code refactoring and cleanup
-      if (!email.envelope.from.endsWith("@dust.tt")) {
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Only dust.tt emails are allowed to trigger the agent",
-          },
-        });
-      }
-
       // At this stage we have a valid email in we can respond 200 to the webhook, no more apiError
       // possible below this point, errors should be reported to the sender.
       res.status(200).json({ success: true });
@@ -283,6 +269,18 @@ async function handler(
         user.sId,
         workspace.sId
       );
+
+      const featureFlags = await getFeatureFlags(
+        auth.getNonNullableWorkspace()
+      );
+      if (!featureFlags.includes("email_agents")) {
+        await replyToError(email, {
+          type: "invalid_email_error",
+          message:
+            "Email interactions with agents are not enabled for your workspace.",
+        });
+        return;
+      }
 
       const agentConfigurations = removeNulls(
         await Promise.all(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -202,6 +202,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
   },
+  email_agents: {
+    description: "Enable triggering and interacting with agents via email",
+    stage: "dust_only",
+  },
   project_butler: {
     description: "Enable user project digest generation in project spaces",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,6 +690,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
   | "discord_bot"
+  | "email_agents"
   | "dust_academy"
   | "dust_internal_global_agents"
   | "dust_no_spa"


### PR DESCRIPTION
## Description

Replaces the hardcoded `@dust.tt` domain check and `PRODUCTION_DUST_WORKSPACE_ID` workspace restriction with a proper `email_agents` feature flag (`dust_only` stage), consistent with how other features are gated.

Changes:
- Webhook handler: removed `@dust.tt` sender domain gate, added feature flag check after authenticator creation
- Email reply (defense-in-depth): replaced `checkEmailReplyGating` (domain + workspace checks) with feature flag check
- Added `email_agents` to feature flags in both `front` and `sdks/js`

## Risks

Blast radius: email agent reply feature (currently dust-only)
Risk: low — feature flag replaces existing gating; must enable flag on Dust workspace to maintain current behavior

## Deploy Plan
- pmrr
- Deploy front
- Enable `email_agents` feature flag on the Dust production workspace