### PR TITLE
Add support for multiple projects in the BigQuery connector

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@dust-tt/client": "file:../sdks/js",
     "@google-cloud/bigquery": "^7.9.2",
+    "@google-cloud/resource-manager": "^6.2.1",
     "@google-cloud/storage": "^7.13.0",
     "@jsonjoy.com/util": "^1.1.3",
     "@mendable/firecrawl-js": "^1.29.1",

--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -11,6 +11,7 @@ import { isBigqueryPermissionsError } from "@connectors/types/bigquery";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok, removeNulls } from "@dust-tt/client";
 import { BigQuery } from "@google-cloud/bigquery";
+import { ProjectsClient } from "@google-cloud/resource-manager";
 
 const MAX_TABLES_PER_SCHEMA = 1500;
 type TestConnectionErrorCode = "INVALID_CREDENTIALS" | "UNKNOWN";
@@ -41,7 +42,7 @@ export const testConnection = async ({
   credentials: BigQueryCredentialsWithLocation;
 }): Promise<Result<string, TestConnectionError>> => {
   // Connect to bigquery, do a simple query.
-  const bigQuery = connectToBigQuery(credentials);
+  const bigQuery = connectToBigQuery(credentials, credentials.project_id);
   try {
     await bigQuery.query("SELECT 1");
     return new Ok("Connection successful");
@@ -58,7 +59,8 @@ export const testConnection = async ({
 };
 
 export function connectToBigQuery(
-  credentials: BigQueryCredentialsWithLocation
+  credentials: BigQueryCredentialsWithLocation,
+  projectId: string
 ): BigQuery {
   return new BigQuery({
     credentials,
@@ -68,17 +70,58 @@ export function connectToBigQuery(
       autoRetry: true,
       maxRetries: 3,
     },
+    projectId,
   });
 }
 
-export const fetchDatabases = ({
+async function listAccessibleProjects(
+  credentials: BigQueryCredentialsWithLocation
+) {
+  const client = new ProjectsClient({
+    credentials: {
+      client_email: credentials.client_email,
+      private_key: credentials.private_key,
+    },
+  });
+
+  const projects = [];
+  const iterable = client.searchProjectsAsync({ query: "" });
+
+  for await (const project of iterable) {
+    projects.push(project);
+  }
+
+  return projects;
+}
+
+export const fetchDatabases = async ({
   credentials,
+  logger,
 }: {
   credentials: BigQueryCredentialsWithLocation;
-}): RemoteDBDatabase[] => {
+  logger?: Logger;
+}): Promise<Array<RemoteDBDatabase>> => {
   // BigQuery do not have a concept of databases per say, the most similar concept is a project.
-  // Since credentials are always scoped to a project, we directly return a single database with the project name.
-  return [{ name: credentials.project_id }];
+
+  // A service account can have access to multiple projects.
+  // We start by the project the credentials are scoped to.
+  let projectIds: string[] = [credentials.project_id];
+  try {
+    const projects = await listAccessibleProjects(credentials);
+    // And then we add the other projects the service account has access to.
+    projectIds = [
+      ...projectIds,
+      ...projects
+        .filter((project) => project.projectId && project.state === "ACTIVE")
+        .map((project) => project.projectId!),
+    ];
+  } catch (error) {
+    logger?.error(error, "Error listing accessible projects");
+  }
+
+  return Array.from(new Set(projectIds)).map((projectId) => ({
+    name: projectId,
+  }));
 };
 
 /**
@@ -88,14 +131,16 @@ export const fetchDatabases = ({
  */
 export const fetchDatasets = async ({
   credentials,
+  database,
   connection,
   logger,
 }: {
   credentials: BigQueryCredentialsWithLocation;
+  database: RemoteDBDatabase;
   connection?: BigQuery;
   logger?: Logger;
 }): Promise<Result<Array<RemoteDBSchema>, Error>> => {
-  const conn = connection ?? connectToBigQuery(credentials);
+  const conn = connection ?? connectToBigQuery(credentials, database.name);
   try {
     const r = await conn.getDatasets();
     const datasets = r[0];
@@ -123,7 +168,7 @@ export const fetchDatasets = async ({
           }
           return {
             name: dataset.id,
-            database_name: credentials.project_id,
+            database_name: database.name,
           };
         })
       )
@@ -144,12 +189,13 @@ export const fetchTables = async ({
   logger,
 }: {
   credentials: BigQueryCredentialsWithLocation;
-  dataset: string;
+  dataset: RemoteDBSchema;
   fetchTablesDescription: boolean;
   connection?: BigQuery;
   logger?: Logger;
 }): Promise<Result<Array<RemoteDBTable>, Error>> => {
-  const conn = connection ?? connectToBigQuery(credentials);
+  const conn =
+    connection ?? connectToBigQuery(credentials, dataset.database_name);
   try {
     // Can't happen, to please TS.
     if (!dataset) {
@@ -157,7 +203,7 @@ export const fetchTables = async ({
     }
 
     // Get the dataset specified by the schema
-    const d = conn.dataset(dataset);
+    const d = conn.dataset(dataset.name);
     const r = await d.getTables();
     const tables = r[0];
     logger?.info(
@@ -187,8 +233,8 @@ export const fetchTables = async ({
               );
               return {
                 name: table.id!,
-                database_name: credentials.project_id,
-                schema_name: dataset,
+                database_name: dataset.database_name,
+                schema_name: dataset.name,
                 description: metadata[0].description,
               };
             } catch (error) {
@@ -203,7 +249,7 @@ export const fetchTables = async ({
                     : "Permission denied";
                 logger?.warn(
                   {
-                    projectId: credentials.project_id,
+                    projectId: dataset.database_name,
                     dataset,
                     table: table.id,
                     error: errorMessage,
@@ -219,8 +265,8 @@ export const fetchTables = async ({
           } else {
             return {
               name: table.id!,
-              database_name: credentials.project_id,
-              schema_name: dataset,
+              database_name: dataset.database_name,
+              schema_name: dataset.name,
             };
           }
         },
@@ -245,26 +291,29 @@ export const fetchTree = async ({
   fetchTablesDescription: boolean;
   logger: Logger;
 }): Promise<Result<RemoteDBTree, Error>> => {
-  const databases = fetchDatabases({ credentials });
-
-  const schemasRes = await fetchDatasets({ credentials, logger });
-  if (schemasRes.isErr()) {
-    return schemasRes;
-  }
-  const schemas = schemasRes.value;
+  const databases = await fetchDatabases({ credentials });
 
   const tree = {
     databases: await concurrentExecutor(
       databases,
       async (db) => {
+        const schemasRes = await fetchDatasets({
+          credentials,
+          database: db,
+          logger,
+        });
+        if (schemasRes.isErr()) {
+          throw schemasRes.error;
+        }
+        const schemas = schemasRes.value;
         return {
           ...db,
           schemas: await concurrentExecutor(
-            schemas.filter((s) => s.database_name === db.name),
+            schemas,
             async (schema) => {
               const tablesRes = await fetchTables({
                 credentials,
-                dataset: schema.name,
+                dataset: schema,
                 fetchTablesDescription,
                 logger,
               });
@@ -282,7 +331,7 @@ export const fetchTree = async ({
                   name:
                     schema.name +
                     ` (sync skipped: exceeded ${MAX_TABLES_PER_SCHEMA} tables limit)`,
-                  database_name: credentials.project_id,
+                  database_name: db.name,
                   tables: [],
                 };
               }
@@ -296,8 +345,7 @@ export const fetchTree = async ({
           ),
         };
       },
-      // There's only one database in BigQuery, so we can use concurrency 1.
-      { concurrency: 1 }
+      { concurrency: 2 }
     ),
   };
 

--- a/connectors/src/connectors/bigquery/lib/permissions.ts
+++ b/connectors/src/connectors/bigquery/lib/permissions.ts
@@ -48,7 +48,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
       (db) => db.internalId
     );
 
-    const allDatabases = fetchDatabases({ credentials });
+    const allDatabases = await fetchDatabases({ credentials });
 
     return new Ok(
       allDatabases.map((row) => {
@@ -76,6 +76,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
 
     const allDatasetsRes = await fetchDatasets({
       credentials,
+      database: { name: databaseName },
     });
     if (allDatasetsRes.isErr()) {
       return new Err(allDatasetsRes.error);
@@ -114,7 +115,7 @@ export const fetchAvailableChildrenInBigQuery = async ({
     );
     const allTablesRes = await fetchTables({
       credentials,
-      dataset: datasetName,
+      dataset: { name: datasetName, database_name: databaseName },
       fetchTablesDescription: false,
     });
     if (allTablesRes.isErr()) {

--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -88,7 +88,10 @@ impl TryFrom<&gcp_bigquery_client::model::table_schema::TableSchema> for TableSc
                     })
                     .collect(),
             )),
-            None => Err(anyhow!("No fields found in schema"))?,
+            None => {
+                info!("No fields found in schema for table");
+                Ok(TableSchema::empty())
+            }
         }
     }
 }
@@ -482,16 +485,17 @@ impl RemoteDatabase for BigQueryRemoteDatabase {
                 if parts.len() != 3 {
                     Err(anyhow!("Invalid opaque ID: {}", opaque_id))?
                 }
-                let (dataset_id, table_id) = (
+                let (project_id, dataset_id, table_id) = (
+                    parts[0].replace("__DUST_DOT__", "."),
                     parts[1].replace("__DUST_DOT__", "."),
                     parts[2].replace("__DUST_DOT__", "."),
                 );
 
                 self.client
                     .table()
-                    .get(&self.project_id, &dataset_id, &table_id, None)
+                    .get(&project_id, &dataset_id, &table_id, None)
                     .await
-                    .map_err(|e| anyhow!("Error getting table metadata: {}", e))
+                    .map_err(|e| anyhow!("Error getting table metadata of {}: {}", opaque_id, e))
             }))
             .await?;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
       "dependencies": {
         "@dust-tt/client": "file:../sdks/js",
         "@google-cloud/bigquery": "^7.9.2",
+        "@google-cloud/resource-manager": "^6.2.1",
         "@google-cloud/storage": "^7.13.0",
         "@jsonjoy.com/util": "^1.1.3",
         "@mendable/firecrawl-js": "^1.29.1",
@@ -6684,6 +6685,206 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/resource-manager/-/resource-manager-6.2.1.tgz",
+      "integrity": "sha512-x/7G3qwLt9e+D2sL3hMS/sa7F0r3mW+b+eikR7IqpJTp4n6l6MPSRo0auprf3xiG16H5IwFaIaJ7HoOaeh5tNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/google-auth-library": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/google-gax": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.1.0",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.3",
+        "retry-request": "^8.0.0",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/teeny-request": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
+      "integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/resource-manager/node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@google-cloud/storage": {


### PR DESCRIPTION
## Description

Remove the static hardcode limit one using the projectID from the service account file to determine the BigQuery database and instead try to list all accessible projectIDs (+ the one from the service account).

## Tests

Checked locally that it didn't break and that the method to list was working.
Fully end-to-end tested.

## Risk

Low

## Deploy Plan

Deploy connectors.