### PR TITLE
Pause sidekick start after new agent is saved

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -724,6 +724,7 @@ function AgentBuilderContent({
             isDuplicate={isDuplicate}
             templateInfo={templateInfo}
             conversationId={conversationId}
+            suppressAutoStart={isCreatedDialogOpen}
           >
             <ConversationSidePanelProvider>
               <AgentBuilderRightPanel

--- a/front/components/agent_builder/AgentBuilderSidekick.tsx
+++ b/front/components/agent_builder/AgentBuilderSidekick.tsx
@@ -147,6 +147,7 @@ export function AgentBuilderSidekick() {
     startConversation,
     resetConversation,
     clientSideMCPServerIds,
+    suppressAutoStart,
   } = useSidekickPanelContext();
 
   // Auto-start conversation when component mounts
@@ -162,6 +163,10 @@ export function AgentBuilderSidekick() {
           description="There was an issue starting the Sidekick session. Please try again later."
         />
       );
+    }
+
+    if (suppressAutoStart) {
+      return null;
     }
 
     if (isCreatingConversation || !conversation) {

--- a/front/components/agent_builder/SidekickPanelContext.tsx
+++ b/front/components/agent_builder/SidekickPanelContext.tsx
@@ -25,6 +25,7 @@ interface SidekickPanelContextType {
   resetConversation: () => void;
   clientSideMCPServerIds: string[];
   conversationId?: string;
+  suppressAutoStart: boolean;
 }
 
 const SidekickPanelContext = createContext<
@@ -50,6 +51,7 @@ interface SidekickPanelProviderProps {
   isDuplicate?: boolean;
   templateInfo?: TemplateInfo;
   conversationId?: string;
+  suppressAutoStart?: boolean;
 }
 
 export const SidekickPanelProvider = ({
@@ -61,6 +63,7 @@ export const SidekickPanelProvider = ({
   isDuplicate = false,
   templateInfo,
   conversationId,
+  suppressAutoStart = false,
 }: SidekickPanelProviderProps) => {
   const { owner } = useAgentBuilderContext();
   const { user } = useAuth();
@@ -94,7 +97,11 @@ export const SidekickPanelProvider = ({
   });
 
   const startConversation = useCallback(async () => {
-    if (hasStartedRef.current || !targetAgentConfigurationId) {
+    if (
+      hasStartedRef.current ||
+      !targetAgentConfigurationId ||
+      suppressAutoStart
+    ) {
       return;
     }
 
@@ -160,6 +167,7 @@ export const SidekickPanelProvider = ({
     getFirstMessage,
     useCase,
     sendNotification,
+    suppressAutoStart,
     targetAgentConfigurationId,
     targetAgentConfigurationVersion,
   ]);
@@ -178,6 +186,7 @@ export const SidekickPanelProvider = ({
       startConversation,
       resetConversation,
       clientSideMCPServerIds,
+      suppressAutoStart,
     }),
     [
       clientSideMCPServerIds,
@@ -186,6 +195,7 @@ export const SidekickPanelProvider = ({
       creationFailed,
       startConversation,
       resetConversation,
+      suppressAutoStart,
     ]
   );
 


### PR DESCRIPTION
## Description
When a new agent is saved, we reroute from /new to /agent/sid routes which re-renders the react tree and starts a new sidekick session for the now existent agent.
This is fine, but looks weird when it happens in the background of the agent saved dialogue box. We should pause initiating the sidekick session until the user presses "Keep editing"
This also ensures we don't waste a sidekick convo starting when they don't keep editing
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually 
https://github.com/user-attachments/assets/db2ea440-f64f-4876-96b3-79d338cd146b


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
