### PR TITLE
[.github] - fix(deployment): enable SDK builds in sandbox image registry

### DIFF
--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ./.github/actions/setup-node-deps
         with:
           node-version: "22.22.0"
+          build-sdks: "true"
 
       - name: Check sandbox images
         id: check
@@ -71,6 +72,7 @@ jobs:
         uses: ./.github/actions/setup-node-deps
         with:
           node-version: "22.22.0"
+          build-sdks: "true"
 
       - name: Write service account JSON
         run: |


### PR DESCRIPTION
## Description

This PR adds `build-sdks` option set to "true" to initiate SDK builds during the setup of node dependencies