### PR TITLE
[front] - feat(SkillsBuilder): description field to TipTap editor

### DIFF
--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -25,7 +25,7 @@ function buildSkillDescriptionExtensions(): Extensions {
       placeholder:
         "When should this skill be used? What is this skill good for?",
       emptyNodeClass:
-        "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+        "first:before:text-gray-400 dark:first:before:text-gray-500 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
     }),
   ];
 }

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -1,25 +1,38 @@
-import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
+import { editorVariants } from "@app/components/editor/editorStyles";
+import {
+  SkillDescriptionEditorContent,
+  useSkillDescriptionEditor,
+} from "@app/components/editor/SkillDescriptionEditor";
 import { SKILL_BUILDER_AGENT_DESCRIPTION_BLUR_EVENT } from "@app/components/skill_builder/events";
 import { SimilarSkillsDisplay } from "@app/components/skill_builder/SimilarSkillsDisplay";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSimilarSkills, useSkills } from "@app/lib/swr/skill_configurations";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { TextArea } from "@dust-tt/sparkle";
-import type { ChangeEvent } from "react";
-import { useCallback, useState } from "react";
+import { cn } from "@dust-tt/sparkle";
+import type { Transaction } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+import debounce from "lodash/debounce";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useController, useFormContext } from "react-hook-form";
 
-const AGENT_FACING_DESCRIPTION_FIELD_NAME = "agentFacingDescription";
+const FIELD_NAME = "agentFacingDescription";
 const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
+const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-[512px]";
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();
+  const { setValue } = useFormContext<SkillBuilderFormData>();
+
+  const { field: descriptionField, fieldState: descriptionFieldState } =
+    useController<SkillBuilderFormData, typeof FIELD_NAME>({
+      name: FIELD_NAME,
+    });
 
   const { getSimilarSkills } = useSimilarSkills({ owner });
-  const { skills } = useSkills({
-    owner,
-  });
+  const { skills } = useSkills({ owner });
 
   const [similarSkills, setSimilarSkills] = useState<SkillType[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -33,11 +46,10 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       }
 
       const result = await getSimilarSkills(description, {
-        excludeSkillId: skillId, // Exclude the skill being edited.
+        excludeSkillId: skillId,
         signal,
       });
 
-      // Only update state if the request was not aborted
       if (!signal.aborted) {
         setIsLoading(false);
         if (result.isOk()) {
@@ -57,52 +69,108 @@ export function SkillBuilderAgentFacingDescriptionSection() {
     delayMs: DEBOUNCE_DELAY_MS,
   });
 
-  const handleDescriptionChange = useCallback(
-    (
-      e: ChangeEvent<HTMLTextAreaElement>,
-      formOnChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
-    ) => {
-      formOnChange(e);
-      const value = e.target.value;
-      // Set loading immediately when description is long enough
-      setIsLoading(value.length >= MIN_DESCRIPTION_LENGTH);
-      triggerSimilarSkillsFetch(value);
-    },
-    [triggerSimilarSkillsFetch]
+  const debouncedUpdate = useMemo(
+    () =>
+      debounce((editor: Editor) => {
+        if (!editor.isDestroyed) {
+          const text = editor.getText().trim();
+          setValue(FIELD_NAME, text, { shouldDirty: true });
+          setIsLoading(text.length >= MIN_DESCRIPTION_LENGTH);
+          triggerSimilarSkillsFetch(text);
+        }
+      }, DEBOUNCE_DELAY_MS),
+    [setValue, triggerSimilarSkillsFetch]
   );
 
+  const handleUpdate = useCallback(
+    ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
+      if (transaction.docChanged) {
+        debouncedUpdate(editor);
+      }
+    },
+    [debouncedUpdate]
+  );
+
+  const handleBlur = useCallback(() => {
+    window.dispatchEvent(
+      new CustomEvent(SKILL_BUILDER_AGENT_DESCRIPTION_BLUR_EVENT)
+    );
+  }, []);
+
+  const { editor } = useSkillDescriptionEditor({
+    content: descriptionField.value ?? "",
+    onUpdate: handleUpdate,
+    onBlur: handleBlur,
+  });
+
+  useEffect(() => {
+    return () => {
+      debouncedUpdate.cancel();
+    };
+  }, [debouncedUpdate]);
+
+  const displayError = !!descriptionFieldState.error;
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setOptions({
+      editorProps: {
+        attributes: {
+          class: cn(
+            editorVariants({ error: displayError }),
+            DESCRIPTION_EDITOR_SIZE
+          ),
+        },
+      },
+    });
+  }, [editor, displayError]);
+
+  // Sync external changes to the editor content.
+  useEffect(() => {
+    if (!editor || descriptionField.value === undefined) {
+      return;
+    }
+
+    if (editor.isFocused) {
+      return;
+    }
+
+    const currentText = editor.getText().trim();
+    if (currentText !== descriptionField.value) {
+      editor.commands.setContent(`<p>${descriptionField.value}</p>`, {
+        emitUpdate: false,
+      });
+    }
+  }, [editor, descriptionField.value]);
+
   return (
-    <BaseFormFieldSection
-      title="What will this skill be used for?"
-      titleClassName="heading-lg"
-      fieldName={AGENT_FACING_DESCRIPTION_FIELD_NAME}
-      triggerValidationOnChange
-    >
-      {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-        <div className="space-y-3">
-          <TextArea
-            ref={registerRef}
-            placeholder="When should this skill be used? What is this skill good for?"
-            className="h-40 text-base placeholder:italic placeholder:text-gray-400"
-            resize="vertical"
-            onChange={(e) => handleDescriptionChange(e, onChange)}
-            error={hasError ? errorMessage : undefined}
-            showErrorLabel={hasError}
-            {...registerProps}
-            onBlur={() => {
-              registerProps.onBlur();
-              window.dispatchEvent(
-                new CustomEvent(SKILL_BUILDER_AGENT_DESCRIPTION_BLUR_EVENT)
-              );
-            }}
-          />
-          <SimilarSkillsDisplay
-            owner={owner}
-            similarSkills={similarSkills}
-            isLoading={isLoading}
-          />
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+          What will this skill be used for?
+        </h3>
+      </div>
+
+      <div className="space-y-3">
+        <div className="space-y-1 p-px">
+          <SkillDescriptionEditorContent editor={editor} />
+
+          {descriptionFieldState.error && (
+            <div className="dark:text-warning-night ml-2 text-xs text-warning">
+              {descriptionFieldState.error.message}
+            </div>
+          )}
         </div>
-      )}
-    </BaseFormFieldSection>
+
+        <SimilarSkillsDisplay
+          owner={owner}
+          similarSkills={similarSkills}
+          isLoading={isLoading}
+        />
+      </div>
+    </section>
   );
 }

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -13,8 +13,7 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
-import debounce from "lodash/debounce";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 const FIELD_NAME = "agentFacingDescription";
@@ -45,6 +44,8 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         return;
       }
 
+      setIsLoading(true);
+
       const result = await getSimilarSkills(description, {
         excludeSkillId: skillId,
         signal,
@@ -53,12 +54,10 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       if (!signal.aborted) {
         setIsLoading(false);
         if (result.isOk()) {
-          const similarSkillIds = result.value;
-          const similarSkillIdsSet = new Set(similarSkillIds);
-          const matchedSkills = skills.filter((skill) =>
-            similarSkillIdsSet.has(skill.sId)
+          const similarSkillIds = new Set(result.value);
+          setSimilarSkills(
+            skills.filter((skill) => similarSkillIds.has(skill.sId))
           );
-          setSimilarSkills(matchedSkills);
         }
       }
     },
@@ -69,26 +68,15 @@ export function SkillBuilderAgentFacingDescriptionSection() {
     delayMs: DEBOUNCE_DELAY_MS,
   });
 
-  const debouncedUpdate = useMemo(
-    () =>
-      debounce((editor: Editor) => {
-        if (!editor.isDestroyed) {
-          const text = editor.getText().trim();
-          setValue(FIELD_NAME, text, { shouldDirty: true });
-          setIsLoading(text.length >= MIN_DESCRIPTION_LENGTH);
-          triggerSimilarSkillsFetch(text);
-        }
-      }, DEBOUNCE_DELAY_MS),
-    [setValue, triggerSimilarSkillsFetch]
-  );
-
   const handleUpdate = useCallback(
     ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
-      if (transaction.docChanged) {
-        debouncedUpdate(editor);
+      if (transaction.docChanged && !editor.isDestroyed) {
+        const text = editor.getText().trim();
+        setValue(FIELD_NAME, text, { shouldDirty: true });
+        triggerSimilarSkillsFetch(text);
       }
     },
-    [debouncedUpdate]
+    [setValue, triggerSimilarSkillsFetch]
   );
 
   const handleBlur = useCallback(() => {
@@ -104,14 +92,6 @@ export function SkillBuilderAgentFacingDescriptionSection() {
   });
 
   useEffect(() => {
-    return () => {
-      debouncedUpdate.cancel();
-    };
-  }, [debouncedUpdate]);
-
-  const displayError = !!descriptionFieldState.error;
-
-  useEffect(() => {
     if (!editor) {
       return;
     }
@@ -120,13 +100,13 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       editorProps: {
         attributes: {
           class: cn(
-            editorVariants({ error: displayError }),
+            editorVariants({ error: !!descriptionFieldState.error }),
             DESCRIPTION_EDITOR_SIZE
           ),
         },
       },
     });
-  }, [editor, displayError]);
+  }, [editor, descriptionFieldState.error]);
 
   // Sync external changes to the editor content.
   useEffect(() => {

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -19,7 +19,7 @@ import { useController, useFormContext } from "react-hook-form";
 const FIELD_NAME = "agentFacingDescription";
 const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
-const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-[512px]";
+const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-96";
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();


### PR DESCRIPTION
## Description

This PR replaces the plain `TextArea` component with the new `SkillDescriptionEditor` TipTap editor in the `SkillBuilderAgentFacingDescriptionSection`. The change improves the UX by providing a consistent rich text editing experience across the Skill Builder, similar to the instructions editor. The description field now uses debounced updates via `react-hook-form` and dispatches a custom blur event to maintain existing form validation behavior.

This refactoring is done in order to leverage the `AgentInstructionDiffExtension` within the description field.

## Tests

- [x] Locally

## Risk

Low - the editor is a simplified TipTap instance with basic text editing only (no markdown formatting), and the form integration maintains the same validation and similar skills fetching logic.

## Deploy Plan

Deploy front
