### PR TITLE
fix(webhooks): remove personal events from creation

### DIFF
--- a/front/lib/triggers/built-in-webhooks/fathom/components/CreateWebhookFathomConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/fathom/components/CreateWebhookFathomConnection.tsx
@@ -1,5 +1,5 @@
 import type { WebhookCreateFormComponentProps } from "@app/components/triggers/webhook_preset_components";
-import { RECORDING_TYPE_OPTIONS } from "@app/lib/triggers/built-in-webhooks/fathom/constants";
+import { CREATABLE_RECORDING_TYPE_OPTIONS } from "@app/lib/triggers/built-in-webhooks/fathom/constants";
 import { CheckBoxWithTextAndDescription, Label, Page } from "@dust-tt/sparkle";
 import type { TriggeredFor } from "fathom-typescript/sdk/models/shared";
 import { useEffect, useState } from "react";
@@ -34,7 +34,7 @@ export function CreateWebhookFathomConnection({
 }: WebhookCreateFormComponentProps) {
   const [selectedRecordingTypes, setSelectedRecordingTypes] = useState<
     TriggeredFor[]
-  >(["my_recordings", "shared_external_recordings"]);
+  >(["shared_external_recordings", "shared_team_recordings"]);
 
   const [includeTranscript, setIncludeTranscript] = useState(true);
   const [includeSummary, setIncludeSummary] = useState(true);
@@ -105,7 +105,7 @@ export function CreateWebhookFathomConnection({
             Select at least one type of recording to receive
           </p>
           <div className="space-y-2">
-            {RECORDING_TYPE_OPTIONS.map((option) => (
+            {CREATABLE_RECORDING_TYPE_OPTIONS.map((option) => (
               <CheckBoxWithTextAndDescription
                 key={option.value}
                 text={option.label}

--- a/front/lib/triggers/built-in-webhooks/fathom/constants.ts
+++ b/front/lib/triggers/built-in-webhooks/fathom/constants.ts
@@ -1,3 +1,5 @@
+// All recording types, including legacy ones. Used for labels and validation
+// to support existing webhooks.
 export const RECORDING_TYPE_OPTIONS = [
   {
     value: "my_recordings",
@@ -20,6 +22,13 @@ export const RECORDING_TYPE_OPTIONS = [
     description: "Recordings from your team members",
   },
 ] as const;
+
+// Recording types available for new webhook creation.
+export const CREATABLE_RECORDING_TYPE_OPTIONS = RECORDING_TYPE_OPTIONS.filter(
+  (option) =>
+    option.value !== "my_recordings" &&
+    option.value !== "my_shared_with_team_recordings"
+);
 
 export const RECORDING_TYPE_LABELS: Record<string, string> =
   RECORDING_TYPE_OPTIONS.reduce(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR removes the personal type of recording from subscribable recording types for the fathom webhook provider.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front