### PR TITLE
Add channels:write and groups:write to slack tool scopes

### DIFF
--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -73,6 +73,9 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
             "canvases:write",
             "search:read.files",
             "search:read.users",
+            // The following two are needed for some customer scenarios that require us to create/invite/archive channels
+            "channels:write",
+            "groups:write",
           ];
         default:
           assert(


### PR DESCRIPTION
## Description

These scopes are needed for some customer scenarios that require us to create/invite/archive channels

## Tests

Manual

## Risk

Need to get Slack approval on our Published app

## Deploy Plan

Front