### PR TITLE
Update proxy to support workers

### DIFF
--- a/preview-proxy/src/index.js
+++ b/preview-proxy/src/index.js
@@ -3,39 +3,50 @@ const PROJECTS = {
   poke: "poke-dust-tt",
 };
 
+const WORKERS_SUBDOMAIN = "dust-account.workers.dev";
+
 export default {
   async fetch(request) {
     const url = new URL(request.url);
     // Expected formats:
-    //   branch--app.preview.dust.tt  → branch.app-dust-tt.pages.dev
-    //   branch--poke.preview.dust.tt → branch.poke-dust-tt.pages.dev
+    //   branch--app.preview.dust.tt         → branch.app-dust-tt.pages.dev (Pages, legacy)
+    //   branch--app-worker.preview.dust.tt  → branch-app-dust-tt.dust-account.workers.dev (Workers preview alias)
     const prefix = url.hostname.split(".preview.dust.tt")[0];
     const separatorIndex = prefix.lastIndexOf("--");
 
     if (separatorIndex === -1) {
       return new Response(
-        "Expected format: <branch>--<app|poke>.preview.dust.tt",
+        "Expected format: <branch>--<app|poke|app-worker|poke-worker>.preview.dust.tt",
         { status: 400 }
       );
     }
 
     const branch = prefix.slice(0, separatorIndex);
-    const project = prefix.slice(separatorIndex + 2);
-    const pagesProject = PROJECTS[project];
+    const target = prefix.slice(separatorIndex + 2);
 
-    if (!pagesProject) {
+    // Check if targeting Workers (suffix "-worker") or Pages (default)
+    const isWorker = target.endsWith("-worker");
+    const project = isWorker ? target.slice(0, -"-worker".length) : target;
+    const projectName = PROJECTS[project];
+
+    if (!projectName) {
       return new Response(`Unknown project: ${project}. Use "app" or "poke".`, {
         status: 400,
       });
     }
 
-    const pagesUrl = new URL(url);
-    pagesUrl.hostname = `${branch}.${pagesProject}.pages.dev`;
+    const upstreamUrl = new URL(url);
+    if (isWorker) {
+      // Workers version preview alias: branch-app-dust-tt.dust-account.workers.dev
+      upstreamUrl.hostname = `${branch}-${projectName}.${WORKERS_SUBDOMAIN}`;
+    } else {
+      upstreamUrl.hostname = `${branch}.${projectName}.pages.dev`;
+    }
 
     const headers = new Headers(request.headers);
-    headers.set("Host", pagesUrl.hostname);
+    headers.set("Host", upstreamUrl.hostname);
 
-    return fetch(pagesUrl.toString(), {
+    return fetch(upstreamUrl.toString(), {
       method: request.method,
       headers,
       body: request.body,


### PR DESCRIPTION
## Summary

Update the SPA preview proxy to support both Cloudflare Pages and Workers backends, enabling side-by-side testing during the Pages → Workers migration.

### Routing

- `<branch>--app.preview.dust.tt` → `<branch>.app-dust-tt.pages.dev` (Pages, existing behavior)
- `<branch>--app-worker.preview.dust.tt` → `<branch>-app-dust-tt.dust-account.workers.dev` (Workers, new)
- Same pattern for `poke` / `poke-worker`

The `-worker` suffix selects the Workers backend; without it, traffic goes to Pages as before. Once the migration is validated, the default can be flipped.

## Test plan

- [ ] Deploy proxy: `wrangler deploy` in `preview-proxy/`
- [ ] Verify `branch--app.preview.dust.tt` still routes to Pages
- [ ] Verify `branch--app-worker.preview.dust.tt` routes to the Workers preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)