### PR TITLE
[front] - refactor(SkillBuilder): version comparison context

### DIFF
--- a/front/components/editor/editorStyles.ts
+++ b/front/components/editor/editorStyles.ts
@@ -4,7 +4,6 @@ export const editorVariants = cva(
   [
     "overflow-auto border rounded-xl px-3 pt-2 pb-8 resize-y",
     "transition-all duration-200",
-    "bg-muted-background dark:bg-muted-background-night",
   ],
   {
     variants: {
@@ -23,9 +22,17 @@ export const editorVariants = cva(
           "focus:border-highlight-300 dark:focus:border-highlight-300-night",
         ],
       },
+      disabled: {
+        true: [
+          "opacity-60 cursor-not-allowed resize-none",
+          "bg-muted-background/50 dark:bg-muted-background-night/50",
+        ],
+        false: ["bg-muted-background dark:bg-muted-background-night"],
+      },
     },
     defaultVariants: {
       error: false,
+      disabled: false,
     },
   }
 );

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -10,6 +10,8 @@ import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/S
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBuilderToolsSection";
+import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
+import { SkillVersionComparisonProvider } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import {
   getDefaultSkillFormData,
   transformSkillTypeToFormData,
@@ -21,6 +23,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillIcon } from "@app/lib/skill";
+import { useSkillHistory } from "@app/lib/swr/skill_configurations";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -57,6 +60,13 @@ export default function SkillBuilder({
   const { editors } = useSkillEditors({
     owner,
     skillId: skill?.sId ?? null,
+  });
+
+  const { skillHistory } = useSkillHistory({
+    owner,
+    skill,
+    disabled: !skill,
+    limit: 30,
   });
 
   const defaultValues = useMemo(() => {
@@ -149,78 +159,88 @@ export default function SkillBuilder({
   return (
     <SkillBuilderFormContext.Provider value={form}>
       <FormProvider form={form} asForm={false}>
-        <div
-          className={cn(
-            "flex h-dvh flex-row",
-            "bg-background text-foreground",
-            "dark:bg-background-night dark:text-foreground-night"
-          )}
-        >
-          <div className="flex h-full w-full flex-col">
-            <BarHeader
-              variant="default"
-              className="mx-4"
-              title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
-              rightActions={
-                <BarHeader.ButtonBar variant="close" onClose={handleCancel} />
-              }
-            />
+        <SkillVersionComparisonProvider>
+          <div
+            className={cn(
+              "flex h-dvh flex-row",
+              "bg-background text-foreground",
+              "dark:bg-background-night dark:text-foreground-night"
+            )}
+          >
+            <div className="flex h-full w-full flex-col">
+              <BarHeader
+                variant="default"
+                className="mx-4"
+                title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
+                centerActions={
+                  skill && skillHistory ? (
+                    <SkillVersionHistoryPicker
+                      skill={skill}
+                      skillHistory={skillHistory}
+                    />
+                  ) : undefined
+                }
+                rightActions={
+                  <BarHeader.ButtonBar variant="close" onClose={handleCancel} />
+                }
+              />
 
-            <ScrollArea className="flex-1">
-              <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
-                {extendedSkill && (
-                  <ContentMessage
-                    title={`Built on ${extendedSkill.name}`}
+              <ScrollArea className="flex-1">
+                <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
+                  {extendedSkill && (
+                    <ContentMessage
+                      title={`Built on ${extendedSkill.name}`}
+                      variant="highlight"
+                      icon={getSkillIcon(extendedSkill.icon)}
+                      size="lg"
+                    >
+                      A customized version of {extendedSkill.name} with your own
+                      guidelines and tools.
+                    </ContentMessage>
+                  )}
+                  {skill?.status === "suggested" && (
+                    <ContentMessage
+                      title="This is a generated skill suggestion"
+                      variant="primary"
+                      icon={InformationCircleIcon}
+                      size="lg"
+                    >
+                      This skill was automatically generated based on your
+                      workspace's configuration. We recommend reviewing and
+                      editing it to match your specific needs before saving.
+                    </ContentMessage>
+                  )}
+                  <SkillBuilderRequestedSpacesSection />
+                  <SkillBuilderAgentFacingDescriptionSection />
+                  <SkillBuilderInstructionsSection />
+                  {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
+                  <SkillBuilderToolsSection extendedSkill={extendedSkill} />
+                  <SkillBuilderSettingsSection />
+                </div>
+              </ScrollArea>
+              <BarFooter
+                variant="default"
+                className="mx-4 justify-between"
+                leftActions={
+                  <Button
+                    variant="outline"
+                    label="Cancel"
+                    onClick={handleCancel}
+                    type="button"
+                  />
+                }
+                rightActions={
+                  <Button
                     variant="highlight"
-                    icon={getSkillIcon(extendedSkill.icon)}
-                    size="lg"
-                  >
-                    A customized version of {extendedSkill.name} with your own
-                    guidelines and tools.
-                  </ContentMessage>
-                )}
-                {skill?.status === "suggested" && (
-                  <ContentMessage
-                    title="This is a generated skill suggestion"
-                    variant="primary"
-                    icon={InformationCircleIcon}
-                    size="lg"
-                  >
-                    This skill was automatically generated based on your
-                    workspace's configuration. We recommend reviewing and
-                    editing it to match your specific needs before saving.
-                  </ContentMessage>
-                )}
-                <SkillBuilderRequestedSpacesSection />
-                <SkillBuilderAgentFacingDescriptionSection />
-                <SkillBuilderInstructionsSection skill={skill} />
-                {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
-                <SkillBuilderToolsSection extendedSkill={extendedSkill} />
-                <SkillBuilderSettingsSection />
-              </div>
-            </ScrollArea>
-            <BarFooter
-              variant="default"
-              className="mx-4 justify-between"
-              leftActions={
-                <Button
-                  variant="outline"
-                  label="Cancel"
-                  onClick={handleCancel}
-                  type="button"
-                />
-              }
-              rightActions={
-                <Button
-                  variant="highlight"
-                  label={isSaving ? "Saving..." : "Save"}
-                  onClick={handleSave}
-                  disabled={isSaving}
-                />
-              }
-            />
+                    label={isSaving ? "Saving..." : "Save"}
+                    onClick={handleSave}
+                    disabled={isSaving}
+                  />
+                }
+              />
+            </div>
           </div>
-        </div>
+        </SkillVersionComparisonProvider>
       </FormProvider>
     </SkillBuilderFormContext.Provider>
   );

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -45,9 +45,9 @@ export function SkillBuilderFilesSection() {
     [fields]
   );
 
-  const onUploadClick = useCallback(() => {
+  const onUploadClick = () => {
     fileInputRef.current?.click();
-  }, []);
+  };
 
   const onFileInputChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -49,8 +49,8 @@ interface SkillBuilderInstructionsEditorProps {
 export function SkillBuilderInstructionsEditor({
   onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
-  const { compareVersion, isDiffMode: isInstructionDiffMode } =
-    useSkillVersionComparisonContext();
+  const { compareVersion } = useSkillVersionComparisonContext();
+  const isDiffMode = !!compareVersion;
   const { setValue } = useFormContext<SkillBuilderFormData>();
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
@@ -71,7 +71,7 @@ export function SkillBuilderInstructionsEditor({
   const debouncedUpdate = useMemo(
     () =>
       debounce((editor: Editor) => {
-        if (!isInstructionDiffMode && !editor.isDestroyed) {
+        if (!isDiffMode && !editor.isDestroyed) {
           setValue(INSTRUCTIONS_FIELD_NAME, editor.getMarkdown().trim(), {
             shouldDirty: true,
           });
@@ -82,7 +82,7 @@ export function SkillBuilderInstructionsEditor({
           );
         }
       }, 250),
-    [isInstructionDiffMode, setValue]
+    [isDiffMode, setValue]
   );
 
   const handleUpdate = useCallback(
@@ -172,14 +172,14 @@ export function SkillBuilderInstructionsEditor({
           class: cn(
             editorVariants({
               error: displayError,
-              disabled: isInstructionDiffMode,
+              disabled: isDiffMode,
             }),
             INSTRUCTIONS_EDITOR_SIZE
           ),
         },
       },
     });
-  }, [editor, displayError, isInstructionDiffMode]);
+  }, [editor, displayError, isDiffMode]);
 
   // Sync external changes to the editor content
   useEffect(() => {
@@ -212,7 +212,7 @@ export function SkillBuilderInstructionsEditor({
       return;
     }
 
-    if (isInstructionDiffMode && compareVersion) {
+    if (compareVersion) {
       if (editor.storage.agentInstructionDiff?.isDiffMode) {
         editor.commands.exitDiff();
       }
@@ -226,15 +226,13 @@ export function SkillBuilderInstructionsEditor({
       });
       editor.commands.applyDiff(compareText, currentText);
       editor.setEditable(false);
-    } else if (!isInstructionDiffMode) {
-      if (editor.storage.agentInstructionDiff?.isDiffMode) {
-        editor.commands.exitDiff();
-        editor.setEditable(true);
-      }
+    } else if (editor.storage.agentInstructionDiff?.isDiffMode) {
+      editor.commands.exitDiff();
+      editor.setEditable(true);
     }
     // Re-run when instructionsField.value changes so that restoring a single
     // field updates the diff overlay.
-  }, [isInstructionDiffMode, compareVersion, editor, instructionsField.value]);
+  }, [compareVersion, editor, instructionsField.value]);
 
   return (
     <div className="space-y-1 p-px">

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -7,7 +7,7 @@ import {
 } from "@app/components/editor/SkillInstructionsEditor";
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -43,16 +43,14 @@ function toAttachedKnowledge(
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 
 interface SkillBuilderInstructionsEditorProps {
-  compareVersion?: SkillType | null;
-  isInstructionDiffMode?: boolean;
   onAddKnowledge?: (addKnowledge: () => void) => void;
 }
 
 export function SkillBuilderInstructionsEditor({
-  compareVersion,
-  isInstructionDiffMode = false,
   onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
+  const { compareVersion, isDiffMode: isInstructionDiffMode } =
+    useSkillVersionComparisonContext();
   const { setValue } = useFormContext<SkillBuilderFormData>();
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
@@ -172,13 +170,16 @@ export function SkillBuilderInstructionsEditor({
       editorProps: {
         attributes: {
           class: cn(
-            editorVariants({ error: displayError }),
+            editorVariants({
+              error: displayError,
+              disabled: isInstructionDiffMode,
+            }),
             INSTRUCTIONS_EDITOR_SIZE
           ),
         },
       },
     });
-  }, [editor, displayError]);
+  }, [editor, displayError, isInstructionDiffMode]);
 
   // Sync external changes to the editor content
   useEffect(() => {
@@ -216,9 +217,13 @@ export function SkillBuilderInstructionsEditor({
         editor.commands.exitDiff();
       }
 
-      const currentText = editor.getMarkdown();
       const compareText = compareVersion.instructions ?? "";
+      const currentText = instructionsField.value ?? "";
 
+      editor.commands.setContent(currentText, {
+        emitUpdate: false,
+        contentType: "markdown",
+      });
       editor.commands.applyDiff(compareText, currentText);
       editor.setEditable(false);
     } else if (!isInstructionDiffMode) {
@@ -227,7 +232,9 @@ export function SkillBuilderInstructionsEditor({
         editor.setEditable(true);
       }
     }
-  }, [isInstructionDiffMode, compareVersion, editor]);
+    // Re-run when instructionsField.value changes so that restoring a single
+    // field updates the diff overlay.
+  }, [isInstructionDiffMode, compareVersion, editor, instructionsField.value]);
 
   return (
     <div className="space-y-1 p-px">

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -1,50 +1,26 @@
-import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillBuilderInstructionsEditor } from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
-import { SkillInstructionsHistory } from "@app/components/skill_builder/SkillInstructionsHistory";
-import { useSkillHistory } from "@app/lib/swr/skill_configurations";
-import type {
-  SkillType,
-  SkillWithVersionType,
-} from "@app/types/assistant/skill_configuration";
-import {
-  ArrowPathIcon,
-  BookOpenIcon,
-  Button,
-  Label,
-  Separator,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
-import { format } from "date-fns/format";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import { ArrowGoBackIcon, BookOpenIcon, Button } from "@dust-tt/sparkle";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 
-interface SkillBuilderInstructionsSectionProps {
-  skill?: SkillType;
-}
-
-export function SkillBuilderInstructionsSection({
-  skill,
-}: SkillBuilderInstructionsSectionProps) {
-  const { owner } = useSkillBuilderContext();
-  const { setValue } = useFormContext<SkillBuilderFormData>();
-  const [compareVersion, setCompareVersion] =
-    useState<SkillWithVersionType | null>(null);
-  const [isInstructionDiffMode, setIsInstructionDiffMode] = useState(false);
+export function SkillBuilderInstructionsSection() {
+  const { setValue, watch } = useFormContext<SkillBuilderFormData>();
+  const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
 
-  const { skillHistory } = useSkillHistory({
-    owner,
-    skill,
-    disabled: !skill,
-    limit: 30,
-  });
+  const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
+  const instructionsDiffer =
+    isDiffMode &&
+    compareVersion &&
+    compareVersion.instructions !== currentInstructions;
 
-  const restoreVersion = () => {
+  const restoreInstructions = () => {
     const text = compareVersion?.instructions;
-    if (!text) {
+    if (text === undefined || text === null) {
       return;
     }
 
@@ -52,22 +28,7 @@ export function SkillBuilderInstructionsSection({
       shouldDirty: true,
       shouldValidate: true,
     });
-    setCompareVersion(null);
-    setIsInstructionDiffMode(false);
   };
-
-  const headerActions = skill && skillHistory && skillHistory.length > 1 && (
-    <SkillInstructionsHistory
-      currentSkill={skill}
-      history={skillHistory}
-      selectedConfig={compareVersion}
-      onSelect={(config) => {
-        setCompareVersion(config);
-        setIsInstructionDiffMode(true);
-      }}
-      owner={owner}
-    />
-  );
 
   return (
     <section className="flex flex-col gap-3">
@@ -76,49 +37,27 @@ export function SkillBuilderInstructionsSection({
           What guidelines should it provide?
         </h3>
         <div className="flex items-center gap-2">
-          {headerActions}
-          <Button
-            variant="primary"
-            label="Attach knowledge"
-            icon={BookOpenIcon}
-            onClick={addKnowledge ?? undefined}
-            disabled={!addKnowledge}
-          />
-        </div>
-      </div>
-      {isInstructionDiffMode && compareVersion && (
-        <>
-          <Separator />
-          {compareVersion?.createdAt && (
-            <Label>
-              Comparing current version with{" "}
-              {format(compareVersion.createdAt, "Pp")}
-            </Label>
-          )}
-          <div className="flex gap-2">
+          {instructionsDiffer && (
             <Button
-              icon={XMarkIcon}
               variant="outline"
               size="sm"
-              onClick={() => {
-                setIsInstructionDiffMode(false);
-                setCompareVersion(null);
-              }}
-              label="Leave comparison mode"
+              icon={ArrowGoBackIcon}
+              onClick={restoreInstructions}
+              label="Restore instructions"
             />
+          )}
+          {!isDiffMode && (
             <Button
-              variant="warning"
-              size="sm"
-              icon={ArrowPathIcon}
-              onClick={restoreVersion}
-              label="Restore this version"
+              variant="primary"
+              label="Attach knowledge"
+              icon={BookOpenIcon}
+              onClick={addKnowledge ?? undefined}
+              disabled={!addKnowledge}
             />
-          </div>
-        </>
-      )}
+          )}
+        </div>
+      </div>
       <SkillBuilderInstructionsEditor
-        compareVersion={compareVersion}
-        isInstructionDiffMode={isInstructionDiffMode}
         onAddKnowledge={(fn) => setAddKnowledge(() => fn)}
       />
     </section>

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -9,22 +9,19 @@ const INSTRUCTIONS_FIELD_NAME = "instructions";
 
 export function SkillBuilderInstructionsSection() {
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
-  const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
+  const { compareVersion } = useSkillVersionComparisonContext();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
 
   const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
   const instructionsDiffer =
-    isDiffMode &&
-    compareVersion &&
-    compareVersion.instructions !== currentInstructions;
+    compareVersion && compareVersion.instructions !== currentInstructions;
 
   const restoreInstructions = () => {
-    const text = compareVersion?.instructions;
-    if (text === undefined || text === null) {
+    if (!compareVersion) {
       return;
     }
 
-    setValue(INSTRUCTIONS_FIELD_NAME, text, {
+    setValue(INSTRUCTIONS_FIELD_NAME, compareVersion.instructions ?? "", {
       shouldDirty: true,
       shouldValidate: true,
     });
@@ -46,7 +43,7 @@ export function SkillBuilderInstructionsSection() {
               label="Restore instructions"
             />
           )}
-          {!isDiffMode && (
+          {!compareVersion && (
             <Button
               variant="primary"
               label="Attach knowledge"

--- a/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
@@ -17,7 +17,7 @@ export function SkillVersionHistoryPicker({
   skillHistory,
 }: SkillVersionHistoryPickerProps) {
   const { owner } = useSkillBuilderContext();
-  const { compareVersion, isDiffMode, enterDiffMode, exitDiffMode } =
+  const { compareVersion, enterDiffMode, exitDiffMode } =
     useSkillVersionComparisonContext();
 
   if (skillHistory.length <= 1) {
@@ -33,7 +33,7 @@ export function SkillVersionHistoryPicker({
         onSelect={enterDiffMode}
         owner={owner}
       />
-      {isDiffMode && (
+      {compareVersion && (
         <Button
           icon={XMarkIcon}
           variant="outline"

--- a/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
@@ -1,0 +1,47 @@
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import { SkillVersionHistory } from "@app/components/skill_builder/SkillVersionHistory";
+import type {
+  SkillType,
+  SkillWithVersionType,
+} from "@app/types/assistant/skill_configuration";
+import { Button, XMarkIcon } from "@dust-tt/sparkle";
+
+interface SkillVersionHistoryPickerProps {
+  skill: SkillType;
+  skillHistory: SkillWithVersionType[];
+}
+
+export function SkillVersionHistoryPicker({
+  skill,
+  skillHistory,
+}: SkillVersionHistoryPickerProps) {
+  const { owner } = useSkillBuilderContext();
+  const { compareVersion, isDiffMode, enterDiffMode, exitDiffMode } =
+    useSkillVersionComparisonContext();
+
+  if (skillHistory.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <SkillVersionHistory
+        currentSkill={skill}
+        history={skillHistory}
+        selectedConfig={compareVersion}
+        onSelect={enterDiffMode}
+        owner={owner}
+      />
+      {isDiffMode && (
+        <Button
+          icon={XMarkIcon}
+          variant="outline"
+          size="sm"
+          onClick={exitDiffMode}
+          tooltip="Leave comparison mode"
+        />
+      )}
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderVersionContext.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionContext.tsx
@@ -9,7 +9,6 @@ import {
 
 interface SkillVersionComparisonContextType {
   compareVersion: SkillWithVersionType | null;
-  isDiffMode: boolean;
   enterDiffMode: (version: SkillWithVersionType) => void;
   exitDiffMode: () => void;
 }
@@ -26,21 +25,18 @@ export function SkillVersionComparisonProvider({
 }: SkillVersionComparisonProviderProps) {
   const [compareVersion, setCompareVersion] =
     useState<SkillWithVersionType | null>(null);
-  const [isDiffMode, setIsDiffMode] = useState(false);
 
   const enterDiffMode = useCallback((version: SkillWithVersionType) => {
     setCompareVersion(version);
-    setIsDiffMode(true);
   }, []);
 
   const exitDiffMode = useCallback(() => {
     setCompareVersion(null);
-    setIsDiffMode(false);
   }, []);
 
   const value = useMemo(
-    () => ({ compareVersion, isDiffMode, enterDiffMode, exitDiffMode }),
-    [compareVersion, isDiffMode, enterDiffMode, exitDiffMode]
+    () => ({ compareVersion, enterDiffMode, exitDiffMode }),
+    [compareVersion, enterDiffMode, exitDiffMode]
   );
 
   return (

--- a/front/components/skill_builder/SkillBuilderVersionContext.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionContext.tsx
@@ -1,0 +1,61 @@
+import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface SkillVersionComparisonContextType {
+  compareVersion: SkillWithVersionType | null;
+  isDiffMode: boolean;
+  enterDiffMode: (version: SkillWithVersionType) => void;
+  exitDiffMode: () => void;
+}
+
+const SkillVersionComparisonContext =
+  createContext<SkillVersionComparisonContextType | null>(null);
+
+interface SkillVersionComparisonProviderProps {
+  children: React.ReactNode;
+}
+
+export function SkillVersionComparisonProvider({
+  children,
+}: SkillVersionComparisonProviderProps) {
+  const [compareVersion, setCompareVersion] =
+    useState<SkillWithVersionType | null>(null);
+  const [isDiffMode, setIsDiffMode] = useState(false);
+
+  const enterDiffMode = useCallback((version: SkillWithVersionType) => {
+    setCompareVersion(version);
+    setIsDiffMode(true);
+  }, []);
+
+  const exitDiffMode = useCallback(() => {
+    setCompareVersion(null);
+    setIsDiffMode(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({ compareVersion, isDiffMode, enterDiffMode, exitDiffMode }),
+    [compareVersion, isDiffMode, enterDiffMode, exitDiffMode]
+  );
+
+  return (
+    <SkillVersionComparisonContext.Provider value={value}>
+      {children}
+    </SkillVersionComparisonContext.Provider>
+  );
+}
+
+export function useSkillVersionComparisonContext(): SkillVersionComparisonContextType {
+  const context = useContext(SkillVersionComparisonContext);
+  if (!context) {
+    throw new Error(
+      "useSkillVersionComparisonContext must be used within a SkillVersionComparisonProvider"
+    );
+  }
+  return context;
+}

--- a/front/components/skill_builder/SkillVersionHistory.tsx
+++ b/front/components/skill_builder/SkillVersionHistory.tsx
@@ -18,7 +18,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { format } from "date-fns/format";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 
 interface SkillVersionHistoryProps {
   currentSkill: SkillType;
@@ -61,21 +61,18 @@ export function SkillVersionHistory({
     return map;
   }, [editedByLookupMembers]);
 
-  const formatVersionLabel = useCallback((config: SkillWithVersionType) => {
+  function formatVersionLabel(config: SkillWithVersionType): string {
     return config.createdAt
       ? format(config.createdAt, "Pp")
       : `Version ${config.version}`;
-  }, []);
+  }
 
-  const getEditedByName = useCallback(
-    (config: SkillType) => {
-      if (!config.editedBy) {
-        return "System";
-      }
-      return editedByUserMap[config.editedBy.toString()] || "Unknown";
-    },
-    [editedByUserMap]
-  );
+  function getEditedByName(config: SkillType): string {
+    if (!config.editedBy) {
+      return "System";
+    }
+    return editedByUserMap[config.editedBy.toString()] || "Unknown";
+  }
 
   // Collapse successive versions where all comparable fields are identical,
   // keeping the first occurrence (highest version number).

--- a/front/components/skill_builder/SkillVersionHistory.tsx
+++ b/front/components/skill_builder/SkillVersionHistory.tsx
@@ -1,3 +1,4 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useMembersLookup } from "@app/lib/swr/memberships";
 import type {
   SkillType,
@@ -17,10 +18,9 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { format } from "date-fns/format";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
-interface SkillInstructionsHistoryProps {
+interface SkillVersionHistoryProps {
   currentSkill: SkillType;
   history: SkillWithVersionType[];
   selectedConfig: SkillWithVersionType | null;
@@ -28,13 +28,13 @@ interface SkillInstructionsHistoryProps {
   owner: LightWorkspaceType;
 }
 
-export function SkillInstructionsHistory({
+export function SkillVersionHistory({
   currentSkill,
   history,
   onSelect,
   selectedConfig,
   owner,
-}: SkillInstructionsHistoryProps) {
+}: SkillVersionHistoryProps) {
   const editedByIdsToLookup = useMemo(() => {
     const ids = new Set<number>();
     history.forEach((config) => {
@@ -77,28 +77,32 @@ export function SkillInstructionsHistory({
     [editedByUserMap]
   );
 
-  // Collapse successive versions that contain the exact same instructions,
-  // keeping the first one (it's the one with the highest version).
-  const historyWithPrev = useMemo(() => {
+  // Collapse successive versions where all comparable fields are identical,
+  // keeping the first occurrence (highest version number).
+  const deduplicatedHistory = useMemo(() => {
     const result: SkillWithVersionType[] = [];
 
-    let lastRawInstructions = currentSkill.instructions;
+    let lastFingerprint = getVersionFingerprint(currentSkill);
 
     for (const config of history) {
-      const { instructions } = config;
-      const isNewRun = instructions !== lastRawInstructions;
+      const fingerprint = getVersionFingerprint(config);
+      const isNew = fingerprint !== lastFingerprint;
 
-      if (isNewRun) {
+      if (isNew) {
         result.push(config);
       } else if (config.version === selectedConfig?.version) {
         result[result.length - 1] = config;
       }
 
-      lastRawInstructions = instructions;
+      lastFingerprint = fingerprint;
     }
 
     return result;
   }, [history, selectedConfig, currentSkill]);
+
+  const triggerLabel = selectedConfig
+    ? formatVersionLabel(selectedConfig)
+    : "History";
 
   return (
     <DropdownMenu>
@@ -107,7 +111,7 @@ export function SkillInstructionsHistory({
           variant="outline"
           icon={HistoryIcon}
           size="sm"
-          tooltip="Compare with previous versions"
+          label={triggerLabel}
           isSelect
         />
       </DropdownMenuTrigger>
@@ -137,7 +141,7 @@ export function SkillInstructionsHistory({
               }
             }}
           >
-            {historyWithPrev.map((config) => (
+            {deduplicatedHistory.map((config) => (
               <DropdownMenuRadioItem
                 key={config.version}
                 value={config.version.toString()}
@@ -157,4 +161,13 @@ export function SkillInstructionsHistory({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function getVersionFingerprint(skill: SkillType): string {
+  return JSON.stringify({
+    instructions: skill.instructions,
+    agentFacingDescription: skill.agentFacingDescription,
+    tools: skill.tools.map((t: MCPServerViewType) => t.sId).sort(),
+    files: skill.fileAttachments.map((f) => f.fileId).sort(),
+  });
 }

--- a/sparkle/src/components/Bar.tsx
+++ b/sparkle/src/components/Bar.tsx
@@ -51,6 +51,7 @@ interface BarProps extends VariantProps<typeof barVariants> {
   description?: React.ReactNode;
   tooltip?: string;
   leftActions?: React.ReactNode;
+  centerActions?: React.ReactNode;
   rightActions?: React.ReactNode;
   className?: string;
 }
@@ -60,6 +61,7 @@ export function Bar({
   description,
   tooltip,
   leftActions,
+  centerActions,
   rightActions,
   className,
   position,
@@ -68,7 +70,7 @@ export function Bar({
 }: BarProps) {
   const titleClasses = cn(
     "s-text-foreground dark:s-text-foreground-night",
-    "s-heading-base s-truncate s-grow"
+    "s-heading-base s-truncate"
   );
 
   return (
@@ -95,7 +97,8 @@ export function Bar({
           )}
         </div>
       )}
-      {!title && !leftActions && <div className="s-flex-grow" />}
+      {centerActions && <div className="s-flex s-gap-1">{centerActions}</div>}
+      <div className="s-flex-grow" />
       {rightActions && <div className="s-flex s-gap-1">{rightActions}</div>}
     </div>
   );
@@ -188,6 +191,7 @@ interface BarHeaderProps {
   description?: React.ReactNode;
   tooltip?: string;
   leftActions?: React.ReactNode;
+  centerActions?: React.ReactNode;
   rightActions?: React.ReactNode;
   className?: string;
   variant?: "full" | "default";
@@ -199,6 +203,7 @@ export function BarHeader({
   description,
   tooltip,
   leftActions,
+  centerActions,
   rightActions,
   className,
   variant,
@@ -211,6 +216,7 @@ export function BarHeader({
       description={description}
       tooltip={tooltip}
       leftActions={leftActions}
+      centerActions={centerActions}
       rightActions={rightActions}
       className={className}
       variant={variant}


### PR DESCRIPTION
## Description

Refactors skill builder version comparison to use React Context instead of prop drilling. Introduces `SkillVersionComparisonProvider` to manage diff mode state globally, making it accessible across `SkillBuilder`, `SkillBuilderInstructionsSection`, and `SkillBuilderInstructionsEditor` without passing props through multiple layers. Renames `SkillInstructionsHistory` to `SkillVersionHistory` and expands version fingerprinting to include tools and files (not just instructions) for more accurate deduplication.

## Tests

- [x] Locally

## Risk

Low. Refactoring that consolidates existing functionality using a cleaner architecture pattern

## Deploy Front

Deploy front
