### PR TITLE
[front] add animation to thinking and sidepanel

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -126,7 +126,7 @@ export function AgentMessageActions({
                       ? "streaming"
                       : "none"
                   }
-                  enableAnimation={true}
+                  enableAnimation
                   animationDurationSeconds={0.3}
                   delimiter=" "
                   forcedTextSize="text-sm"

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -121,6 +121,14 @@ export function AgentMessageActions({
                 <Markdown
                   content={chainOfThought}
                   isStreaming={false}
+                  streamingState={
+                    lastAgentStateClassification === "thinking"
+                      ? "streaming"
+                      : "none"
+                  }
+                  enableAnimation={true}
+                  animationDurationSeconds={0.3}
+                  delimiter=" "
                   forcedTextSize="text-sm"
                   textColor="text-muted-foreground dark:text-muted-foreground-night"
                   isLastMessage={false}

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -35,7 +35,7 @@ export function PanelAgentStep({
               content={reasoningContent}
               isStreaming={isStreaming}
               streamingState={isStreaming ? "streaming" : "none"}
-              enableAnimation={true}
+              enableAnimation
               animationDurationSeconds={0.3}
               delimiter=" "
               forcedTextSize="text-sm"

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -34,6 +34,10 @@ export function PanelAgentStep({
             <Markdown
               content={reasoningContent}
               isStreaming={isStreaming}
+              streamingState={isStreaming ? "streaming" : "none"}
+              enableAnimation={true}
+              animationDurationSeconds={0.3}
+              delimiter=" "
               forcedTextSize="text-sm"
               textColor="text-muted-foreground dark:text-muted-foreground-night"
               isLastMessage={false}


### PR DESCRIPTION
## Description
This PR is to add streaming animation to the thinking token display and the side panel, you can test it here https://4b8a107a--app.preview.dust.tt/


It should look something like that: 

https://github.com/user-attachments/assets/2feb401d-b1e9-4411-9960-d6a3bfe008f8

You might want to have a look this PR to understand how it works 😄 https://github.com/dust-tt/dust/pull/22732

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
