### PR TITLE
feat: get page elements chrome extension

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -1,3 +1,4 @@
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type {
   AuthBackgroundMessage,
   AuthBackgroundResponseError,
@@ -6,6 +7,8 @@ import type {
   CaptureResponse,
   GetActiveTabBackgroundMessage,
   GetActiveTabBackgroundResponse,
+  GetPageElementsMessage,
+  GetPageElementsResponse,
   InputBarStatusMessage,
   TabActionMessage,
   TabActionResponse,
@@ -18,6 +21,7 @@ import { generatePKCE } from "@extension/shared/lib/utils";
 import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
 import type { FileData } from "@extension/shared/services/capture";
 import { jwtDecode } from "jwt-decode";
+import { getPageElements } from "./interactWithPage";
 
 const log = console.error;
 const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
@@ -273,7 +277,8 @@ chrome.runtime.onMessage.addListener(
       | GetActiveTabBackgroundMessage
       | CaptureMesssage
       | InputBarStatusMessage
-      | TabActionMessage,
+      | TabActionMessage
+      | GetPageElementsMessage,
     sender,
     sendResponse: (
       response:
@@ -283,6 +288,7 @@ chrome.runtime.onMessage.addListener(
         | CaptureResponse
         | GetActiveTabBackgroundResponse
         | TabActionResponse
+        | GetPageElementsResponse
     ) => void
   ) => {
     switch (message.type) {
@@ -681,6 +687,39 @@ chrome.runtime.onMessage.addListener(
             });
           }
         })();
+        return true;
+
+      case "GET_ELEMENTS":
+        chrome.tabs.query(
+          { active: true, currentWindow: true },
+          async (tabs) => {
+            const tab = tabs[0];
+            try {
+              const result = await getPageElements(tab);
+
+              if (result.isErr()) {
+                log("Error reading page elements:", result.error);
+                sendResponse({
+                  elements: "",
+                  error: result.error.message,
+                });
+                return;
+              }
+
+              sendResponse({
+                elements: result.value,
+              });
+            } catch (error) {
+              const normalizedError = normalizeError(error);
+              log("Error reading page elements:", normalizedError.message);
+              sendResponse({
+                elements: "",
+                error:
+                  normalizedError.message ?? "Failed to read page elements.",
+              });
+            }
+          }
+        );
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -690,36 +690,32 @@ chrome.runtime.onMessage.addListener(
         return true;
 
       case "GET_ELEMENTS":
-        chrome.tabs.query(
-          { active: true, currentWindow: true },
-          async (tabs) => {
-            const tab = tabs[0];
-            try {
-              const result = await getPageElements(tab);
+        chrome.tabs.query({ currentWindow: true }, async (tabs) => {
+          const tab = tabs.find((t) => t.id === message.tabId);
+          try {
+            const result = await getPageElements(tab);
 
-              if (result.isErr()) {
-                log("Error reading page elements:", result.error);
-                sendResponse({
-                  elements: "",
-                  error: result.error.message,
-                });
-                return;
-              }
-
-              sendResponse({
-                elements: result.value,
-              });
-            } catch (error) {
-              const normalizedError = normalizeError(error);
-              log("Error reading page elements:", normalizedError.message);
+            if (result.isErr()) {
+              log("Error reading page elements:", result.error);
               sendResponse({
                 elements: "",
-                error:
-                  normalizedError.message ?? "Failed to read page elements.",
+                error: result.error.message,
               });
+              return;
             }
+
+            sendResponse({
+              elements: result.value,
+            });
+          } catch (error) {
+            const normalizedError = normalizeError(error);
+            log("Error reading page elements:", normalizedError.message);
+            sendResponse({
+              elements: "",
+              error: normalizedError.message ?? "Failed to read page elements.",
+            });
           }
-        );
+        });
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -23,10 +23,10 @@ type DustWindow = {
 };
 
 export async function getPageElements(
-  tab: chrome.tabs.Tab
+  tab: chrome.tabs.Tab | undefined
 ): Promise<Result<string, Error>> {
   if (!tab?.id) {
-    return new Err(new Error("No active tab found."));
+    return new Err(new Error("Tab not found."));
   }
 
   const utilsResult = await ensureDustPageUtils(tab);
@@ -36,13 +36,16 @@ export async function getPageElements(
 
   const [execution] = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    func: () => {
+    args: [tab.id],
+    func: (tabId: number) => {
       const w = window as unknown as DustWindow;
       const { selector, CONTENT, getElementName } = w.__dustUtils;
 
       w.__dustElementMap = {};
       w.__dustElementSnapshots = {};
       w.__dustElementIdCounter = 0;
+
+      const elementPrefix = `el_${tabId.toString(36)}_`;
 
       const elements: ElementSnapshot[] = [];
       const nodes = document.querySelectorAll<HTMLElement>(selector);
@@ -61,7 +64,7 @@ export async function getPageElements(
           return;
         }
 
-        const elementId = `element_${w.__dustElementIdCounter++}`;
+        const elementId = `${elementPrefix}${w.__dustElementIdCounter++}`;
         w.__dustElementMap[elementId] = new WeakRef<HTMLElement>(el);
 
         const tag = el.tagName.toLowerCase();

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -1,0 +1,207 @@
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+export async function getPageElements(
+  tab: chrome.tabs.Tab
+): Promise<Result<string, Error>> {
+  if (!tab?.id) {
+    return new Err(new Error("No active tab found."));
+  }
+  const [execution] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => {
+      const w = window as unknown as {
+        __dustElementMap: Record<string, WeakRef<HTMLElement>>;
+      };
+
+      w.__dustElementMap = {};
+      let elementIdCounter = 0;
+
+      const FORM_CONTROLS = [
+        "button",
+        "input",
+        "select",
+        "textarea",
+        "[contenteditable='true']",
+      ];
+
+      const NAVIGATION = [
+        "a[href]",
+        '[role="link"]',
+        '[role="tab"]',
+        '[role="menuitem"]',
+        '[role="menuitemcheckbox"]',
+        '[role="menuitemradio"]',
+      ];
+
+      const CLICK_TARGETS = [
+        '[role="button"]',
+        '[role="switch"]',
+        '[role="option"]',
+        '[role="treeitem"]',
+        '[role="gridcell"]',
+      ];
+
+      const INPUT_WIDGETS = [
+        '[role="checkbox"]',
+        '[role="radio"]',
+        '[role="combobox"]',
+        '[role="listbox"]',
+        '[role="searchbox"]',
+        '[role="spinbutton"]',
+        '[role="slider"]',
+      ];
+
+      const FOCUSABLE = ["[tabindex]:not([tabindex='-1'])"];
+
+      const CONTENT = [
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "p",
+        "li",
+        '[role="heading"]',
+        '[role="paragraph"]',
+      ];
+
+      const selector = [
+        ...FORM_CONTROLS,
+        ...NAVIGATION,
+        ...CLICK_TARGETS,
+        ...INPUT_WIDGETS,
+        ...FOCUSABLE,
+        ...CONTENT,
+      ].join(", ");
+
+      const elements: {
+        elementId: string;
+        tag: string;
+        type: "content" | "interactive";
+        role: string;
+        name: string;
+        inputType: string | null;
+        coords: {
+          x: number;
+          y: number;
+        };
+      }[] = [];
+
+      const nodes = document.querySelectorAll<HTMLElement>(selector);
+
+      const getElementName = (el: HTMLElement): string => {
+        // 1. Explicit accessible name — highest priority
+        const ariaLabel = el.getAttribute("aria-label");
+        if (ariaLabel) {
+          return ariaLabel;
+        }
+
+        const ariaLabelledBy = el.getAttribute("aria-labelledby");
+        if (ariaLabelledBy) {
+          const labelEl = document.getElementById(ariaLabelledBy);
+          if (labelEl?.textContent) {
+            return labelEl.textContent.trim();
+          }
+        }
+
+        const placeholder = el.getAttribute("placeholder");
+        if (placeholder) {
+          return placeholder;
+        }
+
+        const title = el.getAttribute("title");
+        if (title) {
+          return title;
+        }
+
+        const alt = el.getAttribute("alt");
+        if (alt) {
+          return alt;
+        }
+
+        // 2. Associated <label>
+        if (el.id) {
+          const label = document
+            .querySelector(`label[for="${el.id}"]`)
+            ?.textContent?.trim();
+          if (label) {
+            return label;
+          }
+        }
+
+        // 3. Text content (non-empty)
+        const text = el.textContent;
+        if (text) {
+          return text;
+        }
+
+        // 4. SVG icon hints — check child SVGs for title or aria-label
+        const svg = el.querySelector("svg");
+        if (svg) {
+          const svgAriaLabel = svg.getAttribute("aria-label");
+          if (svgAriaLabel) {
+            return svgAriaLabel;
+          }
+
+          const svgTitle = svg.querySelector("title")?.textContent?.trim();
+          if (svgTitle) {
+            return svgTitle;
+          }
+        }
+
+        // 5. <img> inside the element
+        const img = el.querySelector("img");
+        if (img) {
+          const imgAlt = img.getAttribute("alt")?.trim();
+          if (imgAlt) {
+            return imgAlt;
+          }
+        }
+
+        return "";
+      };
+
+      nodes.forEach((el) => {
+        const style = window.getComputedStyle(el);
+        if (style.display === "none" || style.visibility === "hidden") {
+          return;
+        }
+        if (el.getAttribute("aria-hidden") === "true") {
+          return;
+        }
+
+        const elementId = `element_${elementIdCounter++}`;
+        w.__dustElementMap[elementId] = new WeakRef<HTMLElement>(el);
+
+        const tag = el.tagName.toLowerCase();
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) {
+          return;
+        }
+
+        elements.push({
+          elementId,
+          tag,
+          type: CONTENT.includes(tag) ? "content" : "interactive",
+          role: el.getAttribute("role") ?? tag,
+          name: getElementName(el),
+          inputType: el.getAttribute("type"),
+          coords: {
+            x: Math.round(rect.x + rect.width / 2),
+            y: Math.round(rect.y + rect.height / 2),
+          },
+        });
+      });
+
+      return JSON.stringify(elements);
+    },
+  });
+
+  const result =
+    (execution && typeof execution.result === "string"
+      ? execution.result
+      : JSON.stringify([])) ?? JSON.stringify([]);
+
+  return new Ok(result);
+}

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -1,4 +1,26 @@
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { ensureDustPageUtils } from "./pageUtils";
+
+type ElementSnapshot = {
+  elementId: string;
+  tag: string;
+  type: "content" | "interactive";
+  role: string;
+  name: string;
+  inputType: string | null;
+  coords: { x: number; y: number };
+};
+
+type DustWindow = {
+  __dustUtils: {
+    selector: string;
+    CONTENT: string[];
+    getElementName: (el: HTMLElement) => string;
+  };
+  __dustElementMap: Record<string, WeakRef<HTMLElement>>;
+  __dustElementSnapshots: Record<string, ElementSnapshot>;
+  __dustElementIdCounter: number;
+};
 
 export async function getPageElements(
   tab: chrome.tabs.Tab
@@ -6,161 +28,24 @@ export async function getPageElements(
   if (!tab?.id) {
     return new Err(new Error("No active tab found."));
   }
+
+  const utilsResult = await ensureDustPageUtils(tab);
+  if (utilsResult.isErr()) {
+    return utilsResult;
+  }
+
   const [execution] = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
     func: () => {
-      const w = window as unknown as {
-        __dustElementMap: Record<string, WeakRef<HTMLElement>>;
-      };
+      const w = window as unknown as DustWindow;
+      const { selector, CONTENT, getElementName } = w.__dustUtils;
 
       w.__dustElementMap = {};
-      let elementIdCounter = 0;
+      w.__dustElementSnapshots = {};
+      w.__dustElementIdCounter = 0;
 
-      const FORM_CONTROLS = [
-        "button",
-        "input",
-        "select",
-        "textarea",
-        "[contenteditable='true']",
-      ];
-
-      const NAVIGATION = [
-        "a[href]",
-        '[role="link"]',
-        '[role="tab"]',
-        '[role="menuitem"]',
-        '[role="menuitemcheckbox"]',
-        '[role="menuitemradio"]',
-      ];
-
-      const CLICK_TARGETS = [
-        '[role="button"]',
-        '[role="switch"]',
-        '[role="option"]',
-        '[role="treeitem"]',
-        '[role="gridcell"]',
-      ];
-
-      const INPUT_WIDGETS = [
-        '[role="checkbox"]',
-        '[role="radio"]',
-        '[role="combobox"]',
-        '[role="listbox"]',
-        '[role="searchbox"]',
-        '[role="spinbutton"]',
-        '[role="slider"]',
-      ];
-
-      const FOCUSABLE = ["[tabindex]:not([tabindex='-1'])"];
-
-      const CONTENT = [
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "p",
-        "li",
-        '[role="heading"]',
-        '[role="paragraph"]',
-      ];
-
-      const selector = [
-        ...FORM_CONTROLS,
-        ...NAVIGATION,
-        ...CLICK_TARGETS,
-        ...INPUT_WIDGETS,
-        ...FOCUSABLE,
-        ...CONTENT,
-      ].join(", ");
-
-      const elements: {
-        elementId: string;
-        tag: string;
-        type: "content" | "interactive";
-        role: string;
-        name: string;
-        inputType: string | null;
-        coords: {
-          x: number;
-          y: number;
-        };
-      }[] = [];
-
+      const elements: ElementSnapshot[] = [];
       const nodes = document.querySelectorAll<HTMLElement>(selector);
-
-      const getElementName = (el: HTMLElement): string => {
-        // 1. Explicit accessible name — highest priority
-        const ariaLabel = el.getAttribute("aria-label");
-        if (ariaLabel) {
-          return ariaLabel;
-        }
-
-        const ariaLabelledBy = el.getAttribute("aria-labelledby");
-        if (ariaLabelledBy) {
-          const labelEl = document.getElementById(ariaLabelledBy);
-          if (labelEl?.textContent) {
-            return labelEl.textContent.trim();
-          }
-        }
-
-        const placeholder = el.getAttribute("placeholder");
-        if (placeholder) {
-          return placeholder;
-        }
-
-        const title = el.getAttribute("title");
-        if (title) {
-          return title;
-        }
-
-        const alt = el.getAttribute("alt");
-        if (alt) {
-          return alt;
-        }
-
-        // 2. Associated <label>
-        if (el.id) {
-          const label = document
-            .querySelector(`label[for="${el.id}"]`)
-            ?.textContent?.trim();
-          if (label) {
-            return label;
-          }
-        }
-
-        // 3. Text content (non-empty)
-        const text = el.textContent;
-        if (text) {
-          return text;
-        }
-
-        // 4. SVG icon hints — check child SVGs for title or aria-label
-        const svg = el.querySelector("svg");
-        if (svg) {
-          const svgAriaLabel = svg.getAttribute("aria-label");
-          if (svgAriaLabel) {
-            return svgAriaLabel;
-          }
-
-          const svgTitle = svg.querySelector("title")?.textContent?.trim();
-          if (svgTitle) {
-            return svgTitle;
-          }
-        }
-
-        // 5. <img> inside the element
-        const img = el.querySelector("img");
-        if (img) {
-          const imgAlt = img.getAttribute("alt")?.trim();
-          if (imgAlt) {
-            return imgAlt;
-          }
-        }
-
-        return "";
-      };
 
       nodes.forEach((el) => {
         const style = window.getComputedStyle(el);
@@ -171,16 +56,16 @@ export async function getPageElements(
           return;
         }
 
-        const elementId = `element_${elementIdCounter++}`;
-        w.__dustElementMap[elementId] = new WeakRef<HTMLElement>(el);
-
-        const tag = el.tagName.toLowerCase();
         const rect = el.getBoundingClientRect();
         if (rect.width === 0 || rect.height === 0) {
           return;
         }
 
-        elements.push({
+        const elementId = `element_${w.__dustElementIdCounter++}`;
+        w.__dustElementMap[elementId] = new WeakRef<HTMLElement>(el);
+
+        const tag = el.tagName.toLowerCase();
+        const snapshot: ElementSnapshot = {
           elementId,
           tag,
           type: CONTENT.includes(tag) ? "content" : "interactive",
@@ -191,7 +76,10 @@ export async function getPageElements(
             x: Math.round(rect.x + rect.width / 2),
             y: Math.round(rect.y + rect.height / 2),
           },
-        });
+        };
+
+        w.__dustElementSnapshots[elementId] = snapshot;
+        elements.push(snapshot);
       });
 
       return JSON.stringify(elements);
@@ -199,9 +87,9 @@ export async function getPageElements(
   });
 
   const result =
-    (execution && typeof execution.result === "string"
+    execution && typeof execution.result === "string"
       ? execution.result
-      : JSON.stringify([])) ?? JSON.stringify([]);
+      : JSON.stringify([]);
 
   return new Ok(result);
 }

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -85,7 +85,7 @@ export type CaptureFullPageMessage = {
   type: "PAGE_CAPTURE_FULL_PAGE";
 };
 
-export type GetPageElementsMessage = { type: "GET_ELEMENTS" };
+export type GetPageElementsMessage = { type: "GET_ELEMENTS"; tabId: number };
 export type GetPageElementsResponse = { elements: string; error?: string };
 
 const sendMessage = <T, U>(message: T): Promise<U> => {
@@ -223,12 +223,14 @@ export const sendTabActionMessage = (message: TabActionMessage) => {
 };
 
 export const sendInteractWithPageMessage = (
-  action: "get_elements"
+  action: "get_elements",
+  tabId: number
 ): Promise<GetPageElementsResponse> => {
   switch (action) {
     case "get_elements":
       return sendMessage<GetPageElementsMessage, GetPageElementsResponse>({
         type: "GET_ELEMENTS",
+        tabId,
       });
   }
 };

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -85,6 +85,9 @@ export type CaptureFullPageMessage = {
   type: "PAGE_CAPTURE_FULL_PAGE";
 };
 
+export type GetPageElementsMessage = { type: "GET_ELEMENTS" };
+export type GetPageElementsResponse = { elements: string; error?: string };
+
 const sendMessage = <T, U>(message: T): Promise<U> => {
   return new Promise((resolve, reject) => {
     chrome.runtime.sendMessage(message, (response: U | undefined) => {
@@ -217,6 +220,17 @@ export const sendListTabsMessage = () => {
 
 export const sendTabActionMessage = (message: TabActionMessage) => {
   return sendMessage<TabActionMessage, TabActionResponse>(message);
+};
+
+export const sendInteractWithPageMessage = (
+  action: "get_elements"
+): Promise<GetPageElementsResponse> => {
+  switch (action) {
+    case "get_elements":
+      return sendMessage<GetPageElementsMessage, GetPageElementsResponse>({
+        type: "GET_ELEMENTS",
+      });
+  }
 };
 
 // Messages from background script to content script

--- a/extension/platforms/chrome/pageUtils.ts
+++ b/extension/platforms/chrome/pageUtils.ts
@@ -1,0 +1,156 @@
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+export async function ensureDustPageUtils(
+  tab: chrome.tabs.Tab
+): Promise<Result<void, Error>> {
+  if (!tab?.id) {
+    return new Err(new Error("No active tab found."));
+  }
+
+  await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => {
+      const w = window as unknown as {
+        __dustUtils?: unknown;
+      };
+      if (w.__dustUtils) {
+        return; // already injected
+      }
+
+      const FORM_CONTROLS = [
+        "button",
+        "input",
+        "select",
+        "textarea",
+        "[contenteditable='true']",
+      ];
+
+      const NAVIGATION = [
+        "a[href]",
+        '[role="link"]',
+        '[role="tab"]',
+        '[role="menuitem"]',
+        '[role="menuitemcheckbox"]',
+        '[role="menuitemradio"]',
+      ];
+
+      const CLICK_TARGETS = [
+        '[role="button"]',
+        '[role="switch"]',
+        '[role="option"]',
+        '[role="treeitem"]',
+        '[role="gridcell"]',
+      ];
+
+      const INPUT_WIDGETS = [
+        '[role="checkbox"]',
+        '[role="radio"]',
+        '[role="combobox"]',
+        '[role="listbox"]',
+        '[role="searchbox"]',
+        '[role="spinbutton"]',
+        '[role="slider"]',
+      ];
+
+      const FOCUSABLE = ["[tabindex]:not([tabindex='-1'])"];
+
+      const CONTENT = [
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "p",
+        "li",
+        '[role="heading"]',
+        '[role="paragraph"]',
+      ];
+
+      const selector = [
+        ...FORM_CONTROLS,
+        ...NAVIGATION,
+        ...CLICK_TARGETS,
+        ...INPUT_WIDGETS,
+        ...FOCUSABLE,
+        ...CONTENT,
+      ].join(", ");
+
+      const getElementName = (el: HTMLElement): string => {
+        // 1. Explicit accessible name — highest priority
+        const ariaLabel = el.getAttribute("aria-label");
+        if (ariaLabel) {
+          return ariaLabel;
+        }
+
+        const ariaLabelledBy = el.getAttribute("aria-labelledby");
+        if (ariaLabelledBy) {
+          const labelEl = document.getElementById(ariaLabelledBy);
+          if (labelEl?.textContent) {
+            return labelEl.textContent.trim();
+          }
+        }
+
+        const placeholder = el.getAttribute("placeholder");
+        if (placeholder) {
+          return placeholder;
+        }
+
+        const title = el.getAttribute("title");
+        if (title) {
+          return title;
+        }
+
+        const alt = el.getAttribute("alt");
+        if (alt) {
+          return alt;
+        }
+
+        // 2. Associated <label>
+        if (el.id) {
+          const label = document
+            .querySelector(`label[for="${el.id}"]`)
+            ?.textContent?.trim();
+          if (label) {
+            return label;
+          }
+        }
+
+        // 3. Text content (non-empty)
+        const text = el.textContent;
+        if (text) {
+          return text;
+        }
+
+        // 4. SVG icon hints — check child SVGs for title or aria-label
+        const svg = el.querySelector("svg");
+        if (svg) {
+          const svgAriaLabel = svg.getAttribute("aria-label");
+          if (svgAriaLabel) {
+            return svgAriaLabel;
+          }
+
+          const svgTitle = svg.querySelector("title")?.textContent?.trim();
+          if (svgTitle) {
+            return svgTitle;
+          }
+        }
+
+        // 5. <img> inside the element
+        const img = el.querySelector("img");
+        if (img) {
+          const imgAlt = img.getAttribute("alt")?.trim();
+          if (imgAlt) {
+            return imgAlt;
+          }
+        }
+
+        return "";
+      };
+
+      w.__dustUtils = { selector, CONTENT, getElementName };
+    },
+  });
+
+  return new Ok(undefined);
+}

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -4,6 +4,7 @@ import { registerListTabsTool } from "@extension/platforms/chrome/tools/listTabs
 import { registerTabActionTools } from "@extension/platforms/chrome/tools/tabActionTools";
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerInteractWithPageTool } from "./interactWithPageTool";
 
 /**
  * Registers all Chrome MCP tools with the server
@@ -19,4 +20,5 @@ export function registerAllTools(
   registerTabActionTools(server);
   registerGetCurrentPageTool(server, captureService);
   registerGetPageViewTool(server, captureService, workspaceId);
+  registerInteractWithPageTool(server);
 }

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 
 const inputSchema = z.object({
   action: z.enum(["get_elements", "click_element", "type_text"]),
+  tab_id: z.number().describe("The ID of the tab to interact with."),
   element_id: z.string().nullable(),
   text: z.string().nullable(),
 });
@@ -17,7 +18,10 @@ export function registerInteractWithPageTool(server: McpServer): void {
       if (input.action === "click_element" || input.action === "type_text") {
         throw new Error("Not implemented");
       }
-      const response = await sendInteractWithPageMessage("get_elements");
+      const response = await sendInteractWithPageMessage(
+        "get_elements",
+        input.tab_id
+      );
 
       if (!response) {
         return {

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -36,8 +36,6 @@ export function registerInteractWithPageTool(server: McpServer): void {
         };
       }
 
-      console.log("response elements", response.elements);
-
       return {
         content: [
           {

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -1,0 +1,51 @@
+import { sendInteractWithPageMessage } from "@extension/platforms/chrome/messages";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+
+const inputSchema = z.object({
+  action: z.enum(["get_elements", "click_element", "type_text"]),
+  element_id: z.string().nullable(),
+  text: z.string().nullable(),
+});
+
+export function registerInteractWithPageTool(server: McpServer): void {
+  server.tool(
+    "chrome-interact-with-page",
+    "Interact with the page the user is currently viewing. Use the get_elements action to get the elements of the page. Use the click_element action to click on an element. Use the type_text action to type text into an element.",
+    inputSchema.shape,
+    async (input) => {
+      if (input.action === "click_element" || input.action === "type_text") {
+        throw new Error("Not implemented");
+      }
+      const response = await sendInteractWithPageMessage("get_elements");
+
+      if (!response) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No response received from background script.",
+            },
+          ],
+        };
+      }
+
+      if (response.error) {
+        return {
+          content: [{ type: "text", text: `Error: ${response.error}` }],
+        };
+      }
+
+      console.log("response elements", response.elements);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: response.elements,
+          },
+        ],
+      };
+    }
+  );
+}


### PR DESCRIPTION
## Description

This PR adds a new `chrome-interact-with-page` MCP tool to the Chrome extension that allows agents to get a structured list of interactive and content elements from the current web page.

- The tool extracts only relevant elements (form controls, buttons, links, headings, paragraphs) rather than the complete DOM to reduce noise and focus on meaningful content
- Each element is captured with metadata: tag, type (content/interactive), role, accessible name, coordinates, and a unique ID

This approach provides agents with a focused view of what users can interact with and what content is visible, without overwhelming them with the entire DOM structure.

<img width="1460" height="861" alt="Capture d’écran 2026-03-10 à 12 10 05" src="https://github.com/user-attachments/assets/6087e58c-eed6-40ea-8a21-b7df997b0ef3" />


## Tests

Manually

## Risks

Low risk. 

## Deploy Plan

Standard deployment.
