### PR TITLE
[front] - feat(analytics): add Skill usage chart

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
+import { WorkspaceSkillUsageChart } from "@app/components/workspace/analytics/WorkspaceSkillUsageChart";
 import { WorkspaceSourceChart } from "@app/components/workspace/analytics/WorkspaceSourceChart";
 import { WorkspaceToolUsageChart } from "@app/components/workspace/analytics/WorkspaceToolUsageChart";
 import { WorkspaceTopAgentsTable } from "@app/components/workspace/analytics/WorkspaceTopAgentsTable";
@@ -165,6 +166,7 @@ export function AnalyticsPage() {
       <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
       <WorkspaceSourceChart workspaceId={owner.sId} period={period} />
       <WorkspaceToolUsageChart workspaceId={owner.sId} period={period} />
+      <WorkspaceSkillUsageChart workspaceId={owner.sId} period={period} />
       <WorkspaceTopUsersTable workspaceId={owner.sId} period={period} />
       <WorkspaceTopAgentsTable workspaceId={owner.sId} period={period} />
       <ActivityReport

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -187,8 +187,14 @@ export function WorkspaceSkillUsageChart({
     });
   }, [selectedSkills, skillUsages]);
 
-  // Show loading only on initial load (when no skills have data yet)
-  const isLoading = isSkillsLoading || skillsWithData.length === 0;
+  const allSkillsSettled = selectedSkills.every((_skill, idx) => {
+    const usage = skillUsages[idx];
+    return usage && !usage.isSkillUsageLoading;
+  });
+
+  // Show loading only on initial load, but not if all requests have settled (even with errors)
+  const isLoading =
+    isSkillsLoading || (skillsWithData.length === 0 && !allSkillsSettled);
 
   const hasError = skillUsages.some(
     (s, i) => skillsToFetch[i] && s.isSkillUsageError
@@ -238,7 +244,7 @@ export function WorkspaceSkillUsageChart({
       if (selectedSkills.length < MAX_SELECTED_SKILLS) {
         setSelectedSkills([...selectedSkills, skill]);
       }
-    } else {
+    } else if (selectedSkills.length > 1) {
       setSelectedSkills(selectedSkills.filter((s) => s !== skill));
     }
   };
@@ -271,8 +277,9 @@ export function WorkspaceSkillUsageChart({
               label={skill.skillName}
               checked={selectedSkills.includes(skill.skillName)}
               disabled={
-                !selectedSkills.includes(skill.skillName) &&
-                selectedSkills.length >= MAX_SELECTED_SKILLS
+                selectedSkills.includes(skill.skillName)
+                  ? selectedSkills.length <= 1
+                  : selectedSkills.length >= MAX_SELECTED_SKILLS
               }
               onCheckedChange={(checked) =>
                 handleSkillToggle(skill.skillName, checked)

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -43,6 +43,20 @@ interface SkillUsageChartPoint {
   values: Record<string, number>;
 }
 
+function isSkillUsageChartPoint(value: unknown): value is SkillUsageChartPoint {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "timestamp" in value &&
+    typeof value.timestamp === "number" &&
+    "date" in value &&
+    typeof value.date === "string" &&
+    "values" in value &&
+    typeof value.values === "object" &&
+    value.values !== null
+  );
+}
+
 function getSkillSelectorLabel(selectedSkills: string[]): string {
   if (selectedSkills.length === 0) {
     return "Select skills";
@@ -73,7 +87,11 @@ function SkillUsageTooltip({
     return null;
   }
 
-  const point = first.payload as SkillUsageChartPoint;
+  if (!isSkillUsageChartPoint(first.payload)) {
+    return null;
+  }
+
+  const point = first.payload;
   const title = point.date ?? formatShortDate(point.timestamp);
   const label = displayMode === "users" ? "users" : "executions";
 

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -1,0 +1,366 @@
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
+import {
+  getIndexedColor,
+  getTimeRangeBounds,
+} from "@app/components/agent_builder/observability/utils";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import type { LegendItem } from "@app/components/charts/ChartLegend";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import {
+  useWorkspaceSkills,
+  useWorkspaceSkillUsage,
+} from "@app/lib/swr/workspaces";
+import { formatShortDate } from "@app/lib/utils/timestamps";
+import {
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useEffect, useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+type SkillUsageDisplayMode = "users" | "executions";
+
+const MAX_SELECTED_SKILLS = 5;
+
+interface SkillUsageChartPoint {
+  timestamp: number;
+  date: string;
+  values: Record<string, number>;
+}
+
+function getSkillSelectorLabel(selectedSkills: string[]): string {
+  if (selectedSkills.length === 0) {
+    return "Select skills";
+  }
+  if (selectedSkills.length === 1) {
+    return selectedSkills[0];
+  }
+  return `${selectedSkills.length} skills`;
+}
+
+interface SkillUsageTooltipProps extends TooltipContentProps<number, string> {
+  displayMode: SkillUsageDisplayMode;
+  skillsForChart: string[];
+}
+
+function SkillUsageTooltip({
+  displayMode,
+  skillsForChart,
+  active,
+  payload,
+}: SkillUsageTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const first = payload[0];
+  if (!first?.payload) {
+    return null;
+  }
+
+  const point = first.payload as SkillUsageChartPoint;
+  const title = point.date ?? formatShortDate(point.timestamp);
+  const label = displayMode === "users" ? "users" : "executions";
+
+  const values = skillsForChart.map((skill) => point.values[skill] ?? 0);
+  const rows = skillsForChart.map((skill, idx) => ({
+    label: skill,
+    value: values[idx].toLocaleString(),
+    colorClassName: getIndexedColor(skill, skillsForChart),
+  }));
+
+  if (skillsForChart.length > 1) {
+    const total = values.reduce((sum, v) => sum + v, 0);
+    rows.push({
+      label: `Total ${label}`,
+      value: total.toLocaleString(),
+      colorClassName: "",
+    });
+  }
+
+  return <ChartTooltipCard title={title} rows={rows} />;
+}
+
+interface WorkspaceSkillUsageChartProps {
+  workspaceId: string;
+  period: ObservabilityTimeRangeType;
+}
+
+export function WorkspaceSkillUsageChart({
+  workspaceId,
+  period,
+}: WorkspaceSkillUsageChartProps) {
+  const [displayMode, setDisplayMode] =
+    useState<SkillUsageDisplayMode>("executions");
+  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+
+  const { skills: availableSkills, isSkillsLoading } = useWorkspaceSkills({
+    workspaceId,
+    days: period,
+    disabled: !workspaceId,
+  });
+
+  // Auto-select first 3 skills when available skills are loaded
+  useEffect(() => {
+    if (availableSkills.length > 0 && selectedSkills.length === 0) {
+      const initialSkills = availableSkills.slice(0, 3).map((s) => s.skillName);
+      setSelectedSkills(initialSkills);
+    }
+  }, [availableSkills, selectedSkills.length]);
+
+  const skillsToFetch = selectedSkills;
+
+  const skill1Usage = useWorkspaceSkillUsage({
+    workspaceId,
+    days: period,
+    skillName: skillsToFetch[0],
+    disabled: !workspaceId || !skillsToFetch[0],
+  });
+  const skill2Usage = useWorkspaceSkillUsage({
+    workspaceId,
+    days: period,
+    skillName: skillsToFetch[1],
+    disabled: !workspaceId || !skillsToFetch[1],
+  });
+  const skill3Usage = useWorkspaceSkillUsage({
+    workspaceId,
+    days: period,
+    skillName: skillsToFetch[2],
+    disabled: !workspaceId || !skillsToFetch[2],
+  });
+  const skill4Usage = useWorkspaceSkillUsage({
+    workspaceId,
+    days: period,
+    skillName: skillsToFetch[3],
+    disabled: !workspaceId || !skillsToFetch[3],
+  });
+  const skill5Usage = useWorkspaceSkillUsage({
+    workspaceId,
+    days: period,
+    skillName: skillsToFetch[4],
+    disabled: !workspaceId || !skillsToFetch[4],
+  });
+
+  const skillUsages = useMemo(
+    () => [skill1Usage, skill2Usage, skill3Usage, skill4Usage, skill5Usage],
+    [skill1Usage, skill2Usage, skill3Usage, skill4Usage, skill5Usage]
+  );
+
+  // Only include skills that have loaded data to prevent chart flickering
+  const skillsWithData = useMemo(() => {
+    return selectedSkills.filter((skill, idx) => {
+      const usage = skillUsages[idx];
+      return usage && !usage.isSkillUsageLoading && !usage.isSkillUsageError;
+    });
+  }, [selectedSkills, skillUsages]);
+
+  // Show loading only on initial load (when no skills have data yet)
+  const isLoading = isSkillsLoading || skillsWithData.length === 0;
+
+  const hasError = skillUsages.some(
+    (s, i) => skillsToFetch[i] && s.isSkillUsageError
+  );
+
+  const skillsForChart = skillsWithData;
+
+  const data = useMemo((): SkillUsageChartPoint[] => {
+    if (skillsWithData.length === 0) {
+      return [];
+    }
+
+    const valueKey = displayMode === "users" ? "uniqueUsers" : "executionCount";
+
+    const [startDate, endDate] = getTimeRangeBounds(period);
+    const startTimeMs = new Date(startDate + "T00:00:00Z").getTime();
+    const endTimeMs = new Date(endDate + "T00:00:00Z").getTime();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const numDays = Math.floor((endTimeMs - startTimeMs) / dayMs) + 1;
+
+    const points: SkillUsageChartPoint[] = [];
+
+    for (let i = 0; i < numDays; i++) {
+      const timestamp = startTimeMs + i * dayMs;
+      const values: Record<string, number> = {};
+
+      skillsWithData.forEach((skill) => {
+        const idx = selectedSkills.indexOf(skill);
+        const skillData = skillUsages[idx]?.skillUsage.find(
+          (p) => p.timestamp === timestamp
+        );
+        values[skill] = skillData ? skillData[valueKey] : 0;
+      });
+
+      points.push({
+        timestamp,
+        date: formatShortDate(timestamp),
+        values,
+      });
+    }
+
+    return points;
+  }, [displayMode, period, skillsWithData, selectedSkills, skillUsages]);
+
+  const handleSkillToggle = (skill: string, checked: boolean) => {
+    if (checked) {
+      if (selectedSkills.length < MAX_SELECTED_SKILLS) {
+        setSelectedSkills([...selectedSkills, skill]);
+      }
+    } else {
+      setSelectedSkills(selectedSkills.filter((s) => s !== skill));
+    }
+  };
+
+  const legendItems: LegendItem[] = skillsForChart.map((skill) => ({
+    key: skill,
+    label: skill,
+    colorClassName: getIndexedColor(skill, skillsForChart),
+  }));
+
+  const skillSelector = (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label={getSkillSelectorLabel(selectedSkills)}
+          size="xs"
+          variant="outline"
+          isSelect
+          disabled={isSkillsLoading}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>
+          Select skills (max {MAX_SELECTED_SKILLS})
+        </DropdownMenuLabel>
+        <div className="max-h-64 overflow-auto">
+          {availableSkills.map((skill) => (
+            <DropdownMenuCheckboxItem
+              key={skill.skillName}
+              label={skill.skillName}
+              checked={selectedSkills.includes(skill.skillName)}
+              disabled={
+                !selectedSkills.includes(skill.skillName) &&
+                selectedSkills.length >= MAX_SELECTED_SKILLS
+              }
+              onCheckedChange={(checked) =>
+                handleSkillToggle(skill.skillName, checked)
+              }
+              onSelect={(event) => {
+                event.preventDefault();
+              }}
+            />
+          ))}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const modeSelector = (
+    <ButtonsSwitchList defaultValue={displayMode} size="xs">
+      <ButtonsSwitch
+        value="executions"
+        label="Executions"
+        onClick={() => setDisplayMode("executions")}
+      />
+      <ButtonsSwitch
+        value="users"
+        label="Users"
+        onClick={() => setDisplayMode("users")}
+      />
+    </ButtonsSwitchList>
+  );
+
+  return (
+    <ChartContainer
+      title="Skill usage"
+      description={`Skill usage across your workspace over the last ${period} days.`}
+      isLoading={isLoading}
+      errorMessage={hasError ? "Failed to load skill usage data." : undefined}
+      emptyMessage={
+        data.length === 0
+          ? "No skill usage data for this selection."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+      additionalControls={
+        <div className="flex items-center gap-2">
+          {skillSelector}
+          {modeSelector}
+        </div>
+      }
+    >
+      <LineChart
+        data={data}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="date"
+          type="category"
+          scale="point"
+          allowDuplicatedCategory={false}
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={16}
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          allowDecimals={false}
+        />
+        <Tooltip
+          isAnimationActive={false}
+          content={(props: TooltipContentProps<number, string>) => (
+            <SkillUsageTooltip
+              {...props}
+              displayMode={displayMode}
+              skillsForChart={skillsForChart}
+            />
+          )}
+          cursor={false}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        {skillsForChart.map((skill) => (
+          <Line
+            key={skill}
+            type={period === 7 || period === 14 ? "linear" : "monotone"}
+            strokeWidth={2}
+            dataKey={(point: SkillUsageChartPoint) => point.values[skill] ?? 0}
+            name={skill}
+            className={getIndexedColor(skill, skillsForChart)}
+            stroke="currentColor"
+            dot={false}
+          />
+        ))}
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/front/lib/api/assistant/observability/skill_usage.ts
+++ b/front/lib/api/assistant/observability/skill_usage.ts
@@ -1,0 +1,206 @@
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type SkillUsagePoint = {
+  timestamp: number;
+  date: string;
+  uniqueUsers: number;
+  executionCount: number;
+};
+
+export type AvailableSkill = {
+  skillName: string;
+  totalExecutions: number;
+};
+
+type DateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  skills_nested: {
+    doc_count: number;
+    unique_users: {
+      doc_count: number;
+      cardinality: estypes.AggregationsCardinalityAggregate;
+    };
+  };
+};
+
+type SkillUsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<DateBucket>;
+};
+
+type FilteredDateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  skills_nested: {
+    filtered: {
+      doc_count: number;
+      unique_users: {
+        doc_count: number;
+        cardinality: estypes.AggregationsCardinalityAggregate;
+      };
+    };
+  };
+};
+
+type FilteredSkillUsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<FilteredDateBucket>;
+};
+
+type SkillBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type SkillListAggs = {
+  skills_nested: {
+    by_skill: estypes.AggregationsMultiBucketAggregateBase<SkillBucket>;
+  };
+};
+
+function bucketToPoint(bucket: DateBucket): SkillUsagePoint {
+  return {
+    timestamp: bucket.key,
+    date: formatUTCDateFromMillis(bucket.key),
+    uniqueUsers: bucket.skills_nested?.unique_users?.cardinality?.value ?? 0,
+    executionCount: bucket.skills_nested?.doc_count ?? 0,
+  };
+}
+
+function filteredBucketToPoint(bucket: FilteredDateBucket): SkillUsagePoint {
+  return {
+    timestamp: bucket.key,
+    date: formatUTCDateFromMillis(bucket.key),
+    uniqueUsers:
+      bucket.skills_nested?.filtered?.unique_users?.cardinality?.value ?? 0,
+    executionCount: bucket.skills_nested?.filtered?.doc_count ?? 0,
+  };
+}
+
+export async function fetchSkillUsageMetrics(
+  baseQuery: estypes.QueryDslQueryContainer,
+  skillName: string | null
+): Promise<Result<SkillUsagePoint[], Error>> {
+  const nestedAggs: Record<string, estypes.AggregationsAggregationContainer> =
+    skillName
+      ? {
+          filtered: {
+            filter: { term: { "skills_used.skill_name": skillName } },
+            aggs: {
+              unique_users: {
+                reverse_nested: {},
+                aggs: {
+                  cardinality: {
+                    cardinality: { field: "user_id" },
+                  },
+                },
+              },
+            },
+          },
+        }
+      : {
+          unique_users: {
+            reverse_nested: {},
+            aggs: {
+              cardinality: {
+                cardinality: { field: "user_id" },
+              },
+            },
+          },
+        };
+
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_date: {
+      date_histogram: {
+        field: "timestamp",
+        calendar_interval: "day",
+        time_zone: "UTC",
+      },
+      aggs: {
+        skills_nested: {
+          nested: { path: "skills_used" },
+          aggs: nestedAggs,
+        },
+      },
+    },
+  };
+
+  if (skillName) {
+    const result = await searchAnalytics<never, FilteredSkillUsageAggs>(
+      baseQuery,
+      { aggregations: aggs, size: 0 }
+    );
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const dateBuckets = bucketsToArray<FilteredDateBucket>(
+      result.value.aggregations?.by_date?.buckets
+    );
+
+    return new Ok(dateBuckets.map(filteredBucketToPoint));
+  }
+
+  const result = await searchAnalytics<never, SkillUsageAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dateBuckets = bucketsToArray<DateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  return new Ok(dateBuckets.map(bucketToPoint));
+}
+
+export async function fetchAvailableSkills(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<AvailableSkill[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    skills_nested: {
+      nested: { path: "skills_used" },
+      aggs: {
+        by_skill: {
+          terms: {
+            field: "skills_used.skill_name",
+            size: 100,
+            order: { _count: "desc" },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, SkillListAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const skillBuckets = bucketsToArray<SkillBucket>(
+    result.value.aggregations?.skills_nested?.by_skill?.buckets
+  );
+
+  const skills: AvailableSkill[] = skillBuckets.map((bucket) => ({
+    skillName: bucket.key,
+    totalExecutions: bucket.doc_count,
+  }));
+
+  return new Ok(skills);
+}

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -10,6 +10,8 @@ import type { GetPendingInvitationsLookupResponseBody } from "@app/pages/api/inv
 import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
 import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
 import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/pages/api/w/[wId]/analytics/overview";
+import type { GetWorkspaceSkillUsageResponse } from "@app/pages/api/w/[wId]/analytics/skill-usage";
+import type { GetWorkspaceSkillsResponse } from "@app/pages/api/w/[wId]/analytics/skills";
 import type { GetWorkspaceContextOriginResponse } from "@app/pages/api/w/[wId]/analytics/source";
 import type { GetWorkspaceToolUsageResponse } from "@app/pages/api/w/[wId]/analytics/tool-usage";
 import type { GetWorkspaceToolsResponse } from "@app/pages/api/w/[wId]/analytics/tools";
@@ -262,6 +264,64 @@ export function useWorkspaceToolUsage({
     isToolUsageLoading: !error && !data && !disabled,
     isToolUsageError: error,
     isToolUsageValidating: isValidating,
+  };
+}
+
+export function useWorkspaceSkills({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetWorkspaceSkillsResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/analytics/skills?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    skills: data?.skills ?? emptyArray(),
+    isSkillsLoading: !error && !data && !disabled,
+    isSkillsError: error,
+    isSkillsValidating: isValidating,
+  };
+}
+
+export function useWorkspaceSkillUsage({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  skillName,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  skillName?: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetWorkspaceSkillUsageResponse> = fetcher;
+  const params = new URLSearchParams({ days: String(days) });
+  if (skillName) {
+    params.set("skillName", skillName);
+  }
+  const key = `/api/w/${workspaceId}/analytics/skill-usage?${params.toString()}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    skillUsage: data?.points ?? emptyArray(),
+    isSkillUsageLoading: !error && !data && !disabled,
+    isSkillUsageError: error,
+    isSkillUsageValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/analytics/skill-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage.ts
@@ -1,0 +1,92 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  skillName: z.string().optional(),
+});
+
+export type GetWorkspaceSkillUsageResponse = {
+  points: SkillUsagePoint[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceSkillUsageResponse>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays, skillName: querySkillName } = req.query;
+      const q = QuerySchema.safeParse({
+        days: queryDays,
+        skillName: isString(querySkillName) ? querySkillName : undefined,
+      });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days, skillName } = q.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days,
+      });
+
+      const usageResult = await fetchSkillUsageMetrics(
+        baseQuery,
+        skillName ?? null
+      );
+
+      if (usageResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve skill usage metrics: ${usageResult.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        points: usageResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/analytics/skills.ts
+++ b/front/pages/api/w/[wId]/analytics/skills.ts
@@ -1,0 +1,84 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceSkillsResponse = {
+  skills: AvailableSkill[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceSkillsResponse>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays } = req.query;
+      const q = QuerySchema.safeParse({ days: queryDays });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days } = q.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days,
+      });
+
+      const skillsResult = await fetchAvailableSkills(baseQuery);
+
+      if (skillsResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve skills: ${skillsResult.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        skills: skillsResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION

## Description

This PR adds a new "Skill usage" chart to the workspace analytics page. The chart visualizes skill adoption across the workspace by displaying execution count or unique user count over time for up to 5 selected skills. Includes two new API endpoints (`/api/w/[wId]/analytics/skills` and `/api/w/[wId]/analytics/skill-usage`) that fetch available skills and usage metrics from Elasticsearch. The component follows patterns from existing analytics charts like `WorkspaceToolUsageChart`, with a dropdown to select skills and a toggle to switch between executions and users view.

## Tests

- [x] Locally
- [x] front-edge

## Risk

Low. Adds new analytics functionality without modifying existing features

## Deploy Plan

Deploy front