### PR TITLE
feat(mcp): deeper RFC compliance for MCP token refresh

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -17,6 +17,33 @@ use tracing::{error, info};
 
 use super::utils::ProviderHttpRequestError;
 
+/// Default expiry (1 hour) for tokens without `expires_in` that have a refresh_token.
+/// When a server returns a refresh_token but no expires_in, the access token likely expires
+/// server-side. This default ensures proactive refresh instead of waiting for a 401.
+const DEFAULT_TOKEN_EXPIRY_SECONDS: u64 = 3600;
+
+/// Compute the access_token_expiry timestamp in milliseconds.
+/// Uses `saturating_sub` to avoid underflow if `expires_in` < `PROVIDER_TIMEOUT_SECONDS`.
+fn compute_expiry(expires_in: u64) -> u64 {
+    utils::now() + expires_in.saturating_sub(PROVIDER_TIMEOUT_SECONDS) * 1000
+}
+
+/// Compute the access_token_expiry, defaulting to `DEFAULT_TOKEN_EXPIRY_SECONDS` when
+/// `expires_in` is missing but a refresh token is present (meaning the token likely expires).
+fn compute_access_token_expiry(expires_in: Option<u64>, has_refresh_token: bool) -> Option<u64> {
+    match expires_in {
+        Some(ei) => Some(compute_expiry(ei)),
+        None if has_refresh_token => {
+            info!(
+                "No expires_in but refresh_token present; defaulting to {}s expiry",
+                DEFAULT_TOKEN_EXPIRY_SECONDS
+            );
+            Some(compute_expiry(DEFAULT_TOKEN_EXPIRY_SECONDS))
+        }
+        None => None,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct MCPConnectionMetadata {
     pub client_id: String,
@@ -74,6 +101,53 @@ impl MCPConnectionProvider {
             .map(|s| s.to_string());
 
         Ok((client_id.to_string(), client_secret))
+    }
+
+    /// Execute a refresh token request against the token endpoint.
+    /// Extracted to allow retrying without the `resource` parameter on failure.
+    async fn execute_refresh_request(
+        &self,
+        token_endpoint: &str,
+        refresh_token: &str,
+        client_id: &str,
+        client_secret: Option<&str>,
+        use_basic_auth: bool,
+        resource: Option<&str>,
+    ) -> Result<serde_json::Value, ProviderHttpRequestError> {
+        let grant_type = "refresh_token";
+
+        let mut form_data = vec![("grant_type", grant_type), ("refresh_token", refresh_token)];
+
+        if !use_basic_auth {
+            form_data.push(("client_id", client_id));
+
+            if let Some(secret) = client_secret {
+                form_data.push(("client_secret", secret));
+            }
+        }
+
+        // Include resource parameter per RFC 8707 if provided.
+        if let Some(resource) = resource {
+            form_data.push(("resource", resource));
+        }
+
+        let mut req = self
+            .reqwest_client()
+            .post(token_endpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&form_data);
+
+        if use_basic_auth {
+            let auth_header = Self::build_basic_auth_header(
+                client_id,
+                client_secret.ok_or(ProviderHttpRequestError::InvalidResponse(anyhow!(
+                    "client_secret required for basic auth"
+                )))?,
+            );
+            req = req.header("Authorization", auth_header);
+        }
+
+        execute_request(ConnectionProvider::Mcp, req).await
     }
 }
 
@@ -174,10 +248,9 @@ impl Provider for MCPConnectionProvider {
         // Some MCP servers do not return a refresh token when finalizing an access token.
         let refresh_token = raw_json["refresh_token"].as_str().map(ToString::to_string);
 
-        let access_token_expiry = match expires_in {
-            Some(expires_in) => Some(utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000),
-            None => None,
-        };
+        // When no expires_in but a refresh_token is present, the access token likely
+        // expires server-side. Default to 1 hour to ensure proactive refresh.
+        let access_token_expiry = compute_access_token_expiry(expires_in, refresh_token.is_some());
 
         Ok(FinalizeResult {
             redirect_uri: redirect_uri.to_string(),
@@ -206,63 +279,61 @@ impl Provider for MCPConnectionProvider {
         let metadata: MCPConnectionMetadata = serde_json::from_value(connection.metadata().clone())
             .map_err(|e| ProviderError::InvalidMetadataError(e.to_string()))?;
 
-        let grant_type = "refresh_token";
-
         let use_basic_auth = matches!(
             metadata.token_endpoint_auth_method.as_deref(),
             Some("client_secret_basic")
         ) && client_secret.is_some();
 
-        let mut form_data = vec![
-            ("grant_type", grant_type),
-            ("refresh_token", &refresh_token),
-        ];
-
-        if !use_basic_auth {
-            form_data.push(("client_id", &client_id));
-
-            // Only include client_secret if it's provided
-            if let Some(ref secret) = client_secret {
-                form_data.push(("client_secret", secret));
-            }
-        }
-
-        // Include resource parameter per RFC 8707 if available.
-        if let Some(ref resource) = metadata.resource {
-            form_data.push(("resource", resource));
-        }
-
-        let mut req = self
-            .reqwest_client()
-            .post(metadata.token_endpoint)
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .form(&form_data);
-
-        if use_basic_auth {
-            let auth_header = Self::build_basic_auth_header(
+        // Try with resource parameter first. If the auth server rejects with 400
+        // (many don't support RFC 8707), retry without resource. Per RFC 8707 §5 the auth
+        // server SHOULD remember the resource from the original grant, so omitting it in
+        // refresh is valid.
+        let raw_json = match self
+            .execute_refresh_request(
+                &metadata.token_endpoint,
+                &refresh_token,
                 &client_id,
-                client_secret
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("client_secret required for basic auth"))?,
-            );
-            req = req.header("Authorization", auth_header);
-        }
-
-        let raw_json = execute_request(ConnectionProvider::Mcp, req)
+                client_secret.as_deref(),
+                use_basic_auth,
+                metadata.resource.as_deref(),
+            )
             .await
-            .map_err(|e| self.handle_provider_request_error(e))?;
+        {
+            Ok(json) => json,
+            Err(ProviderHttpRequestError::RequestFailed { status, .. })
+                if status == 400 && metadata.resource.is_some() =>
+            {
+                info!("MCP refresh failed with resource parameter, retrying without it");
+                self.execute_refresh_request(
+                    &metadata.token_endpoint,
+                    &refresh_token,
+                    &client_id,
+                    client_secret.as_deref(),
+                    use_basic_auth,
+                    None,
+                )
+                .await
+                .map_err(|e| self.handle_provider_request_error(e))?
+            }
+            Err(e) => return Err(self.handle_provider_request_error(e)),
+        };
 
         let access_token = match raw_json["access_token"].as_str() {
             Some(token) => token,
             None => Err(anyhow!("Missing `access_token` in response from MCP"))?,
         };
 
+        // expires_in is RECOMMENDED per OAuth 2.1, not REQUIRED.
+        // Handle missing expires_in the same way as finalize.
         let expires_in = match raw_json.get("expires_in") {
             Some(serde_json::Value::Number(n)) => match n.as_u64() {
-                Some(n) => n,
+                Some(n) => Some(n),
                 None => Err(anyhow!("Invalid `expires_in` in response from MCP"))?,
             },
-            _ => Err(anyhow!("Missing `expires_in` in response from MCP"))?,
+            _ => {
+                info!("Missing `expires_in` in refresh response from MCP.");
+                None
+            }
         };
 
         // The scope should be available in the response, if not it could be available in the connection metadata.
@@ -271,10 +342,14 @@ impl Provider for MCPConnectionProvider {
             None => metadata.scope,
         };
 
-        match raw_json["token_type"].as_str() {
-            Some(_) => (),
-            None => Err(anyhow!("Missing `token_type` in response from MCP"))?,
-        };
+        // token_type is often omitted in refresh responses since it doesn't change.
+        if raw_json
+            .get("token_type")
+            .and_then(|v| v.as_str())
+            .is_none()
+        {
+            info!("Missing `token_type` in refresh response from MCP.");
+        }
 
         let existing_raw_json = connection.unseal_raw_json()?;
 
@@ -294,21 +369,27 @@ impl Provider for MCPConnectionProvider {
             }
         };
 
-        // We checked above the presence of each of these fields in raw_json or the metadata.
         merged_raw_json["access_token"] = raw_json["access_token"].clone();
-        merged_raw_json["expires_in"] = raw_json["expires_in"].clone();
-        merged_raw_json["token_type"] = raw_json["token_type"].clone();
+
+        // Only overwrite expires_in and token_type if present in the refresh response.
+        if let Some(expires_in_val) = raw_json.get("expires_in") {
+            merged_raw_json["expires_in"] = expires_in_val.clone();
+        }
+        if let Some(token_type_val) = raw_json.get("token_type") {
+            merged_raw_json["token_type"] = token_type_val.clone();
+        }
 
         // If we have a scope, we add it to the merged raw_json.
         if let Some(scope) = scope {
             merged_raw_json["scope"] = serde_json::Value::String(scope);
         }
 
+        // In a refresh context there is always a refresh token, so default to 1h if missing.
+        let access_token_expiry = compute_access_token_expiry(expires_in, true);
+
         Ok(RefreshResult {
             access_token: access_token.to_string(),
-            access_token_expiry: Some(
-                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
-            ),
+            access_token_expiry,
             refresh_token: Some(final_refresh_token),
             raw_json: serde_json::Value::Object(merged_raw_json),
         })
@@ -333,7 +414,9 @@ impl Provider for MCPConnectionProvider {
             ProviderHttpRequestError::RequestFailed {
                 status, message, ..
             } if *status == 400 => {
-                let is_revoked = message.contains("invalid_grant");
+                // Detect both "invalid_grant" and "invalid_refresh_token" as revoked token indicators.
+                let is_revoked =
+                    message.contains("invalid_grant") || message.contains("invalid_refresh_token");
                 info!(message, is_revoked, "MCP 400 error");
                 if is_revoked {
                     ProviderError::TokenRevokedError


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  5 customer reports of remote MCP servers becoming unresponsive after hours/days (Customer.io, Dropbox, Granola, Mirakl, Azure Entra). All share the same pattern: OAuth works initially, then breaks after token expiry. Root cause is multiple issues in the `refresh()` path of `MCPConnectionProvider`.

 ## Summary

  - Retry token refresh without RFC 8707 `resource` parameter when auth server returns 400, fixing Azure Entra, Customer.io, Dropbox, Mirakl
  - Make `expires_in` and `token_type` optional in refresh responses (OAuth 2.1 RECOMMENDED, not REQUIRED)
  - Default to 1h token expiry when server omits `expires_in` but returns a `refresh_token`, preventing tokens from silently going stale
  - Map `invalid_refresh_token` to `TokenRevokedError` alongside `invalid_grant`
  - Use `saturating_sub` in expiry calculation to prevent underflow

  ## Context

  The most impactful fix is the `resource` parameter retry: PR #20789 added RFC 8707 `resource` to token requests, but many auth servers reject unknown parameters with 400. Per RFC 8707 §5, the auth server SHOULD remember the resource from the original grant, so omitting it in refresh is spec-compliant.

  ### 1. Retry refresh without `resource` parameter on 400
  Many auth servers (Azure Entra, Customer.io, Dropbox) don't support RFC 8707 and reject token refresh requests containing the `resource` parameter. We now try with `resource` first, and if the server returns 400, retry without it — per RFC 8707 §5 the auth server should already remember the resource from the original grant.

  ### 2. Make `expires_in` optional in refresh responses
  The refresh path treated missing `expires_in` as a fatal error, while the finalize path correctly handled it as optional. OAuth 2.1 says `expires_in` is RECOMMENDED not REQUIRED, so servers that omit it in refresh responses would permanently break.

  ### 3. Make `token_type` optional in refresh responses
  Same issue — missing `token_type` in a refresh response caused a fatal error. Many servers omit it in refresh responses since it doesn't change from the initial grant.

  ### 4. Default to 1h expiry when `expires_in` missing but `refresh_token` present
  When a server returns no `expires_in`, we stored the token as never-expiring, meaning it was never proactively refreshed. When it actually expired server-side (hours/days later), the connection broke silently with no recovery. Now we default to 1h so the token gets refreshed before it goes stale.

  ### 5. Map `invalid_refresh_token` to `TokenRevokedError`
  Only `invalid_grant` was recognized as a revoked token signal — `invalid_refresh_token` (used by some auth servers for the same meaning) fell through to a generic `UnknownError`, producing misleading error messages to users.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Connected granola, it's been running for 3 hours without disconnection.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy core/oauth