### PR TITLE
Improve page use in JIT tools

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -356,7 +356,33 @@ chrome.runtime.onMessage.addListener(
             let captures: string[] | undefined;
             let fileData: FileData | undefined;
             if (includeCapture) {
-              const mimeType = mimetypeExecution.result as string;
+              // Chrome's built-in PDF viewer does not expose document.contentType
+              // via executeScript, so fall back to URL extension detection.
+              const mimeType: string =
+                (mimetypeExecution.result as string) ||
+                (() => {
+                  const path = (tab.url || "").split("?")[0].toLowerCase();
+                  if (path.endsWith(".pdf")) {
+                    return "application/pdf";
+                  }
+                  if (path.endsWith(".png")) {
+                    return "image/png";
+                  }
+                  if (path.endsWith(".jpg") || path.endsWith(".jpeg")) {
+                    return "image/jpeg";
+                  }
+                  if (path.endsWith(".gif")) {
+                    return "image/gif";
+                  }
+                  if (path.endsWith(".webp")) {
+                    return "image/webp";
+                  }
+                  if (path.endsWith(".svg")) {
+                    return "image/svg+xml";
+                  }
+                  return "";
+                })();
+
               const isAttachableFile =
                 tab.url &&
                 tab.url.startsWith("https://") &&
@@ -417,42 +443,68 @@ chrome.runtime.onMessage.addListener(
                       }
                     );
                   } else if (isAttachableFile) {
-                    // Attempt to fetch the actual file and attach it.
-                    // Falls back to a visible-tab screenshot if the file is too
-                    // large or the fetch fails (e.g. auth-gated content).
+                    // Fetch the file by injecting a script into the tab so that
+                    // the request runs in the page's origin (same-origin, no
+                    // CORS) and is not subject to the extension's own
+                    // content_security_policy. Falls back to a visible-tab
+                    // screenshot if the file is too large or the fetch fails.
                     try {
-                      const response = await fetch(tab.url as string, {
-                        credentials: "omit",
-                      });
-                      if (!response.ok) {
+                      const [fetchExecution] =
+                        await chrome.scripting.executeScript({
+                          target: { tabId: tab.id! },
+                          func: async (
+                            url: string,
+                            maxBytes: number
+                          ): Promise<
+                            { base64: string } | { error: string }
+                          > => {
+                            try {
+                              const response = await fetch(url);
+                              if (!response.ok) {
+                                return { error: `HTTP ${response.status}` };
+                              }
+                              const contentLength =
+                                response.headers.get("content-length");
+                              if (
+                                contentLength &&
+                                parseInt(contentLength) > maxBytes
+                              ) {
+                                return { error: "too-large" };
+                              }
+                              const buffer = await response.arrayBuffer();
+                              if (buffer.byteLength > maxBytes) {
+                                return { error: "too-large" };
+                              }
+                              const bytes = new Uint8Array(buffer);
+                              const chunkSize = 8192;
+                              let binary = "";
+                              for (
+                                let i = 0;
+                                i < bytes.byteLength;
+                                i += chunkSize
+                              ) {
+                                binary += String.fromCharCode(
+                                  ...bytes.subarray(i, i + chunkSize)
+                                );
+                              }
+                              return { base64: btoa(binary) };
+                            } catch (e) {
+                              return { error: String(e) };
+                            }
+                          },
+                          args: [tab.url as string, MAX_FILE_SIZE_BYTES],
+                        });
+
+                      const result = fetchExecution?.result;
+                      if (!result || "error" in result) {
                         throw new Error(
-                          `Fetch failed with status ${response.status}`
-                        );
-                      }
-                      const contentLength =
-                        response.headers.get("content-length");
-                      if (
-                        contentLength &&
-                        parseInt(contentLength) > MAX_FILE_SIZE_BYTES
-                      ) {
-                        throw new Error("File exceeds 45 MB limit.");
-                      }
-                      const buffer = await response.arrayBuffer();
-                      if (buffer.byteLength > MAX_FILE_SIZE_BYTES) {
-                        throw new Error("File exceeds 45 MB limit.");
-                      }
-                      // Convert ArrayBuffer to base64 in chunks to avoid
-                      // stack overflow when spreading large typed arrays.
-                      const bytes = new Uint8Array(buffer);
-                      const chunkSize = 8192;
-                      let binary = "";
-                      for (let i = 0; i < bytes.byteLength; i += chunkSize) {
-                        binary += String.fromCharCode(
-                          ...bytes.subarray(i, i + chunkSize)
+                          result && "error" in result
+                            ? result.error
+                            : "Failed to fetch file"
                         );
                       }
                       resultFileData = {
-                        base64: btoa(binary),
+                        base64: result.base64,
                         mimeType,
                         url: tab.url as string,
                       };

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -16,6 +16,7 @@ import { DUST_US_URL } from "@extension/shared/lib/config";
 import { extractPage } from "@extension/shared/lib/extraction";
 import { generatePKCE } from "@extension/shared/lib/utils";
 import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
+import type { FileData } from "@extension/shared/services/capture";
 import { jwtDecode } from "jwt-decode";
 
 const log = console.error;
@@ -348,11 +349,23 @@ chrome.runtime.onMessage.addListener(
               func: () => document.contentType,
             });
 
+            // 45 MB: base64 encoding adds ~33% overhead, keeping the
+            // serialized message well under Chrome's 64 MB limit.
+            const MAX_FILE_SIZE_BYTES = 45 * 1024 * 1024;
+
             let captures: string[] | undefined;
+            let fileData: FileData | undefined;
             if (includeCapture) {
+              const mimeType = mimetypeExecution.result as string;
+              const isAttachableFile =
+                tab.url &&
+                tab.url.startsWith("https://") &&
+                (mimeType === "application/pdf" ||
+                  mimeType.startsWith("image/"));
+
               // Serialize capture operations: captureVisibleTab only captures
               // the currently visible tab, so concurrent captures would race.
-              captures = await withTabLock(async () => {
+              ({ captures, fileData } = await withTabLock(async () => {
                 // If targeting a non-active tab, activate it first so
                 // captureVisibleTab and full-page capture work correctly.
                 let previousTabId: number | undefined;
@@ -367,40 +380,103 @@ chrome.runtime.onMessage.addListener(
                   await new Promise((r) => setTimeout(r, 500));
                 }
 
+                let resultCaptures: string[] | undefined;
+                let resultFileData: FileData | undefined;
                 try {
-                  if (mimetypeExecution.result === "text/html") {
+                  if (mimeType === "text/html") {
                     // Full page capture
                     await chrome.scripting.executeScript({
                       target: { tabId: tab.id! },
                       files: ["page.js"],
                     });
-                    return await new Promise<string[]>((resolve, reject) => {
-                      if (tab?.id) {
-                        const timeout = setTimeout(() => {
-                          console.error(
-                            "Timeout waiting for full page capture"
+                    resultCaptures = await new Promise<string[]>(
+                      (resolve, reject) => {
+                        if (tab?.id) {
+                          const timeout = setTimeout(() => {
+                            console.error(
+                              "Timeout waiting for full page capture"
+                            );
+                            reject(
+                              new Error(
+                                "Timeout waiting for full page screenshot."
+                              )
+                            );
+                          }, 10000);
+                          chrome.tabs.sendMessage(
+                            tab.id,
+                            { type: "PAGE_CAPTURE_FULL_PAGE" },
+                            (res) => {
+                              clearTimeout(timeout);
+                              resolve(res);
+                            }
                           );
-                          reject(
-                            new Error(
-                              "Timeout waiting for full page screenshot."
-                            )
-                          );
-                        }, 10000);
-                        chrome.tabs.sendMessage(
-                          tab.id,
-                          { type: "PAGE_CAPTURE_FULL_PAGE" },
-                          (res) => {
+                        } else {
+                          console.error("No tab id");
+                          reject(new Error("No tab selected."));
+                        }
+                      }
+                    );
+                  } else if (isAttachableFile) {
+                    // Attempt to fetch the actual file and attach it.
+                    // Falls back to a visible-tab screenshot if the file is too
+                    // large or the fetch fails (e.g. auth-gated content).
+                    try {
+                      const response = await fetch(tab.url as string, {
+                        credentials: "omit",
+                      });
+                      if (!response.ok) {
+                        throw new Error(
+                          `Fetch failed with status ${response.status}`
+                        );
+                      }
+                      const contentLength =
+                        response.headers.get("content-length");
+                      if (
+                        contentLength &&
+                        parseInt(contentLength) > MAX_FILE_SIZE_BYTES
+                      ) {
+                        throw new Error("File exceeds 45 MB limit.");
+                      }
+                      const buffer = await response.arrayBuffer();
+                      if (buffer.byteLength > MAX_FILE_SIZE_BYTES) {
+                        throw new Error("File exceeds 45 MB limit.");
+                      }
+                      // Convert ArrayBuffer to base64 in chunks to avoid
+                      // stack overflow when spreading large typed arrays.
+                      const bytes = new Uint8Array(buffer);
+                      const chunkSize = 8192;
+                      let binary = "";
+                      for (let i = 0; i < bytes.byteLength; i += chunkSize) {
+                        binary += String.fromCharCode(
+                          ...bytes.subarray(i, i + chunkSize)
+                        );
+                      }
+                      resultFileData = {
+                        base64: btoa(binary),
+                        mimeType,
+                        url: tab.url as string,
+                      };
+                    } catch (fetchError) {
+                      console.warn(
+                        "File fetch failed, falling back to screenshot:",
+                        fetchError
+                      );
+                      resultCaptures = [
+                        await new Promise<string>((resolve, reject) => {
+                          const timeout = setTimeout(() => {
+                            reject(
+                              new Error("Timeout waiting for page screenshot")
+                            );
+                          }, 2000);
+                          chrome.tabs.captureVisibleTab((res) => {
                             clearTimeout(timeout);
                             resolve(res);
-                          }
-                        );
-                      } else {
-                        console.error("No tab id");
-                        reject(new Error("No tab selected."));
-                      }
-                    });
+                          });
+                        }),
+                      ];
+                    }
                   } else {
-                    return [
+                    resultCaptures = [
                       await new Promise<string>((resolve, reject) => {
                         const timeout = setTimeout(() => {
                           console.error("Timeout waiting for capture");
@@ -421,9 +497,10 @@ chrome.runtime.onMessage.addListener(
                     await chrome.tabs.update(previousTabId, { active: true });
                   }
                 }
-              });
+                return { captures: resultCaptures, fileData: resultFileData };
+              }));
 
-              if (!captures || captures.length === 0) {
+              if (!fileData && (!captures || captures.length === 0)) {
                 console.error("Empty captures array");
                 throw new Error("Failed to get a screenshot of the page.");
               }
@@ -437,6 +514,7 @@ chrome.runtime.onMessage.addListener(
                 });
                 content = execution?.result ?? "no content.";
               } else {
+                // TODO - handle non-HTML content. For now we just extract the page content.
                 const [execution] = await chrome.scripting.executeScript({
                   target: { tabId: tab.id },
                   func: extractPage(tab.url || ""),
@@ -449,6 +527,7 @@ chrome.runtime.onMessage.addListener(
               url: tab.url || "",
               content,
               captures,
+              fileData,
             });
           } catch (error) {
             log("Error getting active tab content:", error);

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -2,7 +2,10 @@ import type {
   AuthService,
   OAuthAuthorizeResponse,
 } from "@extension/shared/services/auth";
-import type { CaptureOptions } from "@extension/shared/services/capture";
+import type {
+  CaptureOptions,
+  FileData,
+} from "@extension/shared/services/capture";
 
 export type AuthBackgroundResponseError = {
   success: false;
@@ -29,6 +32,7 @@ export type GetActiveTabBackgroundResponse = {
   url: string;
   content?: string;
   captures?: string[];
+  fileData?: FileData;
   error?: string;
 };
 

--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -25,10 +25,21 @@ export class ChromeMcpService extends McpService {
 
   createServerForWorkspace(): McpServer | null {
     try {
-      const server = new McpServer({
-        name: "chrome-mcp-server",
-        version: "1.0.0",
-      });
+      const server = new McpServer(
+        {
+          name: "chrome-mcp-server",
+          version: "1.0.0",
+        },
+        {
+          instructions:
+            "You are running inside a Dust Chrome extension. " +
+            "The user is actively browsing the web, so their questions often relate to content on their current browser tab. " +
+            "When the user's message implicitly or explicitly refers to a page, article, document, or 'this' / 'it' / 'the page' without further specification, " +
+            "proactively call `get-current-browser-page` to fetch the page title, URL, and text content before answering. " +
+            "For pages that are visual or non-text (images, PDFs, dashboards), call `get-current-browser-page-view` instead — it will attach the file directly when possible. " +
+            "Do not ask the user to paste the content themselves — retrieve it directly with the available tools.",
+        }
+      );
 
       registerAllTools(server, this.captureService);
 

--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -23,7 +23,7 @@ export class ChromeMcpService extends McpService {
     this.captureService = captureService;
   }
 
-  createServerForWorkspace(): McpServer | null {
+  createServerForWorkspace(workspaceId: string): McpServer | null {
     try {
       const server = new McpServer(
         {
@@ -41,7 +41,7 @@ export class ChromeMcpService extends McpService {
         }
       );
 
-      registerAllTools(server, this.captureService);
+      registerAllTools(server, this.captureService, workspaceId);
 
       this.server = server;
       return server;
@@ -93,7 +93,7 @@ export class ChromeMcpService extends McpService {
         return { server: this.server, serverId: this.serverId };
       }
 
-      const server = this.createServerForWorkspace();
+      const server = this.createServerForWorkspace(owner.sId);
       if (!server) {
         return { server: null, serverId: undefined };
       }

--- a/extension/platforms/chrome/tools/getCurrentPageTool.ts
+++ b/extension/platforms/chrome/tools/getCurrentPageTool.ts
@@ -14,7 +14,7 @@ export function registerGetCurrentPageTool(
     "get-current-browser-page",
     "Extracts the title, URL, and text content of a browser tab. " +
       "Use this to read and understand what the user is viewing. " +
-      "For non-text pages (PDFs, images, etc.), prefer get-current-browser-page-screenshot. " +
+      "For non-text pages (PDFs, images, etc.), use get-current-browser-page-view instead — it will attach the file directly to the conversation." +
       "Use list-browser-tabs to discover tab IDs.",
     {
       tabId: z

--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -1,5 +1,101 @@
+import { clientFetch } from "@app/lib/egress/client";
+import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// Max characters of extracted text to include inline in the tool result.
+// The full content is also indexed in the conversation JIT data source.
+const MAX_EXTRACTED_TEXT_CHARS = 100_000;
+
+/**
+ * Uploads a PDF to the Dust file API and fetches the server-extracted text.
+ * Returns the file ID, name, and extracted text, or null on failure.
+ */
+async function uploadPdf(
+  workspaceId: string,
+  base64: string,
+  mimeType: string,
+  pageUrl: string
+): Promise<{
+  fileId: string;
+  fileName: string;
+  extractedText: string | null;
+} | null> {
+  try {
+    const urlFilename = pageUrl.split("/").pop()?.split("?")[0];
+    const fileName = urlFilename || "document.pdf";
+
+    // Convert base64 to Blob.
+    const binaryStr = atob(base64);
+    const bytes = new Uint8Array(binaryStr.length);
+    for (let i = 0; i < binaryStr.length; i++) {
+      bytes[i] = binaryStr.charCodeAt(i);
+    }
+    const blob = new Blob([bytes], { type: mimeType });
+
+    // Step 1: Create the file record and get the upload URL.
+    const createRes = await clientFetch(`/api/w/${workspaceId}/files`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contentType: mimeType,
+        fileName,
+        fileSize: blob.size,
+        useCase: "conversation",
+      }),
+    });
+
+    if (!createRes.ok) {
+      console.error(
+        "[getPageViewTool] Failed to create file record:",
+        await createRes.text()
+      );
+      return null;
+    }
+
+    const { file } = (await createRes.json()) as FileUploadRequestResponseBody;
+
+    // Step 2: Upload the file contentcreateServerForWorkspace. The server runs text extraction
+    // synchronously, so the processed version is ready when this resolves.
+    const formData = new FormData();
+    formData.append("file", blob, fileName);
+
+    const uploadRes = await clientFetch(file.uploadUrl, {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!uploadRes.ok) {
+      console.error(
+        "[getPageViewTool] Failed to upload file content:",
+        await uploadRes.text()
+      );
+      return null;
+    }
+
+    // Step 3: Fetch the extracted text (processed version).
+    // The server ran OCR-enabled text extraction during upload, so it's ready now.
+    let extractedText: string | null = null;
+    try {
+      const textRes = await clientFetch(
+        `/api/w/${workspaceId}/files/${file.sId}?version=processed&action=view`
+      );
+      if (textRes.ok) {
+        const text = await textRes.text();
+        extractedText = text.slice(0, MAX_EXTRACTED_TEXT_CHARS) || null;
+      }
+    } catch (err) {
+      console.warn("[getPageViewTool] Could not fetch extracted text:", err);
+    }
+
+    return { fileId: file.sId, fileName, extractedText };
+  } catch (error) {
+    console.error("[getPageViewTool] Error uploading PDF:", error);
+    return null;
+  }
+}
 
 /**
  * Registers the get-current-browser-page-view tool with the MCP server.
@@ -7,16 +103,24 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  */
 export function registerGetPageViewTool(
   server: McpServer,
-  captureService: CaptureService | null
+  captureService: CaptureService | null,
+  workspaceId: string
 ): void {
   server.tool(
     "get-current-browser-page-view",
     "Captures or attaches the content of a browser tab. " +
-      "For PDF and image pages, attaches the actual file so you can read or analyze its full content. " +
-      "If the file cannot be attached (too large or access denied), falls back to a screenshot. " +
-      "Also use this for HTML pages when you need to visually inspect the layout (Drive canvas, etc.)." +
+      "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
+      "For image pages, returns the image directly so you can visually analyze it. " +
+      "For HTML pages, takes a screenshot for visual inspection (Drive canvas, dashboards, etc.)." +
       "Use list-browser-tabs to discover tab IDs.",
-    {},
+    {
+      tabId: z
+        .number()
+        .optional()
+        .describe(
+          "The tab ID to capture. If omitted, captures the active tab. Use list-browser-tabs to get tab IDs."
+        ),
+    },
     async ({ tabId }) => {
       if (!captureService) {
         return {
@@ -40,19 +144,47 @@ export function registerGetPageViewTool(
 
         if (fileData) {
           const { base64, mimeType, url } = fileData;
+
+          if (mimeType === "application/pdf") {
+            const data = await uploadPdf(workspaceId, base64, mimeType, url);
+            if (data) {
+              // The MCP SDK strips non-standard fields from resource objects during
+              // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
+              // so they survive the MCP protocol round-trip. The server will move
+              // them back to the root level in mcp_actions.ts (tryCallMCPTool).
+              const resource = {
+                mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+                uri: `/api/v1/w/${workspaceId}/files/${data.fileId}`,
+                text: data.extractedText ?? `PDF from ${url}`,
+                _meta: {
+                  fileId: data.fileId,
+                  title: data.fileName,
+                  contentType: mimeType,
+                  snippet: data.extractedText
+                    ? data.extractedText.slice(0, 500)
+                    : null,
+                },
+              };
+              return {
+                content: [{ type: "resource" as const, resource }],
+              };
+            }
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Failed to process the PDF. It may be too large or inaccessible.",
+                },
+              ],
+            };
+          }
+
+          // For images, return the raw image so the model can analyze it visually.
           if (mimeType.startsWith("image/")) {
             return {
               content: [{ type: "image" as const, data: base64, mimeType }],
             };
           }
-          return {
-            content: [
-              {
-                type: "resource" as const,
-                resource: { uri: url, mimeType, blob: base64 },
-              },
-            ],
-          };
         }
 
         if (!captures || captures.length === 0) {
@@ -73,7 +205,7 @@ export function registerGetPageViewTool(
           content: [
             {
               type: "text",
-              text: `Failed to capture screenshot: ${error instanceof Error ? error.message : String(error)}`,
+              text: `Failed to capture page: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
         };

--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -1,29 +1,22 @@
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 
 /**
- * Registers the get-current-browser-page-screenshot tool with the MCP server.
- * Captures a screenshot of a browser tab.
+ * Registers the get-current-browser-page-view tool with the MCP server.
+ * Captures a screenshot or attaches the file content of a browser tab.
  */
-export function registerGetPageScreenshotTool(
+export function registerGetPageViewTool(
   server: McpServer,
   captureService: CaptureService | null
 ): void {
   server.tool(
-    "get-current-browser-page-screenshot",
-    "Captures a screenshot of a browser tab. " +
-      "Use this when you need to visually inspect the page layout, " +
-      "or when the page contains non-text content (PDFs, images, Drive canvas, etc.). " +
+    "get-current-browser-page-view",
+    "Captures or attaches the content of a browser tab. " +
+      "For PDF and image pages, attaches the actual file so you can read or analyze its full content. " +
+      "If the file cannot be attached (too large or access denied), falls back to a screenshot. " +
+      "Also use this for HTML pages when you need to visually inspect the layout (Drive canvas, etc.)." +
       "Use list-browser-tabs to discover tab IDs.",
-    {
-      tabId: z
-        .number()
-        .optional()
-        .describe(
-          "The tab ID to capture. If omitted, captures the active tab. Use list-browser-tabs to get tab IDs."
-        ),
-    },
+    {},
     async ({ tabId }) => {
       if (!captureService) {
         return {
@@ -43,7 +36,25 @@ export function registerGetPageScreenshotTool(
           };
         }
 
-        const { captures } = result.value;
+        const { captures, fileData } = result.value;
+
+        if (fileData) {
+          const { base64, mimeType, url } = fileData;
+          if (mimeType.startsWith("image/")) {
+            return {
+              content: [{ type: "image" as const, data: base64, mimeType }],
+            };
+          }
+          return {
+            content: [
+              {
+                type: "resource" as const,
+                resource: { uri: url, mimeType, blob: base64 },
+              },
+            ],
+          };
+        }
+
         if (!captures || captures.length === 0) {
           return {
             content: [{ type: "text", text: "No screenshot captured." }],

--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -154,7 +154,7 @@ export function registerGetPageViewTool(
               // them back to the root level in mcp_actions.ts (tryCallMCPTool).
               const resource = {
                 mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-                uri: `/api/v1/w/${workspaceId}/files/${data.fileId}`,
+                uri: `/api/w/${workspaceId}/files/${data.fileId}`,
                 text: data.extractedText ?? `PDF from ${url}`,
                 _meta: {
                   fileId: data.fileId,

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -1,5 +1,5 @@
 import { registerGetCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
-import { registerGetPageScreenshotTool } from "@extension/platforms/chrome/tools/getPageScreenshotTool";
+import { registerGetPageViewTool } from "@extension/platforms/chrome/tools/getPageViewTool";
 import { registerListTabsTool } from "@extension/platforms/chrome/tools/listTabsTool";
 import { registerTabActionTools } from "@extension/platforms/chrome/tools/tabActionTools";
 import type { CaptureService } from "@extension/shared/services/capture";
@@ -17,5 +17,5 @@ export function registerAllTools(
   registerListTabsTool(server);
   registerTabActionTools(server);
   registerGetCurrentPageTool(server, captureService);
-  registerGetPageScreenshotTool(server, captureService);
+  registerGetPageViewTool(server, captureService);
 }

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -12,10 +12,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  */
 export function registerAllTools(
   server: McpServer,
-  captureService: CaptureService | null
+  captureService: CaptureService | null,
+  workspaceId: string
 ): void {
   registerListTabsTool(server);
   registerTabActionTools(server);
   registerGetCurrentPageTool(server, captureService);
-  registerGetPageViewTool(server, captureService);
+  registerGetPageViewTool(server, captureService, workspaceId);
 }

--- a/extension/platforms/front/services/mcp.ts
+++ b/extension/platforms/front/services/mcp.ts
@@ -33,10 +33,21 @@ export class FrontMcpService extends McpService {
    */
   createServerForWorkspace(): McpServer | null {
     try {
-      const server = new McpServer({
-        name: "front-mcp-server",
-        version: "1.0.0",
-      });
+      const server = new McpServer(
+        {
+          name: "front-mcp-server",
+          version: "1.0.0",
+        },
+        {
+          instructions:
+            "You are running inside a Dust plugin embedded in the Front customer support platform. " +
+            "The user is working on email conversations in Front. " +
+            "When the user's message implicitly or explicitly refers to 'this conversation', 'this email', 'the thread', or 'the customer' without further specification, " +
+            "proactively call `front-get-current-conversation` to fetch the current conversation context before answering. " +
+            "When asked to draft, reply, or write a response, use the available draft tools (`front-create-email-reply-draft`, `front-create-new-conversation-draft`, `front-update-draft`) to insert content directly into Front. " +
+            "Do not ask the user to copy-paste conversation content — retrieve it directly with the available tools.",
+        }
+      );
 
       // Register all tools with the server.
       registerAllTools(server, this.frontContext);

--- a/extension/shared/services/capture.ts
+++ b/extension/shared/services/capture.ts
@@ -2,11 +2,18 @@ import type { Result } from "@app/types/shared/result";
 
 export type CaptureOperationId = "capture-page-content" | "capture-screenshot";
 
+export interface FileData {
+  base64: string;
+  mimeType: string;
+  url: string;
+}
+
 export interface TabContent {
   title: string;
   url?: string;
   content?: string;
   captures?: string[];
+  fileData?: FileData;
 }
 
 export interface CaptureOptions {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -561,7 +561,7 @@ export async function* tryCallMCPTool(
         };
       }
     }
-    if (serverType === "internal") {
+    if (serverType === "internal" || serverType === "client") {
       // The MCP SDK is now stripping extra properties from the tool result (both client and server).
       // To keep the same behavior as before, we moved the extra properties on the _meta field of each resource item.
       // We now need to move them back to the resource items root level.

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -235,6 +235,17 @@ export async function processToolResults(
             // who uploaded it to its own conversation but not the main agent's.
             // Skip for project_context files — they are already indexed via their own data source.
             if (file && file.useCase !== "project_context") {
+              // Files uploaded by client-side tools (e.g. the Chrome extension) may not have a
+              // conversationId in their metadata since the tool doesn't know it at upload time.
+              // Patch it here so the JIT data source creation works correctly.
+              if (
+                file.useCase === "conversation" &&
+                !file.useCaseMetadata?.conversationId
+              ) {
+                await file.setUseCaseMetadata(auth, {
+                  conversationId: conversation.sId,
+                });
+              }
               await uploadFileToConversationDataSource({ auth, file });
             }
             return {

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -320,7 +320,12 @@ export class BrowserMCPTransport implements Transport {
       );
 
       if (!response.ok) {
-        const errorData = await response.json();
+        let errorData: unknown;
+        try {
+          errorData = await response.json();
+        } catch {
+          errorData = await response.text();
+        }
         console.error(
           "[BrowserMCPTransport] Failed to send MCP result:",
           errorData


### PR DESCRIPTION
## Description

Enhances the Chrome extension's `get-current-browser-page-view` MCP tool to attach actual file content for PDFs and images instead of screenshots. When viewing a PDF or image page, the tool now fetches and attaches the file directly (as base64) so agents can read or analyze the full content. Falls back to a screenshot if the file exceeds 45 MB or if the fetch fails (e.g., auth-gated content). 

Also adds instructions to both Chrome and Front MCP servers to proactively call page retrieval tools when users reference "this page" or "the page" without explicitly pasting content.

## Tests

Manually tested by asking agents about PDF and image pages in the Chrome extension, verifying that files are attached directly when possible and screenshots are used as fallback.

## Risk

Low. The MCP tools are recently introduced and not yet widely used. The 45 MB limit ensures messages stay under Chrome's 64 MB limit with base64 overhead.

## Deploy Plan

## Deploy Plan
