### PR TITLE
feat(scheduler): more flexible scheduling

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -39,10 +39,25 @@ const agentSettingsSchema = z.object({
   tags: z.array(tagSchema),
 });
 
-const scheduleConfigSchema = z.object({
+const cronScheduleConfigSchema = z.object({
+  type: z.literal("cron").optional(),
   cron: z.string(),
   timezone: z.string(),
 });
+
+const intervalScheduleConfigSchema = z.object({
+  type: z.literal("interval"),
+  intervalDays: z.number(),
+  dayOfWeek: z.number().nullable(),
+  hour: z.number(),
+  minute: z.number(),
+  timezone: z.string(),
+});
+
+const scheduleConfigSchema = z.union([
+  cronScheduleConfigSchema,
+  intervalScheduleConfigSchema,
+]);
 
 const webhookConfigSchema = z.object({
   includePayload: z.boolean(),

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -2,12 +2,12 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 import { ActionCard, TimeIcon } from "@dust-tt/sparkle";
-import cronstrue from "cronstrue";
 import { useMemo } from "react";
 
 function getTriggerIconComponent(trigger: AgentBuilderTriggerType) {
@@ -63,7 +63,7 @@ export function TriggerCard({
     switch (trigger.kind) {
       case "schedule":
         try {
-          return `Runs ${cronstrue.toString(trigger.configuration.cron)}.`;
+          return `Runs ${describeScheduleConfig(trigger.configuration)}.`;
         } catch {
           return "";
         }

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -17,7 +17,7 @@ import {
 } from "@dust-tt/sparkle";
 import type React from "react";
 import { useMemo, useState } from "react";
-import { useController, useFormContext, useWatch } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
 
 const MIN_DESCRIPTION_LENGTH = 10;
 
@@ -70,8 +70,12 @@ export function ScheduleEditionScheduler({
     },
   } = useController({ control, name: "schedule.naturalLanguageDescription" });
 
-  const cron = useWatch({ control, name: "schedule.cron" });
-  const scheduleType = useWatch({ control, name: "schedule.scheduleType" });
+  const {
+    field: { value: cron, onChange: onCronChange },
+  } = useController({ control, name: "schedule.cron" });
+  const {
+    field: { value: scheduleType, onChange: onScheduleTypeChange },
+  } = useController({ control, name: "schedule.scheduleType" });
   const { error: cronError } = getFieldState("schedule.cron", formState);
   const { error: timezoneError } = getFieldState(
     "schedule.timezone",
@@ -97,8 +101,8 @@ export function ScheduleEditionScheduler({
         return;
       }
 
-      setValue("schedule.cron", "");
-      setValue("schedule.scheduleType", "cron");
+      onCronChange("");
+      onScheduleTypeChange("cron");
       const result = await textAsCronRule(txt, signal);
 
       // If the request was not aborted, we can update the form.
@@ -108,18 +112,16 @@ export function ScheduleEditionScheduler({
           setGeneratedConfig(config);
 
           if (isCronScheduleConfig(config)) {
-            setValue("schedule.scheduleType", "cron");
-            setValue("schedule.cron", config.cron);
+            onScheduleTypeChange("cron");
+            onCronChange(config.cron);
             setValue("schedule.timezone", config.timezone);
           } else {
-            setValue("schedule.scheduleType", "interval");
+            onScheduleTypeChange("interval");
             setValue("schedule.intervalDays", config.intervalDays);
             setValue("schedule.dayOfWeek", config.dayOfWeek);
             setValue("schedule.hour", config.hour);
             setValue("schedule.minute", config.minute);
             setValue("schedule.timezone", config.timezone);
-            // Set cron to a placeholder so form validation passes.
-            setValue("schedule.cron", "interval");
           }
           setGeneratedTimezone(config.timezone);
           setGenerationStatus("idle");
@@ -146,20 +148,15 @@ export function ScheduleEditionScheduler({
         if (!hasSchedule) {
           return undefined;
         }
-        try {
-          const config = generatedConfig ?? { cron, timezone: "" };
-          const desc = describeScheduleConfig(config);
-          if (generatedTimezone) {
-            return `${desc}, in ${formatTimezone(generatedTimezone)} timezone.`;
-          }
-          return desc;
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-        } catch (error) {
-          // eslint-disable-next-line react-hooks/set-state-in-render
-          setGenerationStatus("error");
+        const config = generatedConfig ?? {
+          cron,
+          timezone: "",
+        };
+        const desc = describeScheduleConfig(config);
+        if (generatedTimezone) {
+          return `${desc}, in ${formatTimezone(generatedTimezone)} timezone.`;
         }
-        break;
+        return desc;
       }
       default:
         assertNever(generationStatus);

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -1,6 +1,9 @@
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useTextAsCronRule } from "@app/lib/swr/agent_triggers";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
+import { isCronScheduleConfig } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -12,7 +15,6 @@ import {
   Label,
   TextArea,
 } from "@dust-tt/sparkle";
-import cronstrue from "cronstrue";
 import type React from "react";
 import { useMemo, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
@@ -69,6 +71,7 @@ export function ScheduleEditionScheduler({
   } = useController({ control, name: "schedule.naturalLanguageDescription" });
 
   const cron = useWatch({ control, name: "schedule.cron" });
+  const scheduleType = useWatch({ control, name: "schedule.scheduleType" });
   const { error: cronError } = getFieldState("schedule.cron", formState);
   const { error: timezoneError } = getFieldState(
     "schedule.timezone",
@@ -82,6 +85,9 @@ export function ScheduleEditionScheduler({
   const [generatedTimezone, setGeneratedTimezone] = useState<string | null>(
     null
   );
+  const [generatedConfig, setGeneratedConfig] = useState<ScheduleConfig | null>(
+    null
+  );
 
   const textAsCronRule = useTextAsCronRule({ workspace: owner });
 
@@ -92,19 +98,36 @@ export function ScheduleEditionScheduler({
       }
 
       setValue("schedule.cron", "");
+      setValue("schedule.scheduleType", "cron");
       const result = await textAsCronRule(txt, signal);
 
-      // If the request was not aborted, we can update the form
+      // If the request was not aborted, we can update the form.
       if (!signal.aborted) {
         if (result.isOk()) {
-          setValue("schedule.cron", result.value.cron);
-          setValue("schedule.timezone", result.value.timezone);
-          setGeneratedTimezone(result.value.timezone);
+          const config = result.value;
+          setGeneratedConfig(config);
+
+          if (isCronScheduleConfig(config)) {
+            setValue("schedule.scheduleType", "cron");
+            setValue("schedule.cron", config.cron);
+            setValue("schedule.timezone", config.timezone);
+          } else {
+            setValue("schedule.scheduleType", "interval");
+            setValue("schedule.intervalDays", config.intervalDays);
+            setValue("schedule.dayOfWeek", config.dayOfWeek);
+            setValue("schedule.hour", config.hour);
+            setValue("schedule.minute", config.minute);
+            setValue("schedule.timezone", config.timezone);
+            // Set cron to a placeholder so form validation passes.
+            setValue("schedule.cron", "interval");
+          }
+          setGeneratedTimezone(config.timezone);
           setGenerationStatus("idle");
         } else {
           setGenerationStatus("error");
           setCronErrorMessage(extractErrorMessage(result.error));
           setGeneratedTimezone(null);
+          setGeneratedConfig(null);
         }
       }
     },
@@ -117,16 +140,19 @@ export function ScheduleEditionScheduler({
         return "Generating schedule...";
       case "error":
         return cronErrorMessage;
-      case "idle":
-        if (!cron) {
+      case "idle": {
+        const hasSchedule =
+          scheduleType === "interval" ? !!generatedConfig : !!cron;
+        if (!hasSchedule) {
           return undefined;
         }
         try {
-          const cronDesc = cronstrue.toString(cron);
+          const config = generatedConfig ?? { cron, timezone: "" };
+          const desc = describeScheduleConfig(config);
           if (generatedTimezone) {
-            return `${cronDesc}, in ${formatTimezone(generatedTimezone)} timezone.`;
+            return `${desc}, in ${formatTimezone(generatedTimezone)} timezone.`;
           }
-          return cronDesc;
+          return desc;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
         } catch (error) {
@@ -134,10 +160,18 @@ export function ScheduleEditionScheduler({
           setGenerationStatus("error");
         }
         break;
+      }
       default:
         assertNever(generationStatus);
     }
-  }, [generationStatus, cron, generatedTimezone, cronErrorMessage]);
+  }, [
+    generationStatus,
+    cron,
+    scheduleType,
+    generatedConfig,
+    generatedTimezone,
+    cronErrorMessage,
+  ]);
 
   const handleNaturalDescriptionChange = (
     e: React.ChangeEvent<HTMLTextAreaElement>

--- a/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
@@ -3,42 +3,102 @@ import type {
   AgentBuilderTriggerType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { triggerStatusSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
+import {
+  isCronScheduleConfig,
+  isIntervalScheduleConfig,
+} from "@app/types/assistant/triggers";
 import type { UserType } from "@app/types/user";
 import { z } from "zod";
 
-export const ScheduleFormSchema = z.object({
-  name: z
-    .string()
-    .min(1, "Name is required")
-    .max(255, "Name should be less than 255 characters"),
-  status: triggerStatusSchema.default("enabled"),
-  naturalLanguageDescription: z.string().optional(),
-  customPrompt: z.string(),
-  cron: z.string().min(1, "Cron expression is required"),
-  timezone: z.string().min(1, "Timezone is required"),
-});
+export const ScheduleFormSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "Name is required")
+      .max(255, "Name should be less than 255 characters"),
+    status: triggerStatusSchema.default("enabled"),
+    naturalLanguageDescription: z.string().optional(),
+    customPrompt: z.string(),
+    // Cron fields (used when scheduleType is "cron").
+    cron: z.string().default(""),
+    timezone: z.string().min(1, "Timezone is required"),
+    // Interval fields (used when scheduleType is "interval").
+    scheduleType: z.enum(["cron", "interval"]).default("cron"),
+    intervalDays: z.number().optional(),
+    dayOfWeek: z.number().nullable().optional(),
+    hour: z.number().optional(),
+    minute: z.number().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.scheduleType === "cron") {
+        return data.cron.length > 0;
+      }
+      return (
+        typeof data.intervalDays === "number" &&
+        data.intervalDays > 0 &&
+        typeof data.hour === "number" &&
+        typeof data.minute === "number"
+      );
+    },
+    { message: "Schedule configuration is incomplete", path: ["cron"] }
+  );
 
 export type ScheduleFormValues = z.infer<typeof ScheduleFormSchema>;
 
 export function getScheduleFormDefaultValues(
   trigger: AgentBuilderScheduleTriggerType | null
 ): ScheduleFormValues {
-  const scheduleConfig =
-    trigger?.kind === "schedule" &&
-    trigger?.configuration &&
-    "cron" in trigger.configuration
-      ? trigger.configuration
-      : null;
+  const config = trigger?.kind === "schedule" ? trigger.configuration : null;
+
+  if (config && isIntervalScheduleConfig(config)) {
+    return {
+      name: trigger?.name ?? "Schedule",
+      status: trigger?.status ?? "enabled",
+      scheduleType: "interval",
+      cron: "",
+      timezone: config.timezone,
+      intervalDays: config.intervalDays,
+      dayOfWeek: config.dayOfWeek,
+      hour: config.hour,
+      minute: config.minute,
+      naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
+      customPrompt: trigger?.customPrompt ?? "",
+    };
+  }
+
+  const cronConfig = config && isCronScheduleConfig(config) ? config : null;
 
   return {
     name: trigger?.name ?? "Schedule",
     status: trigger?.status ?? "enabled",
-    cron: scheduleConfig?.cron ?? "",
+    scheduleType: "cron",
+    cron: cronConfig?.cron ?? "",
     timezone:
-      scheduleConfig?.timezone ??
-      Intl.DateTimeFormat().resolvedOptions().timeZone,
+      cronConfig?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
     naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
     customPrompt: trigger?.customPrompt ?? "",
+  };
+}
+
+function formValuesToScheduleConfig(
+  schedule: ScheduleFormValues
+): ScheduleConfig {
+  if (schedule.scheduleType === "interval") {
+    return {
+      type: "interval",
+      intervalDays: schedule.intervalDays ?? 14,
+      dayOfWeek: schedule.dayOfWeek ?? null,
+      hour: schedule.hour ?? 9,
+      minute: schedule.minute ?? 0,
+      timezone: schedule.timezone.trim(),
+    };
+  }
+  return {
+    type: "cron",
+    cron: schedule.cron.trim(),
+    timezone: schedule.timezone.trim(),
   };
 }
 
@@ -56,10 +116,7 @@ export function formValuesToScheduleTriggerData({
     status: schedule.status,
     name: schedule.name.trim(),
     kind: "schedule",
-    configuration: {
-      cron: schedule.cron.trim(),
-      timezone: schedule.timezone.trim(),
-    },
+    configuration: formValuesToScheduleConfig(schedule),
     editor:
       editTrigger?.kind === "schedule" ? editTrigger.editor : (user.id ?? null),
     naturalLanguageDescription:

--- a/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
@@ -8,42 +8,40 @@ import {
   isCronScheduleConfig,
   isIntervalScheduleConfig,
 } from "@app/types/assistant/triggers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { UserType } from "@app/types/user";
 import { z } from "zod";
 
-export const ScheduleFormSchema = z
-  .object({
-    name: z
-      .string()
-      .min(1, "Name is required")
-      .max(255, "Name should be less than 255 characters"),
-    status: triggerStatusSchema.default("enabled"),
-    naturalLanguageDescription: z.string().optional(),
-    customPrompt: z.string(),
-    // Cron fields (used when scheduleType is "cron").
-    cron: z.string().default(""),
-    timezone: z.string().min(1, "Timezone is required"),
-    // Interval fields (used when scheduleType is "interval").
-    scheduleType: z.enum(["cron", "interval"]).default("cron"),
-    intervalDays: z.number().optional(),
-    dayOfWeek: z.number().nullable().optional(),
-    hour: z.number().optional(),
-    minute: z.number().optional(),
-  })
-  .refine(
-    (data) => {
-      if (data.scheduleType === "cron") {
-        return data.cron.length > 0;
-      }
-      return (
-        typeof data.intervalDays === "number" &&
-        data.intervalDays > 0 &&
-        typeof data.hour === "number" &&
-        typeof data.minute === "number"
-      );
-    },
-    { message: "Schedule configuration is incomplete", path: ["cron"] }
-  );
+const commonFields = {
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(255, "Name should be less than 255 characters"),
+  status: triggerStatusSchema.default("enabled"),
+  naturalLanguageDescription: z.string().optional(),
+  customPrompt: z.string(),
+  timezone: z.string().min(1, "Timezone is required"),
+};
+
+const cronScheduleSchema = z.object({
+  ...commonFields,
+  scheduleType: z.literal("cron"),
+  cron: z.string().min(1, "Cron expression is required"),
+});
+
+const intervalScheduleSchema = z.object({
+  ...commonFields,
+  scheduleType: z.literal("interval"),
+  intervalDays: z.number().positive(),
+  dayOfWeek: z.number().nullable(),
+  hour: z.number(),
+  minute: z.number(),
+});
+
+export const ScheduleFormSchema = z.discriminatedUnion("scheduleType", [
+  cronScheduleSchema,
+  intervalScheduleSchema,
+]);
 
 export type ScheduleFormValues = z.infer<typeof ScheduleFormSchema>;
 
@@ -52,34 +50,44 @@ export function getScheduleFormDefaultValues(
 ): ScheduleFormValues {
   const config = trigger?.kind === "schedule" ? trigger.configuration : null;
 
-  if (config && isIntervalScheduleConfig(config)) {
+  const commonDefaults = {
+    name: trigger?.name ?? "Schedule",
+    status: trigger?.status ?? "enabled",
+    naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
+    customPrompt: trigger?.customPrompt ?? "",
+  };
+
+  if (!config) {
     return {
-      name: trigger?.name ?? "Schedule",
-      status: trigger?.status ?? "enabled",
-      scheduleType: "interval",
+      ...commonDefaults,
+      scheduleType: "cron" as const,
       cron: "",
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+  }
+
+  if (isIntervalScheduleConfig(config)) {
+    return {
+      ...commonDefaults,
+      scheduleType: "interval" as const,
       timezone: config.timezone,
       intervalDays: config.intervalDays,
       dayOfWeek: config.dayOfWeek,
       hour: config.hour,
       minute: config.minute,
-      naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
-      customPrompt: trigger?.customPrompt ?? "",
     };
   }
 
-  const cronConfig = config && isCronScheduleConfig(config) ? config : null;
+  if (isCronScheduleConfig(config)) {
+    return {
+      ...commonDefaults,
+      scheduleType: "cron" as const,
+      cron: config.cron,
+      timezone: config.timezone,
+    };
+  }
 
-  return {
-    name: trigger?.name ?? "Schedule",
-    status: trigger?.status ?? "enabled",
-    scheduleType: "cron",
-    cron: cronConfig?.cron ?? "",
-    timezone:
-      cronConfig?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
-    naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
-    customPrompt: trigger?.customPrompt ?? "",
-  };
+  assertNever(config);
 }
 
 function formValuesToScheduleConfig(
@@ -88,10 +96,10 @@ function formValuesToScheduleConfig(
   if (schedule.scheduleType === "interval") {
     return {
       type: "interval",
-      intervalDays: schedule.intervalDays ?? 14,
-      dayOfWeek: schedule.dayOfWeek ?? null,
-      hour: schedule.hour ?? 9,
-      minute: schedule.minute ?? 0,
+      intervalDays: schedule.intervalDays,
+      dayOfWeek: schedule.dayOfWeek,
+      hour: schedule.hour,
+      minute: schedule.minute,
       timezone: schedule.timezone.trim(),
     };
   }

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -3,6 +3,7 @@ import {
   useAgentTriggers,
   useDeleteTrigger,
 } from "@app/lib/swr/agent_triggers";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -23,14 +24,13 @@ import {
   Spinner,
   TimeIcon,
 } from "@dust-tt/sparkle";
-import cronstrue from "cronstrue";
 import { useMemo, useState } from "react";
 
 function getTriggerDescription(trigger: TriggerType): string {
   switch (trigger.kind) {
     case "schedule":
       try {
-        return `Runs ${cronstrue.toString(trigger.configuration.cron)}.`;
+        return `Runs ${describeScheduleConfig(trigger.configuration)}.`;
       } catch {
         return "";
       }

--- a/front/components/me/ProfileTriggersTab.tsx
+++ b/front/components/me/ProfileTriggersTab.tsx
@@ -2,6 +2,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useDeleteTrigger, useUserTriggers } from "@app/lib/swr/agent_triggers";
 import { classNames } from "@app/lib/utils";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WorkspaceType } from "@app/types/user";
@@ -25,7 +26,6 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import cronstrue from "cronstrue";
 import { useCallback, useMemo, useState } from "react";
 
 interface ProfileTriggersTabProps {
@@ -144,7 +144,7 @@ export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
               <div className="text-sm font-semibold">{row.original.name}</div>
               {row.original.kind === "schedule" && (
                 <div className="truncate text-sm">
-                  {cronstrue.toString(row.original.configuration.cron)}
+                  {describeScheduleConfig(row.original.configuration)}
                 </div>
               )}
             </div>

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -1,6 +1,7 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import type { TriggerWithProviderType } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
@@ -105,7 +106,7 @@ export function makeColumnsForTriggers(
       cell: ({ row }) => {
         const trigger = row.original;
         if (trigger.kind === "schedule") {
-          return `${trigger.configuration.cron} (${trigger.configuration.timezone})`;
+          return `${describeScheduleConfig(trigger.configuration)} (${trigger.configuration.timezone})`;
         }
         // Webhook: show event + filter summary
         const parts: string[] = [];

--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -75,16 +75,37 @@ export function ViewTriggerTable({
               {/* Configuration - structured by kind */}
               {trigger.kind === "schedule" ? (
                 <>
-                  <PokeTableRow>
-                    <PokeTableHead>Cron</PokeTableHead>
-                    <PokeTableCell>{trigger.configuration.cron}</PokeTableCell>
-                  </PokeTableRow>
-                  <PokeTableRow>
-                    <PokeTableHead>Timezone</PokeTableHead>
-                    <PokeTableCell>
-                      {trigger.configuration.timezone}
-                    </PokeTableCell>
-                  </PokeTableRow>
+                  {trigger.configuration.type === "interval" ? (
+                    <>
+                      <PokeTableRow>
+                        <PokeTableHead>Interval</PokeTableHead>
+                        <PokeTableCell>
+                          Every {trigger.configuration.intervalDays} days
+                        </PokeTableCell>
+                      </PokeTableRow>
+                      <PokeTableRow>
+                        <PokeTableHead>Timezone</PokeTableHead>
+                        <PokeTableCell>
+                          {trigger.configuration.timezone}
+                        </PokeTableCell>
+                      </PokeTableRow>
+                    </>
+                  ) : (
+                    <>
+                      <PokeTableRow>
+                        <PokeTableHead>Cron</PokeTableHead>
+                        <PokeTableCell>
+                          {trigger.configuration.cron}
+                        </PokeTableCell>
+                      </PokeTableRow>
+                      <PokeTableRow>
+                        <PokeTableHead>Timezone</PokeTableHead>
+                        <PokeTableCell>
+                          {trigger.configuration.timezone}
+                        </PokeTableCell>
+                      </PokeTableRow>
+                    </>
+                  )}
                 </>
               ) : (
                 <>

--- a/front/lib/api/actions/servers/schedules_management/tools/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/tools/index.ts
@@ -3,9 +3,10 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SCHEDULES_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/schedules_management/metadata";
-import { generateCronRule } from "@app/lib/api/assistant/configuration/triggers";
+import { generateScheduleRule } from "@app/lib/api/assistant/configuration/triggers";
 import type { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { isUserMessageType } from "@app/types/assistant/conversation";
@@ -16,7 +17,9 @@ import { UniqueConstraintError } from "sequelize";
 
 function renderSchedule(schedule: ScheduleTriggerType): string {
   const config = schedule.configuration;
-  const scheduleInfo = `${schedule.naturalLanguageDescription ?? config.cron} (${config.timezone})`;
+  const scheduleDesc =
+    schedule.naturalLanguageDescription ?? describeScheduleConfig(config);
+  const scheduleInfo = `${scheduleDesc} (${config.timezone})`;
   const lines = [
     `- **${schedule.name}** (ID: ${schedule.sId})`,
     `  Schedule: ${scheduleInfo}`,
@@ -63,15 +66,15 @@ export function createSchedulesManagementTools(
         return new Err(new MCPError("Provide a timezone"));
       }
 
-      const cronResult = await generateCronRule(auth, {
+      const scheduleResult = await generateScheduleRule(auth, {
         naturalDescription: schedule,
         defaultTimezone: resolvedTimezone,
       });
 
-      if (cronResult.isErr()) {
+      if (scheduleResult.isErr()) {
         logger.error(
           {
-            error: cronResult.error,
+            error: scheduleResult.error,
             workspaceId: owner.id,
             schedule,
           },
@@ -79,11 +82,11 @@ export function createSchedulesManagementTools(
         );
         return new Err(
           new MCPError(
-            `Unable to understand the schedule "${schedule}". Please try rephrasing (e.g., "every weekday at 9am", "every Monday at 10am").`
+            `Unable to understand the schedule "${schedule}". Please try rephrasing (e.g., "every weekday at 9am", "every Monday at 10am", "every other Monday at 9am").`
           )
         );
       }
-      const { cron, timezone: resultTimezone } = cronResult.value;
+      const scheduleConfig = scheduleResult.value;
       let result;
       try {
         result = await TriggerResource.makeNew(auth, {
@@ -92,10 +95,7 @@ export function createSchedulesManagementTools(
           name,
           kind: "schedule",
           status: "enabled",
-          configuration: {
-            cron,
-            timezone: resultTimezone,
-          },
+          configuration: scheduleConfig,
           naturalLanguageDescription: schedule,
           customPrompt: prompt,
           editor: user.id,
@@ -128,13 +128,15 @@ export function createSchedulesManagementTools(
         return new Err(new MCPError("Unexpected trigger type"));
       }
 
+      const configDesc = describeScheduleConfig(scheduleConfig);
+
       return new Ok([
         {
           type: "text" as const,
           text:
             `Created schedule "${name}"!\n\n` +
             `Schedule: ${schedule}\n` +
-            `Cron: ${cron} (${resultTimezone})\n\n` +
+            `Configuration: ${configDesc} (${scheduleConfig.timezone})\n\n` +
             `The agent will execute "${prompt}" according to this schedule.\n\n` +
             renderSchedule(trigger),
         },

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -31,26 +31,30 @@ function validateIntervalConfig(config: {
   hour: number;
   minute: number;
   timezone: string;
-}): string | null {
+}): Result<void, Error> {
   if (config.intervalDays <= 0 || !Number.isInteger(config.intervalDays)) {
-    return "Invalid interval: intervalDays must be a positive integer.";
+    return new Err(
+      new Error("Invalid interval: intervalDays must be a positive integer.")
+    );
   }
   if (
     config.dayOfWeek !== null &&
     (config.dayOfWeek < 0 || config.dayOfWeek > 6)
   ) {
-    return "Invalid interval: dayOfWeek must be 0-6 or null.";
+    return new Err(
+      new Error("Invalid interval: dayOfWeek must be 0-6 or null.")
+    );
   }
   if (config.hour < 0 || config.hour > 23) {
-    return "Invalid interval: hour must be 0-23.";
+    return new Err(new Error("Invalid interval: hour must be 0-23."));
   }
   if (config.minute < 0 || config.minute > 59) {
-    return "Invalid interval: minute must be 0-59.";
+    return new Err(new Error("Invalid interval: minute must be 0-59."));
   }
   if (!isValidIANATimezone(config.timezone)) {
-    return INVALID_TIMEZONE_MESSAGE;
+    return new Err(new Error(INVALID_TIMEZONE_MESSAGE));
   }
-  return null;
+  return new Ok(undefined);
 }
 
 export async function generateScheduleRule(
@@ -76,17 +80,16 @@ export async function generateScheduleRule(
       });
     }
 
-    const validationError = validateIntervalConfig(config);
-    if (validationError) {
-      return new Err(new Error(validationError));
+    const validationResult = validateIntervalConfig(config);
+    if (validationResult.isErr()) {
+      return validationResult;
     }
 
     return new Ok(config);
   }
 
   // Cron validation (existing logic).
-  const cronRule = "cron" in config ? config.cron : undefined;
-  const { timezone } = config;
+  const { cron: cronRule, timezone } = config;
 
   if (
     !cronRule ||

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -1,5 +1,6 @@
 import { getCronTimezoneGeneration } from "@app/lib/api/assistant/configuration/triggers/cron_timezone";
 import type { Authenticator } from "@app/lib/auth";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -24,17 +25,68 @@ export const TOO_FREQUENT_MESSAGE =
 const CRON_REGEXP =
   /^((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*(\/\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/;
 
-export async function generateCronRule(
+function validateIntervalConfig(config: {
+  intervalDays: number;
+  dayOfWeek: number | null;
+  hour: number;
+  minute: number;
+  timezone: string;
+}): string | null {
+  if (config.intervalDays <= 0 || !Number.isInteger(config.intervalDays)) {
+    return "Invalid interval: intervalDays must be a positive integer.";
+  }
+  if (
+    config.dayOfWeek !== null &&
+    (config.dayOfWeek < 0 || config.dayOfWeek > 6)
+  ) {
+    return "Invalid interval: dayOfWeek must be 0-6 or null.";
+  }
+  if (config.hour < 0 || config.hour > 23) {
+    return "Invalid interval: hour must be 0-23.";
+  }
+  if (config.minute < 0 || config.minute > 59) {
+    return "Invalid interval: minute must be 0-59.";
+  }
+  if (!isValidIANATimezone(config.timezone)) {
+    return INVALID_TIMEZONE_MESSAGE;
+  }
+  return null;
+}
+
+export async function generateScheduleRule(
   auth: Authenticator,
   inputs: { naturalDescription: string; defaultTimezone: string }
-): Promise<Result<{ cron: string; timezone: string }, Error>> {
+): Promise<Result<ScheduleConfig, Error>> {
   const res = await getCronTimezoneGeneration(auth, inputs);
 
   if (res.isErr()) {
     return res;
   }
 
-  const { cron: cronRule, timezone } = res.value;
+  const config = res.value;
+
+  if (config.type === "interval") {
+    // Safety net: if intervalDays is 7 with a dayOfWeek, convert to weekly cron.
+    if (config.intervalDays === 7 && config.dayOfWeek !== null) {
+      const cronRule = `${config.minute} ${config.hour} * * ${config.dayOfWeek}`;
+      return new Ok({
+        type: "cron",
+        cron: cronRule,
+        timezone: config.timezone,
+      });
+    }
+
+    const validationError = validateIntervalConfig(config);
+    if (validationError) {
+      return new Err(new Error(validationError));
+    }
+
+    return new Ok(config);
+  }
+
+  // Cron validation (existing logic).
+  const cronRule = "cron" in config ? config.cron : undefined;
+  const { timezone } = config;
 
   if (
     !cronRule ||
@@ -52,5 +104,5 @@ export async function generateCronRule(
     return new Err(new Error(INVALID_TIMEZONE_MESSAGE));
   }
 
-  return new Ok({ cron: cronRule, timezone });
+  return new Ok({ type: "cron", cron: cronRule, timezone });
 }

--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -2,6 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import { GPT_4_1_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -11,20 +12,47 @@ const specifications: AgentActionSpecification[] = [
   {
     name: SET_SCHEDULE_FUNCTION_NAME,
     description:
-      "Setup a schedule and timezone for triggering an assistant. Both cron and timezone are required.",
+      "Setup a schedule and timezone for triggering an assistant. Use type 'cron' for standard schedules, 'interval' for multi-day/multi-week intervals.",
     inputSchema: {
       type: "object",
       properties: {
+        type: {
+          type: "string",
+          enum: ["cron", "interval"],
+          description:
+            "Schedule type: 'cron' for standard schedules, 'interval' for multi-day or multi-week intervals not expressible in cron.",
+        },
         cron: {
           type: "string",
-          description: "The schedule expressed in cron format.",
+          description:
+            "The schedule expressed in cron format. Required when type is 'cron'.",
         },
         timezone: {
           type: "string",
           description: "The timezone expressed in IANA Timezone format.",
         },
+        intervalDays: {
+          type: "number",
+          description:
+            "Number of days between each occurrence. Required when type is 'interval'. E.g. 14 for bi-weekly, 3 for every 3 days.",
+        },
+        dayOfWeek: {
+          type: ["number", "null"],
+          description:
+            "Day of week (0=Sunday, 6=Saturday) for week-aligned intervals. Null for pure day intervals. Used when type is 'interval'.",
+        },
+        hour: {
+          type: "number",
+          description:
+            "Hour of day (0-23) for interval schedules. Used when type is 'interval'.",
+        },
+        minute: {
+          type: "number",
+          description:
+            "Minute of hour (0-59) for interval schedules. Used when type is 'interval'.",
+        },
       },
-      required: ["cron", "timezone"],
+      required: ["type", "timezone"],
     },
   },
 ];
@@ -32,7 +60,7 @@ const specifications: AgentActionSpecification[] = [
 export async function getCronTimezoneGeneration(
   auth: Authenticator,
   inputs: { naturalDescription: string; defaultTimezone: string }
-): Promise<Result<{ cron: string; timezone: string }, Error>> {
+): Promise<Result<ScheduleConfig, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
   const model = GPT_4_1_MINI_MODEL_CONFIG;
@@ -60,9 +88,14 @@ export async function getCronTimezoneGeneration(
           },
         ],
       },
-      prompt: `The user is adding a schedule to trigger an assistant. Convert their natural language description to cron format.
+      prompt: `The user is adding a schedule to trigger an assistant. Convert their natural language description to a schedule configuration.
 
-<cron_format>
+You MUST choose the right schedule type:
+
+<type_cron>
+Use type: "cron" for standard schedules that CAN be expressed in 5-field cron format:
+- Every day, every hour, every weekday, every Monday, every 1st of month, every quarter, every N months
+
 5-field cron: minute hour day-of-month month day-of-week
 - minute: 0-59
 - hour: 0-23
@@ -77,17 +110,32 @@ Operators:
 - / : step (e.g., */15 for every 15 minutes)
 
 IMPORTANT: The # and L operators are NOT supported. Do NOT use them.
-</cron_format>
+</type_cron>
+
+<type_interval>
+Use type: "interval" ONLY for multi-day or multi-week intervals that cron CANNOT express:
+- "every other week", "bi-weekly", "every 2 weeks", "every 3 days", "every 10 days"
+
+For interval type, provide: intervalDays, dayOfWeek (or null for pure day intervals), hour, minute.
+</type_interval>
 
 <examples>
-- "Every Monday at 9am" → cron: "0 9 * * 1", timezone: defaultTimezone
-- "Every weekday at 8:30am" → cron: "30 8 * * 1-5", timezone: defaultTimezone
-- "Every day at midnight" → cron: "0 0 * * *", timezone: defaultTimezone
-- "Every hour" → cron: "0 * * * *", timezone: defaultTimezone
-- "Every 15th of the month at noon" → cron: "0 12 15 * *", timezone: defaultTimezone
-- "Every quarter" → cron: "0 0 1 */3 *", timezone: defaultTimezone
-- "Every Monday at 9am in New York" → cron: "0 9 * * 1", timezone: "America/New_York"
-- "Daily at 8am Paris time" → cron: "0 8 * * *", timezone: "Europe/Paris"
+type: "cron" examples:
+- "Every Monday at 9am" → type: "cron", cron: "0 9 * * 1", timezone: defaultTimezone
+- "Every weekday at 8:30am" → type: "cron", cron: "30 8 * * 1-5", timezone: defaultTimezone
+- "Every day at midnight" → type: "cron", cron: "0 0 * * *", timezone: defaultTimezone
+- "Every hour" → type: "cron", cron: "0 * * * *", timezone: defaultTimezone
+- "Every 15th of the month at noon" → type: "cron", cron: "0 12 15 * *", timezone: defaultTimezone
+- "Every quarter" → type: "cron", cron: "0 0 1 */3 *", timezone: defaultTimezone
+- "Every Monday at 9am in New York" → type: "cron", cron: "0 9 * * 1", timezone: "America/New_York"
+- "Daily at 8am Paris time" → type: "cron", cron: "0 8 * * *", timezone: "Europe/Paris"
+
+type: "interval" examples:
+- "Every other Monday at 9am" → type: "interval", intervalDays: 14, dayOfWeek: 1, hour: 9, minute: 0, timezone: defaultTimezone
+- "Bi-weekly on Friday at 3pm" → type: "interval", intervalDays: 14, dayOfWeek: 5, hour: 15, minute: 0, timezone: defaultTimezone
+- "Every 3 days at noon" → type: "interval", intervalDays: 3, dayOfWeek: null, hour: 12, minute: 0, timezone: defaultTimezone
+- "Every 10 days at 8am" → type: "interval", intervalDays: 10, dayOfWeek: null, hour: 8, minute: 0, timezone: defaultTimezone
+- "Every 2 weeks on Wednesday at 10am" → type: "interval", intervalDays: 14, dayOfWeek: 3, hour: 10, minute: 0, timezone: defaultTimezone
 </examples>
 
 <instructions>
@@ -95,7 +143,8 @@ IMPORTANT: The # and L operators are NOT supported. Do NOT use them.
 2. If no time is specified, default to 9:00 AM
 3. Use defaultTimezone unless a specific timezone is mentioned in the description
 4. ALWAYS use IANA timezone format (e.g., Europe/Paris, America/New_York), never UTC offsets
-5. Call set_schedule with both the cron expression and timezone
+5. Use type "cron" when the schedule can be expressed as cron. Use type "interval" ONLY for multi-day or multi-week intervals.
+6. Call set_schedule with the appropriate fields based on the type
 </instructions>`,
       specifications,
       forceToolCall: SET_SCHEDULE_FUNCTION_NAME,
@@ -121,15 +170,34 @@ IMPORTANT: The # and L operators are NOT supported. Do NOT use them.
     return new Err(new Error("No schedule action generated"));
   }
 
-  const { cron, timezone } = action.arguments;
-
-  if (!cron) {
-    return new Err(new Error("No cron rule generated"));
-  }
+  const { type, timezone, cron, intervalDays, dayOfWeek, hour, minute } =
+    action.arguments;
 
   if (!timezone) {
     return new Err(new Error("No timezone generated"));
   }
 
-  return new Ok({ cron, timezone });
+  if (type === "interval") {
+    if (typeof intervalDays !== "number" || intervalDays <= 0) {
+      return new Err(new Error("Invalid intervalDays for interval schedule"));
+    }
+    if (typeof hour !== "number" || typeof minute !== "number") {
+      return new Err(new Error("Missing hour/minute for interval schedule"));
+    }
+    return new Ok({
+      type: "interval",
+      intervalDays,
+      dayOfWeek: typeof dayOfWeek === "number" ? dayOfWeek : null,
+      hour,
+      minute,
+      timezone,
+    });
+  }
+
+  // Default to cron type
+  if (!cron) {
+    return new Err(new Error("No cron rule generated"));
+  }
+
+  return new Ok({ type: "cron", cron, timezone });
 }

--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -143,7 +143,7 @@ type: "interval" examples:
 2. If no time is specified, default to 9:00 AM
 3. Use defaultTimezone unless a specific timezone is mentioned in the description
 4. ALWAYS use IANA timezone format (e.g., Europe/Paris, America/New_York), never UTC offsets
-5. Use type "cron" when the schedule can be expressed as cron. Use type "interval" ONLY for multi-day or multi-week intervals.
+5. ALWAYS prefer type "cron" — it covers the vast majority of schedules. Use type "interval" ONLY when the schedule genuinely cannot be expressed as a 5-field cron (e.g. "every 2 weeks", "every 3 days"). When in doubt, use "cron".
 6. Call set_schedule with the appropriate fields based on the type
 </instructions>`,
       specifications,

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -23,6 +23,7 @@ import type {
 } from "@app/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator";
 import type { GetUserTriggersResponseBody } from "@app/pages/api/w/[wId]/me/triggers";
 import type { GetTriggerEstimationResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
@@ -247,6 +248,22 @@ export function useUpdateTrigger({
   return updateTrigger;
 }
 
+function responseToScheduleConfig(
+  r: PostTextAsCronRuleResponseBody
+): ScheduleConfig {
+  if (r.type === "interval") {
+    return {
+      type: "interval",
+      intervalDays: r.intervalDays,
+      dayOfWeek: r.dayOfWeek,
+      hour: r.hour,
+      minute: r.minute,
+      timezone: r.timezone,
+    };
+  }
+  return { type: "cron", cron: r.cronRule, timezone: r.timezone };
+}
+
 export function useTextAsCronRule({
   workspace,
 }: {
@@ -275,7 +292,7 @@ export function useTextAsCronRule({
         return new Err(normalizeError(e));
       }
 
-      return new Ok({ cron: r.cronRule, timezone: r.timezone });
+      return new Ok(responseToScheduleConfig(r));
     },
     [workspace, fetcher]
   );

--- a/front/lib/utils/schedule_description.ts
+++ b/front/lib/utils/schedule_description.ts
@@ -1,5 +1,6 @@
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import { isCronScheduleConfig } from "@app/types/assistant/triggers";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import cronstrue from "cronstrue";
 
 const DAY_NAMES = [
@@ -21,8 +22,14 @@ export function describeScheduleConfig(config: ScheduleConfig): string {
 
   if (config.dayOfWeek !== null && config.intervalDays % 7 === 0) {
     const weeks = config.intervalDays / 7;
-    return `Every ${weeks} week${weeks > 1 ? "s" : ""} on ${DAY_NAMES[config.dayOfWeek]} at ${time}`;
+    if (weeks === 1) {
+      return `Every ${DAY_NAMES[config.dayOfWeek]} at ${time}`;
+    }
+    return `Every ${weeks} week${pluralize(weeks)} on ${DAY_NAMES[config.dayOfWeek]} at ${time}`;
   }
 
-  return `Every ${config.intervalDays} day${config.intervalDays > 1 ? "s" : ""} at ${time}`;
+  if (config.intervalDays === 1) {
+    return `Every day at ${time}`;
+  }
+  return `Every ${config.intervalDays} day${pluralize(config.intervalDays)} at ${time}`;
 }

--- a/front/lib/utils/schedule_description.ts
+++ b/front/lib/utils/schedule_description.ts
@@ -1,0 +1,28 @@
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
+import { isCronScheduleConfig } from "@app/types/assistant/triggers";
+import cronstrue from "cronstrue";
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+export function describeScheduleConfig(config: ScheduleConfig): string {
+  if (isCronScheduleConfig(config)) {
+    return cronstrue.toString(config.cron);
+  }
+
+  const time = `${config.hour}:${String(config.minute).padStart(2, "0")}`;
+
+  if (config.dayOfWeek !== null && config.intervalDays % 7 === 0) {
+    const weeks = config.intervalDays / 7;
+    return `Every ${weeks} week${weeks > 1 ? "s" : ""} on ${DAY_NAMES[config.dayOfWeek]} at ${time}`;
+  }
+
+  return `Every ${config.intervalDays} day${config.intervalDays > 1 ? "s" : ""} at ${time}`;
+}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -1,25 +1,50 @@
 /** @ignoreswagger */
 import {
   GENERIC_ERROR_MESSAGE,
-  generateCronRule,
+  generateScheduleRule,
   INVALID_TIMEZONE_MESSAGE,
   TOO_FREQUENT_MESSAGE,
 } from "@app/lib/api/assistant/configuration/triggers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export const PostTextAsCronRuleResponseBodySchema = z.object({
-  cronRule: z.string(),
-  timezone: z.string(),
-});
-export type PostTextAsCronRuleResponseBody = z.infer<
-  typeof PostTextAsCronRuleResponseBodySchema
->;
+// Backward-compatible: cron responses include cronRule, interval responses include interval fields.
+export type PostTextAsCronRuleResponseBody =
+  | { type?: "cron"; cronRule: string; timezone: string }
+  | {
+      type: "interval";
+      intervalDays: number;
+      dayOfWeek: number | null;
+      hour: number;
+      minute: number;
+      timezone: string;
+    };
+
+function scheduleConfigToResponse(
+  config: ScheduleConfig
+): PostTextAsCronRuleResponseBody {
+  if (config.type === "interval") {
+    return {
+      type: "interval",
+      intervalDays: config.intervalDays,
+      dayOfWeek: config.dayOfWeek,
+      hour: config.hour,
+      minute: config.minute,
+      timezone: config.timezone,
+    };
+  }
+  return {
+    type: "cron",
+    cronRule: "cron" in config ? config.cron : "",
+    timezone: config.timezone,
+  };
+}
 
 const PostTextAsCronRuleRequestBodySchema = z.object({
   naturalDescription: z.string(),
@@ -68,7 +93,7 @@ async function handler(
         });
       }
 
-      const r = await generateCronRule(auth, bodyValidation.data);
+      const r = await generateScheduleRule(auth, bodyValidation.data);
 
       if (r.isErr()) {
         const cleanMessage = [
@@ -86,10 +111,7 @@ async function handler(
         });
       }
 
-      return res.status(200).json({
-        cronRule: r.value.cron,
-        timezone: r.value.timezone,
-      });
+      return res.status(200).json(scheduleConfigToResponse(r.value));
     }
 
     default:

--- a/front/temporal/triggers/schedule/client.ts
+++ b/front/temporal/triggers/schedule/client.ts
@@ -21,6 +21,7 @@ import {
   ScheduleNotFoundError,
   ScheduleOverlapPolicy,
 } from "@temporalio/client";
+import moment from "moment-timezone";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -34,15 +35,10 @@ function localTimeToUtcMs(
   minute: number,
   timezone: string
 ): number {
-  // Build a date in the target timezone and compute UTC offset.
-  const now = new Date();
-  const localStr = now.toLocaleString("en-US", { timeZone: timezone });
-  const localDate = new Date(localStr);
-  const offsetMs = localDate.getTime() - now.getTime();
-
-  // Local time in ms, then subtract the tz offset to get UTC equivalent.
-  const localTimeMs = (hour * 60 + minute) * 60 * 1000;
-  return (((localTimeMs - offsetMs) % DAY_MS) + DAY_MS) % DAY_MS;
+  const localTime = moment.tz({ hour, minute }, timezone);
+  const utcHour = localTime.utc().hour();
+  const utcMinute = localTime.utc().minute();
+  return (utcHour * 60 + utcMinute) * 60 * 1000;
 }
 
 /**
@@ -60,8 +56,8 @@ function computeIntervalOffsetMs(config: IntervalScheduleConfig): number {
   if (config.dayOfWeek !== null) {
     // Week-aligned: offset to reach target day-of-week from epoch Thursday.
     const epochDayOfWeek = 4; // Thursday
-    const daysToTarget = (config.dayOfWeek - epochDayOfWeek + 7) % 7;
-    return daysToTarget * DAY_MS + utcTimeMs;
+    const offsetDays = (config.dayOfWeek - epochDayOfWeek + 7) % 7;
+    return offsetDays * DAY_MS + utcTimeMs;
   }
 
   // Pure day interval: just set the time-of-day offset.

--- a/front/temporal/triggers/schedule/client.ts
+++ b/front/temporal/triggers/schedule/client.ts
@@ -4,16 +4,87 @@ import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME as COMMON_QUEUE_NAME } from "@app/temporal/triggers/common/config";
 import { agentTriggerWorkflow } from "@app/temporal/triggers/common/workflows";
-import type { ScheduleTriggerType } from "@app/types/assistant/triggers";
-import { isScheduleTrigger } from "@app/types/assistant/triggers";
+import type {
+  IntervalScheduleConfig,
+  ScheduleConfig,
+  ScheduleTriggerType,
+} from "@app/types/assistant/triggers";
+import {
+  isCronScheduleConfig,
+  isScheduleTrigger,
+} from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { ScheduleOptions } from "@temporalio/client";
+import type { ScheduleOptions, ScheduleSpec } from "@temporalio/client";
 import {
   ScheduleNotFoundError,
   ScheduleOverlapPolicy,
 } from "@temporalio/client";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Convert local hour/minute in a given IANA timezone to a UTC-based
+ * millisecond-of-day value. Uses the current UTC offset of the timezone,
+ * so DST changes may shift the firing time by ~1h (accepted trade-off).
+ */
+function localTimeToUtcMs(
+  hour: number,
+  minute: number,
+  timezone: string
+): number {
+  // Build a date in the target timezone and compute UTC offset.
+  const now = new Date();
+  const localStr = now.toLocaleString("en-US", { timeZone: timezone });
+  const localDate = new Date(localStr);
+  const offsetMs = localDate.getTime() - now.getTime();
+
+  // Local time in ms, then subtract the tz offset to get UTC equivalent.
+  const localTimeMs = (hour * 60 + minute) * 60 * 1000;
+  return (((localTimeMs - offsetMs) % DAY_MS) + DAY_MS) % DAY_MS;
+}
+
+/**
+ * Compute the epoch-based offset for Temporal's IntervalSpec.
+ * Temporal fires at: epoch + offset + n * every.
+ * Epoch (Jan 1, 1970 00:00 UTC) was a Thursday (dayOfWeek=4).
+ */
+function computeIntervalOffsetMs(config: IntervalScheduleConfig): number {
+  const utcTimeMs = localTimeToUtcMs(
+    config.hour,
+    config.minute,
+    config.timezone
+  );
+
+  if (config.dayOfWeek !== null) {
+    // Week-aligned: offset to reach target day-of-week from epoch Thursday.
+    const epochDayOfWeek = 4; // Thursday
+    const daysToTarget = (config.dayOfWeek - epochDayOfWeek + 7) % 7;
+    return daysToTarget * DAY_MS + utcTimeMs;
+  }
+
+  // Pure day interval: just set the time-of-day offset.
+  return utcTimeMs;
+}
+
+function buildScheduleSpec(config: ScheduleConfig): ScheduleSpec {
+  if (isCronScheduleConfig(config)) {
+    return {
+      cronExpressions: [config.cron],
+      timezone: config.timezone,
+    };
+  }
+
+  // Interval-based (N-day, N-week).
+  const everyMs = config.intervalDays * DAY_MS;
+  const offsetMs = computeIntervalOffsetMs(config);
+  return {
+    intervals: [{ every: everyMs, offset: offsetMs }],
+    // Note: timezone field on ScheduleSpec only applies to cron/calendar specs,
+    // not intervals (which are epoch-based). The offset accounts for the target time.
+  };
+}
 
 function getTriggerScheduleOptions(
   auth: Authenticator,
@@ -37,10 +108,7 @@ function getTriggerScheduleOptions(
     policies: {
       overlap: ScheduleOverlapPolicy.SKIP,
     },
-    spec: {
-      cronExpressions: [triggerData.configuration.cron],
-      timezone: triggerData.configuration.timezone,
-    },
+    spec: buildScheduleSpec(triggerData.configuration),
   };
 }
 

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -1,11 +1,54 @@
 import { z } from "zod";
 
-export const ScheduleConfigSchema = z.object({
+export type CronScheduleConfig = {
+  type?: "cron"; // optional for backward compat with existing DB records
+  cron: string;
+  timezone: string;
+};
+
+// For "every N days" or "every N weeks on <dayOfWeek>"
+export type IntervalScheduleConfig = {
+  type: "interval";
+  intervalDays: number; // e.g. 14 for bi-weekly, 3 for every 3 days
+  dayOfWeek: number | null; // 0-6 (0=Sunday), null for pure day intervals
+  hour: number; // 0-23
+  minute: number; // 0-59
+  timezone: string;
+};
+
+export type ScheduleConfig = CronScheduleConfig | IntervalScheduleConfig;
+
+export function isCronScheduleConfig(
+  config: ScheduleConfig
+): config is CronScheduleConfig {
+  return !config.type || config.type === "cron";
+}
+
+export function isIntervalScheduleConfig(
+  config: ScheduleConfig
+): config is IntervalScheduleConfig {
+  return config.type === "interval";
+}
+
+const CronScheduleConfigSchema = z.object({
+  type: z.literal("cron").optional(),
   cron: z.string(),
   timezone: z.string(),
 });
 
-export type ScheduleConfig = z.infer<typeof ScheduleConfigSchema>;
+const IntervalScheduleConfigSchema = z.object({
+  type: z.literal("interval"),
+  intervalDays: z.number(),
+  dayOfWeek: z.number().nullable(),
+  hour: z.number(),
+  minute: z.number(),
+  timezone: z.string(),
+});
+
+export const ScheduleConfigSchema = z.union([
+  CronScheduleConfigSchema,
+  IntervalScheduleConfigSchema,
+]);
 
 export const WebhookConfigSchema = z.object({
   includePayload: z.boolean(),
@@ -13,7 +56,11 @@ export const WebhookConfigSchema = z.object({
   filter: z.string().optional(),
 });
 
-export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
+export type WebhookConfig = {
+  includePayload: boolean;
+  event?: string;
+  filter?: string;
+};
 
 export type TriggerConfigurationType = ScheduleConfig | WebhookConfig;
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Standard 5-field cron cannot express multi-day or multi-week intervals like "every other Monday" or "every 3 days", only fixed weekday recurrence.

This PR adds a new `IntervalScheduleConfig` alongside the existing cron config, forming a backward-compatible discriminated union (existing DB records without a type field are implicitly cron, no migration needed). This extends `ScheduleConfig` into a discriminated union `CronScheduleConfig | IntervalScheduleConfig`

Multi-month intervals are intentionally excluded since cron already handles those (by specifying specific months like 1/3/5/7/9/11).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, can generated both regular crons, and interval schedules

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front