### PR TITLE
feat: click on page extension

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -5,6 +5,8 @@ import type {
   AuthBackgroundResponseSuccess,
   CaptureMesssage,
   CaptureResponse,
+  ClickPageElementMessage,
+  ClickPageElementResponse,
   GetActiveTabBackgroundMessage,
   GetActiveTabBackgroundResponse,
   GetPageElementsMessage,
@@ -21,7 +23,7 @@ import { generatePKCE } from "@extension/shared/lib/utils";
 import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
 import type { FileData } from "@extension/shared/services/capture";
 import { jwtDecode } from "jwt-decode";
-import { getPageElements } from "./interactWithPage";
+import { clickPageElement, getPageElements } from "./interactWithPage";
 
 const log = console.error;
 const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
@@ -278,7 +280,8 @@ chrome.runtime.onMessage.addListener(
       | CaptureMesssage
       | InputBarStatusMessage
       | TabActionMessage
-      | GetPageElementsMessage,
+      | GetPageElementsMessage
+      | ClickPageElementMessage,
     sender,
     sendResponse: (
       response:
@@ -289,6 +292,7 @@ chrome.runtime.onMessage.addListener(
         | GetActiveTabBackgroundResponse
         | TabActionResponse
         | GetPageElementsResponse
+        | ClickPageElementResponse
     ) => void
   ) => {
     switch (message.type) {
@@ -716,6 +720,39 @@ chrome.runtime.onMessage.addListener(
             });
           }
         });
+        return true;
+
+      case "CLICK_ELEMENT":
+        chrome.tabs.query(
+          { active: true, currentWindow: true },
+          async (tabs) => {
+            const tab = tabs[0];
+            try {
+              const result = await clickPageElement(tab, message.elementId);
+
+              if (result.isErr()) {
+                log("Error clicking page element:", result.error);
+                sendResponse({
+                  success: false,
+                  error: result.error.message,
+                });
+                return;
+              }
+
+              sendResponse({
+                success: true,
+              });
+            } catch (error) {
+              const normalizedError = normalizeError(error);
+              log("Error clicking page element:", normalizedError.message);
+              sendResponse({
+                success: false,
+                error:
+                  normalizedError.message ?? "Failed to click page element.",
+              });
+            }
+          }
+        );
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -723,36 +723,32 @@ chrome.runtime.onMessage.addListener(
         return true;
 
       case "CLICK_ELEMENT":
-        chrome.tabs.query(
-          { active: true, currentWindow: true },
-          async (tabs) => {
-            const tab = tabs[0];
-            try {
-              const result = await clickPageElement(tab, message.elementId);
+        chrome.tabs.query({ currentWindow: true }, async (tabs) => {
+          const tab = tabs.find((t) => t.id === message.tabId);
+          try {
+            const result = await clickPageElement(tab, message.elementId);
 
-              if (result.isErr()) {
-                log("Error clicking page element:", result.error);
-                sendResponse({
-                  success: false,
-                  error: result.error.message,
-                });
-                return;
-              }
-
-              sendResponse({
-                success: true,
-              });
-            } catch (error) {
-              const normalizedError = normalizeError(error);
-              log("Error clicking page element:", normalizedError.message);
+            if (result.isErr()) {
+              log("Error clicking page element:", result.error);
               sendResponse({
                 success: false,
-                error:
-                  normalizedError.message ?? "Failed to click page element.",
+                error: result.error.message,
               });
+              return;
             }
+
+            sendResponse({
+              success: true,
+            });
+          } catch (error) {
+            const normalizedError = normalizeError(error);
+            log("Error clicking page element:", normalizedError.message);
+            sendResponse({
+              success: false,
+              error: normalizedError.message ?? "Failed to click page element.",
+            });
           }
-        );
+        });
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -99,7 +99,7 @@ export async function getPageElements(
 }
 
 export async function clickPageElement(
-  tab: chrome.tabs.Tab,
+  tab: chrome.tabs.Tab | undefined,
   elementId: string
 ): Promise<Result<boolean, Error>> {
   if (!tab?.id) {

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -96,3 +96,86 @@ export async function getPageElements(
 
   return new Ok(result);
 }
+
+export async function clickPageElement(
+  tab: chrome.tabs.Tab,
+  elementId: string
+): Promise<Result<boolean, Error>> {
+  if (!tab?.id) {
+    return new Err(new Error("No active tab found."));
+  }
+
+  const [execution] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    args: [elementId],
+    func: (elementId: string) => {
+      const w = window as unknown as {
+        __dustElementMap?: Record<string, WeakRef<HTMLElement>>;
+      };
+
+      const element = w.__dustElementMap?.[elementId].deref();
+      if (!element) {
+        return "NOT_FOUND";
+      }
+
+      const opts: MouseEventInit = {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        buttons: 1,
+      };
+
+      try {
+        element.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+          inline: "center",
+        });
+      } catch {
+        // scrollIntoView may fail on some elements; ignore.
+      }
+
+      const rect = element.getBoundingClientRect();
+      const overlay = document.createElement("div");
+
+      Object.assign(overlay.style, {
+        position: "absolute",
+        top: `${rect.top + window.scrollY - 8}px`,
+        left: `${rect.left + window.scrollX - 8}px`,
+        width: `${rect.width + 16}px`,
+        height: `${rect.height + 16}px`,
+        borderRadius: "9999px",
+        boxShadow: "0 0 0 3px #418B5C, 0 0 16px 4px rgba(65, 139, 92, 0.9)",
+        background: "rgba(65, 139, 92, 0.12)",
+        pointerEvents: "none",
+        zIndex: "2147483647",
+        transition: "opacity 0.5s ease-out",
+      });
+
+      document.body.appendChild(overlay);
+
+      setTimeout(() => {
+        overlay.style.opacity = "0";
+        setTimeout(() => overlay.remove(), 500);
+      }, 100);
+
+      element.dispatchEvent(new MouseEvent("mouseover", opts));
+      element.dispatchEvent(new MouseEvent("mousedown", opts));
+      element.dispatchEvent(new MouseEvent("mouseup", opts));
+      element.dispatchEvent(new MouseEvent("click", opts));
+
+      return "OK";
+    },
+  });
+
+  const result = execution?.result;
+
+  if (!result) {
+    return new Err(new Error("Unexpected error"));
+  }
+
+  if (result === "NOT_FOUND") {
+    return new Err(new Error("Element not found"));
+  }
+  return new Ok(true);
+}

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -16,6 +16,7 @@ type DustWindow = {
     selector: string;
     CONTENT: string[];
     getElementName: (el: HTMLElement) => string;
+    highlightElement: (el: HTMLElement) => void;
   };
   __dustElementMap: Record<string, WeakRef<HTMLElement>>;
   __dustElementSnapshots: Record<string, ElementSnapshot>;
@@ -105,13 +106,16 @@ export async function clickPageElement(
     return new Err(new Error("No active tab found."));
   }
 
+  const utilsResult = await ensureDustPageUtils(tab);
+  if (utilsResult.isErr()) {
+    return utilsResult;
+  }
+
   const [execution] = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
     args: [elementId],
     func: (elementId: string) => {
-      const w = window as unknown as {
-        __dustElementMap?: Record<string, WeakRef<HTMLElement>>;
-      };
+      const w = window as unknown as DustWindow;
 
       const element = w.__dustElementMap?.[elementId].deref();
       if (!element) {
@@ -125,39 +129,9 @@ export async function clickPageElement(
         buttons: 1,
       };
 
-      try {
-        element.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-          inline: "center",
-        });
-      } catch {
-        // scrollIntoView may fail on some elements; ignore.
-      }
+      const { highlightElement } = w.__dustUtils;
 
-      const rect = element.getBoundingClientRect();
-      const overlay = document.createElement("div");
-
-      Object.assign(overlay.style, {
-        position: "absolute",
-        top: `${rect.top + window.scrollY - 8}px`,
-        left: `${rect.left + window.scrollX - 8}px`,
-        width: `${rect.width + 16}px`,
-        height: `${rect.height + 16}px`,
-        borderRadius: "9999px",
-        boxShadow: "0 0 0 3px #418B5C, 0 0 16px 4px rgba(65, 139, 92, 0.9)",
-        background: "rgba(65, 139, 92, 0.12)",
-        pointerEvents: "none",
-        zIndex: "2147483647",
-        transition: "opacity 0.5s ease-out",
-      });
-
-      document.body.appendChild(overlay);
-
-      setTimeout(() => {
-        overlay.style.opacity = "0";
-        setTimeout(() => overlay.remove(), 500);
-      }, 100);
+      highlightElement(element);
 
       element.dispatchEvent(new MouseEvent("mouseover", opts));
       element.dispatchEvent(new MouseEvent("mousedown", opts));

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -90,6 +90,7 @@ export type GetPageElementsResponse = { elements: string; error?: string };
 
 export type ClickPageElementMessage = {
   type: "CLICK_ELEMENT";
+  tabId: number;
   elementId: string;
 };
 export type ClickPageElementResponse = { success: boolean; error?: string };

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -88,6 +88,12 @@ export type CaptureFullPageMessage = {
 export type GetPageElementsMessage = { type: "GET_ELEMENTS"; tabId: number };
 export type GetPageElementsResponse = { elements: string; error?: string };
 
+export type ClickPageElementMessage = {
+  type: "CLICK_ELEMENT";
+  elementId: string;
+};
+export type ClickPageElementResponse = { success: boolean; error?: string };
+
 const sendMessage = <T, U>(message: T): Promise<U> => {
   return new Promise((resolve, reject) => {
     chrome.runtime.sendMessage(message, (response: U | undefined) => {
@@ -222,18 +228,36 @@ export const sendTabActionMessage = (message: TabActionMessage) => {
   return sendMessage<TabActionMessage, TabActionResponse>(message);
 };
 
-export const sendInteractWithPageMessage = (
-  action: "get_elements",
-  tabId: number
-): Promise<GetPageElementsResponse> => {
-  switch (action) {
+export function sendInteractWithPageMessage(input: {
+  action: "get_elements";
+  tabId: number;
+}): Promise<GetPageElementsResponse>;
+
+export function sendInteractWithPageMessage(input: {
+  action: "click_element";
+  elementId: string;
+  tabId: number;
+}): Promise<ClickPageElementResponse>;
+
+export function sendInteractWithPageMessage(
+  input:
+    | { action: "get_elements"; tabId: number }
+    | { action: "click_element"; tabId: number; elementId: string }
+): Promise<GetPageElementsResponse | ClickPageElementResponse> {
+  switch (input.action) {
     case "get_elements":
       return sendMessage<GetPageElementsMessage, GetPageElementsResponse>({
         type: "GET_ELEMENTS",
-        tabId,
+        tabId: input.tabId,
+      });
+    case "click_element":
+      return sendMessage<ClickPageElementMessage, ClickPageElementResponse>({
+        type: "CLICK_ELEMENT",
+        elementId: input.elementId,
+        tabId: input.tabId,
       });
   }
-};
+}
 
 // Messages from background script to content script
 

--- a/extension/platforms/chrome/pageUtils.ts
+++ b/extension/platforms/chrome/pageUtils.ts
@@ -148,7 +148,43 @@ export async function ensureDustPageUtils(
         return "";
       };
 
-      w.__dustUtils = { selector, CONTENT, getElementName };
+      const highlightElement = (el: HTMLElement) => {
+        try {
+          el.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+            inline: "center",
+          });
+        } catch {
+          // ignore
+        }
+
+        const rect = el.getBoundingClientRect();
+        const overlay = document.createElement("div");
+
+        Object.assign(overlay.style, {
+          position: "absolute",
+          top: `${rect.top + window.scrollY - 8}px`,
+          left: `${rect.left + window.scrollX - 8}px`,
+          width: `${rect.width + 16}px`,
+          height: `${rect.height + 16}px`,
+          borderRadius: "9999px",
+          boxShadow: "0 0 0 3px #418B5C, 0 0 16px 4px rgba(65, 139, 92, 0.9)",
+          background: "rgba(65, 139, 92, 0.12)",
+          pointerEvents: "none",
+          zIndex: "2147483647",
+          transition: "opacity 0.5s ease-out",
+        });
+
+        document.body.appendChild(overlay);
+
+        setTimeout(() => {
+          overlay.style.opacity = "0";
+          setTimeout(() => overlay.remove(), 500);
+        }, 100);
+      };
+
+      w.__dustUtils = { selector, CONTENT, getElementName, highlightElement };
     },
   });
 

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -15,13 +15,51 @@ export function registerInteractWithPageTool(server: McpServer): void {
     "Interact with the page the user is currently viewing. Use the get_elements action to get the elements of the page. Use the click_element action to click on an element. Use the type_text action to type text into an element.",
     inputSchema.shape,
     async (input) => {
-      if (input.action === "click_element" || input.action === "type_text") {
+      if (input.action === "type_text") {
         throw new Error("Not implemented");
       }
-      const response = await sendInteractWithPageMessage(
-        "get_elements",
-        input.tab_id
-      );
+
+      if (input.action === "click_element") {
+        const elementId = input.element_id;
+        if (!elementId) {
+          return {
+            content: [{ type: "text", text: "No elementId specified" }],
+            isError: true,
+          };
+        }
+        const clickResponse = await sendInteractWithPageMessage({
+          action: "click_element",
+          tabId: input.tab_id,
+          elementId,
+        });
+
+        if (!clickResponse.success) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  clickResponse.error ??
+                  "Unexpected error when clicking element",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Button clicked successfully",
+            },
+          ],
+        };
+      }
+
+      const response = await sendInteractWithPageMessage({
+        action: "get_elements",
+        tabId: input.tab_id,
+      });
 
       if (!response) {
         return {


### PR DESCRIPTION
## Description

This PR adds click element functionality to the Chrome extension's page interaction tool.

- Implements `clickPageElement` function that dispatches mouse events (mouseover, mousedown, mouseup, click) on page elements referenced by their element ID
- Adds visual feedback by highlighting clicked elements with a green glow animation

## Tests

Manually

## Risks

Mouse event dispatching may not trigger all event listeners depending on how websites implement their click handlers (some sites may check for trusted events)

## Deploy Plan

Standard deployment - no special considerations needed.
