### PR TITLE
feat: type text tool

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -29,7 +29,6 @@ import type { FileData } from "@extension/shared/services/capture";
 import { jwtDecode } from "jwt-decode";
 import {
   clickPageElement,
-  deleteText,
   getPageElements,
   typeText,
 } from "./interactWithPage";
@@ -808,10 +807,15 @@ chrome.runtime.onMessage.addListener(
           async (tabs) => {
             const tab = tabs[0];
             try {
-              const result = await deleteText(tab, message.elementId);
+              const result = await typeText(
+                tab,
+                message.elementId,
+                "",
+                "delete"
+              );
 
               if (result.isErr()) {
-                log("Error deliting text in element:", result.error);
+                log("Error deleting text in element:", result.error);
                 sendResponse({
                   success: false,
                   error: result.error.message,
@@ -824,7 +828,7 @@ chrome.runtime.onMessage.addListener(
               });
             } catch (error) {
               const normalizedError = normalizeError(error);
-              log("Error deliting text in element:", normalizedError.message);
+              log("Error deleting text in element:", normalizedError.message);
               sendResponse({
                 success: false,
                 error:

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -764,80 +764,68 @@ chrome.runtime.onMessage.addListener(
         return true;
 
       case "TYPE_TEXT":
-        chrome.tabs.query(
-          { active: true, currentWindow: true },
-          async (tabs) => {
-            const tab = tabs[0];
-            try {
-              const result = await typeText(
-                tab,
-                message.elementId,
-                message.text,
-                message.variant
-              );
+        chrome.tabs.query({ currentWindow: true }, async (tabs) => {
+          const tab = tabs.find((t) => t.id === message.tabId);
+          try {
+            const result = await typeText(
+              tab,
+              message.elementId,
+              message.text,
+              message.variant
+            );
 
-              if (result.isErr()) {
-                log("Error typing text in element:", result.error);
-                sendResponse({
-                  success: false,
-                  error: result.error.message,
-                });
-                return;
-              }
-
-              sendResponse({
-                success: true,
-              });
-            } catch (error) {
-              const normalizedError = normalizeError(error);
-              log("Error typing text in element:", normalizedError.message);
+            if (result.isErr()) {
+              log("Error typing text in element:", result.error);
               sendResponse({
                 success: false,
-                error:
-                  normalizedError.message ?? "Failed to type text in element.",
+                error: result.error.message,
               });
+              return;
             }
+
+            sendResponse({
+              success: true,
+            });
+          } catch (error) {
+            const normalizedError = normalizeError(error);
+            log("Error typing text in element:", normalizedError.message);
+            sendResponse({
+              success: false,
+              error:
+                normalizedError.message ?? "Failed to type text in element.",
+            });
           }
-        );
+        });
         return true;
 
       case "DELETE_TEXT":
-        chrome.tabs.query(
-          { active: true, currentWindow: true },
-          async (tabs) => {
-            const tab = tabs[0];
-            try {
-              const result = await typeText(
-                tab,
-                message.elementId,
-                "",
-                "delete"
-              );
+        chrome.tabs.query({ currentWindow: true }, async (tabs) => {
+          const tab = tabs.find((t) => t.id === message.tabId);
+          try {
+            const result = await typeText(tab, message.elementId, "", "delete");
 
-              if (result.isErr()) {
-                log("Error deleting text in element:", result.error);
-                sendResponse({
-                  success: false,
-                  error: result.error.message,
-                });
-                return;
-              }
-
-              sendResponse({
-                success: true,
-              });
-            } catch (error) {
-              const normalizedError = normalizeError(error);
-              log("Error deleting text in element:", normalizedError.message);
+            if (result.isErr()) {
+              log("Error deleting text in element:", result.error);
               sendResponse({
                 success: false,
-                error:
-                  normalizedError.message ??
-                  "Failed to delete text in element.",
+                error: result.error.message,
               });
+              return;
             }
+
+            sendResponse({
+              success: true,
+            });
+          } catch (error) {
+            const normalizedError = normalizeError(error);
+            log("Error deleting text in element:", normalizedError.message);
+            sendResponse({
+              success: false,
+              error:
+                normalizedError.message ?? "Failed to delete text in element.",
+            });
           }
-        );
+        });
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -7,6 +7,8 @@ import type {
   CaptureResponse,
   ClickPageElementMessage,
   ClickPageElementResponse,
+  DeleteTextMessage,
+  DeleteTextResponse,
   GetActiveTabBackgroundMessage,
   GetActiveTabBackgroundResponse,
   GetPageElementsMessage,
@@ -14,6 +16,8 @@ import type {
   InputBarStatusMessage,
   TabActionMessage,
   TabActionResponse,
+  TypeTextMessage,
+  TypeTextResponse,
 } from "@extension/platforms/chrome/messages";
 import type { PendingUpdate } from "@extension/platforms/chrome/services/platform";
 import { ChromePlatformService } from "@extension/platforms/chrome/services/platform";
@@ -23,7 +27,12 @@ import { generatePKCE } from "@extension/shared/lib/utils";
 import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
 import type { FileData } from "@extension/shared/services/capture";
 import { jwtDecode } from "jwt-decode";
-import { clickPageElement, getPageElements } from "./interactWithPage";
+import {
+  clickPageElement,
+  deleteText,
+  getPageElements,
+  typeText,
+} from "./interactWithPage";
 
 const log = console.error;
 const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
@@ -281,7 +290,9 @@ chrome.runtime.onMessage.addListener(
       | InputBarStatusMessage
       | TabActionMessage
       | GetPageElementsMessage
-      | ClickPageElementMessage,
+      | ClickPageElementMessage
+      | TypeTextMessage
+      | DeleteTextMessage,
     sender,
     sendResponse: (
       response:
@@ -293,6 +304,8 @@ chrome.runtime.onMessage.addListener(
         | TabActionResponse
         | GetPageElementsResponse
         | ClickPageElementResponse
+        | TypeTextResponse
+        | DeleteTextResponse
     ) => void
   ) => {
     switch (message.type) {
@@ -749,6 +762,78 @@ chrome.runtime.onMessage.addListener(
             });
           }
         });
+        return true;
+
+      case "TYPE_TEXT":
+        chrome.tabs.query(
+          { active: true, currentWindow: true },
+          async (tabs) => {
+            const tab = tabs[0];
+            try {
+              const result = await typeText(
+                tab,
+                message.elementId,
+                message.text,
+                message.variant
+              );
+
+              if (result.isErr()) {
+                log("Error typing text in element:", result.error);
+                sendResponse({
+                  success: false,
+                  error: result.error.message,
+                });
+                return;
+              }
+
+              sendResponse({
+                success: true,
+              });
+            } catch (error) {
+              const normalizedError = normalizeError(error);
+              log("Error typing text in element:", normalizedError.message);
+              sendResponse({
+                success: false,
+                error:
+                  normalizedError.message ?? "Failed to type text in element.",
+              });
+            }
+          }
+        );
+        return true;
+
+      case "DELETE_TEXT":
+        chrome.tabs.query(
+          { active: true, currentWindow: true },
+          async (tabs) => {
+            const tab = tabs[0];
+            try {
+              const result = await deleteText(tab, message.elementId);
+
+              if (result.isErr()) {
+                log("Error deliting text in element:", result.error);
+                sendResponse({
+                  success: false,
+                  error: result.error.message,
+                });
+                return;
+              }
+
+              sendResponse({
+                success: true,
+              });
+            } catch (error) {
+              const normalizedError = normalizeError(error);
+              log("Error deliting text in element:", normalizedError.message);
+              sendResponse({
+                success: false,
+                error:
+                  normalizedError.message ??
+                  "Failed to delete text in element.",
+              });
+            }
+          }
+        );
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -159,10 +159,15 @@ export async function typeText(
   tab: chrome.tabs.Tab,
   elementId: string,
   text: string,
-  variant: "replace" | "append"
+  variant: "replace" | "append" | "delete"
 ): Promise<Result<boolean, Error>> {
   if (!tab?.id) {
     return new Err(new Error("No active tab found."));
+  }
+
+  const utilsResult = await ensureDustPageUtils(tab);
+  if (utilsResult.isErr()) {
+    return utilsResult;
   }
 
   const [execution] = await chrome.scripting.executeScript({
@@ -171,7 +176,7 @@ export async function typeText(
     func: (
       elementId: string,
       text: string,
-      variant: "replace" | "append"
+      variant: "replace" | "append" | "delete"
     ):
       | "OK"
       | "NOT_FOUND"
@@ -179,14 +184,16 @@ export async function typeText(
       | "SELECTION_UNAVAILABLE"
       | "OPTION_NOT_FOUND"
       | "UNSUPPORTED_ELEMENT" => {
-      const w = window as unknown as {
-        __dustElementMap?: Record<string, WeakRef<HTMLElement>>;
-      };
+      const w = window as unknown as DustWindow;
 
       const element = w.__dustElementMap?.[elementId].deref();
       if (!element) {
         return "NOT_FOUND";
       }
+
+      const { highlightElement } = w.__dustUtils;
+
+      highlightElement(element);
 
       const tag = element.tagName.toLowerCase();
 
@@ -205,6 +212,13 @@ export async function typeText(
         }
 
         element.focus();
+
+        if (variant === "delete") {
+          nativeSetter.call(element, "");
+          element.dispatchEvent(new Event("input", { bubbles: true }));
+          element.dispatchEvent(new Event("change", { bubbles: true }));
+          return "OK";
+        }
 
         const baseValue =
           variant === "append"
@@ -237,6 +251,13 @@ export async function typeText(
 
           inner.focus();
 
+          if (variant === "delete") {
+            nativeSetter.call(inner, "");
+            inner.dispatchEvent(new Event("input", { bubbles: true }));
+            inner.dispatchEvent(new Event("change", { bubbles: true }));
+            return "OK";
+          }
+
           const baseValue = variant === "append" ? inner.value : "";
           let current = baseValue;
           for (const char of text) {
@@ -267,6 +288,43 @@ export async function typeText(
 
         sel.removeAllRanges();
         sel.addRange(range);
+
+        if (variant === "delete") {
+          element.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: "Backspace",
+              code: "Backspace",
+              keyCode: 8,
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+          element.dispatchEvent(
+            new InputEvent("beforeinput", {
+              inputType: "deleteContentBackward",
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+
+          range.deleteContents();
+
+          element.dispatchEvent(
+            new InputEvent("input", {
+              inputType: "deleteContentBackward",
+              bubbles: true,
+            })
+          );
+          element.dispatchEvent(
+            new KeyboardEvent("keyup", {
+              key: "Backspace",
+              code: "Backspace",
+              keyCode: 8,
+              bubbles: true,
+            })
+          );
+          return "OK";
+        }
 
         for (const char of text) {
           element.dispatchEvent(
@@ -307,6 +365,13 @@ export async function typeText(
 
       if (tag === "select") {
         const select = element as HTMLSelectElement;
+
+        if (variant === "delete") {
+          select.value = "";
+          select.dispatchEvent(new Event("change", { bubbles: true }));
+          return "OK";
+        }
+
         const option = Array.from(select.options).find(
           (o) => o.text === text || o.value === text
         );
@@ -343,159 +408,6 @@ export async function typeText(
       return new Err(
         new Error(`Option "${text}" not found in select element.`)
       );
-    case "UNSUPPORTED_ELEMENT":
-      return new Err(new Error("Element is not a supported input type."));
-    default:
-      assertNever(result);
-  }
-}
-
-export async function deleteText(
-  tab: chrome.tabs.Tab,
-  elementId: string
-): Promise<Result<boolean, Error>> {
-  if (!tab?.id) {
-    return new Err(new Error("No active tab found."));
-  }
-
-  const [execution] = await chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    args: [elementId],
-    func: (
-      elementId: string
-    ):
-      | "OK"
-      | "NOT_FOUND"
-      | "SETTER_NOT_FOUND"
-      | "SELECTION_UNAVAILABLE"
-      | "UNSUPPORTED_ELEMENT" => {
-      const w = window as unknown as {
-        __dustElementMap?: Record<string, WeakRef<HTMLElement>>;
-      };
-
-      const element = w.__dustElementMap?.[elementId].deref();
-      if (!element) {
-        return "NOT_FOUND";
-      }
-
-      const tag = element.tagName.toLowerCase();
-
-      if (tag === "input" || tag === "textarea") {
-        const proto =
-          tag === "input"
-            ? HTMLInputElement.prototype
-            : HTMLTextAreaElement.prototype;
-
-        const nativeSetter = Object.getOwnPropertyDescriptor(
-          proto,
-          "value"
-        )?.set;
-        if (!nativeSetter) {
-          return "SETTER_NOT_FOUND";
-        }
-
-        element.focus();
-
-        nativeSetter.call(element, "");
-        element.dispatchEvent(new Event("input", { bubbles: true }));
-        element.dispatchEvent(new Event("change", { bubbles: true }));
-        return "OK";
-      }
-
-      if (
-        element.getAttribute("role") === "combobox" ||
-        element.getAttribute("role") === "searchbox"
-      ) {
-        const inner = element.querySelector<HTMLInputElement>("input");
-        if (inner) {
-          const nativeSetter = Object.getOwnPropertyDescriptor(
-            HTMLInputElement.prototype,
-            "value"
-          )?.set;
-          if (!nativeSetter) {
-            return "SETTER_NOT_FOUND";
-          }
-
-          inner.focus();
-
-          nativeSetter.call(inner, "");
-          inner.dispatchEvent(new Event("input", { bubbles: true }));
-          inner.dispatchEvent(new Event("change", { bubbles: true }));
-          return "OK";
-        }
-      }
-
-      if (element.isContentEditable) {
-        element.focus();
-
-        const sel = window.getSelection();
-        if (!sel) {
-          return "SELECTION_UNAVAILABLE";
-        }
-
-        const range = document.createRange();
-        range.selectNodeContents(element);
-
-        sel.removeAllRanges();
-        sel.addRange(range);
-
-        element.dispatchEvent(
-          new KeyboardEvent("keydown", {
-            key: "Backspace",
-            code: "Backspace",
-            keyCode: 8,
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-        element.dispatchEvent(
-          new InputEvent("beforeinput", {
-            inputType: "deleteContentBackward",
-            bubbles: true,
-            cancelable: true,
-          })
-        );
-
-        range.deleteContents();
-
-        element.dispatchEvent(
-          new InputEvent("input", {
-            inputType: "deleteContentBackward",
-            bubbles: true,
-          })
-        );
-        element.dispatchEvent(
-          new KeyboardEvent("keyup", {
-            key: "Backspace",
-            code: "Backspace",
-            keyCode: 8,
-            bubbles: true,
-          })
-        );
-        return "OK";
-      }
-
-      return "UNSUPPORTED_ELEMENT";
-    },
-  });
-
-  const result = execution?.result;
-
-  if (!result) {
-    return new Err(new Error("Unexpected error"));
-  }
-
-  switch (result) {
-    case "OK":
-      return new Ok(true);
-    case "NOT_FOUND":
-      return new Err(
-        new Error("Element not found. Call getPageElements first.")
-      );
-    case "SETTER_NOT_FOUND":
-      return new Err(new Error("Could not resolve native setter for element."));
-    case "SELECTION_UNAVAILABLE":
-      return new Err(new Error("Could not get selection for element."));
     case "UNSUPPORTED_ELEMENT":
       return new Err(new Error("Element is not a supported input type."));
     default:

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -1,4 +1,5 @@
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { ensureDustPageUtils } from "./pageUtils";
 
 type ElementSnapshot = {
@@ -152,4 +153,352 @@ export async function clickPageElement(
     return new Err(new Error("Element not found"));
   }
   return new Ok(true);
+}
+
+export async function typeText(
+  tab: chrome.tabs.Tab,
+  elementId: string,
+  text: string,
+  variant: "replace" | "append"
+): Promise<Result<boolean, Error>> {
+  if (!tab?.id) {
+    return new Err(new Error("No active tab found."));
+  }
+
+  const [execution] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    args: [elementId, text, variant],
+    func: (
+      elementId: string,
+      text: string,
+      variant: "replace" | "append"
+    ):
+      | "OK"
+      | "NOT_FOUND"
+      | "SETTER_NOT_FOUND"
+      | "SELECTION_UNAVAILABLE"
+      | "OPTION_NOT_FOUND"
+      | "UNSUPPORTED_ELEMENT" => {
+      const w = window as unknown as {
+        __dustElementMap?: Record<string, WeakRef<HTMLElement>>;
+      };
+
+      const element = w.__dustElementMap?.[elementId].deref();
+      if (!element) {
+        return "NOT_FOUND";
+      }
+
+      const tag = element.tagName.toLowerCase();
+
+      if (tag === "input" || tag === "textarea") {
+        const proto =
+          tag === "input"
+            ? HTMLInputElement.prototype
+            : HTMLTextAreaElement.prototype;
+
+        const nativeSetter = Object.getOwnPropertyDescriptor(
+          proto,
+          "value"
+        )?.set;
+        if (!nativeSetter) {
+          return "SETTER_NOT_FOUND";
+        }
+
+        element.focus();
+
+        const baseValue =
+          variant === "append"
+            ? (element as HTMLInputElement | HTMLTextAreaElement).value
+            : "";
+
+        let current = baseValue;
+        for (const char of text) {
+          current += char;
+          nativeSetter.call(element, current);
+          element.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        element.dispatchEvent(new Event("change", { bubbles: true }));
+        return "OK";
+      }
+
+      if (
+        element.getAttribute("role") === "combobox" ||
+        element.getAttribute("role") === "searchbox"
+      ) {
+        const inner = element.querySelector<HTMLInputElement>("input");
+        if (inner) {
+          const nativeSetter = Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            "value"
+          )?.set;
+          if (!nativeSetter) {
+            return "SETTER_NOT_FOUND";
+          }
+
+          inner.focus();
+
+          const baseValue = variant === "append" ? inner.value : "";
+          let current = baseValue;
+          for (const char of text) {
+            current += char;
+            nativeSetter.call(inner, current);
+            inner.dispatchEvent(new Event("input", { bubbles: true }));
+          }
+          inner.dispatchEvent(new Event("change", { bubbles: true }));
+          return "OK";
+        }
+        // No inner input — fall through to contenteditable check
+      }
+
+      if (element.isContentEditable) {
+        element.focus();
+
+        const sel = window.getSelection();
+        if (!sel) {
+          return "SELECTION_UNAVAILABLE";
+        }
+
+        const range = document.createRange();
+        range.selectNodeContents(element);
+
+        if (variant === "append") {
+          range.collapse(false);
+        }
+
+        sel.removeAllRanges();
+        sel.addRange(range);
+
+        for (const char of text) {
+          element.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: char,
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+          element.dispatchEvent(
+            new KeyboardEvent("keypress", {
+              key: char,
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+
+          // Even if deprecated execCommand works with Notion
+          // while other alternatives do not
+          document.execCommand("insertText", false, char);
+
+          element.dispatchEvent(
+            new InputEvent("input", {
+              inputType: "insertText",
+              data: char,
+              bubbles: true,
+            })
+          );
+          element.dispatchEvent(
+            new KeyboardEvent("keyup", {
+              key: char,
+              bubbles: true,
+            })
+          );
+        }
+        return "OK";
+      }
+
+      if (tag === "select") {
+        const select = element as HTMLSelectElement;
+        const option = Array.from(select.options).find(
+          (o) => o.text === text || o.value === text
+        );
+        if (!option) {
+          return "OPTION_NOT_FOUND";
+        }
+        select.value = option.value;
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+        return "OK";
+      }
+
+      return "UNSUPPORTED_ELEMENT";
+    },
+  });
+
+  const result = execution?.result;
+
+  if (!result) {
+    return new Err(new Error("Unexpected error"));
+  }
+
+  switch (result) {
+    case "OK":
+      return new Ok(true);
+    case "NOT_FOUND":
+      return new Err(
+        new Error("Element not found. Call getPageElements first.")
+      );
+    case "SETTER_NOT_FOUND":
+      return new Err(new Error("Could not resolve native setter for element."));
+    case "SELECTION_UNAVAILABLE":
+      return new Err(new Error("Could not get selection for element."));
+    case "OPTION_NOT_FOUND":
+      return new Err(
+        new Error(`Option "${text}" not found in select element.`)
+      );
+    case "UNSUPPORTED_ELEMENT":
+      return new Err(new Error("Element is not a supported input type."));
+    default:
+      assertNever(result);
+  }
+}
+
+export async function deleteText(
+  tab: chrome.tabs.Tab,
+  elementId: string
+): Promise<Result<boolean, Error>> {
+  if (!tab?.id) {
+    return new Err(new Error("No active tab found."));
+  }
+
+  const [execution] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    args: [elementId],
+    func: (
+      elementId: string
+    ):
+      | "OK"
+      | "NOT_FOUND"
+      | "SETTER_NOT_FOUND"
+      | "SELECTION_UNAVAILABLE"
+      | "UNSUPPORTED_ELEMENT" => {
+      const w = window as unknown as {
+        __dustElementMap?: Record<string, WeakRef<HTMLElement>>;
+      };
+
+      const element = w.__dustElementMap?.[elementId].deref();
+      if (!element) {
+        return "NOT_FOUND";
+      }
+
+      const tag = element.tagName.toLowerCase();
+
+      if (tag === "input" || tag === "textarea") {
+        const proto =
+          tag === "input"
+            ? HTMLInputElement.prototype
+            : HTMLTextAreaElement.prototype;
+
+        const nativeSetter = Object.getOwnPropertyDescriptor(
+          proto,
+          "value"
+        )?.set;
+        if (!nativeSetter) {
+          return "SETTER_NOT_FOUND";
+        }
+
+        element.focus();
+
+        nativeSetter.call(element, "");
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+        element.dispatchEvent(new Event("change", { bubbles: true }));
+        return "OK";
+      }
+
+      if (
+        element.getAttribute("role") === "combobox" ||
+        element.getAttribute("role") === "searchbox"
+      ) {
+        const inner = element.querySelector<HTMLInputElement>("input");
+        if (inner) {
+          const nativeSetter = Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            "value"
+          )?.set;
+          if (!nativeSetter) {
+            return "SETTER_NOT_FOUND";
+          }
+
+          inner.focus();
+
+          nativeSetter.call(inner, "");
+          inner.dispatchEvent(new Event("input", { bubbles: true }));
+          inner.dispatchEvent(new Event("change", { bubbles: true }));
+          return "OK";
+        }
+      }
+
+      if (element.isContentEditable) {
+        element.focus();
+
+        const sel = window.getSelection();
+        if (!sel) {
+          return "SELECTION_UNAVAILABLE";
+        }
+
+        const range = document.createRange();
+        range.selectNodeContents(element);
+
+        sel.removeAllRanges();
+        sel.addRange(range);
+
+        element.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Backspace",
+            code: "Backspace",
+            keyCode: 8,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        element.dispatchEvent(
+          new InputEvent("beforeinput", {
+            inputType: "deleteContentBackward",
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+
+        range.deleteContents();
+
+        element.dispatchEvent(
+          new InputEvent("input", {
+            inputType: "deleteContentBackward",
+            bubbles: true,
+          })
+        );
+        element.dispatchEvent(
+          new KeyboardEvent("keyup", {
+            key: "Backspace",
+            code: "Backspace",
+            keyCode: 8,
+            bubbles: true,
+          })
+        );
+        return "OK";
+      }
+
+      return "UNSUPPORTED_ELEMENT";
+    },
+  });
+
+  const result = execution?.result;
+
+  if (!result) {
+    return new Err(new Error("Unexpected error"));
+  }
+
+  switch (result) {
+    case "OK":
+      return new Ok(true);
+    case "NOT_FOUND":
+      return new Err(
+        new Error("Element not found. Call getPageElements first.")
+      );
+    case "SETTER_NOT_FOUND":
+      return new Err(new Error("Could not resolve native setter for element."));
+    case "SELECTION_UNAVAILABLE":
+      return new Err(new Error("Could not get selection for element."));
+    case "UNSUPPORTED_ELEMENT":
+      return new Err(new Error("Element is not a supported input type."));
+    default:
+      assertNever(result);
+  }
 }

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -156,7 +156,7 @@ export async function clickPageElement(
 }
 
 export async function typeText(
-  tab: chrome.tabs.Tab,
+  tab: chrome.tabs.Tab | undefined,
   elementId: string,
   text: string,
   variant: "replace" | "append" | "delete"

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -95,6 +95,24 @@ export type ClickPageElementMessage = {
 };
 export type ClickPageElementResponse = { success: boolean; error?: string };
 
+export type TypeTextMessage = {
+  type: "TYPE_TEXT";
+  tabId: number;
+  elementId: string;
+  text: string;
+  variant: "replace" | "append";
+};
+
+export type TypeTextResponse = { success: boolean; error?: string };
+
+export type DeleteTextMessage = {
+  type: "DELETE_TEXT";
+  tabId: number;
+  elementId: string;
+};
+
+export type DeleteTextResponse = { success: boolean; error?: string };
+
 const sendMessage = <T, U>(message: T): Promise<U> => {
   return new Promise((resolve, reject) => {
     chrome.runtime.sendMessage(message, (response: U | undefined) => {
@@ -236,15 +254,46 @@ export function sendInteractWithPageMessage(input: {
 
 export function sendInteractWithPageMessage(input: {
   action: "click_element";
-  elementId: string;
   tabId: number;
+  elementId: string;
 }): Promise<ClickPageElementResponse>;
+
+export function sendInteractWithPageMessage(input: {
+  action: "type_text";
+  tabId: number;
+  elementId: string;
+  text: string;
+  variant: "replace" | "append";
+}): Promise<TypeTextResponse>;
+
+export function sendInteractWithPageMessage(input: {
+  action: "delete_text";
+  tabId: number;
+  elementId: string;
+}): Promise<DeleteTextResponse>;
 
 export function sendInteractWithPageMessage(
   input:
     | { action: "get_elements"; tabId: number }
     | { action: "click_element"; tabId: number; elementId: string }
-): Promise<GetPageElementsResponse | ClickPageElementResponse> {
+    | {
+        action: "type_text";
+        tabId: number;
+        elementId: string;
+        text: string;
+        variant: "replace" | "append";
+      }
+    | {
+        action: "delete_text";
+        tabId: number;
+        elementId: string;
+      }
+): Promise<
+  | GetPageElementsResponse
+  | ClickPageElementResponse
+  | TypeTextResponse
+  | DeleteTextResponse
+> {
   switch (input.action) {
     case "get_elements":
       return sendMessage<GetPageElementsMessage, GetPageElementsResponse>({
@@ -256,6 +305,20 @@ export function sendInteractWithPageMessage(
         type: "CLICK_ELEMENT",
         elementId: input.elementId,
         tabId: input.tabId,
+      });
+    case "type_text":
+      return sendMessage<TypeTextMessage, TypeTextResponse>({
+        type: "TYPE_TEXT",
+        tabId: input.tabId,
+        elementId: input.elementId,
+        text: input.text,
+        variant: input.variant,
+      });
+    case "delete_text":
+      return sendMessage<DeleteTextMessage, DeleteTextResponse>({
+        type: "DELETE_TEXT",
+        tabId: input.tabId,
+        elementId: input.elementId,
       });
   }
 }

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -3,20 +3,130 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 
 const inputSchema = z.object({
-  action: z.enum(["get_elements", "click_element", "type_text"]),
+  action: z
+    .enum(["get_elements", "click_element", "type_text", "delete_text"])
+    .describe("Action to perform."),
   tab_id: z.number().describe("The ID of the tab to interact with."),
-  element_id: z.string().nullable(),
-  text: z.string().nullable(),
+  element_id: z
+    .string()
+    .nullable()
+    .describe(
+      "ID of the element to interact with. Required for click_element, type_text and delete_text. Must match an element returned by get_elements."
+    ),
+
+  text: z.string().nullable().describe("Text to insert when using type_text."),
+
+  textActionVariant: z
+    .enum(["replace", "append"])
+    .nullable()
+    .describe(
+      "How text should be applied when using type_text: replace existing content or append to it."
+    ),
 });
 
 export function registerInteractWithPageTool(server: McpServer): void {
   server.tool(
     "chrome-interact-with-page",
-    "Interact with the page the user is currently viewing. Use the get_elements action to get the elements of the page. Use the click_element action to click on an element. Use the type_text action to type text into an element.",
+    `Interact with the webpage the user is currently viewing.
+
+Available actions:
+- get_elements: retrieve the interactive and text elements on the page.
+- click_element: trigger an element's click behavior (e.g., buttons, links, toggles, menu items).
+- type_text: insert text into an editable element.
+- delete_text: deletes the text of an editable element.
+
+Important rules:
+- Use get_elements when you need to see what elements are available.
+- Use click_element for controls like buttons or links.
+- Use type_text for entering text into inputs. Or removing text with the replace option.
+
+type_text automatically focuses the element before typing.
+delete_text automatically focuses the element before deleting the text.
+For the above reasons do NOT click an element before calling type_text or delete_text.
+Avoid unnecessary actions.`,
     inputSchema.shape,
     async (input) => {
       if (input.action === "type_text") {
-        throw new Error("Not implemented");
+        const elementId = input.element_id;
+        if (!elementId) {
+          return {
+            content: [{ type: "text", text: "No elementId specified" }],
+            isError: true,
+          };
+        }
+        const variant = input.textActionVariant;
+        if (!variant) {
+          return {
+            content: [{ type: "text", text: "No textActionVariant specified" }],
+            isError: true,
+          };
+        }
+
+        const typeResponse = await sendInteractWithPageMessage({
+          action: "type_text",
+          tabId: input.tab_id,
+          elementId,
+          text: input.text ?? "",
+          variant,
+        });
+        if (!typeResponse.success) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  typeResponse.error ??
+                  "Unexpected error when typing in element",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Text inserted successfully",
+            },
+          ],
+        };
+      }
+
+      if (input.action === "delete_text") {
+        const elementId = input.element_id;
+        if (!elementId) {
+          return {
+            content: [{ type: "text", text: "No elementId specified" }],
+            isError: true,
+          };
+        }
+
+        const typeResponse = await sendInteractWithPageMessage({
+          action: "delete_text",
+          tabId: input.tab_id,
+          elementId,
+        });
+        if (!typeResponse.success) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  typeResponse.error ??
+                  "Unexpected error when deleting text in element",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Text deleted successfully",
+            },
+          ],
+        };
       }
 
       if (input.action === "click_element") {


### PR DESCRIPTION
## Description

This PR implements a text typing tool for the Chrome extension, enabling agents to input text into editable elements on web pages.

- Adds `typeText` function in `interactWithPage.ts` supporting multiple element types (input, textarea, contenteditable, select, combobox/searchbox)
- Implements three text manipulation variants: `replace`, `append`, and `delete`


## Tests

Manually

## Risks

- The `typeText` function relies on various DOM manipulation techniques (native setters, execCommand, event dispatching) that may not work consistently across all web applications
- Using the deprecated `execCommand` API for contenteditable elements could break in future browser versions, though it's currently necessary for Notion compatibility

## Deploy Plan

Standard deployment