### PR TITLE
feat: get elements diffs after page interactions

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -30,6 +30,7 @@ import { jwtDecode } from "jwt-decode";
 import {
   clickPageElement,
   getPageElements,
+  getPageElementsDiff,
   typeText,
 } from "./interactWithPage";
 
@@ -749,8 +750,23 @@ chrome.runtime.onMessage.addListener(
               return;
             }
 
+            const elementsDiff = await getPageElementsDiff(tab);
+
+            if (elementsDiff.isErr()) {
+              log(
+                "Error getting page elements diff after click:",
+                elementsDiff.error
+              );
+              sendResponse({
+                success: false,
+                error: `Element clicked successfully. Error while getting page elements diff: ${elementsDiff.error.message}`,
+              });
+              return;
+            }
+
             sendResponse({
               success: true,
+              elementsDiff: elementsDiff.value,
             });
           } catch (error) {
             const normalizedError = normalizeError(error);
@@ -783,8 +799,23 @@ chrome.runtime.onMessage.addListener(
               return;
             }
 
+            const elementsDiff = await getPageElementsDiff(tab);
+
+            if (elementsDiff.isErr()) {
+              log(
+                "Error getting page elements diff after typing text:",
+                elementsDiff.error
+              );
+              sendResponse({
+                success: false,
+                error: `Text typed successfully. Error while getting page elements diff: ${elementsDiff.error.message}`,
+              });
+              return;
+            }
+
             sendResponse({
               success: true,
+              elementsDiff: elementsDiff.value,
             });
           } catch (error) {
             const normalizedError = normalizeError(error);
@@ -813,8 +844,23 @@ chrome.runtime.onMessage.addListener(
               return;
             }
 
+            const elementsDiff = await getPageElementsDiff(tab);
+
+            if (elementsDiff.isErr()) {
+              log(
+                "Error getting page elements diff after deleting text:",
+                elementsDiff.error
+              );
+              sendResponse({
+                success: false,
+                error: `Text deleted successfully. Error while getting page elements diff: ${elementsDiff.error.message}`,
+              });
+              return;
+            }
+
             sendResponse({
               success: true,
+              elementsDiff: elementsDiff.value,
             });
           } catch (error) {
             const normalizedError = normalizeError(error);

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -708,7 +708,10 @@ chrome.runtime.onMessage.addListener(
 
       case "GET_ELEMENTS":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab = tabs.find((t) => t.id === message.tabId);
+          const tab =
+            message.tabId !== null && message.tabId !== undefined
+              ? tabs.find((t) => t.id === message.tabId)
+              : tabs.find((t) => t.active);
           try {
             const result = await getPageElements(tab);
 
@@ -737,7 +740,10 @@ chrome.runtime.onMessage.addListener(
 
       case "CLICK_ELEMENT":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab = tabs.find((t) => t.id === message.tabId);
+          const tab =
+            message.tabId !== null && message.tabId !== undefined
+              ? tabs.find((t) => t.id === message.tabId)
+              : tabs.find((t) => t.active);
           try {
             const result = await clickPageElement(tab, message.elementId);
 
@@ -781,7 +787,10 @@ chrome.runtime.onMessage.addListener(
 
       case "TYPE_TEXT":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab = tabs.find((t) => t.id === message.tabId);
+          const tab =
+            message.tabId !== null && message.tabId !== undefined
+              ? tabs.find((t) => t.id === message.tabId)
+              : tabs.find((t) => t.active);
           try {
             const result = await typeText(
               tab,
@@ -831,7 +840,10 @@ chrome.runtime.onMessage.addListener(
 
       case "DELETE_TEXT":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab = tabs.find((t) => t.id === message.tabId);
+          const tab =
+            message.tabId !== null && message.tabId !== undefined
+              ? tabs.find((t) => t.id === message.tabId)
+              : tabs.find((t) => t.active);
           try {
             const result = await typeText(tab, message.elementId, "", "delete");
 

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -708,10 +708,7 @@ chrome.runtime.onMessage.addListener(
 
       case "GET_ELEMENTS":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab =
-            message.tabId !== null && message.tabId !== undefined
-              ? tabs.find((t) => t.id === message.tabId)
-              : tabs.find((t) => t.active);
+          const tab = tabs.find((t) => t.id === message.tabId);
           try {
             const result = await getPageElements(tab);
 
@@ -740,10 +737,7 @@ chrome.runtime.onMessage.addListener(
 
       case "CLICK_ELEMENT":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab =
-            message.tabId !== null && message.tabId !== undefined
-              ? tabs.find((t) => t.id === message.tabId)
-              : tabs.find((t) => t.active);
+          const tab = tabs.find((t) => t.id === message.tabId);
           try {
             const result = await clickPageElement(tab, message.elementId);
 
@@ -787,10 +781,7 @@ chrome.runtime.onMessage.addListener(
 
       case "TYPE_TEXT":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab =
-            message.tabId !== null && message.tabId !== undefined
-              ? tabs.find((t) => t.id === message.tabId)
-              : tabs.find((t) => t.active);
+          const tab = tabs.find((t) => t.id === message.tabId);
           try {
             const result = await typeText(
               tab,
@@ -840,10 +831,7 @@ chrome.runtime.onMessage.addListener(
 
       case "DELETE_TEXT":
         chrome.tabs.query({ currentWindow: true }, async (tabs) => {
-          const tab =
-            message.tabId !== null && message.tabId !== undefined
-              ? tabs.find((t) => t.id === message.tabId)
-              : tabs.find((t) => t.active);
+          const tab = tabs.find((t) => t.id === message.tabId);
           try {
             const result = await typeText(tab, message.elementId, "", "delete");
 

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -78,8 +78,8 @@ export async function getPageElements(
           name: getElementName(el),
           inputType: el.getAttribute("type"),
           coords: {
-            x: Math.round(rect.x + rect.width / 2),
-            y: Math.round(rect.y + rect.height / 2),
+            x: Math.round(rect.x + rect.width / 2 + window.scrollX),
+            y: Math.round(rect.y + rect.height / 2 + window.scrollY),
           },
         };
 
@@ -483,8 +483,8 @@ export async function getPageElementsDiff(
           name: getElementName(el),
           inputType: el.getAttribute("type"),
           coords: {
-            x: Math.round(rect.x + rect.width / 2),
-            y: Math.round(rect.y + rect.height / 2),
+            x: Math.round(rect.x + rect.width / 2 + window.scrollX),
+            y: Math.round(rect.y + rect.height / 2 + window.scrollY),
           },
         };
 
@@ -496,9 +496,7 @@ export async function getPageElementsDiff(
           const changed =
             prev.role !== current.role ||
             prev.name !== current.name ||
-            prev.inputType !== current.inputType ||
-            prev.coords.x !== current.coords.x ||
-            prev.coords.y !== current.coords.y;
+            prev.inputType !== current.inputType;
 
           if (changed) {
             const editedElement: ElementSnapshot = {

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -414,3 +414,132 @@ export async function typeText(
       assertNever(result);
   }
 }
+
+export async function getPageElementsDiff(
+  tab: chrome.tabs.Tab | undefined
+): Promise<Result<string, Error>> {
+  if (!tab?.id) {
+    return new Err(new Error("No active tab found."));
+  }
+
+  const utilsResult = await ensureDustPageUtils(tab);
+  if (utilsResult.isErr()) {
+    return utilsResult;
+  }
+
+  const [execution] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => {
+      const w = window as unknown as DustWindow;
+
+      if (!w.__dustElementMap || !w.__dustElementSnapshots) {
+        return JSON.stringify({ added: [], edited: [], deleted: [] });
+      }
+
+      const { selector, CONTENT, getElementName } = w.__dustUtils;
+      const {
+        __dustElementMap: elementMap,
+        __dustElementSnapshots: snapshots,
+      } = w;
+
+      // ── Build reverse map: DOM node → elementId ───────────────────────────
+      const domNodeToId = new Map<HTMLElement, string>();
+      for (const [elementId, weakRef] of Object.entries(elementMap)) {
+        const el = weakRef.deref();
+        if (el) {
+          domNodeToId.set(el, elementId);
+        }
+      }
+
+      const added: ElementSnapshot[] = [];
+      const edited: ElementSnapshot[] = [];
+      const seenIds = new Set<string>();
+      let counter = w.__dustElementIdCounter ?? 0;
+
+      const nodes = document.querySelectorAll<HTMLElement>(selector);
+
+      nodes.forEach((el) => {
+        const style = window.getComputedStyle(el);
+        if (style.display === "none" || style.visibility === "hidden") {
+          return;
+        }
+        if (el.getAttribute("aria-hidden") === "true") {
+          return;
+        }
+
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) {
+          return;
+        }
+
+        const tag = el.tagName.toLowerCase();
+        const current: Omit<ElementSnapshot, "elementId"> = {
+          tag,
+          type: CONTENT.includes(tag) ? "content" : "interactive",
+          role: el.getAttribute("role") ?? tag,
+          name: getElementName(el),
+          inputType: el.getAttribute("type"),
+          coords: {
+            x: Math.round(rect.x + rect.width / 2),
+            y: Math.round(rect.y + rect.height / 2),
+          },
+        };
+
+        const existingId = domNodeToId.get(el);
+
+        if (existingId !== undefined) {
+          seenIds.add(existingId);
+          const prev = snapshots[existingId];
+          const changed =
+            prev.role !== current.role ||
+            prev.name !== current.name ||
+            prev.inputType !== current.inputType ||
+            prev.coords.x !== current.coords.x ||
+            prev.coords.y !== current.coords.y;
+
+          if (changed) {
+            const editedElement: ElementSnapshot = {
+              ...current,
+              elementId: existingId,
+            };
+            edited.push(editedElement);
+            snapshots[existingId] = editedElement;
+          }
+        } else {
+          let elementId: string;
+          do {
+            elementId = `element_${counter++}`;
+          } while (elementMap[elementId] !== undefined);
+
+          const newSnapshot: ElementSnapshot = { ...current, elementId };
+          elementMap[elementId] = new WeakRef<HTMLElement>(el);
+          snapshots[elementId] = newSnapshot;
+          domNodeToId.set(el, elementId);
+          seenIds.add(elementId);
+          added.push(newSnapshot);
+        }
+      });
+
+      w.__dustElementIdCounter = counter;
+
+      // ── Deleted: tracked entries not seen in current DOM walk ─────────────
+      const deleted: ElementSnapshot[] = [];
+      for (const elementId of Object.keys(elementMap)) {
+        if (!seenIds.has(elementId)) {
+          deleted.push(snapshots[elementId]);
+          delete elementMap[elementId];
+          delete snapshots[elementId];
+        }
+      }
+
+      return JSON.stringify({ added, edited, deleted });
+    },
+  });
+
+  const result =
+    execution && typeof execution.result === "string"
+      ? execution.result
+      : JSON.stringify({ added: [], edited: [], deleted: [] });
+
+  return new Ok(result);
+}

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -429,7 +429,8 @@ export async function getPageElementsDiff(
 
   const [execution] = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
-    func: () => {
+    args: [tab.id],
+    func: (tabId: number) => {
       const w = window as unknown as DustWindow;
 
       if (!w.__dustElementMap || !w.__dustElementSnapshots) {
@@ -441,6 +442,8 @@ export async function getPageElementsDiff(
         __dustElementMap: elementMap,
         __dustElementSnapshots: snapshots,
       } = w;
+
+      const elementPrefix = `el_${tabId.toString(36)}_`;
 
       // ── Build reverse map: DOM node → elementId ───────────────────────────
       const domNodeToId = new Map<HTMLElement, string>();
@@ -508,7 +511,7 @@ export async function getPageElementsDiff(
         } else {
           let elementId: string;
           do {
-            elementId = `element_${counter++}`;
+            elementId = `${elementPrefix}${counter++}`;
           } while (elementMap[elementId] !== undefined);
 
           const newSnapshot: ElementSnapshot = { ...current, elementId };

--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -162,7 +162,7 @@ export async function typeText(
   variant: "replace" | "append" | "delete"
 ): Promise<Result<boolean, Error>> {
   if (!tab?.id) {
-    return new Err(new Error("No active tab found."));
+    return new Err(new Error("Tab not found."));
   }
 
   const utilsResult = await ensureDustPageUtils(tab);
@@ -419,7 +419,7 @@ export async function getPageElementsDiff(
   tab: chrome.tabs.Tab | undefined
 ): Promise<Result<string, Error>> {
   if (!tab?.id) {
-    return new Err(new Error("No active tab found."));
+    return new Err(new Error("Tab not found."));
   }
 
   const utilsResult = await ensureDustPageUtils(tab);

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -85,12 +85,15 @@ export type CaptureFullPageMessage = {
   type: "PAGE_CAPTURE_FULL_PAGE";
 };
 
-export type GetPageElementsMessage = { type: "GET_ELEMENTS"; tabId: number };
+export type GetPageElementsMessage = {
+  type: "GET_ELEMENTS";
+  tabId: number | null | undefined;
+};
 export type GetPageElementsResponse = { elements: string; error?: string };
 
 export type ClickPageElementMessage = {
   type: "CLICK_ELEMENT";
-  tabId: number;
+  tabId: number | null | undefined;
   elementId: string;
 };
 export type ClickPageElementResponse = {
@@ -101,7 +104,7 @@ export type ClickPageElementResponse = {
 
 export type TypeTextMessage = {
   type: "TYPE_TEXT";
-  tabId: number;
+  tabId: number | null | undefined;
   elementId: string;
   text: string;
   variant: "replace" | "append";
@@ -115,7 +118,7 @@ export type TypeTextResponse = {
 
 export type DeleteTextMessage = {
   type: "DELETE_TEXT";
-  tabId: number;
+  tabId: number | null | undefined;
   elementId: string;
 };
 
@@ -261,18 +264,18 @@ export const sendTabActionMessage = (message: TabActionMessage) => {
 
 export function sendInteractWithPageMessage(input: {
   action: "get_elements";
-  tabId: number;
+  tabId: number | null | undefined;
 }): Promise<GetPageElementsResponse>;
 
 export function sendInteractWithPageMessage(input: {
   action: "click_element";
-  tabId: number;
+  tabId: number | null | undefined;
   elementId: string;
 }): Promise<ClickPageElementResponse>;
 
 export function sendInteractWithPageMessage(input: {
   action: "type_text";
-  tabId: number;
+  tabId: number | null | undefined;
   elementId: string;
   text: string;
   variant: "replace" | "append";
@@ -280,24 +283,28 @@ export function sendInteractWithPageMessage(input: {
 
 export function sendInteractWithPageMessage(input: {
   action: "delete_text";
-  tabId: number;
+  tabId: number | null | undefined;
   elementId: string;
 }): Promise<DeleteTextResponse>;
 
 export function sendInteractWithPageMessage(
   input:
-    | { action: "get_elements"; tabId: number }
-    | { action: "click_element"; tabId: number; elementId: string }
+    | { action: "get_elements"; tabId: number | null | undefined }
+    | {
+        action: "click_element";
+        tabId: number | null | undefined;
+        elementId: string;
+      }
     | {
         action: "type_text";
-        tabId: number;
+        tabId: number | null | undefined;
         elementId: string;
         text: string;
         variant: "replace" | "append";
       }
     | {
         action: "delete_text";
-        tabId: number;
+        tabId: number | null | undefined;
         elementId: string;
       }
 ): Promise<

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -93,7 +93,11 @@ export type ClickPageElementMessage = {
   tabId: number;
   elementId: string;
 };
-export type ClickPageElementResponse = { success: boolean; error?: string };
+export type ClickPageElementResponse = {
+  success: boolean;
+  elementsDiff?: string;
+  error?: string;
+};
 
 export type TypeTextMessage = {
   type: "TYPE_TEXT";
@@ -103,7 +107,11 @@ export type TypeTextMessage = {
   variant: "replace" | "append";
 };
 
-export type TypeTextResponse = { success: boolean; error?: string };
+export type TypeTextResponse = {
+  success: boolean;
+  elementsDiff?: string;
+  error?: string;
+};
 
 export type DeleteTextMessage = {
   type: "DELETE_TEXT";
@@ -111,7 +119,11 @@ export type DeleteTextMessage = {
   elementId: string;
 };
 
-export type DeleteTextResponse = { success: boolean; error?: string };
+export type DeleteTextResponse = {
+  success: boolean;
+  elementsDiff?: string;
+  error?: string;
+};
 
 const sendMessage = <T, U>(message: T): Promise<U> => {
   return new Promise((resolve, reject) => {

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -87,13 +87,13 @@ export type CaptureFullPageMessage = {
 
 export type GetPageElementsMessage = {
   type: "GET_ELEMENTS";
-  tabId: number | null | undefined;
+  tabId: number;
 };
 export type GetPageElementsResponse = { elements: string; error?: string };
 
 export type ClickPageElementMessage = {
   type: "CLICK_ELEMENT";
-  tabId: number | null | undefined;
+  tabId: number;
   elementId: string;
 };
 export type ClickPageElementResponse = {
@@ -104,7 +104,7 @@ export type ClickPageElementResponse = {
 
 export type TypeTextMessage = {
   type: "TYPE_TEXT";
-  tabId: number | null | undefined;
+  tabId: number;
   elementId: string;
   text: string;
   variant: "replace" | "append";
@@ -118,7 +118,7 @@ export type TypeTextResponse = {
 
 export type DeleteTextMessage = {
   type: "DELETE_TEXT";
-  tabId: number | null | undefined;
+  tabId: number;
   elementId: string;
 };
 
@@ -264,18 +264,18 @@ export const sendTabActionMessage = (message: TabActionMessage) => {
 
 export function sendInteractWithPageMessage(input: {
   action: "get_elements";
-  tabId: number | null | undefined;
+  tabId: number;
 }): Promise<GetPageElementsResponse>;
 
 export function sendInteractWithPageMessage(input: {
   action: "click_element";
-  tabId: number | null | undefined;
+  tabId: number;
   elementId: string;
 }): Promise<ClickPageElementResponse>;
 
 export function sendInteractWithPageMessage(input: {
   action: "type_text";
-  tabId: number | null | undefined;
+  tabId: number;
   elementId: string;
   text: string;
   variant: "replace" | "append";
@@ -283,28 +283,28 @@ export function sendInteractWithPageMessage(input: {
 
 export function sendInteractWithPageMessage(input: {
   action: "delete_text";
-  tabId: number | null | undefined;
+  tabId: number;
   elementId: string;
 }): Promise<DeleteTextResponse>;
 
 export function sendInteractWithPageMessage(
   input:
-    | { action: "get_elements"; tabId: number | null | undefined }
+    | { action: "get_elements"; tabId: number }
     | {
         action: "click_element";
-        tabId: number | null | undefined;
+        tabId: number;
         elementId: string;
       }
     | {
         action: "type_text";
-        tabId: number | null | undefined;
+        tabId: number;
         elementId: string;
         text: string;
         variant: "replace" | "append";
       }
     | {
         action: "delete_text";
-        tabId: number | null | undefined;
+        tabId: number;
         elementId: string;
       }
 ): Promise<

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -6,19 +6,24 @@ const inputSchema = z.object({
   action: z
     .enum(["get_elements", "click_element", "type_text", "delete_text"])
     .describe("Action to perform."),
-  tab_id: z.number().describe("The ID of the tab to interact with."),
+  tab_id: z
+    .number()
+    .nullish()
+    .describe(
+      "The ID of the tab to interact with. If not specified, the active tab will be used."
+    ),
   element_id: z
     .string()
-    .nullable()
+    .nullish()
     .describe(
       "ID of the element to interact with. Required for click_element, type_text and delete_text. Must match an element returned by get_elements."
     ),
 
-  text: z.string().nullable().describe("Text to insert when using type_text."),
+  text: z.string().nullish().describe("Text to insert when using type_text."),
 
   textActionVariant: z
     .enum(["replace", "append"])
-    .nullable()
+    .nullish()
     .describe(
       "How text should be applied when using type_text: replace existing content or append to it."
     ),

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -42,7 +42,7 @@ Important rules:
 
 type_text automatically focuses the element before typing.
 delete_text automatically focuses the element before deleting the text.
-For the above reasons do NOT click an element before calling type_text or delete_text.
+For the above reasons in most cases you do NOT need to click an element before calling type_text or delete_text.
 Avoid unnecessary actions.`,
     inputSchema.shape,
     async (input) => {
@@ -74,9 +74,7 @@ Avoid unnecessary actions.`,
             content: [
               {
                 type: "text",
-                text:
-                  typeResponse.error ??
-                  "Unexpected error when typing in element",
+                text: `${typeResponse.error ?? "Unexpected error when typing in element"} ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
               },
             ],
             isError: true,
@@ -86,7 +84,7 @@ Avoid unnecessary actions.`,
           content: [
             {
               type: "text",
-              text: "Text inserted successfully",
+              text: `Text inserted successfully. ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
             },
           ],
         };
@@ -111,9 +109,7 @@ Avoid unnecessary actions.`,
             content: [
               {
                 type: "text",
-                text:
-                  typeResponse.error ??
-                  "Unexpected error when deleting text in element",
+                text: `${typeResponse.error ?? "Unexpected error when deleting text in element"} ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
               },
             ],
             isError: true,
@@ -123,7 +119,7 @@ Avoid unnecessary actions.`,
           content: [
             {
               type: "text",
-              text: "Text deleted successfully",
+              text: `Text deleted successfully. ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
             },
           ],
         };
@@ -148,9 +144,7 @@ Avoid unnecessary actions.`,
             content: [
               {
                 type: "text",
-                text:
-                  clickResponse.error ??
-                  "Unexpected error when clicking element",
+                text: `${clickResponse.error ?? "Unexpected error when clicking element"} ${clickResponse.elementsDiff ? `Elements diff: ${clickResponse.elementsDiff}` : ""}`,
               },
             ],
             isError: true,
@@ -160,7 +154,7 @@ Avoid unnecessary actions.`,
           content: [
             {
               type: "text",
-              text: "Button clicked successfully",
+              text: `Button clicked successfully. ${clickResponse.elementsDiff ? `Elements diff: ${clickResponse.elementsDiff}` : ""}`,
             },
           ],
         };

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -6,12 +6,7 @@ const inputSchema = z.object({
   action: z
     .enum(["get_elements", "click_element", "type_text", "delete_text"])
     .describe("Action to perform."),
-  tab_id: z
-    .number()
-    .nullish()
-    .describe(
-      "The ID of the tab to interact with. If not specified, the active tab will be used."
-    ),
+  tab_id: z.number().describe("The ID of the tab to interact with."),
   element_id: z
     .string()
     .nullish()


### PR DESCRIPTION
## Description

This PR adds functionality to capture and return DOM element differences after page interactions in the Chrome extension.

- Implements `getPageElementsDiff()` function that tracks added, edited, and deleted elements by comparing current DOM state against stored snapshots
- Modifies click, type text, and delete text operations to return element diffs alongside success/error messages

https://github.com/user-attachments/assets/893d76f6-2066-453a-861f-e963517a56ff


## Tests

Manually

## Risks

Low. This is an additive change that extends existing functionality without breaking current behavior. The element diff is optional and only returned when successfully retrieved.

## Deploy Plan

Standard deployment - no special considerations needed.