### PR TITLE
[sparkle] fix markdown doesn't show the last token correctly 

### DIFF
--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -53,14 +53,20 @@ export function useAnimatedText(
 
     return () => {
       controlsRef.current?.stop();
+      controlsRef.current = null;
     };
   }, [startingCursor, text, delimiter, animationDurationSeconds]);
 
   useEffect(() => {
-    // stop animation if streaming is cancelled.
     if (streamingState === "cancelled") {
       controlsRef.current?.stop();
       controlsRef.current = null;
+    }
+    // When streaming ends and no animation is running (e.g. the last animation
+    // was stopped by cleanup before onComplete could fire), ensure we show the
+    // full text instead of getting stuck on a truncated cursor position.
+    if (streamingState === "none" && !controlsRef.current) {
+      setDisableAnimation(true);
     }
   }, [streamingState]);
 

--- a/sparkle/src/components/markdown/useAnimatedText.tsx
+++ b/sparkle/src/components/markdown/useAnimatedText.tsx
@@ -26,6 +26,13 @@ export function useAnimatedText(
 
   useEffect(() => {
     if (streamingStateRef.current !== "streaming") {
+      // When streaming ended before this effect ran (e.g. the last text chunk
+      // arrived at the same time as streamingState transitioned to "none"),
+      // ensure we show the full text instead of getting stuck on a truncated
+      // cursor position.
+      if (streamingStateRef.current === "none") {
+        setDisableAnimation(true);
+      }
       return;
     }
 
@@ -53,20 +60,14 @@ export function useAnimatedText(
 
     return () => {
       controlsRef.current?.stop();
-      controlsRef.current = null;
     };
   }, [startingCursor, text, delimiter, animationDurationSeconds]);
 
   useEffect(() => {
+    // stop animation if streaming is cancelled.
     if (streamingState === "cancelled") {
       controlsRef.current?.stop();
       controlsRef.current = null;
-    }
-    // When streaming ends and no animation is running (e.g. the last animation
-    // was stopped by cleanup before onComplete could fire), ensure we show the
-    // full text instead of getting stuck on a truncated cursor position.
-    if (streamingState === "none" && !controlsRef.current) {
-      setDisableAnimation(true);
     }
   }, [streamingState]);
 


### PR DESCRIPTION
## Description
I noticed sometimes the last token doesn't display the full text, and I think it's because there are some race condition going on and I think this will fix it 🤔

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
