### PR TITLE
[RUNNER] remove error details debug popover from ErrorMessage

### DIFF
--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -5,10 +5,7 @@ import {
   ArrowPathIcon,
   Button,
   ContentMessage,
-  DocumentPileIcon,
-  EyeIcon,
   InformationCircleIcon,
-  Popover,
 } from "@dust-tt/sparkle";
 
 interface ErrorMessageProps {
@@ -21,13 +18,6 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
     isAgentErrorCategory(error.metadata?.category) &&
     (error.metadata?.category === "retryable_model_error" ||
       error.metadata?.category === "stream_error");
-
-  const debugInfo = [
-    error.metadata?.category ? `category: ${error.metadata?.category}` : "",
-    error.code ? `code: ${error.code}` : "",
-  ]
-    .filter((s) => s.length > 0)
-    .join(", ");
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
@@ -50,37 +40,6 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
           label="Retry"
           onClick={retry}
           disabled={isRetrying}
-        />
-        <Popover
-          popoverTriggerAsChild
-          trigger={
-            <Button
-              variant="outline"
-              size="xs"
-              icon={EyeIcon}
-              label="Details"
-            />
-          }
-          content={
-            <div className="flex flex-col gap-3">
-              <div className="whitespace-normal text-sm font-normal text-warning">
-                {debugInfo}
-              </div>
-              <div className="self-end">
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  icon={DocumentPileIcon}
-                  label={"Copy"}
-                  onClick={() =>
-                    void navigator.clipboard.writeText(
-                      error.message + (debugInfo ? ` (${debugInfo})` : "")
-                    )
-                  }
-                />
-              </div>
-            </div>
-          }
         />
       </div>
     </ContentMessage>


### PR DESCRIPTION
## Description

Removes the "Details" popover from the `ErrorMessage` component that was displaying internal error metadata (category, code) and a copy button. This was a debugging aid and should not ship to users.

<img width="1132" height="522" alt="image" src="https://github.com/user-attachments/assets/4d183c4c-1562-4761-8d59-bed2e46a1581" />


## Tests

No

## Risk

Low — pure UI deletion, no logic change.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`