### PR TITLE
Make attachment button consistent in extensions

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -18,6 +18,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
+import { useClientType } from "@app/lib/context/clientType";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -142,6 +143,7 @@ const InputBarContainer = ({
   const [pastedCount, setPastedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(true);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
+  const clientType = useClientType();
 
   const [selectedNode, setSelectedNode] =
     useState<DataSourceViewContentNode | null>(null);
@@ -747,37 +749,38 @@ const InputBarContainer = ({
                     className="flex sm:hidden"
                     onClick={() => setIsToolbarOpen(!isToolbarOpen)}
                   />
-                  {actions.includes("attachment") && !captureActions && (
-                    <>
-                      <input
-                        accept={getSupportedFileExtensions().join(",")}
-                        onChange={async (e) => {
-                          await fileUploaderService.handleFileChange(e);
-                          if (fileInputRef.current) {
-                            fileInputRef.current.value = "";
-                          }
-                          editorService.focusEnd();
-                        }}
-                        ref={fileInputRef}
-                        style={{ display: "none" }}
-                        type="file"
-                        multiple={true}
-                      />
-                      <InputBarAttachmentsPicker
-                        fileUploaderService={fileUploaderService}
-                        owner={owner}
-                        isLoading={false}
-                        onNodeSelect={onNodeSelect}
-                        onNodeUnselect={onNodeUnselect}
-                        attachedNodes={attachedNodes}
-                        disabled={disableInput}
-                        buttonSize={buttonSize}
-                        conversation={conversation}
-                        space={space}
-                        type="dropdown"
-                      />
-                    </>
-                  )}
+                  {actions.includes("attachment") &&
+                    clientType !== "extension" && (
+                      <>
+                        <input
+                          accept={getSupportedFileExtensions().join(",")}
+                          onChange={async (e) => {
+                            await fileUploaderService.handleFileChange(e);
+                            if (fileInputRef.current) {
+                              fileInputRef.current.value = "";
+                            }
+                            editorService.focusEnd();
+                          }}
+                          ref={fileInputRef}
+                          style={{ display: "none" }}
+                          type="file"
+                          multiple={true}
+                        />
+                        <InputBarAttachmentsPicker
+                          fileUploaderService={fileUploaderService}
+                          owner={owner}
+                          isLoading={false}
+                          onNodeSelect={onNodeSelect}
+                          onNodeUnselect={onNodeUnselect}
+                          attachedNodes={attachedNodes}
+                          disabled={disableInput}
+                          buttonSize={buttonSize}
+                          conversation={conversation}
+                          space={space}
+                          type="dropdown"
+                        />
+                      </>
+                    )}
                   {actions.includes("capabilities") && (
                     <CapabilitiesPicker
                       owner={owner}
@@ -823,7 +826,7 @@ const InputBarContainer = ({
                       showStopLabel={!isMobile}
                     />
                   )}
-                {captureActions && (
+                {clientType === "extension" && (
                   <DropdownMenu
                     open={isCaptureDropdownOpen}
                     onOpenChange={setIsCaptureDropdownOpen}
@@ -853,24 +856,30 @@ const InputBarContainer = ({
                           onFileChange={() => setIsCaptureDropdownOpen(false)}
                         />
                       )}
-                      <DropdownMenuItem
-                        icon={GlobeAltIcon}
-                        label="Attach page content"
-                        disabled={
-                          captureActions.isCapturing ||
-                          fileUploaderService.isProcessingFiles
-                        }
-                        onClick={() => captureActions.onCapture("text")}
-                      />
-                      <DropdownMenuItem
-                        icon={CameraIcon}
-                        label="Take screenshot"
-                        disabled={
-                          captureActions.isCapturing ||
-                          fileUploaderService.isProcessingFiles
-                        }
-                        onClick={() => captureActions.onCapture("screenshot")}
-                      />
+                      {captureActions && (
+                        <>
+                          <DropdownMenuItem
+                            icon={GlobeAltIcon}
+                            label="Attach page content"
+                            disabled={
+                              captureActions.isCapturing ||
+                              fileUploaderService.isProcessingFiles
+                            }
+                            onClick={() => captureActions.onCapture("text")}
+                          />
+                          <DropdownMenuItem
+                            icon={CameraIcon}
+                            label="Take screenshot"
+                            disabled={
+                              captureActions.isCapturing ||
+                              fileUploaderService.isProcessingFiles
+                            }
+                            onClick={() =>
+                              captureActions.onCapture("screenshot")
+                            }
+                          />
+                        </>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )}


### PR DESCRIPTION
## Description

Makes the attachment "+" dropdown button always visible in extension contexts (Chrome, Front), regardless of whether page capture is available for the current domain.

Previously, the dropdown was gated on `captureActions` being defined, which meant it disappeared entirely on blacklisted domains — hiding the attachment picker along with it. Now:

- The dropdown shows whenever `clientType === "extension"`
- Attachment picker (files, data sources) is always available inside the dropdown
- Capture items (page content, screenshot) are conditionally shown only when `captureActions` is defined (i.e. domain is not blacklisted)
- The standalone attachment picker (outside the dropdown) shows only in the web app (`clientType !== "extension"`)

## Tests

Manual testing in Chrome extension on blacklisted and non-blacklisted domains.

## Risk

Low — only changes UI visibility conditions in InputBarContainer. No backend changes.

## Deploy Plan

Standard deploy.