### PR TITLE
[front] - feat(SkillBuilder): full diff

### DIFF
--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -1,16 +1,36 @@
+import {
+  InternalActionIcons,
+  isCustomResourceIconType,
+} from "@app/components/resources/resources_icons";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { isDefaultActionName } from "@app/components/shared/tools_picker/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { Card, CardActionButton, XMarkIcon } from "@dust-tt/sparkle";
+import type { ActionCardDiffStatus } from "@dust-tt/sparkle";
+
+import {
+  ActionIcons,
+  Avatar,
+  BookOpenIcon,
+  Card,
+  CardActionButton,
+  ActionCard as SparkleActionCard,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 
 function actionIcon(mcpServerView: MCPServerViewType | null) {
-  if (mcpServerView?.server) {
-    return getAvatar(mcpServerView.server, "xs");
+  if (!mcpServerView?.server) {
+    return BookOpenIcon;
   }
+
+  const { icon } = mcpServerView.server;
+  if (isCustomResourceIconType(icon)) {
+    return ActionIcons[icon];
+  }
+
+  return InternalActionIcons[icon] ?? BookOpenIcon;
 }
 
 function actionDisplayName(
@@ -26,13 +46,30 @@ function actionDisplayName(
   }`;
 }
 
-export interface ActionCardProps {
+interface ActionCardBaseProps {
   action: BuilderAction;
-  onRemove: () => void;
   onClick?: () => void;
 }
 
-export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
+interface ActionCardDefaultProps extends ActionCardBaseProps {
+  diffStatus?: never;
+  onRemove: () => void;
+}
+
+interface ActionCardDiffProps extends ActionCardBaseProps {
+  diffStatus: ActionCardDiffStatus;
+  onRemove?: never;
+}
+
+export type ActionCardProps = ActionCardDefaultProps | ActionCardDiffProps;
+
+// TODO: rename to not conflict with the sparkle component
+export function ActionCard({
+  action,
+  diffStatus,
+  onRemove,
+  onClick,
+}: ActionCardProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
 
@@ -45,6 +82,21 @@ export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
 
   const displayName = actionDisplayName(action, mcpServerView);
   const description = action.description ?? "";
+  const icon = actionIcon(mcpServerView);
+
+  if (diffStatus) {
+    return (
+      <SparkleActionCard
+        icon={icon}
+        label={displayName}
+        description={description}
+        diffStatus={diffStatus}
+        canAdd={false}
+        onClick={onClick}
+        cardContainerClassName="h-28"
+      />
+    );
+  }
 
   return (
     <Card
@@ -64,7 +116,7 @@ export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          {actionIcon(mcpServerView)}
+          <Avatar icon={icon} size="xs" />
           <span className="truncate">{displayName}</span>
         </div>
 

--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -1,7 +1,4 @@
-import {
-  InternalActionIcons,
-  isCustomResourceIconType,
-} from "@app/components/resources/resources_icons";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { isDefaultActionName } from "@app/components/shared/tools_picker/types";
@@ -11,7 +8,6 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { ActionCardDiffStatus } from "@dust-tt/sparkle";
 
 import {
-  ActionIcons,
   Avatar,
   BookOpenIcon,
   Card,
@@ -25,12 +21,7 @@ function actionIcon(mcpServerView: MCPServerViewType | null) {
     return BookOpenIcon;
   }
 
-  const { icon } = mcpServerView.server;
-  if (isCustomResourceIconType(icon)) {
-    return ActionIcons[icon];
-  }
-
-  return InternalActionIcons[icon] ?? BookOpenIcon;
+  return getIcon(mcpServerView.server.icon);
 }
 
 function actionDisplayName(
@@ -53,7 +44,7 @@ interface ActionCardBaseProps {
 
 interface ActionCardDefaultProps extends ActionCardBaseProps {
   diffStatus?: never;
-  onRemove: () => void;
+  onRemove?: () => void;
 }
 
 interface ActionCardDiffProps extends ActionCardBaseProps {
@@ -104,14 +95,16 @@ export function ActionCard({
       className="h-28"
       onClick={onClick}
       action={
-        <CardActionButton
-          size="icon"
-          icon={XMarkIcon}
-          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-            onRemove();
-            e.stopPropagation();
-          }}
-        />
+        onRemove ? (
+          <CardActionButton
+            size="icon"
+            icon={XMarkIcon}
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              onRemove();
+              e.stopPropagation();
+            }}
+          />
+        ) : undefined
       }
     >
       <div className="flex w-full flex-col gap-2 text-sm">

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -10,8 +10,14 @@ import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/S
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBuilderToolsSection";
-import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
-import { SkillVersionComparisonProvider } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import {
+  SkillBuilderVersionComparisonFooter,
+  SkillVersionHistoryPicker,
+} from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
+import {
+  SkillVersionComparisonProvider,
+  useSkillVersionComparisonContext,
+} from "@app/components/skill_builder/SkillBuilderVersionContext";
 import {
   getDefaultSkillFormData,
   transformSkillTypeToFormData,
@@ -215,7 +221,7 @@ export default function SkillBuilder({
                   <SkillBuilderInstructionsSection />
                   {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
                   <SkillBuilderToolsSection extendedSkill={extendedSkill} />
-                  <SkillBuilderSettingsSection />
+                  <SkillBuilderSettingsOrComparisonFooter />
                 </div>
               </ScrollArea>
               <BarFooter
@@ -244,4 +250,14 @@ export default function SkillBuilder({
       </FormProvider>
     </SkillBuilderFormContext.Provider>
   );
+}
+
+function SkillBuilderSettingsOrComparisonFooter() {
+  const { compareVersion } = useSkillVersionComparisonContext();
+
+  if (compareVersion) {
+    return <SkillBuilderVersionComparisonFooter />;
+  }
+
+  return <SkillBuilderSettingsSection />;
 }

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -10,10 +10,8 @@ import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/S
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBuilderToolsSection";
-import {
-  SkillBuilderVersionComparisonFooter,
-  SkillVersionHistoryPicker,
-} from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
+import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
+import { SkillBuilderVersionComparisonFooter } from "@app/components/skill_builder/SkillBuilderVersionComparisonFooter";
 import {
   SkillVersionComparisonProvider,
   useSkillVersionComparisonContext,

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -87,13 +87,13 @@ export function SkillBuilderAgentFacingDescriptionSection() {
 
   const handleUpdate = useCallback(
     ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
-      if (transaction.docChanged && !editor.isDestroyed) {
+      if (transaction.docChanged && !editor.isDestroyed && !isDiffMode) {
         const text = editor.getText().trim();
         setValue(FIELD_NAME, text, { shouldDirty: true });
         triggerSimilarSkillsFetch(text);
       }
     },
-    [setValue, triggerSimilarSkillsFetch]
+    [isDiffMode, setValue, triggerSimilarSkillsFetch]
   );
 
   const handleBlur = useCallback(() => {

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -7,10 +7,11 @@ import { SKILL_BUILDER_AGENT_DESCRIPTION_BLUR_EVENT } from "@app/components/skil
 import { SimilarSkillsDisplay } from "@app/components/skill_builder/SimilarSkillsDisplay";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSimilarSkills, useSkills } from "@app/lib/swr/skill_configurations";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { cn } from "@dust-tt/sparkle";
+import { ArrowGoBackIcon, Button, cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import { useCallback, useEffect, useState } from "react";
@@ -23,7 +24,9 @@ const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-96";
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();
-  const { setValue } = useFormContext<SkillBuilderFormData>();
+  const { setValue, watch } = useFormContext<SkillBuilderFormData>();
+  const { compareVersion } = useSkillVersionComparisonContext();
+  const isDiffMode = !!compareVersion;
 
   const { field: descriptionField, fieldState: descriptionFieldState } =
     useController<SkillBuilderFormData, typeof FIELD_NAME>({
@@ -35,6 +38,21 @@ export function SkillBuilderAgentFacingDescriptionSection() {
 
   const [similarSkills, setSimilarSkills] = useState<SkillType[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  const currentDescription = watch(FIELD_NAME);
+  const descriptionDiffers =
+    compareVersion &&
+    compareVersion.agentFacingDescription !== currentDescription;
+
+  const restoreDescription = () => {
+    if (!compareVersion) {
+      return;
+    }
+    setValue(FIELD_NAME, compareVersion.agentFacingDescription, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
 
   const fetchSimilarSkills = useCallback(
     async (description: string, signal: AbortSignal) => {
@@ -54,9 +72,8 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       if (!signal.aborted) {
         setIsLoading(false);
         if (result.isOk()) {
-          const similarSkillIds = new Set(result.value);
           setSimilarSkills(
-            skills.filter((skill) => similarSkillIds.has(skill.sId))
+            skills.filter((skill) => new Set(result.value).has(skill.sId))
           );
         }
       }
@@ -100,13 +117,16 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       editorProps: {
         attributes: {
           class: cn(
-            editorVariants({ error: !!descriptionFieldState.error }),
+            editorVariants({
+              error: !!descriptionFieldState.error,
+              disabled: isDiffMode,
+            }),
             DESCRIPTION_EDITOR_SIZE
           ),
         },
       },
     });
-  }, [editor, descriptionFieldState.error]);
+  }, [editor, descriptionFieldState.error, isDiffMode]);
 
   // Sync external changes to the editor content.
   useEffect(() => {
@@ -126,12 +146,46 @@ export function SkillBuilderAgentFacingDescriptionSection() {
     }
   }, [editor, descriptionField.value]);
 
+  // Apply/exit diff mode for description.
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    if (compareVersion) {
+      if (editor.storage.agentInstructionDiff?.isDiffMode) {
+        editor.commands.exitDiff();
+      }
+
+      const compareText = compareVersion.agentFacingDescription;
+      const currentText = descriptionField.value ?? "";
+
+      editor.commands.setContent(`<p>${currentText}</p>`, {
+        emitUpdate: false,
+      });
+      editor.commands.applyDiff(compareText, currentText);
+      editor.setEditable(false);
+    } else if (editor.storage.agentInstructionDiff?.isDiffMode) {
+      editor.commands.exitDiff();
+      editor.setEditable(true);
+    }
+  }, [compareVersion, editor, descriptionField.value]);
+
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
           What will this skill be used for?
         </h3>
+        {descriptionDiffers && (
+          <Button
+            variant="outline"
+            size="sm"
+            icon={ArrowGoBackIcon}
+            onClick={restoreDescription}
+            label="Restore description"
+          />
+        )}
       </div>
 
       <div className="space-y-3">
@@ -145,11 +199,13 @@ export function SkillBuilderAgentFacingDescriptionSection() {
           )}
         </div>
 
-        <SimilarSkillsDisplay
-          owner={owner}
-          similarSkills={similarSkills}
-          isLoading={isLoading}
-        />
+        {!isDiffMode && (
+          <SimilarSkillsDisplay
+            owner={owner}
+            similarSkills={similarSkills}
+            isLoading={isLoading}
+          />
+        )}
       </div>
     </section>
   );

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -25,8 +25,7 @@ const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-96";
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
-  const { compareVersion } = useSkillVersionComparisonContext();
-  const isDiffMode = !!compareVersion;
+  const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
 
   const { field: descriptionField, fieldState: descriptionFieldState } =
     useController<SkillBuilderFormData, typeof FIELD_NAME>({
@@ -72,8 +71,9 @@ export function SkillBuilderAgentFacingDescriptionSection() {
       if (!signal.aborted) {
         setIsLoading(false);
         if (result.isOk()) {
+          const similarSkillIds = new Set(result.value);
           setSimilarSkills(
-            skills.filter((skill) => new Set(result.value).has(skill.sId))
+            skills.filter((skill) => similarSkillIds.has(skill.sId))
           );
         }
       }

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -24,7 +24,7 @@ const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-96";
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();
-  const { setValue, watch } = useFormContext<SkillBuilderFormData>();
+  const { setValue } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
 
   const { field: descriptionField, fieldState: descriptionFieldState } =
@@ -38,10 +38,9 @@ export function SkillBuilderAgentFacingDescriptionSection() {
   const [similarSkills, setSimilarSkills] = useState<SkillType[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  const currentDescription = watch(FIELD_NAME);
   const descriptionDiffers =
     compareVersion &&
-    compareVersion.agentFacingDescription !== currentDescription;
+    compareVersion.agentFacingDescription !== descriptionField.value;
 
   const restoreDescription = () => {
     if (!compareVersion) {

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -20,8 +20,7 @@ export function SkillBuilderFilesSection() {
   const { owner, skillId } = useSkillBuilderContext();
   const sendNotification = useSendNotification();
   const { setValue } = useFormContext<SkillBuilderFormData>();
-  const { compareVersion } = useSkillVersionComparisonContext();
-  const isDiffMode = !!compareVersion;
+  const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
 
   const { fields, append, remove } = useFieldArray<
     SkillBuilderFormData,

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -7,6 +7,7 @@ import {
   ArrowGoBackIcon,
   Button,
   ContextItem,
+  cn,
   DocumentIcon,
   EmptyCTA,
   PlusIcon,
@@ -194,7 +195,10 @@ export function SkillBuilderFilesSection() {
                   key={field.id}
                   title={
                     <span
-                      className={`text-sm font-normal ${isAdded ? "text-success dark:text-success-night" : ""}`}
+                      className={cn(
+                        "text-sm font-normal",
+                        isAdded && "text-success dark:text-success-night"
+                      )}
                     >
                       {field.fileName}
                     </span>

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,8 +1,10 @@
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
+  ArrowGoBackIcon,
   Button,
   ContextItem,
   DocumentIcon,
@@ -12,11 +14,15 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useRef } from "react";
-import { useFieldArray } from "react-hook-form";
+import { useFieldArray, useFormContext } from "react-hook-form";
 
 export function SkillBuilderFilesSection() {
   const { owner, skillId } = useSkillBuilderContext();
   const sendNotification = useSendNotification();
+  const { setValue } = useFormContext<SkillBuilderFormData>();
+  const { compareVersion } = useSkillVersionComparisonContext();
+  const isDiffMode = !!compareVersion;
+
   const { fields, append, remove } = useFieldArray<
     SkillBuilderFormData,
     "fileAttachments"
@@ -44,6 +50,33 @@ export function SkillBuilderFilesSection() {
         .sort((a, b) => a.field.fileName.localeCompare(b.field.fileName)),
     [fields]
   );
+
+  const currentFileIds = useMemo(
+    () => new Set(fields.map((f) => f.fileId)),
+    [fields]
+  );
+
+  const compareFileIds = useMemo(
+    () =>
+      compareVersion
+        ? new Set(compareVersion.fileAttachments.map((f) => f.fileId))
+        : new Set<string>(),
+    [compareVersion]
+  );
+
+  const filesDiffer =
+    isDiffMode &&
+    (currentFileIds.size !== compareFileIds.size ||
+      [...currentFileIds].some((id) => !compareFileIds.has(id)));
+
+  const restoreFiles = () => {
+    if (!compareVersion) {
+      return;
+    }
+    setValue("fileAttachments", compareVersion.fileAttachments, {
+      shouldDirty: true,
+    });
+  };
 
   const onUploadClick = () => {
     fileInputRef.current?.click();
@@ -85,7 +118,7 @@ export function SkillBuilderFilesSection() {
     [handleFilesUpload, append, existingFileNames, sendNotification]
   );
 
-  const headerActions = fields.length > 0 && (
+  const headerActions = !isDiffMode && fields.length > 0 && (
     <Button
       type="button"
       onClick={onUploadClick}
@@ -108,20 +141,33 @@ export function SkillBuilderFilesSection() {
             schemas, scripts, or reference materials.
           </p>
         </div>
-        {headerActions}
+        <div className="flex items-center gap-2">
+          {filesDiffer && (
+            <Button
+              variant="outline"
+              size="sm"
+              icon={ArrowGoBackIcon}
+              onClick={restoreFiles}
+              label="Restore files"
+            />
+          )}
+          {headerActions}
+        </div>
       </div>
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        className="hidden"
-        onChange={onFileInputChange}
-      />
+      {!isDiffMode && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={onFileInputChange}
+        />
+      )}
 
       <div className="flex-1">
         {fields.length === 0 ? (
-          isProcessingFiles ? (
+          isDiffMode ? null : isProcessingFiles ? (
             <div className="flex h-40 w-full items-center justify-center">
               <Spinner />
             </div>
@@ -142,25 +188,34 @@ export function SkillBuilderFilesSection() {
           )
         ) : (
           <ContextItem.List>
-            {sortedFields.map(({ field, originalIndex }) => (
-              <ContextItem
-                key={field.id}
-                title={
-                  <span className="text-sm font-normal">{field.fileName}</span>
-                }
-                visual={<ContextItem.Visual visual={DocumentIcon} />}
-                hoverAction
-                action={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    icon={XMarkIcon}
-                    size="xs"
-                    onClick={() => remove(originalIndex)}
-                  />
-                }
-              />
-            ))}
+            {sortedFields.map(({ field, originalIndex }) => {
+              const isAdded = isDiffMode && !compareFileIds.has(field.fileId);
+              return (
+                <ContextItem
+                  key={field.id}
+                  title={
+                    <span
+                      className={`text-sm font-normal ${isAdded ? "text-success dark:text-success-night" : ""}`}
+                    >
+                      {field.fileName}
+                    </span>
+                  }
+                  visual={<ContextItem.Visual visual={DocumentIcon} />}
+                  hoverAction={!isDiffMode}
+                  action={
+                    !isDiffMode ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        icon={XMarkIcon}
+                        size="xs"
+                        onClick={() => remove(originalIndex)}
+                      />
+                    ) : undefined
+                  }
+                />
+              );
+            })}
           </ContextItem.List>
         )}
       </div>

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -49,8 +49,7 @@ interface SkillBuilderInstructionsEditorProps {
 export function SkillBuilderInstructionsEditor({
   onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
-  const { compareVersion } = useSkillVersionComparisonContext();
-  const isDiffMode = !!compareVersion;
+  const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { setValue } = useFormContext<SkillBuilderFormData>();
 
   const { field: instructionsField, fieldState: instructionsFieldState } =

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -30,7 +30,7 @@ interface SkillBuilderToolsSectionProps {
 export function SkillBuilderToolsSection({
   extendedSkill,
 }: SkillBuilderToolsSectionProps) {
-  const { getValues, setValue } = useFormContext<SkillBuilderFormData>();
+  const { setValue } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
 
   const { fields, remove, append } = useFieldArray<
@@ -51,7 +51,7 @@ export function SkillBuilderToolsSection({
     []
   );
 
-  const selectedActionsForSheet = getValues("tools");
+  const selectedActionsForSheet = fields;
 
   const handleOpenSheet = () => {
     setSheetMode({ type: "add" });

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -31,8 +31,7 @@ export function SkillBuilderToolsSection({
   extendedSkill,
 }: SkillBuilderToolsSectionProps) {
   const { getValues, setValue } = useFormContext<SkillBuilderFormData>();
-  const { compareVersion } = useSkillVersionComparisonContext();
-  const isDiffMode = !!compareVersion;
+  const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
 
   const { fields, remove, append } = useFieldArray<
     SkillBuilderFormData,

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -1,14 +1,17 @@
 import type { SheetMode } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
 import { MCPServerViewsSheet } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { ActionCard } from "@app/components/shared/tools_picker/ActionCard";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { getSkillIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
+  ArrowGoBackIcon,
   Button,
   CardGrid,
   Chip,
@@ -17,7 +20,7 @@ import {
   ToolsIcon,
 } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 interface SkillBuilderToolsSectionProps {
@@ -27,7 +30,10 @@ interface SkillBuilderToolsSectionProps {
 export function SkillBuilderToolsSection({
   extendedSkill,
 }: SkillBuilderToolsSectionProps) {
-  const { getValues } = useFormContext<SkillBuilderFormData>();
+  const { getValues, setValue } = useFormContext<SkillBuilderFormData>();
+  const { compareVersion } = useSkillVersionComparisonContext();
+  const isDiffMode = !!compareVersion;
+
   const { fields, remove, append } = useFieldArray<
     SkillBuilderFormData,
     "tools"
@@ -38,7 +44,6 @@ export function SkillBuilderToolsSection({
 
   const [sheetMode, setSheetMode] = useState<SheetMode | null>(null);
 
-  // Filter to only show tools that don't require configuration
   const filterNoConfigTools = useCallback(
     (view: MCPServerViewTypeWithLabel) => {
       const requirements = getMCPServerRequirements(view);
@@ -57,7 +62,34 @@ export function SkillBuilderToolsSection({
     setSheetMode({ type: "info", action, source: "addedTool" });
   };
 
-  const headerActions = fields.length > 0 && (
+  const currentToolIds = useMemo(
+    () => new Set(fields.map((f) => f.configuration.mcpServerViewId)),
+    [fields]
+  );
+
+  const compareToolIds = useMemo(
+    () =>
+      compareVersion
+        ? new Set(compareVersion.tools.map((t) => t.sId))
+        : new Set<string>(),
+    [compareVersion]
+  );
+
+  const toolsDiffer =
+    isDiffMode &&
+    (currentToolIds.size !== compareToolIds.size ||
+      [...currentToolIds].some((id) => !compareToolIds.has(id)));
+
+  const restoreTools = () => {
+    if (!compareVersion) {
+      return;
+    }
+    setValue("tools", compareVersion.tools.map(getDefaultMCPAction), {
+      shouldDirty: true,
+    });
+  };
+
+  const headerActions = !isDiffMode && fields.length > 0 && (
     <Button
       type="button"
       onClick={handleOpenSheet}
@@ -83,7 +115,18 @@ export function SkillBuilderToolsSection({
             />
           )}
         </div>
-        {headerActions}
+        <div className="flex items-center gap-2">
+          {toolsDiffer && (
+            <Button
+              variant="outline"
+              size="sm"
+              icon={ArrowGoBackIcon}
+              onClick={restoreTools}
+              label="Restore tools"
+            />
+          )}
+          {headerActions}
+        </div>
       </div>
 
       <div className="flex-1">
@@ -92,40 +135,61 @@ export function SkillBuilderToolsSection({
             <Spinner />
           </div>
         ) : fields.length === 0 ? (
-          <EmptyCTA
-            action={
-              <Button
-                type="button"
-                onClick={handleOpenSheet}
-                label="Add tools"
-                icon={ToolsIcon}
-                variant="outline"
-              />
-            }
-            className="py-8"
-          />
+          isDiffMode ? null : (
+            <EmptyCTA
+              action={
+                <Button
+                  type="button"
+                  onClick={handleOpenSheet}
+                  label="Add tools"
+                  icon={ToolsIcon}
+                  variant="outline"
+                />
+              }
+              className="py-8"
+            />
+          )
         ) : (
           <CardGrid>
-            {fields.map((field, index) => (
-              <ActionCard
-                key={field.id}
-                action={field}
-                onRemove={() => remove(index)}
-                onClick={() => handleClickActionCard(field)}
-              />
-            ))}
+            {fields.map((field, index) => {
+              if (!isDiffMode) {
+                return (
+                  <ActionCard
+                    key={field.id}
+                    action={field}
+                    onRemove={() => remove(index)}
+                    onClick={() => handleClickActionCard(field)}
+                  />
+                );
+              }
+              const isAdded = !compareToolIds.has(
+                field.configuration.mcpServerViewId
+              );
+              if (isAdded) {
+                return (
+                  <ActionCard
+                    key={field.id}
+                    action={field}
+                    diffStatus="added"
+                  />
+                );
+              }
+              return <ActionCard key={field.id} action={field} />;
+            })}
           </CardGrid>
         )}
       </div>
 
-      <MCPServerViewsSheet
-        addTools={append}
-        mode={sheetMode}
-        onModeChange={setSheetMode}
-        selectedActions={selectedActionsForSheet}
-        getAgentInstructions={() => ""}
-        filterMCPServerViews={filterNoConfigTools}
-      />
+      {!isDiffMode && (
+        <MCPServerViewsSheet
+          addTools={append}
+          mode={sheetMode}
+          onModeChange={setSheetMode}
+          selectedActions={selectedActionsForSheet}
+          getAgentInstructions={() => ""}
+          filterMCPServerViews={filterNoConfigTools}
+        />
+      )}
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
@@ -1,19 +1,11 @@
-import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
-import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { SkillVersionHistory } from "@app/components/skill_builder/SkillVersionHistory";
 import type {
   SkillType,
   SkillWithVersionType,
 } from "@app/types/assistant/skill_configuration";
-import {
-  ArrowGoBackIcon,
-  Button,
-  Separator,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
-import { useFormContext } from "react-hook-form";
+import { Button, XMarkIcon } from "@dust-tt/sparkle";
 
 interface SkillVersionHistoryPickerProps {
   skill: SkillType;
@@ -50,46 +42,6 @@ export function SkillVersionHistoryPicker({
           tooltip="Leave comparison mode"
         />
       )}
-    </div>
-  );
-}
-
-export function SkillBuilderVersionComparisonFooter() {
-  const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
-  const { setValue } = useFormContext<SkillBuilderFormData>();
-
-  if (!compareVersion) {
-    return null;
-  }
-
-  const restoreAll = () => {
-    setValue("instructions", compareVersion.instructions ?? "", {
-      shouldDirty: true,
-    });
-    setValue("agentFacingDescription", compareVersion.agentFacingDescription, {
-      shouldDirty: true,
-    });
-    setValue("tools", compareVersion.tools.map(getDefaultMCPAction), {
-      shouldDirty: true,
-    });
-    setValue("fileAttachments", compareVersion.fileAttachments, {
-      shouldDirty: true,
-    });
-    exitDiffMode();
-  };
-
-  return (
-    <div className="space-y-4">
-      <Separator />
-      <div className="flex items-center justify-end">
-        <Button
-          variant="outline"
-          size="sm"
-          icon={ArrowGoBackIcon}
-          onClick={restoreAll}
-          label="Restore all fields from this version"
-        />
-      </div>
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonBanner.tsx
@@ -1,11 +1,19 @@
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { SkillVersionHistory } from "@app/components/skill_builder/SkillVersionHistory";
 import type {
   SkillType,
   SkillWithVersionType,
 } from "@app/types/assistant/skill_configuration";
-import { Button, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  ArrowGoBackIcon,
+  Button,
+  Separator,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useFormContext } from "react-hook-form";
 
 interface SkillVersionHistoryPickerProps {
   skill: SkillType;
@@ -42,6 +50,46 @@ export function SkillVersionHistoryPicker({
           tooltip="Leave comparison mode"
         />
       )}
+    </div>
+  );
+}
+
+export function SkillBuilderVersionComparisonFooter() {
+  const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
+  const { setValue } = useFormContext<SkillBuilderFormData>();
+
+  if (!compareVersion) {
+    return null;
+  }
+
+  const restoreAll = () => {
+    setValue("instructions", compareVersion.instructions ?? "", {
+      shouldDirty: true,
+    });
+    setValue("agentFacingDescription", compareVersion.agentFacingDescription, {
+      shouldDirty: true,
+    });
+    setValue("tools", compareVersion.tools.map(getDefaultMCPAction), {
+      shouldDirty: true,
+    });
+    setValue("fileAttachments", compareVersion.fileAttachments, {
+      shouldDirty: true,
+    });
+    exitDiffMode();
+  };
+
+  return (
+    <div className="space-y-4">
+      <Separator />
+      <div className="flex items-center justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          icon={ArrowGoBackIcon}
+          onClick={restoreAll}
+          label="Restore all fields from this version"
+        />
+      </div>
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderVersionComparisonFooter.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonFooter.tsx
@@ -1,0 +1,45 @@
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import { ArrowGoBackIcon, Button, Separator } from "@dust-tt/sparkle";
+import { useFormContext } from "react-hook-form";
+
+export function SkillBuilderVersionComparisonFooter() {
+  const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
+  const { setValue } = useFormContext<SkillBuilderFormData>();
+
+  if (!compareVersion) {
+    return null;
+  }
+
+  const restoreAll = () => {
+    setValue("instructions", compareVersion.instructions ?? "", {
+      shouldDirty: true,
+    });
+    setValue("agentFacingDescription", compareVersion.agentFacingDescription, {
+      shouldDirty: true,
+    });
+    setValue("tools", compareVersion.tools.map(getDefaultMCPAction), {
+      shouldDirty: true,
+    });
+    setValue("fileAttachments", compareVersion.fileAttachments, {
+      shouldDirty: true,
+    });
+    exitDiffMode();
+  };
+
+  return (
+    <div className="space-y-4">
+      <Separator />
+      <div className="flex items-center justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          icon={ArrowGoBackIcon}
+          onClick={restoreAll}
+          label="Restore all fields from this version"
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderVersionContext.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionContext.tsx
@@ -9,6 +9,7 @@ import {
 
 interface SkillVersionComparisonContextType {
   compareVersion: SkillWithVersionType | null;
+  isDiffMode: boolean;
   enterDiffMode: (version: SkillWithVersionType) => void;
   exitDiffMode: () => void;
 }
@@ -34,9 +35,11 @@ export function SkillVersionComparisonProvider({
     setCompareVersion(null);
   }, []);
 
+  const isDiffMode = compareVersion !== null;
+
   const value = useMemo(
-    () => ({ compareVersion, enterDiffMode, exitDiffMode }),
-    [compareVersion, enterDiffMode, exitDiffMode]
+    () => ({ compareVersion, isDiffMode, enterDiffMode, exitDiffMode }),
+    [compareVersion, isDiffMode, enterDiffMode, exitDiffMode]
   );
 
   return (


### PR DESCRIPTION
## Description

This PR adds full diff mode visualization across all `SkillBuilder` sections (instructions, description, tools, files). When comparing versions, users can now see visual diffs with green highlights for additions and toggle between diff mode and edit mode. Each section includes "Restore" buttons to selectively revert individual fields, plus a footer with "Restore all fields from this version" for bulk restoration.

## Tests

- [x] Locally
- [x] Front-edge

## Risk

Medium - This is an additive feature that only activates when comparing versions shouldn't impact editing mode

## Deploy Plan

Deploy front
