### PR TITLE
[Agent Email] Fix email validation 405 after SPA migration

### DIFF
--- a/front/components/pages/email/ValidationPage.tsx
+++ b/front/components/pages/email/ValidationPage.tsx
@@ -88,7 +88,7 @@ function ConfirmView({ token }: ConfirmViewProps) {
       <form
         ref={formRef}
         method="POST"
-        action="/api/email/validate-action"
+        action={`${config.getApiBaseUrl()}/api/email/validate-action`}
         style={{ display: "none" }}
       >
         <input type="hidden" name="token" value={token} />


### PR DESCRIPTION
## Description

Fixes regression from https://github.com/dust-tt/dust/pull/22570 which moved the email validation page to the SPA.

The validation page's hidden form used a relative URL (`/api/email/validate-action`), which worked when the page was served by Next.js on `dust.tt`. After the SPA migration, the page is served from `app.dust.tt`, so the POST goes to `app.dust.tt/api/email/validate-action` — which doesn't exist, causing a 405.

Fix: use `config.getApiBaseUrl()` for an absolute URL, matching the pattern used by other SPA pages (login, logout).

## Risks

Blast radius: email tool validation approve/reject links
Risk: none — one-liner fix, aligns with existing SPA patterns

## Deploy Plan
- pmrr
- Deploy front