### PR TITLE
[front] add UI entry points for importing skills

### DIFF
--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -98,7 +98,11 @@ export const CreateDropdown = ({
             <>
               <DropdownMenuLabel label="Skills" />
               <DropdownMenuItem
-                label="skill from scratch"
+                label={
+                  hasFeature("sandbox_tools")
+                    ? "skill from scratch"
+                    : "skill"
+                }
                 icon={PuzzleIcon}
                 onClick={withTracking(
                   TRACKING_AREAS.BUILDER,
@@ -109,11 +113,13 @@ export const CreateDropdown = ({
                   }
                 )}
               />
-              <DropdownMenuItem
-                label="skill from existing"
-                icon={FolderOpenIcon}
-                onClick={() => setIsImportSkillDialogOpen(true)}
-              />
+              {hasFeature("sandbox_tools") && (
+                <DropdownMenuItem
+                  label="skill from existing"
+                  icon={FolderOpenIcon}
+                  onClick={() => setIsImportSkillDialogOpen(true)}
+                />
+              )}
             </>
           )}
         </DropdownMenuContent>

--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -44,90 +44,88 @@ export const CreateDropdown = ({
   const { hasFeature } = useFeatureFlags();
 
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="primary"
-            icon={PlusIcon}
-            label="Create"
-            data-gtm-label="assistantCreationButton"
-            data-gtm-location={dataGtmLocation}
-            onClick={withTracking(TRACKING_AREAS.BUILDER, "create_menu")}
-            size="sm"
-            isSelect
-            isLoading={isLoading}
-            disabled={isLoading}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          {isBuilder(owner) && <DropdownMenuLabel label="Agents" />}
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="primary"
+          icon={PlusIcon}
+          label="Create"
+          data-gtm-label="assistantCreationButton"
+          data-gtm-location={dataGtmLocation}
+          onClick={withTracking(TRACKING_AREAS.BUILDER, "create_menu")}
+          size="sm"
+          isSelect
+          isLoading={isLoading}
+          disabled={isLoading}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {isBuilder(owner) && <DropdownMenuLabel label="Agents" />}
+        <DropdownMenuItem
+          label="agent from scratch"
+          icon={DocumentIcon}
+          onClick={withTracking(
+            TRACKING_AREAS.BUILDER,
+            "create_from_scratch",
+            () => {
+              setIsLoading(true);
+              void router.push(getAgentBuilderRoute(owner.sId, "new"));
+            }
+          )}
+        />
+        <DropdownMenuItem
+          label="agent from template"
+          icon={MagicIcon}
+          onClick={withTracking(
+            TRACKING_AREAS.BUILDER,
+            "create_from_template",
+            () => {
+              setIsLoading(true);
+              void router.push(getAgentBuilderRoute(owner.sId, "create"));
+            }
+          )}
+        />
+        {hasFeature("agent_to_yaml") && (
           <DropdownMenuItem
-            label="agent from scratch"
-            icon={DocumentIcon}
-            onClick={withTracking(
-              TRACKING_AREAS.BUILDER,
-              "create_from_scratch",
-              () => {
-                setIsLoading(true);
-                void router.push(getAgentBuilderRoute(owner.sId, "new"));
-              }
-            )}
+            label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
+            icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpenIcon}
+            disabled={isUploadingYAML}
+            onClick={triggerYAMLUpload}
           />
-          <DropdownMenuItem
-            label="agent from template"
-            icon={MagicIcon}
-            onClick={withTracking(
-              TRACKING_AREAS.BUILDER,
-              "create_from_template",
-              () => {
-                setIsLoading(true);
-                void router.push(getAgentBuilderRoute(owner.sId, "create"));
-              }
-            )}
-          />
-          {hasFeature("agent_to_yaml") && (
+        )}
+        {isBuilder(owner) && (
+          <>
+            <DropdownMenuLabel label="Skills" />
             <DropdownMenuItem
-              label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
-              icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpenIcon}
-              disabled={isUploadingYAML}
-              onClick={triggerYAMLUpload}
-            />
-          )}
-          {isBuilder(owner) && (
-            <>
-              <DropdownMenuLabel label="Skills" />
-              <DropdownMenuItem
-                label={
-                  hasFeature("sandbox_tools") ? "skill from scratch" : "skill"
+              label={
+                hasFeature("sandbox_tools") ? "skill from scratch" : "skill"
+              }
+              icon={PuzzleIcon}
+              onClick={withTracking(
+                TRACKING_AREAS.BUILDER,
+                "create_skill",
+                () => {
+                  setIsLoading(true);
+                  void router.push(getSkillBuilderRoute(owner.sId, "new"));
                 }
-                icon={PuzzleIcon}
-                onClick={withTracking(
-                  TRACKING_AREAS.BUILDER,
-                  "create_skill",
-                  () => {
-                    setIsLoading(true);
-                    void router.push(getSkillBuilderRoute(owner.sId, "new"));
-                  }
-                )}
-              />
-              {hasFeature("sandbox_tools") && (
-                <DropdownMenuItem
-                  label="skill from existing"
-                  icon={FolderOpenIcon}
-                  onClick={() => setIsImportSkillDialogOpen(true)}
-                />
               )}
-            </>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            />
+            {hasFeature("sandbox_tools") && (
+              <DropdownMenuItem
+                label="skill from existing"
+                icon={FolderOpenIcon}
+                onClick={() => setIsImportSkillDialogOpen(true)}
+              />
+            )}
+          </>
+        )}
+      </DropdownMenuContent>
       {isImportSkillDialogOpen && (
         <ImportSkillsDialog
           onClose={() => setIsImportSkillDialogOpen(false)}
           owner={owner}
         />
       )}
-    </>
+    </DropdownMenu>
   );
 };

--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -1,3 +1,4 @@
+import { ImportSkillsDialog } from "@app/components/skills/ImportSkillsDialog";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
@@ -35,6 +36,7 @@ export const CreateDropdown = ({
 }: CreateDropdownProps) => {
   const router = useAppRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const [isImportSkillDialogOpen, setIsImportSkillDialogOpen] = useState(false);
   const { isUploading: isUploadingYAML, triggerYAMLUpload } = useYAMLUpload({
     owner,
   });
@@ -42,73 +44,86 @@ export const CreateDropdown = ({
   const { hasFeature } = useFeatureFlags();
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="primary"
-          icon={PlusIcon}
-          label="Create"
-          data-gtm-label="assistantCreationButton"
-          data-gtm-location={dataGtmLocation}
-          onClick={withTracking(TRACKING_AREAS.BUILDER, "create_menu")}
-          size="sm"
-          isSelect
-          isLoading={isLoading}
-          disabled={isLoading}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {isBuilder(owner) && <DropdownMenuLabel label="Agents" />}
-        <DropdownMenuItem
-          label="agent from scratch"
-          icon={DocumentIcon}
-          onClick={withTracking(
-            TRACKING_AREAS.BUILDER,
-            "create_from_scratch",
-            () => {
-              setIsLoading(true);
-              void router.push(getAgentBuilderRoute(owner.sId, "new"));
-            }
-          )}
-        />
-        <DropdownMenuItem
-          label="agent from template"
-          icon={MagicIcon}
-          onClick={withTracking(
-            TRACKING_AREAS.BUILDER,
-            "create_from_template",
-            () => {
-              setIsLoading(true);
-              void router.push(getAgentBuilderRoute(owner.sId, "create"));
-            }
-          )}
-        />
-        {hasFeature("agent_to_yaml") && (
-          <DropdownMenuItem
-            label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
-            icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpenIcon}
-            disabled={isUploadingYAML}
-            onClick={triggerYAMLUpload}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="primary"
+            icon={PlusIcon}
+            label="Create"
+            data-gtm-label="assistantCreationButton"
+            data-gtm-location={dataGtmLocation}
+            onClick={withTracking(TRACKING_AREAS.BUILDER, "create_menu")}
+            size="sm"
+            isSelect
+            isLoading={isLoading}
+            disabled={isLoading}
           />
-        )}
-        {isBuilder(owner) && (
-          <>
-            <DropdownMenuLabel label="Skills" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {isBuilder(owner) && <DropdownMenuLabel label="Agents" />}
+          <DropdownMenuItem
+            label="agent from scratch"
+            icon={DocumentIcon}
+            onClick={withTracking(
+              TRACKING_AREAS.BUILDER,
+              "create_from_scratch",
+              () => {
+                setIsLoading(true);
+                void router.push(getAgentBuilderRoute(owner.sId, "new"));
+              }
+            )}
+          />
+          <DropdownMenuItem
+            label="agent from template"
+            icon={MagicIcon}
+            onClick={withTracking(
+              TRACKING_AREAS.BUILDER,
+              "create_from_template",
+              () => {
+                setIsLoading(true);
+                void router.push(getAgentBuilderRoute(owner.sId, "create"));
+              }
+            )}
+          />
+          {hasFeature("agent_to_yaml") && (
             <DropdownMenuItem
-              label="skill"
-              icon={PuzzleIcon}
-              onClick={withTracking(
-                TRACKING_AREAS.BUILDER,
-                "create_skill",
-                () => {
-                  setIsLoading(true);
-                  void router.push(getSkillBuilderRoute(owner.sId, "new"));
-                }
-              )}
+              label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
+              icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpenIcon}
+              disabled={isUploadingYAML}
+              onClick={triggerYAMLUpload}
             />
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          )}
+          {isBuilder(owner) && (
+            <>
+              <DropdownMenuLabel label="Skills" />
+              <DropdownMenuItem
+                label="skill from scratch"
+                icon={PuzzleIcon}
+                onClick={withTracking(
+                  TRACKING_AREAS.BUILDER,
+                  "create_skill",
+                  () => {
+                    setIsLoading(true);
+                    void router.push(getSkillBuilderRoute(owner.sId, "new"));
+                  }
+                )}
+              />
+              <DropdownMenuItem
+                label="skill from existing"
+                icon={FolderOpenIcon}
+                onClick={() => setIsImportSkillDialogOpen(true)}
+              />
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {isImportSkillDialogOpen && (
+        <ImportSkillsDialog
+          onClose={() => setIsImportSkillDialogOpen(false)}
+          owner={owner}
+        />
+      )}
+    </>
   );
 };

--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -99,9 +99,7 @@ export const CreateDropdown = ({
               <DropdownMenuLabel label="Skills" />
               <DropdownMenuItem
                 label={
-                  hasFeature("sandbox_tools")
-                    ? "skill from scratch"
-                    : "skill"
+                  hasFeature("sandbox_tools") ? "skill from scratch" : "skill"
                 }
                 icon={PuzzleIcon}
                 onClick={withTracking(

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -5,6 +5,7 @@ import {
 import { CreateProjectModal } from "@app/components/assistant/conversation/CreateProjectModal";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { AcademyBanner } from "@app/components/assistant/conversation/InAppBanner";
+import { ImportSkillsDialog } from "@app/components/skills/ImportSkillsDialog";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { ProjectsBrowsePopover } from "@app/components/assistant/conversation/sidebar/ProjectsBrowsePopover";
 import { renderProjectsList } from "@app/components/assistant/conversation/sidebar/ProjectsList";
@@ -62,6 +63,7 @@ import {
   cn,
   DocumentIcon,
   DropdownMenu,
+  FolderOpenIcon,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -482,6 +484,8 @@ export function AgentSidebarMenu({
   const [titleFilter, setTitleFilter] = useState<string>("");
   const [isCreateProjectModalOpen, setIsCreateProjectModalOpen] =
     useState(false);
+  const [isImportSkillDialogOpen, setIsImportSkillDialogOpen] =
+    useState(false);
 
   const {
     projects: allProjects,
@@ -774,6 +778,12 @@ export function AgentSidebarMenu({
         onClose={() => setIsCreateProjectModalOpen(false)}
         owner={owner}
       />
+      {isImportSkillDialogOpen && (
+        <ImportSkillsDialog
+          onClose={() => setIsImportSkillDialogOpen(false)}
+          owner={owner}
+        />
+      )}
       <div className="flex grow flex-col">
         <div className="flex h-0 min-h-full w-full">
           <div className="flex w-full flex-col">
@@ -943,11 +953,31 @@ export function AgentSidebarMenu({
                         {isBuilder(owner) && (
                           <>
                             <DropdownMenuLabel>Skills</DropdownMenuLabel>
-                            <DropdownMenuItem
-                              href={getSkillBuilderRoute(owner.sId, "new")}
-                              icon={PlusIcon}
-                              label="New skill"
-                            />
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger
+                                icon={PlusIcon}
+                                label="New skill"
+                              />
+                              <DropdownMenuPortal>
+                                <DropdownMenuSubContent className="pointer-events-auto">
+                                  <DropdownMenuItem
+                                    href={getSkillBuilderRoute(
+                                      owner.sId,
+                                      "new"
+                                    )}
+                                    icon={SKILL_ICON}
+                                    label="From scratch"
+                                  />
+                                  <DropdownMenuItem
+                                    icon={FolderOpenIcon}
+                                    label="From existing"
+                                    onClick={() =>
+                                      setIsImportSkillDialogOpen(true)
+                                    }
+                                  />
+                                </DropdownMenuSubContent>
+                              </DropdownMenuPortal>
+                            </DropdownMenuSub>
                             <DropdownMenuItem
                               href={getSkillBuilderRoute(owner.sId, "manage")}
                               icon={SKILL_ICON}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -953,31 +953,39 @@ export function AgentSidebarMenu({
                         {isBuilder(owner) && (
                           <>
                             <DropdownMenuLabel>Skills</DropdownMenuLabel>
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger
+                            {hasFeature("sandbox_tools") ? (
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger
+                                  icon={PlusIcon}
+                                  label="New skill"
+                                />
+                                <DropdownMenuPortal>
+                                  <DropdownMenuSubContent className="pointer-events-auto">
+                                    <DropdownMenuItem
+                                      href={getSkillBuilderRoute(
+                                        owner.sId,
+                                        "new"
+                                      )}
+                                      icon={SKILL_ICON}
+                                      label="From scratch"
+                                    />
+                                    <DropdownMenuItem
+                                      icon={FolderOpenIcon}
+                                      label="From existing"
+                                      onClick={() =>
+                                        setIsImportSkillDialogOpen(true)
+                                      }
+                                    />
+                                  </DropdownMenuSubContent>
+                                </DropdownMenuPortal>
+                              </DropdownMenuSub>
+                            ) : (
+                              <DropdownMenuItem
+                                href={getSkillBuilderRoute(owner.sId, "new")}
                                 icon={PlusIcon}
                                 label="New skill"
                               />
-                              <DropdownMenuPortal>
-                                <DropdownMenuSubContent className="pointer-events-auto">
-                                  <DropdownMenuItem
-                                    href={getSkillBuilderRoute(
-                                      owner.sId,
-                                      "new"
-                                    )}
-                                    icon={SKILL_ICON}
-                                    label="From scratch"
-                                  />
-                                  <DropdownMenuItem
-                                    icon={FolderOpenIcon}
-                                    label="From existing"
-                                    onClick={() =>
-                                      setIsImportSkillDialogOpen(true)
-                                    }
-                                  />
-                                </DropdownMenuSubContent>
-                              </DropdownMenuPortal>
-                            </DropdownMenuSub>
+                            )}
                             <DropdownMenuItem
                               href={getSkillBuilderRoute(owner.sId, "manage")}
                               icon={SKILL_ICON}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -958,25 +958,23 @@ export function AgentSidebarMenu({
                                   icon={PlusIcon}
                                   label="New skill"
                                 />
-                                <DropdownMenuPortal>
-                                  <DropdownMenuSubContent className="pointer-events-auto">
-                                    <DropdownMenuItem
-                                      href={getSkillBuilderRoute(
-                                        owner.sId,
-                                        "new"
-                                      )}
-                                      icon={SKILL_ICON}
-                                      label="From scratch"
-                                    />
-                                    <DropdownMenuItem
-                                      icon={FolderOpenIcon}
-                                      label="From existing"
-                                      onClick={() =>
-                                        setIsImportSkillDialogOpen(true)
-                                      }
-                                    />
-                                  </DropdownMenuSubContent>
-                                </DropdownMenuPortal>
+                                <DropdownMenuSubContent>
+                                  <DropdownMenuItem
+                                    href={getSkillBuilderRoute(
+                                      owner.sId,
+                                      "new"
+                                    )}
+                                    icon={SKILL_ICON}
+                                    label="From scratch"
+                                  />
+                                  <DropdownMenuItem
+                                    icon={FolderOpenIcon}
+                                    label="From existing"
+                                    onClick={() =>
+                                      setIsImportSkillDialogOpen(true)
+                                    }
+                                  />
+                                </DropdownMenuSubContent>
                               </DropdownMenuSub>
                             ) : (
                               <DropdownMenuItem

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -5,7 +5,6 @@ import {
 import { CreateProjectModal } from "@app/components/assistant/conversation/CreateProjectModal";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { AcademyBanner } from "@app/components/assistant/conversation/InAppBanner";
-import { ImportSkillsDialog } from "@app/components/skills/ImportSkillsDialog";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { ProjectsBrowsePopover } from "@app/components/assistant/conversation/sidebar/ProjectsBrowsePopover";
 import { renderProjectsList } from "@app/components/assistant/conversation/sidebar/ProjectsList";
@@ -16,6 +15,7 @@ import {
   getGroupConversationsByUnreadAndActionRequired,
 } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
+import { ImportSkillsDialog } from "@app/components/skills/ImportSkillsDialog";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import {
   useConversations,
@@ -63,7 +63,6 @@ import {
   cn,
   DocumentIcon,
   DropdownMenu,
-  FolderOpenIcon,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -73,6 +72,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  FolderOpenIcon,
   Label,
   ListCheckIcon,
   MagicIcon,
@@ -484,8 +484,7 @@ export function AgentSidebarMenu({
   const [titleFilter, setTitleFilter] = useState<string>("");
   const [isCreateProjectModalOpen, setIsCreateProjectModalOpen] =
     useState(false);
-  const [isImportSkillDialogOpen, setIsImportSkillDialogOpen] =
-    useState(false);
+  const [isImportSkillDialogOpen, setIsImportSkillDialogOpen] = useState(false);
 
   const {
     projects: allProjects,

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -258,11 +258,7 @@ export function ManageSkillsPage() {
             {hasFeature("sandbox_tools") ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button
-                    label="Create skill"
-                    icon={PlusIcon}
-                    isSelect
-                  />
+                  <Button label="Create skill" icon={PlusIcon} isSelect />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                   <DropdownMenuItem

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -12,6 +12,7 @@ import {
 import { useHashParam } from "@app/hooks/useHashParams";
 import {
   useAuth,
+  useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { SKILL_ICON } from "@app/lib/skill";
@@ -87,6 +88,7 @@ function sortSkillsByName(skills: SkillWithRelationsType[]) {
 export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -253,27 +255,36 @@ export function ManageSkillsPage() {
                 setSkillSearch(s);
               }}
             />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  label="Create skill"
-                  icon={PlusIcon}
-                  isSelect
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem
-                  label="From scratch"
-                  icon={SKILL_ICON}
-                  href={getSkillBuilderRoute(owner.sId, "new")}
-                />
-                <DropdownMenuItem
-                  label="From existing"
-                  icon={FolderOpenIcon}
-                  onClick={() => setIsImportDialogOpen(true)}
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
+            {hasFeature("sandbox_tools") ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    label="Create skill"
+                    icon={PlusIcon}
+                    isSelect
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    label="From scratch"
+                    icon={SKILL_ICON}
+                    href={getSkillBuilderRoute(owner.sId, "new")}
+                  />
+                  <DropdownMenuItem
+                    label="From existing"
+                    icon={FolderOpenIcon}
+                    onClick={() => setIsImportDialogOpen(true)}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <Button
+                label="Create skill"
+                href={getSkillBuilderRoute(owner.sId, "new")}
+                icon={PlusIcon}
+                tooltip="Create a new skill"
+              />
+            )}
           </div>
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -12,7 +12,6 @@ import {
 import { useHashParam } from "@app/hooks/useHashParams";
 import {
   useAuth,
-  useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { SKILL_ICON } from "@app/lib/skill";
@@ -22,8 +21,12 @@ import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
-  ArrowDownOnSquareIcon,
   Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  FolderOpenIcon,
   MagnifyingGlassIcon,
   Page,
   PlusIcon,
@@ -84,8 +87,6 @@ function sortSkillsByName(skills: SkillWithRelationsType[]) {
 export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
-  const { hasFeature } = useFeatureFlags();
-
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -252,21 +253,27 @@ export function ManageSkillsPage() {
                 setSkillSearch(s);
               }}
             />
-            {hasFeature("sandbox_tools") && (
-              <Button
-                label="Import skill"
-                variant="outline"
-                icon={ArrowDownOnSquareIcon}
-                tooltip="Import skills from a GitHub repository"
-                onClick={() => setIsImportDialogOpen(true)}
-              />
-            )}
-            <Button
-              label="Create skill"
-              href={getSkillBuilderRoute(owner.sId, "new")}
-              icon={PlusIcon}
-              tooltip="Create a new skill"
-            />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  label="Create skill"
+                  icon={PlusIcon}
+                  isSelect
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  label="From scratch"
+                  icon={SKILL_ICON}
+                  href={getSkillBuilderRoute(owner.sId, "new")}
+                />
+                <DropdownMenuItem
+                  label="From existing"
+                  icon={FolderOpenIcon}
+                  onClick={() => setIsImportDialogOpen(true)}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7018
- This PR implements the Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=3676-82836&t=LndAkHsklvDecDIF-0), specifically to add all the buttons that will be used to allowing importing skills from a GitHub repo/a local zip file.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
