### PR TITLE
[front] feat: mount skill files in sandbox

### DIFF
--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -9,6 +9,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { buffer } from "node:stream/consumers";
 
 const SKILLS_BASE_PATH = "/skills";
 
@@ -110,14 +111,8 @@ async function loadSkillFilesToSandbox(
     const fileName = file.fileName ?? `file_${file.sId}`;
     const targetPath = `${SKILLS_BASE_PATH}/${skill.name}/${fileName}`;
 
-    // Always get the original for the sandbox.
     const readStream = file.getReadStream({ auth, version: "original" });
-
-    const chunks: Buffer[] = [];
-    for await (const chunk of readStream) {
-      chunks.push(chunk);
-    }
-    const content = Buffer.concat(chunks);
+    const content = await buffer(readStream);
 
     const writeResult = await sandbox.writeFile(targetPath, content);
     if (writeResult.isErr()) {

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -52,8 +52,6 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
     const owner = auth.getNonNullableWorkspace();
     const featureFlags = await getFeatureFlags(owner);
 
-    let fileMessage: string | null = null;
-
     if (!featureFlags.includes("sandbox_tools")) {
       return new Ok([
         {
@@ -65,15 +63,14 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
     const ensureResult = await SandboxResource.ensureActive(auth, conversation);
     if (ensureResult.isErr()) {
-      return new Err(
-        new MCPError(ensureResult.error.message, { tracked: false })
-      );
+      return new Err(new MCPError(ensureResult.error.message));
     }
+
     const { sandbox } = ensureResult.value;
 
+    let fileMessage: string | null = null;
     const fileLoadResult = await sandbox.loadSkillFiles(auth, skill);
 
-    let fileMessage: string | null = null;
     // We don't say anything if there are no files to load.
     if (fileLoadResult.isOk() && fileLoadResult.value.loadedPaths.length > 0) {
       fileMessage =

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -6,6 +6,8 @@ import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/sk
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
+const SKILLS_BASE_PATH = "/skills";
+
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
   [ENABLE_SKILL_TOOL_NAME]: async (
     { skillName },
@@ -39,15 +41,90 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
     const { alreadyEnabled } = enableResult.value;
 
+    if (alreadyEnabled) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Skill "${skill.name}" was already enabled. No action taken.`,
+        },
+      ]);
+    }
+
+    // Load skill file attachments to the sandbox.
+    const fileLoadResult = await loadSkillFilesToSandbox(auth, {
+      skill,
+      conversation,
+    });
+
+    let fileMessage: string | null = null;
+    // We don't say anything if there are no files to load.
+    if (fileLoadResult.isOk() && fileLoadResult.value.loadedPaths.length > 0) {
+      fileMessage =
+        "Skill files successfully loaded:\n" +
+        fileLoadResult.value.loadedPaths.map((p) => `  - ${p}`).join("\n");
+    } else if (fileLoadResult.isErr()) {
+      fileMessage = `Failed to load skill files: ${fileLoadResult.error.message}`;
+    }
+
     return new Ok([
       {
         type: "text" as const,
-        text: alreadyEnabled
-          ? `Skill "${skill.name}" was already enabled. No action taken.`
-          : `Skill "${skill.name}" has been enabled.`,
+        text:
+          `Skill "${skill.name}" has been enabled.` +
+          (fileMessage ? `\n\n${fileMessage}` : ""),
       },
     ]);
   },
 };
+
+/**
+ * Load a skill's file attachments onto the conversation's sandbox.
+ * Files are written to /files/skills/{skillName}/{fileName}.
+ */
+async function loadSkillFilesToSandbox(
+  auth: Authenticator,
+  {
+    skill,
+    conversation,
+  }: {
+    skill: SkillResource;
+    conversation: ConversationType;
+  }
+): Promise<Result<{ loadedPaths: string[] }, Error>> {
+  const fileAttachments = skill.getFileAttachments();
+  if (fileAttachments.length === 0) {
+    return new Ok({ loadedPaths: [] });
+  }
+
+  const ensureResult = await SandboxResource.ensureActive(auth, conversation);
+  if (ensureResult.isErr()) {
+    return ensureResult;
+  }
+  const { sandbox } = ensureResult.value;
+
+  const loadedPaths: string[] = [];
+
+  for (const file of fileAttachments) {
+    const fileName = file.fileName ?? `file_${file.sId}`;
+    const targetPath = `${SKILLS_BASE_PATH}/${skill.name}/${fileName}`;
+
+    const readStream = file.getReadStream({ auth, version: "original" });
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of readStream) {
+      chunks.push(chunk);
+    }
+    const content = Buffer.concat(chunks);
+
+    const writeResult = await sandbox.writeFile(auth, targetPath, content);
+    if (writeResult.isErr()) {
+      return writeResult;
+    }
+
+    loadedPaths.push(targetPath);
+  }
+
+  return new Ok({ loadedPaths });
+}
 
 export const TOOLS = buildTools(SKILL_MANAGEMENT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -112,6 +112,7 @@ async function loadSkillFilesToSandbox(
     const fileName = file.fileName ?? `file_${file.sId}`;
     const targetPath = `${SKILLS_BASE_PATH}/${skill.name}/${fileName}`;
 
+    // Always get the original for the sandbox.
     const readStream = file.getReadStream({ auth, version: "original" });
 
     const chunks: Buffer[] = [];

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -121,7 +121,7 @@ async function loadSkillFilesToSandbox(
     }
     const content = Buffer.concat(chunks);
 
-    const writeResult = await sandbox.writeFile(auth, targetPath, content);
+    const writeResult = await sandbox.writeFile(targetPath, content);
     if (writeResult.isErr()) {
       return writeResult;
     }

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -1,3 +1,4 @@
+import { buffer } from "node:stream/consumers";
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -9,7 +10,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { buffer } from "node:stream/consumers";
 
 const SKILLS_BASE_PATH = "/skills";
 

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -43,9 +43,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       );
     }
 
-    const { alreadyEnabled } = enableResult.value;
-
-    if (alreadyEnabled) {
+    if (enableResult.value.alreadyEnabled) {
       return new Ok([
         {
           type: "text" as const,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -49,8 +49,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
     }
 
     // Load skill file attachments to the sandbox (behind feature flag).
-    const owner = auth.getNonNullableWorkspace();
-    const featureFlags = await getFeatureFlags(owner);
+    const featureFlags = await getFeatureFlags(auth);
 
     if (
       !featureFlags.includes("sandbox_tools") ||

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -3,6 +3,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/skill_management/metadata";
+import { getFeatureFlags } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { Err, Ok } from "@app/types/shared/result";
@@ -47,7 +48,21 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       ]);
     }
 
-    // Load skill file attachments to the sandbox.
+    // Load skill file attachments to the sandbox (behind feature flag).
+    const owner = auth.getNonNullableWorkspace();
+    const featureFlags = await getFeatureFlags(owner);
+
+    let fileMessage: string | null = null;
+
+    if (!featureFlags.includes("sandbox_tools")) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Skill "${skill.name}" has been enabled.`,
+        },
+      ]);
+    }
+
     const ensureResult = await SandboxResource.ensureActive(auth, conversation);
     if (ensureResult.isErr()) {
       return new Err(

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -52,7 +52,10 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
     const owner = auth.getNonNullableWorkspace();
     const featureFlags = await getFeatureFlags(owner);
 
-    if (!featureFlags.includes("sandbox_tools")) {
+    if (
+      !featureFlags.includes("sandbox_tools") ||
+      skill.getFileAttachments().length === 0) {
+    
       return new Ok([
         {
           type: "text" as const,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -1,18 +1,11 @@
-import type { ReadableStream } from "node:stream/web";
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/skill_management/metadata";
-import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { ConversationType } from "@app/types/assistant/conversation";
-import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { Readable } from "stream";
-
-const SKILLS_BASE_PATH = "/skills";
 
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
   [ENABLE_SKILL_TOOL_NAME]: async (
@@ -55,10 +48,15 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
     }
 
     // Load skill file attachments to the sandbox.
-    const fileLoadResult = await loadSkillFilesToSandbox(auth, {
-      skill,
-      conversation,
-    });
+    const ensureResult = await SandboxResource.ensureActive(auth, conversation);
+    if (ensureResult.isErr()) {
+      return new Err(
+        new MCPError(ensureResult.error.message, { tracked: false })
+      );
+    }
+    const { sandbox } = ensureResult.value;
+
+    const fileLoadResult = await sandbox.loadSkillFiles(auth, skill);
 
     let fileMessage: string | null = null;
     // We don't say anything if there are no files to load.
@@ -80,50 +78,5 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
     ]);
   },
 };
-
-/**
- * Load a skill's file attachments onto the conversation's sandbox.
- * Files are written under /skills/{skillName}.
- */
-async function loadSkillFilesToSandbox(
-  auth: Authenticator,
-  {
-    skill,
-    conversation,
-  }: {
-    skill: SkillResource;
-    conversation: ConversationType;
-  }
-): Promise<Result<{ loadedPaths: string[] }, Error>> {
-  const fileAttachments = skill.getFileAttachments();
-  if (fileAttachments.length === 0) {
-    return new Ok({ loadedPaths: [] });
-  }
-
-  const ensureResult = await SandboxResource.ensureActive(auth, conversation);
-  if (ensureResult.isErr()) {
-    return ensureResult;
-  }
-  const { sandbox } = ensureResult.value;
-
-  const loadedPaths: string[] = [];
-
-  for (const file of fileAttachments) {
-    const fileName = file.fileName ?? `file_${file.sId}`;
-    const targetPath = `${SKILLS_BASE_PATH}/${skill.name}/${fileName}`;
-
-    const readStream = file.getReadStream({ auth, version: "original" });
-    const readable: ReadableStream = Readable.toWeb(readStream);
-
-    const writeResult = await sandbox.writeFile(targetPath, readable);
-    if (writeResult.isErr()) {
-      return writeResult;
-    }
-
-    loadedPaths.push(targetPath);
-  }
-
-  return new Ok({ loadedPaths });
-}
 
 export const TOOLS = buildTools(SKILL_MANAGEMENT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -1,4 +1,4 @@
-import { buffer } from "node:stream/consumers";
+import type { ReadableStream } from "node:stream/web";
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -10,6 +10,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { Readable } from "stream";
 
 const SKILLS_BASE_PATH = "/skills";
 
@@ -112,9 +113,9 @@ async function loadSkillFilesToSandbox(
     const targetPath = `${SKILLS_BASE_PATH}/${skill.name}/${fileName}`;
 
     const readStream = file.getReadStream({ auth, version: "original" });
-    const content = await buffer(readStream);
+    const readable: ReadableStream = Readable.toWeb(readStream);
 
-    const writeResult = await sandbox.writeFile(targetPath, content);
+    const writeResult = await sandbox.writeFile(targetPath, readable);
     if (writeResult.isErr()) {
       return writeResult;
     }

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -54,8 +54,8 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
     if (
       !featureFlags.includes("sandbox_tools") ||
-      skill.getFileAttachments().length === 0) {
-    
+      skill.getFileAttachments().length === 0
+    ) {
       return new Ok([
         {
           type: "text" as const,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -3,7 +3,11 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/skill_management/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 const SKILLS_BASE_PATH = "/skills";
@@ -79,7 +83,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
 /**
  * Load a skill's file attachments onto the conversation's sandbox.
- * Files are written to /files/skills/{skillName}/{fileName}.
+ * Files are written under /skills/{skillName}.
  */
 async function loadSkillFilesToSandbox(
   auth: Authenticator,

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -159,6 +159,7 @@ SHELLEOF`)
         "sudo mv /tmp/dsbx /opt/bin/dsbx",
     }
   )
+  .runCmd("sudo mkdir -p /skills && sudo chmod 755 /skills")
   .registerTool(
     {
       name: "apply_patch",

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -7,7 +7,6 @@
  * adapter.
  */
 
-import type { ReadableStream } from "node:stream/web";
 import type {
   NetworkPolicy,
   SandboxImageId,
@@ -112,7 +111,7 @@ export interface SandboxProvider {
   writeFile(
     providerId: string,
     path: string,
-    stream: ReadableStream
+    data: ArrayBuffer
   ): Promise<Result<void, Error>>;
 
   readFile(providerId: string, path: string): Promise<Buffer>;

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -108,7 +108,11 @@ export interface SandboxProvider {
     opts?: ExecOptions
   ): Promise<Result<ExecResult, Error>>;
 
-  writeFile(providerId: string, path: string, content: Buffer): Promise<void>;
+  writeFile(
+    providerId: string,
+    path: string,
+    content: Buffer
+  ): Promise<Result<void, Error>>;
 
   readFile(providerId: string, path: string): Promise<Buffer>;
 

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -111,7 +111,7 @@ export interface SandboxProvider {
   writeFile(
     providerId: string,
     path: string,
-    data: ReadableStream
+    data: ArrayBuffer
   ): Promise<Result<void, Error>>;
 
   readFile(providerId: string, path: string): Promise<Buffer>;

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -111,7 +111,7 @@ export interface SandboxProvider {
   writeFile(
     providerId: string,
     path: string,
-    data: ArrayBuffer
+    data: ReadableStream
   ): Promise<Result<void, Error>>;
 
   readFile(providerId: string, path: string): Promise<Buffer>;

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -7,6 +7,7 @@
  * adapter.
  */
 
+import type { ReadableStream } from "node:stream/web";
 import type {
   NetworkPolicy,
   SandboxImageId,
@@ -111,7 +112,7 @@ export interface SandboxProvider {
   writeFile(
     providerId: string,
     path: string,
-    content: Buffer
+    stream: ReadableStream
   ): Promise<Result<void, Error>>;
 
   readFile(providerId: string, path: string): Promise<Buffer>;

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -240,8 +240,12 @@ export class E2BSandboxProvider implements SandboxProvider {
       return new Err(normalizeError(err));
     }
 
-    // This automatically creates the necessary directory structure if needed.
-    await sandbox.files.write(path, content.toString("utf-8"));
+    try {
+      // E2B automatically creates the necessary directory structure.
+      await sandbox.files.write(path, new Uint8Array(content).buffer);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
 
     return new Ok(undefined);
   }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -225,7 +225,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   async writeFile(
     providerId: string,
     path: string,
-    data: ArrayBuffer
+    data: ReadableStream
   ): Promise<Result<void, Error>> {
     let sandbox: Sandbox;
     try {

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -241,7 +241,10 @@ export class E2BSandboxProvider implements SandboxProvider {
     }
 
     try {
-      // E2B automatically creates the necessary directory structure.
+      // We cannot use Node's Buffer directly as it shares a large pooled
+      // ArrayBuffer and buffer.buffer would send the entire pool, hence
+      // the copy into a fresh area of memory here.
+      // Note: this creates the necessary directories if missing.
       await sandbox.files.write(path, new Uint8Array(content).buffer);
     } catch (err) {
       return new Err(normalizeError(err));

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,4 +1,3 @@
-import type { ReadableStream } from "node:stream/web";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -226,7 +225,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   async writeFile(
     providerId: string,
     path: string,
-    stream: ReadableStream
+    data: ArrayBuffer
   ): Promise<Result<void, Error>> {
     let sandbox: Sandbox;
     try {
@@ -243,7 +242,7 @@ export class E2BSandboxProvider implements SandboxProvider {
 
     try {
       // Note: this creates the necessary directories if missing.
-      await sandbox.files.write(path, stream);
+      await sandbox.files.write(path, data);
     } catch (err) {
       return new Err(normalizeError(err));
     }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -240,7 +240,7 @@ export class E2BSandboxProvider implements SandboxProvider {
       return new Err(normalizeError(err));
     }
 
-    await sandbox.files.write(path, new Blob([content]));
+    await sandbox.files.write(path, new Blob([new Uint8Array(content)]));
 
     return new Ok(undefined);
   }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,3 +1,4 @@
+import type { ReadableStream } from "node:stream/web";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -225,7 +226,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   async writeFile(
     providerId: string,
     path: string,
-    content: Buffer
+    stream: ReadableStream
   ): Promise<Result<void, Error>> {
     let sandbox: Sandbox;
     try {
@@ -241,11 +242,8 @@ export class E2BSandboxProvider implements SandboxProvider {
     }
 
     try {
-      // We cannot use Node's Buffer directly as it shares a large pooled
-      // ArrayBuffer and buffer.buffer would send the entire pool, hence
-      // the copy into a fresh area of memory here.
       // Note: this creates the necessary directories if missing.
-      await sandbox.files.write(path, new Uint8Array(content).buffer);
+      await sandbox.files.write(path, stream);
     } catch (err) {
       return new Err(normalizeError(err));
     }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -12,7 +12,7 @@ import type {
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
-import type { Result } from "@app/types/shared/result";
+import type { Result, Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -223,11 +223,26 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   async writeFile(
-    _providerId: string,
-    _path: string,
-    _content: Buffer
-  ): Promise<void> {
-    throw new Error("writeFile is not implemented yet.");
+    providerId: string,
+    path: string,
+    content: Buffer
+  ): Promise<Result<void, Error>> {
+    let sandbox: Sandbox;
+    try {
+      sandbox = await Sandbox.connect(providerId, {
+        ...this.connectionOpts(),
+        timeoutMs: SANDBOX_LIFETIME_MS,
+      });
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return new Err(new SandboxNotFoundError(providerId));
+      }
+      return new Err(normalizeError(err));
+    }
+
+    await sandbox.files.write(path, new Blob([content]));
+
+    return new Ok(undefined);
   }
 
   async readFile(_providerId: string, _path: string): Promise<Buffer> {

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -12,7 +12,7 @@ import type {
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
-import type { Result, Result } from "@app/types/shared/result";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -225,7 +225,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   async writeFile(
     providerId: string,
     path: string,
-    data: ReadableStream
+    data: ArrayBuffer
   ): Promise<Result<void, Error>> {
     let sandbox: Sandbox;
     try {

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -240,7 +240,8 @@ export class E2BSandboxProvider implements SandboxProvider {
       return new Err(normalizeError(err));
     }
 
-    await sandbox.files.write(path, new Blob([new Uint8Array(content)]));
+    // This automatically creates the necessary directory structure if needed.
+    await sandbox.files.write(path, content.toString("utf-8"));
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -16,6 +16,7 @@ import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
@@ -26,6 +27,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
+import { Readable } from "stream";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -528,6 +530,39 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return result;
+  }
+
+  /**
+   * Load a skill's file attachments onto this sandbox.
+   * Files are written under /skills/{skillName}/{fileName}.
+   */
+  async loadSkillFiles(
+    auth: Authenticator,
+    skill: SkillResource
+  ): Promise<Result<{ loadedPaths: string[] }, Error>> {
+    const fileAttachments = skill.getFileAttachments();
+    if (fileAttachments.length === 0) {
+      return new Ok({ loadedPaths: [] });
+    }
+
+    const loadedPaths: string[] = [];
+
+    for (const file of fileAttachments) {
+      const fileName = file.fileName ?? `file_${file.sId}`;
+      const targetPath = `/skills/${skill.name}/${fileName}`;
+
+      const readStream = file.getReadStream({ auth, version: "original" });
+      const readable: ReadableStream = Readable.toWeb(readStream);
+
+      const writeResult = await this.writeFile(targetPath, readable);
+      if (writeResult.isErr()) {
+        return writeResult;
+      }
+
+      loadedPaths.push(targetPath);
+    }
+
+    return new Ok({ loadedPaths });
   }
 
   toLogJSON() {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -504,6 +504,28 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
   }
 
+  /**
+   * Write a file to the sandbox filesystem.
+   */
+  async writeFile(path: string, content: Buffer): Promise<Result<void, Error>> {
+    const provider = getSandboxProvider();
+    if (!provider) {
+      return new Err(new Error("Sandbox provider not configured."));
+    }
+
+    const result = await provider.writeFile(this.providerId, path, content);
+
+    if (result.isErr() && result.error instanceof SandboxNotFoundError) {
+      logger.error(
+        { sandbox: this.toLogJSON() },
+        "Sandbox not found at provider during writeFile — marking as deleted"
+      );
+      await this.updateStatus("deleted");
+    }
+
+    return result;
+  }
+
   toLogJSON() {
     return {
       id: this.sId,

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,3 +1,4 @@
+import type { ReadableStream } from "node:stream/web";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
@@ -507,13 +508,16 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   /**
    * Write a file to the sandbox filesystem.
    */
-  async writeFile(path: string, content: Buffer): Promise<Result<void, Error>> {
+  async writeFile(
+    path: string,
+    stream: ReadableStream
+  ): Promise<Result<void, Error>> {
     const provider = getSandboxProvider();
     if (!provider) {
       return new Err(new Error("Sandbox provider not configured."));
     }
 
-    const result = await provider.writeFile(this.providerId, path, content);
+    const result = await provider.writeFile(this.providerId, path, stream);
 
     if (result.isErr() && result.error instanceof SandboxNotFoundError) {
       logger.error(

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,4 +1,4 @@
-import type { ReadableStream } from "node:stream/web";
+import streamConsumers from "stream/consumers";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
@@ -12,11 +12,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
@@ -27,7 +27,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
-import { Readable } from "stream";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -512,14 +511,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   async writeFile(
     path: string,
-    stream: ReadableStream
+    data: ArrayBuffer
   ): Promise<Result<void, Error>> {
     const provider = getSandboxProvider();
     if (!provider) {
       return new Err(new Error("Sandbox provider not configured."));
     }
 
-    const result = await provider.writeFile(this.providerId, path, stream);
+    const result = await provider.writeFile(this.providerId, path, data);
 
     if (result.isErr() && result.error instanceof SandboxNotFoundError) {
       logger.error(
@@ -552,9 +551,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       const targetPath = `/skills/${skill.name}/${fileName}`;
 
       const readStream = file.getReadStream({ auth, version: "original" });
-      const readable: ReadableStream = Readable.toWeb(readStream);
+      const data = await streamConsumers.arrayBuffer(readStream);
 
-      const writeResult = await this.writeFile(targetPath, readable);
+      const writeResult = await this.writeFile(targetPath, data);
       if (writeResult.isErr()) {
         return writeResult;
       }

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,4 +1,3 @@
-import streamConsumers from "stream/consumers";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
@@ -29,6 +28,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
+import streamConsumers from "stream/consumers";
 
 interface EnsureSandboxResult {
   freshlyCreated: boolean;

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -509,7 +509,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   /**
    * Write a file to the sandbox filesystem.
    */
-  async writeFile(
+  private async writeFile(
     path: string,
     data: ArrayBuffer
   ): Promise<Result<void, Error>> {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -547,8 +547,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     const loadedPaths: string[] = [];
 
     for (const file of fileAttachments) {
-      const fileName = file.fileName ?? `file_${file.sId}`;
-      const targetPath = `/skills/${skill.name}/${fileName}`;
+      const targetPath = `/skills/${skill.name}/${file.fileName}`;
 
       const readStream = file.getReadStream({ auth, version: "original" });
       const data = await streamConsumers.arrayBuffer(readStream);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -235,6 +235,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this._mcpServerConfigurations.map((config) => config.view);
   }
 
+  getFileAttachments(): readonly FileResource[] {
+    return this.fileAttachments;
+  }
+
   get mcpServerConfigurations(): SkillMCPServerConfiguration[] {
     return this._mcpServerConfigurations;
   }

--- a/front/types/shared/utils/streams.ts
+++ b/front/types/shared/utils/streams.ts
@@ -12,3 +12,9 @@ export function readableStreamToReadable<T = unknown>(
 ): Readable {
   return Readable.fromWeb(webStream as NodeReadableStream<T>);
 }
+
+export function readableToReadableStream<T = unknown>(
+  readable: Readable
+): ReadableStream<T> {
+  return Readable.toWeb(readable) as ReadableStream<T>;
+}


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6801
- This PR implements skill files loading on the sandbox on skill enablement.
- Important note: this requires the agent to have both the sandbox tools and the skill to use. Leaving this part TBD: I think we're gonna need to move sandbox to a skill at some point, in which case we'll enable it when enabling a skill that relies on files.

<img width="607" height="328" alt="Screenshot 2026-03-11 at 10 15 30 AM" src="https://github.com/user-attachments/assets/f6a40512-bd52-4f04-9106-c90271a6328f" />

## Tests

- Tested locally.

## Risk

- Low, behind FF.

## Deploy Plan

- Deploy front.
