### PR TITLE
[front] fix: Project search order by case insensitive

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -40,7 +40,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -291,30 +291,27 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     hasMore: boolean;
     lastValue: string | null;
   }> {
-    const nameConditions: Record<symbol, string> = {};
-
-    if (query?.trim()) {
-      nameConditions[Op.iLike] = `%${query}%`;
-    }
-
-    if (pagination.lastValue) {
-      const operator = pagination.orderDirection === "desc" ? Op.lt : Op.gt;
-      nameConditions[operator] = pagination.lastValue;
-    }
-
-    const whereClause: WhereOptions<SpaceModel> = {
-      kind: "project",
-    };
-
-    if (Object.getOwnPropertySymbols(nameConditions).length > 0) {
-      whereClause.name = nameConditions;
-    }
+    const cursorOperator = pagination.orderDirection === "desc" ? Op.lt : Op.gt;
 
     const fetchLimit = pagination.limit + 1;
+    const orderDirection =
+      pagination.orderDirection === "desc" ? "DESC" : "ASC";
 
     const spaces = await this.baseFetch(auth, {
-      where: whereClause,
-      order: [["name", pagination.orderDirection === "desc" ? "DESC" : "ASC"]],
+      where: {
+        kind: "project",
+        ...(query?.trim() && { name: { [Op.iLike]: `%${query}%` } }),
+        ...(pagination.lastValue && {
+          [Op.and]: [
+            Sequelize.where(
+              Sequelize.fn("LOWER", Sequelize.col("spaces.name")),
+              cursorOperator,
+              pagination.lastValue.toLowerCase()
+            ),
+          ],
+        }),
+      },
+      order: [[Sequelize.literal(`LOWER("spaces"."name")`), orderDirection]],
       limit: fetchLimit,
     });
 

--- a/front/pages/api/w/[wId]/spaces/search_projects.test.ts
+++ b/front/pages/api/w/[wId]/spaces/search_projects.test.ts
@@ -153,7 +153,7 @@ describe("GET /api/w/[wId]/spaces/search_projects", () => {
         workspace.sId
       );
 
-      for (let i = 0; i < 3; i++) {
+      for (let i = 0; i < 10; i++) {
         const project = await SpaceFactory.project(workspace);
         await project.addMembers(adminAuth, { userIds: [user.sId] });
       }
@@ -167,11 +167,7 @@ describe("GET /api/w/[wId]/spaces/search_projects", () => {
       expect(res._getStatusCode()).toBe(200);
       const data = res._getJSONData();
       const names = data.spaces.map((s: { name: string }) => s.name);
-      expect(names).toEqual(
-        [...names].sort((a, b) =>
-          a.localeCompare(b, undefined, { sensitivity: "base" })
-        )
-      );
+      expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
     });
 
     it("respects the limit parameter", async () => {


### PR DESCRIPTION
## Description

- Fix a test to align with the paginated search case sensitive paging / sorting.
- Also cleanup a bit the method itself

## Tests

- Unit tests

## Risk

Low


## Deploy Plan

- [ ] Deploy front