### PR TITLE
[Agent Email] Make email agent matching case-insensitive

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -295,14 +295,13 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return subFilterLastIndexA - subFilterLastIndexB;
   }
 
-  // Favor exact match
-  if (a.length !== b.length) {
-    if (normalizedA === normalizedQuery) {
-      return -1;
-    }
-    if (normalizedB === normalizedQuery) {
-      return 1;
-    }
+  const isExactMatchA = normalizedA === normalizedQuery;
+  const isExactMatchB = normalizedB === normalizedQuery;
+  if (isExactMatchA && !isExactMatchB) {
+    return -1;
+  }
+  if (isExactMatchB && !isExactMatchA) {
+    return 1;
   }
 
   return 0;

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -258,19 +258,29 @@ export function subFilter(a: string, b: string) {
  * lexicographic order
  */
 export function compareForFuzzySort(query: string, a: string, b: string) {
-  if (a.includes(query) && !b.includes(query)) {
+  const normalizedQuery = query.toLowerCase();
+  const normalizedA = a.toLowerCase();
+  const normalizedB = b.toLowerCase();
+
+  if (
+    normalizedA.includes(normalizedQuery) &&
+    !normalizedB.includes(normalizedQuery)
+  ) {
     return -1;
   }
-  if (b.includes(query) && !a.includes(query)) {
+  if (
+    normalizedB.includes(normalizedQuery) &&
+    !normalizedA.includes(normalizedQuery)
+  ) {
     return 1;
   }
 
-  const spreadA = spreadLength(query, a);
+  const spreadA = spreadLength(normalizedQuery, normalizedA);
   if (spreadA === -1) {
     return 1;
   }
 
-  const spreadB = spreadLength(query, b);
+  const spreadB = spreadLength(normalizedQuery, normalizedB);
   if (spreadB === -1) {
     return -1;
   }
@@ -279,18 +289,18 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return spreadA - spreadB;
   }
 
-  const subFilterLastIndexA = subFilterLastIndex(query, a);
-  const subFilterLastIndexB = subFilterLastIndex(query, b);
+  const subFilterLastIndexA = subFilterLastIndex(normalizedQuery, normalizedA);
+  const subFilterLastIndexB = subFilterLastIndex(normalizedQuery, normalizedB);
   if (subFilterLastIndexA !== subFilterLastIndexB) {
     return subFilterLastIndexA - subFilterLastIndexB;
   }
 
   // Favor exact match
   if (a.length !== b.length) {
-    if (a === query) {
+    if (normalizedA === normalizedQuery) {
       return -1;
     }
-    if (b === query) {
+    if (normalizedB === normalizedQuery) {
       return 1;
     }
   }

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -39,3 +39,11 @@ test("compareForFuzzySort should correctly compare strings", () => {
     ).toBe(0);
   }
 });
+
+test("compareForFuzzySort stays symmetric for normalized exact matches", () => {
+  const query = "\u0130";
+  const normalizedExactMatch = "i\u0307";
+
+  expect(compareForFuzzySort(query, query, normalizedExactMatch)).toBe(0);
+  expect(compareForFuzzySort(query, normalizedExactMatch, query)).toBe(0);
+});

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -14,6 +14,8 @@ test("compareForFuzzySort should correctly compare strings", () => {
     { query: "test", a: "testlonger", b: "longtest" },
     { query: "eng", a: "eng", b: "slack-engineering-highlights" },
     { query: "c", a: "c", b: "RadicalFeedback" },
+    { query: "issuebot", a: "issueBot", b: "FDEIssueBot" },
+    { query: "issuebot", a: "ISSUEBOT", b: "FDEIssueBot" },
   ];
 
   const dataEqual = [


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1773141630010469)

Normalize `compareForFuzzySort` inputs before scoring so mixed-case names rank consistently.
This fixes email agent lookup cases where `issuebot@dust.team` could rank `FDEIssueBot` ahead of Dust's `issueBot`.
Adds regression coverage for mixed-case exact matches.

## Risks
Blast radius: fuzzy ordering for agent and other search surfaces that rely on `compareForFuzzySort`
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `cd front && NODE_ENV=test npm test tests/lib/utils.test.ts`
