### PR TITLE
[front] feat: add support for attachments in Zendesk MCP

### DIFF
--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -351,6 +351,21 @@ export type ZendeskTicketFieldsResponse = z.infer<
   typeof ZendeskTicketFieldsResponseSchema
 >;
 
+// Attachment schemas
+export const ZendeskAttachmentSchema = z
+  .object({
+    id: z.number(),
+    file_name: z.string(),
+    content_url: z.string(),
+    content_type: z.string(),
+    size: z.number(),
+    inline: z.boolean().optional(),
+    deleted: z.boolean().optional(),
+  })
+  .passthrough();
+
+export type ZendeskAttachment = z.infer<typeof ZendeskAttachmentSchema>;
+
 // Ticket comment schemas
 export const ZendeskTicketCommentSchema = z
   .object({
@@ -359,6 +374,7 @@ export const ZendeskTicketCommentSchema = z
     author_id: z.number(),
     created_at: z.string(),
     plain_body: z.string().optional(),
+    attachments: z.array(ZendeskAttachmentSchema).optional(),
   })
   .passthrough();
 

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -302,6 +302,7 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicketComment[], Error>> {
     const url = new URL(`tickets/${ticketId}/comments`);
     if (includeInlineImages) {
+      // https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#parameters
       url.searchParams.append("include_inline_images", "");
     }
 

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -300,14 +300,13 @@ class ZendeskClient {
     ticketId: number,
     { includeInlineImages = false }: { includeInlineImages?: boolean } = {}
   ): Promise<Result<ZendeskTicketComment[], Error>> {
-    const url = new URL(`tickets/${ticketId}/comments`);
+    const params = new URLSearchParams();
     if (includeInlineImages) {
       // https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#parameters
-      url.searchParams.append("include_inline_images", "");
+      params.append("include_inline_images", "");
     }
-
     const result = await this.request(
-      url.toString(),
+      `tickets/${ticketId}/comments${params.toString()}`,
       ZendeskTicketCommentsResponseSchema
     );
 

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -22,6 +22,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { Readable } from "stream";
 import type { z } from "zod";
 
 export class ZendeskApiError extends Error {
@@ -344,7 +345,9 @@ class ZendeskClient {
     return new Ok(result.value.tags);
   }
 
-  async downloadAttachment(contentUrl: string): Promise<Result<Buffer, Error>> {
+  async fetchAttachment(
+    contentUrl: string
+  ): Promise<Result<{ body: Readable; contentLength: number | null }, Error>> {
     const url = new URL(contentUrl);
     // Only send Zendesk credentials to our own subdomain to avoid leaking
     // the token to external hosts.
@@ -369,8 +372,19 @@ class ZendeskClient {
       );
     }
 
-    const arrayBuffer = await response.arrayBuffer();
-    return new Ok(Buffer.from(arrayBuffer));
+    if (!response.body) {
+      return new Err(
+        new ZendeskApiError("Attachment response body is null", {
+          isInvalidInput: false,
+        })
+      );
+    }
+
+    const contentLengthHeader = response.headers.get("content-length");
+    return new Ok({
+      body: Readable.fromWeb(response.body),
+      contentLength: contentLengthHeader ? parseInt(contentLengthHeader) : null,
+    });
   }
 
   async getUsersByIds(

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -303,10 +303,10 @@ class ZendeskClient {
     const params = new URLSearchParams();
     if (includeInlineImages) {
       // https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#parameters
-      params.append("include_inline_images", "");
+      params.append("include_inline_images", "true");
     }
     const result = await this.request(
-      `tickets/${ticketId}/comments${params.toString()}`,
+      `tickets/${ticketId}/comments?${params.toString()}`,
       ZendeskTicketCommentsResponseSchema
     );
 

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -344,14 +344,11 @@ class ZendeskClient {
     return new Ok(result.value.tags);
   }
 
-  async downloadAttachment(
-    contentUrl: string
-  ): Promise<Result<Buffer, Error>> {
+  async downloadAttachment(contentUrl: string): Promise<Result<Buffer, Error>> {
     const url = new URL(contentUrl);
     // Only send Zendesk credentials to our own subdomain to avoid leaking
     // the token to external hosts.
-    const isOwnZendeskUrl =
-      url.hostname === `${this.subdomain}.zendesk.com`;
+    const isOwnZendeskUrl = url.hostname === `${this.subdomain}.zendesk.com`;
 
     const headers: Record<string, string> = {};
     if (isOwnZendeskUrl) {

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -344,6 +344,38 @@ class ZendeskClient {
     return new Ok(result.value.tags);
   }
 
+  async downloadAttachment(
+    contentUrl: string
+  ): Promise<Result<Buffer, Error>> {
+    const url = new URL(contentUrl);
+    // Only send Zendesk credentials to our own subdomain to avoid leaking
+    // the token to external hosts.
+    const isOwnZendeskUrl =
+      url.hostname === `${this.subdomain}.zendesk.com`;
+
+    const headers: Record<string, string> = {};
+    if (isOwnZendeskUrl) {
+      headers["Authorization"] = `Bearer ${this.accessToken}`;
+    }
+
+    const response = await untrustedFetch(contentUrl, {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      return new Err(
+        new ZendeskApiError(
+          `Failed to download attachment (${response.status}): ${response.statusText}`,
+          { isInvalidInput: false }
+        )
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return new Ok(Buffer.from(arrayBuffer));
+  }
+
   async getUsersByIds(
     userIds: number[]
   ): Promise<Result<ZendeskUser[], Error>> {

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -297,10 +297,16 @@ class ZendeskClient {
   }
 
   async getTicketComments(
-    ticketId: number
+    ticketId: number,
+    { includeInlineImages = false }: { includeInlineImages?: boolean } = {}
   ): Promise<Result<ZendeskTicketComment[], Error>> {
+    const url = new URL(`tickets/${ticketId}/comments`);
+    if (includeInlineImages) {
+      url.searchParams.append("include_inline_images", "");
+    }
+
     const result = await this.request(
-      `tickets/${ticketId}/comments`,
+      url.toString(),
       ZendeskTicketCommentsResponseSchema
     );
 

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -10,7 +10,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       "Retrieve a Zendesk ticket by its ID. Returns the ticket details including subject, " +
       "description, status, priority, assignee, and other metadata. Optionally include ticket metrics " +
       "such as resolution times, wait times, and reply counts. Optionally include the full conversation " +
-      "with all comments.",
+      "with all comments. Optionally download and include file attachments from comments.",
     schema: {
       ticketId: z
         .number()
@@ -28,6 +28,12 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe(
           "Whether to include the full conversation (all comments) for the ticket. Defaults to false."
+        ),
+      includeAttachments: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to download and include the content of file attachments from ticket comments."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -213,6 +213,16 @@ export function renderTicketComments(
       ? `${author.name} (${author.email ?? "Unknown email"})`
       : `Unknown User (ID: ${comment.author_id})`;
     lines.push(`\n[${date}] ${authorLabel}:\n${body}`);
+
+    const nonDeletedAttachments = (comment.attachments ?? []).filter(
+      (a) => !a.deleted
+    );
+    if (nonDeletedAttachments.length > 0) {
+      lines.push("  Attachments:");
+      for (const att of nonDeletedAttachments) {
+        lines.push(`  - ${att.file_name} (${att.content_type})`);
+      }
+    }
   }
 
   return lines.join("\n");

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -2,6 +2,10 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  extractTextFromBuffer,
+  processAttachment,
+} from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
+import {
   getUniqueCustomFieldIds,
   getZendeskClient,
   ZendeskApiError,
@@ -13,13 +17,16 @@ import {
   renderTicketFields,
   renderTicketMetrics,
 } from "@app/lib/api/actions/servers/zendesk/rendering";
-import type { ZendeskUser } from "@app/lib/api/actions/servers/zendesk/types";
+import type {
+  ZendeskTicketComment,
+  ZendeskUser,
+} from "@app/lib/api/actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
+import { Err, Ok } from "@app/types/shared/result";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const ZENDESK_TAG_MAX_LENGTH = 255;
 const ZENDESK_TAG_REGEX = /^[a-z0-9_\-/]+$/;
-
-import { Err, Ok } from "@app/types/shared/result";
 
 function isTrackedError(error: Error): boolean {
   return !(error instanceof ZendeskApiError && error.isInvalidInput);
@@ -27,7 +34,7 @@ function isTrackedError(error: Error): boolean {
 
 const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
   get_ticket: async (
-    { ticketId, includeMetrics, includeConversation },
+    { ticketId, includeMetrics, includeConversation, includeAttachments },
     { authInfo }
   ) => {
     const clientResult = getZendeskClient(authInfo);
@@ -69,7 +76,12 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
       ticketText += "\n" + renderTicketMetrics(metricsResult.value);
     }
 
-    if (includeConversation) {
+    // Fetch comments when conversation or attachments are requested.
+    const needComments = includeConversation || includeAttachments;
+    let comments: ZendeskTicketComment[] = [];
+    let users: ZendeskUser[] = [];
+
+    if (needComments) {
       const commentsResult = await client.getTicketComments(ticketId);
 
       if (commentsResult.isErr()) {
@@ -81,12 +93,11 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
         );
       }
 
-      const comments = commentsResult.value;
+      comments = commentsResult.value;
       const authorIds = Array.from(
         new Set(comments.map((comment) => comment.author_id))
       );
 
-      let users: ZendeskUser[] = [];
       if (authorIds.length > 0) {
         const usersResult = await client.getUsersByIds(authorIds);
         if (usersResult.isErr()) {
@@ -100,16 +111,66 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
           users = usersResult.value;
         }
       }
+    }
 
+    if (includeConversation) {
       ticketText += renderTicketComments(comments, users);
     }
 
-    return new Ok([
-      {
-        type: "text" as const,
-        text: ticketText,
-      },
-    ]);
+    const contentBlocks: CallToolResult["content"] = [
+      { type: "text" as const, text: ticketText },
+    ];
+
+    if (includeAttachments) {
+      const allAttachments = comments.flatMap((c) =>
+        (c.attachments ?? []).filter((a) => !a.deleted)
+      );
+
+      for (const attachment of allAttachments) {
+        const downloadResult = await client.downloadAttachment(
+          attachment.content_url
+        );
+        if (downloadResult.isErr()) {
+          logger.error(
+            {
+              attachmentId: attachment.id,
+              filename: attachment.file_name,
+              error: downloadResult.error.message,
+            },
+            "[Zendesk] Failed to download attachment"
+          );
+          continue;
+        }
+        const buffer = downloadResult.value;
+
+        const attachmentResult = await processAttachment({
+          mimeType: attachment.content_type,
+          filename: attachment.file_name,
+          extractText: async () =>
+            extractTextFromBuffer(buffer, attachment.content_type),
+          downloadContent: async () => new Ok(buffer),
+        });
+
+        if (attachmentResult.isOk()) {
+          contentBlocks.push({
+            type: "text" as const,
+            text: `\n--- Attachment: ${attachment.file_name} (${attachment.content_type}) ---`,
+          });
+          contentBlocks.push(...attachmentResult.value);
+        } else {
+          logger.error(
+            {
+              attachmentId: attachment.id,
+              filename: attachment.file_name,
+              error: attachmentResult.error.message,
+            },
+            "[Zendesk] Failed to process attachment"
+          );
+        }
+      }
+    }
+
+    return new Ok(contentBlocks);
   },
 
   search_tickets: async ({ query, sortBy, sortOrder }, { authInfo }) => {

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -191,7 +191,7 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
           title: attachment.file_name,
           text: `Attachment: ${attachment.file_name}`,
           snippet: storedFile.snippet,
-          uri: "",
+          uri: storedFile.getPublicUrl(auth),
         };
         contentBlocks.push({
           type: "resource" as const,

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -2,10 +2,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
-  extractTextFromBuffer,
-  processAttachment,
-} from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
-import {
   getUniqueCustomFieldIds,
   getZendeskClient,
   ZendeskApiError,
@@ -21,8 +17,12 @@ import type {
   ZendeskTicketComment,
   ZendeskUser,
 } from "@app/lib/api/actions/servers/zendesk/types";
+import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
+import { isSupportedFileContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const ZENDESK_TAG_MAX_LENGTH = 255;
@@ -35,7 +35,7 @@ function isTrackedError(error: Error): boolean {
 const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
   get_ticket: async (
     { ticketId, includeMetrics, includeConversation, includeAttachments },
-    { authInfo }
+    { authInfo, auth }
   ) => {
     const clientResult = getZendeskClient(authInfo);
     if (clientResult.isErr()) {
@@ -127,46 +127,76 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
       );
 
       for (const attachment of allAttachments) {
-        const downloadResult = await client.downloadAttachment(
+        const contentType = attachment.content_type;
+
+        if (!isSupportedFileContentType(contentType)) {
+          contentBlocks.push({
+            type: "text" as const,
+            text: `\n--- Attachment: ${attachment.file_name} ---\nUnsupported file type (${contentType}), skipped.`,
+          });
+          continue;
+        }
+
+        const fetchResult = await client.fetchAttachment(
           attachment.content_url
         );
-        if (downloadResult.isErr()) {
+        if (fetchResult.isErr()) {
           logger.error(
             {
               attachmentId: attachment.id,
               filename: attachment.file_name,
-              error: downloadResult.error.message,
+              error: fetchResult.error.message,
             },
-            "[Zendesk] Failed to download attachment"
+            "[Zendesk] Failed to fetch attachment"
           );
           continue;
         }
-        const buffer = downloadResult.value;
+        const { body, contentLength } = fetchResult.value;
 
-        const attachmentResult = await processAttachment({
-          mimeType: attachment.content_type,
-          filename: attachment.file_name,
-          extractText: async () =>
-            extractTextFromBuffer(buffer, attachment.content_type),
-          downloadContent: async () => new Ok(buffer),
+        const file = await FileResource.makeNew({
+          workspaceId: auth.getNonNullableWorkspace().id,
+          userId: auth.user()?.id ?? null,
+          contentType,
+          fileName: attachment.file_name,
+          fileSize: contentLength ?? attachment.size,
+          useCase: "conversation",
+          useCaseMetadata: {},
         });
 
-        if (attachmentResult.isOk()) {
-          contentBlocks.push({
-            type: "text" as const,
-            text: `\n--- Attachment: ${attachment.file_name} (${attachment.content_type}) ---`,
-          });
-          contentBlocks.push(...attachmentResult.value);
-        } else {
+        const processResult = await processAndStoreFile(auth, {
+          file,
+          content: {
+            type: "readable",
+            value: body,
+          },
+        });
+
+        if (processResult.isErr()) {
           logger.error(
             {
               attachmentId: attachment.id,
               filename: attachment.file_name,
-              error: attachmentResult.error.message,
+              error: processResult.error,
             },
             "[Zendesk] Failed to process attachment"
           );
+          continue;
         }
+
+        const storedFile = processResult.value;
+        const fileResource = {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+          fileId: storedFile.sId,
+          contentType,
+          title: attachment.file_name,
+          text: `Attachment: ${attachment.file_name}`,
+          snippet: storedFile.snippet,
+          uri: "",
+        };
+        contentBlocks.push({
+          type: "resource" as const,
+          resource: fileResource,
+        });
       }
     }
 

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -20,7 +20,11 @@ import type {
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-import { isSupportedFileContentType } from "@app/types/files";
+import {
+  ensureFileSize,
+  fileSizeToHumanReadable,
+  isSupportedFileContentType,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -149,6 +153,10 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
             },
             "[Zendesk] Failed to fetch attachment"
           );
+          contentBlocks.push({
+            type: "text" as const,
+            text: `\n--- Attachment: ${attachment.file_name} ---\nFailed to download attachment.`,
+          });
           continue;
         }
         const { body, contentLength } = fetchResult.value;
@@ -180,6 +188,10 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
             },
             "[Zendesk] Failed to process attachment"
           );
+          contentBlocks.push({
+            type: "text" as const,
+            text: `\n--- Attachment: ${attachment.file_name} ---\nFailed to process attachment.`,
+          });
           continue;
         }
 

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -86,7 +86,9 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
     let users: ZendeskUser[] = [];
 
     if (needComments) {
-      const commentsResult = await client.getTicketComments(ticketId);
+      const commentsResult = await client.getTicketComments(ticketId, {
+        includeInlineImages: includeAttachments,
+      });
 
       if (commentsResult.isErr()) {
         return new Err(

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -141,6 +141,16 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
           continue;
         }
 
+        if (!ensureFileSize(contentType, attachment.size)) {
+          contentBlocks.push({
+            type: "text" as const,
+            text:
+              `\n--- Attachment: ${attachment.file_name} ---\n` +
+              `File too large (${fileSizeToHumanReadable(attachment.size)}), skipped.`,
+          });
+          continue;
+        }
+
         const fetchResult = await client.fetchAttachment(
           attachment.content_url
         );

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -351,6 +351,21 @@ export type ZendeskTicketFieldsResponse = z.infer<
   typeof ZendeskTicketFieldsResponseSchema
 >;
 
+// Attachment schemas
+export const ZendeskAttachmentSchema = z
+  .object({
+    id: z.number(),
+    file_name: z.string(),
+    content_url: z.string(),
+    content_type: z.string(),
+    size: z.number(),
+    inline: z.boolean().optional(),
+    deleted: z.boolean().optional(),
+  })
+  .passthrough();
+
+export type ZendeskAttachment = z.infer<typeof ZendeskAttachmentSchema>;
+
 // Ticket comment schemas
 export const ZendeskTicketCommentSchema = z
   .object({
@@ -359,6 +374,7 @@ export const ZendeskTicketCommentSchema = z
     author_id: z.number(),
     created_at: z.string(),
     plain_body: z.string().optional(),
+    attachments: z.array(ZendeskAttachmentSchema).optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

- This PR adds an option on the Zendesk tools to retrieve the attachments on a ticket.
- Uploads the attachments as conversation files.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
