### PR TITLE
[front] Allow naming duplicate internal MCP tools when creating the tool.

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -136,10 +136,26 @@ export const AdminActionsList = ({
     setIsCreateOpen(true);
   };
 
+  const existingViewNames = useMemo(
+    () =>
+      mcpServers.flatMap((s) =>
+        (s.views ?? []).map((v) => v.name ?? v.server.name)
+      ),
+    [mcpServers]
+  );
+
   const onCreateInternalMCPServer = async (mcpServer: MCPServerType) => {
+    // Open the dialog when OAuth/bearer token is required, OR when a
+    // multi-instance server already has an instance with the same name
+    // (so the user can pick a custom name).
+    const hasNameConflict =
+      mcpServer.allowMultipleInstances &&
+      existingViewNames.includes(mcpServer.name);
+
     if (
       mcpServer.authorization ??
-      requiresBearerTokenConfiguration(mcpServer)
+      requiresBearerTokenConfiguration(mcpServer) ??
+      hasNameConflict
     ) {
       setInternalMCPServerToCreate(mcpServer);
       setDefaultServerConfig(undefined);
@@ -372,6 +388,7 @@ export const AdminActionsList = ({
         owner={owner}
         setMCPServerToShow={setMcpServerToShow}
         defaultServerConfig={defaultServerConfig}
+        existingViewNames={existingViewNames}
       />
       {rows.length > 0 &&
         portalToHeader(

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -41,10 +41,29 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Input,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
+
+/**
+ * Generate a unique view name for a multi-instance MCP server by trying
+ * incrementing suffixes until one is not already taken.
+ */
+export function generateUniqueViewName(
+  baseName: string,
+  existingViewNames: string[]
+): string {
+  const existingSet = new Set(existingViewNames);
+  let index = 2;
+  let candidate = `${baseName}_${index}`;
+  while (existingSet.has(candidate)) {
+    index += 1;
+    candidate = `${baseName}_${index}`;
+  }
+  return candidate;
+}
 
 function getSubmitButtonLabel(
   isLoading: boolean,
@@ -72,6 +91,7 @@ interface CreateMCPServerDialogProps {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   defaultServerConfig?: DefaultRemoteMCPServerConfig;
+  existingViewNames?: string[];
 }
 
 export function CreateMCPServerDialog({
@@ -82,13 +102,33 @@ export function CreateMCPServerDialog({
   isOpen = false,
   setIsOpen,
   defaultServerConfig,
+  existingViewNames = [],
 }: CreateMCPServerDialogProps) {
   const sendNotification = useSendNotification();
   const regionContext = useRegionContext();
 
+  // Determine if this is a multi-instance server that already has an existing instance.
+  const needsCustomName = useMemo(
+    () =>
+      !!internalMCPServer?.allowMultipleInstances &&
+      existingViewNames.includes(internalMCPServer.name),
+    [internalMCPServer, existingViewNames]
+  );
+
+  const suggestedViewName = useMemo(
+    () =>
+      needsCustomName && internalMCPServer
+        ? generateUniqueViewName(internalMCPServer.name, existingViewNames)
+        : undefined,
+    [needsCustomName, internalMCPServer, existingViewNames]
+  );
+
   const defaultValues = useMemo<CreateMCPServerDialogFormValues>(() => {
-    return getCreateMCPServerDialogDefaultValues(defaultServerConfig);
-  }, [defaultServerConfig]);
+    return {
+      ...getCreateMCPServerDialogDefaultValues(defaultServerConfig),
+      viewName: suggestedViewName,
+    };
+  }, [defaultServerConfig, suggestedViewName]);
 
   const form = useForm<CreateMCPServerDialogFormValues>({
     resolver: zodResolver(createMCPServerDialogFormSchema),
@@ -106,6 +146,26 @@ export function CreateMCPServerDialog({
     control: form.control,
     name: "authCredentials",
   });
+
+  const viewName = useWatch({
+    control: form.control,
+    name: "viewName",
+  });
+
+  // Client-side validation for the view name field.
+  const viewNameError = useMemo(() => {
+    if (!needsCustomName) {
+      return null;
+    }
+    const trimmed = (viewName ?? "").trim();
+    if (trimmed.length === 0) {
+      return "Name is required.";
+    }
+    if (existingViewNames.includes(trimmed)) {
+      return "This name is already in use.";
+    }
+    return null;
+  }, [needsCustomName, viewName, existingViewNames]);
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -154,7 +214,7 @@ export function CreateMCPServerDialog({
 
   const handleSave = async (values: CreateMCPServerDialogFormValues) => {
     // Guard: handleSubmit only checks Zod schema errors, not manual setError errors.
-    if (credentialError) {
+    if (credentialError || viewNameError) {
       return;
     }
 
@@ -270,7 +330,7 @@ export function CreateMCPServerDialog({
   );
 
   const handleCreateServerAndSubmitStaticCredentials = async () => {
-    if (!internalMCPServer || !authorization || !useCase) {
+    if (!internalMCPServer || !authorization || !useCase || viewNameError) {
       return;
     }
 
@@ -283,6 +343,7 @@ export function CreateMCPServerDialog({
         name: internalMCPServer.name,
         useCase,
         includeGlobal: true,
+        viewName: form.getValues("viewName"),
       });
 
       if (createRes.isErr()) {
@@ -332,7 +393,7 @@ export function CreateMCPServerDialog({
   const isOAuthValid = authorization
     ? !!useCase && (hasStaticForm ? isStaticFormValid : !credentialError)
     : true;
-  const isSubmitDisabled = !isOAuthValid || isLoading;
+  const isSubmitDisabled = !isOAuthValid || isLoading || !!viewNameError;
 
   return (
     <Dialog
@@ -351,6 +412,24 @@ export function CreateMCPServerDialog({
           </DialogHeader>
           <DialogContainer className="max-h-[80vh]">
             <div className="space-y-4">
+              {needsCustomName && (
+                <div className="space-y-4">
+                  <div className="heading-lg text-foreground dark:text-foreground-night">
+                    Tool name
+                  </div>
+                  <Input
+                    placeholder="Enter a name for this instance"
+                    {...form.register("viewName")}
+                    isError={!!viewNameError}
+                    message={
+                      viewNameError ??
+                      `${toolName} is already installed. This name tells them apart.`
+                    }
+                    messageStatus={viewNameError ? "error" : "info"}
+                  />
+                </div>
+              )}
+
               {!internalMCPServer &&
                 (!authorization || authorization.provider === "mcp_static") && (
                   <RemoteMCPServerConfigurationSection

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -70,6 +70,7 @@ type CreateInternalMCPServerFn = (
     includeGlobal: boolean;
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
+    viewName?: string;
   } & (
     | { oauthConnection: MCPConnectionType; useCase?: never }
     | { oauthConnection?: never; useCase: MCPOAuthUseCase }
@@ -225,11 +226,13 @@ export async function submitCreateMCPServerDialogForm({
           name: internalMCPServer.name,
           oauthConnection,
           includeGlobal: true,
+          viewName: values.viewName,
           ...optionalFields,
         })
       : await createInternalMCPServer({
           name: internalMCPServer.name,
           includeGlobal: true,
+          viewName: values.viewName,
           ...optionalFields,
         });
 

--- a/front/components/actions/mcp/forms/types.ts
+++ b/front/components/actions/mcp/forms/types.ts
@@ -77,6 +77,7 @@ export const createMCPServerDialogFormSchema = mcpServerOAuthFormSchema.extend({
   customHeaders: z
     .array(z.object({ key: z.string(), value: z.string() }))
     .default([]),
+  viewName: z.string().optional(),
 });
 
 export type CreateMCPServerDialogFormValues = z.infer<

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -334,6 +334,11 @@ export function CapabilitiesPicker({
     }
   }, [serverViews, pendingServerToAdd, onSelect]);
 
+  const existingViewNames = useMemo(
+    () => serverViews.map((v) => v.name ?? v.server.name),
+    [serverViews]
+  );
+
   const filteredServerViewsUnselected = useMemo(() => {
     return serverViews
       .filter(
@@ -609,6 +614,7 @@ export function CapabilitiesPicker({
           owner={owner}
           internalMCPServer={setupSheetServer ?? undefined}
           defaultServerConfig={setupSheetRemoteServerConfig ?? undefined}
+          existingViewNames={existingViewNames}
           setMCPServerToShow={async (createdServer) => {
             const updatedData = await mutateServerViews();
 

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -70,6 +70,14 @@ export function ToolSetupCard({
     owner,
   });
 
+  const existingViewNames = useMemo(
+    () =>
+      mcpServers.flatMap((s) =>
+        (s.views ?? []).map((v) => v.name ?? v.server.name)
+      ),
+    [mcpServers]
+  );
+
   // Find the matching MCP server for the tool we want to activate.
   const matchingMCPServer = useMemo(() => {
     const installedServer = mcpServers.find((s) =>
@@ -203,6 +211,7 @@ export function ToolSetupCard({
         <CreateMCPServerDialog
           owner={owner}
           internalMCPServer={matchingMCPServer}
+          existingViewNames={existingViewNames}
           setMCPServerToShow={handleSetupComplete}
           setIsLoading={setIsActivating}
           isOpen={isSetupSheetOpen}

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -102,9 +102,11 @@ export class InternalMCPServerInMemoryResource {
     {
       name,
       useCase,
+      viewName,
     }: {
       name: InternalMCPServerNameType;
       useCase: MCPOAuthUseCase | null;
+      viewName?: string;
     }
   ) {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
@@ -184,6 +186,7 @@ export class InternalMCPServerInMemoryResource {
       editedAt: new Date(),
       editedByUserId: auth.user()?.id,
       oAuthUseCase: useCase ?? null,
+      ...(viewName ? { name: viewName } : {}),
     });
 
     return server;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -285,11 +285,13 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
     includeGlobal,
     sharedSecret,
     customHeaders,
+    viewName,
   }: {
     name: string;
     includeGlobal: boolean;
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
+    viewName?: string;
   } & (
     | { oauthConnection: MCPConnectionType; useCase?: never }
     | { oauthConnection?: never; useCase: MCPOAuthUseCase }
@@ -306,6 +308,7 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
         includeGlobal,
         ...(sharedSecret !== undefined ? { sharedSecret } : {}),
         ...(customHeaders !== undefined ? { customHeaders } : {}),
+        ...(viewName !== undefined ? { viewName } : {}),
       }),
     });
 

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -80,6 +80,7 @@ const PostQueryParamsSchema = t.union([
       t.array(t.type({ key: t.string, value: t.string })),
       t.undefined,
     ]),
+    viewName: t.union([t.string, t.undefined]),
   }),
 ]);
 
@@ -335,7 +336,7 @@ async function handler(
           });
         }
         case "internal": {
-          const { name } = body;
+          const { name, viewName } = body;
 
           if (!isInternalMCPServerName(name)) {
             return apiError(req, res, {
@@ -345,6 +346,19 @@ async function handler(
                 message: "Invalid internal MCP server name",
               },
             });
+          }
+
+          if (viewName !== undefined) {
+            const trimmed = viewName.trim();
+            if (trimmed.length === 0 || trimmed.length > MAX_NAME_LENGTH) {
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: "viewName must be a non-empty string.",
+                },
+              });
+            }
           }
 
           if (!allowsMultipleInstancesOfInternalMCPServerByName(name)) {
@@ -371,6 +385,10 @@ async function handler(
             }
           }
 
+          // Use viewName for the conflict check when provided (multi-instance),
+          // otherwise fall back to the internal server name.
+          const nameForConflictCheck = viewName ?? name;
+
           // Check for name conflicts before creating the server.
           if (body.includeGlobal) {
             const globalSpace =
@@ -379,7 +397,7 @@ async function handler(
             const { hasConflict } =
               await MCPServerViewResource.hasNameConflictInSpaceByName(
                 auth,
-                name,
+                nameForConflictCheck,
                 globalSpace
               );
 
@@ -388,7 +406,7 @@ async function handler(
                 status_code: 400,
                 api_error: {
                   type: "invalid_request_error",
-                  message: `An existing Tool is already using the name "${name}"`,
+                  message: `An existing Tool is already using the name "${nameForConflictCheck}"`,
                 },
               });
             }
@@ -398,6 +416,7 @@ async function handler(
             await InternalMCPServerInMemoryResource.makeNew(auth, {
               name,
               useCase: body.useCase ?? null,
+              viewName,
             });
 
           if (body.connectionId) {


### PR DESCRIPTION
## Description

When adding a second instance of a multi-instance internal MCP server (e.g. Google Drive), the creation would fail with "An existing Tool is already using the name" because both instances shared the same default name.

This change adds a "Tool name" field in the CreateMCPServerDialog, shown only when an instance of the same server type already exists. The field is pre-filled with an auto-generated unique name (e.g. google_drive_2) and validated client-side against existing view names to prevent conflicts. The name is stored on the  MCPServerView as a custom viewName, which the backend now accepts and uses for the conflict check. To be challenged if we want to set such a default name or leave it empty. I thought better as is even though "Google Drive" and "Google Drive 2 is anything but explicit". 

For servers that don't require OAuth/bearer setup, the dialog is now also opened when a name conflict would occur, instead of silently failing on the direct creation path.

This is only for the creation flow. I have another PR for the edit flow. 


<kbd>
<img width="754" height="475" alt="Screenshot 2026-03-10 at 17 48 41" src="https://github.com/user-attachments/assets/bfb32e08-b903-413d-8bc9-0a4e506b3b26" />
</kbd>
<kbd>
<img width="722" height="449" alt="Screenshot 2026-03-10 at 17 49 14" src="https://github.com/user-attachments/assets/4caf568e-fc7b-45a2-b1d3-75ab1cbf7862" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 