### PR TITLE
Add global kill switch for anthropic and openai

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -23,6 +23,14 @@ const killSwitchMap: Record<
     title: "Data Source Views",
     description: "Disable saving of data source views",
   },
+  global_blacklist_anthropic: {
+    title: "Global Blacklist Anthropic",
+    description: "Disable Anthropic models in global agents",
+  },
+  global_blacklist_openai: {
+    title: "Global Blacklist OpenAI",
+    description: "Disable OpenAI models in global agents",
+  },
 };
 
 export function KillPage() {

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -1,6 +1,8 @@
 export const KILL_SWITCH_TYPES = [
   "save_agent_configurations",
   "save_data_source_views",
+  "global_blacklist_anthropic",
+  "global_blacklist_openai",
 ] as const;
 export type KillSwitchType = (typeof KILL_SWITCH_TYPES)[number];
 export function isKillSwitchType(type: string): type is KillSwitchType {

--- a/front/lib/resources/kill_switch_resource.ts
+++ b/front/lib/resources/kill_switch_resource.ts
@@ -2,6 +2,7 @@ import type { KillSwitchType } from "@app/lib/poke/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { KillSwitchModel } from "@app/lib/resources/storage/models/kill_switches";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { Attributes, ModelStatic } from "sequelize";
@@ -10,6 +11,10 @@ import type { Attributes, ModelStatic } from "sequelize";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+
+const KILL_SWITCH_ENABLED_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const KILL_SWITCH_ENABLED_CACHE_KEY = "kill_switches_enabled";
+
 export interface KillSwitchResource
   extends ReadonlyAttributesType<KillSwitchModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -33,6 +38,11 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
         },
       })) ?? (await KillSwitchModel.create({ type }));
 
+    await invalidateCacheWithRedis(
+      KillSwitchResource.listEnabledKillSwitches,
+      () => KILL_SWITCH_ENABLED_CACHE_KEY
+    );
+
     return new KillSwitchResource(KillSwitchModel, ks.get());
   }
 
@@ -42,11 +52,34 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
         type,
       },
     });
+
+    await invalidateCacheWithRedis(
+      KillSwitchResource.listEnabledKillSwitches,
+      () => KILL_SWITCH_ENABLED_CACHE_KEY
+    );
   }
 
   static async listEnabledKillSwitches(): Promise<KillSwitchType[]> {
     const killSwitches = await KillSwitchModel.findAll();
     return killSwitches.map((ks) => ks.type);
+  }
+
+  static async listEnabledKillSwitchesCached(): Promise<KillSwitchType[]> {
+    return cacheWithRedis(
+      KillSwitchResource.listEnabledKillSwitches,
+      () => KILL_SWITCH_ENABLED_CACHE_KEY,
+      {
+        ttlMs: KILL_SWITCH_ENABLED_CACHE_TTL_MS,
+      }
+    )();
+  }
+
+  static async isKillSwitchEnabledCached(
+    type: KillSwitchType
+  ): Promise<boolean> {
+    const enabledKillSwitches =
+      await KillSwitchResource.listEnabledKillSwitchesCached();
+    return enabledKillSwitches.includes(type);
   }
 
   async delete(): Promise<Result<number | undefined, Error>> {

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -74,6 +74,15 @@ vi.mock("@app/lib/api/workos/organization_primitives", async () => {
   };
 });
 
+const listEnabledKillSwitchesCached = vi.hoisted(() =>
+  vi.fn().mockResolvedValue([])
+);
+vi.mock("@app/lib/resources/kill_switch_resource", () => ({
+  KillSwitchResource: {
+    listEnabledKillSwitchesCached,
+  },
+}));
+
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
@@ -417,6 +426,110 @@ describe("WorkspaceResource", () => {
 
         expect(found).toBeNull();
       });
+    });
+  });
+
+  describe("getWhiteListedProvidersFilteredByKillSwitches", () => {
+    beforeEach(() => {
+      listEnabledKillSwitchesCached.mockResolvedValue([]);
+    });
+
+    it("returns whiteListedProviders when no kill switches are enabled", async () => {
+      const providers = ["openai", "anthropic", "mistral"] as const;
+
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches([
+          ...providers,
+        ]);
+
+      expect(result).toEqual([...providers]);
+    });
+
+    it("returns null when whiteListedProviders is null and no kill switches", async () => {
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+          null
+        );
+
+      expect(result).toBeNull();
+    });
+
+    it("filters out anthropic when global_blacklist_anthropic is enabled", async () => {
+      listEnabledKillSwitchesCached.mockResolvedValue([
+        "global_blacklist_anthropic",
+      ]);
+
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches([
+          "openai",
+          "anthropic",
+          "mistral",
+        ]);
+
+      expect(result).toEqual(["openai", "mistral"]);
+    });
+
+    it("filters out openai when global_blacklist_openai is enabled", async () => {
+      listEnabledKillSwitchesCached.mockResolvedValue([
+        "global_blacklist_openai",
+      ]);
+
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches([
+          "openai",
+          "anthropic",
+          "mistral",
+        ]);
+
+      expect(result).toEqual(["anthropic", "mistral"]);
+    });
+
+    it("filters out both anthropic and openai when both kill switches are enabled", async () => {
+      listEnabledKillSwitchesCached.mockResolvedValue([
+        "global_blacklist_anthropic",
+        "global_blacklist_openai",
+      ]);
+
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches([
+          "openai",
+          "anthropic",
+          "mistral",
+        ]);
+
+      expect(result).toEqual(["mistral"]);
+    });
+
+    it("uses MODEL_PROVIDER_IDS and filters anthropic when whiteListedProviders is null and anthropic is blacklisted", async () => {
+      listEnabledKillSwitchesCached.mockResolvedValue([
+        "global_blacklist_anthropic",
+      ]);
+
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+          null
+        );
+
+      expect(result).not.toBeNull();
+      expect(result).not.toContain("anthropic");
+      expect(result).toContain("openai");
+      expect(result).toContain("mistral");
+    });
+
+    it("uses MODEL_PROVIDER_IDS and filters openai when whiteListedProviders is null and openai is blacklisted", async () => {
+      listEnabledKillSwitchesCached.mockResolvedValue([
+        "global_blacklist_openai",
+      ]);
+
+      const result =
+        await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+          null
+        );
+
+      expect(result).not.toBeNull();
+      expect(result).not.toContain("openai");
+      expect(result).toContain("anthropic");
+      expect(result).toContain("mistral");
     });
   });
 });

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -6,6 +6,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import type { ResourceLogJSON } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
@@ -19,6 +20,7 @@ import {
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateAllAgentLoopWorkflowsForConversation } from "@app/temporal/agent_loop/terminate";
+import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -137,6 +139,28 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return killSwitched.conversationIds.includes(conversationId);
   }
 
+  public static async getWhiteListedProvidersFilteredByKillSwitches(
+    whiteListedProviders: ModelProviderIdType[] | null
+  ): Promise<ModelProviderIdType[] | null> {
+    const enabledKillSwitches =
+      await KillSwitchResource.listEnabledKillSwitchesCached();
+
+    const isAnthropicBlacklisted = enabledKillSwitches.includes(
+      "global_blacklist_anthropic"
+    );
+    const isOpenaiBlacklisted = enabledKillSwitches.includes(
+      "global_blacklist_openai"
+    );
+    if (isAnthropicBlacklisted || isOpenaiBlacklisted) {
+      return (whiteListedProviders ?? MODEL_PROVIDER_IDS).filter(
+        (p) =>
+          (isAnthropicBlacklisted ? p !== "anthropic" : true) &&
+          (isOpenaiBlacklisted ? p !== "openai" : true)
+      );
+    }
+    return whiteListedProviders;
+  }
+
   private static async _fetchByIdUncached(
     wId: string
   ): Promise<CachedWorkspaceData | null> {
@@ -146,6 +170,12 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     if (!workspace) {
       return null;
     }
+
+    const whiteListedProviders =
+      await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+        workspace.whiteListedProviders
+      );
+
     return {
       id: workspace.id,
       sId: workspace.sId,
@@ -154,7 +184,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       segmentation: workspace.segmentation,
       ssoEnforced: workspace.ssoEnforced ?? false,
       workOSOrganizationId: workspace.workOSOrganizationId,
-      whiteListedProviders: workspace.whiteListedProviders,
+      whiteListedProviders: whiteListedProviders,
       defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
       metadata: workspace.metadata,
       conversationsRetentionDays: workspace.conversationsRetentionDays,
@@ -233,7 +263,16 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     if (!cached) {
       return null;
     }
-    return this.fromCachedData(cached);
+
+    const whiteListedProviders =
+      await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
+        cached.whiteListedProviders
+      );
+
+    return this.fromCachedData({
+      ...cached,
+      whiteListedProviders: whiteListedProviders,
+    });
   }
 
   static async fetchByName(name: string): Promise<WorkspaceResource | null> {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -200,8 +200,11 @@ async function handler(
         agentConfigurations,
       });
     case "POST":
-      const killSwitches = await KillSwitchResource.listEnabledKillSwitches();
-      if (killSwitches?.includes("save_agent_configurations")) {
+      const isSaveAgentConfigurationsEnabled =
+        await KillSwitchResource.isKillSwitchEnabledCached(
+          "save_agent_configurations"
+        );
+      if (isSaveAgentConfigurationsEnabled) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -42,8 +42,11 @@ async function handler(
     });
   }
 
-  const killSwitches = await KillSwitchResource.listEnabledKillSwitches();
-  if (killSwitches?.includes("save_agent_configurations")) {
+  const isSaveAgentConfigurationsEnabled =
+    await KillSwitchResource.isKillSwitchEnabledCached(
+      "save_agent_configurations"
+    );
+  if (isSaveAgentConfigurationsEnabled) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -68,8 +68,11 @@ async function handler(
     }
 
     case "PATCH": {
-      const killSwitches = await KillSwitchResource.listEnabledKillSwitches();
-      if (killSwitches?.includes("save_data_source_views")) {
+      const isSaveDataSourceViewsEnabled =
+        await KillSwitchResource.isKillSwitchEnabledCached(
+          "save_data_source_views"
+        );
+      if (isSaveDataSourceViewsEnabled) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -155,8 +155,11 @@ async function handler(
         });
       }
 
-      const killSwitches = await KillSwitchResource.listEnabledKillSwitches();
-      if (killSwitches?.includes("save_data_source_views")) {
+      const isSaveDataSourceViewsEnabled =
+        await KillSwitchResource.isKillSwitchEnabledCached(
+          "save_data_source_views"
+        );
+      if (isSaveDataSourceViewsEnabled) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -818,8 +818,9 @@ DataTable.Row = function Row({
           "s-group/dt-row s-justify-center s-border-b s-transition-colors s-duration-300 s-ease-out",
           "s-border-separator dark:s-border-separator-night",
           (onClick || onDoubleClick) &&
-            "s-cursor-pointer [&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted dark:[&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted-night",
-          props["data-selected"] && "s-bg-muted/50 dark:s-bg-muted/50",
+            "s-cursor-pointer [&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted-background dark:[&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted-background-night",
+          props["data-selected"] &&
+            "s-bg-muted-background/50 dark:s-bg-muted-background-night/50",
           widthClassName,
           className
         )}


### PR DESCRIPTION
## Description

Add global kill switches for anthropic and openai, to switch our global agents to another provider.

## Tests

Local
<img width="535" height="581" alt="image" src="https://github.com/user-attachments/assets/121b3d54-a9cf-4a16-9f2f-5b67f08e7219" />


## Risk

Add an extra query from time to time and an extra redis call.

## Deploy Plan

Deploy front