### PR TITLE
Add tab manipulation MCP tools and fix concurrent tool call routing

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -7,6 +7,8 @@ import type {
   GetActiveTabBackgroundMessage,
   GetActiveTabBackgroundResponse,
   InputBarStatusMessage,
+  TabActionMessage,
+  TabActionResponse,
 } from "@extension/platforms/chrome/messages";
 import type { PendingUpdate } from "@extension/platforms/chrome/services/platform";
 import { ChromePlatformService } from "@extension/platforms/chrome/services/platform";
@@ -27,6 +29,18 @@ function isGoogleChrome(): boolean {
       }
     ).userAgentData?.brands ?? [];
   return brands.some((b) => b.brand === "Google Chrome");
+}
+
+// Mutex to serialize tab capture operations. captureVisibleTab only captures
+// the currently visible tab, so concurrent captures would produce duplicates.
+let tabOpMutex: Promise<void> = Promise.resolve();
+function withTabLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = tabOpMutex.then(fn, fn);
+  tabOpMutex = next.then(
+    () => {},
+    () => {}
+  );
+  return next;
 }
 
 // Initialize the platform service.
@@ -257,7 +271,8 @@ chrome.runtime.onMessage.addListener(
       | AuthBackgroundMessage
       | GetActiveTabBackgroundMessage
       | CaptureMesssage
-      | InputBarStatusMessage,
+      | InputBarStatusMessage
+      | TabActionMessage,
     sender,
     sendResponse: (
       response:
@@ -266,6 +281,7 @@ chrome.runtime.onMessage.addListener(
         | AuthBackgroundResponseError
         | CaptureResponse
         | GetActiveTabBackgroundResponse
+        | TabActionResponse
     ) => void
   ) => {
     switch (message.type) {
@@ -296,121 +312,230 @@ chrome.runtime.onMessage.addListener(
         return true;
 
       case "GET_ACTIVE_TAB":
-        chrome.tabs.query(
-          { active: true, currentWindow: true },
-          async (tabs) => {
-            const tab = tabs[0];
-            if (!tab?.id) {
-              log("No active tab found.");
-              sendResponse({ url: "", content: "", title: "" });
-              return;
-            }
+        void (async () => {
+          let tab: chrome.tabs.Tab | undefined;
+          if (message.tabId) {
+            tab = await chrome.tabs.get(message.tabId);
+          } else {
+            const tabs = await chrome.tabs.query({
+              active: true,
+              currentWindow: true,
+            });
+            tab = tabs[0];
+          }
 
-            if (tab.url && (await shouldDisableContextMenuForDomain(tab.url))) {
-              sendResponse({
-                url: tab.url || "",
-                content: "",
-                title: "",
-                error: "Capture is disabled for this domain.",
-              });
-              return;
-            }
+          if (!tab?.id) {
+            log("No active tab found.");
+            sendResponse({ url: "", content: "", title: "" });
+            return;
+          }
 
-            try {
-              const includeContent = message.includeContent ?? true;
-              const includeCapture = message.includeCapture ?? false;
-              const [mimetypeExecution] = await chrome.scripting.executeScript({
-                target: { tabId: tab.id },
-                func: () => document.contentType,
-              });
+          if (tab.url && (await shouldDisableContextMenuForDomain(tab.url))) {
+            sendResponse({
+              url: tab.url || "",
+              content: "",
+              title: "",
+              error: "Capture is disabled for this domain.",
+            });
+            return;
+          }
 
-              let captures: string[] | undefined;
-              if (includeCapture) {
-                if (mimetypeExecution.result === "text/html") {
-                  // Full page capture
-                  await chrome.scripting.executeScript({
-                    target: { tabId: tab.id },
-                    files: ["page.js"],
+          try {
+            const includeContent = message.includeContent ?? true;
+            const includeCapture = message.includeCapture ?? false;
+            const [mimetypeExecution] = await chrome.scripting.executeScript({
+              target: { tabId: tab.id },
+              func: () => document.contentType,
+            });
+
+            let captures: string[] | undefined;
+            if (includeCapture) {
+              // Serialize capture operations: captureVisibleTab only captures
+              // the currently visible tab, so concurrent captures would race.
+              captures = await withTabLock(async () => {
+                // If targeting a non-active tab, activate it first so
+                // captureVisibleTab and full-page capture work correctly.
+                let previousTabId: number | undefined;
+                if (!tab.active && tab.id) {
+                  const [activeTab] = await chrome.tabs.query({
+                    active: true,
+                    windowId: tab.windowId,
                   });
-                  captures = await new Promise((resolve, reject) => {
-                    if (tab?.id) {
-                      const timeout = setTimeout(() => {
-                        console.error("Timeout waiting for full page capture");
-                        reject(
-                          new Error("Timeout waiting for full page screenshot.")
+                  previousTabId = activeTab?.id;
+                  await chrome.tabs.update(tab.id, { active: true });
+                  // Brief wait for the tab to render.
+                  await new Promise((r) => setTimeout(r, 500));
+                }
+
+                try {
+                  if (mimetypeExecution.result === "text/html") {
+                    // Full page capture
+                    await chrome.scripting.executeScript({
+                      target: { tabId: tab.id! },
+                      files: ["page.js"],
+                    });
+                    return await new Promise<string[]>((resolve, reject) => {
+                      if (tab?.id) {
+                        const timeout = setTimeout(() => {
+                          console.error(
+                            "Timeout waiting for full page capture"
+                          );
+                          reject(
+                            new Error(
+                              "Timeout waiting for full page screenshot."
+                            )
+                          );
+                        }, 10000);
+                        chrome.tabs.sendMessage(
+                          tab.id,
+                          { type: "PAGE_CAPTURE_FULL_PAGE" },
+                          (res) => {
+                            clearTimeout(timeout);
+                            resolve(res);
+                          }
                         );
-                      }, 10000);
-                      chrome.tabs.sendMessage(
-                        tab.id,
-                        { type: "PAGE_CAPTURE_FULL_PAGE" },
-                        (res) => {
+                      } else {
+                        console.error("No tab id");
+                        reject(new Error("No tab selected."));
+                      }
+                    });
+                  } else {
+                    return [
+                      await new Promise<string>((resolve, reject) => {
+                        const timeout = setTimeout(() => {
+                          console.error("Timeout waiting for capture");
+                          reject(
+                            new Error("Timeout waiting for page screenshot")
+                          );
+                        }, 2000);
+                        chrome.tabs.captureVisibleTab((res) => {
                           clearTimeout(timeout);
                           resolve(res);
-                        }
-                      );
-                    } else {
-                      console.error("No tab id");
-                      reject(new Error("No tab selected."));
-                    }
-                  });
-                } else {
-                  captures = [
-                    await new Promise<string>((resolve, reject) => {
-                      const timeout = setTimeout(() => {
-                        console.error("Timeout waiting for capture");
-                        reject(
-                          new Error("Timeout waiting for page screenshot")
-                        );
-                      }, 2000);
-                      chrome.tabs.captureVisibleTab((res) => {
-                        clearTimeout(timeout);
-                        resolve(res);
-                      });
-                    }),
-                  ];
+                        });
+                      }),
+                    ];
+                  }
+                } finally {
+                  // Restore the previously active tab.
+                  if (previousTabId !== undefined) {
+                    await chrome.tabs.update(previousTabId, { active: true });
+                  }
                 }
-                if (!captures || captures.length === 0) {
-                  console.error("Empty captures array");
-                  throw new Error("Failed to get a screenshot of the page.");
-                }
-              }
-              let content: string | undefined;
-              if (includeContent) {
-                if (message.includeSelectionOnly) {
-                  const [execution] = await chrome.scripting.executeScript({
-                    target: { tabId: tab.id },
-                    func: () => window.getSelection()?.toString(),
-                  });
-                  content = execution?.result ?? "no content.";
-                } else {
-                  // TODO - handle non-HTML content. For now we just extract the page content.
-                  const [execution] = await chrome.scripting.executeScript({
-                    target: { tabId: tab.id },
-                    func: extractPage(tab.url || ""),
-                  });
-                  content = execution?.result ?? "no content.";
-                }
-              }
-              sendResponse({
-                title: tab.title || "",
-                url: tab.url || "",
-                content,
-                captures,
               });
-            } catch (error) {
-              log("Error getting active tab content:", error);
-              sendResponse({
-                url: tab.url || "",
-                content: "",
-                title: "",
-                error:
-                  error instanceof Error
-                    ? error.message
-                    : "Failed to get content from the current tab.",
-              });
+
+              if (!captures || captures.length === 0) {
+                console.error("Empty captures array");
+                throw new Error("Failed to get a screenshot of the page.");
+              }
             }
+            let content: string | undefined;
+            if (includeContent) {
+              if (message.includeSelectionOnly) {
+                const [execution] = await chrome.scripting.executeScript({
+                  target: { tabId: tab.id },
+                  func: () => window.getSelection()?.toString(),
+                });
+                content = execution?.result ?? "no content.";
+              } else {
+                const [execution] = await chrome.scripting.executeScript({
+                  target: { tabId: tab.id },
+                  func: extractPage(tab.url || ""),
+                });
+                content = execution?.result ?? "no content.";
+              }
+            }
+            sendResponse({
+              title: tab.title || "",
+              url: tab.url || "",
+              content,
+              captures,
+            });
+          } catch (error) {
+            log("Error getting active tab content:", error);
+            sendResponse({
+              url: tab.url || "",
+              content: "",
+              title: "",
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to get content from the current tab.",
+            });
           }
-        );
+        })();
+        return true;
+
+      case "LIST_TABS":
+        void (async () => {
+          const tabs = await chrome.tabs.query({ currentWindow: true });
+          sendResponse({
+            success: true,
+            tabs: tabs
+              .filter((t) => t.id !== undefined && t.url)
+              .map((t) => ({
+                tabId: t.id!,
+                title: t.title || "",
+                url: t.url || "",
+                active: t.active,
+              })),
+          });
+        })();
+        return true;
+
+      case "ACTIVATE_TAB":
+        void (async () => {
+          try {
+            await chrome.tabs.update(message.tabId, { active: true });
+            sendResponse({ success: true });
+          } catch (error) {
+            sendResponse({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
+        return true;
+
+      case "CLOSE_TAB":
+        void (async () => {
+          try {
+            await chrome.tabs.remove(message.tabId);
+            sendResponse({ success: true });
+          } catch (error) {
+            sendResponse({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
+        return true;
+
+      case "OPEN_TAB":
+        void (async () => {
+          try {
+            const tab = await chrome.tabs.create({ url: message.url });
+            sendResponse({ success: true, tabId: tab.id });
+          } catch (error) {
+            sendResponse({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
+        return true;
+
+      case "MOVE_TAB":
+        void (async () => {
+          try {
+            await chrome.tabs.move(message.tabId, { index: message.index });
+            sendResponse({ success: true });
+          } catch (error) {
+            sendResponse({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
         return true;
 
       case "INPUT_BAR_STATUS":

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -32,6 +32,27 @@ export type GetActiveTabBackgroundResponse = {
   error?: string;
 };
 
+export type TabInfo = {
+  tabId: number;
+  title: string;
+  url: string;
+  active: boolean;
+};
+
+export type TabActionMessage =
+  | { type: "LIST_TABS" }
+  | { type: "ACTIVATE_TAB"; tabId: number }
+  | { type: "CLOSE_TAB"; tabId: number }
+  | { type: "OPEN_TAB"; url: string }
+  | { type: "MOVE_TAB"; tabId: number; index: number };
+
+export type TabActionResponse = {
+  success: boolean;
+  error?: string;
+  tabId?: number;
+  tabs?: TabInfo[];
+};
+
 export type InputBarStatusMessage = {
   type: "INPUT_BAR_STATUS";
   available: boolean;
@@ -181,6 +202,16 @@ export const sendGetActiveTabMessage = (params: CaptureOptions) => {
     type: "GET_ACTIVE_TAB",
     ...params,
   });
+};
+
+export const sendListTabsMessage = () => {
+  return sendMessage<TabActionMessage, TabActionResponse>({
+    type: "LIST_TABS",
+  });
+};
+
+export const sendTabActionMessage = (message: TabActionMessage) => {
+  return sendMessage<TabActionMessage, TabActionResponse>(message);
 };
 
 // Messages from background script to content script

--- a/extension/platforms/chrome/tools/getCurrentPageTool.ts
+++ b/extension/platforms/chrome/tools/getCurrentPageTool.ts
@@ -1,9 +1,10 @@
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 /**
  * Registers the get-current-browser-page tool with the MCP server.
- * Extracts the text content of the active browser tab.
+ * Extracts the text content of a browser tab.
  */
 export function registerGetCurrentPageTool(
   server: McpServer,
@@ -11,11 +12,19 @@ export function registerGetCurrentPageTool(
 ): void {
   server.tool(
     "get-current-browser-page",
-    "Extracts the title, URL, and text content of the active browser tab. " +
-      "Use this to read and understand what the user is currently viewing. " +
-      "For non-text pages (PDFs, images, etc.), prefer get-current-browser-page-screenshot.",
-    {},
-    async () => {
+    "Extracts the title, URL, and text content of a browser tab. " +
+      "Use this to read and understand what the user is viewing. " +
+      "For non-text pages (PDFs, images, etc.), prefer get-current-browser-page-screenshot. " +
+      "Use list-browser-tabs to discover tab IDs.",
+    {
+      tabId: z
+        .number()
+        .optional()
+        .describe(
+          "The tab ID to read. If omitted, reads the active tab. Use list-browser-tabs to get tab IDs."
+        ),
+    },
+    async ({ tabId }) => {
       if (!captureService) {
         return {
           content: [{ type: "text", text: "Capture service not available." }],
@@ -25,7 +34,7 @@ export function registerGetCurrentPageTool(
       try {
         const result = await captureService.handleOperation(
           "capture-page-content",
-          { includeContent: true, includeCapture: false }
+          { includeContent: true, includeCapture: false, tabId }
         );
 
         if (result.isErr()) {

--- a/extension/platforms/chrome/tools/getPageScreenshotTool.ts
+++ b/extension/platforms/chrome/tools/getPageScreenshotTool.ts
@@ -1,9 +1,10 @@
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 /**
  * Registers the get-current-browser-page-screenshot tool with the MCP server.
- * Captures a screenshot of the active browser tab.
+ * Captures a screenshot of a browser tab.
  */
 export function registerGetPageScreenshotTool(
   server: McpServer,
@@ -11,11 +12,19 @@ export function registerGetPageScreenshotTool(
 ): void {
   server.tool(
     "get-current-browser-page-screenshot",
-    "Captures a screenshot of the active browser tab. " +
+    "Captures a screenshot of a browser tab. " +
       "Use this when you need to visually inspect the page layout, " +
-      "or when the page contains non-text content (PDFs, images, Drive canvas, etc.).",
-    {},
-    async () => {
+      "or when the page contains non-text content (PDFs, images, Drive canvas, etc.). " +
+      "Use list-browser-tabs to discover tab IDs.",
+    {
+      tabId: z
+        .number()
+        .optional()
+        .describe(
+          "The tab ID to capture. If omitted, captures the active tab. Use list-browser-tabs to get tab IDs."
+        ),
+    },
+    async ({ tabId }) => {
       if (!captureService) {
         return {
           content: [{ type: "text", text: "Capture service not available." }],
@@ -25,7 +34,7 @@ export function registerGetPageScreenshotTool(
       try {
         const result = await captureService.handleOperation(
           "capture-page-content",
-          { includeContent: false, includeCapture: true }
+          { includeContent: false, includeCapture: true, tabId }
         );
 
         if (result.isErr()) {

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -1,5 +1,7 @@
 import { registerGetCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
 import { registerGetPageScreenshotTool } from "@extension/platforms/chrome/tools/getPageScreenshotTool";
+import { registerListTabsTool } from "@extension/platforms/chrome/tools/listTabsTool";
+import { registerTabActionTools } from "@extension/platforms/chrome/tools/tabActionTools";
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -12,6 +14,8 @@ export function registerAllTools(
   server: McpServer,
   captureService: CaptureService | null
 ): void {
+  registerListTabsTool(server);
+  registerTabActionTools(server);
   registerGetCurrentPageTool(server, captureService);
   registerGetPageScreenshotTool(server, captureService);
 }

--- a/extension/platforms/chrome/tools/listTabsTool.ts
+++ b/extension/platforms/chrome/tools/listTabsTool.ts
@@ -1,0 +1,45 @@
+import { sendListTabsMessage } from "@extension/platforms/chrome/messages";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Registers the list-browser-tabs tool with the MCP server.
+ * Lists all open tabs in the current browser window.
+ */
+export function registerListTabsTool(server: McpServer): void {
+  server.tool(
+    "list-browser-tabs",
+    "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
+      "Use this to discover which tabs the user has open. " +
+      "Tab IDs can be passed to get-current-browser-page or get-current-browser-page-screenshot to read a specific tab.",
+    {},
+    async () => {
+      try {
+        const result = await sendListTabsMessage();
+        const tabs = result.tabs ?? [];
+
+        if (!tabs || tabs.length === 0) {
+          return {
+            content: [{ type: "text", text: "No tabs found." }],
+          };
+        }
+
+        const lines = tabs.map(
+          (t) => `${t.active ? "* " : "  "}[${t.tabId}] ${t.title} — ${t.url}`
+        );
+
+        return {
+          content: [{ type: "text", text: lines.join("\n") }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to list tabs: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}

--- a/extension/platforms/chrome/tools/tabActionTools.ts
+++ b/extension/platforms/chrome/tools/tabActionTools.ts
@@ -1,0 +1,163 @@
+import { sendTabActionMessage } from "@extension/platforms/chrome/messages";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+/**
+ * Registers tab manipulation tools with the MCP server.
+ */
+export function registerTabActionTools(server: McpServer): void {
+  server.tool(
+    "activate-browser-tab",
+    "Switches to the specified browser tab, making it the active tab. " +
+      "Use list-browser-tabs to discover tab IDs.",
+    {
+      tabId: z.number().describe("The tab ID to activate."),
+    },
+    async ({ tabId }) => {
+      try {
+        const result = await sendTabActionMessage({
+          type: "ACTIVATE_TAB",
+          tabId,
+        });
+        if (!result.success) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
+            ],
+          };
+        }
+        return {
+          content: [{ type: "text", text: `Activated tab ${tabId}.` }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to activate tab: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "close-browser-tab",
+    "Closes the specified browser tab. Use list-browser-tabs to discover tab IDs.",
+    {
+      tabId: z.number().describe("The tab ID to close."),
+    },
+    async ({ tabId }) => {
+      try {
+        const result = await sendTabActionMessage({
+          type: "CLOSE_TAB",
+          tabId,
+        });
+        if (!result.success) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
+            ],
+          };
+        }
+        return {
+          content: [{ type: "text", text: `Closed tab ${tabId}.` }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to close tab: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "open-browser-tab",
+    "Opens a new browser tab with the specified URL.",
+    {
+      url: z.string().url().describe("The URL to open in a new tab."),
+    },
+    async ({ url }) => {
+      try {
+        const result = await sendTabActionMessage({ type: "OPEN_TAB", url });
+        if (!result.success) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Opened new tab${result.tabId ? ` (ID: ${result.tabId})` : ""} with URL: ${url}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to open tab: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "move-browser-tab",
+    "Moves a browser tab to a new position (index) in the tab bar. " +
+      "Use list-browser-tabs to discover tab IDs and current order.",
+    {
+      tabId: z.number().describe("The tab ID to move."),
+      index: z
+        .number()
+        .describe(
+          "The zero-based position to move the tab to. Use -1 to move to the end."
+        ),
+    },
+    async ({ tabId, index }) => {
+      try {
+        const result = await sendTabActionMessage({
+          type: "MOVE_TAB",
+          tabId,
+          index,
+        });
+        if (!result.success) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Moved tab ${tabId} to position ${index}.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to move tab: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}

--- a/extension/shared/services/capture.ts
+++ b/extension/shared/services/capture.ts
@@ -13,6 +13,7 @@ export interface CaptureOptions {
   includeContent?: boolean;
   includeSelectionOnly?: boolean;
   includeCapture?: boolean;
+  tabId?: number;
 }
 
 export interface CaptureService {

--- a/front/lib/api/actions/mcp_client_side.ts
+++ b/front/lib/api/actions/mcp_client_side.ts
@@ -22,28 +22,26 @@ interface ClientSideMCPRequestId {
 }
 
 /**
- * Generate a unique MCP request ID for a conversation and message
+ * Generate a unique MCP request ID for a conversation and message.
+ * Format: mcp_req_{conversationId}_{messageId}_{uuid}_{originalRequestId}
  */
 function makeClientSideMCPRequestIdForMessageAndConversation({
   conversationId,
   messageId,
   originalRequestId,
 }: ClientSideMCPRequestId): string {
-  // Format: mcp_req_{conversationId}_{messageId}_{timestamp}_{originalRequestId}.
-  // The timestamp ensures uniqueness even for the same message.
-  return `mcp_req_${conversationId}_${messageId}_${Date.now()}_${originalRequestId}`;
+  return `mcp_req_${conversationId}_${messageId}_${crypto.randomUUID()}_${originalRequestId}`;
 }
 
 /**
- * Parse a client-side MCP request ID to extract the conversation ID and message ID
+ * Parse a client-side MCP request ID to extract the conversation ID and message ID.
  * @param requestId The request ID to parse
  * @returns An object containing the conversation ID and message ID, or null if the format is invalid
  */
 export function parseClientSideMCPRequestId(
   requestId: string
 ): ClientSideMCPRequestId | null {
-  // Check if the request ID follows our format.
-  const match = requestId.match(/^mcp_req_([^_]+)_([^_]+)_\d+_(\d+)$/);
+  const match = requestId.match(/^mcp_req_([^_]+)_([^_]+)_([a-f0-9-]+)_(\d+)$/);
 
   if (!match) {
     return null;
@@ -52,7 +50,7 @@ export function parseClientSideMCPRequestId(
   return {
     conversationId: match[1],
     messageId: match[2],
-    originalRequestId: match[3],
+    originalRequestId: match[4],
   };
 }
 
@@ -178,6 +176,9 @@ export function isMCPEventResult(value: unknown): value is MCPEventResult {
  */
 export class ClientSideRedisMCPTransport implements Transport {
   private unsubscribe?: () => void;
+
+  // Track transformed IDs sent by this transport to only process matching responses.
+  private readonly pendingRequestIds = new Set<string>();
 
   private readonly conversationId: string;
   private readonly messageId: string;
@@ -309,6 +310,7 @@ export class ClientSideRedisMCPTransport implements Transport {
     if (isJSONRPCMessageWithId(payload)) {
       const transformedId = this.transformRequestId(payload.id);
       payload.id = transformedId;
+      this.pendingRequestIds.add(transformedId);
     }
 
     // Publish MCP requests to Redis
@@ -336,6 +338,13 @@ export class ClientSideRedisMCPTransport implements Transport {
       // Handle ID transformation for responses
       if (isMCPEventResult(payload.result)) {
         const { id: requestId } = payload.result;
+
+        // Only process responses for requests sent by THIS transport.
+        if (!this.pendingRequestIds.has(requestId)) {
+          return;
+        }
+        this.pendingRequestIds.delete(requestId);
+
         const restored = this.restoreRequestId(requestId);
 
         if (restored) {


### PR DESCRIPTION
## Description

**New MCP tools for tab management:**
- `list-browser-tabs` — lists all open tabs with ID, title, URL, active status
- `activate-browser-tab`, `close-browser-tab`, `open-browser-tab`, `move-browser-tab` — full tab manipulation
- `tabId` parameter on `get-current-browser-page` and `get-current-browser-page-screenshot` to target specific tabs

**Bug fixes for concurrent client-side MCP tool calls:**
- Fix responses routed to wrong transport: each `ClientSideRedisMCPTransport` now tracks its own `pendingRequestIds` and ignores responses for other transports
- Fix request ID collisions: replaced `Date.now()` (collides within same millisecond) with `crypto.randomUUID()`
- Fix missing IIFE invocation `()` in background `GET_ACTIVE_TAB` handler causing `sendResponse` to never be called
- Serialize `captureVisibleTab` with a mutex so concurrent screenshot captures don't race

## Tests

Manual testing:
- Ask agent to list tabs → returns all open tabs with IDs
- Ask agent to read content from multiple specific tabs simultaneously → returns distinct content for each
- Ask agent to take screenshots of multiple tabs → returns distinct screenshots
- Tab action tools (open/close/activate/move) work correctly
- Single tool calls still work (no regression)

## Risk

Low — extension-only changes plus a targeted fix in `mcp_client_side.ts` (request ID generation and response filtering). The `pendingRequestIds` filtering is additive and backward-compatible (regex matches both old timestamp and new UUID formats).

## Deploy Plan

Standard deploy. No migration needed. Extension users will get the update on next extension refresh.