### PR TITLE
Refactor file processing pipeline and add conversation mount paths for sandbox

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -809,11 +809,12 @@ export async function upsertTable({
     }
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
+    const { bucket, path } = file.getContentBucketAndPath(auth);
     const schemaRes = await coreAPI.tableValidateCSVContent({
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
-      bucket: file.getBucketForVersion("processed").name,
-      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+      bucket,
+      bucketCSVPath: path,
     });
     if (schemaRes.isErr()) {
       if (schemaRes.error.code === "invalid_csv_content") {
@@ -825,8 +826,8 @@ export async function upsertTable({
       } else {
         logger.error(
           {
-            bucket: file.getBucketForVersion("processed").name,
-            bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+            bucket,
+            bucketCSVPath: path,
             dataSourceId: dataSource.sId,
             error: schemaRes.error,
           },

--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -1,0 +1,138 @@
+import {
+  hasProcessedVersion,
+  isUploadSupportedForContentType,
+} from "@app/lib/api/files/processing";
+import { describe, expect, it } from "vitest";
+
+describe("hasProcessedVersion", () => {
+  it("should return false for plain text files", () => {
+    expect(hasProcessedVersion("text/plain")).toBe(false);
+  });
+
+  it("should return false for Python files", () => {
+    expect(hasProcessedVersion("text/x-python")).toBe(false);
+  });
+
+  it("should return false for JSON files", () => {
+    expect(hasProcessedVersion("application/json")).toBe(false);
+  });
+
+  it("should return false for CSV files", () => {
+    expect(hasProcessedVersion("text/csv")).toBe(false);
+  });
+
+  it("should return false for SVG files", () => {
+    expect(hasProcessedVersion("image/svg+xml")).toBe(false);
+  });
+
+  it("should return true for PDF files (text extraction)", () => {
+    expect(hasProcessedVersion("application/pdf")).toBe(true);
+  });
+
+  it("should return true for Word documents (text extraction)", () => {
+    expect(
+      hasProcessedVersion(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      )
+    ).toBe(true);
+  });
+
+  it("should return true for image files (resize)", () => {
+    expect(hasProcessedVersion("image/png")).toBe(true);
+  });
+
+  it("should return true for Excel files (text extraction)", () => {
+    expect(
+      hasProcessedVersion(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+      )
+    ).toBe(true);
+  });
+
+  it("should return true for audio files (transcription)", () => {
+    expect(hasProcessedVersion("audio/mpeg")).toBe(true);
+  });
+});
+
+describe("isUploadSupportedForContentType", () => {
+  it("should return true for plain text files (uploadable without processing)", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "text/plain",
+        useCase: "conversation",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for Python files (uploadable without processing)", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "text/x-python",
+        useCase: "conversation",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for CSV files (uploadable without processing)", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "text/csv",
+        useCase: "conversation",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for PDF files (uploadable with processing)", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "application/pdf",
+        useCase: "conversation",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for SVG files in conversation", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "image/svg+xml",
+        useCase: "conversation",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for image files as skill_attachment", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "image/png",
+        useCase: "skill_attachment",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for Slack thread attachments", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "text/vnd.dust.attachment.slack.thread",
+        useCase: "conversation",
+      })
+    ).toBe(true);
+  });
+
+  it("should return true for section JSON as tool_output", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "application/vnd.dust.section.json",
+        useCase: "tool_output",
+      })
+    ).toBe(true);
+  });
+
+  it("should return false for unsupported content type / use case combo", () => {
+    expect(
+      isUploadSupportedForContentType({
+        contentType: "image/png",
+        useCase: "upsert_table",
+      })
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -76,10 +76,10 @@ const resizeImage: ProcessingFunction = async (
     try {
       await pipeline(readStream, writeStream);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : "Unexpected error";
       return new Err(
-        new Error(`Failed uploading to public bucket. ${errorMessage}`)
+        new Error(
+          `Failed uploading to public bucket. ${normalizeError(err).message}`
+        )
       );
     }
   }
@@ -219,10 +219,9 @@ const resizeAndWriteToProcessed = async (
       "Failed to resize image."
     );
 
-    const errorMessage =
-      err instanceof Error ? err.message : "Unexpected error";
-
-    return new Err(new Error(`Failed resizing image. ${errorMessage}`));
+    return new Err(
+      new Error(`Failed resizing image. ${normalizeError(err).message}`)
+    );
   }
 };
 
@@ -267,11 +266,10 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
       "Failed to extract text from File."
     );
 
-    const errorMessage =
-      err instanceof Error ? err.message : "Unexpected error";
-
     return new Err(
-      new Error(`Failed extracting text from File. ${errorMessage}`)
+      new Error(
+        `Failed extracting text from File. ${normalizeError(err).message}`
+      )
     );
   }
 };
@@ -347,10 +345,10 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
       "Failed to extract text from Audio."
     );
 
-    const errorMessage =
-      err instanceof Error ? err.message : "Unexpected error";
     return new Err(
-      new Error(`Failed extracting text from Audio. ${errorMessage}`)
+      new Error(
+        `Failed extracting text from Audio. ${normalizeError(err).message}`
+      )
     );
   } finally {
     // 5) Cleanup temp file.
@@ -368,7 +366,7 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
 
 // Preprocessing for file upload.
 
-// Shared map: content type → processing function. Only content types that produce a meaningful
+// Shared map: content type -> processing function. Only content types that produce a meaningful
 // "processed" version are listed here. Content types not in this map are used as-is (original).
 const PROCESSING_BY_CONTENT_TYPE = new Map<
   AllSupportedFileContentType,
@@ -414,7 +412,7 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
 
 // Returns the processing function that transforms the original file into a processed version (e.g.,
 // text extraction, image resize, audio transcription). Returns undefined when no transformation is
-// needed — the original file is used as-is. Processing is purely content-type-driven; upload
+// needed. The original file is used as-is. Processing is purely content-type-driven. Upload
 // support per use case is handled separately by the per-use-case files.
 const getProcessingFunction = (
   contentType: AllSupportedFileContentType

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -1,4 +1,12 @@
 import config from "@app/lib/api/config";
+import { isSupportedForAvatar } from "@app/lib/api/files/use_cases/avatar";
+import { isSupportedForConversation } from "@app/lib/api/files/use_cases/conversation";
+import { isSupportedForFoldersDocument } from "@app/lib/api/files/use_cases/folders_document";
+import { isSupportedForProjectContext } from "@app/lib/api/files/use_cases/project_context";
+import { isSupportedForSkillAttachment } from "@app/lib/api/files/use_cases/skill_attachment";
+import { isSupportedForToolOutput } from "@app/lib/api/files/use_cases/tool_output";
+import { isSupportedForUpsertDocument } from "@app/lib/api/files/use_cases/upsert_document";
+import { isSupportedForUpsertTable } from "@app/lib/api/files/use_cases/upsert_table";
 import { parseUploadRequest } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
@@ -9,15 +17,8 @@ import logger from "@app/logger/logger";
 import type {
   AllSupportedFileContentType,
   FileUseCase,
-  SupportedFileContentType,
 } from "@app/types/files";
-import {
-  extensionsForContentType,
-  isInteractiveContentType,
-  isSupportedAudioContentType,
-  isSupportedDelimitedTextContentType,
-  isSupportedImageContentType,
-} from "@app/types/files";
+import { extensionsForContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import {
@@ -26,8 +27,6 @@ import {
 } from "@app/types/shared/text_extraction";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
-import { isDustMimeType } from "@dust-tt/client";
 import ConvertAPI from "convertapi";
 import fs from "fs";
 import type { IncomingMessage } from "http";
@@ -47,45 +46,6 @@ type ProcessingFunction = (
 ) => Promise<Result<undefined, Error>>;
 
 // Images processing functions.
-const resizeAndUploadToPublicBucket: ProcessingFunction = async (
-  auth: Authenticator,
-  file: FileResource
-) => {
-  const result = await makeResizeAndUploadImageToFileStorage(
-    AVATAR_IMG_MAX_SIZE_PIXELS
-  )(auth, file);
-  if (result.isErr()) {
-    return result;
-  }
-  const readStream = file.getReadStream({
-    auth,
-    version: "processed",
-  });
-  const writeStream = file.getWriteStream({
-    auth,
-    version: "public",
-  });
-  try {
-    await pipeline(readStream, writeStream);
-    return new Ok(undefined);
-  } catch (err) {
-    logger.error(
-      {
-        fileModelId: file.id,
-        workspaceId: auth.workspace()?.sId,
-        error: err,
-      },
-      "Failed to upload file to public url."
-    );
-
-    const errorMessage =
-      err instanceof Error ? err.message : "Unexpected error";
-
-    return new Err(
-      new Error(`Failed uploading to public bucket. ${errorMessage}`)
-    );
-  }
-};
 
 const createReadableFromUrl = async (url: string): Promise<Readable> => {
   const response = await untrustedFetch(url);
@@ -95,34 +55,57 @@ const createReadableFromUrl = async (url: string): Promise<Readable> => {
   return Readable.fromWeb(response.body);
 };
 
-const makeResizeAndUploadImageToFileStorage = (maxSize: string) => {
-  return async (auth: Authenticator, file: FileResource) =>
-    resizeAndUploadToFileStorage(auth, file, {
-      ImageHeight: maxSize,
-      ImageWidth: maxSize,
-    });
+const resizeImage: ProcessingFunction = async (
+  auth: Authenticator,
+  file: FileResource
+) => {
+  const maxSize =
+    file.useCase === "avatar"
+      ? AVATAR_IMG_MAX_SIZE_PIXELS
+      : CONVERSATION_IMG_MAX_SIZE_PIXELS;
+
+  const resizeResult = await resizeAndWriteToProcessed(auth, file, maxSize);
+  if (resizeResult.isErr()) {
+    return resizeResult;
+  }
+
+  // Avatar images are also copied to the public bucket.
+  if (file.useCase === "avatar") {
+    const readStream = file.getReadStream({ auth, version: "processed" });
+    const writeStream = file.getWriteStream({ auth, version: "public" });
+    try {
+      await pipeline(readStream, writeStream);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Unexpected error";
+      return new Err(
+        new Error(`Failed uploading to public bucket. ${errorMessage}`)
+      );
+    }
+  }
+
+  return new Ok(undefined);
 };
 
-interface ImageResizeParams {
-  ImageHeight: string;
-  ImageWidth: string;
-}
-
-const resizeAndUploadToFileStorage = async (
+/**
+ * Resize an image and write the result to the "processed" version. If the image is already within
+ * size limits, copies the original to processed without calling ConvertAPI.
+ */
+const resizeAndWriteToProcessed = async (
   auth: Authenticator,
   file: FileResource,
-  resizeParams: ImageResizeParams
-) => {
-  const maxSizePixels = parseInt(resizeParams.ImageWidth);
+  maxSize: string
+): Promise<Result<undefined, Error>> => {
+  const maxSizePixels = parseInt(maxSize);
 
-  // Check image dimensions before calling ConvertAPI
+  // Check image dimensions before calling ConvertAPI.
   try {
     const readStreamForProbe = file.getReadStream({
       auth,
       version: "original",
     });
 
-    // Read first 32KB (sufficient for all image format headers)
+    // Read first 32KB (sufficient for all image format headers).
     const chunks: Buffer[] = [];
     let totalSize = 0;
     const maxBufferSize = 32 * 1024;
@@ -148,7 +131,6 @@ const resizeAndUploadToFileStorage = async (
       dimensions.width <= maxSizePixels &&
       dimensions.height <= maxSizePixels
     ) {
-      // Upload without resizing
       const readStream = file.getReadStream({ auth, version: "original" });
       const writeStream = file.getWriteStream({
         auth,
@@ -168,7 +150,7 @@ const resizeAndUploadToFileStorage = async (
       return new Ok(undefined);
     }
   } catch (err) {
-    // If dimension check fails, fall back to ConvertAPI for safety
+    // If dimension check fails, fall back to ConvertAPI for safety.
     logger.warn(
       {
         fileModelId: file.id,
@@ -179,7 +161,7 @@ const resizeAndUploadToFileStorage = async (
     );
   }
 
-  // ConvertAPI flow
+  // ConvertAPI flow.
   if (!process.env.CONVERTAPI_API_KEY) {
     throw new Error("CONVERTAPI_API_KEY is not set");
   }
@@ -192,9 +174,6 @@ const resizeAndUploadToFileStorage = async (
 
   let result;
   try {
-    // Upload the original file content directly to ConvertAPI to avoid exposing a signed URL
-    // which could be fetched by the third-party service. This still sends the file contents to
-    // ConvertAPI for conversion but removes the use of a signed download URL.
     const uploadResult = await convertapi.upload(
       file.getReadStream({ auth, version: "original" }),
       `${file.fileName}.${originalFormat}`
@@ -208,7 +187,8 @@ const resizeAndUploadToFileStorage = async (
         ImageResolution: "72",
         ScaleImage: "true",
         ScaleIfLarger: "true",
-        ...resizeParams,
+        ImageHeight: maxSize,
+        ImageWidth: maxSize,
       },
       originalFormat,
       30
@@ -300,7 +280,13 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
   auth: Authenticator,
   file: FileResource
 ) => {
-  // Only handle supported audio types via getProcessingFunction gate.
+  // Skip transcription if the workspace has disabled voice transcription.
+  if (
+    auth.getNonNullableWorkspace().metadata?.allowVoiceTranscription === false
+  ) {
+    return new Ok(undefined);
+  }
+
   // Strategy:
   // 1) Buffer original audio stream to a temporary file on disk.
   // 2) Build a minimal formidable-like File pointing to that temp filepath.
@@ -380,239 +366,115 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
   }
 };
 
-// Other text files processing.
-
-// We don't apply any processing to these files, we just store the raw text.
-const storeRawText: ProcessingFunction = async (
-  auth: Authenticator,
-  file: FileResource
-) => {
-  const readStream = file.getReadStream({
-    auth,
-    version: "original",
-  });
-  const writeStream = file.getWriteStream({
-    auth,
-    version: "processed",
-  });
-
-  try {
-    await pipeline(readStream, writeStream);
-    return new Ok(undefined);
-  } catch (err) {
-    logger.error(
-      {
-        fileModelId: file.id,
-        workspaceId: auth.workspace()?.sId,
-        error: err,
-      },
-      "Failed to store raw text."
-    );
-
-    const errorMessage =
-      err instanceof Error ? err.message : "Unexpected error";
-
-    return new Err(new Error(`Failed to store raw text ${errorMessage}`));
-  }
-};
-
 // Preprocessing for file upload.
 
-const getProcessingFunction = ({
-  auth,
+// Shared map: content type → processing function. Only content types that produce a meaningful
+// "processed" version are listed here. Content types not in this map are used as-is (original).
+const PROCESSING_BY_CONTENT_TYPE = new Map<
+  AllSupportedFileContentType,
+  ProcessingFunction
+>([
+  // Images (resized).
+  ["image/jpeg", resizeImage],
+  ["image/png", resizeImage],
+  ["image/gif", resizeImage],
+  ["image/webp", resizeImage],
+  ["image/bmp", resizeImage],
+
+  // Audio (transcribed).
+  ["audio/mpeg", extractTextFromAudioAndUpload],
+  ["audio/wav", extractTextFromAudioAndUpload],
+  ["audio/x-wav", extractTextFromAudioAndUpload],
+  ["audio/webm", extractTextFromAudioAndUpload],
+  ["audio/ogg", extractTextFromAudioAndUpload],
+  ["audio/x-m4a", extractTextFromAudioAndUpload],
+
+  // Documents (text extracted via Tika).
+  ["application/pdf", extractTextFromFileAndUpload],
+  ["application/msword", extractTextFromFileAndUpload],
+  [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    extractTextFromFileAndUpload,
+  ],
+  ["application/vnd.ms-powerpoint", extractTextFromFileAndUpload],
+  [
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    extractTextFromFileAndUpload,
+  ],
+  ["application/vnd.google-apps.document", extractTextFromFileAndUpload],
+  ["application/vnd.google-apps.presentation", extractTextFromFileAndUpload],
+
+  // Excel (text extracted via Tika → HTML table).
+  [
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    extractTextFromFileAndUpload,
+  ],
+  ["application/vnd.ms-excel", extractTextFromFileAndUpload],
+]);
+
+// Returns the processing function that transforms the original file into a processed version (e.g.,
+// text extraction, image resize, audio transcription). Returns undefined when no transformation is
+// needed — the original file is used as-is. Processing is purely content-type-driven; upload
+// support per use case is handled separately by the per-use-case files.
+const getProcessingFunction = (
+  contentType: AllSupportedFileContentType
+): ProcessingFunction | undefined => {
+  return PROCESSING_BY_CONTENT_TYPE.get(contentType);
+};
+
+// Whether uploading this content type for this use case is supported. Dispatches to per-use-case
+// files that each define their own set of supported content types.
+export function isUploadSupportedForContentType({
   contentType,
   useCase,
 }: {
-  auth: Authenticator;
   contentType: AllSupportedFileContentType;
   useCase: FileUseCase;
-}): ProcessingFunction | undefined => {
-  // Interactive Content file types are not processed.
-  if (isInteractiveContentType(contentType)) {
-    return undefined;
-  }
-
-  // SVG files are stored as-is without any processing (no resize).
-  if (contentType === "image/svg+xml") {
-    if (
-      [
-        "conversation",
-        "project_context",
-        "skill_attachment",
-        "tool_output",
-      ].includes(useCase)
-    ) {
-      return storeRawText;
-    }
-    return undefined;
-  }
-
-  if (isSupportedImageContentType(contentType)) {
-    if (useCase === "skill_attachment") {
-      return storeRawText;
-    }
-    if (useCase === "conversation" || useCase === "project_context") {
-      return makeResizeAndUploadImageToFileStorage(
-        CONVERSATION_IMG_MAX_SIZE_PIXELS
-      );
-    } else if (useCase === "avatar") {
-      return resizeAndUploadToPublicBucket;
-    }
-    return undefined;
-  }
-
-  if (isSupportedDelimitedTextContentType(contentType)) {
-    if (
-      contentType ===
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
-      contentType === "application/vnd.ms-excel"
-    ) {
-      // We use Tika to extract from Excel files, it will turn into an HTML table
-      // We will upsert from the HTML table later
-      return extractTextFromFileAndUpload;
-    } else if (
-      [
-        "conversation",
-        "upsert_document",
-        "folders_document",
-        "upsert_table",
-        "tool_output",
-        "project_context",
-        "skill_attachment",
-      ].includes(useCase)
-    ) {
-      return storeRawText;
-    }
-    return undefined;
-  }
-
-  if (isSupportedAudioContentType(contentType)) {
-    if (
-      (useCase === "conversation" || useCase === "project_context") &&
-      // Only handle voice transcription if the workspace has enabled it.
-      auth.getNonNullableWorkspace().metadata?.allowVoiceTranscription !== false
-    ) {
-      return extractTextFromAudioAndUpload;
-    }
-    return undefined;
-  }
-
-  switch (contentType) {
-    case "application/msword":
-    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-    case "application/vnd.ms-powerpoint":
-    case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-    case "application/vnd.google-apps.document":
-    case "application/vnd.google-apps.presentation":
-    case "application/pdf":
-      if (
-        [
-          "conversation",
-          "upsert_document",
-          "folders_document",
-          "project_context",
-          "skill_attachment",
-        ].includes(useCase)
-      ) {
-        return extractTextFromFileAndUpload;
-      }
-      break;
-    case "application/octet-stream":
-    case "text/plain":
-    case "text/markdown":
-    case "text/html":
-    case "text/xml":
-    case "text/calendar":
-    case "text/css":
-    case "text/javascript":
-    case "text/typescript":
-    case "application/json":
-    case "application/xml":
-    case "application/x-sh":
-    case "text/x-sh":
-    case "text/x-python":
-    case "text/x-python-script":
-    case "application/x-yaml":
-    case "text/yaml":
-    case "text/vnd.yaml":
-    case "text/x-c":
-    case "text/x-csharp":
-    case "text/x-java-source":
-    case "text/x-php":
-    case "text/x-ruby":
-    case "text/x-sql":
-    case "text/x-swift":
-    case "text/x-rust":
-    case "text/x-go":
-    case "text/x-kotlin":
-    case "text/x-scala":
-    case "text/x-groovy":
-    case "text/x-perl":
-    case "text/x-perl-script":
-    case "message/rfc822":
-      if (
-        [
-          "conversation",
-          "upsert_document",
-          "tool_output",
-          "folders_document",
-          "project_context",
-          "skill_attachment",
-        ].includes(useCase)
-      ) {
-        return storeRawText;
-      }
-      break;
-    case "text/vnd.dust.attachment.slack.thread":
-      if (useCase === "conversation" || useCase === "project_context") {
-        return storeRawText;
-      }
-      break;
-    case "text/vnd.dust.attachment.pasted":
-      if (useCase === "conversation" || useCase === "project_context") {
-        return storeRawText;
-      }
-      break;
-    case "application/vnd.dust.section.json":
-      if (useCase === "tool_output") {
-        return storeRawText;
-      }
-      break;
-    // Processing is assumed to be irrelevant for internal mime types.
+}): boolean {
+  switch (useCase) {
+    case "conversation":
+      return isSupportedForConversation(contentType);
+    case "avatar":
+      return isSupportedForAvatar(contentType);
+    case "tool_output":
+      return isSupportedForToolOutput(contentType);
+    case "project_context":
+      return isSupportedForProjectContext(contentType);
+    case "skill_attachment":
+      return isSupportedForSkillAttachment(contentType);
+    case "upsert_document":
+      return isSupportedForUpsertDocument(contentType);
+    case "folders_document":
+      return isSupportedForFoldersDocument(contentType);
+    case "upsert_table":
+      return isSupportedForUpsertTable(contentType);
     default:
-      if (isDustMimeType(contentType)) {
-        break;
-      }
-      assertNever(contentType);
+      assertNever(useCase);
   }
+}
 
-  return undefined;
-};
+/**
+ * Whether a file with this content type has a meaningful processed version (e.g., text extraction,
+ * image resize, audio transcription). When false, readers should use the "original" version
+ * directly. Purely content-type-driven — no use-case branching.
+ */
+export function hasProcessedVersion(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return getProcessingFunction(contentType) !== undefined;
+}
 
-export const isUploadSupported = (arg: {
-  auth: Authenticator;
-  contentType: SupportedFileContentType;
-  useCase: FileUseCase;
-}): boolean => {
-  const processing = getProcessingFunction(arg);
-  return !!processing;
-};
-
-const maybeApplyProcessing: ProcessingFunction = async (
+const maybeApplyProcessing = async (
   auth: Authenticator,
   file: FileResource
-) => {
-  const start = performance.now();
-
-  const processing = getProcessingFunction({ auth, ...file });
+): Promise<Result<undefined, Error>> => {
+  const processing = getProcessingFunction(file.contentType);
   if (!processing) {
-    return new Err(
-      new Error(
-        `Processing not supported for content type ${file.contentType} and use case ${file.useCase}`
-      )
-    );
+    // No processing needed. The original file is used as-is.
+    return new Ok(undefined);
   }
 
+  const start = performance.now();
   const res = await processing(auth, file);
 
   const elapsed = performance.now() - start;

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -414,11 +414,11 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
 // text extraction, image resize, audio transcription). Returns undefined when no transformation is
 // needed. The original file is used as-is. Processing is purely content-type-driven. Upload
 // support per use case is handled separately by the per-use-case files.
-const getProcessingFunction = (
+function getProcessingFunction(
   contentType: AllSupportedFileContentType
-): ProcessingFunction | undefined => {
+): ProcessingFunction | undefined {
   return PROCESSING_BY_CONTENT_TYPE.get(contentType);
-};
+}
 
 // Whether uploading this content type for this use case is supported. Dispatches to per-use-case
 // files that each define their own set of supported content types.

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -35,11 +35,12 @@ export async function generateSnippet(
   }
 
   if (isSupportedDelimitedTextContentType(file.contentType)) {
+    const { bucket, path } = file.getContentBucketAndPath(auth);
     const schemaRes = await coreAPI.tableValidateCSVContent({
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
-      bucket: file.getBucketForVersion("processed").name,
-      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+      bucket,
+      bucketCSVPath: path,
     });
 
     if (schemaRes.isErr()) {
@@ -76,7 +77,7 @@ export async function generateSnippet(
   }
 
   if (isSupportedAudioContentType(file.contentType)) {
-    const content = await getFileContent(auth, file, "processed");
+    const content = await getFileContent(auth, file);
     if (!content) {
       return new Err(new Error("Failed to get file processed content"));
     }

--- a/front/lib/api/files/use_cases/avatar.ts
+++ b/front/lib/api/files/use_cases/avatar.ts
@@ -1,0 +1,15 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+]);
+
+export function isSupportedForAvatar(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/conversation.ts
+++ b/front/lib/api/files/use_cases/conversation.ts
@@ -1,0 +1,83 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  // Images (resized during processing).
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  "image/svg+xml",
+
+  // Audio (transcribed during processing).
+  "audio/mpeg",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/webm",
+  "audio/ogg",
+  "audio/x-m4a",
+
+  // Documents (text extracted during processing).
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+
+  // Plain text and code (used as-is).
+  "application/octet-stream",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/xml",
+  "text/calendar",
+  "text/css",
+  "text/javascript",
+  "text/typescript",
+  "application/json",
+  "application/xml",
+  "application/x-sh",
+  "text/x-sh",
+  "text/x-python",
+  "text/x-python-script",
+  "application/x-yaml",
+  "text/yaml",
+  "text/vnd.yaml",
+  "text/x-c",
+  "text/x-csharp",
+  "text/x-java-source",
+  "text/x-php",
+  "text/x-ruby",
+  "text/x-sql",
+  "text/x-swift",
+  "text/x-rust",
+  "text/x-go",
+  "text/x-kotlin",
+  "text/x-scala",
+  "text/x-groovy",
+  "text/x-perl",
+  "text/x-perl-script",
+  "message/rfc822",
+
+  // Dust-specific content types.
+  "text/vnd.dust.attachment.slack.thread",
+  "text/vnd.dust.attachment.pasted",
+
+  // Interactive content (frames).
+  "application/vnd.dust.frame",
+  "application/vnd.dust.frame.slideshow",
+]);
+
+export function isSupportedForConversation(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/folders_document.ts
+++ b/front/lib/api/files/use_cases/folders_document.ts
@@ -1,0 +1,59 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  // Documents (text extracted during processing).
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+
+  // Plain text and code (used as-is).
+  "application/octet-stream",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/xml",
+  "text/calendar",
+  "text/css",
+  "text/javascript",
+  "text/typescript",
+  "application/json",
+  "application/xml",
+  "application/x-sh",
+  "text/x-sh",
+  "text/x-python",
+  "text/x-python-script",
+  "application/x-yaml",
+  "text/yaml",
+  "text/vnd.yaml",
+  "text/x-c",
+  "text/x-csharp",
+  "text/x-java-source",
+  "text/x-php",
+  "text/x-ruby",
+  "text/x-sql",
+  "text/x-swift",
+  "text/x-rust",
+  "text/x-go",
+  "text/x-kotlin",
+  "text/x-scala",
+  "text/x-groovy",
+  "text/x-perl",
+  "text/x-perl-script",
+  "message/rfc822",
+]);
+
+export function isSupportedForFoldersDocument(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/project_context.ts
+++ b/front/lib/api/files/use_cases/project_context.ts
@@ -66,6 +66,10 @@ const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
   "text/x-perl",
   "text/x-perl-script",
   "message/rfc822",
+
+  // Dust-specific content types.
+  "text/vnd.dust.attachment.slack.thread",
+  "text/vnd.dust.attachment.pasted",
 ]);
 
 export function isSupportedForProjectContext(

--- a/front/lib/api/files/use_cases/project_context.ts
+++ b/front/lib/api/files/use_cases/project_context.ts
@@ -1,0 +1,75 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  // Images (resized during processing).
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  "image/svg+xml",
+
+  // Audio (transcribed during processing).
+  "audio/mpeg",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/webm",
+  "audio/ogg",
+  "audio/x-m4a",
+
+  // Documents (text extracted during processing).
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+
+  // Plain text and code (used as-is).
+  "application/octet-stream",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/xml",
+  "text/calendar",
+  "text/css",
+  "text/javascript",
+  "text/typescript",
+  "application/json",
+  "application/xml",
+  "application/x-sh",
+  "text/x-sh",
+  "text/x-python",
+  "text/x-python-script",
+  "application/x-yaml",
+  "text/yaml",
+  "text/vnd.yaml",
+  "text/x-c",
+  "text/x-csharp",
+  "text/x-java-source",
+  "text/x-php",
+  "text/x-ruby",
+  "text/x-sql",
+  "text/x-swift",
+  "text/x-rust",
+  "text/x-go",
+  "text/x-kotlin",
+  "text/x-scala",
+  "text/x-groovy",
+  "text/x-perl",
+  "text/x-perl-script",
+  "message/rfc822",
+]);
+
+export function isSupportedForProjectContext(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/skill_attachment.ts
+++ b/front/lib/api/files/use_cases/skill_attachment.ts
@@ -1,0 +1,67 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  // Images (used as-is, no resize for skill attachments).
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  "image/svg+xml",
+
+  // Documents (text extracted during processing).
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+
+  // Plain text and code (used as-is).
+  "application/octet-stream",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/xml",
+  "text/calendar",
+  "text/css",
+  "text/javascript",
+  "text/typescript",
+  "application/json",
+  "application/xml",
+  "application/x-sh",
+  "text/x-sh",
+  "text/x-python",
+  "text/x-python-script",
+  "application/x-yaml",
+  "text/yaml",
+  "text/vnd.yaml",
+  "text/x-c",
+  "text/x-csharp",
+  "text/x-java-source",
+  "text/x-php",
+  "text/x-ruby",
+  "text/x-sql",
+  "text/x-swift",
+  "text/x-rust",
+  "text/x-go",
+  "text/x-kotlin",
+  "text/x-scala",
+  "text/x-groovy",
+  "text/x-perl",
+  "text/x-perl-script",
+  "message/rfc822",
+]);
+
+export function isSupportedForSkillAttachment(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/tool_output.ts
+++ b/front/lib/api/files/use_cases/tool_output.ts
@@ -1,0 +1,55 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  "image/svg+xml",
+
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+
+  // Plain text and code (used as-is).
+  "application/octet-stream",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/xml",
+  "text/calendar",
+  "text/css",
+  "text/javascript",
+  "text/typescript",
+  "application/json",
+  "application/xml",
+  "application/x-sh",
+  "text/x-sh",
+  "text/x-python",
+  "text/x-python-script",
+  "application/x-yaml",
+  "text/yaml",
+  "text/vnd.yaml",
+  "text/x-c",
+  "text/x-csharp",
+  "text/x-java-source",
+  "text/x-php",
+  "text/x-ruby",
+  "text/x-sql",
+  "text/x-swift",
+  "text/x-rust",
+  "text/x-go",
+  "text/x-kotlin",
+  "text/x-scala",
+  "text/x-groovy",
+  "text/x-perl",
+  "text/x-perl-script",
+  "message/rfc822",
+
+  // Dust-specific content types.
+  "application/vnd.dust.section.json",
+]);
+
+export function isSupportedForToolOutput(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/upsert_document.ts
+++ b/front/lib/api/files/use_cases/upsert_document.ts
@@ -1,0 +1,59 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  // Documents (text extracted during processing).
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+
+  // Plain text and code (used as-is).
+  "application/octet-stream",
+  "text/plain",
+  "text/markdown",
+  "text/html",
+  "text/xml",
+  "text/calendar",
+  "text/css",
+  "text/javascript",
+  "text/typescript",
+  "application/json",
+  "application/xml",
+  "application/x-sh",
+  "text/x-sh",
+  "text/x-python",
+  "text/x-python-script",
+  "application/x-yaml",
+  "text/yaml",
+  "text/vnd.yaml",
+  "text/x-c",
+  "text/x-csharp",
+  "text/x-java-source",
+  "text/x-php",
+  "text/x-ruby",
+  "text/x-sql",
+  "text/x-swift",
+  "text/x-rust",
+  "text/x-go",
+  "text/x-kotlin",
+  "text/x-scala",
+  "text/x-groovy",
+  "text/x-perl",
+  "text/x-perl-script",
+  "message/rfc822",
+]);
+
+export function isSupportedForUpsertDocument(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/use_cases/upsert_table.ts
+++ b/front/lib/api/files/use_cases/upsert_table.ts
@@ -1,0 +1,15 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
+const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+  // Spreadsheets (Excel: text extracted; CSV/TSV: used as-is).
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "text/csv",
+  "text/tab-separated-values",
+]);
+
+export function isSupportedForUpsertTable(
+  contentType: AllSupportedFileContentType
+): boolean {
+  return SUPPORTED_CONTENT_TYPES.has(contentType);
+}

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -95,9 +95,11 @@ export const parseUploadRequest = async (
 export async function getFileContent(
   auth: Authenticator,
   file: FileResource,
-  version: FileVersion = "processed"
+  version?: FileVersion
 ): Promise<string | null> {
-  const readStream = file.getReadStream({ auth, version });
+  const readStream = version
+    ? file.getReadStream({ auth, version })
+    : file.getContentReadStream(auth);
   const bufferResult = await streamToBuffer(readStream);
 
   if (bufferResult.isErr()) {

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -195,12 +195,13 @@ export async function upsertTableFromCsv({
   }
 
   if (file) {
+    const { bucket, path } = file.getContentBucketAndPath(auth);
     const csvRes = await coreAPI.tableUpsertCSVContent({
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
       tableId,
-      bucket: file.getBucketForVersion("processed").name,
-      bucketCSVPath: file.getCloudStoragePath(auth, "processed"),
+      bucket,
+      bucketCSVPath: path,
       truncate,
     });
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -11,12 +11,16 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
+import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
+import {
+  FileResource,
+  type FileVersion,
+} from "@app/lib/resources/file_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -499,40 +503,15 @@ export function fileAttachmentLocation({
   };
 }
 
-async function getOriginalFileContent(
+async function getSignedUrlForVersion(
   auth: Authenticator,
-  fileId: string
+  fileId: string,
+  version: FileVersion
 ): Promise<string> {
   const fileCloudStoragePath = FileResource.getCloudStoragePathForId({
     fileId,
     workspaceId: auth.getNonNullableWorkspace().sId,
-    version: "original",
-  });
-
-  return getPrivateUploadBucket().fetchFileContent(fileCloudStoragePath);
-}
-
-async function getProcessedFileContent(
-  auth: Authenticator,
-  fileId: string
-): Promise<string> {
-  const fileCloudStoragePath = FileResource.getCloudStoragePathForId({
-    fileId,
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    version: "processed",
-  });
-
-  return getPrivateUploadBucket().fetchFileContent(fileCloudStoragePath);
-}
-
-async function getSignedUrlForProcessedContent(
-  auth: Authenticator,
-  fileId: string
-): Promise<string> {
-  const fileCloudStoragePath = FileResource.getCloudStoragePathForId({
-    fileId,
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    version: "processed",
+    version,
   });
 
   return getPrivateUploadBucket().getSignedUrl(fileCloudStoragePath);
@@ -591,7 +570,12 @@ export async function getContentFragmentFromAttachmentFile(
       );
     }
 
-    const signedUrl = await getSignedUrlForProcessedContent(auth, fileStringId);
+    // Images always have real processing (resize), so we always use "processed".
+    const signedUrl = await getSignedUrlForVersion(
+      auth,
+      fileStringId,
+      "processed"
+    );
 
     return new Ok({
       role: "content_fragment",
@@ -650,19 +634,11 @@ export async function getContentFragmentFromAttachmentFile(
       ],
     });
   } else if (fileStringId) {
-    let content = await getProcessedFileContent(auth, fileStringId);
-
-    if (!content) {
-      logger.warn(
-        {
-          fileId: fileStringId,
-          contentType: attachment.contentType,
-          workspaceId: auth.getNonNullableWorkspace().sId,
-        },
-        "No content extracted from file processed version, we are retrieving the original file as a fallback."
-      );
-      content = await getOriginalFileContent(auth, fileStringId);
+    const file = await FileResource.fetchById(auth, fileStringId);
+    if (!file) {
+      return new Err(new Error(`File not found: ${fileStringId}`));
     }
+    const content = (await getFileContent(auth, file)) ?? "";
 
     // Check if this is a pasted content (large paste) - use simplified XML format
     if (isPastedFile(attachment.contentType)) {
@@ -783,7 +759,12 @@ export async function renderLightContentFragmentForModel(
       };
     }
 
-    const signedUrl = await getSignedUrlForProcessedContent(auth, fileStringId);
+    // Images always have real processing (resize), so we always use "processed".
+    const signedUrl = await getSignedUrlForVersion(
+      auth,
+      fileStringId,
+      "processed"
+    );
 
     return {
       role: "content_fragment",

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -549,6 +549,135 @@ describe("FileResource", () => {
     });
   });
 
+  describe("getContentBucketAndPath", () => {
+    it("should resolve to 'original' version for plain text files", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "readme.txt",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/original");
+    });
+
+    it("should resolve to 'original' version for Python files", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/x-python",
+        fileName: "script.py",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/original");
+    });
+
+    it("should resolve to 'original' version for CSV files", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/csv",
+        fileName: "data.csv",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/original");
+    });
+
+    it("should resolve to 'processed' version for PDF files", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "application/pdf",
+        fileName: "document.pdf",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/processed");
+    });
+
+    it("should resolve to 'processed' version for Word documents", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        fileName: "document.docx",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/processed");
+    });
+
+    it("should resolve to 'processed' version for images in conversation", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "image/png",
+        fileName: "photo.png",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/processed");
+    });
+
+    it("should resolve to 'original' version for JSON files", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "application/json",
+        fileName: "config.json",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/original");
+    });
+  });
+
   describe("uploadContent dual write", () => {
     it("should write to both canonical and mount path when mountFilePath is set", async () => {
       const { authenticator: auth, workspace } = await createResourceTest({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -7,6 +7,7 @@ import {
   getConversationFilePath,
   makeProcessedMountFileName,
 } from "@app/lib/api/files/mount_path";
+import { hasProcessedVersion } from "@app/lib/api/files/processing";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
@@ -454,6 +455,42 @@ export class FileResource extends BaseResource<FileModel> {
     return isInteractiveContentType(this.contentType);
   }
 
+  // Content access logic.
+  //
+  // Files may have a "processed" version (text extraction, image resize, audio transcription) or
+  // only the "original". These methods abstract the version selection so callers never deal with
+  // versions directly.
+
+  /**
+   * Returns the file version to read for "best available" content.
+   */
+  private getContentVersion(): FileVersion {
+    return hasProcessedVersion(this.contentType) ? "processed" : "original";
+  }
+
+  /**
+   * Read stream for the best available content.
+   */
+  getContentReadStream(auth: Authenticator): Readable {
+    return this.getReadStream({ auth, version: this.getContentVersion() });
+  }
+
+  /**
+   * Bucket name and GCS path for the best available content. Used by CoreAPI callers that need
+   * to pass bucket + path for CSV validation / upsert.
+   */
+  getContentBucketAndPath(auth: Authenticator): {
+    bucket: string;
+    path: string;
+  } {
+    const version = this.getContentVersion();
+
+    return {
+      bucket: this.getBucketForVersion(version).name,
+      path: this.getCloudStoragePath(auth, version),
+    };
+  }
+
   // Cloud storage logic.
 
   getPrivateUrl(auth: Authenticator): string {
@@ -860,13 +897,11 @@ export class FileResource extends BaseResource<FileModel> {
     const srcOriginalPath = this.getCloudStoragePath(auth, "original");
     await bucket.file(srcOriginalPath).copy(bucket.file(mountFilePath));
 
-    // Copy processed version if it exists.
-    const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
-    const processedMountPath = makeProcessedMountFileName(mountFilePath);
-    try {
+    // Copy processed version only if this file type has real processing.
+    if (this.getContentVersion() === "processed") {
+      const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
+      const processedMountPath = makeProcessedMountFileName(mountFilePath);
       await bucket.file(srcProcessedPath).copy(bucket.file(processedMountPath));
-    } catch {
-      // Processed version may not exist. Ignore.
     }
 
     await this.update({ mountFilePath });
@@ -887,9 +922,10 @@ export class FileResource extends BaseResource<FileModel> {
 
     const bucket = getPrivateUploadBucket();
     await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
-    await bucket.delete(makeProcessedMountFileName(this.mountFilePath), {
-      ignoreNotFound: true,
-    });
+
+    // Only delete processed mount file if this file type has real processing.
+    const processedMountPath = makeProcessedMountFileName(this.mountFilePath);
+    await bucket.delete(processedMountPath, { ignoreNotFound: true });
   }
 
   static async bulkSetUseCaseMetadata(

--- a/front/pages/api/v1/w/[wId]/files/fileId.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/fileId.test.ts
@@ -29,9 +29,14 @@ vi.mock("@app/pages/api/w/[wId]/files/[fileId]", () => ({
   }),
 }));
 
-vi.mock("@app/lib/api/files/processing", () => ({
-  processAndStoreFile: vi.fn().mockResolvedValue({ isErr: () => false }),
-}));
+vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@app/lib/api/files/processing")>();
+  return {
+    ...mod,
+    processAndStoreFile: vi.fn().mockResolvedValue({ isErr: () => false }),
+  };
+});
 
 vi.mock("@app/lib/api/files/upsert", () => ({
   isFileTypeUpsertableForUseCase: vi.fn().mockReturnValue(true),

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -1,5 +1,5 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { isUploadSupported } from "@app/lib/api/files/processing";
+import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -150,7 +150,7 @@ async function handler(
         });
       }
 
-      if (!isUploadSupported({ auth, contentType, useCase })) {
+      if (!isUploadSupportedForContentType({ contentType, useCase })) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -151,7 +151,7 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
 
       if ((url as string).endsWith("/csv")) {
         expect(req.bucket_csv_path).toBe(
-          `files/w/${workspace.sId}/${file.sId}/processed`
+          `files/w/${workspace.sId}/${file.sId}/original`
         );
         expect(req.truncate).toBe(true);
         return Promise.resolve(
@@ -171,7 +171,7 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
 
       if ((url as string).endsWith("/validate_csv_content")) {
         expect(req.bucket_csv_path).toBe(
-          `files/w/${workspace.sId}/${file.sId}/processed`
+          `files/w/${workspace.sId}/${file.sId}/original`
         );
         return Promise.resolve(
           new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -289,7 +289,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
 
       if ((url as string).endsWith("/csv")) {
         expect(req.bucket_csv_path).toBe(
-          `files/w/${workspace.sId}/${file.sId}/processed`
+          `files/w/${workspace.sId}/${file.sId}/original`
         );
         expect(req.truncate).toBe(true);
         return Promise.resolve(
@@ -309,7 +309,7 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
 
       if ((url as string).endsWith("/validate_csv_content")) {
         expect(req.bucket_csv_path).toBe(
-          `files/w/${workspace.sId}/${file.sId}/processed`
+          `files/w/${workspace.sId}/${file.sId}/original`
         );
         return Promise.resolve(
           new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {

--- a/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
@@ -25,12 +25,17 @@ vi.mock("@app/lib/api/data_sources", () => ({
 }));
 
 // Mock the file processing functions
-vi.mock("@app/lib/api/files/processing", () => ({
-  processAndStoreFile: vi.fn().mockResolvedValue({
-    isErr: () => false,
-    value: {},
-  }),
-}));
+vi.mock("@app/lib/api/files/processing", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@app/lib/api/files/processing")>();
+  return {
+    ...mod,
+    processAndStoreFile: vi.fn().mockResolvedValue({
+      isErr: () => false,
+      value: {},
+    }),
+  };
+});
 
 vi.mock("@app/lib/api/files/upsert", () => ({
   isFileTypeUpsertableForUseCase: vi.fn().mockReturnValue(true),

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -1,5 +1,5 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { isUploadSupported } from "@app/lib/api/files/processing";
+import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -130,7 +130,7 @@ async function handler(
         });
       }
 
-      if (!isUploadSupported({ auth, contentType, useCase })) {
+      if (!isUploadSupportedForContentType({ contentType, useCase })) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
For sandbox file mounting (see https://github.com/dust-tt/dust/pull/22752), we need conversation files available at predictable, human-readable GCS paths. While working on this, we found that the processing pipeline was creating useless duplicate files.
For every text and code file (plain text, Python, JSON, CSV, etc.), `storeRawText` was copying the original file byte-for-byte into a "processed" version. This doubled storage for the majority of uploaded files, and would double the work again when copying files to mount paths + create model confusion when listing those files.

The root cause was that the old pipeline assumed every file needed a "processed" version in some scenarioes. Rather than checking whether processing actually transforms the content, it always wrote one, using a no-op copy for files that didn't need it. This was done to keep the read path simple (always read from "processed"), but it's wasteful and becomes a real problem when we need to replicate files to mount paths for the sandbox.

### What this PR does

This PR removes `storeRawText` entirely. Instead, we derive whether a processed version exists from the content type alone: images get resized, audio gets transcribed, PDFs and Office documents get text-extracted. Everything else
(text, code, CSV, JSON, etc.) is used as-is from the original. No duplicate, no wasted storage.

The version logic is encapsulated inside `FileResource` through two methods: `getContentReadStream(auth)` and `getContentBucketAndPath(auth)`. Callers never pick a version themselves. The resource knows whether to serve original or processed based on the content type.

The upload support check ("can this content type be uploaded for this use case?") is split into per-use-case files under  a dedicated folder, each with a clear `isSupportedForXxx` function and an explicit set of supported
content types. This replaces the old monolithic switch statement that mixed upload gating with processing logic and had use-case exceptions scattered throughout.

Processing itself is now purely content-type-driven: a shared map goes from content type to processing function, with no use-case branching. The only runtime check left is the workspace-level `allowVoiceTranscription` setting, which lives inside the audio transcription function itself and the image resize which uses different size for conversation and avatar usecase.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
