### PR TITLE
LLM: support batch mode for anthropic

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -1,5 +1,8 @@
 import Anthropic, { APIError } from "@anthropic-ai/sdk";
-import type { MessageCountTokensParams } from "@anthropic-ai/sdk/resources";
+import type {
+  MessageCountTokensParams,
+  MessageCreateParamsNonStreaming,
+} from "@anthropic-ai/sdk/resources";
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
 
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
@@ -13,13 +16,17 @@ import {
   toThinkingConfig,
   toToolChoiceParam,
 } from "@app/lib/api/llm/clients/anthropic/utils";
-import { streamLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/anthropic_to_events";
+import {
+  batchResultToLLMEvents,
+  streamLLMEvents,
+} from "@app/lib/api/llm/clients/anthropic/utils/anthropic_to_events";
 import {
   toMessage,
   toTool,
 } from "@app/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic";
 import { handleError } from "@app/lib/api/llm/clients/anthropic/utils/errors";
 import { LLM } from "@app/lib/api/llm/llm";
+import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
@@ -30,7 +37,6 @@ import type {
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types/api/credentials";
-import type { WorkspaceType } from "@app/types/user";
 
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
@@ -87,8 +93,6 @@ function buildSystemBlocks(
 
 export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   private client: Anthropic;
-  private workspace: WorkspaceType;
-
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters & { modelId: AnthropicWhitelistedModelId }
@@ -105,17 +109,15 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
     });
-
-    this.workspace = auth.getNonNullableWorkspace();
   }
 
-  protected buildStreamRequestPayload({
+  private buildBaseRequestPayload({
     conversation,
     hasConditionalJITTools,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): BetaMessageStreamParams {
+  }: LLMStreamParameters): MessageCreateParamsNonStreaming {
     const messages = conversation.messages.map((msg, index, array) =>
       toMessage(msg, { isLast: index === array.length - 1 })
     );
@@ -132,13 +134,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
             this.modelConfig.useNativeLightReasoning
           );
 
-    // Merge betas, always include structured-outputs, add custom betas if specified.
-    // TODO(fabien): Remove beta tag and beta client when structured outputs are generally available.
-    const betas = [
-      "structured-outputs-2025-11-13",
-      ...(this.modelConfig.customBetas ?? []),
-    ];
-
     const system = buildSystemBlocks(normalizePrompt(prompt), {
       hasConditionalJITTools,
     });
@@ -149,10 +144,25 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       system,
       messages,
       temperature: this.temperature ?? undefined,
-      stream: true,
       tools: specifications.map(toTool),
       max_tokens: this.modelConfig.generationTokensCount,
       tool_choice: toToolChoiceParam(specifications, forceToolCall),
+    };
+  }
+
+  protected buildStreamRequestPayload(
+    streamParameters: LLMStreamParameters
+  ): BetaMessageStreamParams {
+    // Merge betas, always include structured-outputs, add custom betas if specified.
+    // TODO(fabien): Remove beta tag and beta client when structured outputs are generally available.
+    const betas = [
+      "structured-outputs-2025-11-13",
+      ...(this.modelConfig.customBetas ?? []),
+    ];
+
+    return {
+      ...this.buildBaseRequestPayload(streamParameters),
+      stream: true,
       betas,
       output_format: toOutputFormatParam(this.responseFormat),
       cache_control: { type: "ephemeral" },
@@ -191,5 +201,46 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
         yield handleGenericError(err, this.metadata);
       }
     }
+  }
+
+  private buildBatchRequestPayload(
+    streamParameters: LLMStreamParameters
+  ): MessageCreateParamsNonStreaming {
+    return this.buildBaseRequestPayload(streamParameters);
+  }
+
+  override async sendBatchProcessing(
+    conversations: Map<string, LLMStreamParameters>
+  ): Promise<string> {
+    const requests = Array.from(conversations.entries()).map(
+      ([customId, streamParams]) => ({
+        custom_id: customId,
+        params: this.buildBatchRequestPayload(streamParams),
+      })
+    );
+
+    const batch = await this.client.messages.batches.create({ requests });
+    return batch.id;
+  }
+
+  override async getBatchStatus(batchId: string): Promise<BatchStatus> {
+    const batch = await this.client.messages.batches.retrieve(batchId);
+    return batch.processing_status === "ended" ? "ready" : "computing";
+  }
+
+  override async getBatchResult(batchId: string): Promise<BatchResult> {
+    const results = await this.client.messages.batches.results(batchId);
+    const batchResult: BatchResult = new Map();
+
+    for await (const item of results) {
+      const events = await batchResultToLLMEvents(
+        item.result,
+        this.metadata,
+        this.createCountTokensCallback()
+      );
+      batchResult.set(item.custom_id, events);
+    }
+
+    return batchResult;
   }
 }

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -203,19 +203,13 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     }
   }
 
-  private buildBatchRequestPayload(
-    streamParameters: LLMStreamParameters
-  ): MessageCreateParamsNonStreaming {
-    return this.buildBaseRequestPayload(streamParameters);
-  }
-
   override async sendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     const requests = Array.from(conversations.entries()).map(
       ([customId, streamParams]) => ({
         custom_id: customId,
-        params: this.buildBatchRequestPayload(streamParams),
+        params: this.buildBaseRequestPayload(streamParams),
       })
     );
 

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert";
 import type { APIPromise } from "@anthropic-ai/sdk";
 import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
+import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import type {
+  Message,
   MessageCountTokensParams,
   MessageParam,
   MessageStreamEvent,
@@ -12,6 +14,7 @@ import type { StreamState } from "@app/lib/api/llm/clients/anthropic/utils/types
 import { SuccessAggregate } from "@app/lib/api/llm/types/aggregates";
 import type {
   LLMEvent,
+  LLMOutputItem,
   ReasoningDeltaEvent,
   ReasoningGeneratedEvent,
   TextDeltaEvent,
@@ -26,6 +29,7 @@ import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isRecord } from "@app/types/shared/utils/general";
 import cloneDeep from "lodash/cloneDeep";
 
 export async function* streamLLMEvents(
@@ -454,4 +458,167 @@ function toolCall({
     },
     metadata,
   };
+}
+
+/**
+ * Converts a single Anthropic batch result to a list of LLMEvents,
+ * mirroring what streamLLMEvents would have produced for a streaming call.
+ */
+export async function batchResultToLLMEvents(
+  result: MessageBatchResult,
+  metadata: LLMClientMetadata,
+  countTokensCallback?: (
+    body: MessageCountTokensParams
+  ) => APIPromise<MessageTokensCount>
+): Promise<LLMEvent[]> {
+  switch (result.type) {
+    case "succeeded":
+      return succeededMessageToEvents(
+        result.message,
+        metadata,
+        countTokensCallback
+      );
+    case "errored":
+      return [
+        new EventError(
+          {
+            type: "server_error",
+            message: result.error.error.message,
+            isRetryable: false,
+          },
+          metadata
+        ),
+      ];
+    case "canceled":
+      return [
+        new EventError(
+          {
+            type: "stream_error",
+            message: "Batch request was canceled.",
+            isRetryable: false,
+          },
+          metadata
+        ),
+      ];
+    case "expired":
+      return [
+        new EventError(
+          {
+            type: "stream_error",
+            message: "Batch request expired before processing completed.",
+            isRetryable: true,
+          },
+          metadata
+        ),
+      ];
+    default:
+      assertNever(result);
+  }
+}
+
+export async function succeededMessageToEvents(
+  message: Message,
+  metadata: LLMClientMetadata,
+  countTokensCallback?: (
+    body: MessageCountTokensParams
+  ) => APIPromise<MessageTokensCount>
+): Promise<LLMEvent[]> {
+  const events: LLMEvent[] = [];
+
+  events.push({
+    type: "interaction_id",
+    content: { modelInteractionId: message.id },
+    metadata,
+  });
+
+  const textBlocks: string[] = [];
+  const toolCalls: ToolCallEvent[] = [];
+  let reasoningGeneratedEvent: ReasoningGeneratedEvent | undefined = undefined;
+
+  for (const block of message.content) {
+    switch (block.type) {
+      case "text":
+        textBlocks.push(block.text);
+        events.push(textGenerated(block.text, metadata));
+        break;
+      case "thinking":
+        reasoningGeneratedEvent = reasoningGenerated(
+          block.thinking,
+          metadata,
+          block.signature
+        );
+        events.push(reasoningGeneratedEvent);
+        break;
+      case "tool_use": {
+        const input =
+          typeof block.input === "object" &&
+          block.input !== null &&
+          isRecord(block.input)
+            ? block.input
+            : {};
+        const toolCallEvent: ToolCallEvent = {
+          type: "tool_call",
+          content: { id: block.id, name: block.name, arguments: input },
+          metadata,
+        };
+        toolCalls.push(toolCallEvent);
+        events.push(toolCallEvent);
+        break;
+      }
+      default:
+        // Ignore other block types (redacted_thinking, server_tool_use, etc.)
+        break;
+    }
+  }
+
+  const usage = message.usage;
+  const cachedTokens = usage.cache_read_input_tokens ?? 0;
+  const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+  const uncachedInputTokens = usage.input_tokens;
+  const inputTokens = uncachedInputTokens + cachedTokens + cacheCreationTokens;
+  const tokenUsageAccumulator = {
+    inputTokens,
+    outputTokens: usage.output_tokens,
+    cachedTokens,
+    cacheCreationTokens,
+    uncachedInputTokens,
+    totalTokens: inputTokens + usage.output_tokens,
+    reasoningTokens: 0,
+  };
+
+  const textGeneratedEvent: TextGeneratedEvent | undefined =
+    textBlocks.length > 0
+      ? textGenerated(textBlocks.join(""), metadata)
+      : undefined;
+
+  await estimateReasoningTokens(
+    tokenUsageAccumulator,
+    textGeneratedEvent,
+    toolCalls.length > 0 ? toolCalls : undefined,
+    countTokensCallback,
+    metadata
+  );
+
+  events.push(tokenUsage(tokenUsageAccumulator, metadata));
+
+  const aggregated: LLMOutputItem[] = [];
+
+  if (textGeneratedEvent) {
+    aggregated.push(textGeneratedEvent);
+  }
+  if (reasoningGeneratedEvent) {
+    aggregated.push(reasoningGeneratedEvent);
+  }
+  aggregated.push(...toolCalls);
+
+  events.push({
+    type: "success",
+    aggregated,
+    textGenerated: textGeneratedEvent,
+    reasoningGenerated: reasoningGeneratedEvent,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    metadata,
+  });
+
+  return events;
 }

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -516,7 +516,7 @@ export async function batchResultToLLMEvents(
   }
 }
 
-export async function succeededMessageToEvents(
+async function succeededMessageToEvents(
   message: Message,
   metadata: LLMClientMetadata,
   countTokensCallback?: (

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -7,6 +7,7 @@ import type {
   LLMTraceContext,
   LLMTraceCustomization,
 } from "@app/lib/api/llm/traces/types";
+import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type {
@@ -333,6 +334,38 @@ export abstract class LLM<TPayload = unknown> {
     streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {
     yield* this.streamWithTracing(streamParameters);
+  }
+
+  /**
+   * Submit a batch of conversations for asynchronous processing.
+   * Returns a string that can be used to poll status and retrieve results.
+   * Each entry in the map is keyed by a conversation identifier (custom_id).
+   */
+  async sendBatchProcessing(
+    _conversations: Map<string, LLMStreamParameters>
+  ): Promise<string> {
+    throw new Error(
+      `Batch processing is not supported for ${this.metadata.clientId}/${this.metadata.modelId}`
+    );
+  }
+
+  /**
+   * Poll the status of a previously submitted batch.
+   */
+  async getBatchStatus(_batchId: string): Promise<BatchStatus> {
+    throw new Error(
+      `Batch processing is not supported for ${this.metadata.clientId}/${this.metadata.modelId}`
+    );
+  }
+
+  /**
+   * Retrieve the results of a completed batch.
+   * Only call this when getBatchStatus returns "ready".
+   */
+  async getBatchResult(_batchId: string): Promise<BatchResult> {
+    throw new Error(
+      `Batch processing is not supported for ${this.metadata.clientId}/${this.metadata.modelId}`
+    );
   }
 
   /**

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -25,7 +25,7 @@ const SYSTEM_PROMPT = "You are a helpful assistant.";
  * Creates a mock Authenticator for testing purposes.
  * This is a minimal mock that bypasses actual authentication.
  */
-function createMockAuthenticator(): Authenticator {
+export function createMockAuthenticator(): Authenticator {
   return new Authenticator({
     workspace: null,
     user: null,

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -1,0 +1,311 @@
+import { isDeepStrictEqual } from "node:util";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { getLLM } from "@app/lib/api/llm";
+import { createMockAuthenticator } from "@app/lib/api/llm/tests/conversations";
+import { MODELS } from "@app/lib/api/llm/tests/models";
+import type { ResponseChecker } from "@app/lib/api/llm/tests/types";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { isModelProviderId } from "@app/types/assistant/models/providers";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { describe, expect, it, vi } from "vitest";
+
+const POLL_INTERVAL_MS = 5000;
+const TEST_TIMEOUT_MS = 60 * 60 * 1000; // 1-hour timeout — batches can take a while
+
+// Mock the openai module to inject dangerouslyAllowBrowser: true
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalOpenAI = actual.OpenAI;
+
+  class OpenAIWithBrowserSupport extends OriginalOpenAI {
+    constructor(config: ConstructorParameters<typeof OriginalOpenAI>[0]) {
+      super({
+        ...config,
+        dangerouslyAllowBrowser: true,
+      });
+    }
+  }
+
+  return {
+    // @ts-expect-error actual is unknown
+    ...actual,
+    OpenAI: OpenAIWithBrowserSupport,
+  };
+});
+
+// Mock the @anthropic-ai/sdk module to inject dangerouslyAllowBrowser: true
+vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalAnthropic = actual.default;
+
+  class AnthropicWithBrowserSupport extends OriginalAnthropic {
+    constructor(config: ConstructorParameters<typeof OriginalAnthropic>[0]) {
+      super({
+        ...config,
+        dangerouslyAllowBrowser: true,
+      });
+    }
+  }
+
+  return {
+    // @ts-expect-error actual is unknown
+    ...actual,
+    default: AnthropicWithBrowserSupport,
+  };
+});
+
+const RUN_LLM_BATCH_TEST = process.env.RUN_LLM_BATCH_TEST === "true";
+const RUN_ALL_MODEL_TESTS = process.env.RUN_ALL_MODEL_TESTS === "true";
+
+const modelsWithBatchSupport = Object.entries(MODELS)
+  .filter(([modelId, { providerId }]) => {
+    const config = getSupportedModelConfig({
+      modelId: modelId as ModelIdType,
+      providerId,
+    });
+    return config?.supportsBatchProcessing === true;
+  })
+  .filter(([, config]) => config.runTest || RUN_ALL_MODEL_TESTS)
+  .map(([modelId, config]) => ({ modelId, ...config }));
+
+interface BatchConversation {
+  id: string;
+  streamParameters: LLMStreamParameters;
+  expectedInResponse: ResponseChecker;
+}
+
+interface BatchTest {
+  name: string;
+  conversations: BatchConversation[];
+}
+
+function checkResponse(
+  convId: string,
+  events: LLMEvent[],
+  checker: ResponseChecker
+): void {
+  if (checker === null) {
+    return;
+  }
+
+  const errorEvent = events.find((e) => e.type === "error");
+  if (errorEvent?.type === "error") {
+    throw new Error(
+      `Batch returned error for ${convId}: ${errorEvent.message}`
+    );
+  }
+
+  switch (checker.type) {
+    case "text_contains": {
+      const textEvent = events.find((e) => e.type === "text_generated");
+      expect(
+        textEvent,
+        `Expected text_generated event for ${convId}`
+      ).toBeDefined();
+      if (textEvent?.type === "text_generated") {
+        const lowerText = textEvent.content.text.toLowerCase();
+        const expected = checker.anyString.map((s) => s.toLowerCase());
+        expect(
+          expected.some((str) => lowerText.includes(str)),
+          `Response for ${convId} should contain at least one of: ${expected.join(", ")}`
+        ).toBe(true);
+      }
+      break;
+    }
+    case "has_tool_call": {
+      const toolCallEvent = events.find((e) => e.type === "tool_call");
+      expect(
+        toolCallEvent,
+        `Expected tool_call event for ${convId}`
+      ).toBeDefined();
+      if (toolCallEvent?.type === "tool_call") {
+        expect(toolCallEvent.content.name).toBe(checker.toolName);
+        expect(
+          isDeepStrictEqual(
+            toolCallEvent.content.arguments,
+            checker.expectedArguments
+          ),
+          `Arguments mismatch for ${convId}: expected ${JSON.stringify(checker.expectedArguments)}, got ${JSON.stringify(toolCallEvent.content.arguments)}`
+        ).toBe(true);
+      }
+      break;
+    }
+    case "check_json_output": {
+      // Not applicable for batch tests
+      break;
+    }
+    default:
+      assertNever(checker);
+  }
+}
+
+const getUserIdTool: AgentActionSpecification = {
+  name: "GetUserId",
+  description: "Get the user ID given the user's name.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "The name of the user.",
+      },
+    },
+    required: ["name"],
+  },
+};
+
+const BATCH_TESTS: BatchTest[] = [
+  {
+    name: "simple math",
+    conversations: [
+      {
+        id: "simple-math-1",
+        streamParameters: {
+          conversation: {
+            messages: [
+              {
+                role: "user",
+                name: "User",
+                content: [
+                  {
+                    type: "text",
+                    text: "What is 1+1? Reply with just the number.",
+                  },
+                ],
+              },
+            ],
+          },
+          prompt: "You are a helpful assistant.",
+          specifications: [],
+        },
+        expectedInResponse: { type: "text_contains", anyString: ["2"] },
+      },
+      {
+        id: "simple-math-2",
+        streamParameters: {
+          conversation: {
+            messages: [
+              {
+                role: "user",
+                name: "User",
+                content: [
+                  {
+                    type: "text",
+                    text: "What is 2+2? Reply with just the number.",
+                  },
+                ],
+              },
+            ],
+          },
+          prompt: "You are a helpful assistant.",
+          specifications: [],
+        },
+        expectedInResponse: { type: "text_contains", anyString: ["4"] },
+      },
+    ],
+  },
+  {
+    name: "forced tool call",
+    conversations: [
+      {
+        id: "forced-tool-call",
+        streamParameters: {
+          conversation: {
+            messages: [
+              {
+                role: "user",
+                name: "User",
+                content: [
+                  { type: "text", text: "What is the user ID of Alice?" },
+                ],
+              },
+            ],
+          },
+          prompt: "You are a helpful assistant.",
+          specifications: [getUserIdTool],
+          forceToolCall: "GetUserId",
+        },
+        expectedInResponse: {
+          type: "has_tool_call",
+          toolName: "GetUserId",
+          expectedArguments: { name: "Alice" },
+        },
+      },
+    ],
+  },
+];
+
+/**
+ * Batch Processing Integration Tests
+ *
+ * To run these tests from the front directory:
+ *
+ *   RUN_LLM_BATCH_TEST=true npx vitest --config lib/api/llm/tests/vite.config.js lib/api/llm/tests/llmBatch.test.ts --run
+ */
+describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
+  "Batch Processing Integration Tests",
+  () => {
+    describe.concurrent.each(
+      modelsWithBatchSupport
+    )("$providerId / $modelId", ({ modelId, providerId }) => {
+      if (!isModelProviderId(providerId)) {
+        throw new Error(`Invalid providerId: ${providerId}`);
+      }
+
+      it.concurrent.each(BATCH_TESTS)(
+        "$name",
+        async ({ conversations }) => {
+          const llm = await getLLM(createMockAuthenticator(), {
+            modelId: modelId as ModelIdType,
+            bypassFeatureFlag: true,
+          });
+          if (llm === null) {
+            throw new Error("LLM instance is null");
+          }
+
+          const batchMap: Map<string, LLMStreamParameters> = new Map(
+            conversations.map(({ id, streamParameters }) => [
+              id,
+              streamParameters,
+            ])
+          );
+
+          const batchId = await llm.sendBatchProcessing(batchMap);
+          expect(typeof batchId).toBe("string");
+          expect(batchId.length).toBeGreaterThan(0);
+
+          // Poll until the batch is done (up to the test timeout).
+          let status = await llm.getBatchStatus(batchId);
+          while (status === "computing") {
+            await new Promise((resolve) =>
+              setTimeout(resolve, POLL_INTERVAL_MS)
+            );
+            status = await llm.getBatchStatus(batchId);
+          }
+
+          expect(status).toBe("ready");
+
+          const result = await llm.getBatchResult(batchId);
+          expect(result.size).toBe(batchMap.size);
+
+          for (const { id, expectedInResponse } of conversations) {
+            const events = result.get(id);
+            expect(
+              events,
+              `Expected results for conversation ${id}`
+            ).toBeDefined();
+            if (events) {
+              checkResponse(id, events, expectedInResponse);
+            }
+          }
+        },
+        TEST_TIMEOUT_MS
+      );
+    });
+  }
+);

--- a/front/lib/api/llm/types/batch.ts
+++ b/front/lib/api/llm/types/batch.ts
@@ -1,0 +1,8 @@
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+
+export type BatchStatus = "computing" | "ready";
+
+/**
+ * Maps each conversation's custom_id to the sequence of LLM events produced for it.
+ */
+export type BatchResult = Map<string, LLMEvent[]>;

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -69,6 +69,7 @@ export const CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  supportsBatchProcessing: true,
   availableIfOneOf: {
     featureFlag: "claude_4_opus_feature",
   },
@@ -94,6 +95,7 @@ export const CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -118,6 +120,7 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
+  supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -139,6 +142,7 @@ export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -182,6 +186,7 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -206,6 +211,7 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
+  supportsBatchProcessing: true,
   availableIfOneOf: {
     featureFlag: "claude_4_5_opus_feature",
   },
@@ -233,6 +239,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
+  supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
@@ -271,6 +278,7 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
+  supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   customBetas: [

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -50,6 +50,7 @@ export const ModelConfigurationSchema = z.object({
   customThinkingType: z.enum(CUSTOM_THINKING_TYPES).optional(),
   customBetas: z.array(z.string()).optional(),
   disablePrefill: z.boolean().optional(),
+  supportsBatchProcessing: z.boolean().optional(),
 });
 
 // Base type inferred from the schema.


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/5935

 - Add API for batch processing with LLM
 - Add one test to make sure it works
 - Implement it for anthropic, other model incoming

The new api in LLM is 

```
async sendBatchProcessing(conversations: Map<string, LLMStreamParameters>): Promise<string> 

async getBatchStatus(_batchId: string): Promise<BatchStatus>

async getBatchResult(_batchId: string): Promise<BatchResult>
```

Both anthropic and openai are charging 50% less with the batch API.

From tests, it took between 90s and 13 minutes to answer my call, mostly depending on the model.

This will be used in Reinforced Agent to analyse the conversations.

## Tests

One unit test:

```
 RUN_LLM_BATCH_TEST=true FRONT_DATABASE_URI=postgres://dev:dev@localhost:11432/dust_front_test NODE_ENV=test npx vitest --config lib/api/llm/tests/vite.config.js --run  lib/api/llm/tests/llmBatch.test.ts

 RUN  v4.0.18 /Users/fabiencelier/dust-hive/reinf-agent/front

 ✓ lib/api/llm/tests/llmBatch.test.ts (6 tests) 352860ms
   ✓ Batch Processing Integration Tests (6)
     ✓ 'anthropic' / 'claude-haiku-4-5-20251001' (2)
       ✓ 'simple math'  100504ms
       ✓ 'forced tool call'  63631ms
     ✓ 'anthropic' / 'claude-opus-4-6' (2)
       ✓ 'simple math'  63719ms
       ✓ 'forced tool call'  63636ms
     ✓ 'anthropic' / 'claude-sonnet-4-6' (2)
       ✓ 'simple math'  352858ms
       ✓ 'forced tool call'  63789ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  09:50:43
   Duration  360.48s (transform 4.14s, setup 500ms, import 6.65s, tests 352.86s, environment 370ms)
```

## Risk

low

## Deploy Plan

deploy front
