### PR TITLE
[front] enh: Improve sandbox img devX

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,10 +210,8 @@ jobs:
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
   deploy:
-    # TODO(@jd) uncomment when ensure-sandbox-images is good to go
-    # needs: [prepare, notify-start, build, ensure-sandbox-images, deploy-app, deploy-poke]
-    needs: [prepare, notify-start, build, deploy-app, deploy-poke]
-    if: ${{ !failure() && !cancelled() }}
+    needs: [prepare, notify-start, build, deploy-app, deploy-poke, ensure-sandbox-images]
+    if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sandbox-bedrock-release.yml
+++ b/.github/workflows/sandbox-bedrock-release.yml
@@ -6,6 +6,15 @@ on:
     paths:
       - "dockerfiles/sandbox-bedrock.Dockerfile"
   workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: false
+        default: "minor"
+        type: choice
+        options:
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -32,6 +41,7 @@ jobs:
       - name: Calculate next version
         id: version
         run: |
+          BUMP_TYPE="${{ inputs.bump || 'minor' }}"
           LATEST=$(git tag -l 'sbx-bedrock/v*' --sort=-v:refname | head -1)
           if [ -z "$LATEST" ]; then
             NEXT_VERSION="0.1.0"
@@ -39,7 +49,11 @@ jobs:
             CURRENT="${LATEST#sbx-bedrock/v}"
             MAJOR=$(echo "$CURRENT" | cut -d. -f1)
             MINOR=$(echo "$CURRENT" | cut -d. -f2)
-            NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+            if [ "$BUMP_TYPE" = "major" ]; then
+              NEXT_VERSION="$((MAJOR + 1)).0.0"
+            else
+              NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+            fi
           fi
           echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -7,15 +7,14 @@ on:
         description: "Number of images built"
         value: ${{ jobs.summary.outputs.built-count }}
   workflow_dispatch:
-    inputs:
-      force-rebuild:
-        description: "Force rebuild all images"
-        type: boolean
-        default: false
 
 permissions:
   contents: read
   id-token: write
+
+env:
+  E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+  E2B_DOMAIN: e2b-juliett.dev
 
 jobs:
   check:
@@ -37,21 +36,20 @@ jobs:
       - name: Check sandbox images
         id: check
         working-directory: front
-        env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: |
-          set -e
-          FORCE_FLAG=""
-          if [ "${{ inputs.force-rebuild }}" == "true" ]; then
-            FORCE_FLAG="--force-rebuild"
+          set -eo pipefail
+          echo "Running sandbox image check..."
+          if ! RESULT=$(npx tsx scripts/sandbox_image_check.ts --json 2>&1); then
+            echo "::error::Sandbox image check failed"
+            echo "$RESULT"
+            exit 1
           fi
-          RESULT=$(npx tsx scripts/sandbox_image_check.ts --json $FORCE_FLAG)
           echo "Check result:"
           echo "$RESULT"
 
-          MISSING=$(echo "$RESULT" | jq -c '.missing')
-          MATRIX=$(echo "$RESULT" | jq -c '{include: .buildMatrix}')
-          HAS_MISSING=$(echo "$RESULT" | jq -r 'if (.missing | length) > 0 then "true" else "false" end')
+          MISSING=$(echo "$RESULT" | jq -c '.result.missing')
+          MATRIX=$(echo "$RESULT" | jq -c '{include: .result.buildMatrix}')
+          HAS_MISSING=$(echo "$RESULT" | jq -r 'if (.result.missing | length) > 0 then "true" else "false" end')
 
           echo "missing=$MISSING" >> $GITHUB_OUTPUT
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
@@ -81,14 +79,13 @@ jobs:
       - name: Build sandbox image
         working-directory: front
         env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          SBX_GCP_ARTIFACT_RO_SERVICE_ACCOUNT: /tmp/service-account.json
+          SBX_GCP_ARTIFACT_SERVICE_ACCOUNT: /tmp/service-account.json
         run: |
           npx tsx scripts/sandbox_image_build.ts \
             --image ${{ matrix.image }} \
             --tag ${{ matrix.tag }} \
             --docker-registry us-central1-docker.pkg.dev/or1g1n-186209/dust-sbx \
-            --execute
+            --confirm
 
       - name: Cleanup service account JSON
         if: always()

--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -13,19 +13,20 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
 
 RUN GCSFUSE_REPO=$(lsb_release -c -s) \
   && echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt gcsfuse-$GCSFUSE_REPO main" \
-     > /etc/apt/sources.list.d/gcsfuse.list
+  > /etc/apt/sources.list.d/gcsfuse.list
 
 # Install gcsfuse
 RUN apt-get update && apt-get install -y --no-install-recommends gcsfuse \
   && rm -rf /var/lib/apt/lists/*
 
 # Python via uv (official Astral approach)
+# UV handles arch automatically
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 RUN uv python install 3.14 \
-  && PYTHON_BIN=$(find /opt/python -name "python3" -path "*/bin/*" | head -1) \
-  && ln -s "$PYTHON_BIN" /usr/local/bin/python3 \
-  && ln -s "$PYTHON_BIN" /usr/local/bin/python
+  && uv python pin 3.14 \
+  && ln -s "$(uv python find 3.14)" /usr/local/bin/python3 \
+  && ln -s "$(uv python find 3.14)" /usr/local/bin/python
 ENV VIRTUAL_ENV=/opt/venv
 RUN uv venv /opt/venv --python 3.14
 

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,7 +1,3 @@
-import {
-  DUST_SANDBOX_IMAGE_ID,
-  type SandboxImageId,
-} from "@app/lib/api/sandbox/image/types";
 import { isDevelopment } from "@app/types/shared/env";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
@@ -479,19 +475,21 @@ const config = {
   // E2B Sandbox.
   getE2BSandboxConfig: (): {
     apiKey: string;
-    imageId: SandboxImageId;
     domain: string | undefined;
   } => {
-    const apiKey = EnvironmentConfig.getEnvVariable("E2B_API_KEY");
     return {
-      apiKey,
-      imageId: DUST_SANDBOX_IMAGE_ID,
+      apiKey: EnvironmentConfig.getEnvVariable("E2B_API_KEY"),
       domain: EnvironmentConfig.getOptionalEnvVariable("E2B_DOMAIN"),
     };
   },
-  getSandboxGcpArtifactServiceAccountPath: (): string => {
-    return EnvironmentConfig.getEnvVariable(
-      "SBX_GCP_ARTIFACT_RO_SERVICE_ACCOUNT"
+  getSandboxGcpArtifactServiceAccountPath: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "SBX_GCP_ARTIFACT_SERVICE_ACCOUNT"
+    );
+  },
+  getSandboxGcpArtifactRegistry: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "SBX_GCP_ARTIFACT_REGISTRY"
     );
   },
 };

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -1,31 +1,18 @@
 import {
-  getRequiredSandboxImages,
+  getRegisteredImages,
   getSandboxImageFromRegistry,
-  getSandboxImageFromRegistryByName,
 } from "@app/lib/api/sandbox/image/registry";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
 
 export function getSandboxImage(
   _auth?: Authenticator
 ): Result<SandboxImage, Error> {
-  const result = getSandboxImageFromRegistry({
-    imageName: "dust-base",
-    tag: "v0.2.0",
-  });
-  if (result.isErr()) {
-    return new Err(new Error("Default sandbox image not found in registry"));
-  }
-  return result;
+  return getSandboxImageFromRegistry({ name: "dust-base" });
 }
 
-export {
-  getRequiredSandboxImages,
-  getSandboxImageFromRegistry,
-  getSandboxImageFromRegistryByName,
-};
+export { getRegisteredImages, getSandboxImageFromRegistry };
 export { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 export {
   createToolManifest,
@@ -38,17 +25,8 @@ export type {
   NetworkPolicy,
   Operation,
   SandboxImageId,
-  SandboxImageName,
-  SandboxImageTag,
   SandboxResources,
   ToolEntry,
   ToolManifest,
 } from "@app/lib/api/sandbox/image/types";
-export {
-  DUST_SANDBOX_IMAGE_ID,
-  formatSandboxImageId,
-  getSandboxImageNames,
-  getSandboxImageTags,
-  isValidSandboxImageName,
-  isValidSandboxImageTag,
-} from "@app/lib/api/sandbox/image/types";
+export { formatSandboxImageId } from "@app/lib/api/sandbox/image/types";

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -1,14 +1,27 @@
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
-import type {
-  SandboxImageId,
-  SandboxImageName,
-} from "@app/lib/api/sandbox/image/types";
 import { ALLOWLIST_NETWORK_POLICY } from "@app/lib/api/sandbox/image/types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:0.2.0")
+  // Conversation files bootstrap
+  // Pre-create workspace directory for faster GCS mounts.
+  .runCmd(
+    "sudo mkdir -p /files/conversation && sudo chmod 777 /files/conversation"
+  )
+  // Create simple netcat-based token server script.
+  .runCmd("sudo mkdir -p /home/user/.bin")
+  // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.
+  .runCmd(`sudo tee /home/user/.bin/token-server.sh > /dev/null << 'SHELLEOF'
+#!/bin/bash
+while true; do
+  (echo -ne "HTTP/1.1 200 OK\\r\\nContent-Type: application/json\\r\\nContent-Length: $(stat -c %s /tmp/token.json 2>/dev/null || echo 0)\\r\\n\\r\\n"; cat /tmp/token.json 2>/dev/null) | nc -l -p 9876 -q 1
+done
+SHELLEOF`)
+  .runCmd("sudo chmod 755 /home/user/.bin/token-server.sh")
+  // Add sentinel file to indicate when mounts are pending.
+  .runCmd("sudo touch /files/conversation/.mount-pending")
   .registerTool(
     [
       { name: "git", description: "Version control system" },
@@ -57,30 +70,17 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:0.2.0")
         "sudo mv /tmp/dsbx /opt/bin/dsbx",
     }
   )
-  // Pre-create workspace directory for faster GCS mounts.
-  .runCmd(
-    "sudo mkdir -p /files/conversation && sudo chmod 777 /files/conversation"
-  )
-  // Create simple netcat-based token server script.
-  .runCmd("sudo mkdir -p /home/user/.bin")
-  // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.
-  .runCmd(`sudo tee /home/user/.bin/token-server.sh > /dev/null << 'SHELLEOF'
-#!/bin/bash
-while true; do
-  (echo -ne "HTTP/1.1 200 OK\\r\\nContent-Type: application/json\\r\\nContent-Length: $(stat -c %s /tmp/token.json 2>/dev/null || echo 0)\\r\\n\\r\\n"; cat /tmp/token.json 2>/dev/null) | nc -l -p 9876 -q 1
-done
-SHELLEOF`)
-  .runCmd("sudo chmod 755 /home/user/.bin/token-server.sh")
-  // Add sentinel file to indicate when mounts are pending.
-  .runCmd("sudo touch /files/conversation/.mount-pending")
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(ALLOWLIST_NETWORK_POLICY)
   .setWorkdir("/home/user")
-  .register({ imageName: "dust-base", tag: "v0.2.0" });
+  .register({
+    imageName: "dust-base",
+    tag: "0.2.1",
+  });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];
 
-function getRegisteredImages(): readonly SandboxImage[] {
+export function getRegisteredImages(): readonly SandboxImage[] {
   return IMAGES.filter((image) => {
     if (!image.imageId) {
       logger.warn("Skipping unregistered sandbox image (no imageId)");
@@ -90,35 +90,23 @@ function getRegisteredImages(): readonly SandboxImage[] {
   });
 }
 
-export function getRequiredSandboxImages(): readonly SandboxImageId[] {
-  return getRegisteredImages()
-    .map((image) => image.imageId)
-    .filter((id): id is SandboxImageId => id !== undefined);
-}
-
-export function getSandboxImageFromRegistry(
-  id: SandboxImageId
-): Result<SandboxImage, Error> {
-  const image = getRegisteredImages().find(
-    (img) =>
-      img.imageId?.imageName === id.imageName && img.imageId?.tag === id.tag
-  );
+export function getSandboxImageFromRegistry(opts: {
+  name: string;
+  tag?: string;
+}): Result<SandboxImage, Error> {
+  const { name, tag } = opts;
+  const image = getRegisteredImages().find((img) => {
+    if (img.imageId?.imageName !== name) {
+      return false;
+    }
+    if (tag !== undefined && img.imageId?.tag !== tag) {
+      return false;
+    }
+    return true;
+  });
   if (!image) {
-    return new Err(
-      new Error(`No sandbox image found for id: ${id.imageName}:${id.tag}`)
-    );
-  }
-  return new Ok(image);
-}
-
-export function getSandboxImageFromRegistryByName(
-  name: SandboxImageName
-): Result<SandboxImage, Error> {
-  const image = getRegisteredImages().find(
-    (img) => img.imageId?.imageName === name
-  );
-  if (!image) {
-    return new Err(new Error(`No sandbox image found for name: ${name}`));
+    const id = tag ? `${name}:${tag}` : name;
+    return new Err(new Error(`No sandbox image found: ${id}`));
   }
   return new Ok(image);
 }

--- a/front/lib/api/sandbox/image/sandbox_image.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.test.ts
@@ -434,7 +434,8 @@ describe("SandboxImage.toCreateConfig()", () => {
   test("returns network and resources from image", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04")
       .withResources({ vcpu: 2, memoryMb: 1024 })
-      .withNetwork({ mode: "allow_all" });
+      .withNetwork({ mode: "allow_all" })
+      .register({ imageName: "test-image", tag: "v1" });
 
     const config = image.toCreateConfig();
 
@@ -443,7 +444,10 @@ describe("SandboxImage.toCreateConfig()", () => {
   });
 
   test("returns undefined envVars when runEnv is empty", () => {
-    const image = SandboxImage.fromDocker("ubuntu:22.04");
+    const image = SandboxImage.fromDocker("ubuntu:22.04").register({
+      imageName: "test-image",
+      tag: "v1",
+    });
 
     const config = image.toCreateConfig();
 
@@ -451,10 +455,12 @@ describe("SandboxImage.toCreateConfig()", () => {
   });
 
   test("returns envVars when runEnv is non-empty", () => {
-    const image = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
-      FOO: "bar",
-      BAZ: "qux",
-    });
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
+      .setRunEnv({
+        FOO: "bar",
+        BAZ: "qux",
+      })
+      .register({ imageName: "test-image", tag: "v1" });
 
     const config = image.toCreateConfig();
 
@@ -462,9 +468,11 @@ describe("SandboxImage.toCreateConfig()", () => {
   });
 
   test("returns a copy of runEnv (not the same reference)", () => {
-    const image = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
-      KEY: "value",
-    });
+    const image = SandboxImage.fromDocker("ubuntu:22.04")
+      .setRunEnv({
+        KEY: "value",
+      })
+      .register({ imageName: "test-image", tag: "v1" });
 
     const config = image.toCreateConfig();
 
@@ -472,7 +480,10 @@ describe("SandboxImage.toCreateConfig()", () => {
   });
 
   test("returns default values for new image", () => {
-    const image = SandboxImage.fromDocker("ubuntu:22.04");
+    const image = SandboxImage.fromDocker("ubuntu:22.04").register({
+      imageName: "test-image",
+      tag: "v1",
+    });
 
     const config = image.toCreateConfig();
 
@@ -481,60 +492,65 @@ describe("SandboxImage.toCreateConfig()", () => {
     expect(config.resources).toEqual({ vcpu: 1, memoryMb: 512 });
   });
 
-  test("returns undefined imageId when not registered", () => {
+  test("throws error when not registered", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04");
 
-    const config = image.toCreateConfig();
-
-    expect(config.imageId).toBeUndefined();
+    expect(() => image.toCreateConfig()).toThrow(
+      "Cannot create config from unregistered SandboxImage"
+    );
   });
 
   test("returns imageId when registered", () => {
-    const imageId: SandboxImageId = {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").register({
       imageName: "dust-base",
       tag: "production",
-    };
-    const image = SandboxImage.fromDocker("ubuntu:22.04").register(imageId);
+    });
 
     const config = image.toCreateConfig();
 
-    expect(config.imageId).toEqual(imageId);
+    expect(config.imageId).toEqual({
+      imageName: "dust-base",
+      tag: "production",
+    });
   });
 });
 
 describe("SandboxImage.register()", () => {
-  test("sets imageId", () => {
-    const imageId: SandboxImageId = {
+  test("sets imageId with string tag", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").register({
       imageName: "dust-base",
       tag: "production",
-    };
-    const image = SandboxImage.fromDocker("ubuntu:22.04").register(imageId);
+    });
 
-    expect(image.imageId).toEqual(imageId);
+    expect(image.imageId).toEqual({
+      imageName: "dust-base",
+      tag: "production",
+    });
   });
 
   test("returns new image instance", () => {
-    const imageId: SandboxImageId = {
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const modified = original.register({
       imageName: "dust-base",
       tag: "production",
-    };
-    const original = SandboxImage.fromDocker("ubuntu:22.04");
-    const modified = original.register(imageId);
+    });
 
     expect(modified).not.toBe(original);
     expect(original.imageId).toBeUndefined();
-    expect(modified.imageId).toEqual(imageId);
+    expect(modified.imageId).toEqual({
+      imageName: "dust-base",
+      tag: "production",
+    });
   });
 
   test("chains with other operations", () => {
-    const imageId: SandboxImageId = { imageName: "dust-base", tag: "staging" };
     const image = SandboxImage.fromDocker("ubuntu:22.04")
       .registerTool({ name: "curl", description: "HTTP client" })
       .withResources({ vcpu: 2, memoryMb: 1024 })
-      .register(imageId)
+      .register({ imageName: "dust-base", tag: "staging" })
       .setRunEnv({ DEBUG: "true" });
 
-    expect(image.imageId).toEqual(imageId);
+    expect(image.imageId).toEqual({ imageName: "dust-base", tag: "staging" });
     expect(image.tools).toHaveLength(1);
     expect(image.resources.vcpu).toBe(2);
     expect(image.runEnv).toEqual({ DEBUG: "true" });

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -180,8 +180,10 @@ export class SandboxImage {
     return this.clone({ network: policy });
   }
 
-  register(imageId: SandboxImageId): SandboxImage {
-    return this.clone({ imageId });
+  register(opts: { imageName: string; tag: string }): SandboxImage {
+    return this.clone({
+      imageId: { imageName: opts.imageName, tag: opts.tag },
+    });
   }
 
   withToolManifest(options?: {
@@ -206,11 +208,16 @@ export class SandboxImage {
   }
 
   toCreateConfig(): {
-    imageId?: SandboxImageId;
+    imageId: SandboxImageId;
     envVars?: Record<string, string>;
     network: NetworkPolicy;
     resources: SandboxResources;
   } {
+    if (!this.imageId) {
+      throw new Error(
+        "Cannot create config from unregistered SandboxImage. Call .register() first."
+      );
+    }
     return {
       imageId: this.imageId,
       envVars:

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -1,51 +1,16 @@
 // ---------------------------------------------------------------------------
-// SandboxImage Name & Tag Types
+// SandboxImage Id
 // ---------------------------------------------------------------------------
 
-const SANDBOX_IMAGE_NAMES = ["dust-base"] as const;
-export type SandboxImageName = (typeof SANDBOX_IMAGE_NAMES)[number];
-
-export function isValidSandboxImageName(
-  name: string
-): name is SandboxImageName {
-  return SANDBOX_IMAGE_NAMES.includes(name as SandboxImageName);
-}
-
-export function getSandboxImageNames(): readonly SandboxImageName[] {
-  return SANDBOX_IMAGE_NAMES;
-}
-
-const SANDBOX_IMAGE_TAGS = [
-  "edge",
-  "staging",
-  "production",
-  "v0.1.1",
-  "v0.2.0",
-] as const;
-export type SandboxImageTag = (typeof SANDBOX_IMAGE_TAGS)[number];
-
-export function isValidSandboxImageTag(tag: string): tag is SandboxImageTag {
-  return SANDBOX_IMAGE_TAGS.includes(tag as SandboxImageTag);
-}
-
-export function getSandboxImageTags(): readonly SandboxImageTag[] {
-  return SANDBOX_IMAGE_TAGS;
-}
-
 export interface SandboxImageId {
-  readonly imageName: SandboxImageName;
-  readonly tag: SandboxImageTag;
+  readonly imageName: string;
+  readonly tag: string;
 }
-
-// TODO(@jd): Replace with a proper typed link to dust-base
-export const DUST_SANDBOX_IMAGE_ID: SandboxImageId = {
-  imageName: "dust-base",
-  tag: "v0.2.0",
-};
 
 export function formatSandboxImageId(id: SandboxImageId): string {
   // E2B template IDs only allow lowercase alphanumeric characters and hyphens.
-  return `${id.imageName}-${id.tag}`.replace(/[^a-z0-9-]/g, "-");
+  const sanitize = (s: string) => s.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+  return `${sanitize(id.imageName)}_${sanitize(id.tag)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -31,8 +31,8 @@ export interface SandboxHandle {
  * Flat structure derived from SandboxImage.toCreateConfig() with optional overrides.
  */
 export interface SandboxCreateConfig {
-  /** Typed image identifier (name + tag) override - E2B specific but exposed for overrides. */
-  imageId?: SandboxImageId;
+  /** Typed image identifier (name + tag) - required. Use getSandboxImage().toCreateConfig(). */
+  imageId: SandboxImageId;
   /** Environment variables for the sandbox runtime. */
   envVars?: Record<string, string>;
   /** Network egress policy. */

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,7 +1,6 @@
 import {
   formatSandboxImageId,
   type NetworkPolicy,
-  type SandboxImageId,
 } from "@app/lib/api/sandbox/image/types";
 import type {
   ExecOptions,
@@ -47,7 +46,6 @@ function toE2BNetworkOpts(policy: NetworkPolicy): E2BNetworkOpts {
 
 interface E2BConfig {
   apiKey: string;
-  imageId: SandboxImageId;
   domain: string | undefined;
 }
 
@@ -59,12 +57,10 @@ interface E2BConfig {
  */
 export class E2BSandboxProvider implements SandboxProvider {
   private readonly apiKey: string;
-  private readonly imageId: SandboxImageId;
   private readonly domain: string | undefined;
 
   constructor(config: E2BConfig) {
     this.apiKey = config.apiKey;
-    this.imageId = config.imageId;
     this.domain = config.domain;
   }
 
@@ -78,10 +74,17 @@ export class E2BSandboxProvider implements SandboxProvider {
   async create(
     config: SandboxCreateConfig
   ): Promise<Result<SandboxHandle, Error>> {
-    const imageId = config.imageId ?? this.imageId;
-    const templateId = formatSandboxImageId(imageId);
+    if (!config.imageId) {
+      throw new Error(
+        "imageId is required in SandboxCreateConfig. Use getSandboxImage().toCreateConfig() to get the config."
+      );
+    }
+    const templateId = formatSandboxImageId(config.imageId);
 
-    logger.info({ templateId, imageId }, "Creating E2B sandbox");
+    logger.info(
+      { templateId, imageId: config.imageId },
+      "Creating E2B sandbox"
+    );
 
     let sandbox: Sandbox;
     try {

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -1,33 +1,26 @@
-import type { SandboxImage } from "@app/lib/api/sandbox/image";
 import {
-  getSandboxImageFromRegistry,
+  formatSandboxImageId,
   type SandboxImageId,
 } from "@app/lib/api/sandbox/image";
+import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { TemplateBuilder } from "e2b";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { DockerRegistryFactory } from "./e2b_template";
 import { buildSandboxImage } from "./e2b_template";
 
-const TEST_IMAGE_ID: SandboxImageId = { imageName: "dust-base", tag: "edge" };
-const STAGING_IMAGE_ID: SandboxImageId = {
-  imageName: "dust-base",
-  tag: "staging",
-};
-const PRODUCTION_IMAGE_ID: SandboxImageId = {
-  imageName: "dust-base",
-  tag: "production",
-};
-
-function getTestImage(): SandboxImage {
-  const result = getSandboxImageFromRegistry({
-    imageName: "dust-base",
-    tag: "v0.2.0",
-  });
-  if (result.isErr()) {
-    throw new Error("Test setup failed: dust-base image not in registry");
-  }
-  return result.value;
+function createTestImage(): SandboxImage {
+  return SandboxImage.fromDocker("test-image:v1")
+    .registerTool(
+      { name: "tool-a", description: "Test tool A" },
+      { installCmd: "apt-get install -y tool-a" }
+    )
+    .registerTool(
+      { name: "tool-b", description: "Test tool B" },
+      { installCmd: "pip install tool-b" }
+    )
+    .withResources({ vcpu: 2, memoryMb: 1024 })
+    .setWorkdir("/workspace");
 }
 
 vi.mock("@app/lib/api/config", () => ({
@@ -84,6 +77,33 @@ vi.mock("e2b", () => ({
   defaultBuildLogger: vi.fn(() => vi.fn()),
 }));
 
+describe("formatSandboxImageId()", () => {
+  test("replaces dots with hyphens in tag", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "v0.1.1" };
+    expect(formatSandboxImageId(id)).toBe("dust-base_v0-1-1");
+  });
+
+  test("replaces underscores with hyphens in tag", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "my_tag" };
+    expect(formatSandboxImageId(id)).toBe("dust-base_my-tag");
+  });
+
+  test("lowercases uppercase characters", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "Staging" };
+    expect(formatSandboxImageId(id)).toBe("dust-base_staging");
+  });
+
+  test("sanitizes both imageName and tag", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "v0.1.1" };
+    expect(formatSandboxImageId(id)).toBe("dust-base_v0-1-1");
+  });
+
+  test("handles alphanumeric and hyphens without modification", () => {
+    const id: SandboxImageId = { imageName: "dust-base", tag: "edge" };
+    expect(formatSandboxImageId(id)).toBe("dust-base_edge");
+  });
+});
+
 describe("buildSandboxImage()", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -91,28 +111,32 @@ describe("buildSandboxImage()", () => {
 
   test("calls E2B Template builder methods in operation order", async () => {
     mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
-    const testImage = getTestImage();
+    const testImage = createTestImage();
+    const imageId: SandboxImageId = { imageName: "dust-base", tag: "edge" };
 
-    const result = await buildSandboxImage(testImage, TEST_IMAGE_ID, {
+    const result = await buildSandboxImage(testImage, imageId, {
       apiKey: "test-api-key",
       dockerRegistryFactory: mockDockerRegistryFactory,
     });
 
     expect(result.isOk()).toBe(true);
-    expect(mockDockerRegistryFactory).toHaveBeenCalledWith(
-      "dust-sbx-bedrock:0.2.0"
-    );
+    if (testImage.baseImage.type === "docker") {
+      expect(mockDockerRegistryFactory).toHaveBeenCalledWith(
+        testImage.baseImage.imageRef
+      );
+    }
     expect(mockDockerRegistryBuilder.runCmd).toHaveBeenCalled();
     expect(mockDockerRegistryBuilder.setWorkdir).toHaveBeenCalledWith(
-      "/home/user"
+      "/workspace"
     );
   });
 
   test("returns templateId from E2B build result", async () => {
     mockBuild.mockResolvedValueOnce({ templateId: "my-template-123" });
-    const testImage = getTestImage();
+    const testImage = createTestImage();
+    const imageId: SandboxImageId = { imageName: "dust-base", tag: "staging" };
 
-    const result = await buildSandboxImage(testImage, STAGING_IMAGE_ID, {
+    const result = await buildSandboxImage(testImage, imageId, {
       apiKey: "test-api-key",
       dockerRegistryFactory: mockDockerRegistryFactory,
     });
@@ -123,11 +147,12 @@ describe("buildSandboxImage()", () => {
     }
   });
 
-  test("passes name_tag format to E2B build", async () => {
+  test("passes sanitized name_tag format to E2B build", async () => {
     mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
-    const testImage = getTestImage();
+    const testImage = createTestImage();
+    const imageId: SandboxImageId = { imageName: "dust-base", tag: "v0.1.1" };
 
-    await buildSandboxImage(testImage, PRODUCTION_IMAGE_ID, {
+    await buildSandboxImage(testImage, imageId, {
       apiKey: "test-api-key",
       domain: "custom.e2b.dev",
       dockerRegistryFactory: mockDockerRegistryFactory,
@@ -135,7 +160,7 @@ describe("buildSandboxImage()", () => {
 
     expect(mockBuild).toHaveBeenCalledWith(
       mockDockerRegistryBuilder,
-      "dust-base-production",
+      "dust-base_v0-1-1",
       expect.objectContaining({
         apiKey: "test-api-key",
         domain: "custom.e2b.dev",
@@ -147,9 +172,10 @@ describe("buildSandboxImage()", () => {
 
   test("returns Err when E2B build fails", async () => {
     mockBuild.mockRejectedValueOnce(new Error("Build failed"));
-    const testImage = getTestImage();
+    const testImage = createTestImage();
+    const imageId: SandboxImageId = { imageName: "dust-base", tag: "edge" };
 
-    const result = await buildSandboxImage(testImage, TEST_IMAGE_ID, {
+    const result = await buildSandboxImage(testImage, imageId, {
       apiKey: "test-api-key",
       dockerRegistryFactory: mockDockerRegistryFactory,
     });
@@ -160,25 +186,10 @@ describe("buildSandboxImage()", () => {
     }
   });
 
-  test("installs npm packages via runCmd", async () => {
-    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
-    const testImage = getTestImage();
-
-    await buildSandboxImage(testImage, TEST_IMAGE_ID, {
-      apiKey: "test-api-key",
-      dockerRegistryFactory: mockDockerRegistryFactory,
-    });
-
-    const runCmdCalls = mockDockerRegistryBuilder.runCmd.mock.calls;
-    const hasNpmInstall = runCmdCalls.some((call: string[]) =>
-      call[0].includes("npm install -g")
-    );
-    expect(hasNpmInstall).toBe(true);
-  });
-
   test("processes operations in correct order", async () => {
     mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
-    const testImage = getTestImage();
+    const testImage = createTestImage();
+    const imageId: SandboxImageId = { imageName: "dust-base", tag: "edge" };
 
     const callOrder: string[] = [];
     const trackingDockerRegistryFactory: DockerRegistryFactory = (
@@ -192,12 +203,10 @@ describe("buildSandboxImage()", () => {
       return mockDockerRegistryBuilder;
     });
     mockDockerRegistryBuilder.runCmd.mockImplementation((cmd: string) => {
-      if (cmd.includes("uv pip install")) {
-        callOrder.push("runCmd:pip");
-      } else if (cmd.includes("npm install")) {
-        callOrder.push("runCmd:npm");
-      } else if (cmd.includes("apt-get install")) {
+      if (cmd.includes("apt-get install")) {
         callOrder.push("runCmd:apt");
+      } else if (cmd.includes("pip install")) {
+        callOrder.push("runCmd:pip");
       } else {
         callOrder.push("runCmd");
       }
@@ -208,53 +217,14 @@ describe("buildSandboxImage()", () => {
       return mockDockerRegistryBuilder;
     });
 
-    await buildSandboxImage(testImage, TEST_IMAGE_ID, {
+    await buildSandboxImage(testImage, imageId, {
       apiKey: "test-api-key",
       dockerRegistryFactory: trackingDockerRegistryFactory,
     });
 
     expect(callOrder[0]).toBe("fromDockerRegistry");
+    expect(callOrder).toContain("runCmd:apt");
     expect(callOrder).toContain("runCmd:pip");
-    expect(callOrder).toContain("runCmd:npm");
     expect(callOrder[callOrder.length - 1]).toBe("setWorkdir");
-  });
-
-  test("passes correct apt packages via runCmd", async () => {
-    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
-    const testImage = getTestImage();
-
-    await buildSandboxImage(testImage, TEST_IMAGE_ID, {
-      apiKey: "test-api-key",
-      dockerRegistryFactory: mockDockerRegistryFactory,
-    });
-
-    const runCmdCalls = mockDockerRegistryBuilder.runCmd.mock.calls;
-    const aptInstallCall = runCmdCalls.find(
-      (call: string[]) =>
-        call[0].includes("apt-get install") &&
-        call[0].includes("jq") &&
-        call[0].includes("pandoc")
-    );
-    expect(aptInstallCall).toBeDefined();
-  });
-
-  test("passes correct pip packages via runCmd", async () => {
-    mockBuild.mockResolvedValueOnce({ templateId: "built-template-id" });
-    const testImage = getTestImage();
-
-    await buildSandboxImage(testImage, TEST_IMAGE_ID, {
-      apiKey: "test-api-key",
-      dockerRegistryFactory: mockDockerRegistryFactory,
-    });
-
-    const runCmdCalls = mockDockerRegistryBuilder.runCmd.mock.calls;
-    const pipInstallCall = runCmdCalls.find(
-      (call: string[]) =>
-        call[0].includes("uv pip install") &&
-        call[0].includes("pandas") &&
-        call[0].includes("numpy") &&
-        call[0].includes("matplotlib")
-    );
-    expect(pipInstallCall).toBeDefined();
   });
 });

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -20,7 +20,12 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { TemplateBuilder } from "e2b";
-import { defaultBuildLogger, Template as E2BTemplate } from "e2b";
+import {
+  ApiClient,
+  ConnectionConfig,
+  defaultBuildLogger,
+  Template as E2BTemplate,
+} from "e2b";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -178,17 +183,6 @@ export interface E2BTemplateInfo {
   aliases: readonly string[];
 }
 
-interface E2BAPITemplateResponse {
-  templateID: string;
-  aliases?: string[];
-  buildID: string;
-  cpuCount: number;
-  memoryMB: number;
-  public: boolean;
-}
-
-const E2B_API_BASE_URL = "https://api.e2b.dev";
-
 export async function listE2BTemplates(
   apiKey?: string
 ): Promise<Result<E2BTemplateInfo[], Error>> {
@@ -196,25 +190,20 @@ export async function listE2BTemplates(
   const key = apiKey ?? e2bConfig.apiKey;
   const domain = e2bConfig.domain;
 
-  const baseUrl = domain ? `https://api.${domain}` : E2B_API_BASE_URL;
-
   try {
-    const response = await fetch(`${baseUrl}/templates`, {
-      method: "GET",
-      headers: {
-        "X-API-Key": key,
-        "Content-Type": "application/json",
-      },
+    const connectionConfig = new ConnectionConfig({
+      apiKey: key,
+      ...(domain ? { domain } : {}),
     });
+    const client = new ApiClient(connectionConfig, { requireApiKey: true });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        `E2B API error: ${response.status} ${response.statusText} - ${errorText}`
-      );
+    const response = await client.api.GET("/templates");
+
+    if (response.error) {
+      throw new Error(`E2B API error: ${JSON.stringify(response.error)}`);
     }
 
-    const templates: E2BAPITemplateResponse[] = await response.json();
+    const templates = response.data ?? [];
     return new Ok(
       templates.map((t) => ({
         templateId: t.templateID,
@@ -225,6 +214,23 @@ export async function listE2BTemplates(
     logger.error({ err: normalizeError(err) }, "Failed to list E2B templates");
     return new Err(normalizeError(err));
   }
+}
+
+export async function templateExists(
+  imageId: SandboxImageId,
+  apiKey?: string
+): Promise<Result<boolean, Error>> {
+  const templatesResult = await listE2BTemplates(apiKey);
+  if (templatesResult.isErr()) {
+    return templatesResult;
+  }
+
+  const expectedAlias = formatSandboxImageId(imageId);
+  const exists = templatesResult.value.some((template) =>
+    template.aliases.includes(expectedAlias)
+  );
+
+  return new Ok(exists);
 }
 
 export async function buildSandboxImage(

--- a/front/scripts/sandbox_image_build.ts
+++ b/front/scripts/sandbox_image_build.ts
@@ -1,111 +1,154 @@
+import config from "@app/lib/api/config";
 import {
   formatSandboxImageId,
   getSandboxImageFromRegistry,
-  getSandboxImageFromRegistryByName,
-  getSandboxImageNames,
-  getSandboxImageTags,
-  isValidSandboxImageName,
-  isValidSandboxImageTag,
   type SandboxImageId,
 } from "@app/lib/api/sandbox/image";
 import {
   buildSandboxImage,
   createGCPRegistryFactory,
+  templateExists,
 } from "@app/lib/api/sandbox/providers/e2b_template";
-import type { Logger } from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+import logger from "@app/logger/logger";
+import * as fs from "fs";
+import * as readline from "readline";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 interface BuildArgs {
   image: string;
   tag: string;
-  execute: boolean;
   skipCache: boolean;
-  dockerRegistry?: string;
-  force: boolean;
+  dockerRegistry: string;
+  rebuild: boolean;
+  confirm: boolean;
 }
 
-async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
+async function promptYesNo(question: string): Promise<boolean> {
+  // Flush async logger (pino-pretty) before prompting
+  await new Promise<void>((resolve) => logger.flush(() => resolve()));
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    let answered = false;
+
+    rl.on("close", () => {
+      if (!answered) {
+        process.exit(1);
+      }
+    });
+
+    rl.question(`${question} [y/N] `, (answer) => {
+      answered = true;
+      rl.close();
+      resolve(answer.toLowerCase() === "y");
+    });
+  });
+}
+
+async function buildImage(args: BuildArgs): Promise<void> {
   const {
     image: imageName,
     tag,
-    execute,
     skipCache,
     dockerRegistry,
-    force,
+    rebuild,
+    confirm,
   } = args;
-
-  if (!isValidSandboxImageName(imageName)) {
-    const available = getSandboxImageNames().join(", ");
-    logger.error(
-      { imageName, available },
-      "Invalid image name. Available: " + available
-    );
-    process.exit(1);
-  }
-
-  if (!isValidSandboxImageTag(tag)) {
-    const available = getSandboxImageTags().join(", ");
-    logger.error({ tag, available }, "Invalid tag. Available: " + available);
-    process.exit(1);
-  }
 
   const imageId: SandboxImageId = { imageName, tag };
 
-  const sandboxImageResult = force
-    ? getSandboxImageFromRegistryByName(imageName)
-    : getSandboxImageFromRegistry(imageId);
+  logger.info({ imageName, tag }, "Starting sandbox image build");
 
-  if (sandboxImageResult.isErr()) {
+  const existsResult = await templateExists(imageId);
+  if (existsResult.isErr()) {
     logger.error(
-      { imageId: formatSandboxImageId(imageId) },
-      "Image not found in registry"
+      { err: existsResult.error },
+      "Failed to check if template exists"
     );
     process.exit(1);
   }
 
-  if (force) {
-    logger.warn(
-      { imageName, tag },
-      "Force mode: building image with tag that may differ from registry"
+  if (existsResult.value && !rebuild) {
+    logger.error(
+      { imageId: formatSandboxImageId(imageId) },
+      "Template already exists in E2B. Use --rebuild to rebuild."
     );
+    process.exit(1);
   }
 
+  if (existsResult.value && rebuild && !confirm) {
+    const confirmed = await promptYesNo(
+      `Template ${formatSandboxImageId(imageId)} already exists. Rebuild?`
+    );
+    if (!confirmed) {
+      return;
+    }
+  }
+
+  const sandboxImageResult = getSandboxImageFromRegistry({ name: imageName });
+  if (sandboxImageResult.isErr()) {
+    logger.error({ imageName }, "Image not found in registry. Cannot proceed.");
+    process.exit(1);
+  }
   const sandboxImage = sandboxImageResult.value;
+
+  logger.info(
+    { imageName, tag },
+    `Building E2B template '${formatSandboxImageId(imageId)}' from registry config`
+  );
 
   const usesDockerBase = sandboxImage.baseImage.type === "docker";
   if (usesDockerBase && !dockerRegistry) {
     logger.error(
       { imageName },
-      "Image uses Docker base. Please provide --docker-registry option"
+      "Image uses Docker base. Please provide --docker-registry option or set SBX_GCP_ARTIFACT_REGISTRY env var"
     );
     process.exit(1);
   }
 
+  const serviceAccountPath = config.getSandboxGcpArtifactServiceAccountPath();
+  if (usesDockerBase && !serviceAccountPath) {
+    logger.error(
+      { imageName },
+      "Image uses Docker base. Please set SBX_GCP_ARTIFACT_SERVICE_ACCOUNT env var to the path of your GCP service account JSON file"
+    );
+    process.exit(1);
+  }
+
+  if (usesDockerBase && serviceAccountPath) {
+    if (!fs.existsSync(serviceAccountPath)) {
+      logger.error({ serviceAccountPath }, "Service account file not found");
+      process.exit(1);
+    }
+    const stat = fs.statSync(serviceAccountPath);
+    if (!stat.isFile()) {
+      logger.error(
+        { serviceAccountPath },
+        "SBX_GCP_ARTIFACT_SERVICE_ACCOUNT must point to a file, not a directory"
+      );
+      process.exit(1);
+    }
+  }
+
   logger.info(
-    { imageName, tag, usesDockerBase, dockerRegistry: dockerRegistry ?? "N/A" },
+    {
+      imageName,
+      tag,
+      usesDockerBase,
+      dockerRegistry: usesDockerBase ? dockerRegistry : "N/A",
+    },
     "Building sandbox image"
   );
 
-  if (!execute) {
-    logger.info(
-      {
-        imageName,
-        tag,
-        skipCache,
-        operationCount: sandboxImage.operations.length,
-        toolCount: sandboxImage.tools.length,
-      },
-      "Would build sandbox image via E2B SDK (dry-run)"
-    );
-    return;
-  }
-
-  const dockerRegistryFactory = dockerRegistry
-    ? createGCPRegistryFactory(
-        dockerRegistry,
-        process.env.SBX_GCP_ARTIFACT_RO_SERVICE_ACCOUNT ?? ""
-      )
-    : undefined;
+  const dockerRegistryFactory =
+    usesDockerBase && serviceAccountPath
+      ? createGCPRegistryFactory(dockerRegistry, serviceAccountPath)
+      : undefined;
 
   const result = await buildSandboxImage(sandboxImage, imageId, {
     skipCache,
@@ -113,7 +156,6 @@ async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
   });
 
   if (result.isErr()) {
-    logger.error({ err: result.error }, "Failed to build sandbox image");
     process.exit(1);
   }
 
@@ -123,47 +165,60 @@ async function buildImage(args: BuildArgs, logger: Logger): Promise<void> {
   );
 }
 
-makeScript(
-  {
-    image: {
-      type: "string" as const,
-      demandOption: true,
-      describe: "Image name (e.g., dust-base)",
-    },
-    tag: {
-      type: "string" as const,
-      demandOption: true,
-      describe: "E2B image tag (e.g., production, staging)",
-    },
-    "skip-cache": {
-      type: "boolean" as const,
-      default: false,
-      describe: "Force rebuild without using cache",
-    },
-    "docker-registry": {
-      type: "string" as const,
-      describe:
-        "Docker registry URL for images using Docker base (e.g., us-docker.pkg.dev/project/repo)",
-    },
-    force: {
-      alias: "f",
-      type: "boolean" as const,
-      default: false,
-      describe:
-        "Build image even if exact tag is not registered (uses image config by name)",
-    },
-  },
-  async (args, logger) => {
-    await buildImage(
-      {
-        image: args.image,
-        tag: args.tag,
-        execute: args.execute,
-        skipCache: args["skip-cache"],
-        dockerRegistry: args["docker-registry"],
-        force: args.force,
-      },
-      logger
-    );
+function getDockerRegistry(cliValue: string | undefined): string {
+  if (cliValue) {
+    return cliValue;
   }
-);
+  return config.getSandboxGcpArtifactRegistry() ?? "";
+}
+
+yargs(hideBin(process.argv))
+  .option("image", {
+    type: "string",
+    demandOption: true,
+    describe: "Image name (e.g., dust-base)",
+  })
+  .option("tag", {
+    type: "string",
+    demandOption: true,
+    describe: "E2B image tag (e.g., production, staging)",
+  })
+  .option("skip-cache", {
+    type: "boolean",
+    default: false,
+    describe: "Force rebuild without using cache",
+  })
+  .option("docker-registry", {
+    type: "string",
+    describe:
+      "Docker registry URL (fallback: SBX_GCP_ARTIFACT_REGISTRY env var)",
+  })
+  .option("rebuild", {
+    type: "boolean",
+    default: false,
+    describe:
+      "Rebuild even if template exists in E2B (prompts for confirmation unless --confirm)",
+  })
+  .option("confirm", {
+    type: "boolean",
+    default: false,
+    describe: "Skip all interactive prompts",
+  })
+  .help("h")
+  .alias("h", "help")
+  .parseAsync()
+  .then(async (args) => {
+    await buildImage({
+      image: args.image,
+      tag: args.tag,
+      skipCache: args["skip-cache"],
+      dockerRegistry: getDockerRegistry(args["docker-registry"]),
+      rebuild: args.rebuild,
+      confirm: args.confirm,
+    });
+    process.exit(0);
+  })
+  .catch((error) => {
+    logger.error({ err: error }, "An error occurred");
+    process.exit(1);
+  });

--- a/front/scripts/sandbox_image_check.ts
+++ b/front/scripts/sandbox_image_check.ts
@@ -1,10 +1,12 @@
 import {
   formatSandboxImageId,
-  getRequiredSandboxImages,
+  getRegisteredImages,
+  type SandboxImageId,
 } from "@app/lib/api/sandbox/image";
 import { listE2BTemplates } from "@app/lib/api/sandbox/providers/e2b_template";
-import type { Logger } from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
+import logger from "@app/logger/logger";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 interface CheckResult {
   required: string[];
@@ -13,22 +15,24 @@ interface CheckResult {
   buildMatrix: Array<{ image: string; tag: string }>;
 }
 
-async function checkSandboxImages(
-  args: { json: boolean; failOnMissing: boolean; forceRebuild: boolean },
-  logger: Logger
-): Promise<void> {
-  const { json, failOnMissing, forceRebuild } = args;
+interface CheckArgs {
+  json: boolean;
+  failOnMissing: boolean;
+}
 
-  const requiredImages = getRequiredSandboxImages();
+async function checkSandboxImages(args: CheckArgs): Promise<void> {
+  const { json, failOnMissing } = args;
+
+  const requiredImages = getRegisteredImages()
+    .map((img) => img.imageId)
+    .filter((id): id is SandboxImageId => id !== undefined);
   const requiredIds = requiredImages.map(formatSandboxImageId);
 
   const templatesResult = await listE2BTemplates();
 
   if (templatesResult.isErr()) {
     if (json) {
-      logger.info(
-        JSON.stringify({ error: templatesResult.error.message }, null, 2)
-      );
+      logger.info({ result: { error: templatesResult.error.message } }, "");
     } else {
       logger.error(
         { err: templatesResult.error },
@@ -53,7 +57,7 @@ async function checkSandboxImages(
   const buildMatrix: Array<{ image: string; tag: string }> = [];
 
   for (const id of requiredIds) {
-    if (existingIds.has(id) && !forceRebuild) {
+    if (existingIds.has(id)) {
       existing.push(id);
     } else {
       missing.push(id);
@@ -62,7 +66,7 @@ async function checkSandboxImages(
 
   for (const imageId of requiredImages) {
     const formattedId = formatSandboxImageId(imageId);
-    if (!existingIds.has(formattedId) || forceRebuild) {
+    if (!existingIds.has(formattedId)) {
       buildMatrix.push({
         image: imageId.imageName,
         tag: imageId.tag,
@@ -78,7 +82,7 @@ async function checkSandboxImages(
   };
 
   if (json) {
-    logger.info(JSON.stringify(result, null, 2));
+    logger.info({ result }, "");
   } else {
     logger.info(
       {
@@ -101,32 +105,27 @@ async function checkSandboxImages(
   }
 }
 
-makeScript(
-  {
-    json: {
-      type: "boolean" as const,
-      default: false,
-      describe: "Output results as JSON",
-    },
-    "fail-on-missing": {
-      type: "boolean" as const,
-      default: false,
-      describe: "Exit with error code if images are missing",
-    },
-    "force-rebuild": {
-      type: "boolean" as const,
-      default: false,
-      describe: "Treat all images as missing (for rebuild)",
-    },
-  },
-  async (args, logger) => {
-    await checkSandboxImages(
-      {
-        json: args.json,
-        failOnMissing: args["fail-on-missing"],
-        forceRebuild: args["force-rebuild"],
-      },
-      logger
-    );
-  }
-);
+yargs(hideBin(process.argv))
+  .option("json", {
+    type: "boolean",
+    default: false,
+    describe: "Output results as JSON",
+  })
+  .option("fail-on-missing", {
+    type: "boolean",
+    default: false,
+    describe: "Exit with error code if images are missing",
+  })
+  .help("h")
+  .alias("h", "help")
+  .parseAsync()
+  .then(async (args) => {
+    await checkSandboxImages({
+      json: args.json,
+      failOnMissing: args["fail-on-missing"],
+    });
+  })
+  .catch((error) => {
+    logger.error({ err: error }, "An error occurred");
+    process.exit(1);
+  });


### PR DESCRIPTION
## Description

This PRs aims at making engineers at dust fall into the "pit of success" in 99% of cases (the 1% being when you iterate on bedrock image, I'm not going to optimise for this)

- relax & simplify image id typing, if you want to bump up, you update the .register(..) and that's it.
- the ci/cd will take it from there, checking against E2B production if the tag+name exist, and build it if not, before deploying front (without impacting deploy wall clock time)
- improve front/scripts/sandbox_image_build.ts 
  - Make it harder for you to overwrite an image by mistake
  - Rely more on env vars for stuff that don't change a lot (docker repository), while still have flexibility
  - Make the errors a bit more human friendly

On bedrock side, allows to bump up major from the CI/CD (minor stays the default)


## Tests

- Unit tests + manual + ci / cd runs

## Risk

Low, we may block front deploy but easy to revert


## Deploy Plan

- [ ] Deploy front