### PR TITLE
Add option to skip history

### DIFF
--- a/front/lib/api/actions/mcp_client_side.ts
+++ b/front/lib/api/actions/mcp_client_side.ts
@@ -178,7 +178,6 @@ export function isMCPEventResult(value: unknown): value is MCPEventResult {
  */
 export class ClientSideRedisMCPTransport implements Transport {
   private unsubscribe?: () => void;
-  private lastEventId: string | null = null;
 
   private readonly conversationId: string;
   private readonly messageId: string;
@@ -262,12 +261,14 @@ export class ClientSideRedisMCPTransport implements Transport {
       mcpServerId: this.mcpServerId,
     });
 
-    // Subscribe to the response channel.
+    // Subscribe to the response channel (real-time pub/sub only, no history).
+    // This transport is created fresh per tool call and only needs events
+    // published after it subscribes. Skip history to avoid fetching old events.
     const subscription = await getRedisHybridManager().subscribe(
       resultsChannelId,
       this.handleRedisEvent.bind(this),
-      this.lastEventId,
-      "mcp_client_side_transport"
+      "mcp_client_side_transport",
+      { skipHistory: true }
     );
 
     this.unsubscribe = subscription.unsubscribe;
@@ -331,7 +332,6 @@ export class ClientSideRedisMCPTransport implements Transport {
 
     try {
       const payload = JSON.parse(event.message.payload);
-      this.lastEventId = event.id;
 
       // Handle ID transformation for responses
       if (isMCPEventResult(payload.result)) {

--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -29,8 +29,8 @@ export async function* getMCPEventsForServer(
   const { history, unsubscribe } = await getRedisHybridManager().subscribe(
     channelId,
     callbackReader.callback,
-    lastEventId,
-    "mcp_events"
+    "mcp_events",
+    { lastEventId }
   );
 
   // Unsubscribe if the signal is aborted.

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -46,8 +46,8 @@ export async function* getConversationEvents({
   const { history, unsubscribe } = await getRedisHybridManager().subscribe(
     pubsubChannel,
     callbackReader.callback,
-    lastEventId,
-    "conversation_events"
+    "conversation_events",
+    { lastEventId }
   );
 
   // Unsubscribe if the signal is aborted
@@ -170,8 +170,8 @@ export async function* getMessagesEvents(
   const { history, unsubscribe } = await getRedisHybridManager().subscribe(
     pubsubChannel,
     callbackReader.callback,
-    lastEventId,
-    "message_events"
+    "message_events",
+    { lastEventId }
   );
 
   // Unsubscribe if the signal is aborted

--- a/front/lib/api/assistant/streaming/blocking.ts
+++ b/front/lib/api/assistant/streaming/blocking.ts
@@ -112,7 +112,6 @@ async function waitForAgentCompletion(
                 checkCompletion();
               }
             },
-            null, // lastEventId.
             "user_message_events"
           );
 

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -268,8 +268,11 @@ class RedisHybridManager {
   public async subscribe(
     channelName: string,
     callback: EventCallback,
-    lastEventId: string | null = null,
-    origin: string
+    origin: string,
+    {
+      lastEventId = null,
+      skipHistory = false,
+    }: { lastEventId?: string | null; skipHistory?: boolean } = {}
   ): Promise<{
     history: EventPayload[];
     unsubscribe: () => void;
@@ -305,41 +308,75 @@ class RedisHybridManager {
           channelSetupDurationMs
         );
 
-        const eventsDuringHistoryFetch: EventPayload[] = [];
-        const eventsDuringHistoryFetchCallback: EventCallback = (
-          event: EventPayload | "close"
-        ) => {
-          if (event !== "close") {
-            eventsDuringHistoryFetch.push(event);
-          }
-        };
+        const history: EventPayload[] = [];
 
-        // Add to subscribers map during history fetch to avoid race condition
-        this.subscribers
-          .get(pubSubChannelName)!
-          .add(eventsDuringHistoryFetchCallback);
+        if (skipHistory) {
+          // No history needed — just register the callback for real-time pub/sub events.
+          this.subscribers.get(pubSubChannelName)!.add(callback);
+        } else {
+          const eventsDuringHistoryFetch: EventPayload[] = [];
+          const eventsDuringHistoryFetchCallback: EventCallback = (
+            event: EventPayload | "close"
+          ) => {
+            if (event !== "close") {
+              eventsDuringHistoryFetch.push(event);
+            }
+          };
 
-        const historyFetchStartMs = Date.now();
-        const { events: history, hasMore: historyHasMore } =
-          await this.getHistory(
-            streamClient,
-            streamName,
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            lastEventId || "0-0"
+          // Add to subscribers map during history fetch to avoid race condition
+          this.subscribers
+            .get(pubSubChannelName)!
+            .add(eventsDuringHistoryFetchCallback);
+
+          const historyFetchStartMs = Date.now();
+          const { events: historyEvents, hasMore: historyHasMore } =
+            await this.getHistory(
+              streamClient,
+              streamName,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+              lastEventId || "0-0"
+            );
+          const historyFetchDurationMs = Date.now() - historyFetchStartMs;
+          statsDClient.distribution(
+            "sse.subscribe.history_fetch_duration_ms",
+            historyFetchDurationMs
           );
-        const historyFetchDurationMs = Date.now() - historyFetchStartMs;
-        statsDClient.distribution(
-          "sse.subscribe.history_fetch_duration_ms",
-          historyFetchDurationMs
-        );
 
-        // Remove the temporary callback from the subscribers map
-        this.subscribers
-          .get(pubSubChannelName)!
-          .delete(eventsDuringHistoryFetchCallback);
+          // Remove the temporary callback from the subscribers map
+          this.subscribers
+            .get(pubSubChannelName)!
+            .delete(eventsDuringHistoryFetchCallback);
 
-        // Immediately add the real callback to the subscribers map
-        this.subscribers.get(pubSubChannelName)!.add(callback);
+          // Immediately add the real callback to the subscribers map
+          this.subscribers.get(pubSubChannelName)!.add(callback);
+
+          // Append the events during history fetch to the history, if any
+          const dedupeStartMs = Date.now();
+          history.push(...historyEvents);
+          if (eventsDuringHistoryFetch.length > 0) {
+            // Use Set for O(1) deduplication instead of O(n) find
+            const historyIds = new Set(history.map((h) => h.id));
+
+            for (const event of eventsDuringHistoryFetch) {
+              // deduplicate events
+              if (!historyIds.has(event.id)) {
+                history.push(event);
+              }
+            }
+            // Sort the history just in case
+            history.sort((a, b) => a.id.localeCompare(b.id));
+          }
+          const dedupeDurationMs = Date.now() - dedupeStartMs;
+          statsDClient.distribution(
+            "sse.subscribe.dedupe_duration_ms",
+            dedupeDurationMs
+          );
+
+          if (historyHasMore) {
+            // Force the client to re-subscribe with the latest event id it had in order to get more events from history.
+            callback("close");
+          }
+        }
 
         // Track active subscription count for monitoring.
         this.activeSubscriptionCount++;
@@ -347,34 +384,7 @@ class RedisHybridManager {
           "sse.active_subscriptions",
           this.activeSubscriptionCount
         );
-        // Track subscription rate (increment counter to get rate per second).
         statsDClient.increment("sse.subscription_established", 1);
-
-        // Append the events during history fetch to the history, if any
-        const dedupeStartMs = Date.now();
-        if (eventsDuringHistoryFetch.length > 0) {
-          // Use Set for O(1) deduplication instead of O(n) find
-          const historyIds = new Set(history.map((h) => h.id));
-
-          for (const event of eventsDuringHistoryFetch) {
-            // deduplicate events
-            if (!historyIds.has(event.id)) {
-              history.push(event);
-            }
-          }
-          // Sort the history just in case
-          history.sort((a, b) => a.id.localeCompare(b.id));
-        }
-        const dedupeDurationMs = Date.now() - dedupeStartMs;
-        statsDClient.distribution(
-          "sse.subscribe.dedupe_duration_ms",
-          dedupeDurationMs
-        );
-
-        if (historyHasMore) {
-          // Force the client to re-subscribe with the latest event id it had in order to get more events from history.
-          callback("close");
-        }
 
         // Track total subscription establishment time.
         const subscribeDurationMs = Date.now() - subscribeStartMs;
@@ -620,8 +630,8 @@ class RedisHybridManager {
           eventEmitter.emit("error", error);
         }
       },
-      lastEventId,
-      origin
+      origin,
+      { lastEventId }
     );
 
     // Create the async iterator using fromEvent.


### PR DESCRIPTION
## Description

Fix client-side MCP tool calls failing after ~12 sequential invocations with:
```
Error: Not connected
```

**Root cause:** The `:results` Redis stream is never cleaned up. Each tool call adds 4 events (2 connections × init + response). After ~12 calls the stream exceeds `HISTORY_FETCH_COUNT` (50). When the next `ClientSideRedisMCPTransport.start()` subscribes, the hybrid manager detects `historyHasMore = true` and synchronously calls `callback("close")` — which triggers the MCP SDK's `_onclose()`, setting `_transport = undefined` before `connect()` can send `initialize`.

**Fix:**
- Add a `skipHistory` option to `RedisHybridManager.subscribe()` that bypasses the stream history fetch entirely — only registers for real-time pub/sub events.
- Use `skipHistory: true` in `ClientSideRedisMCPTransport.start()` since this transport is created fresh per tool call and never needs history replay.
- Move `lastEventId` into the options object alongside `skipHistory` for a cleaner API.

## Tests

Manually tested: 20+ sequential client-side MCP tool calls with no failure (previously failed consistently at call 13). Confirmed lowering `HISTORY_FETCH_COUNT` moves the failure point proportionally.

## Risk

Low. The `skipHistory` option is additive — all existing callers pass `lastEventId` via the new options object with no behavior change. Only `ClientSideRedisMCPTransport` opts into `skipHistory`.

## Deploy Plan

Standard deploy — no migration, no feature flag needed.