### PR TITLE
[Front] feat(byok): add LLMCredentialsType and workspace-aware credential resolution

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -204,6 +204,9 @@ const config = {
   getRegionResolverSecret: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("REGION_RESOLVER_SECRET");
   },
+  getRegion: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("REGION");
+  },
   // OAuth
   getOAuthGithubApp: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_GITHUB_APP");

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -1,7 +1,6 @@
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
-import { dustManagedLLMCredentials } from "@app/types/api/credentials";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -127,13 +126,27 @@ describe("ProviderCredentialResource", () => {
   });
 
   describe("getCredentials", () => {
-    it("returns dustManagedLLMCredentials for non-BYOK workspaces", async () => {
+    it("returns Dust-managed LLM credentials for non-BYOK workspaces", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 
       const credentials =
         await ProviderCredentialResource.getCredentials(authenticator);
 
-      expect(credentials).toEqual(dustManagedLLMCredentials());
+      expect(credentials).toEqual({
+        ANTHROPIC_API_KEY: "",
+        AZURE_OPENAI_API_KEY: "",
+        AZURE_OPENAI_ENDPOINT: "",
+        MISTRAL_API_KEY: "",
+        OPENAI_API_KEY: "",
+        OPENAI_BASE_URL: "",
+        OPENAI_USE_EU_ENDPOINT: "false",
+        TEXTSYNTH_API_KEY: "",
+        GOOGLE_AI_STUDIO_API_KEY: "",
+        TOGETHERAI_API_KEY: "",
+        DEEPSEEK_API_KEY: "",
+        FIREWORKS_API_KEY: "",
+        XAI_API_KEY: "",
+      });
     });
 
     it("returns mapped credentials for BYOK workspace with multiple providers", async () => {

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -1,7 +1,23 @@
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
-import { describe, expect, it } from "vitest";
+import { dustManagedLLMCredentials } from "@app/types/api/credentials";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
+
+const mockGetCredentials = vi.fn();
+
+vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    OAuthAPI: vi.fn().mockImplementation(function () {
+      return {
+        getCredentials: mockGetCredentials,
+      };
+    }),
+  };
+});
 
 describe("ProviderCredentialResource", () => {
   describe("listByWorkspace", () => {
@@ -107,6 +123,92 @@ describe("ProviderCredentialResource", () => {
       const remaining =
         await ProviderCredentialResource.listByWorkspace(authenticator);
       expect(remaining).toHaveLength(0);
+    });
+  });
+
+  describe("getCredentials", () => {
+    it("returns dustManagedLLMCredentials for non-BYOK workspaces", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const credentials =
+        await ProviderCredentialResource.getCredentials(authenticator);
+
+      expect(credentials).toEqual(dustManagedLLMCredentials());
+    });
+
+    it("returns mapped credentials for BYOK workspace with multiple providers", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+      await ProviderCredentialFactory.basic(workspace, "anthropic");
+
+      mockGetCredentials.mockImplementation(
+        ({ credentialsId }: { credentialsId: string }) => {
+          if (credentialsId === "cred-openai") {
+            return new Ok({
+              credential: {
+                content: {
+                  api_key: "sk-openai-test",
+                  base_url: "https://custom.openai.com",
+                },
+              },
+            });
+          }
+          if (credentialsId === "cred-anthropic") {
+            return new Ok({
+              credential: { content: { api_key: "sk-anthropic-test" } },
+            });
+          }
+          throw new Error(`Unexpected credentialsId: ${credentialsId}`);
+        }
+      );
+
+      const credentials =
+        await ProviderCredentialResource.getCredentials(authenticator);
+
+      expect(credentials).toEqual({
+        OPENAI_API_KEY: "sk-openai-test",
+        OPENAI_BASE_URL: "https://custom.openai.com",
+        ANTHROPIC_API_KEY: "sk-anthropic-test",
+        OPENAI_USE_EU_ENDPOINT: "false",
+      });
+    });
+
+    it("returns empty credentials for BYOK workspace with no providers", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+
+      const credentials =
+        await ProviderCredentialResource.getCredentials(authenticator);
+
+      expect(credentials).toEqual({});
+    });
+
+    it("throws when OAuth fetch fails for a provider", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      mockGetCredentials.mockResolvedValue({
+        isErr: () => true,
+        error: { message: "OAuth service unavailable" },
+      });
+
+      await expect(
+        ProviderCredentialResource.getCredentials(authenticator)
+      ).rejects.toThrow(
+        "Failed to fetch OAuth credentials for provider openai"
+      );
     });
   });
 });

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -7,7 +7,6 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { dustManagedLLMCredentials } from "@app/types/api/credentials";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ConnectionCredentials } from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
@@ -20,6 +19,7 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { EnvironmentConfig } from "@app/types/shared/utils/config";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { Attributes, ModelStatic } from "sequelize";
@@ -46,10 +46,26 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     });
   }
 
-  static async listByWorkspace(
-    auth: Authenticator
-  ): Promise<ProviderCredentialResource[]> {
-    return this.baseFetch(auth);
+  private static get dustManagedLLMCredentials(): LLMCredentialsType {
+    const env = (key: string) =>
+      EnvironmentConfig.getOptionalEnvVariable(key) ?? "";
+
+    return {
+      ANTHROPIC_API_KEY: env("DUST_MANAGED_ANTHROPIC_API_KEY"),
+      AZURE_OPENAI_API_KEY: env("DUST_MANAGED_AZURE_OPENAI_API_KEY"),
+      AZURE_OPENAI_ENDPOINT: env("DUST_MANAGED_AZURE_OPENAI_ENDPOINT"),
+      MISTRAL_API_KEY: env("DUST_MANAGED_MISTRAL_API_KEY"),
+      OPENAI_API_KEY: env("DUST_MANAGED_OPENAI_API_KEY"),
+      OPENAI_BASE_URL: env("DUST_MANAGED_OPENAI_BASE_URL"),
+      OPENAI_USE_EU_ENDPOINT:
+        config.getRegion() === "europe-west1" ? "true" : "false",
+      TEXTSYNTH_API_KEY: env("DUST_MANAGED_TEXTSYNTH_API_KEY"),
+      GOOGLE_AI_STUDIO_API_KEY: env("DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY"),
+      TOGETHERAI_API_KEY: env("DUST_MANAGED_TOGETHERAI_API_KEY"),
+      DEEPSEEK_API_KEY: env("DUST_MANAGED_DEEPSEEK_API_KEY"),
+      FIREWORKS_API_KEY: env("DUST_MANAGED_FIREWORKS_API_KEY"),
+      XAI_API_KEY: env("DUST_MANAGED_XAI_API_KEY"),
+    };
   }
 
   private static async baseFetch(
@@ -69,20 +85,26 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     );
   }
 
+  static async listByWorkspace(
+    auth: Authenticator
+  ): Promise<ProviderCredentialResource[]> {
+    return this.baseFetch(auth);
+  }
+
   static async getCredentials(
     auth: Authenticator
   ): Promise<LLMCredentialsType> {
     const plan = auth.getNonNullablePlan();
 
     if (!plan.isByok) {
-      return dustManagedLLMCredentials();
+      return this.dustManagedLLMCredentials;
     }
 
     const providerCredentials = await this.baseFetch(auth);
 
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
-    const oauthCredentialsByProvider = await concurrentExecutor(
+    const oauthCredentials = await concurrentExecutor(
       providerCredentials,
       async (cred) => {
         const credentialRes = await oauthApi.getCredentials({
@@ -103,9 +125,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       { concurrency: 8 }
     );
 
-    return oauthCredentialsByProvider
-      .map(mapOauthCredentialToLlmCredential)
-      .reduce((acc, partial) => ({ ...acc, ...partial }), {});
+    return mapOauthCredentialsToLlmCredentials(oauthCredentials);
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
@@ -147,44 +167,47 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   }
 }
 
-function mapOauthCredentialToLlmCredential({
-  providerId,
-  content,
-}: {
-  providerId: ModelProviderIdType;
-  content: ConnectionCredentials;
-}): Partial<LLMCredentialsType> {
-  if (providerId === "noop") {
-    return {};
+function mapOauthCredentialsToLlmCredentials(
+  oauthCredentials: {
+    providerId: ModelProviderIdType;
+    content: ConnectionCredentials;
+  }[]
+): LLMCredentialsType {
+  const result: LLMCredentialsType = {};
+
+  for (const { providerId, content } of oauthCredentials) {
+    if (providerId === "noop") {
+      continue;
+    }
+
+    switch (providerId) {
+      case "openai": {
+        const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
+        const parsedContent = schema.parse(content);
+
+        result.OPENAI_API_KEY = parsedContent.api_key;
+        result.OPENAI_BASE_URL = parsedContent.base_url;
+        result.OPENAI_USE_EU_ENDPOINT =
+          config.getRegion() === "europe-west1" ? "true" : "false";
+        break;
+      }
+      case "anthropic":
+      case "mistral":
+      case "google_ai_studio":
+      case "deepseek":
+      case "fireworks":
+      case "xai":
+      case "togetherai": {
+        const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
+        const parsedContent = schema.parse(content);
+
+        result[PROVIDER_TO_CREDENTIAL_KEY[providerId]] = parsedContent.api_key;
+        break;
+      }
+      default:
+        assertNever(providerId);
+    }
   }
 
-  switch (providerId) {
-    case "openai": {
-      const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
-      const parsedContent = schema.parse(content);
-
-      return {
-        OPENAI_API_KEY: parsedContent.api_key,
-        OPENAI_BASE_URL: parsedContent.base_url,
-        OPENAI_USE_EU_ENDPOINT:
-          config.getRegion() === "europe-west1" ? "true" : "false",
-      };
-    }
-    case "anthropic":
-    case "mistral":
-    case "google_ai_studio":
-    case "deepseek":
-    case "fireworks":
-    case "xai":
-    case "togetherai": {
-      const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
-      const parsedContent = schema.parse(content);
-
-      return {
-        [PROVIDER_TO_CREDENTIAL_KEY[providerId]]: parsedContent.api_key,
-      };
-    }
-    default:
-      assertNever(providerId);
-  }
+  return result;
 }

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -1,12 +1,25 @@
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialModel } from "@app/lib/models/provider_credential";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
-import type { ProviderCredentialType } from "@app/types/provider_credential";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { dustManagedLLMCredentials } from "@app/types/api/credentials";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ConnectionCredentials } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
+import {
+  PROVIDER_CREDENTIAL_CONTENT_SCHEMAS,
+  PROVIDER_TO_CREDENTIAL_KEY,
+  type ProviderCredentialType,
+} from "@app/types/provider_credential";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { Attributes, ModelStatic } from "sequelize";
@@ -33,6 +46,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     });
   }
 
+  static async listByWorkspace(
+    auth: Authenticator
+  ): Promise<ProviderCredentialResource[]> {
+    return this.baseFetch(auth);
+  }
+
   private static async baseFetch(
     auth: Authenticator
   ): Promise<ProviderCredentialResource[]> {
@@ -50,10 +69,43 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     );
   }
 
-  static async listByWorkspace(
+  static async getCredentials(
     auth: Authenticator
-  ): Promise<ProviderCredentialResource[]> {
-    return this.baseFetch(auth);
+  ): Promise<LLMCredentialsType> {
+    const plan = auth.getNonNullablePlan();
+
+    if (!plan.isByok) {
+      return dustManagedLLMCredentials();
+    }
+
+    const providerCredentials = await this.baseFetch(auth);
+
+    const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+    const oauthCredentialsByProvider = await concurrentExecutor(
+      providerCredentials,
+      async (cred) => {
+        const credentialRes = await oauthApi.getCredentials({
+          credentialsId: cred.credentialId,
+        });
+
+        if (credentialRes.isErr()) {
+          throw new Error(
+            `Failed to fetch OAuth credentials for provider ${cred.providerId}: ${credentialRes.error.message}`
+          );
+        }
+
+        return {
+          providerId: cred.providerId,
+          content: credentialRes.value.credential.content,
+        };
+      },
+      { concurrency: 8 }
+    );
+
+    return oauthCredentialsByProvider
+      .map(mapOauthCredentialToLlmCredential)
+      .reduce((acc, partial) => ({ ...acc, ...partial }), {});
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
@@ -92,5 +144,47 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       placeholder: this.placeholder,
       editedByUserId: this.editedByUserId,
     };
+  }
+}
+
+function mapOauthCredentialToLlmCredential({
+  providerId,
+  content,
+}: {
+  providerId: ModelProviderIdType;
+  content: ConnectionCredentials;
+}): Partial<LLMCredentialsType> {
+  if (providerId === "noop") {
+    return {};
+  }
+
+  switch (providerId) {
+    case "openai": {
+      const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
+      const parsedContent = schema.parse(content);
+
+      return {
+        OPENAI_API_KEY: parsedContent.api_key,
+        OPENAI_BASE_URL: parsedContent.base_url,
+        OPENAI_USE_EU_ENDPOINT:
+          config.getRegion() === "europe-west1" ? "true" : "false",
+      };
+    }
+    case "anthropic":
+    case "mistral":
+    case "google_ai_studio":
+    case "deepseek":
+    case "fireworks":
+    case "xai":
+    case "togetherai": {
+      const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
+      const parsedContent = schema.parse(content);
+
+      return {
+        [PROVIDER_TO_CREDENTIAL_KEY[providerId]]: parsedContent.api_key,
+      };
+    }
+    default:
+      assertNever(providerId);
   }
 }

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -1,5 +1,4 @@
 import type { CredentialsType, ProviderType } from "../provider";
-import type { LLMCredentialsType } from "../provider_credential";
 
 const {
   DUST_MANAGED_ANTHROPIC_API_KEY = "",
@@ -91,7 +90,7 @@ export const credentialsFromProviders = (
   return credentials;
 };
 
-export const dustManagedLLMCredentials = (): LLMCredentialsType => {
+export const dustManagedCredentials = (): CredentialsType => {
   return {
     ANTHROPIC_API_KEY: DUST_MANAGED_ANTHROPIC_API_KEY,
     AZURE_OPENAI_API_KEY: DUST_MANAGED_AZURE_OPENAI_API_KEY,
@@ -99,27 +98,16 @@ export const dustManagedLLMCredentials = (): LLMCredentialsType => {
     MISTRAL_API_KEY: DUST_MANAGED_MISTRAL_API_KEY,
     OPENAI_API_KEY: DUST_MANAGED_OPENAI_API_KEY,
     OPENAI_BASE_URL: DUST_MANAGED_OPENAI_BASE_URL,
+    // In Core this will determine the openai endpoint we use (EU vs US).
     OPENAI_USE_EU_ENDPOINT: REGION === "europe-west1" ? "true" : "false",
     TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
     GOOGLE_AI_STUDIO_API_KEY: DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
+    SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,
+    BROWSERLESS_API_KEY: DUST_MANAGED_BROWSERLESS_API_KEY,
     TOGETHERAI_API_KEY: DUST_MANAGED_TOGETHERAI_API_KEY,
     DEEPSEEK_API_KEY: DUST_MANAGED_DEEPSEEK_API_KEY,
     FIREWORKS_API_KEY: DUST_MANAGED_FIREWORKS_API_KEY,
     XAI_API_KEY: DUST_MANAGED_XAI_API_KEY,
-  };
-};
-
-export const dustManagedCredentials = (): CredentialsType => {
-  return {
-    ...dustManagedLLMCredentials(),
-    ...dustManagedServiceCredentials(),
-  };
-};
-
-export const dustManagedServiceCredentials = (): CredentialsType => {
-  return {
-    SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,
-    BROWSERLESS_API_KEY: DUST_MANAGED_BROWSERLESS_API_KEY,
     FIRECRAWL_API_KEY: DUST_MANAGED_FIRECRAWL_API_KEY,
     ELEVENLABS_API_KEY: DUST_MANAGED_ELEVENLABS_API_KEY,
     SPIDER_API_KEY: DUST_MANAGED_SPIDER_API_KEY,

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -1,4 +1,5 @@
 import type { CredentialsType, ProviderType } from "../provider";
+import type { LLMCredentialsType } from "../provider_credential";
 
 const {
   DUST_MANAGED_ANTHROPIC_API_KEY = "",
@@ -90,7 +91,7 @@ export const credentialsFromProviders = (
   return credentials;
 };
 
-export const dustManagedCredentials = (): CredentialsType => {
+export const dustManagedLLMCredentials = (): LLMCredentialsType => {
   return {
     ANTHROPIC_API_KEY: DUST_MANAGED_ANTHROPIC_API_KEY,
     AZURE_OPENAI_API_KEY: DUST_MANAGED_AZURE_OPENAI_API_KEY,
@@ -98,16 +99,27 @@ export const dustManagedCredentials = (): CredentialsType => {
     MISTRAL_API_KEY: DUST_MANAGED_MISTRAL_API_KEY,
     OPENAI_API_KEY: DUST_MANAGED_OPENAI_API_KEY,
     OPENAI_BASE_URL: DUST_MANAGED_OPENAI_BASE_URL,
-    // In Core this will determine the openai endpoint we use (EU vs US).
     OPENAI_USE_EU_ENDPOINT: REGION === "europe-west1" ? "true" : "false",
     TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
     GOOGLE_AI_STUDIO_API_KEY: DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
-    SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,
-    BROWSERLESS_API_KEY: DUST_MANAGED_BROWSERLESS_API_KEY,
     TOGETHERAI_API_KEY: DUST_MANAGED_TOGETHERAI_API_KEY,
     DEEPSEEK_API_KEY: DUST_MANAGED_DEEPSEEK_API_KEY,
     FIREWORKS_API_KEY: DUST_MANAGED_FIREWORKS_API_KEY,
     XAI_API_KEY: DUST_MANAGED_XAI_API_KEY,
+  };
+};
+
+export const dustManagedCredentials = (): CredentialsType => {
+  return {
+    ...dustManagedLLMCredentials(),
+    ...dustManagedServiceCredentials(),
+  };
+};
+
+export const dustManagedServiceCredentials = (): CredentialsType => {
+  return {
+    SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,
+    BROWSERLESS_API_KEY: DUST_MANAGED_BROWSERLESS_API_KEY,
     FIRECRAWL_API_KEY: DUST_MANAGED_FIRECRAWL_API_KEY,
     ELEVENLABS_API_KEY: DUST_MANAGED_ELEVENLABS_API_KEY,
     SPIDER_API_KEY: DUST_MANAGED_SPIDER_API_KEY,

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -1,5 +1,23 @@
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
+import { z } from "zod";
+
+export type LLMCredentialsType = {
+  OPENAI_API_KEY?: string;
+  OPENAI_BASE_URL?: string;
+  OPENAI_USE_EU_ENDPOINT?: string;
+  ANTHROPIC_API_KEY?: string;
+  MISTRAL_API_KEY?: string;
+  GOOGLE_AI_STUDIO_API_KEY?: string;
+  DEEPSEEK_API_KEY?: string;
+  FIREWORKS_API_KEY?: string;
+  XAI_API_KEY?: string;
+  TOGETHERAI_API_KEY?: string;
+  // Azure OpenAI and TextSynth are not in ModelProviderIdType yet.
+  AZURE_OPENAI_API_KEY?: string;
+  AZURE_OPENAI_ENDPOINT?: string;
+  TEXTSYNTH_API_KEY?: string;
+};
 
 export type ProviderCredentialType = {
   sId: string;
@@ -11,3 +29,40 @@ export type ProviderCredentialType = {
   placeholder: string;
   editedByUserId: ModelId | null;
 };
+
+const ApiKeyCredentialContentSchema = z.object({
+  api_key: z.string(),
+});
+
+export const OpenAICredentialContentSchema =
+  ApiKeyCredentialContentSchema.extend({
+    base_url: z.string().optional(),
+  });
+
+export const PROVIDER_CREDENTIAL_CONTENT_SCHEMAS = {
+  openai: OpenAICredentialContentSchema,
+  anthropic: ApiKeyCredentialContentSchema,
+  mistral: ApiKeyCredentialContentSchema,
+  google_ai_studio: ApiKeyCredentialContentSchema,
+  deepseek: ApiKeyCredentialContentSchema,
+  fireworks: ApiKeyCredentialContentSchema,
+  xai: ApiKeyCredentialContentSchema,
+  togetherai: ApiKeyCredentialContentSchema,
+} as const satisfies Record<
+  Exclude<ModelProviderIdType, "noop">,
+  typeof ApiKeyCredentialContentSchema
+>;
+
+export const PROVIDER_TO_CREDENTIAL_KEY = {
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  google_ai_studio: "GOOGLE_AI_STUDIO_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
+  fireworks: "FIREWORKS_API_KEY",
+  xai: "XAI_API_KEY",
+  togetherai: "TOGETHERAI_API_KEY",
+} as const satisfies Record<
+  Exclude<ModelProviderIdType, "noop">,
+  keyof LLMCredentialsType
+>;

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -38,6 +38,7 @@ export default async function setup() {
     DUST_SANDBOX_JWT_SECRET: "sandbox-secret-for-tests",
     REGION: "us-central1",
     DUST_MCP_SERVER_CREDENTIALS_SECRET: "test-secret",
+    OAUTH_API: process.env.OAUTH_API ?? "http://fake-oauth-api",
 
     // Variables that modify the behavior of certain tests
     UPDATE_MCP_METADATA_SNAPSHOT: process.env.UPDATE_MCP_METADATA_SNAPSHOT,


### PR DESCRIPTION
## Description

Introduces `LLMCredentialsType` to separate LLM provider keys from service keys, and adds `ProviderCredentialResource.getCredentials(auth)` for workspace-aware credential resolution.

Non-BYOK workspaces get Dust-managed env var keys. BYOK workspaces fetch keys from the OAuth DB per provider, with per-provider zod schema validation. Hard error on OAuth failure — never degrade to Dust keys.

`dustManagedCredentials()` is preserved in this PR for backward compat. The follow-up PR threads credentials through all callers and deletes it.

Part of https://github.com/dust-tt/tasks/issues/6962