### PR TITLE
Wire pod identity to StatsD metrics via DD_ENTITY_ID

### DIFF
--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -5,7 +5,11 @@ let statsDClient: StatsD | undefined = undefined;
 export function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {
-    statsDClient = new StatsD();
+    statsDClient = new StatsD({
+      globalTags: process.env.DD_ENTITY_ID
+        ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
+        : {},
+    });
   }
   return statsDClient;
 }

--- a/front/logger/statsDClient.ts
+++ b/front/logger/statsDClient.ts
@@ -1,3 +1,7 @@
 import StatsD from "hot-shots";
 
-export const statsDClient = new StatsD();
+export const statsDClient = new StatsD({
+  globalTags: process.env.DD_ENTITY_ID
+    ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
+    : {},
+});

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -1,7 +1,11 @@
 import { StatsD } from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export const statsDClient = new StatsD();
+export const statsDClient = new StatsD({
+  globalTags: process.env.DD_ENTITY_ID
+    ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
+    : {},
+});
 
 // TODO(2026-01-12): Delete once helm chart has been updated to use /api/healthz/ready.
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
- Pass `DD_ENTITY_ID` as `dd.internal.entity_tag` global tag on all StatsD clients (hot-shots)
- This allows the Datadog agent to resolve Kubernetes pod tags (pod_name, namespace, etc.) for custom StatsD metrics sent over UDP

## Context

Our DogStatsD setup uses UDP (`useHostPort: true`) rather than Unix Domain Sockets. Over UDP, the DD agent cannot identify the sending pod via socket credentials, so origin detection doesn't work. Even though `originDetection: true` is set in the agent config.

The `DD_ENTITY_ID` env var (already injected into pods from `metadata.uid`) solves this: when the client includes it as `dd.internal.entity_tag`, the agent maps it back to the pod and enriches metrics with k8s tags.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
