### PR TITLE
feat: conversation file popover in extension

### DIFF
--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -1,9 +1,9 @@
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { ConversationFilesPopover } from "@app/components/assistant/conversation/ConversationFilesPopover";
 import {
   ConversationMenu,
   useConversationMenu,
 } from "@app/components/assistant/conversation/ConversationMenu";
-import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { useConversation } from "@app/hooks/conversations/useConversation";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
@@ -71,25 +71,31 @@ export const MainPage = () => {
       }
       rightActions={
         conversationId ? (
-          <ConversationMenu
-            activeConversationId={conversationId}
-            conversation={conversation}
-            owner={workspace}
-            trigger={
-              <Button
-                size="sm"
-                variant="ghost"
-                icon={MoreIcon}
-                aria-label="Conversation menu"
-              />
-            }
-            isConversationDisplayed={true}
-            isOpen={isMenuOpen}
-            onOpenChange={handleMenuOpenChange}
-            triggerPosition={menuTriggerPosition}
-            displayOpenInBrowser
-            openDetailsInNewTab
-          />
+          <div className="flex items-center gap-2">
+            <ConversationFilesPopover
+              conversationId={conversationId}
+              owner={workspace}
+            />
+            <ConversationMenu
+              activeConversationId={conversationId}
+              conversation={conversation}
+              owner={workspace}
+              trigger={
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  icon={MoreIcon}
+                  aria-label="Conversation menu"
+                />
+              }
+              isConversationDisplayed={true}
+              isOpen={isMenuOpen}
+              onOpenChange={handleMenuOpenChange}
+              triggerPosition={menuTriggerPosition}
+              displayOpenInBrowser
+              openDetailsInNewTab
+            />
+          </div>
         ) : (
           <div className="items-right flex flex-row space-x-1">
             <UserDropdownMenu />
@@ -105,18 +111,16 @@ export const MainPage = () => {
         </div>
       )}
       <BlockedActionsProvider owner={workspace} conversation={conversation}>
-        <ConversationSidePanelProvider>
-          <GenerationContextProvider>
-            <ConversationContainer
-              workspace={workspace}
-              user={user}
-              subscription={subscription}
-              conversationId={conversationId}
-              conversation={conversation}
-              serverId={serverId}
-            />
-          </GenerationContextProvider>
-        </ConversationSidePanelProvider>
+        <GenerationContextProvider>
+          <ConversationContainer
+            workspace={workspace}
+            user={user}
+            subscription={subscription}
+            conversationId={conversationId}
+            conversation={conversation}
+            serverId={serverId}
+          />
+        </GenerationContextProvider>
       </BlockedActionsProvider>
     </ConversationLayout>
   );

--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -4,6 +4,7 @@ import { SidebarProvider } from "@app/components/sparkle/SidebarContext";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import { useStripUtmParams } from "@app/hooks/useStripUtmParams";
 import { Notification } from "@dust-tt/sparkle";
+import { ConversationSidePanelProvider } from "../assistant/conversation/ConversationSidePanelContext";
 
 /**
  * This layout is used in _app only
@@ -16,7 +17,9 @@ export function RootLayout({ children }: { children: React.ReactNode }) {
       <SidebarProvider>
         <NoOpDesktopNavigationProvider>
           <ConfirmPopupArea>
-            <Notification.Area>{children}</Notification.Area>
+            <ConversationSidePanelProvider>
+              <Notification.Area>{children}</Notification.Area>
+            </ConversationSidePanelProvider>
           </ConfirmPopupArea>
         </NoOpDesktopNavigationProvider>
       </SidebarProvider>


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7023

This PR adds the conversation file popover to the browser extension's conversation interface.

- Added `ConversationFilesPopover` component to the extension's main page header alongside the conversation menu
- Moved `ConversationSidePanelProvider` from the extension's `MainPage` component to the root `RootLayout` because it is needed by the `ConversationFilesPopover`

<img width="597" height="336" alt="Capture d’écran 2026-03-11 à 11 37 46" src="https://github.com/user-attachments/assets/2f2ba7c9-a7ce-4f08-8e07-e7d742f4de85" />


## Tests

Manually

## Risks

Low risk. The change is primarily a UI addition.

## Deploy Plan

Standard deployment.
