### PR TITLE
[front] - refacto(poke): usage activity usage chart

### DIFF
--- a/front/components/poke/analytics/PokeWorkspaceUsageChart.tsx
+++ b/front/components/poke/analytics/PokeWorkspaceUsageChart.tsx
@@ -1,0 +1,408 @@
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import {
+  ACTIVE_USERS_PALETTE,
+  CHART_HEIGHT,
+  USAGE_METRICS_PALETTE,
+} from "@app/components/agent_builder/observability/constants";
+import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import type { LegendItem } from "@app/components/charts/ChartLegend";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { formatShortDate } from "@app/lib/utils/timestamps";
+import {
+  usePokeWorkspaceActiveUsersMetrics,
+  usePokeWorkspaceUsageMetrics,
+} from "@app/poke/swr/analytics";
+import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+type UsageDisplayMode = "activity" | "users";
+
+function getLineType(
+  period: ObservabilityTimeRangeType
+): "linear" | "monotone" {
+  return period === 7 || period === 14 ? "linear" : "monotone";
+}
+
+function getLegendItemsForMode(displayMode: UsageDisplayMode): LegendItem[] {
+  switch (displayMode) {
+    case "activity":
+      return [
+        {
+          key: "messages",
+          label: "Messages",
+          colorClassName: USAGE_METRICS_PALETTE.messages,
+        },
+        {
+          key: "conversations",
+          label: "Conversations",
+          colorClassName: USAGE_METRICS_PALETTE.conversations,
+        },
+      ];
+    case "users":
+      return [
+        {
+          key: "dau",
+          label: "Daily",
+          colorClassName: ACTIVE_USERS_PALETTE.dau,
+        },
+        {
+          key: "wau",
+          label: "Weekly",
+          colorClassName: ACTIVE_USERS_PALETTE.wau,
+        },
+        {
+          key: "mau",
+          label: "Monthly",
+          colorClassName: ACTIVE_USERS_PALETTE.mau,
+        },
+      ];
+  }
+}
+
+function getDescriptionForMode(
+  displayMode: UsageDisplayMode,
+  period: ObservabilityTimeRangeType
+): string {
+  switch (displayMode) {
+    case "activity":
+      return `Messages and conversations over the last ${period} days.`;
+    case "users":
+      return `Percentage of workspace members active daily, weekly, and monthly over the last ${period} days.`;
+  }
+}
+
+interface WorkspaceUsageMetricsDatum {
+  timestamp: number;
+  count: number;
+  conversations: number;
+  activeUsers: number;
+  date?: string;
+}
+
+function isWorkspaceUsageMetricsDatum(
+  data: unknown
+): data is WorkspaceUsageMetricsDatum {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "timestamp" in data &&
+    "count" in data &&
+    "conversations" in data &&
+    "activeUsers" in data
+  );
+}
+
+function zeroFactory(timestamp: number): WorkspaceUsageMetricsDatum {
+  return {
+    timestamp,
+    count: 0,
+    conversations: 0,
+    activeUsers: 0,
+  };
+}
+
+interface ActiveUsersMetricsDatum {
+  timestamp: number;
+  dau: number;
+  wau: number;
+  mau: number;
+  memberCount: number;
+  date?: string;
+}
+
+function toPercentage(count: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+  return Math.round((count / total) * 100);
+}
+
+function isActiveUsersMetricsDatum(
+  data: unknown
+): data is ActiveUsersMetricsDatum {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "timestamp" in data &&
+    "dau" in data &&
+    "wau" in data &&
+    "mau" in data &&
+    "memberCount" in data
+  );
+}
+
+function activeUsersZeroFactory(timestamp: number): ActiveUsersMetricsDatum {
+  return {
+    timestamp,
+    dau: 0,
+    wau: 0,
+    mau: 0,
+    memberCount: 0,
+  };
+}
+
+interface UsageMetricsTooltipProps extends TooltipContentProps<number, string> {
+  displayMode: UsageDisplayMode;
+}
+
+function UsageMetricsTooltip({
+  active,
+  payload,
+  displayMode,
+}: UsageMetricsTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const first = payload[0];
+  if (!first?.payload) {
+    return null;
+  }
+
+  if (displayMode === "users") {
+    if (!isActiveUsersMetricsDatum(first.payload)) {
+      return null;
+    }
+    const row = first.payload;
+    const title = row.date ?? formatShortDate(row.timestamp);
+    const rows = [
+      {
+        label: "DAU (Daily)",
+        value: `${row.dau}%`,
+        colorClassName: ACTIVE_USERS_PALETTE.dau,
+      },
+      {
+        label: "WAU (7-day)",
+        value: `${row.wau}%`,
+        colorClassName: ACTIVE_USERS_PALETTE.wau,
+      },
+      {
+        label: "MAU (28-day)",
+        value: `${row.mau}%`,
+        colorClassName: ACTIVE_USERS_PALETTE.mau,
+      },
+    ];
+    return <ChartTooltipCard title={title} rows={rows} />;
+  }
+
+  if (!isWorkspaceUsageMetricsDatum(first.payload)) {
+    return null;
+  }
+
+  const row = first.payload;
+  const title = row.date ?? formatShortDate(row.timestamp);
+
+  const rows = [
+    {
+      label: "Messages",
+      value: row.count.toLocaleString(),
+      colorClassName: USAGE_METRICS_PALETTE.messages,
+    },
+    {
+      label: "Conversations",
+      value: row.conversations.toLocaleString(),
+      colorClassName: USAGE_METRICS_PALETTE.conversations,
+    },
+  ];
+
+  return <ChartTooltipCard title={title} rows={rows} />;
+}
+
+interface PokeWorkspaceUsageChartProps {
+  workspaceId: string;
+  period: ObservabilityTimeRangeType;
+}
+
+export function PokeWorkspaceUsageChart({
+  workspaceId,
+  period,
+}: PokeWorkspaceUsageChartProps) {
+  const [displayMode, setDisplayMode] = useState<UsageDisplayMode>("activity");
+
+  const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
+    usePokeWorkspaceUsageMetrics({
+      workspaceId,
+      days: period,
+      interval: "day",
+      disabled: !workspaceId || displayMode === "users",
+    });
+
+  const {
+    activeUsersMetrics,
+    isActiveUsersMetricsLoading,
+    isActiveUsersMetricsError,
+  } = usePokeWorkspaceActiveUsersMetrics({
+    workspaceId,
+    days: period,
+    disabled: !workspaceId || displayMode !== "users",
+  });
+
+  const legendItems = getLegendItemsForMode(displayMode);
+
+  const usageData = padSeriesToTimeRange<WorkspaceUsageMetricsDatum>(
+    usageMetrics,
+    "timeRange",
+    period,
+    zeroFactory
+  );
+
+  const activeUsersData = padSeriesToTimeRange<ActiveUsersMetricsDatum>(
+    activeUsersMetrics,
+    "timeRange",
+    period,
+    activeUsersZeroFactory
+  ).map((point) => ({
+    ...point,
+    dau: toPercentage(point.dau, point.memberCount),
+    wau: toPercentage(point.wau, point.memberCount),
+    mau: toPercentage(point.mau, point.memberCount),
+  }));
+
+  const data = displayMode === "users" ? activeUsersData : usageData;
+  const isLoading =
+    displayMode === "users"
+      ? isActiveUsersMetricsLoading
+      : isUsageMetricsLoading;
+  const isError =
+    displayMode === "users" ? isActiveUsersMetricsError : isUsageMetricsError;
+
+  const description = getDescriptionForMode(displayMode, period);
+
+  const controls = (
+    <ButtonsSwitchList defaultValue={displayMode} size="xs">
+      <ButtonsSwitch
+        value="activity"
+        label="Activity"
+        onClick={() => setDisplayMode("activity")}
+      />
+      <ButtonsSwitch
+        value="users"
+        label="Users"
+        onClick={() => setDisplayMode("users")}
+      />
+    </ButtonsSwitchList>
+  );
+
+  return (
+    <ChartContainer
+      title="Activity"
+      description={description}
+      isLoading={isLoading}
+      errorMessage={isError ? "Failed to load workspace usage." : undefined}
+      emptyMessage={
+        data.length === 0 ? "No usage metrics for this selection." : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+      additionalControls={controls}
+    >
+      <LineChart
+        data={data}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="date"
+          type="category"
+          scale="point"
+          allowDuplicatedCategory={false}
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={16}
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          allowDecimals={false}
+          domain={displayMode === "users" ? [0, 100] : undefined}
+          tickFormatter={
+            displayMode === "users" ? (v: number) => `${v}%` : undefined
+          }
+        />
+        <Tooltip
+          isAnimationActive={false}
+          content={(props: TooltipContentProps<number, string>) => (
+            <UsageMetricsTooltip {...props} displayMode={displayMode} />
+          )}
+          cursor={false}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        {displayMode === "activity" ? (
+          <>
+            <Line
+              type={getLineType(period)}
+              strokeWidth={2}
+              dataKey="count"
+              name="Messages"
+              className={USAGE_METRICS_PALETTE.messages}
+              stroke="currentColor"
+              dot={false}
+            />
+            <Line
+              type={getLineType(period)}
+              strokeWidth={2}
+              dataKey="conversations"
+              name="Conversations"
+              className={USAGE_METRICS_PALETTE.conversations}
+              stroke="currentColor"
+              dot={false}
+            />
+          </>
+        ) : (
+          <>
+            <Line
+              type={getLineType(period)}
+              strokeWidth={2}
+              dataKey="dau"
+              name="DAU"
+              className={ACTIVE_USERS_PALETTE.dau}
+              stroke="currentColor"
+              dot={false}
+            />
+            <Line
+              type={getLineType(period)}
+              strokeWidth={2}
+              dataKey="wau"
+              name="WAU"
+              className={ACTIVE_USERS_PALETTE.wau}
+              stroke="currentColor"
+              dot={false}
+            />
+            <Line
+              type={getLineType(period)}
+              strokeWidth={2}
+              dataKey="mau"
+              name="MAU"
+              className={ACTIVE_USERS_PALETTE.mau}
+              stroke="currentColor"
+              dot={false}
+            />
+          </>
+        )}
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -1,3 +1,4 @@
+import { PokeWorkspaceUsageChart } from "@app/components/poke/analytics/PokeWorkspaceUsageChart";
 import { AppDataTable } from "@app/components/poke/apps/table";
 import { AssistantsDataTable } from "@app/components/poke/assistants/table";
 import { CreditsDataTable } from "@app/components/poke/credits/table";
@@ -23,7 +24,6 @@ import {
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
 import { WebhookSourceDataTable } from "@app/components/poke/webhook_sources/table";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
-import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -309,7 +309,7 @@ export function WorkspacePage() {
             </TabsContent>
             <TabsContent value="analytics">
               <div className="flex flex-col gap-6">
-                <WorkspaceUsageChart workspaceId={owner.sId} period={30} />
+                <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />
                 <WorkspaceDatasourceRetrievalTreemapPluginChart
                   workspaceId={owner.sId}
                   period={30}

--- a/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,0 +1,90 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceActiveUsersResponse>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays } = req.query;
+      const q = QuerySchema.safeParse({ days: queryDays });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days } = q.data;
+
+      const result = await fetchActiveUsersMetrics(owner, days);
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve active users metrics: ${result.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        points: result.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -1,0 +1,106 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  interval: z.enum(["day", "week"]).optional().default("day"),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceUsageMetricsResponse>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays, interval: queryInterval } = req.query;
+      const q = QuerySchema.safeParse({
+        days: queryDays,
+        interval: queryInterval,
+      });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days, interval } = q.data;
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days,
+      });
+
+      const usageMetricsResult = await fetchMessageMetrics(
+        baseQuery,
+        interval,
+        ["conversations", "activeUsers"] as const
+      );
+
+      if (usageMetricsResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        interval,
+        points: usageMetricsResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/analytics.ts
+++ b/front/poke/swr/analytics.ts
@@ -1,0 +1,59 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
+import type { Fetcher } from "swr";
+
+export function usePokeWorkspaceUsageMetrics({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  interval = "day",
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  interval?: "day" | "week";
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetWorkspaceUsageMetricsResponse> = fetcher;
+  const key = `/api/poke/workspaces/${workspaceId}/analytics/usage-metrics?days=${days}&interval=${interval}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    usageMetrics: data?.points ?? emptyArray(),
+    isUsageMetricsLoading: !error && !data && !disabled,
+    isUsageMetricsError: error,
+    isUsageMetricsValidating: isValidating,
+  };
+}
+
+export function usePokeWorkspaceActiveUsersMetrics({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetWorkspaceActiveUsersResponse> = fetcher;
+  const key = `/api/poke/workspaces/${workspaceId}/analytics/active-users?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    activeUsersMetrics: data?.points ?? emptyArray(),
+    isActiveUsersMetricsLoading: !error && !data && !disabled,
+    isActiveUsersMetricsError: error,
+    isActiveUsersMetricsValidating: isValidating,
+  };
+}


### PR DESCRIPTION

## Description

This PR creates a dedicated `PokeWorkspaceUsageChart` component for Poke workspace analytics with a toggle between "Activity" and "Users" display modes. The Activity view displays messages and conversations over time, while the Users view shows DAU/WAU/MAU as percentages of total workspace members. Two new Poke API endpoints (`/api/poke/workspaces/[wId]/analytics/usage-metrics` and `/api/poke/workspaces/[wId]/analytics/active-users`) replicate workspace analytics functionality with Poke authentication. The component replaces the existing `WorkspaceUsageChart` in the Poke workspace analytics tab.

## Tests

Manually tested locally

## Risk

Low. Adds new Poke-specific analytics endpoints and component without modifying existing workspace analytics functionality.

## Deploy Plan

Deploy front