### PR TITLE
Handle focus in extensions

### DIFF
--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -258,6 +258,15 @@ function showSidebar(): void {
     sidebarElement.style.transform = "translateX(0)";
     sidebarVisible = true;
 
+    // Focus the iframe and notify the React app to focus the input bar.
+    if (iframeElement) {
+      iframeElement.contentWindow?.focus();
+      iframeElement.contentWindow?.postMessage(
+        { type: "DUST_SIDEBAR_SHOWN" },
+        "*"
+      );
+    }
+
     // Save state
     chrome.storage.local
       .set({ [STORAGE_KEY_VISIBLE]: true })

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -555,6 +555,32 @@ const InputBarContainer = ({
     }
   }, [animate, editorService]);
 
+  // Focus the input bar when the extension panel is opened (content-script sidebar or Front iframe).
+  // Not gated by disableAutoFocus: that flag prevents autofocus on mount (to avoid mobile keyboard
+  // popping up), but focusing when the user explicitly opens the panel is intentional.
+  useEffect(() => {
+    if (clientType !== "extension") {
+      return;
+    }
+    // Focus immediately on mount (handles navigation within an already-open panel).
+    queueMicrotask(() => editorService.focusEnd());
+
+    const handleWindowFocus = () => {
+      queueMicrotask(() => editorService.focusEnd());
+    };
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === "DUST_SIDEBAR_SHOWN") {
+        queueMicrotask(() => editorService.focusEnd());
+      }
+    };
+    window.addEventListener("focus", handleWindowFocus);
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("focus", handleWindowFocus);
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [clientType, editorService]);
+
   // Restore draft when switching conversations (including new conversations).
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {

--- a/front/lib/swr/useIsMobile.ts
+++ b/front/lib/swr/useIsMobile.ts
@@ -1,8 +1,10 @@
+import { useClientType } from "@app/lib/context/clientType";
 import { useEffect, useState } from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
+  const clientType = useClientType();
   const [isMobile, setIsMobile] = useState<boolean | undefined>();
 
   useEffect(() => {
@@ -14,6 +16,11 @@ export function useIsMobile() {
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     return () => mql.removeEventListener("change", onChange);
   }, []);
+
+  // The extension is narrow but not mobile.
+  if (clientType === "extension") {
+    return false;
+  }
 
   return !!isMobile;
 }


### PR DESCRIPTION
## Description

Auto-focus the input bar when opening the extension panel (Front iframe, Arc content-script sidebar).

**Changes:**
- `useIsMobile()` now returns `false` for the extension client type — the extension sidebar is narrow (< 768px) but is not a mobile device
- `InputBarContainer` focuses the editor on mount and listens for `window` `focus` and `DUST_SIDEBAR_SHOWN` postMessage events (extension only)
- Arc's content-script `showSidebar()` posts `DUST_SIDEBAR_SHOWN` to the iframe and calls `contentWindow.focus()` after revealing the sidebar

**Limitation:** Chrome's native Side Panel does not support programmatic focus — the browser does not allow extensions to steal focus from the main window. Users must click into the side panel to focus it. This is a Chrome platform restriction, not something we can work around.

## Tests

Manually tested on:
- Chrome (native side panel): autofocus works on initial open; no focus on reopen (Chrome limitation)
- Arc (content-script sidebar): autofocus works on open, close/reopen, and navigation between pages
- Front (iframe): autofocus works on open and navigation

## Risk

Low. Focus behavior is scoped to extension client type only — no impact on the web app. The `useIsMobile` change affects extension UI layout decisions but the extension was never truly mobile.

## Deploy Plan

Standard extension deploy.