### PR TITLE
[MCP Slack Bot] Deleted list_user_group, missing scope usergroups:read in bot

### DIFF
--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -66,16 +66,6 @@ The search_all parameter should only be set to true if the user explicitly reque
       done: "Search Slack user",
     },
   },
-  list_user_groups: {
-    description:
-      "List all user groups in the workspace. User groups (e.g., @engineering, @marketing) can be mentioned in messages.",
-    schema: {},
-    stake: "never_ask",
-    displayLabels: {
-      running: "Listing Slack user groups",
-      done: "List Slack user groups",
-    },
-  },
   list_public_channels: {
     description: "List all public channels in the workspace",
     schema: {

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -7,7 +7,6 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   executeListPublicChannels,
-  executeListUserGroups,
   executePostMessage,
   executeSearchUser,
   getSlackClient,
@@ -62,21 +61,6 @@ export function createSlackBotTools(
       } catch (error) {
         return new Err(
           new MCPError(`Error searching user: ${normalizeError(error)}`)
-        );
-      }
-    },
-
-    list_user_groups: async (_params, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Err(new MCPError("Access token not found"));
-      }
-
-      try {
-        return await executeListUserGroups({ accessToken });
-      } catch (error) {
-        return new Err(
-          new MCPError(`Error listing user groups: ${normalizeError(error)}`)
         );
       }
     },


### PR DESCRIPTION
## Description

Removes the `list_user_groups` tool from the Slack Bot MCP server. The tool requires the `usergroups:read` scope which is not included in the slack_bot OAuth configuration, causing missing scope errors. The `list_user_groups` tool was previously calling the Slack API's `usergroups.list` endpoint without the necessary permissions.

## Tests

Verified the slack_bot MCP server tools still work correctly without the removed tool.

## Risk

None. Removing a tool that was non-functional due to missing scope.

## Deploy Plan

Deploy front