### PR TITLE
Add single-page PDF export for frames

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -39,6 +39,19 @@ export const OAUTH_USE_CASE_TO_DESCRIPTION: Record<MCPOAuthUseCase, string> = {
     "Each member logs in with their own credentials when they use the tool.",
 };
 
+const TOKEN_ENDPOINT_AUTH_METHOD_KEY = "token_endpoint_auth_method" as const;
+
+const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
+  {
+    value: "client_secret_post",
+    label: "Request body (recommended)",
+  },
+  {
+    value: "client_secret_basic",
+    label: "Basic auth header",
+  },
+] as const;
+
 // Error key used for credential validation errors.
 // Parent components can check formState.errors[AUTH_CREDENTIALS_ERROR_KEY].
 export const AUTH_CREDENTIALS_ERROR_KEY = "authCredentials" as const;
@@ -219,6 +232,10 @@ export function MCPServerOAuthConnexion({
       {inputs && (
         <div className="w-full space-y-4 pt-4">
           {Object.entries(inputs).map(([key, inputData]) => {
+            if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
+              return null;
+            }
+
             if (inputData.value || !isSupportedOAuthCredential(key)) {
               return null; // Skip pre-filled or unsupported credentials.
             }
@@ -244,6 +261,49 @@ export function MCPServerOAuthConnexion({
               </div>
             );
           })}
+          {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
+            <div className="w-full space-y-2">
+              <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
+              </Label>
+              <div className="grid w-full grid-cols-2 gap-2">
+                {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => {
+                  const selected =
+                    (authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ||
+                      TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value) ===
+                    option.value;
+
+                  return (
+                    <Card
+                      key={option.value}
+                      variant={selected ? "secondary" : "primary"}
+                      selected={selected}
+                      className={cn(
+                        "cursor-pointer",
+                        "px-3 py-2",
+                        "text-xs"
+                      )}
+                      onClick={() =>
+                        handleCredentialChange(
+                          TOKEN_ENDPOINT_AUTH_METHOD_KEY,
+                          option.value
+                        )
+                      }
+                    >
+                      <div className="font-medium text-foreground dark:text-foreground-night">
+                        {option.label}
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -80,7 +80,10 @@ function ExportContentDropdown({
     }
   };
 
-  const exportAsPdf = async (orientation: "portrait" | "landscape") => {
+  const exportAsPdf = async (
+    orientation: "portrait" | "landscape",
+    pageMode: "paged" | "single" = "paged"
+  ) => {
     if (isExportingPdf) {
       return;
     }
@@ -94,12 +97,28 @@ function ExportContentDropdown({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ orientation }),
+          body: JSON.stringify({ orientation, pageMode }),
         }
       );
 
       if (!response.ok) {
         throw new Error("Failed to generate PDF");
+      }
+
+      const resolvedPageMode =
+        response.headers.get("X-Dust-Pdf-Page-Mode") || pageMode;
+      const pageNotice = response.headers.get("X-Dust-Pdf-Notice");
+
+      if (pageMode === "single" && resolvedPageMode !== "single") {
+        const noticeText =
+          pageNotice === "single-page-dimension-parse-failed"
+            ? "Single-page export failed to measure content. Exported as paged PDF instead."
+            : "Single-page export was not available. Exported as paged PDF instead.";
+        sendNotification({
+          title: "Single-page export fallback",
+          type: "warning",
+          description: noticeText,
+        });
       }
 
       // Get the PDF blob and trigger download.
@@ -164,11 +183,17 @@ function ExportContentDropdown({
         <DropdownMenuSub>
           <DropdownMenuSubTrigger disabled={isExportingPdf} label="PDF" />
           <DropdownMenuSubContent>
-            <DropdownMenuItem onClick={() => exportAsPdf("portrait")}>
-              Portrait
+            <DropdownMenuItem onClick={() => exportAsPdf("portrait", "paged")}>
+              Portrait (Paged)
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => exportAsPdf("landscape")}>
-              Landscape
+            <DropdownMenuItem onClick={() => exportAsPdf("landscape", "paged")}>
+              Landscape (Paged)
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => exportAsPdf("portrait", "single")}>
+              Portrait (Single Page)
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => exportAsPdf("landscape", "single")}>
+              Landscape (Single Page)
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -88,6 +88,20 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       );
     }
 
+    const supportedTokenAuthMethods = (
+      this.metadata as OAuthMetadata & {
+        token_endpoint_auth_methods_supported?: string[];
+      }
+    ).token_endpoint_auth_methods_supported;
+
+    const tokenEndpointAuthMethod = supportedTokenAuthMethods?.includes(
+      "client_secret_basic"
+    )
+      ? "client_secret_basic"
+      : supportedTokenAuthMethods?.includes("client_secret_post")
+      ? "client_secret_post"
+      : undefined;
+
     // Raise an error to let the client know that the server requires an OAuth connection.
     // We pass the metadata to the client to allow them to handle the oauth flow.
     throw new MCPOAuthRequiredError({
@@ -97,6 +111,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,
       resource: this.resource,
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
     });
   }
 

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -37,11 +37,13 @@ const MCPOAuthConnectionMetadataSchema = BaseMCPMetadataSchema.extend({
   client_secret: z.string().optional(),
   scope: z.string().optional(),
   resource: z.string().optional(),
+  token_endpoint_auth_method: z.string().optional(),
 });
 
 const MCPMetadataSchema = BaseMCPMetadataSchema.extend({
   code_challenge: z.string(),
   code_verifier: z.string(),
+  token_endpoint_auth_method: z.string().optional(),
 });
 
 export type MCPOAuthConnectionMetadataType = z.infer<
@@ -241,6 +243,8 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           authorization_endpoint: connection.metadata.authorization_endpoint,
           scope: connection.metadata.scope,
           resource: connection.metadata.resource,
+          token_endpoint_auth_method:
+            connection.metadata.token_endpoint_auth_method,
           code_verifier,
           code_challenge,
           ...restConfig,

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -19,7 +19,39 @@ import { DocumentRenderer, frameContentType, isString } from "@app/types";
 
 const PostPdfExportBodySchema = z.object({
   orientation: z.enum(["portrait", "landscape"]).optional().default("portrait"),
+  pageMode: z.enum(["paged", "single"]).optional().default("paged"),
 });
+
+const CSS_PX_PER_IN = 96;
+const A4_WIDTH_IN = 8.27;
+const A4_HEIGHT_IN = 11.69;
+const MEASURE_VIEWPORT_HEIGHT_PX = 1000;
+
+function parsePngDimensions(
+  buffer: Buffer
+): { width: number; height: number } | null {
+  if (buffer.length < 24) {
+    return null;
+  }
+
+  const signature = buffer.subarray(0, 8);
+  const pngSignature = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
+  if (!signature.equals(pngSignature)) {
+    return null;
+  }
+
+  const ihdrType = buffer.subarray(12, 16).toString("ascii");
+  if (ihdrType !== "IHDR") {
+    return null;
+  }
+
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+
+  return { width, height };
+}
 
 async function handler(
   req: NextApiRequest,
@@ -148,14 +180,22 @@ async function handler(
     });
   }
 
+  const { orientation, pageMode } = bodyResult.data;
+  const isSinglePage = pageMode === "single";
+  const pageWidthIn =
+    orientation === "landscape" ? A4_HEIGHT_IN : A4_WIDTH_IN;
+  const pageWidthPx = Math.round(pageWidthIn * CSS_PX_PER_IN);
+
   const params = new URLSearchParams({
     accessToken,
     identifier: `viz-${fileId}`,
     pdfMode: "true",
   });
+  if (isSinglePage) {
+    params.set("singlePage", "true");
+    params.set("pageWidthPx", pageWidthPx.toString());
+  }
   const targetUrl = `${vizUrl}/content?${params.toString()}`;
-
-  const { orientation } = bodyResult.data;
 
   // Only show footer for non-Enterprise plans and non-FriendsAndFamily plans.
   const plan = auth.plan();
@@ -173,6 +213,50 @@ async function handler(
       }
     : {};
 
+  let singlePageOptions: Partial<PdfOptions> = {};
+  let singlePageNotice: string | null = null;
+  if (isSinglePage) {
+    const measureResult = await renderer.captureScreenshot(
+      {
+        url: targetUrl,
+        waitForExpression:
+          "document.querySelector('[data-viz-ready=\"true\"]') !== null",
+      },
+      {
+        clip: false,
+        width: pageWidthPx,
+        height: MEASURE_VIEWPORT_HEIGHT_PX,
+      }
+    );
+
+    if (measureResult.isOk()) {
+      const dims = parsePngDimensions(measureResult.value);
+      if (dims && dims.height > 0) {
+        const heightIn = Math.max(dims.height / CSS_PX_PER_IN, 1);
+        singlePageOptions = {
+          paperWidth: `${pageWidthIn}in`,
+          paperHeight: `${heightIn.toFixed(2)}in`,
+          scale: 1,
+        };
+        logger.info(
+          { fileId, heightIn, pageWidthIn },
+          "Single-page PDF sizing computed"
+        );
+      } else {
+        singlePageNotice = "single-page-dimension-parse-failed";
+        logger.warn({ fileId }, "Failed to parse screenshot dimensions");
+      }
+    } else {
+      singlePageNotice = "single-page-measure-failed";
+      logger.warn(
+        { fileId, error: measureResult.error },
+        "Failed to measure single-page height"
+      );
+    }
+  }
+  const hasSinglePageSizing =
+    !!singlePageOptions.paperWidth && !!singlePageOptions.paperHeight;
+
   const result = await renderer.exportToPdf(
     {
       url: targetUrl,
@@ -181,7 +265,8 @@ async function handler(
     },
     {
       ...options,
-      orientation,
+      ...singlePageOptions,
+      orientation: hasSinglePageSizing ? undefined : orientation,
     }
   );
 
@@ -197,9 +282,15 @@ async function handler(
 
   // Set response headers for PDF download.
   const fileName = file.fileName?.replace(/\.[^.]+$/, ".pdf") || "frame.pdf";
+  const resolvedPageMode =
+    isSinglePage && hasSinglePageSizing ? "single" : "paged";
   res.setHeader("Content-Type", "application/pdf");
   res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
   res.setHeader("Content-Length", result.value.length);
+  res.setHeader("X-Dust-Pdf-Page-Mode", resolvedPageMode);
+  if (isSinglePage && resolvedPageMode === "paged" && singlePageNotice) {
+    res.setHeader("X-Dust-Pdf-Notice", singlePageNotice);
+  }
 
   res.status(200).send(result.value);
 }

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -99,6 +99,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "scope",
   "resource",
   "token_endpoint",
+  "token_endpoint_auth_method",
   "authorization_endpoint",
   "freshservice_domain",
   "freshworks_org_url",
@@ -375,6 +376,13 @@ export function getProviderRequiredOAuthCredentialInputs({
             helpMessage: "The scope(s) to request (space separated list).",
             validator: isValidScope,
           },
+          token_endpoint_auth_method: {
+            label: "Token Endpoint Authentication",
+            value: "client_secret_post",
+            helpMessage:
+              "How to send the client ID/secret when exchanging tokens.",
+            validator: isValidTokenEndpointAuthMethod,
+          },
         };
         return result;
       }
@@ -490,6 +498,13 @@ export function isValidOptionalClientSecret(s: unknown): s is string {
 
 export function isValidUrl(s: unknown): s is string {
   return typeof s === "string" && validateUrl(s).valid;
+}
+
+export function isValidTokenEndpointAuthMethod(s: unknown): s is string {
+  return (
+    typeof s === "string" &&
+    (s === "client_secret_post" || s === "client_secret_basic")
+  );
 }
 
 export function isValidSnowflakeAccount(s: unknown): s is string {

--- a/front/types/shared/document_renderer/index.ts
+++ b/front/types/shared/document_renderer/index.ts
@@ -17,6 +17,8 @@ export interface PdfOptions {
   marginRight?: string;
   marginTop?: string;
   orientation?: PdfOrientation;
+  paperHeight?: string;
+  paperWidth?: string;
   scale?: number;
 }
 
@@ -93,6 +95,8 @@ export class DocumentRenderer {
       marginRight,
       marginTop,
       orientation,
+      paperHeight,
+      paperWidth,
       scale,
     } = { ...DEFAULT_PDF_OPTIONS, ...options };
 
@@ -106,6 +110,14 @@ export class DocumentRenderer {
     formData.append("marginBottom", marginBottom);
     formData.append("marginLeft", marginLeft);
     formData.append("marginRight", marginRight);
+
+    if (paperWidth) {
+      formData.append("paperWidth", paperWidth);
+    }
+
+    if (paperHeight) {
+      formData.append("paperHeight", paperHeight);
+    }
 
     if (footerHtml) {
       const footerBlob = new Blob([footerHtml], { type: "text/html" });

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -252,7 +252,13 @@ export function VisualizationWrapper({
   config: VisualizationConfig;
   api: VisualizationAPI;
 }) {
-  const { identifier, isFullHeight = false, isPdfMode = false } = config;
+  const {
+    identifier,
+    isFullHeight = false,
+    isPdfMode = false,
+    isSinglePage = false,
+    pdfPageWidthPx,
+  } = config;
   const [runnerParams, setRunnerParams] = useState<RunnerParams | null>(null);
   const [vizReady, setVizReady] = useState(false);
 
@@ -417,6 +423,10 @@ export function VisualizationWrapper({
   const heightClass = isPdfMode ? "" : isFullHeight ? "h-screen" : "";
 
   const shouldShowControls = !isFullHeight && !isPdfMode;
+  const singlePageStyle =
+    isPdfMode && isSinglePage && pdfPageWidthPx
+      ? { width: `${pdfPageWidthPx}px`, margin: "0 auto" }
+      : undefined;
 
   return (
     <div
@@ -448,7 +458,7 @@ export function VisualizationWrapper({
           </button>
         </div>
       )}
-      <div ref={ref}>
+      <div ref={ref} style={singlePageStyle}>
         <Runner
           code={runnerParams.code}
           scope={runnerParams.scope}

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -9,6 +9,8 @@ interface ServerSideVisualizationWrapperProps {
   identifier: string;
   isFullHeight?: boolean;
   isPdfMode?: boolean;
+  isSinglePage?: boolean;
+  pdfPageWidthPx?: number;
 }
 
 /**
@@ -28,6 +30,8 @@ export async function ServerSideVisualizationWrapper({
   identifier,
   isFullHeight = false,
   isPdfMode = false,
+  isSinglePage = false,
+  pdfPageWidthPx,
 }: ServerSideVisualizationWrapperProps) {
   let prefetchedCode: string | undefined;
   let preFetchedFiles: PreFetchedFile[] = [];
@@ -115,6 +119,8 @@ export async function ServerSideVisualizationWrapper({
       identifier={identifier}
       isFullHeight={isFullHeight}
       isPdfMode={isPdfMode}
+      isSinglePage={isSinglePage}
+      pdfPageWidthPx={pdfPageWidthPx}
       prefetchedCode={prefetchedCode}
       prefetchedFiles={preFetchedFiles}
     />

--- a/viz/app/content/ServerVisualizationWrapperClient.tsx
+++ b/viz/app/content/ServerVisualizationWrapperClient.tsx
@@ -18,6 +18,8 @@ interface ServerVisualizationWrapperClientProps {
   identifier: string;
   isFullHeight?: boolean;
   isPdfMode?: boolean;
+  isSinglePage?: boolean;
+  pdfPageWidthPx?: number;
   prefetchedCode?: string;
   prefetchedFiles?: PreFetchedFile[];
 }
@@ -39,6 +41,8 @@ export function ServerVisualizationWrapperClient({
   allowedOrigins,
   isFullHeight = false,
   isPdfMode = false,
+  isSinglePage = false,
+  pdfPageWidthPx,
   prefetchedCode,
   prefetchedFiles = [],
 }: ServerVisualizationWrapperClientProps) {
@@ -53,6 +57,8 @@ export function ServerVisualizationWrapperClient({
     identifier,
     isFullHeight,
     isPdfMode,
+    isSinglePage,
+    pdfPageWidthPx,
   };
 
   return (

--- a/viz/app/content/page.tsx
+++ b/viz/app/content/page.tsx
@@ -6,6 +6,8 @@ interface RenderVisualizationSearchParams {
   fullHeight?: string;
   identifier?: string;
   pdfMode?: string;
+  singlePage?: string;
+  pageWidthPx?: string;
 }
 
 const { ALLOWED_VISUALIZATION_ORIGIN } = process.env;
@@ -19,10 +21,16 @@ export default function RenderVisualization({
     ? ALLOWED_VISUALIZATION_ORIGIN.split(",").map((s) => s.trim())
     : [];
 
-  const { accessToken, fullHeight, identifier, pdfMode } = searchParams;
+  const { accessToken, fullHeight, identifier, pdfMode, singlePage, pageWidthPx } =
+    searchParams;
 
   const isFullHeight = fullHeight === "true";
   const isPdfMode = pdfMode === "true";
+  const isSinglePage = singlePage === "true";
+  const parsedPageWidthPx = pageWidthPx ? parseInt(pageWidthPx, 10) : NaN;
+  const pdfPageWidthPx = Number.isFinite(parsedPageWidthPx)
+    ? parsedPageWidthPx
+    : undefined;
 
   // Use SSR approach for access tokens (publicly accessible).
   if (accessToken) {
@@ -33,6 +41,8 @@ export default function RenderVisualization({
         identifier={identifier!}
         isFullHeight={isFullHeight}
         isPdfMode={isPdfMode}
+        isSinglePage={isSinglePage}
+        pdfPageWidthPx={pdfPageWidthPx}
       />
     );
   }

--- a/viz/app/lib/visualization-api.ts
+++ b/viz/app/lib/visualization-api.ts
@@ -45,5 +45,7 @@ export interface VisualizationConfig {
   allowedOrigins: string[];
   isFullHeight?: boolean;
   isPdfMode?: boolean;
+  isSinglePage?: boolean;
+  pdfPageWidthPx?: number;
   dataAPI: VisualizationDataAPI;
 }


### PR DESCRIPTION
## Description
Hello Dust team, Tomas from Novutech, one of your clients, here 👋🏼. I'm making this pull request for a suggestion of adding a single‑page PDF export mode for Frames to avoid broken pagination on very long renders. The PDF export flow would now support a pageMode: "single" option that measures the rendered height at A4 width and passes explicit paperWidth/paperHeight to the Gotenberg renderer. I’m proposing this as we have quite some problems with long‑frame pagination issue when exporting to PDF.

## Tests
Not run, don't have access, obviously :)

## Risk
Low. Additive and backwards‑compatible: existing paged export remains the default; single‑page only triggers when explicitly selected.
## Deploy Plan

