### PR TITLE
fix(connectors): add max retry on drivesheet syncing

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -496,11 +496,47 @@ export async function syncSpreadSheet(
         }
       }
 
-      const sheets = await getAllSheetsFromSpreadSheet(
-        sheetsAPI,
-        spreadsheet.data,
-        localLogger
-      );
+      let sheets: Sheet[];
+      // We do 3 local retries for 500 Internal Server Error on batchGet too.
+      // If we still get 500 after 3 retries and the activity has been retried
+      // 20+ times, we skip the file (same logic as getSpreadsheet above).
+      internalErrorsCount = 0;
+      for (;;) {
+        try {
+          sheets = await getAllSheetsFromSpreadSheet(
+            sheetsAPI,
+            spreadsheet.data,
+            localLogger
+          );
+          break;
+        } catch (err) {
+          if (isGAxiosServiceUnavailableError(err)) {
+            throw new ProviderWorkflowError(
+              "google_drive",
+              "503 - Service Unavailable from Google Sheets (batchGet)",
+              "transient_upstream_activity_error",
+              err
+            );
+          } else if (isGAxiosInternalServerError(err)) {
+            internalErrorsCount++;
+            if (internalErrorsCount > maxInternalErrors) {
+              if (Context.current().info.attempt > 20) {
+                localLogger.info(
+                  "[Spreadsheet] Consistently getting 500 Internal Server Error from Google Sheets on batchGet, skipping further processing."
+                );
+                return {
+                  isSupported: true,
+                  skipReason: "google_internal_server_error",
+                };
+              }
+            } else {
+              // Allow locally retrying the API call.
+              continue;
+            }
+          }
+          throw err;
+        }
+      }
 
       // List synced sheets.
       const syncedSheets = await GoogleDriveSheetModel.findAll({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

The syncSpreadSheet function already handled Google 500 errors with local retries and skip logic for the initial spreadsheets.get() call, but the subsequent batchGetSheets() call had no such handling, 500 errors propagated uncaught to the interceptor, causing infinite Temporal retries.
Applied the same retry/skip pattern to the getAllSheetsFromSpreadSheet() call: 3 local retries, then skip the file after 20+ Temporal attempts.

Logs in question : https://app.datadoghq.eu/logs?query=%28"Activity%20failed"%20OR%20"Unhandled%20activity%20error"%29%20%40attempt%3A>15%20status%3Aerror&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZzcu_sL4e91KgAAABhBWnpjdkFsWEFBQnlWdVZLbEhLakNBQ2MAAAAkZjE5Y2RjYmMtMTAwMy00YWM2LTk0NTYtYzZiNDNkYmZkYzljAAAB_w&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=pattern&x_missing=true&from_ts=1773158377452&to_ts=1773161977452&live=true

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy connectors