### PR TITLE
[front] Add name conflict validation to MCP server edit flow

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -16,6 +16,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   useMCPServer,
+  useMCPServers,
   useMutateMCPServersViewsForAdmin,
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
@@ -51,6 +52,20 @@ export function MCPServerDetails({
     serverId: mcpServerView?.server.sId ?? "",
     disabled: !isOpen || !mcpServerView,
   });
+
+  const { mcpServers } = useMCPServers({
+    owner,
+    disabled: !isOpen || readOnly,
+  });
+
+  // Collect all effective view names from other servers (excluding the current one).
+  const existingViewNames = useMemo(
+    () =>
+      mcpServers
+        .filter((s) => s.sId !== mcpServerView?.server.sId)
+        .flatMap((s) => (s.views ?? []).map((v) => v.name ?? v.server.name)),
+    [mcpServers, mcpServerView]
+  );
   const { mutate: mutateMCPServersViewsForAdmin } =
     useMutateMCPServersViewsForAdmin(owner);
   const sendNotification = useSendNotification(true);
@@ -79,7 +94,12 @@ export function MCPServerDetails({
       keepDirtyValues: true, // Preserve user edits on SWR refetch.
     },
     resolver: mcpServerView
-      ? zodResolver(getMCPServerFormSchema(mcpServerView))
+      ? zodResolver(
+          getMCPServerFormSchema(mcpServerView, {
+            existingViewNames,
+            initialName: mcpServerView.name ?? mcpServerView.server.name,
+          })
+        )
       : undefined,
   });
 

--- a/front/components/actions/mcp/MCPServerDetailsSheet.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSheet.tsx
@@ -240,7 +240,11 @@ export function MCPServerDetailsSheet({
                   isSaving || form.formState.isSubmitting ? "Saving..." : "Save"
                 }
                 variant="primary"
-                disabled={isSaving || form.formState.isSubmitting}
+                disabled={
+                  isSaving ||
+                  form.formState.isSubmitting ||
+                  !!form.formState.errors.name
+                }
                 onClick={async () => {
                   setIsSaving(true);
                   try {

--- a/front/components/actions/mcp/create/MCPServerViewForm.tsx
+++ b/front/components/actions/mcp/create/MCPServerViewForm.tsx
@@ -20,6 +20,7 @@ export function MCPServerViewForm({ mcpServerView }: MCPServerViewFormProps) {
             label="Name"
             isError={!!form.formState.errors.name}
             message={form.formState.errors.name?.message}
+            messageStatus={form.formState.errors.name ? "error" : undefined}
             placeholder={mcpServerView.server.name}
           />
         </div>

--- a/front/components/actions/mcp/forms/mcpServerFormSchema.ts
+++ b/front/components/actions/mcp/forms/mcpServerFormSchema.ts
@@ -157,10 +157,29 @@ export function getMCPServerFormDefaults(
   return defaults;
 }
 
-export function getMCPServerFormSchema(view: MCPServerViewType) {
+export function getMCPServerFormSchema(
+  view: MCPServerViewType,
+  options?: {
+    existingViewNames?: string[];
+    initialName?: string;
+  }
+) {
+  const { existingViewNames = [], initialName } = options ?? {};
   const requiresBearerToken = requiresBearerTokenConfiguration(view.server);
   let schema = z.object({
-    name: z.string().min(1, "Name is required."),
+    name: z
+      .string()
+      .min(1, "Name is required.")
+      .refine(
+        (val) => {
+          const trimmed = val.trim();
+          if (!initialName || trimmed === initialName) {
+            return true;
+          }
+          return !existingViewNames.includes(trimmed);
+        },
+        { message: "This name is already in use." }
+      ),
     description: z.string().min(1, "Description is required."),
     toolSettings: z.record(
       z.object({

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -41,6 +41,7 @@ export type DustErrorCode =
   | "remote_server_not_found"
   | "internal_server_not_found"
   | "mcp_server_view_not_found"
+  | "name_conflict"
   | "action_not_found"
   | "action_not_blocked"
   | "mcp_access_token_error"

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/index.test.ts
@@ -248,6 +248,65 @@ describe("PATCH /api/w/[wId]/mcp/views/[viewId]", () => {
     }
   });
 
+  it("should return 400 when renaming to a name already used by another server", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
+
+    const server1 = await RemoteMCPServerFactory.create(workspace, {
+      name: "server-one",
+    });
+    const server2 = await RemoteMCPServerFactory.create(workspace, {
+      name: "server-two",
+    });
+
+    const systemView1 =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        server1.sId
+      );
+    // Ensure server2 exists in system space (created automatically).
+    const systemView2 =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        server2.sId
+      );
+    expect(systemView1).toBeDefined();
+    expect(systemView2).toBeDefined();
+
+    // Try to rename server1 to server2's name.
+    req.query.viewId = systemView1!.sId;
+    req.body = { name: "server-two", description: "updated" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toContain("server-two");
+  });
+
+  it("should allow renaming when the new name is unique", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "original-name",
+    });
+
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        server.sId
+      );
+    expect(systemView).toBeDefined();
+
+    req.query.viewId = systemView!.sId;
+    req.body = { name: "unique-new-name", description: "updated" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.success).toBe(true);
+    expect(responseData.serverView.name).toBe("unique-new-name");
+  });
+
   it("should support updating null name and description", async () => {
     const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
 

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
@@ -159,6 +159,14 @@ async function handler(
                   message: "Could not find the associated MCP server views.",
                 },
               });
+            case "name_conflict":
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: updateResult.error.message,
+                },
+              });
             default:
               assertNever(updateResult.error.code);
           }
@@ -257,13 +265,45 @@ async function updateNameAndDescriptionForMCPServerViews(
     description?: string;
   }
 ): Promise<
-  Result<undefined, DustError<"mcp_server_view_not_found" | "unauthorized">>
+  Result<
+    undefined,
+    DustError<"mcp_server_view_not_found" | "unauthorized" | "name_conflict">
+  >
 > {
   const r = await getAllMCPServerViewsInWorkspace(auth, mcpServerId);
   if (r.isErr()) {
     return r;
   }
   const views = r.value;
+
+  // Check for name conflicts in the system space (which contains all tools).
+  // Names are set on the system view and propagate to all spaces, so checking
+  // the system space is sufficient.
+  if (name) {
+    const systemView = views.find((v) => v.space.kind === "system");
+    if (systemView) {
+      const systemViews = await MCPServerViewResource.listBySpace(
+        auth,
+        systemView.space
+      );
+      const hasConflict = systemViews.some((v) => {
+        if (v.mcpServerId === mcpServerId) {
+          return false;
+        }
+        const viewJson = v.toJSON();
+        return (viewJson.name ?? viewJson.server.name) === name;
+      });
+
+      if (hasConflict) {
+        return new Err(
+          new DustError(
+            "name_conflict",
+            `An existing tool is already using the name "${name}".`
+          )
+        );
+      }
+    }
+  }
 
   for (const view of views) {
     const result = await view.updateNameAndDescription(auth, name, description);


### PR DESCRIPTION
## Description

Equivalent of https://github.com/dust-tt/dust/pull/22795 but on the Edit flow. 

When renaming an MCP server view through the edit sheet, there was no validation preventing a user from setting a name already used by another tool in the same workspace. This could lead to duplicate names and confusing behavior.

This PR adds name conflict validation to the PATCH endpoint for MCP server views, rejecting renames that would collide with an existing tool name. On the frontend, the edit form now shows an inline error on the name field and disables the Save button when a conflict is detected.

To avoid regressing workspaces that already have legacy duplicate names, the conflict check only triggers when the user actively changes the name to something new that collides, not when the current name already matches another server.

## Tests

Locally:  Open the edit sheet for an installed tool, try renaming it to the name of another installed tool, and confirm the name field shows "This name is already in use." in red with the Save button disabled. Confirm saving other changes (description, tools, sharing) still works when the name is unchanged.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 