### PR TITLE
Fixed main preview link in slack

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -188,13 +188,15 @@ jobs:
             exit 1
           fi
           echo "version_id=${VERSION_ID}" >> $GITHUB_OUTPUT
-          echo "Extracted version ID: ${VERSION_ID}"
+          VERSION_PREFIX=$(echo "$VERSION_ID" | cut -c1-8)
+          echo "version_prefix=${VERSION_PREFIX}" >> $GITHUB_OUTPUT
+          echo "Extracted version ID: ${VERSION_ID} (prefix: ${VERSION_PREFIX})"
 
       - name: Derive preview URL
         id: preview_url
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "url=https://${{ inputs.app }}.dust.tt" >> $GITHUB_OUTPUT
+            echo "url=https://${{ steps.extract_version.outputs.version_prefix }}--${{ inputs.app }}-worker.preview.dust.tt" >> $GITHUB_OUTPUT
           else
             echo "url=https://${{ steps.branch.outputs.sanitized }}--${{ inputs.app }}-worker.preview.dust.tt" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary

When deploying from main, the Slack notification now shows the actual version preview URL instead of the production URL. This lets you test the uploaded version before it's promoted to production.

- Before: `https://app.dust.tt` (production, not yet updated)
- After: `https://{version-prefix}--app-worker.preview.dust.tt` (preview of the uploaded version)

The version prefix (first 8 chars of the Worker Version ID) is extracted from the `versions upload` output and used to construct the preview URL through the proxy.

## Test plan

- [ ] Deploy from main, verify Slack shows a preview URL like `https://abcd1234--app-worker.preview.dust.tt`
- [ ] Verify the preview URL is accessible and serves the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)