### PR TITLE
fix(drive): add auto skip in google docs

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
@@ -3,107 +3,152 @@ import { getDriveClient } from "@connectors/connectors/google_drive/temporal/uti
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import type { Logger } from "@connectors/logger/logger";
 import type { GoogleDriveObjectType } from "@connectors/types";
+import { Context } from "@temporalio/activity";
 import type { OAuth2Client } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
+
+export type GoogleDriveExportResult = {
+  content: CoreAPIDataSourceDocumentSection | null;
+  skipReason?: string;
+};
 
 export async function handleGoogleDriveExport(
   oauth2client: OAuth2Client,
   file: GoogleDriveObjectType,
   localLogger: Logger
-): Promise<CoreAPIDataSourceDocumentSection | null> {
+): Promise<GoogleDriveExportResult> {
   const drive = await getDriveClient(oauth2client);
-  try {
-    const res = await drive.files.export({
-      fileId: file.id,
-      mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
-    });
-    if (res.status !== 200) {
-      localLogger.error({}, "Error exporting Google document");
-      throw new Error(
-        `Error exporting Google document. status_code: ${res.status}. status_text: ${res.statusText}`
-      );
-    }
 
-    if (typeof res.data === "string") {
-      return res.data.trim().length > 0
-        ? {
-            prefix: null,
-            content: res.data.trim(),
-            sections: [],
-          }
-        : null;
-    } else if (
-      ["object", "number", "boolean", "bigint"].includes(typeof res.data)
-    ) {
-      // In case the contents returned by the file export matches a JS type,
-      // we need to convert it
-      // Example: a Google presentation with just the number
-      // 1 in it, the export will return the number 1 instead of a string
-      return res.data && res.data.toString().trim().length > 0
-        ? {
-            prefix: null,
-            content: res.data.toString().trim(),
-            sections: [],
-          }
-        : null;
-    } else {
-      localLogger.error(
-        {
-          resDataTypeOf: typeof res.data,
-          type: "export",
-        },
-        "Unexpected GDrive export response type"
-      );
-      return null;
-    }
-  } catch (e) {
-    if (e instanceof GaxiosError) {
-      if (e.response?.status === 404) {
-        localLogger.info(
-          {
-            error: e,
-          },
-          "Can't export Gdrive document. 404 error returned, even though we know the file exists. Skipping."
+  // We do 3 local retries for 500 Internal Server Error.
+  // If we still get 500 Internal Server Error after 3 retries and the activity already
+  // has been retried 20 times, we mark the file as skipped.
+  let internalErrorsCount = 0;
+  const maxInternalErrors = 3;
+
+  for (;;) {
+    try {
+      const res = await drive.files.export({
+        fileId: file.id,
+        mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
+      });
+      if (res.status !== 200) {
+        localLogger.error({}, "Error exporting Google document");
+        throw new Error(
+          `Error exporting Google document. status_code: ${res.status}. status_text: ${res.statusText}`
         );
-        return null;
       }
 
-      if (e.response?.status === 403) {
-        const skippableReasons = ["exportRestricted"];
-
-        const parsedBody =
-          typeof e.response.data === "string"
-            ? JSON.parse(e.response.data)
-            : e.response.data;
-
-        const errors: { reason: string }[] | undefined =
-          parsedBody.error?.errors;
-        const firstSkippableReason = errors?.find((error) =>
-          skippableReasons.includes(error.reason)
-        )?.reason;
-        if (firstSkippableReason) {
+      if (typeof res.data === "string") {
+        return {
+          content:
+            res.data.trim().length > 0
+              ? {
+                  prefix: null,
+                  content: res.data.trim(),
+                  sections: [],
+                }
+              : null,
+        };
+      } else if (
+        ["object", "number", "boolean", "bigint"].includes(typeof res.data)
+      ) {
+        // In case the contents returned by the file export matches a JS type,
+        // we need to convert it
+        // Example: a Google presentation with just the number
+        // 1 in it, the export will return the number 1 instead of a string
+        return {
+          content:
+            res.data && res.data.toString().trim().length > 0
+              ? {
+                  prefix: null,
+                  content: res.data.toString().trim(),
+                  sections: [],
+                }
+              : null,
+        };
+      } else {
+        localLogger.error(
+          {
+            resDataTypeOf: typeof res.data,
+            type: "export",
+          },
+          "Unexpected GDrive export response type"
+        );
+        return { content: null };
+      }
+    } catch (e) {
+      if (e instanceof GaxiosError) {
+        if (e.response?.status === 404) {
           localLogger.info(
-            { error: parsedBody.error },
-            `Can't export Gdrive document. Skippable reason: ${firstSkippableReason}. Skipping.`
+            {
+              error: e,
+            },
+            "Can't export Gdrive document. 404 error returned, even though we know the file exists. Skipping."
           );
-          return null;
+          return { content: null };
+        }
+
+        if (e.response?.status === 403) {
+          const skippableReasons = ["exportRestricted"];
+
+          const parsedBody =
+            typeof e.response.data === "string"
+              ? JSON.parse(e.response.data)
+              : e.response.data;
+
+          const errors: { reason: string }[] | undefined =
+            parsedBody.error?.errors;
+          const firstSkippableReason = errors?.find((error) =>
+            skippableReasons.includes(error.reason)
+          )?.reason;
+          if (firstSkippableReason) {
+            localLogger.info(
+              { error: parsedBody.error },
+              `Can't export Gdrive document. Skippable reason: ${firstSkippableReason}. Skipping.`
+            );
+            return { content: null };
+          }
+        }
+
+        // Check if the error message indicates the file is too large to export
+        if (
+          e.message &&
+          e.message.includes("This file is too large to be exported")
+        ) {
+          localLogger.info(
+            { error: e.message },
+            "File is too large to be exported. Skipping."
+          );
+          return { content: null };
+        }
+
+        // If Google consistently returns 500 Internal Server Error after many
+        // retries, skip the file to avoid infinite retries.
+        if (e.response?.status === 500) {
+          internalErrorsCount++;
+          if (internalErrorsCount > maxInternalErrors) {
+            if (Context.current().info.attempt > 20) {
+              localLogger.info(
+                {
+                  fileId: file.id,
+                  attempt: Context.current().info.attempt,
+                },
+                "Consistently getting 500 Internal Server Error from Google Drive export, skipping."
+              );
+              return {
+                content: null,
+                skipReason: "google_internal_server_error",
+              };
+            }
+          } else {
+            // Allow locally retrying the API call.
+            continue;
+          }
         }
       }
 
-      // Check if the error message indicates the file is too large to export
-      if (
-        e.message &&
-        e.message.includes("This file is too large to be exported")
-      ) {
-        localLogger.info(
-          { error: e.message },
-          "File is too large to be exported. Skipping."
-        );
-        return null;
-      }
+      localLogger.error({ error: e }, "Error exporting Google document");
+      throw e;
     }
-
-    localLogger.error({ error: e }, "Error exporting Google document");
-    throw e;
   }
 }

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
@@ -30,6 +30,7 @@ export async function syncOneFileTextDocument(
   maxDocumentLen: number
 ) {
   let documentContent: CoreAPIDataSourceDocumentSection | null = null;
+  let skipReason: string | undefined;
 
   const mimeTypesToDownload = getMimeTypesToDownload({
     pdfEnabled: config?.pdfEnabled || false,
@@ -39,11 +40,15 @@ export async function syncOneFileTextDocument(
   const documentId = getInternalId(file.id);
 
   if (MIME_TYPES_TO_EXPORT[file.mimeType]) {
-    documentContent = await handleGoogleDriveExport(
-      oauth2client,
-      file,
-      localLogger
-    );
+    const res = await handleGoogleDriveExport(oauth2client, file, localLogger);
+    documentContent = res.content;
+    if (res.skipReason) {
+      localLogger.info(
+        {},
+        `Google Drive document skipped with skip reason ${res.skipReason}`
+      );
+      skipReason = res.skipReason;
+    }
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
     try {
       documentContent = await handleFileExport(
@@ -66,6 +71,7 @@ export async function syncOneFileTextDocument(
       }
     }
   }
+
   if (documentContent) {
     const upsertTimestampMs = await upsertGdriveDocument(
       dataSourceConfig,
@@ -84,10 +90,21 @@ export async function syncOneFileTextDocument(
       connectorId,
       documentId,
       file,
-      undefined,
+      skipReason,
       upsertTimestampMs
     );
     return true;
   }
-  return false;
+
+  if (skipReason) {
+    await updateGoogleDriveFiles(
+      connectorId,
+      documentId,
+      file,
+      skipReason,
+      undefined
+    );
+  }
+
+  return !skipReason;
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Google Drive text document exports (Google Docs, Slides, etc.) can get stuck in infinite Temporal retry loops when Google returns persistent 500 Internal Server errors, since unlike spreadsheets there was no skip mechanism for these files.

This adds the same pattern used for spreadsheets: 3 local retries followed by a persistent `skipReason` in the database after 20+ activity attempts, so the file is skipped in future sync cycles and the workflow can move on. The `handleGoogleDriveExport` return type now includes an optional `skipReason` that gets threaded through `syncOneFileTextDocument` into `updateGoogleDriveFiles`.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy connectors