### PR TITLE
Fix the log lines to avoid the reserved name 'message'

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -308,11 +308,13 @@ impl Provider for MCPConnectionProvider {
         {
             Ok(json) => json,
             Err(ProviderHttpRequestError::RequestFailed {
-                status, message, ..
+                status,
+                message: error_message,
+                ..
             }) if status == 400 => {
                 if metadata.resource.is_some() {
                     info!(
-                        message,
+                        error_message,
                         "MCP refresh failed with resource parameter, retrying without it"
                     );
                     self.execute_refresh_request(
@@ -328,7 +330,7 @@ impl Provider for MCPConnectionProvider {
                     .map_err(|e| self.handle_provider_request_error(e))?
                 } else {
                     info!(
-                        message,
+                        error_message,
                         "MCP refresh failed without scope, retrying with scope"
                     );
                     self.execute_refresh_request(


### PR DESCRIPTION
## Description

The previous change appears to work, but the log lines are busted due to using the name 'message', which is reserved and ends up overriding the format string.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

oauth