### PR TITLE
chore: use singleton statsD client

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -5,8 +5,9 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
@@ -17,6 +18,8 @@ import type {
   ServerNotification,
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
+
+const statsDClient = getStatsDClient();
 
 export function registerTool(
   auth: Authenticator,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -17,8 +17,9 @@ import type {
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
 import type {
   ModelConfigurationType,
@@ -30,6 +31,8 @@ import { type LangfuseGeneration, startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
 import startCase from "lodash/startCase";
+
+const statsDClient = getStatsDClient();
 
 export abstract class LLM<TPayload = unknown> {
   protected modelId: ModelIdType;

--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -14,14 +14,17 @@ import type {
 import type { SystemPromptInput } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getLLMTracesBucket } from "@app/lib/file_storage";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type {
   ModelIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+const statsDClient = getStatsDClient();
 
 const LLM_TRACE_PREFIX = "llm_trace_";
 

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -21,14 +21,17 @@ import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
+
+const statsDClient = getStatsDClient();
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -14,13 +14,16 @@ import type { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { launchCreditAlertWorkflow } from "@app/temporal/credit_alerts/client";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+const statsDClient = getStatsDClient();
 
 const CREDIT_ALERT_THRESHOLD_PERCENT = 80;
 

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -1,12 +1,15 @@
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { createRedisStreamClient } from "@app/lib/api/redis";
 import { fromEvent } from "@app/lib/utils/events";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import tracer from "@app/logger/tracer";
 import { EventEmitter } from "events";
 import type { RedisClientType } from "redis";
 import { commandOptions } from "redis";
+
+const statsDClient = getStatsDClient();
 
 type EventCallback = (event: EventPayload | "close") => void;
 

--- a/front/lib/api/redis.test.ts
+++ b/front/lib/api/redis.test.ts
@@ -16,11 +16,11 @@ vi.mock("@app/logger/logger", () => ({
   },
 }));
 
-vi.mock("@app/logger/statsDClient", () => ({
-  statsDClient: {
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
     increment: vi.fn(),
     decrement: vi.fn(),
-  },
+  }),
 }));
 
 describe("getRedisStreamClient", () => {

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -1,10 +1,13 @@
 import config from "@app/lib/api/config";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { RedisClientType } from "redis";
 export type { RedisClientType };
 
 import { createClient } from "redis";
+
+const statsDClient = getStatsDClient();
 
 const clients = new Map<string, RedisClientType>();
 

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -13,12 +13,15 @@ import {
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import type Stripe from "stripe";
+
+const statsDClient = getStatsDClient();
 
 export async function startCreditFromProOneOffInvoice({
   auth,

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -6,14 +6,17 @@ import {
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 import type Stripe from "stripe";
+
+const statsDClient = getStatsDClient();
 
 const BRACKET_1_USERS = 10;
 const BRACKET_1_MICRO_USD_PER_USER = 5_000_000; // $5

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -7,13 +7,16 @@ import {
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 import type Stripe from "stripe";
+
+const statsDClient = getStatsDClient();
 
 type CreatePAYGCreditError = {
   error_type: "already_exists" | "invalid_discount" | "unknown";

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -14,8 +14,9 @@ import {
   invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
 } from "@app/lib/utils/cache";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -38,6 +39,8 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+
+const statsDClient = getStatsDClient();
 
 export interface SearchMembersPaginationParams {
   offset: number;

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -1,6 +1,7 @@
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import type logger from "@app/logger/logger";
 import type { Logger } from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import tracer from "@app/logger/tracer";
 import type { Context } from "@temporalio/activity";
 import type {
@@ -8,6 +9,8 @@ import type {
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
+
+const statsDClient = getStatsDClient();
 
 /** An Activity Context with an attached logger */
 export interface ContextWithLogger extends Context {

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -16,9 +16,10 @@ import {
   checkWebhookRequestForRateLimit,
 } from "@app/lib/triggers/rate_limits";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import { verifySignature } from "@app/lib/webhookSource";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { launchAgentTriggerWorkflow } from "@app/temporal/triggers/common/client";
 import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal/assistant";
 import type {
@@ -37,6 +38,8 @@ import {
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
+
+const statsDClient = getStatsDClient();
 
 /**
  * To avoid storing sensitive information, only these headers are allowed to be stored in GCS.

--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/file_storage/config";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { launchUpsertDocumentWorkflow } from "@app/temporal/upsert_queue/client";
 import { launchUpsertTableWorkflow } from "@app/temporal/upsert_tables/client";
 import {
@@ -12,6 +13,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { Storage } from "@google-cloud/storage";
 import * as t from "io-ts";
 import { v4 as uuidv4 } from "uuid";
+
+const statsDClient = getStatsDClient();
 
 export const EnqueueUpsertDocument = t.type({
   workspaceId: t.string,

--- a/front/logger/statsDClient.ts
+++ b/front/logger/statsDClient.ts
@@ -1,7 +1,0 @@
-import StatsD from "hot-shots";
-
-export const statsDClient = new StatsD({
-  globalTags: process.env.DD_ENTITY_ID
-    ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
-    : {},
-});

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -10,6 +10,7 @@ import type {
   BaseResource,
   ResourceLogJSON,
 } from "@app/lib/resources/base_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import tracer from "@app/logger/tracer";
 import type {
   APIErrorWithStatusCode,
@@ -24,7 +25,8 @@ import type {
   NextApiResponse,
 } from "next";
 import logger from "./logger";
-import { statsDClient } from "./statsDClient";
+
+const statsDClient = getStatsDClient();
 
 export type RequestContext = {
   [key: string]: ResourceLogJSON;

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -6,12 +6,15 @@ import {
 } from "@app/lib/constants/timeouts";
 import { markShuttingDown } from "@app/lib/shutdown_signal";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { WakeLockEntry } from "@app/lib/wake_lock";
 import { getWakeLockDetails, wakeLockIsFree } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { withLogging } from "@app/logger/withlogging";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 const PRESTOP_LOG_INTERVAL_MS = 1000; // 1 second log interval.
 const PRESTOP_LOG_MAX_LOCKS = 3; // Show top 3 longest running wake locks.

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -1,11 +1,7 @@
-import { StatsD } from "hot-shots";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export const statsDClient = new StatsD({
-  globalTags: process.env.DD_ENTITY_ID
-    ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
-    : {},
-});
+const statsDClient = getStatsDClient();
 
 // TODO(2026-01-12): Delete once helm chart has been updated to use /api/healthz/ready.
 

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -38,9 +38,10 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
@@ -53,6 +54,8 @@ import { pipeline, Writable } from "stream";
 import type Stripe from "stripe";
 import { promisify } from "util";
 import { z } from "zod";
+
+const statsDClient = getStatsDClient();
 
 export type GetResponseBody = {
   success: boolean;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -7,12 +7,15 @@ import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ConversationEventType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -9,12 +9,15 @@ import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { AgentMessageEventType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -22,11 +22,11 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
 }));
 
 // Avoid UDP socket usage from StatsD in tests
-vi.mock("@app/logger/statsDClient", () => ({
-  statsDClient: {
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
     increment: vi.fn(),
     distribution: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock("@app/lib/file_storage", () => ({

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -7,7 +7,8 @@ import {
   processWebhookRequest,
   storePayloadInGCS,
 } from "@app/lib/triggers/webhook";
-import { statsDClient } from "@app/logger/statsDClient";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -15,6 +16,8 @@ import { isString } from "@app/types/shared/utils/general";
 import type { PostWebhookTriggerResponseType } from "@dust-tt/client";
 import type { NextApiResponse } from "next";
 import getRawBody from "raw-body";
+
+const statsDClient = getStatsDClient();
 
 /**
  * @swagger

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -6,11 +6,14 @@ import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -7,11 +7,14 @@ import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -8,7 +8,8 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { statsDClient } from "@app/logger/statsDClient";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+
 import { apiError } from "@app/logger/withlogging";
 import { InternalPostMessagesRequestBodySchema } from "@app/types/api/internal/assistant";
 import type {
@@ -25,6 +26,8 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 export type PostMessagesResponseBody = {
   message: UserMessageType;

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -12,15 +12,18 @@ import { getSession } from "@app/lib/auth";
 import { DUST_HAS_SESSION } from "@app/lib/cookies";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { isDevelopment } from "@app/types/shared/env";
 import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
 import { GenericServerException, OauthException } from "@workos-inc/node";
 import { sealData } from "iron-session";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const statsDClient = getStatsDClient();
 
 function isValidScreenHint(
   screenHint: string | string[] | undefined

--- a/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
+++ b/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
@@ -7,9 +7,12 @@ import {
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { Op } from "sequelize";
+
+const statsDClient = getStatsDClient();
 
 const COST_WARNING_THRESHOLDS_USD = [10, 50, 100] as const;
 const COST_THRESHOLD_CROSSED_METRIC = "agent_loop.cost_threshold_crossed";

--- a/front/temporal/agent_loop/activities/instrumentation.ts
+++ b/front/temporal/agent_loop/activities/instrumentation.ts
@@ -1,4 +1,6 @@
-import { statsDClient } from "@app/logger/statsDClient";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+
+const statsDClient = getStatsDClient();
 
 // StatsD metric names.
 export const METRICS = {

--- a/front/temporal/agent_loop/sinks.ts
+++ b/front/temporal/agent_loop/sinks.ts
@@ -1,8 +1,11 @@
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
 import type { InjectedSinks } from "@temporalio/worker";
 import type { Sinks } from "@temporalio/workflow";
+
+const statsDClient = getStatsDClient();
 
 /**
  * Sink interface for agent loop instrumentation.

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -3,15 +3,18 @@ import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { WorkflowError } from "@app/lib/temporal_monitoring";
 import { EnqueueUpsertDocument } from "@app/lib/upsert_queue";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
 import mainLogger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import { dustManagedCredentials } from "@app/types/api/credentials";
 import { CoreAPI } from "@app/types/core/core_api";
 import { safeSubstring } from "@app/types/shared/utils/string_utils";
 import { Storage } from "@google-cloud/storage";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
+
+const statsDClient = getStatsDClient();
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 

--- a/front/temporal/upsert_tables/activities.ts
+++ b/front/temporal/upsert_tables/activities.ts
@@ -3,12 +3,15 @@ import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { WorkflowError } from "@app/lib/temporal_monitoring";
 import { EnqueueUpsertTable } from "@app/lib/upsert_queue";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import mainLogger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
+
 import config from "@app/temporal/config";
 import { Storage } from "@google-cloud/storage";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
+
+const statsDClient = getStatsDClient();
 
 export async function upsertTableActivity(
   upsertQueueId: string,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Harmonize StatsD client creation across the front codebase. Previously, three separate files each instantiated their own new `StatsD()` client. Now everything goes through the singleton `getStatsDClient()` from `front/lib/utils/statsd.ts`, and the redundant `front/logger/statsDClient.ts` file has been deleted.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, the statsDClient were identical, mainly moving code around

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front