### PR TITLE
Pierre/byok/configure byok

### DIFF
--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -13,8 +13,6 @@ export function ModelProvidersPage() {
   const { providersSelection, setProvidersSelection } =
     useProvidersSelection(workspace);
 
-  const isWorkspacePending = isWorkspaceLoading || isWorkspaceValidating;
-
   return (
     <Page.Vertical align="stretch" gap="xl">
       <Page.Header
@@ -23,18 +21,22 @@ export function ModelProvidersPage() {
         description="Configure model providers."
       />
       <Page.Vertical align="stretch" gap="md">
-        <div className="flex flex-col gap-8">
-          <AllProvidersToggle
-            providersSelection={providersSelection}
-            setProvidersSelection={setProvidersSelection}
-          />
-          <ProvidersList
-            providersSelection={providersSelection}
-            setProvidersSelection={setProvidersSelection}
-            isWorkspacePending={isWorkspacePending}
-          />
-          <EmbeddingModelSelect workspace={workspace} />
-        </div>
+        {isWorkspaceLoading ? (
+          <></>
+        ) : (
+          <div className="flex flex-col gap-8">
+            <AllProvidersToggle
+              providersSelection={providersSelection}
+              setProvidersSelection={setProvidersSelection}
+            />
+            <ProvidersList
+              providersSelection={providersSelection}
+              setProvidersSelection={setProvidersSelection}
+              isWorkspaceValidating={isWorkspaceValidating}
+            />
+            <EmbeddingModelSelect workspace={workspace} />
+          </div>
+        )}
       </Page.Vertical>
     </Page.Vertical>
   );

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -6,8 +6,7 @@ import { BrainIcon, Page } from "@dust-tt/sparkle";
 
 export function ModelProvidersPage() {
   const owner = useWorkspace();
-  const { workspace, isWorkspaceLoading, isWorkspaceValidating } =
-    useWorkspaceDetails({ owner });
+  const { workspace, isWorkspaceValidating } = useWorkspaceDetails({ owner });
   const { providersSelection, setProvidersSelection } =
     useProvidersSelection(workspace);
 
@@ -19,9 +18,7 @@ export function ModelProvidersPage() {
         description="Configure model providers."
       />
       <Page.Vertical align="stretch" gap="md">
-        {isWorkspaceLoading || !workspace ? (
-          <></>
-        ) : (
+        {workspace && (
           <ModelProvidersPageContent
             workspace={workspace}
             setProvidersSelection={setProvidersSelection}

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -1,6 +1,4 @@
-import { AllProvidersToggle } from "@app/components/pages/workspace/model_providers/AllProvidersToggle";
-import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_providers/EmbeddingModelSelect";
-import { ProvidersList } from "@app/components/pages/workspace/model_providers/ProvidersList";
+import { ModelProvidersPageContent } from "@app/components/pages/workspace/model_providers/ModelProvidersPageContent";
 import { useProvidersSelection } from "@app/hooks/useProvidersSelection";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useWorkspace as useWorkspaceDetails } from "@app/lib/swr/workspaces";
@@ -21,21 +19,15 @@ export function ModelProvidersPage() {
         description="Configure model providers."
       />
       <Page.Vertical align="stretch" gap="md">
-        {isWorkspaceLoading ? (
+        {isWorkspaceLoading || !workspace ? (
           <></>
         ) : (
-          <div className="flex flex-col gap-8">
-            <AllProvidersToggle
-              providersSelection={providersSelection}
-              setProvidersSelection={setProvidersSelection}
-            />
-            <ProvidersList
-              providersSelection={providersSelection}
-              setProvidersSelection={setProvidersSelection}
-              isWorkspaceValidating={isWorkspaceValidating}
-            />
-            <EmbeddingModelSelect workspace={workspace} />
-          </div>
+          <ModelProvidersPageContent
+            workspace={workspace}
+            setProvidersSelection={setProvidersSelection}
+            providersSelection={providersSelection}
+            isWorkspaceValidating={isWorkspaceValidating}
+          />
         )}
       </Page.Vertical>
     </Page.Vertical>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -1,0 +1,40 @@
+import { AllProvidersToggle } from "@app/components/pages/workspace/model_providers/AllProvidersToggle";
+import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_providers/EmbeddingModelSelect";
+import { ProvidersList } from "@app/components/pages/workspace/model_providers/ProvidersList";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import type { ProvidersSelection } from "@app/types/provider_selection";
+import type { WorkspaceType } from "@app/types/user";
+import type { Dispatch, SetStateAction } from "react";
+
+interface ModelProvidersPageContentProps {
+  workspace: WorkspaceType;
+  setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
+  providersSelection: ProvidersSelection;
+  isWorkspaceValidating: boolean;
+}
+
+export function ModelProvidersPageContent({
+  workspace,
+  setProvidersSelection,
+  providersSelection,
+  isWorkspaceValidating,
+}: ModelProvidersPageContentProps) {
+  const { subscription } = useAuth();
+  const { plan } = subscription;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <AllProvidersToggle
+        providersSelection={providersSelection}
+        setProvidersSelection={setProvidersSelection}
+      />
+      <ProvidersList
+        providersSelection={providersSelection}
+        setProvidersSelection={setProvidersSelection}
+        isWorkspaceValidating={isWorkspaceValidating}
+        plan={plan}
+      />
+      <EmbeddingModelSelect workspace={workspace} />
+    </div>
+  );
+}

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -1,9 +1,21 @@
 import { AllProvidersToggle } from "@app/components/pages/workspace/model_providers/AllProvidersToggle";
 import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_providers/EmbeddingModelSelect";
 import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  REASONING_MODEL_CONFIGS,
+  USED_MODEL_CONFIGS,
+} from "@app/components/providers/types";
+import { isModelCustomAvailable } from "@app/lib/assistant";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import type { WorkspaceType } from "@app/types/user";
+import groupBy from "lodash/groupBy";
+import mapValues from "lodash/mapValues";
+import uniqBy from "lodash/uniqBy";
 import type { Dispatch, SetStateAction } from "react";
 
 interface ModelProvidersPageContentProps {
@@ -21,6 +33,24 @@ export function ModelProvidersPageContent({
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
+  const { featureFlags } = useFeatureFlags();
+
+  // Filter models based on feature flags and build modelProviders dynamically
+  const filteredModels = uniqBy(
+    [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
+    (m) => m.modelId
+  ).filter(
+    (model) =>
+      !model.isLegacy && isModelCustomAvailable(model, featureFlags, plan)
+  );
+
+  const modelsDescriptionByProvider: Partial<
+    Record<ModelProviderIdType, string>
+  > = mapValues(
+    groupBy(filteredModels, "providerId"),
+    (modelConfigurations: ModelConfigurationType[]) =>
+      modelConfigurations.map(({ displayName }) => displayName).join(", ")
+  );
 
   return (
     <div className="flex flex-col gap-8">
@@ -37,6 +67,7 @@ export function ModelProvidersPageContent({
             setProvidersSelection={setProvidersSelection}
             isWorkspaceValidating={isWorkspaceValidating}
             plan={plan}
+            modelsDescriptionByProvider={modelsDescriptionByProvider}
           />
         </>
       )}

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -66,7 +66,6 @@ export function ModelProvidersPageContent({
             providersSelection={providersSelection}
             setProvidersSelection={setProvidersSelection}
             isWorkspaceValidating={isWorkspaceValidating}
-            plan={plan}
             modelsDescriptionByProvider={modelsDescriptionByProvider}
           />
         </>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -1,5 +1,6 @@
 import { AllProvidersToggle } from "@app/components/pages/workspace/model_providers/AllProvidersToggle";
 import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_providers/EmbeddingModelSelect";
+import { ProvidersConfigurationList } from "@app/components/pages/workspace/model_providers/ProvidersConfigurationList";
 import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
 import {
   REASONING_MODEL_CONFIGS,
@@ -55,7 +56,9 @@ export function ModelProvidersPageContent({
   return (
     <div className="flex flex-col gap-8">
       {plan.isByok ? (
-        <></>
+        <ProvidersConfigurationList
+          modelsDescriptionByProvider={modelsDescriptionByProvider}
+        />
       ) : (
         <>
           <AllProvidersToggle

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -1,6 +1,6 @@
 import { AllProvidersToggle } from "@app/components/pages/workspace/model_providers/AllProvidersToggle";
 import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_providers/EmbeddingModelSelect";
-import { ProvidersList } from "@app/components/pages/workspace/model_providers/ProvidersList";
+import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import type { WorkspaceType } from "@app/types/user";
@@ -24,16 +24,22 @@ export function ModelProvidersPageContent({
 
   return (
     <div className="flex flex-col gap-8">
-      <AllProvidersToggle
-        providersSelection={providersSelection}
-        setProvidersSelection={setProvidersSelection}
-      />
-      <ProvidersList
-        providersSelection={providersSelection}
-        setProvidersSelection={setProvidersSelection}
-        isWorkspaceValidating={isWorkspaceValidating}
-        plan={plan}
-      />
+      {plan.isByok ? (
+        <></>
+      ) : (
+        <>
+          <AllProvidersToggle
+            providersSelection={providersSelection}
+            setProvidersSelection={setProvidersSelection}
+          />
+          <ProvidersToggleList
+            providersSelection={providersSelection}
+            setProvidersSelection={setProvidersSelection}
+            isWorkspaceValidating={isWorkspaceValidating}
+            plan={plan}
+          />
+        </>
+      )}
       <EmbeddingModelSelect workspace={workspace} />
     </div>
   );

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -1,0 +1,32 @@
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
+import { Button, ContextItem, Icon } from "@dust-tt/sparkle";
+
+interface ProviderConfigurationContextItemProps {
+  providerId: ModelProviderIdType;
+  description: string;
+}
+export function ProviderConfigurationContextItem({
+  providerId,
+  description,
+}: ProviderConfigurationContextItemProps) {
+  const { isDark } = useTheme();
+  const LogoComponent = getModelProviderLogo(providerId, isDark);
+
+  return (
+    <ContextItem
+      key={providerId}
+      title={PRETTIFIED_PROVIDER_NAMES[providerId]}
+      visual={<Icon visual={LogoComponent} size="lg" />}
+      action={<Button label="Configure" variant="outline" />}
+    >
+      <ContextItem.Description>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </span>
+      </ContextItem.Description>
+    </ContextItem>
+  );
+}

--- a/front/components/pages/workspace/model_providers/ProviderToggleContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderToggleContextItem.tsx
@@ -7,20 +7,20 @@ import {
 } from "@app/types/provider_selection";
 import { ContextItem, Icon, SliderToggle } from "@dust-tt/sparkle";
 
-interface ProviderContextItemProps {
+interface ProviderToggleContextItemProps {
   providerId: ModelProviderIdType;
   description: string;
   providersSelection: ProvidersSelection;
   handleToggleChange: () => void;
   disabled: boolean;
 }
-export function ProviderContextItem({
+export function ProviderToggleContextItem({
   providerId,
   description,
   providersSelection,
   handleToggleChange,
   disabled,
-}: ProviderContextItemProps) {
+}: ProviderToggleContextItemProps) {
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
 

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -1,0 +1,28 @@
+import { ProviderConfigurationContextItem } from "@app/components/pages/workspace/model_providers/ProviderConfigurationContextItem";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { ContextItem } from "@dust-tt/sparkle";
+
+interface ProvidersConfigurationListProps {
+  modelsDescriptionByProvider: Partial<Record<ModelProviderIdType, string>>;
+}
+
+export function ProvidersConfigurationList({
+  modelsDescriptionByProvider,
+}: ProvidersConfigurationListProps) {
+  return (
+    <ContextItem.List>
+      {(
+        Object.entries(modelsDescriptionByProvider) as [
+          ModelProviderIdType,
+          string,
+        ][]
+      ).map(([providerId, description]) => (
+        <ProviderConfigurationContextItem
+          key={providerId}
+          providerId={providerId}
+          description={description}
+        />
+      ))}
+    </ContextItem.List>
+  );
+}

--- a/front/components/pages/workspace/model_providers/ProvidersList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersList.tsx
@@ -19,13 +19,13 @@ import { type Dispatch, type SetStateAction, useCallback } from "react";
 interface ProviderContextItemProps {
   providersSelection: ProvidersSelection;
   setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
-  isWorkspacePending: boolean;
+  isWorkspaceValidating: boolean;
 }
 
 export function ProvidersList({
   providersSelection,
   setProvidersSelection,
-  isWorkspacePending,
+  isWorkspaceValidating,
 }: ProviderContextItemProps) {
   const { featureFlags } = useFeatureFlags();
   const { subscription } = useAuth();
@@ -72,7 +72,7 @@ export function ProvidersList({
           description={description}
           providersSelection={providersSelection}
           handleToggleChange={() => toggleProvider(providerId)}
-          disabled={isWorkspacePending}
+          disabled={isWorkspaceValidating}
         />
       ))}
     </ContextItem.List>

--- a/front/components/pages/workspace/model_providers/ProvidersList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersList.tsx
@@ -4,11 +4,12 @@ import {
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/types";
 import { isModelCustomAvailable } from "@app/lib/assistant";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
+import type { PlanType } from "@app/types/plan";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import { ContextItem } from "@dust-tt/sparkle";
 import groupBy from "lodash/groupBy";
@@ -20,15 +21,16 @@ interface ProviderContextItemProps {
   providersSelection: ProvidersSelection;
   setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
   isWorkspaceValidating: boolean;
+  plan: PlanType;
 }
 
 export function ProvidersList({
   providersSelection,
   setProvidersSelection,
   isWorkspaceValidating,
+  plan,
 }: ProviderContextItemProps) {
   const { featureFlags } = useFeatureFlags();
-  const { subscription } = useAuth();
 
   // Filter models based on feature flags and build modelProviders dynamically
   const filteredModels = uniqBy(
@@ -36,8 +38,7 @@ export function ProvidersList({
     (m) => m.modelId
   ).filter(
     (model) =>
-      !model.isLegacy &&
-      isModelCustomAvailable(model, featureFlags, subscription.plan)
+      !model.isLegacy && isModelCustomAvailable(model, featureFlags, plan)
   );
 
   const modelsDescriptionByProvider: Partial<

--- a/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
@@ -1,11 +1,10 @@
-import { ProviderContextItem } from "@app/components/pages/workspace/model_providers/ProviderContextItem";
+import { ProviderToggleContextItem } from "@app/components/pages/workspace/model_providers/ProviderToggleContextItem";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
-import type { PlanType } from "@app/types/plan";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import { ContextItem } from "@dust-tt/sparkle";
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 
-interface ProviderContextItemProps {
+interface ProvidersToggleListProps {
   providersSelection: ProvidersSelection;
   setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
   isWorkspaceValidating: boolean;
@@ -17,7 +16,7 @@ export function ProvidersToggleList({
   setProvidersSelection,
   isWorkspaceValidating,
   modelsDescriptionByProvider,
-}: ProviderContextItemProps) {
+}: ProvidersToggleListProps) {
   const toggleProvider = useCallback(
     (provider: ModelProviderIdType) => {
       setProvidersSelection((previousSelection: ProvidersSelection) => ({
@@ -36,7 +35,7 @@ export function ProvidersToggleList({
           string,
         ][]
       ).map(([providerId, description]) => (
-        <ProviderContextItem
+        <ProviderToggleContextItem
           key={providerId}
           providerId={providerId}
           description={description}

--- a/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
@@ -24,7 +24,7 @@ interface ProviderContextItemProps {
   plan: PlanType;
 }
 
-export function ProvidersList({
+export function ProvidersToggleList({
   providersSelection,
   setProvidersSelection,
   isWorkspaceValidating,

--- a/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
@@ -1,20 +1,8 @@
 import { ProviderContextItem } from "@app/components/pages/workspace/model_providers/ProviderContextItem";
-import {
-  REASONING_MODEL_CONFIGS,
-  USED_MODEL_CONFIGS,
-} from "@app/components/providers/types";
-import { isModelCustomAvailable } from "@app/lib/assistant";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import type {
-  ModelConfigurationType,
-  ModelProviderIdType,
-} from "@app/types/assistant/models/types";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import { ContextItem } from "@dust-tt/sparkle";
-import groupBy from "lodash/groupBy";
-import mapValues from "lodash/mapValues";
-import uniqBy from "lodash/uniqBy";
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 
 interface ProviderContextItemProps {
@@ -22,6 +10,7 @@ interface ProviderContextItemProps {
   setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
   isWorkspaceValidating: boolean;
   plan: PlanType;
+  modelsDescriptionByProvider: Partial<Record<ModelProviderIdType, string>>;
 }
 
 export function ProvidersToggleList({
@@ -29,26 +18,8 @@ export function ProvidersToggleList({
   setProvidersSelection,
   isWorkspaceValidating,
   plan,
+  modelsDescriptionByProvider,
 }: ProviderContextItemProps) {
-  const { featureFlags } = useFeatureFlags();
-
-  // Filter models based on feature flags and build modelProviders dynamically
-  const filteredModels = uniqBy(
-    [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
-    (m) => m.modelId
-  ).filter(
-    (model) =>
-      !model.isLegacy && isModelCustomAvailable(model, featureFlags, plan)
-  );
-
-  const modelsDescriptionByProvider: Partial<
-    Record<ModelProviderIdType, string>
-  > = mapValues(
-    groupBy(filteredModels, "providerId"),
-    (modelConfigurations: ModelConfigurationType[]) =>
-      modelConfigurations.map(({ displayName }) => displayName).join(", ")
-  );
-
   const toggleProvider = useCallback(
     (provider: ModelProviderIdType) => {
       setProvidersSelection((previousSelection: ProvidersSelection) => ({

--- a/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
@@ -9,7 +9,6 @@ interface ProviderContextItemProps {
   providersSelection: ProvidersSelection;
   setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
   isWorkspaceValidating: boolean;
-  plan: PlanType;
   modelsDescriptionByProvider: Partial<Record<ModelProviderIdType, string>>;
 }
 
@@ -17,7 +16,6 @@ export function ProvidersToggleList({
   providersSelection,
   setProvidersSelection,
   isWorkspaceValidating,
-  plan,
   modelsDescriptionByProvider,
 }: ProviderContextItemProps) {
   const toggleProvider = useCallback(

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -4,10 +4,18 @@ import {
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
+
+const BYOK_AVAILABLE_PROVIDER_IDS: ModelProviderIdType[] = [
+  "anthropic",
+  "openai",
+];
 
 export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   return (
@@ -22,6 +30,10 @@ export function isModelAvailable(
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null
 ) {
+  if (plan?.isByok && !BYOK_AVAILABLE_PROVIDER_IDS.includes(m.providerId)) {
+    return false;
+  }
+
   if (!m.availableIfOneOf) {
     return true;
   }


### PR DESCRIPTION
## Description

For workspaces on BYOK plans, replace the toggle-based provider list with a configuration list (`ProvidersConfigurationList`) showing only Anthropic and OpenAI, each with a "Configure" action. Also extracts `ModelProvidersPageContent` for cleaner separation between BYOK and standard plan UIs.

<img width="1582" height="465" alt="image" src="https://github.com/user-attachments/assets/2f2c6753-f157-4d8e-875d-3d920c541d81" />


## Tests

Tested manually on a BYOK workspace — configuration list renders correctly, standard workspace toggle list is unaffected.

## Risk

Low — BYOK UI path was previously a no-op (`<></>`); standard workspace behavior is unchanged.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
