### PR TITLE
Fix group chat when admin perms are not sufficient

### DIFF
--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -27,6 +27,7 @@ import {
   isMCPServerPersonalAuthRequiredError,
   Ok,
 } from "@dust-tt/client";
+import type { ChatMessage } from "@microsoft/microsoft-graph-types";
 import type { Activity, TurnContext } from "botbuilder";
 import removeMarkdown from "remove-markdown";
 
@@ -614,14 +615,38 @@ async function makeContentFragments(
     );
   }
 
-  // Get conversation history using Microsoft Graph API
-  const conversationHistory = await getMessagesFromConversation(
-    localLogger,
-    client,
-    teamsConversationId
-  );
-
-  const messages = conversationHistory.results || [];
+  // Get conversation history using Microsoft Graph API.
+  // This can fail with InsufficientPrivileges if the connector admin user is
+  // not a member of the chat/channel. In that case, gracefully continue
+  // without conversation history (the bot can still respond to the current message).
+  let messages: ChatMessage[] = [];
+  try {
+    const conversationHistory = await getMessagesFromConversation(
+      localLogger,
+      client,
+      teamsConversationId
+    );
+    messages = conversationHistory.results || [];
+  } catch (error) {
+    localLogger.warn(
+      { error, teamsConversationId },
+      "Failed to fetch conversation history, continuing without it"
+    );
+    // Process only current message attachments (like we do for non-channel conversations)
+    const currentMessageAttachments = context.activity.attachments || [];
+    if (currentMessageAttachments.length === 0) {
+      return new Ok(undefined);
+    }
+    const allContentFragments = await processFileAttachments(
+      currentMessageAttachments,
+      dustAPI,
+      client,
+      localLogger
+    );
+    return new Ok(
+      allContentFragments.length > 0 ? allContentFragments : undefined
+    );
+  }
 
   const startIndex =
     messages.findIndex((msg) => msg.id === context.activity.id) + 1;


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/7031

## Description

Fixes Teams bot crashing with "An error occurred processing your request" in group conversations, private channels, and public channels (1:1 DMs worked fine).

**Root cause:** When the bot receives a message in a group chat or channel, it fetches conversation history via the Microsoft Graph API (`/chats/{id}/messages`) using the connector admin's delegated OAuth token. The `Chat.Read` delegated permission only allows reading chats the authenticated user is a member of. When the admin who set up the bot isn't a member of the specific chat/channel, Microsoft returns a `403 InsufficientPrivileges` error. This error was thrown as an uncaught exception that bypassed the existing `Result`-based error handling, reaching the Bot Framework's `onTurnError` handler which displayed the generic error message.

**Fix:** Wrap the `getMessagesFromConversation()` call in a try-catch so the bot gracefully degrades — it still responds to the user's message and processes file attachments, just without prior conversation history context. This matches the existing behavior for 1:1 DMs, which already skip the history fetch.

**Note:** Fully fixing conversation history retrieval in all contexts would require switching to application-level permissions (`Chat.Read.All`) with a client credentials flow, which is a larger architectural change.

## Tests

Manual — verified that the error path now falls through to the catch block and the bot can respond in group chats.

## Risk

Low. The change only adds graceful error handling around an existing API call. Worst case, the bot responds without conversation history context (same as 1:1 DMs today).

## Deploy Plan

Standard deploy — no migration or feature flag needed.