### PR TITLE
[front] - fix(biome): add linting rule for `s-*` tailwind classes

### DIFF
--- a/biome-plugins/noSparkleClassInFront.grit
+++ b/biome-plugins/noSparkleClassInFront.grit
@@ -1,0 +1,16 @@
+engine biome(1.0)
+language js
+
+// Prevents usage of 's-' prefixed Tailwind classes in front/ code.
+// These classes are reserved for sparkle components.
+// Matches string literals like "s-foo" or "flex s-foo".
+// Due to GritQL limitations with JSX attribute matching, this matches
+// any string literal with s- prefixed class names. In practice these
+// only appear in className attributes.
+r"\"(?:s-|[^\"]*\ss-)[^\"]*\"" as $val where {
+    register_diagnostic(
+        span = $val,
+        message = "className values with 's-' prefix are not allowed in front. These are reserved for sparkle components.",
+        severity = "error"
+    )
+}

--- a/biome.json
+++ b/biome.json
@@ -85,7 +85,7 @@
       "plugins": ["./biome-plugins/noNextImports.grit"]
     },
     {
-      "includes": ["front/**/*.tsx"],
+      "includes": ["front/**/*.tsx", "front-spa/**/*.tsx"],
       "plugins": ["./biome-plugins/noSparkleClassInFront.grit"]
     },
     {

--- a/biome.json
+++ b/biome.json
@@ -85,6 +85,10 @@
       "plugins": ["./biome-plugins/noNextImports.grit"]
     },
     {
+      "includes": ["front/**/*.tsx"],
+      "plugins": ["./biome-plugins/noSparkleClassInFront.grit"]
+    },
+    {
       "includes": ["cli/dust-cli/**", "sparkle/**"],
       "javascript": {
         "jsxRuntime": "reactClassic"

--- a/front/components/assistant/conversation/ButlerThinkingIndicator.tsx
+++ b/front/components/assistant/conversation/ButlerThinkingIndicator.tsx
@@ -3,8 +3,8 @@ import { AnimatedText, SparklesIcon } from "@dust-tt/sparkle";
 export function ButlerThinkingIndicator() {
   return (
     <div className="flex items-center gap-2 py-2 pl-2">
-      <SparklesIcon className="s-h-4 s-w-4 s-text-highlight" />
-      <AnimatedText variant="highlight" className="s-text-xs s-font-semibold">
+      <SparklesIcon className="h-4 w-4 text-highlight" />
+      <AnimatedText variant="highlight" className="text-xs font-semibold">
         Butler is thinking...
       </AnimatedText>
     </div>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -34,7 +34,6 @@ import type { DustError } from "@app/lib/error";
 import { serializeMention } from "@app/lib/mentions/format";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type {
   AgentGenerationCancelledEvent,
@@ -61,6 +60,7 @@ import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
+import { cn } from "@dust-tt/sparkle";
 import type {
   ListScrollLocation,
   VirtuosoMessageListMethods,
@@ -80,7 +80,6 @@ import React, {
 } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
-
 import { findFirstUnreadMessageIndex } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
@@ -859,11 +858,11 @@ export const ConversationViewer = ({
           ItemContent={MessageItem}
           StickyFooter={AgentInputBar}
           // Note: do NOT put any verticalpadding here as it will mess with the auto scroll to bottom.
-          className={classNames(
+          className={cn(
             "dd-privacy-mask",
-            "s-@container/conversation",
-            "h-full w-full",
-            agentBuilderContext ? "px-4" : "px-4 md:px-8"
+            "@container/conversation",
+            "h-full w-full px-4",
+            !agentBuilderContext && "md:px-8"
           )}
           shortSizeAlign="top"
           computeItemKey={computeItemKey}
@@ -873,7 +872,7 @@ export const ConversationViewer = ({
           EmptyPlaceholder={ConversationViewerEmptyState}
           // Large buffer to avoid manipulating the dom too much when the user scrolls a bit.
           increaseViewportBy={8192}
-          enforceStickyFooterAtBottom={true}
+          enforceStickyFooterAtBottom
         />
       </VirtuosoMessageListLicense>
     </>

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -82,7 +82,7 @@ export function AttachmentCitation({
           <Citation
             {...dialogOrDownloadProps}
             isLoading={isLoading}
-            containerClassName={cn("s-h-full", isImage && "s-aspect-square")}
+            containerClassName={cn("h-full", isImage && "aspect-square")}
             action={
               !isImage &&
               attachmentCitation.onRemove && (

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -948,7 +948,7 @@ export function DataSourceViewSelector({
                   checked: isChecked === true,
                   disabled: !isRootSelectable,
                   onCheckedChange: handleSelectAll,
-                  className: "s-rounded-full",
+                  className: "rounded-full",
                 }
               : {
                   checked: isChecked,

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -18,7 +18,7 @@ import { useLandingAuthContext } from "@app/lib/swr/website";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames, getFaviconPath } from "@app/lib/utils";
 import { appendUTMParams } from "@app/lib/utils/utm";
-import { Button, DustLogo } from "@dust-tt/sparkle";
+import { Button, cn, DustLogo } from "@dust-tt/sparkle";
 import { cva } from "class-variance-authority";
 import Head from "next/head";
 import Link from "next/link";
@@ -99,7 +99,6 @@ export default function LandingLayout({
   // you can have dark theme so we need to remove them manually
   useEffect(() => {
     document.documentElement.classList.remove("dark");
-    document.documentElement.classList.remove("s-dark");
     document.body.classList.remove("bg-background-night");
   }, []);
 
@@ -254,10 +253,10 @@ const CookieBanner = ({
 
   return (
     <div
-      className={classNames(
+      className={cn(
         "fixed bottom-0 left-0 z-30 flex w-full flex-col items-center justify-between gap-6 border-t border-slate-700 bg-slate-900/90 p-8 shadow-2xl backdrop-blur-sm md:flex-row md:gap-8",
-        "s-transition-opacity s-duration-300 s-ease-in-out",
-        isVisible ? "s-opacity-100" : "s-opacity-0",
+        "transition-opacity duration-300 ease-in-out",
+        isVisible ? "opacity-100" : "opacity-0",
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         className || ""
       )}

--- a/front/components/markdown/Image.tsx
+++ b/front/components/markdown/Image.tsx
@@ -40,7 +40,7 @@ export function Img({ src, alt, owner }: ImgProps) {
   // Show loading state while fetching metadata.
   if (isFileMetadataLoading) {
     return (
-      <Citation containerClassName="s-aspect-square s-w-48">
+      <Citation containerClassName="aspect-square w-48">
         <CitationImage
           imgSrc={viewURL.toString()}
           downloadUrl={downloadURL.toString()}
@@ -57,7 +57,7 @@ export function Img({ src, alt, owner }: ImgProps) {
   }
 
   return (
-    <Citation containerClassName="s-aspect-square s-w-48">
+    <Citation containerClassName="aspect-square w-48">
       <CitationImage
         imgSrc={viewURL.toString()}
         downloadUrl={downloadURL.toString()}

--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -65,7 +65,7 @@ export function InviteChoosePage() {
                     key={invitation.workspaceName}
                     className={cn(
                       "bg-muted-background dark:bg-muted-background-night",
-                      "s-border-border dark:s-border-border-night",
+                      "border-border dark:border-border-night",
                       "flex items-center justify-between gap-4 rounded-xl border p-4 shadow-sm"
                     )}
                   >

--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -86,10 +86,9 @@ export function ResourceAvatar({
 }: ResourceAvatarProps) {
   return (
     <SparkleAvatar
-      iconColor={iconColor ?? "s-text-foreground dark:s-text-foreground-night"}
+      iconColor={iconColor ?? "text-foreground dark:text-foreground-night"}
       backgroundColor={
-        backgroundColor ??
-        "s-bg-muted-background dark:s-bg-muted-background-night"
+        backgroundColor ?? "bg-muted-background dark:bg-muted-background-night"
       }
       {...props}
     />

--- a/front/components/sparkle/ThemeContext.tsx
+++ b/front/components/sparkle/ThemeContext.tsx
@@ -108,7 +108,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
     const restoreAnimation = disableAnimation();
     document.documentElement.classList.toggle("dark", nextIsDark);
-    document.documentElement.classList.toggle("s-dark", nextIsDark);
 
     if (nextIsDark) {
       document.body.classList.add("bg-background-night");


### PR DESCRIPTION

## Description

Introduces a new Biome GritQL linting rule to enforce that `s-` prefixed Tailwind classes are reserved exclusively for Sparkle components and cannot be used in `front/` or `front-spa/` code. The rule detects any string literals containing `s-` prefixed class names and raises an error. Existing violations across the front codebase are fixed by replacing Sparkle-prefixed classes with standard Tailwind equivalents (e.g., `s-h-4` → `h-4`, `s-text-highlight` → `text-highlight`). 

We used to have this rule, which probably got lost when transitioning to Biome

## Tests

Manually tested locally - biome check now catches violations

## Risk

Low

## Deploy Plan

N/A
