### PR TITLE
[front] fix Manage Skills GitHub link input bar

### DIFF
--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -261,9 +261,7 @@ export function ManageAgentsPage() {
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "/") {
         event.preventDefault();
-        if (searchBarRef.current) {
-          searchBarRef.current.focus();
-        }
+        searchBarRef.current?.focus();
       }
     };
 

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -193,12 +193,14 @@ export function ManageSkillsPage() {
   }, [searchBarRef.current]);
 
   useEffect(() => {
+    if (isImportDialogOpen) {
+      return;
+    }
+
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "/") {
         event.preventDefault();
-        if (searchBarRef.current) {
-          searchBarRef.current.focus();
-        }
+        searchBarRef.current?.focus();
       }
     };
 
@@ -206,7 +208,7 @@ export function ManageSkillsPage() {
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, []);
+  }, [isImportDialogOpen]);
 
   const navChildren = useMemo(
     () => <AgentSidebarMenu owner={owner} />,


### PR DESCRIPTION
## Description

- This PR fixes an issue in the input bar for adding a skill from a GitHub repository.
- This page contains a global keydown handler that intercepts `/` to focus the search bar.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
