### PR TITLE
Improve file storage mock and fix PDF text extraction content type

### DIFF
--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -1,8 +1,25 @@
 import {
   hasProcessedVersion,
   isUploadSupportedForContentType,
+  processAndStoreFile,
 } from "@app/lib/api/files/processing";
-import { describe, expect, it } from "vitest";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { assert, describe, expect, it, vi } from "vitest";
+
+// Mock config to provide required env vars.
+vi.mock("@app/lib/api/config", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@app/lib/api/config")>();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      getTextExtractionUrl: () => "http://fake-tika:9998",
+      getApiBaseUrl: () => "http://localhost:3000",
+    },
+  };
+});
 
 describe("hasProcessedVersion", () => {
   it("should return false for plain text files", () => {
@@ -134,5 +151,66 @@ describe("isUploadSupportedForContentType", () => {
         useCase: "upsert_table",
       })
     ).toBe(false);
+  });
+});
+
+describe("processAndStoreFile", () => {
+  it("should store extracted text from PDF with text/plain content type", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const file = await FileFactory.create(auth, null, {
+      contentType: "application/pdf",
+      fileName: "document.pdf",
+      fileSize: 1000,
+      status: "created",
+      useCase: "conversation",
+    });
+
+    const result = await processAndStoreFile(auth, {
+      file,
+      content: { type: "string", value: "fake pdf bytes" },
+    });
+
+    assert(
+      result.isOk(),
+      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+    );
+
+    // Should have 2 writes: original (application/pdf) + processed (text/plain).
+    const writes = fileStorageMock.writeStreamCalls;
+    expect(writes).toHaveLength(2);
+    expect(writes[0].contentType).toBe("application/pdf");
+    expect(writes[1].contentType).toBe("text/plain");
+  });
+
+  it("should not create a processed version for plain text files", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "readme.txt",
+      fileSize: 100,
+      status: "created",
+      useCase: "conversation",
+    });
+
+    const result = await processAndStoreFile(auth, {
+      file,
+      content: { type: "string", value: "hello world" },
+    });
+
+    assert(
+      result.isOk(),
+      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+    );
+
+    // Only one write: the original. No processed version created.
+    const writes = fileStorageMock.writeStreamCalls;
+    expect(writes).toHaveLength(1);
+    expect(writes[0].contentType).toBe("text/plain");
   });
 });

--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -4,8 +4,8 @@ import {
   processAndStoreFile,
 } from "@app/lib/api/files/processing";
 import { FileFactory } from "@app/tests/utils/FileFactory";
-import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { assert, describe, expect, it, vi } from "vitest";
 
 // Mock config to provide required env vars.

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -251,6 +251,7 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
     const writeStream = file.getWriteStream({
       auth,
       version: "processed",
+      overrideContentType: "text/plain", // Text extractor extracts plain text from binary documents.
     });
 
     await pipeline(processedStream, writeStream);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -85,7 +85,7 @@ const mockFileContent = {
 
 // Mock file storage with parameterizable content
 vi.mock("@app/lib/file_storage", async () => {
-  const { mockFileStorage } = await import(
+  const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
   const mockFile = () => ({
@@ -93,7 +93,7 @@ vi.mock("@app/lib/file_storage", async () => {
     createReadStream: () => Readable.from([mockFileContent.content]),
   });
   return {
-    ...mockFileStorage(),
+    ...fileStorageMock.mock(),
     getUpsertQueueBucket: vi.fn(() => ({ file: mockFile })),
     getPrivateUploadBucket: vi.fn(() => ({ file: mockFile })),
   };

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -79,11 +79,11 @@ const mockFileContent = {
 
 // Mock file storage with parameterizable content
 vi.mock("@app/lib/file_storage", async () => {
-  const { mockFileStorage } = await import(
+  const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
   return {
-    ...mockFileStorage(),
+    ...fileStorageMock.mock(),
     getUpsertQueueBucket: vi.fn(() => ({
       file: () => ({
         copy: vi.fn().mockResolvedValue(undefined),

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -17,56 +17,9 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { RequestMethod } from "node-mocks-http";
 import type { WhereOptions } from "sequelize";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import handler from "./index";
-
-// Mock FileStorage to avoid GCS calls during file deletion.
-vi.mock("@app/lib/file_storage", () => {
-  const createMockGCSFile = () => ({
-    copy: vi.fn().mockResolvedValue(undefined),
-    createReadStream: vi.fn().mockReturnValue({
-      on: vi.fn().mockImplementation(function (this: any) {
-        return this;
-      }),
-      pipe: vi.fn(),
-    }),
-    getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
-    createWriteStream: vi.fn().mockReturnValue({
-      on: vi.fn().mockImplementation(function (
-        this: any,
-        event: string,
-        cb: any
-      ) {
-        if (event === "finish") {
-          // eslint-disable-next-line @typescript-eslint/no-implied-eval
-          setImmediate(cb);
-        }
-        return this;
-      }),
-      write: vi.fn(),
-      end: vi.fn(),
-    }),
-    delete: vi.fn().mockResolvedValue(undefined),
-    publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
-  });
-
-  const createMockFileStorage = () => ({
-    file: vi.fn(createMockGCSFile),
-    getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
-    uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
-    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
-    fetchFileContent: vi.fn().mockResolvedValue("mock content"),
-    delete: vi.fn().mockResolvedValue(undefined),
-  });
-
-  return {
-    FileStorage: vi.fn().mockImplementation(createMockFileStorage),
-    getPrivateUploadBucket: vi.fn(createMockFileStorage),
-    getPublicUploadBucket: vi.fn(createMockFileStorage),
-    getUpsertQueueBucket: vi.fn(createMockFileStorage),
-  };
-});
 
 async function setupTest(
   options: {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -1,55 +1,78 @@
+import { PassThrough } from "stream";
 import { vi } from "vitest";
 
-function createMockGCSFile() {
-  return {
-    copy: vi.fn().mockResolvedValue(undefined),
-    createReadStream: vi.fn().mockReturnValue({
-      on: vi.fn().mockImplementation(function (this: any) {
-        return this;
-      }),
-      pipe: vi.fn(),
-    }),
-    createWriteStream: vi.fn().mockReturnValue({
-      on: vi.fn().mockImplementation(function (
-        this: any,
-        event: string,
-        cb: any
-      ) {
-        if (event === "finish") {
-          setImmediate(cb);
-        }
-        return this;
-      }),
-      write: vi.fn(),
-      end: vi.fn(),
-    }),
-    delete: vi.fn().mockResolvedValue(undefined),
-    getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
-    publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
-  };
-}
-
-function createMockFileStorage() {
-  return {
-    file: vi.fn(createMockGCSFile),
-    getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
-    uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
-    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
-    fetchFileContent: vi.fn().mockResolvedValue("mock content"),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
+export interface WriteStreamCall {
+  filePath: string;
+  contentType: string | undefined;
 }
 
 /**
- * Mock for @app/lib/file_storage. Call via vi.mock at the top of test files:
+ * Mock for @app/lib/file_storage. Globally registered in vite.setup.ts.
  *
- *   vi.mock("@app/lib/file_storage", () => mockFileStorage());
+ * Uses real PassThrough streams (compatible with `pipeline`) and records every
+ * `createWriteStream` call. Use `writeStreamCalls` to inspect recorded writes and `reset()`
+ * to clear them between tests.
+ *
+ * Usage in tests:
+ *   import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+ *   const writes = fileStorageMock.writeStreamCalls;
  */
-export function mockFileStorage() {
-  return {
-    FileStorage: vi.fn().mockImplementation(createMockFileStorage),
-    getPrivateUploadBucket: vi.fn(createMockFileStorage),
-    getPublicUploadBucket: vi.fn(createMockFileStorage),
-    getUpsertQueueBucket: vi.fn(createMockFileStorage),
-  };
+class FileStorageMock {
+  private _writeStreamCalls: WriteStreamCall[] = [];
+
+  get writeStreamCalls(): readonly WriteStreamCall[] {
+    return this._writeStreamCalls;
+  }
+
+  reset(): void {
+    this._writeStreamCalls.length = 0;
+  }
+
+  /**
+   * Returns the module shape expected by `vi.mock("@app/lib/file_storage", ...)`.
+   */
+  mock() {
+    const createStorage = () => this.createMockStorage();
+
+    return {
+      FileStorage: vi.fn().mockImplementation(createStorage),
+      getPrivateUploadBucket: vi.fn(createStorage),
+      getPublicUploadBucket: vi.fn(createStorage),
+      getUpsertQueueBucket: vi.fn(createStorage),
+    };
+  }
+
+  private createMockGCSFile(filePath?: string) {
+    return {
+      copy: vi.fn().mockResolvedValue(undefined),
+      createReadStream: vi.fn().mockReturnValue(new PassThrough()),
+      createWriteStream: vi
+        .fn()
+        .mockImplementation((opts?: { contentType?: string }) => {
+          this._writeStreamCalls.push({
+            filePath: filePath ?? "unknown",
+            contentType: opts?.contentType,
+          });
+          return new PassThrough();
+        }),
+      delete: vi.fn().mockResolvedValue(undefined),
+      getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
+      publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
+    };
+  }
+
+  private createMockStorage() {
+    return {
+      file: vi.fn((path: string) => this.createMockGCSFile(path)),
+      name: "mock-bucket",
+      getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
+      uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
+      uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+      fetchFileContent: vi.fn().mockResolvedValue("mock content"),
+      delete: vi.fn().mockResolvedValue(undefined),
+      deleteFiles: vi.fn().mockResolvedValue(undefined),
+    };
+  }
 }
+
+export const fileStorageMock = new FileStorageMock();

--- a/front/tests/utils/mocks/text_extraction.ts
+++ b/front/tests/utils/mocks/text_extraction.ts
@@ -1,0 +1,19 @@
+import { Readable } from "stream";
+import { vi } from "vitest";
+
+/**
+ * Mock for @app/types/shared/text_extraction. Globally registered in vite.setup.ts.
+ * Returns a dummy plain-text stream from `fromStream`.
+ */
+export function mockTextExtraction() {
+  class MockTextExtraction {
+    fromStream = vi
+      .fn()
+      .mockResolvedValue(Readable.from("mock extracted text"));
+  }
+
+  return {
+    isTextExtractionSupportedContentType: vi.fn().mockReturnValue(true),
+    TextExtraction: MockTextExtraction,
+  };
+}

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -2,8 +2,8 @@ import "@testing-library/jest-dom/vitest";
 import "vitest-canvas-mock";
 
 import { frontSequelize } from "@app/lib/resources/storage";
-import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { cleanup } from "@testing-library/react";
 import { default as cls } from "cls-hooked";
 import { Sequelize } from "sequelize";

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import "vitest-canvas-mock";
 
 import { frontSequelize } from "@app/lib/resources/storage";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { cleanup } from "@testing-library/react";
 import { default as cls } from "cls-hooked";
@@ -77,10 +78,18 @@ vi.mock("@app/lib/utils/cache", () => ({
 
 // Mock file storage (GCS) - must be at module level to avoid SERVICE_ACCOUNT env requirement.
 vi.mock("@app/lib/file_storage", async () => {
-  const { mockFileStorage } = await import(
+  const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
-  return mockFileStorage();
+  return fileStorageMock.mock();
+});
+
+// Mock TextExtraction (Tika) - must be at module level to avoid connecting to Tika.
+vi.mock("@app/types/shared/text_extraction", async () => {
+  const { mockTextExtraction } = await import(
+    "@app/tests/utils/mocks/text_extraction"
+  );
+  return mockTextExtraction();
 });
 
 // Mock sandbox provider - must be at module level
@@ -118,6 +127,7 @@ vi.mock("@app/temporal/es_indexation/client", async (importOriginal) => {
 
 beforeEach(async (c) => {
   vi.clearAllMocks();
+  fileStorageMock.reset();
 
   const namespace = cls.createNamespace("test-namespace");
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Fixes a pre-existing bug where text extracted from PDFs and other documents was stored with the original
content type (e.g. `application/pdf`) instead of `text/plain`. The `extractTextFromFileAndUpload` function now
passes `overrideContentType: "text/plain"` to the write stream, matching what `extractTextFromAudioAndUpload`
already did for audio transcription.

Took the opportunity to write a proper file storage mock that exposes interactions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
