### PR TITLE
fix(msft): don't retry on billing policy errors

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -292,6 +292,11 @@ export async function getRootNodesToSyncFromResources(
           { errorCode: error.code, errorMessage: error.message },
           "Skipping sites-root due to 401 generalException - possible permission change. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when"
         );
+      } else if (isBillingPolicyError(error)) {
+        logger.warn(
+          { error: error.message },
+          "Billing policy error from Microsoft, skipping sites-root"
+        );
       } else {
         throw error;
       }
@@ -333,6 +338,13 @@ export async function getRootNodesToSyncFromResources(
                   errorMessage: error.message,
                 },
                 "Skipping site drives due to 401 generalException - possible site permission change. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when"
+              );
+              return { results: [] };
+            }
+            if (isBillingPolicyError(error)) {
+              logger.warn(
+                { sitePath, error: error.message },
+                "Billing policy error from Microsoft, skipping site drives"
               );
               return { results: [] };
             }
@@ -760,6 +772,22 @@ export async function syncFiles({
           parent,
         },
         "Skipping syncFiles due to 401 generalException - possible site permission change. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when"
+      );
+      return {
+        count: 0,
+        childNodes: [],
+        nextLink: undefined,
+      };
+    }
+    if (isBillingPolicyError(e)) {
+      logger.warn(
+        {
+          connectorId,
+          dataSourceId: dataSourceConfig.dataSourceId,
+          parent,
+          error: e.message,
+        },
+        "Billing policy error from Microsoft, skipping syncFiles"
       );
       return {
         count: 0,
@@ -1718,6 +1746,12 @@ export async function microsoftGarbageCollectionActivity({
             body: null,
           })),
         };
+      } else if (isBillingPolicyError(error)) {
+        logger.warn(
+          { connectorId, error: error.message },
+          "Billing policy error from Microsoft during garbage collection batch, skipping chunk"
+        );
+        continue;
       } else if (isJSONParsingError(error)) {
         logger.error(
           {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

The Microsoft connector already had `isBillingPolicyError` detection but it was missing in several catch blocks (`getSites`, `getDrives`, `syncFiles`, garbage collection batch requests). This caused 402 "Billing Policy Not Found Or Invalid" errors to bubble up as unhandled activity errors and retry indefinitely in Temporal.

Now all Graph API call sites gracefully skip on billing policy errors and log a warning. Skipped resources are retried on the next sync cycle, so everything resumes automatically once the customer fixes their Microsoft 365 billing.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy connectors