### PR TITLE
Show all conversations attachments in popover

### DIFF
--- a/front/components/assistant/conversation/ConversationAttachmentsPopover.tsx
+++ b/front/components/assistant/conversation/ConversationAttachmentsPopover.tsx
@@ -1,0 +1,327 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  FilePreviewSheet,
+  type MinimalFileForPreview,
+} from "@app/components/spaces/FilePreviewSheet";
+import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import {
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import type { GetConversationAttachmentsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/attachments";
+import { isInteractiveContentType } from "@app/types/files";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  AttachmentIcon,
+  Button,
+  DataTable,
+  Icon,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  RobotIcon,
+  ScrollArea,
+  Spinner,
+  Tooltip,
+  UserIcon,
+} from "@dust-tt/sparkle";
+import type {
+  CellContext,
+  ColumnDef,
+  SortingState,
+} from "@tanstack/react-table";
+import moment from "moment";
+import { useCallback, useMemo, useState } from "react";
+
+type ConversationAttachmentItem =
+  GetConversationAttachmentsResponseBody["attachments"][number];
+
+type ConversationAttachmentRow = {
+  title: string;
+  contentType: string;
+  fileId: string | null;
+  updatedAt: number | null;
+  source: "agent" | "user" | null;
+  sourceUrl: string | null;
+  onClick?: () => void;
+};
+
+function conversationAttachmentToRow(
+  item: ConversationAttachmentItem,
+  onFileClick: (fileId: string, title: string, contentType: string) => void
+): ConversationAttachmentRow {
+  if (isFileAttachmentType(item)) {
+    return {
+      title: item.title,
+      contentType: item.contentType,
+      fileId: item.fileId,
+      updatedAt: item.updatedAt ?? item.createdAt ?? null,
+      source: item.source,
+      sourceUrl: null,
+      onClick: () => {
+        onFileClick(item.fileId, item.title, item.contentType);
+      },
+    };
+  } else if (isContentNodeAttachmentType(item)) {
+    return {
+      title: item.title,
+      contentType: item.contentType,
+      fileId: null,
+      updatedAt: null,
+      source: null,
+      sourceUrl: item.sourceUrl,
+      onClick: item.sourceUrl
+        ? () => window.open(item.sourceUrl!, "_blank", "noopener,noreferrer")
+        : undefined,
+    };
+  } else {
+    assertNever(item);
+  }
+}
+
+function conversationFileToPreviewFile(
+  fileId: string,
+  title: string,
+  contentType: string
+): MinimalFileForPreview {
+  return {
+    sId: fileId,
+    fileName: title,
+    contentType,
+  };
+}
+
+function formatDate(timestamp: number): string {
+  return moment(timestamp).fromNow();
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Conversation attachments & generated content will appear here.
+      </div>
+    </div>
+  );
+}
+
+const DEFAULT_SORTING: SortingState = [{ id: "updatedAt", desc: true }];
+
+interface ConversationAttachmentsPopoverProps {
+  conversationId: string;
+  owner: LightWorkspaceType;
+}
+
+export const ConversationAttachmentsPopover = ({
+  conversationId,
+  owner,
+}: ConversationAttachmentsPopoverProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(
+    null
+  );
+  const [showPreviewSheet, setShowPreviewSheet] = useState(false);
+  const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
+  const { openPanel } = useConversationSidePanelContext();
+
+  const { attachments, isConversationAttachmentsLoading } =
+    useConversationAttachments({
+      conversationId,
+      owner,
+      options: {
+        disabled: !isOpen,
+      },
+    });
+
+  const handleFileClick = useCallback(
+    (fileId: string, title: string, contentType: string) => {
+      if (isInteractiveContentType(contentType)) {
+        openPanel({ type: "interactive_content", fileId });
+        setIsOpen(false);
+      } else {
+        setPreviewFile(
+          conversationFileToPreviewFile(fileId, title, contentType)
+        );
+        setShowPreviewSheet(true);
+      }
+    },
+    [openPanel]
+  );
+
+  const { conversationContextFiles } = useMemo(() => {
+    const project: ConversationAttachmentItem[] = [];
+    const conversation: ConversationAttachmentItem[] = [];
+    for (const f of attachments) {
+      if (f.isInProjectContext) {
+        project.push(f);
+      } else {
+        conversation.push(f);
+      }
+    }
+    return {
+      projectContextFiles: project.map((a) =>
+        conversationAttachmentToRow(a, handleFileClick)
+      ),
+      conversationContextFiles: conversation.map((a) =>
+        conversationAttachmentToRow(a, handleFileClick)
+      ),
+    };
+  }, [attachments, handleFileClick]);
+
+  const titleColumn: ColumnDef<ConversationAttachmentRow, unknown> = {
+    id: "title",
+    accessorKey: "title",
+    header: "Title",
+    sortingFn: "text",
+    meta: { className: "w-full" },
+    cell: (info: CellContext<ConversationAttachmentRow, unknown>) => {
+      const row = info.row.original;
+      const FileIcon = getFileTypeIcon(row.contentType, row.title);
+      return (
+        <DataTable.CellContent>
+          <div className="flex min-w-0 items-center gap-2">
+            <Icon visual={FileIcon} size="sm" className="shrink-0" />
+            <Tooltip
+              tooltipTriggerAsChild
+              label={row.title}
+              trigger={
+                <span className="min-w-0 truncate text-sm">{row.title}</span>
+              }
+            />
+          </div>
+        </DataTable.CellContent>
+      );
+    },
+  };
+
+  const updatedColumn: ColumnDef<ConversationAttachmentRow, unknown> = {
+    id: "updatedAt",
+    accessorKey: "updatedAt",
+    header: "Updated",
+    meta: { className: "w-[115px]" },
+    cell: (info: CellContext<ConversationAttachmentRow, unknown>) => {
+      const updatedAt = info.row.original.updatedAt;
+      if (updatedAt == null) {
+        return <DataTable.BasicCellContent label="" />;
+      }
+      return <DataTable.BasicCellContent label={formatDate(updatedAt)} />;
+    },
+  };
+
+  const sourceColumn: ColumnDef<ConversationAttachmentRow, unknown> = {
+    id: "source",
+    accessorKey: "source",
+    header: "",
+    meta: { className: "w-10 shrink-0" },
+    cell: (info: CellContext<ConversationAttachmentRow, unknown>) => {
+      const source = info.row.original.source;
+      if (source === "agent") {
+        return (
+          <DataTable.CellContent>
+            <Tooltip
+              tooltipTriggerAsChild
+              label="Generated by agent"
+              trigger={
+                <span className="inline-flex">
+                  <Icon visual={RobotIcon} size="sm" />
+                </span>
+              }
+            />
+          </DataTable.CellContent>
+        );
+      }
+      if (source === "user") {
+        return (
+          <DataTable.CellContent>
+            <Tooltip
+              tooltipTriggerAsChild
+              label="Uploaded by user"
+              trigger={
+                <span className="inline-flex">
+                  <Icon visual={UserIcon} size="sm" />
+                </span>
+              }
+            />
+          </DataTable.CellContent>
+        );
+      }
+      return <DataTable.BasicCellContent label="" />;
+    },
+  };
+
+  const conversationColumns: ColumnDef<ConversationAttachmentRow, unknown>[] = [
+    titleColumn,
+    sourceColumn,
+    updatedColumn,
+  ];
+
+  const hasFiles = attachments.length > 0;
+
+  return (
+    <>
+      <PopoverRoot
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            size="sm"
+            tooltip="Conversation attachments & generated content"
+            icon={AttachmentIcon}
+            variant="ghost"
+            isSelect
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          className="flex w-[420px] flex-col gap-3"
+          align="end"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            if (showPreviewSheet) {
+              e.preventDefault();
+            }
+          }}
+        >
+          <ScrollArea className="flex max-h-[80vh] flex-col gap-4">
+            {isConversationAttachmentsLoading ? (
+              <div className="flex w-full items-center justify-center p-8">
+                <Spinner />
+              </div>
+            ) : !hasFiles ? (
+              <EmptyState />
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <div className="text-base font-medium text-primary dark:text-primary-night">
+                    Attached and Generated content
+                  </div>
+                  {conversationContextFiles.length > 0 ? (
+                    <DataTable
+                      columns={conversationColumns}
+                      data={conversationContextFiles}
+                      sorting={sorting}
+                      setSorting={setSorting}
+                    />
+                  ) : (
+                    <EmptyState />
+                  )}
+                </div>
+              </div>
+            )}
+          </ScrollArea>
+        </PopoverContent>
+      </PopoverRoot>
+
+      <FilePreviewSheet
+        owner={owner}
+        file={previewFile}
+        isOpen={showPreviewSheet}
+        onOpenChange={setShowPreviewSheet}
+      />
+    </>
+  );
+};

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -1,4 +1,4 @@
-import { ConversationFilesPopover } from "@app/components/assistant/conversation/ConversationFilesPopover";
+import { ConversationAttachmentsPopover } from "@app/components/assistant/conversation/ConversationAttachmentsPopover";
 import {
   ConversationMenu,
   useConversationMenu,
@@ -92,7 +92,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           currentTitle={currentTitle}
         />
         <div className="flex items-center gap-2">
-          <ConversationFilesPopover
+          <ConversationAttachmentsPopover
             conversationId={activeConversationId}
             owner={owner}
           />

--- a/front/components/spaces/FilePreviewSheet.tsx
+++ b/front/components/spaces/FilePreviewSheet.tsx
@@ -17,6 +17,14 @@ import {
   isMarkdownContentType,
   isPdfContentType,
 } from "@app/types/files";
+
+/** Minimal file shape for preview (e.g. conversation files). Only sId, fileName, contentType are used by the renderer. */
+export type MinimalFileForPreview = {
+  sId: string;
+  fileName: string;
+  contentType: string;
+};
+
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -179,7 +187,7 @@ function AudioFileRenderer({
 }
 
 interface FileContentRendererProps {
-  file: FileWithCreatorType;
+  file: FileWithCreatorType | MinimalFileForPreview;
   owner: WorkspaceType;
   previewConfig: FilePreviewConfig;
   rawFileContent: string | null;
@@ -246,7 +254,11 @@ function FileContentRenderer({
       return (
         <FrameRenderer
           fileId={file.sId}
-          projectId={file.useCaseMetadata?.spaceId ?? null}
+          projectId={
+            "useCaseMetadata" in file
+              ? (file.useCaseMetadata?.spaceId ?? null)
+              : null
+          }
           owner={owner}
           lastEditedByAgentConfigurationId={undefined}
           contentHash={undefined}
@@ -274,7 +286,7 @@ function FileContentRenderer({
 }
 
 interface FilePreviewContentProps {
-  file: FileWithCreatorType | null;
+  file: FileWithCreatorType | MinimalFileForPreview | null;
   owner: WorkspaceType;
   isOpen: boolean;
 }
@@ -404,7 +416,7 @@ function FilePreviewContent({ file, owner, isOpen }: FilePreviewContentProps) {
 
 interface FilePreviewSheetProps {
   owner: WorkspaceType;
-  file: FileWithCreatorType | null;
+  file: FileWithCreatorType | MinimalFileForPreview | null;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
 }

--- a/front/hooks/conversations/useConversationAttachments.ts
+++ b/front/hooks/conversations/useConversationAttachments.ts
@@ -1,0 +1,34 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationAttachmentsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/attachments";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+export function useConversationAttachments({
+  conversationId,
+  options,
+  owner,
+}: {
+  conversationId?: string | null;
+  options?: { disabled?: boolean };
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const conversationAttachmentsFetcher: Fetcher<GetConversationAttachmentsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    conversationId
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/attachments`
+      : null,
+    conversationAttachmentsFetcher,
+    options
+  );
+
+  return {
+    attachments: useMemo(() => data?.attachments ?? [], [data]),
+    isConversationAttachmentsLoading: !error && !data,
+    isConversationAttachmentsError: error,
+    mutateConversationAttachments: mutate,
+  };
+}

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -398,6 +398,8 @@ export async function processToolResults(
         fileId: c.file.sId,
         snippet: c.file.snippet,
         title: c.file.fileName,
+        createdAt: c.file.createdAt.getTime(),
+        updatedAt: c.file.updatedAt.getTime(),
         isInProjectContext: c.file.useCase === "project_context",
         ...(isHidden ? { hidden: true } : {}),
       } satisfies ActionGeneratedFileType;

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -70,6 +70,9 @@ export async function getFileFromConversationAttachment(
         if (f.fileId === fileId) {
           attachment = getAttachmentFromFile({
             fileId: f.fileId,
+            source: "agent",
+            createdAt: f.createdAt,
+            updatedAt: f.updatedAt,
             contentType: f.contentType,
             title: f.title,
             snippet: f.snippet,

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -95,6 +95,7 @@ export function rewriteContentForModel(
   ) {
     const attachment = getAttachmentFromFile({
       fileId: content.resource.fileId,
+      source: "agent",
       contentType: content.resource.contentType,
       title: content.resource.title,
       snippet: content.resource.snippet,

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -171,6 +171,8 @@ export async function generateProcessToolOutput({
     contentType: jsonFile.contentType,
     snippet: jsonSnippet,
     isInProjectContext: jsonFile.useCase === "project_context",
+    createdAt: jsonFile.createdAt.getTime(),
+    updatedAt: jsonFile.updatedAt.getTime(),
   };
   const timeFrameAsString = timeFrame
     ? "the last " +

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -169,6 +169,8 @@ export function getLightAgentMessageFromAgentMessage(
         title: f.title,
         contentType: f.contentType,
         isInProjectContext: f.isInProjectContext,
+        createdAt: f.createdAt,
+        updatedAt: f.updatedAt,
         ...(f.hidden ? { hidden: true } : {}),
       })),
     richMentions: agentMessage.richMentions,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -40,6 +40,9 @@ export type BaseConversationAttachmentType = {
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
   fileId: string;
+  source: "agent" | "user" | null;
+  createdAt?: number;
+  updatedAt?: number;
 };
 
 export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
@@ -193,17 +196,25 @@ export function getAttachmentFromFileContentFragment(
   return {
     ...baseAttachment,
     fileId,
+    source: "user",
+    createdAt: cf.created,
   };
 }
 
 export function getAttachmentFromFile({
   fileId,
+  source,
+  createdAt,
+  updatedAt,
   contentType,
   title,
   snippet,
   isInProjectContext,
 }: {
   fileId: string;
+  source: "agent" | "user" | null;
+  createdAt?: number;
+  updatedAt?: number;
   contentType: AllSupportedFileContentType;
   title: string;
   snippet: string | null;
@@ -216,6 +227,9 @@ export function getAttachmentFromFile({
 
   return {
     fileId,
+    source,
+    createdAt,
+    updatedAt,
     contentType,
     title,
     snippet,

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -96,6 +96,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.csv",
           contentType: "text/csv",
           contentFragmentVersion: "latest",
@@ -351,6 +352,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.csv",
           contentType: "text/csv",
           contentFragmentVersion: "latest",
@@ -403,6 +405,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.txt",
           contentType: "text/plain",
           contentFragmentVersion: "latest",
@@ -451,6 +454,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.txt",
           contentType: "text/plain",
           contentFragmentVersion: "latest",
@@ -490,6 +494,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.csv",
           contentType: "text/csv",
           contentFragmentVersion: "latest",
@@ -532,6 +537,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.csv",
           contentType: "text/csv",
           contentFragmentVersion: "latest",
@@ -582,6 +588,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.csv",
           contentType: "text/csv",
           contentFragmentVersion: "latest",
@@ -660,6 +667,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          source: "user",
           title: "test.csv",
           contentType: "text/csv",
           contentFragmentVersion: "latest",

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -47,6 +47,9 @@ export async function listAttachments(
           f.fileId,
           getAttachmentFromFile({
             fileId: f.fileId,
+            source: "agent",
+            createdAt: f.createdAt ?? 0,
+            updatedAt: f.updatedAt ?? 0,
             contentType: f.contentType,
             title: f.title,
             snippet: f.snippet,
@@ -74,6 +77,9 @@ export async function listAttachments(
           f.sId,
           getAttachmentFromFile({
             fileId: f.sId,
+            source: null,
+            createdAt: f.createdAt.getTime(),
+            updatedAt: f.updatedAt.getTime(),
             contentType: f.contentType,
             title: f.fileName,
             snippet: f.snippet,

--- a/front/lib/file_icon_utils.ts
+++ b/front/lib/file_icon_utils.ts
@@ -2,15 +2,74 @@ import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import {
   ActionFrameIcon,
   ActionVolumeUpIcon,
+  BigQueryLogo,
   BracesIcon,
+  ConfluenceLogo,
   DocumentIcon,
+  DriveLogo,
+  DustLogoSquare,
+  GithubLogo,
+  GongLogo,
+  GoogleDocLogo,
   GooglePdfLogo,
+  GoogleSlideLogo,
+  GoogleSpreadsheetLogo,
   ImageIcon,
+  IntercomLogo,
   MicrosoftExcelLogo,
+  MicrosoftLogo,
+  MicrosoftPowerpointLogo,
   MicrosoftWordLogo,
+  NotionLogo,
+  SalesforceLogo,
+  SlackLogo,
+  SnowflakeLogo,
+  TableIcon,
   TextIcon,
+  ZendeskLogo,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
+
+const DUST_MIME_PREFIX = "application/vnd.dust.";
+const VND_MIME_PREFIX = "application/vnd.";
+
+/** Map provider segment from Dust internal MIME (e.g. "notion", "googledrive") to colored logo. */
+const INTERNAL_PROVIDER_ICONS: Record<string, ComponentType> = {
+  notion: NotionLogo,
+  bigquery: BigQueryLogo,
+  googledrive: DriveLogo,
+  confluence: ConfluenceLogo,
+  slack: SlackLogo,
+  github: GithubLogo,
+  microsoft: MicrosoftLogo,
+  intercom: IntercomLogo,
+  zendesk: ZendeskLogo,
+  snowflake: SnowflakeLogo,
+  salesforce: SalesforceLogo,
+  gong: GongLogo,
+  dustproject: DustLogoSquare,
+};
+
+/**
+ * Generic map for application/vnd.{vendor}.{subtype} MIME types.
+ * Add new types under the vendor key; no need to touch the lookup logic.
+ * e.g. application/vnd.google-apps.document → vendor "google-apps", subtype "document"
+ */
+const VND_VENDOR_SUBTYPE_ICONS: Record<
+  string,
+  Record<string, ComponentType>
+> = {
+  "google-apps": {
+    document: GoogleDocLogo,
+    spreadsheet: GoogleSpreadsheetLogo,
+    presentation: GoogleSlideLogo,
+  },
+  "openxmlformats-officedocument": {
+    "wordprocessingml.document": MicrosoftWordLogo,
+    "spreadsheetml.sheet": MicrosoftExcelLogo,
+    "presentationml.presentation": MicrosoftPowerpointLogo,
+  },
+};
 
 interface FileTypeMapping {
   icon: ComponentType;
@@ -26,19 +85,18 @@ const FILE_TYPE_MAPPINGS: FileTypeMapping[] = [
   },
   {
     icon: MicrosoftWordLogo,
-    mimeTypes: [
-      "application/msword",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ],
+    mimeTypes: ["application/msword"],
     extensions: ["doc", "docx"],
   },
   {
     icon: MicrosoftExcelLogo,
-    mimeTypes: [
-      "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ],
+    mimeTypes: ["application/vnd.ms-excel"],
     extensions: ["xls", "xlsx"],
+  },
+  {
+    icon: TableIcon,
+    mimeTypes: ["text/csv", "text/tab-separated-values"],
+    extensions: ["csv", "tsv"],
   },
   {
     icon: TextIcon,
@@ -75,6 +133,29 @@ export function getFileTypeIcon(
   }
   if (contentType.startsWith("audio/")) {
     return ActionVolumeUpIcon;
+  }
+
+  // Internal Dust types (Notion, BigQuery, Slack, etc.) – use colored provider logos
+  if (contentType.startsWith(DUST_MIME_PREFIX)) {
+    const suffix = contentType.slice(DUST_MIME_PREFIX.length);
+    const provider = suffix.split(".")[0]?.toLowerCase();
+    if (provider && provider in INTERNAL_PROVIDER_ICONS) {
+      return INTERNAL_PROVIDER_ICONS[provider];
+    }
+  }
+
+  // Generic application/vnd.{vendor}.{subtype} lookup (Google Apps, Office Open XML, etc.)
+  if (contentType.startsWith(VND_MIME_PREFIX)) {
+    const suffix = contentType.slice(VND_MIME_PREFIX.length);
+    const parts = suffix.split(".");
+    const vendor = parts[0]?.toLowerCase();
+    const subtype = parts.slice(1).join(".").toLowerCase();
+    if (vendor && subtype) {
+      const vendorMap = VND_VENDOR_SUBTYPE_ICONS[vendor];
+      if (vendorMap && subtype in vendorMap) {
+        return vendorMap[subtype];
+      }
+    }
   }
 
   const extension = fileName ? getExtension(fileName) : undefined;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -1,0 +1,58 @@
+import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetConversationAttachmentsResponseBody = {
+  attachments: ConversationAttachmentType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationAttachmentsResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId } = req.query;
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationRes = await getConversation(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const { value: conversation } = conversationRes;
+
+  const attachments = await listAttachments(auth, { conversation });
+
+  return res.status(200).json({
+    attachments,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

New conversation popover to improve discoverability and usability of the attached and generated content.
- Separate endpoint, hook, component (to avoid breaking existing clients, will remove after).
- Now show both generated AND uploaded content.
- Uses a datatable and nicer preview to mimic Project's knowledge section.
- Uses "Clip" icon + "isSelect" to show it's okay to click on it.

## Tests

Locally

<img width="453" height="143" alt="image" src="https://github.com/user-attachments/assets/40026e2a-8184-4140-a20e-1a3057877b75" />

<img width="459" height="619" alt="image" src="https://github.com/user-attachments/assets/9a40c1bd-1132-4b06-b115-742d830d41ba" />

## Risk

Low

## Deploy Plan

Deploy front