### PR TITLE
[front] chore: Harden our startup probe for pg connection

### DIFF
--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -11,6 +11,16 @@ import type {
 } from "sequelize";
 import { Sequelize } from "sequelize";
 
+// Why are we doing this?
+// Sequelize is loosely typed and connection parameters are passed as is
+// to the host, meaning a wrong parameter can result in wide database connection outage
+// For this reason, new parameters must be reviewed carefully and peer-reviewed by a tenured engineer
+// (ping @flvdvd)
+// TODO(unknown time): Remove this once we move away from Sequelize
+type StrictDialectOptions<T extends { appName?: string }> = T & {
+  [K in keyof T as K extends "appName" ? never : K]?: never;
+};
+
 /**
  * Wrapper around Sequelize that adds sqlcommenter-style tags to queries.
  *
@@ -21,9 +31,16 @@ import { Sequelize } from "sequelize";
  *   https://github.com/google/sqlcommenter/blob/master/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-sequelize/index.js
  * - The official sqlcommenter package is unmaintained and incompatible with modern OpenTelemetry
  */
-export class SequelizeWithComments extends Sequelize {
-  constructor(uri: string, options?: Options) {
-    super(uri, options);
+export class SequelizeWithComments<
+  T extends { appName?: string } = { appName?: string },
+> extends Sequelize {
+  constructor(
+    uri: string,
+    options?: Omit<Options, "dialectOptions"> & {
+      dialectOptions?: StrictDialectOptions<T>;
+    }
+  ) {
+    super(uri, options as Options);
   }
 
   /**

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -126,7 +126,6 @@ export const frontSequelize = new SequelizeWithComments(
     },
     dialectOptions: {
       appName: "front master",
-      statement_timeout: 60_000,
     },
   }
 );

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -126,6 +126,7 @@ export const frontSequelize = new SequelizeWithComments(
     },
     dialectOptions: {
       appName: "front master",
+      statement_timeout: 60_000,
     },
   }
 );

--- a/front/pages/api/healthz/startup.ts
+++ b/front/pages/api/healthz/startup.ts
@@ -64,7 +64,7 @@ export default async function handler(
     checkDependency("redis", () => getRedisHybridManager().ping()),
     checkDependency("database", () =>
       // biome-ignore lint/plugin: health check needs direct DB ping
-      frontSequelize.query("SELECT 1 from workspaces;")
+      frontSequelize.query("SELECT 1")
     ),
   ]);
 

--- a/front/pages/api/healthz/startup.ts
+++ b/front/pages/api/healthz/startup.ts
@@ -62,8 +62,10 @@ export default async function handler(
 
   const results = await Promise.all([
     checkDependency("redis", () => getRedisHybridManager().ping()),
-    // biome-ignore lint/plugin: health check needs direct DB ping
-    checkDependency("database", () => frontSequelize.query("SELECT 1")),
+    checkDependency("database", () =>
+      // biome-ignore lint/plugin: health check needs direct DB ping
+      frontSequelize.query("SELECT 1 from workspaces;")
+    ),
   ]);
 
   const failed = results.filter((r) => !r.ok);

--- a/front/pages/api/healthz/startup.ts
+++ b/front/pages/api/healthz/startup.ts
@@ -62,7 +62,8 @@ export default async function handler(
 
   const results = await Promise.all([
     checkDependency("redis", () => getRedisHybridManager().ping()),
-    checkDependency("database", () => frontSequelize.authenticate()),
+    // biome-ignore lint/plugin: health check needs direct DB ping
+    checkDependency("database", () => frontSequelize.query("SELECT 1")),
   ]);
 
   const failed = results.filter((r) => !r.ok);


### PR DESCRIPTION
## Description

Currently our startup probe only checks that we can authenticate, which just means the host is joinable considering the postgres:// URI given.
That does not guarantee that a SQL statement will succeed, especially when there is a middleman (PGBouncer in our case).

Replace this with a `SELECT 1` which is very lightweight and should be micro-seconds.


## Tests

N/A

## Risk

Low, will test on front-edge

## Deploy Plan

- [ ] Deploy front