### PR TITLE
 fix: dismiss auth/file authorization cards after successful connection

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1018,6 +1018,7 @@ function AgentMessageContent({
       case "blocked_authentication_required":
         return (
           <MCPServerPersonalAuthenticationRequired
+            blockedAction={blockedAction}
             triggeringUser={triggeringUser}
             owner={owner}
             mcpServerId={blockedAction.metadata.mcpServerId}
@@ -1035,6 +1036,7 @@ function AgentMessageContent({
       case "blocked_file_authorization_required":
         return (
           <GoogleDriveFileAuthorizationRequired
+            blockedAction={blockedAction}
             triggeringUser={triggeringUser}
             owner={owner}
             fileAuthorizationInfo={blockedAction.fileAuthorizationInfo}

--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -1,6 +1,10 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import type { GooglePickerFile } from "@app/hooks/useGooglePicker";
 import { useGooglePicker } from "@app/hooks/useGooglePicker";
-import type { FileAuthorizationInfo } from "@app/lib/actions/mcp";
+import type {
+  BlockedToolExecution,
+  FileAuthorizationInfo,
+} from "@app/lib/actions/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PickerTokenResponseType } from "@app/pages/api/w/[wId]/google_drive/picker_token";
@@ -14,6 +18,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface GoogleDriveFileAuthorizationRequiredProps {
+  blockedAction: BlockedToolExecution;
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   fileAuthorizationInfo: FileAuthorizationInfo;
@@ -22,6 +27,7 @@ interface GoogleDriveFileAuthorizationRequiredProps {
 }
 
 export function GoogleDriveFileAuthorizationRequired({
+  blockedAction,
   triggeringUser,
   owner,
   fileAuthorizationInfo,
@@ -38,6 +44,8 @@ export function GoogleDriveFileAuthorizationRequired({
     appId: string;
   } | null>(null);
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
+
+  const { removeCompletedAction } = useBlockedActionsContext();
 
   const isTriggeredByCurrentUser = useMemo(
     () => triggeringUser?.sId === user?.sId,
@@ -76,7 +84,7 @@ export function GoogleDriveFileAuthorizationRequired({
   }, [isTriggeredByCurrentUser, owner.sId, mcpServerId, pickerCredentials]);
 
   const handleFilesSelected = useCallback(
-    (files: GooglePickerFile[]) => {
+    async (files: GooglePickerFile[]) => {
       // When user selects files in the picker, they authorize them via the drive.file scope.
       // Check if the file we needed was selected.
       const targetFileSelected = files.some(
@@ -85,13 +93,17 @@ export function GoogleDriveFileAuthorizationRequired({
 
       if (targetFileSelected) {
         setIsAuthorized(true);
-        setTimeout(() => {
-          retryHandler();
-        }, 100);
+        await retryHandler();
+        removeCompletedAction(blockedAction.actionId);
       }
       // If wrong file selected, user can click the button again
     },
-    [fileAuthorizationInfo.fileId, retryHandler]
+    [
+      fileAuthorizationInfo.fileId,
+      retryHandler,
+      removeCompletedAction,
+      blockedAction.actionId,
+    ]
   );
 
   const handlePickerCancel = useCallback(() => {

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -1,12 +1,13 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import {
   areCredentialOverridesValid,
   PersonalAuthCredentialOverrides,
 } from "@app/components/oauth/PersonalAuthCredentialOverrides";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   useCreatePersonalConnection,
   useMCPServer,
@@ -18,6 +19,7 @@ import { ActionCardBlock, Button } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
 interface MCPServerPersonalAuthenticationRequiredProps {
+  blockedAction: BlockedToolExecution;
   triggeringUser: UserType | null;
   mcpServerId: string;
   owner: LightWorkspaceType;
@@ -27,6 +29,7 @@ interface MCPServerPersonalAuthenticationRequiredProps {
 }
 
 export function MCPServerPersonalAuthenticationRequired({
+  blockedAction,
   triggeringUser,
   mcpServerId,
   owner,
@@ -42,7 +45,7 @@ export function MCPServerPersonalAuthenticationRequired({
 
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
-  const { submit: retry } = useSubmitFunction(async () => retryHandler());
+  const { removeCompletedAction } = useBlockedActionsContext();
 
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
@@ -92,7 +95,8 @@ export function MCPServerPersonalAuthenticationRequired({
         }
       } else {
         setIsConnected(true);
-        await retry();
+        await retryHandler();
+        removeCompletedAction(blockedAction.actionId);
       }
     } finally {
       setIsConnecting(false);


### PR DESCRIPTION
## Description

Runner card: https://github.com/dust-tt/tasks/issues/6942

After connecting OAuth  the action card was stuck showing "Connected successfully" for too long while the agent loop had already restarted and completed. The card was never removed from the blocked actions queue because removeCompletedAction was never called, unlike the validation flow which already did this.

Added removeCompletedAction after the retry completes in both MCPServerPersonalAuthenticationRequired and GoogleDriveFileAuthorizationRequired. The retry must complete before removing the action from the queue to avoid interfering with the workflow restart. Also removed an unnecessary setTimeout workaround in the Google Drive flow.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 