### PR TITLE
Fixed dark theme

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -99,6 +99,8 @@ export default function LandingLayout({
   // you can have dark theme so we need to remove them manually
   useEffect(() => {
     document.documentElement.classList.remove("dark");
+    // biome-ignore lint/plugin/noSparkleClassInFront: s-dark is needed for Sparkle dark mode
+    document.documentElement.classList.remove("s-dark");
     document.body.classList.remove("bg-background-night");
   }, []);
 

--- a/front/components/sparkle/ThemeContext.tsx
+++ b/front/components/sparkle/ThemeContext.tsx
@@ -108,6 +108,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
     const restoreAnimation = disableAnimation();
     document.documentElement.classList.toggle("dark", nextIsDark);
+    // biome-ignore lint/plugin/noSparkleClassInFront: s-dark is needed for Sparkle dark mode
+    document.documentElement.classList.toggle("s-dark", nextIsDark);
 
     if (nextIsDark) {
       document.body.classList.add("bg-background-night");


### PR DESCRIPTION
## Description

PR #22833 introduced a biome lint rule to prevent `s-` prefixed Tailwind classes in front/ code. However, it also removed the `s-dark` class toggle from `ThemeContext` and `LandingLayout`, which Sparkle components rely on for dark mode styling. This restores the toggle with biome-ignore comments.

## Tests

Manual — verified dark mode works correctly after restoring the toggle.

## Risk

Low — restores previously working behavior.

## Deploy Plan

Standard deploy, no special steps needed.