### PR TITLE
fix(file): log bucket.file errors instead of throwing

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -895,13 +895,33 @@ export class FileResource extends BaseResource<FileModel> {
     const bucket = getPrivateUploadBucket();
 
     const srcOriginalPath = this.getCloudStoragePath(auth, "original");
-    await bucket.file(srcOriginalPath).copy(bucket.file(mountFilePath));
 
-    // Copy processed version only if this file type has real processing.
-    if (this.getContentVersion() === "processed") {
-      const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
-      const processedMountPath = makeProcessedMountFileName(mountFilePath);
-      await bucket.file(srcProcessedPath).copy(bucket.file(processedMountPath));
+    try {
+      await bucket.file(srcOriginalPath).copy(bucket.file(mountFilePath));
+
+      // Copy processed version only if this file type has real processing.
+      if (this.getContentVersion() === "processed") {
+        const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
+        const processedMountPath = makeProcessedMountFileName(mountFilePath);
+        await bucket
+          .file(srcProcessedPath)
+          .copy(bucket.file(processedMountPath));
+      }
+    } catch (err) {
+      // Transient GCS errors (e.g. socket hang up) should not crash the
+      // request. The file is already marked as ready; the mount copy can be
+      // retried later. Log with enough context to investigate.
+      logger.error(
+        {
+          fileId: this.sId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          srcPath: srcOriginalPath,
+          mountFilePath,
+          error: normalizeError(err),
+        },
+        "Failed to copy file to mount path in GCS"
+      );
+      return;
     }
 
     await this.update({ mountFilePath });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

The GCS `rewriteTo` operation in `setMountFilePath` (used to copy files to the `gcsfuse`-mountable conversation path) had no error handling, so transient network errors like socket hang ups would bubble up as unhandled 500s. This wraps the GCS copy in a `try`/`catch` that logs an actionable error with file and path context instead of crashing the request.

The file upload itself is unaffected since the DB status is already set to "ready" before the mount copy is attempted. When the copy fails, the `mountFilePath` field stays null, which means the next natural trigger (attaching to a conversation via setUseCaseMetadata, or a frame edit via uploadContent) will automatically retry the copy. The only degraded state is that the file won't be visible in sandboxes via `gcsfuse` until that retry succeeds, but direct reads and downloads from the canonical path work normally.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

None

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front