### PR TITLE
Add a "Reload tab" MCP tool

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -669,6 +669,20 @@ chrome.runtime.onMessage.addListener(
         })();
         return true;
 
+      case "RELOAD_TAB":
+        void (async () => {
+          try {
+            await chrome.tabs.reload(message.tabId);
+            sendResponse({ success: true });
+          } catch (error) {
+            sendResponse({
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
+        return true;
+
       case "INPUT_BAR_STATUS":
         void (async () => {
           if (message.available) {

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -48,7 +48,8 @@ export type TabActionMessage =
   | { type: "ACTIVATE_TAB"; tabId: number }
   | { type: "CLOSE_TAB"; tabId: number }
   | { type: "OPEN_TAB"; url: string }
-  | { type: "MOVE_TAB"; tabId: number; index: number };
+  | { type: "MOVE_TAB"; tabId: number; index: number }
+  | { type: "RELOAD_TAB"; tabId: number };
 
 export type TabActionResponse = {
   success: boolean;

--- a/extension/platforms/chrome/tools/tabActionTools.ts
+++ b/extension/platforms/chrome/tools/tabActionTools.ts
@@ -115,6 +115,42 @@ export function registerTabActionTools(server: McpServer): void {
   );
 
   server.tool(
+    "reload-browser-tab",
+    "Reloads the specified browser tab. Useful after server-side actions that modify page content. " +
+      "Use list-browser-tabs to discover tab IDs.",
+    {
+      tabId: z.number().describe("The tab ID to reload."),
+    },
+    async ({ tabId }) => {
+      try {
+        const result = await sendTabActionMessage({
+          type: "RELOAD_TAB",
+          tabId,
+        });
+        if (!result.success) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
+            ],
+          };
+        }
+        return {
+          content: [{ type: "text", text: `Reloaded tab ${tabId}.` }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to reload tab: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
     "move-browser-tab",
     "Moves a browser tab to a new position (index) in the tab bar. " +
       "Use list-browser-tabs to discover tab IDs and current order.",


### PR DESCRIPTION
## Description

Adds a `reload-browser-tab` MCP tool to the Chrome extension, completing the set of tab manipulation tools introduced in #22798. The tool takes a `tabId` parameter and reloads the specified browser tab. Can be useful after calling a server-side MCP tools that edit page content. 

## Tests

Manual testing with agents using the new reload after calling server-side MCP tools.

## Risk

Low. Extension-only changes following the same pattern as the tab manipulation tools from #22798.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
