### PR TITLE
Add: pulsing animation when a content is added to the conversation.

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -50,6 +50,7 @@ import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
+import { ConversationAttachmentsUpdatedEvent } from "@app/lib/notifications/events";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import {
@@ -286,7 +287,13 @@ export function AgentMessage({
               conversationId,
             });
             break;
-          case "agent_action_success":
+          case "agent_action_success": {
+            const action = eventPayload.data.action;
+            if (action.generatedFiles.length > 0) {
+              window.dispatchEvent(new ConversationAttachmentsUpdatedEvent());
+            }
+            break;
+          }
           case "end-of-stream":
           case "tool_error":
           case "tool_notification":

--- a/front/components/assistant/conversation/ConversationAttachmentsPopover.tsx
+++ b/front/components/assistant/conversation/ConversationAttachmentsPopover.tsx
@@ -9,6 +9,7 @@ import {
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import { CONVERSATION_ATTACHMENTS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import type { GetConversationAttachmentsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/attachments";
 import { isInteractiveContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -33,7 +34,7 @@ import type {
   SortingState,
 } from "@tanstack/react-table";
 import moment from "moment";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type ConversationAttachmentItem =
   GetConversationAttachmentsResponseBody["attachments"][number];
@@ -125,6 +126,31 @@ export const ConversationAttachmentsPopover = ({
   const [showPreviewSheet, setShowPreviewSheet] = useState(false);
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
   const { openPanel } = useConversationSidePanelContext();
+  const [isPulsing, setIsPulsing] = useState(false);
+  const pulsingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const handler = () => {
+      setIsPulsing(true);
+      if (pulsingTimeoutRef.current) {
+        clearTimeout(pulsingTimeoutRef.current);
+      }
+      pulsingTimeoutRef.current = setTimeout(() => {
+        setIsPulsing(false);
+      }, 9000);
+    };
+    window.addEventListener(CONVERSATION_ATTACHMENTS_UPDATED_EVENT, handler);
+
+    return () => {
+      if (pulsingTimeoutRef.current) {
+        clearTimeout(pulsingTimeoutRef.current);
+      }
+      window.removeEventListener(
+        CONVERSATION_ATTACHMENTS_UPDATED_EVENT,
+        handler
+      );
+    };
+  }, []);
 
   const { attachments, isConversationAttachmentsLoading } =
     useConversationAttachments({
@@ -265,15 +291,23 @@ export const ConversationAttachmentsPopover = ({
         open={isOpen}
         onOpenChange={(open) => {
           setIsOpen(open);
+
+          if (open) {
+            setIsPulsing(false);
+            if (pulsingTimeoutRef.current) {
+              clearTimeout(pulsingTimeoutRef.current);
+            }
+          }
         }}
       >
         <PopoverTrigger asChild>
           <Button
             size="sm"
-            tooltip="Conversation attachments & generated content"
+            tooltip="Attached and Generated content"
             icon={AttachmentIcon}
             variant="ghost"
             isSelect
+            isPulsing={isPulsing}
           />
         </PopoverTrigger>
         <PopoverContent

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -32,7 +32,10 @@ import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/ev
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { serializeMention } from "@app/lib/mentions/format";
-import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
+import {
+  AgentMessageCompletedEvent,
+  ConversationAttachmentsUpdatedEvent,
+} from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
 import type {
@@ -450,6 +453,10 @@ export const ConversationViewer = ({
                 );
               }
               void debouncedMarkAsRead(conversationId);
+
+              if (userMessage.contentFragments.length > 0) {
+                window.dispatchEvent(new ConversationAttachmentsUpdatedEvent());
+              }
             }
             break;
           case "agent_message_new":

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -13,3 +13,12 @@ export class AgentMessageCompletedEvent extends CustomEvent<void> {
     super(AGENT_MESSAGE_COMPLETED_EVENT);
   }
 }
+
+export const CONVERSATION_ATTACHMENTS_UPDATED_EVENT =
+  "conversation-attachments-updated";
+
+export class ConversationAttachmentsUpdatedEvent extends CustomEvent<void> {
+  constructor() {
+    super(CONVERSATION_ATTACHMENTS_UPDATED_EVENT);
+  }
+}


### PR DESCRIPTION
## Description

To help discovery of the attachments button, pulse it when a new content is added to a conversation.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front