### PR TITLE
Remove CUSTOM_MODEL_IDS from llm tests

### DIFF
--- a/front/lib/api/llm/tests/models.ts
+++ b/front/lib/api/llm/tests/models.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_OPUS_4_6_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import type { CUSTOM_MODEL_IDS } from "@app/types/assistant/models/custom_models.generated";
 import {
   FIREWORKS_DEEPSEEK_V3P2_MODEL_ID,
   FIREWORKS_GLM_5_MODEL_ID,
@@ -56,9 +57,11 @@ import {
 } from "@app/types/assistant/models/openai";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
+type CustomModelId = (typeof CUSTOM_MODEL_IDS)[number];
+
 export const MODELS: Record<
   | OpenAIWhitelistedModelId
-  | AnthropicWhitelistedModelId
+  | Exclude<AnthropicWhitelistedModelId, CustomModelId>
   | GoogleAIStudioWhitelistedModelId
   | MistralWhitelistedModelId
   | FireworksWhitelistedModelId,


### PR DESCRIPTION
## Description

Build currently failing with 

```
[5](https://github.com/dust-tt/dust/actions/runs/22958307227/job/66641380788#step:4:492)
#31 105.6 ./lib/api/llm/tests/models.ts:59:14
#31 105.6 Type error: Property '"claude-churro-eap"' is missing in type '{ "claude-3-5-haiku-20241022": { runTest: false; providerId: "anthropic"; }; "claude-3-opus-20240229": { runTest: false; providerId: "anthropic"; }; "claude-haiku-4-5-20251001": { runTest: false; providerId: "anthropic"; }; "claude-opus-4-5-20251101": { runTest: false; providerId: "anthropic"; }; "claude-sonnet-4-5-20250929": { runTest: false; providerId: "anthropic"; }; "claude-4-opus-20250514": { runTest: false; providerId: "anthropic"; }; "claude-4-sonnet-20250514": { runTest: false; providerId: "anthropic"; }; "claude-opus-4-6": { runTest: false; providerId: "anthropic"; }; "claude-sonnet-4-6": { runTest: false; providerId: "anthropic"; }; "gemini-2.5-flash-lite": { runTest: false; providerId: "google_ai_studio"; }; "gemini-2.5-flash": { runTest: false; providerId: "google_ai_studio"; }; "gemini-2.5-pro": { runTest: false; providerId: "google_ai_studio"; }; "gemini-3-pro-preview": { runTest: false; providerId: "google_ai_studio"; }; "gemini-3.1-pro-preview": { runTest: false; providerId: "google_ai_studio"; }; "gemini-3-flash-preview": { runTest: false; providerId: "google_ai_studio"; }; "codestral-latest": { runTest: false; providerId: "mistral"; }; "mistral-large-latest": { runTest: false; providerId: "mistral"; }; "mistral-medium": { runTest: false; providerId: "mistral"; }; "mistral-small-latest": { runTest: false; providerId: "mistral"; }; "gpt-3.5-turbo": { runTest: false; providerId: "openai"; }; "gpt-4.1-mini-2025-04-14": { runTest: false; providerId: "openai"; }; "gpt-4.1-2025-04-14": { runTest: false; providerId: "openai"; }; "gpt-4-turbo": { runTest: false; providerId: "openai"; }; "gpt-4o-2024-08-06": { runTest: false; providerId: "openai"; }; "gpt-4o-mini": { runTest: false; providerId: "openai"; }; "gpt-4o": { runTest: false; providerId: "openai"; }; "gpt-5.1": { runTest: false; providerId: "openai"; }; "gpt-5.2": { runTest: false; providerId: "openai"; }; "gpt-5.4": { runTest: false; providerId: "openai"; }; "gpt-5-mini": { runTest: false; providerId: "openai"; }; "gpt-5": { runTest: false; providerId: "openai"; }; "gpt-5-nano": { runTest: false; providerId: "openai"; }; o1: { runTest: false; providerId: "openai"; }; "o3-mini": { runTest: false; providerId: "openai"; }; o3: { runTest: false; providerId: "openai"; }; "o4-mini": { runTest: false; providerId: "openai"; }; "accounts/fireworks/models/deepseek-v3p2": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/kimi-k2-instruct-0905": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/kimi-k2p5": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/minimax-m2p5": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/glm-5": { runTest: false; providerId: "fireworks"; }; }' but required in type 'Record<"gpt-3.5-turbo" | "gpt-4-turbo" | "gpt-4o" | "gpt-4.1-2025-04-14" | "gpt-4.1-mini-2025-04-14" | "gpt-4o-2024-08-06" | "gpt-4o-mini" | "gpt-5.1" | "gpt-5.2" | "gpt-5.4" | "gpt-5" | "gpt-5-mini" | "gpt-5-nano" | "o1" | "o3" | "o3-mini" | "o4-mini" | "claude-4-opus-20250514" | "claude-4-sonnet-20250514" | "claude-sonnet-4-5-20250929" | "claude-opus-4-5-20251101" | "claude-opus-4-6" | "claude-sonnet-4-6" | "claude-3-opus-20240229" | "claude-3-5-haiku-20241022" | "claude-haiku-4-5-20251001" | "mistral-large-latest" | "mistral-medium" | "mistral-small-latest" | "codestral-latest" | "gemini-2.5-flash" | "gemini-2.5-flash-lite" | "gemini-2.5-pro" | "gemini-3-pro-preview" | "gemini-3.1-pro-preview" | "gemini-3-flash-preview" | "accounts/fireworks/models/deepseek-v3p2" | "accounts/fireworks/models/kimi-k2-instruct-0905" | "accounts/fireworks/models/kimi-k2p5" | "accounts/fireworks/models/minimax-m2p5" | "accounts/fireworks/models/glm-5" | "claude-churro-eap", { runTest: boolean; providerId: "openai" | "anthropic" | "mistral" | "google_ai_studio" | "togetherai" | "deepseek" | "fireworks" | "xai" | "noop"; }>'.[5](https://github.com/dust-tt/dust/actions/runs/22958307227/job/66641380788#step:4:492)
#31 105.6 ./lib/api/llm/tests/models.ts:59:14
#31 105.6 Type error: Property '"claude-churro-eap"' is missing in type '{ "claude-3-5-haiku-20241022": { runTest: false; providerId: "anthropic"; }; "claude-3-opus-20240229": { runTest: false; providerId: "anthropic"; }; "claude-haiku-4-5-20251001": { runTest: false; providerId: "anthropic"; }; "claude-opus-4-5-20251101": { runTest: false; providerId: "anthropic"; }; "claude-sonnet-4-5-20250929": { runTest: false; providerId: "anthropic"; }; "claude-4-opus-20250514": { runTest: false; providerId: "anthropic"; }; "claude-4-sonnet-20250514": { runTest: false; providerId: "anthropic"; }; "claude-opus-4-6": { runTest: false; providerId: "anthropic"; }; "claude-sonnet-4-6": { runTest: false; providerId: "anthropic"; }; "gemini-2.5-flash-lite": { runTest: false; providerId: "google_ai_studio"; }; "gemini-2.5-flash": { runTest: false; providerId: "google_ai_studio"; }; "gemini-2.5-pro": { runTest: false; providerId: "google_ai_studio"; }; "gemini-3-pro-preview": { runTest: false; providerId: "google_ai_studio"; }; "gemini-3.1-pro-preview": { runTest: false; providerId: "google_ai_studio"; }; "gemini-3-flash-preview": { runTest: false; providerId: "google_ai_studio"; }; "codestral-latest": { runTest: false; providerId: "mistral"; }; "mistral-large-latest": { runTest: false; providerId: "mistral"; }; "mistral-medium": { runTest: false; providerId: "mistral"; }; "mistral-small-latest": { runTest: false; providerId: "mistral"; }; "gpt-3.5-turbo": { runTest: false; providerId: "openai"; }; "gpt-4.1-mini-2025-04-14": { runTest: false; providerId: "openai"; }; "gpt-4.1-2025-04-14": { runTest: false; providerId: "openai"; }; "gpt-4-turbo": { runTest: false; providerId: "openai"; }; "gpt-4o-2024-08-06": { runTest: false; providerId: "openai"; }; "gpt-4o-mini": { runTest: false; providerId: "openai"; }; "gpt-4o": { runTest: false; providerId: "openai"; }; "gpt-5.1": { runTest: false; providerId: "openai"; }; "gpt-5.2": { runTest: false; providerId: "openai"; }; "gpt-5.4": { runTest: false; providerId: "openai"; }; "gpt-5-mini": { runTest: false; providerId: "openai"; }; "gpt-5": { runTest: false; providerId: "openai"; }; "gpt-5-nano": { runTest: false; providerId: "openai"; }; o1: { runTest: false; providerId: "openai"; }; "o3-mini": { runTest: false; providerId: "openai"; }; o3: { runTest: false; providerId: "openai"; }; "o4-mini": { runTest: false; providerId: "openai"; }; "accounts/fireworks/models/deepseek-v3p2": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/kimi-k2-instruct-0905": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/kimi-k2p5": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/minimax-m2p5": { runTest: false; providerId: "fireworks"; }; "accounts/fireworks/models/glm-5": { runTest: false; providerId: "fireworks"; }; }' but required in type 'Record<"gpt-3.5-turbo" | "gpt-4-turbo" | "gpt-4o" | "gpt-4.1-2025-04-14" | "gpt-4.1-mini-2025-04-14" | "gpt-4o-2024-08-06" | "gpt-4o-mini" | "gpt-5.1" | "gpt-5.2" | "gpt-5.4" | "gpt-5" | "gpt-5-mini" | "gpt-5-nano" | "o1" | "o3" | "o3-mini" | "o4-mini" | "claude-4-opus-20250514" | "claude-4-sonnet-20250514" | "claude-sonnet-4-5-20250929" | "claude-opus-4-5-20251101" | "claude-opus-4-6" | "claude-sonnet-4-6" | "claude-3-opus-20240229" | "claude-3-5-haiku-20241022" | "claude-haiku-4-5-20251001" | "mistral-large-latest" | "mistral-medium" | "mistral-small-latest" | "codestral-latest" | "gemini-2.5-flash" | "gemini-2.5-flash-lite" | "gemini-2.5-pro" | "gemini-3-pro-preview" | "gemini-3.1-pro-preview" | "gemini-3-flash-preview" | "accounts/fireworks/models/deepseek-v3p2" | "accounts/fireworks/models/kimi-k2-instruct-0905" | "accounts/fireworks/models/kimi-k2p5" | "accounts/fireworks/models/minimax-m2p5" | "accounts/fireworks/models/glm-5" | "claude-churro-eap", { runTest: boolean; providerId: "openai" | "anthropic" | "mistral" | "google_ai_studio" | "togetherai" | "deepseek" | "fireworks" | "xai" | "noop"; }>'.
```

## Tests
no

## Risk

low

## Deploy Plan

deploy front
