### PR TITLE
Fix memory leaks in agent-loop worker from uncancelled timers

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -453,9 +453,10 @@ export async function* tryCallMCPTool(
     let notificationPromise = notificationStream.next();
 
     // Frequently heartbeat to get notified of cancellation.
+    let heartbeatTimer: NodeJS.Timeout | undefined;
     const createHeartbeatPromise = (): Promise<void> =>
       new Promise((resolve) => {
-        setTimeout(() => {
+        heartbeatTimer = setTimeout(() => {
           logger.info(toolLogContext, "MCP tool heartbeat");
           heartbeat();
           resolve();
@@ -494,6 +495,11 @@ export async function* tryCallMCPTool(
         yield makeToolNotificationEvent(iteratorResult.value);
       }
     }
+
+    // Clean up: cancel pending heartbeat timer and close the notification stream
+    // to remove the EventEmitter listener and release pending promises.
+    clearTimeout(heartbeatTimer);
+    await notificationStream.return();
 
     let toolCallResult: Awaited<typeof toolPromise>;
     try {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -191,131 +191,133 @@ export abstract class LLM<TPayload = unknown> {
     let currentEvent: LLMEvent | null = null;
     let timeToFirstEventMs: number | undefined = undefined;
 
-    for await (const event of this.completeStream(streamParameters)) {
-      if (currentEvent === null) {
-        timeToFirstEventMs = Date.now() - startTime;
-      }
-      currentEvent = event;
-      buffer.addEvent(currentEvent);
-
-      if (currentEvent.type === "interaction_id") {
-        buffer.setModelInteractionId(currentEvent.content.modelInteractionId);
-        this.generation.updateTrace({
-          metadata: {
-            modelInteractionId: currentEvent.content.modelInteractionId,
-          },
-        });
-      }
-
-      if (currentEvent.type !== "success" && currentEvent.type !== "error") {
-        yield currentEvent;
-        continue;
-      }
-
-      // Logging before it gets stopped and retried downstream
-      if (currentEvent.type === "error") {
-        // Temporary: track LLM error metric
-        statsDClient.increment("llm_error.count", 1, metricTags);
-        this.generation.updateTrace({
-          tags: ["isError:true", `errorType:${currentEvent.content.type}`],
-        });
-
-        logger.error(
-          {
-            llmEventType: "error",
-            errorContent: currentEvent.content,
-            modelId: this.modelId,
-            context: this.context,
-            traceId: this.traceId,
-          },
-          "LLM Error"
-        );
-      }
-
-      if (currentEvent.type === "success") {
-        // Temporary: track LLM success metric
-        statsDClient.increment("llm_success.count", 1, metricTags);
-
-        logger.info(
-          {
-            llmEventType: "success",
-            modelId: this.modelId,
-            context: this.context,
-            traceId: this.traceId,
-          },
-          "LLM Success"
-        );
-      }
-
-      const durationMs = Date.now() - startTime;
-      buffer
-        .writeToGCS({ durationMs, startTime, timeToFirstEventMs })
-        .catch(() => {});
-
-      const { tokenUsage, ...rest } = buffer.currentOutput;
-
-      this.generation.update({
-        output: { ...rest },
-      });
-
-      // Use custom trace output transformer if provided, otherwise use the full output.
-      if (this.getTraceOutput) {
-        const traceOutput = this.getTraceOutput(rest);
-        if (traceOutput) {
-          this.generation.updateTrace({ output: traceOutput });
+    try {
+      for await (const event of this.completeStream(streamParameters)) {
+        if (currentEvent === null) {
+          timeToFirstEventMs = Date.now() - startTime;
         }
-      } else {
-        this.generation.updateTrace({ output: { ...rest } });
-      }
+        currentEvent = event;
+        buffer.addEvent(currentEvent);
 
-      if (tokenUsage) {
+        if (currentEvent.type === "interaction_id") {
+          buffer.setModelInteractionId(currentEvent.content.modelInteractionId);
+          this.generation.updateTrace({
+            metadata: {
+              modelInteractionId: currentEvent.content.modelInteractionId,
+            },
+          });
+        }
+
+        if (currentEvent.type !== "success" && currentEvent.type !== "error") {
+          yield currentEvent;
+          continue;
+        }
+
+        // Logging before it gets stopped and retried downstream
+        if (currentEvent.type === "error") {
+          // Temporary: track LLM error metric
+          statsDClient.increment("llm_error.count", 1, metricTags);
+          this.generation.updateTrace({
+            tags: ["isError:true", `errorType:${currentEvent.content.type}`],
+          });
+
+          logger.error(
+            {
+              llmEventType: "error",
+              errorContent: currentEvent.content,
+              modelId: this.modelId,
+              context: this.context,
+              traceId: this.traceId,
+            },
+            "LLM Error"
+          );
+        }
+
+        if (currentEvent.type === "success") {
+          // Temporary: track LLM success metric
+          statsDClient.increment("llm_success.count", 1, metricTags);
+
+          logger.info(
+            {
+              llmEventType: "success",
+              modelId: this.modelId,
+              context: this.context,
+              traceId: this.traceId,
+            },
+            "LLM Success"
+          );
+        }
+
+        const durationMs = Date.now() - startTime;
+        buffer
+          .writeToGCS({ durationMs, startTime, timeToFirstEventMs })
+          .catch(() => {});
+
+        const { tokenUsage, ...rest } = buffer.currentOutput;
+
         this.generation.update({
-          usageDetails: {
-            // Report the uncached input tokens if provider supports it.
-            input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
-            output: tokenUsage.outputTokens,
-            total: tokenUsage.totalTokens,
-            cache_read_input_tokens: tokenUsage.cachedTokens ?? 0,
-            cache_creation_input_tokens: tokenUsage.cacheCreationTokens ?? 0,
-            reasoning_tokens: tokenUsage.reasoningTokens ?? 0,
-          },
+          output: { ...rest },
         });
-      }
 
-      if (buffer.error) {
-        this.generation.update({
-          level: "ERROR",
-          statusMessage: buffer.error.message,
-          metadata: {
-            errorType: buffer.error.type,
-            errorMessage: buffer.error.message,
-          },
+        // Use custom trace output transformer if provided, otherwise use the full output.
+        if (this.getTraceOutput) {
+          const traceOutput = this.getTraceOutput(rest);
+          if (traceOutput) {
+            this.generation.updateTrace({ output: traceOutput });
+          }
+        } else {
+          this.generation.updateTrace({ output: { ...rest } });
+        }
+
+        if (tokenUsage) {
+          this.generation.update({
+            usageDetails: {
+              // Report the uncached input tokens if provider supports it.
+              input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
+              output: tokenUsage.outputTokens,
+              total: tokenUsage.totalTokens,
+              cache_read_input_tokens: tokenUsage.cachedTokens ?? 0,
+              cache_creation_input_tokens: tokenUsage.cacheCreationTokens ?? 0,
+              reasoning_tokens: tokenUsage.reasoningTokens ?? 0,
+            },
+          });
+        }
+
+        if (buffer.error) {
+          this.generation.update({
+            level: "ERROR",
+            statusMessage: buffer.error.message,
+            metadata: {
+              errorType: buffer.error.type,
+              errorMessage: buffer.error.message,
+            },
+          });
+        }
+
+        const run = await RunResource.makeNew({
+          appId: null,
+          dustRunId: this.traceId,
+          runType: "deploy",
+          // Assumption made that this class exclusively uses Dust credentials.
+          useWorkspaceCredentials: false,
+          workspaceId: this.authenticator.getNonNullableWorkspace().id,
         });
-      }
 
+        // Run usage is only populated if the run is successful.
+        if (buffer.runTokenUsage) {
+          await run.recordTokenUsage(
+            this.authenticator,
+            buffer.runTokenUsage,
+            this.modelId
+          );
+        }
+
+        yield currentEvent;
+
+        break;
+      }
+    } finally {
       this.generation.end();
-
-      const run = await RunResource.makeNew({
-        appId: null,
-        dustRunId: this.traceId,
-        runType: "deploy",
-        // Assumption made that this class exclusively uses Dust credentials.
-        useWorkspaceCredentials: false,
-        workspaceId: this.authenticator.getNonNullableWorkspace().id,
-      });
-
-      // Run usage is only populated if the run is successful.
-      if (buffer.runTokenUsage) {
-        await run.recordTokenUsage(
-          this.authenticator,
-          buffer.runTokenUsage,
-          this.modelId
-        );
-      }
-
-      yield currentEvent;
-
-      break;
     }
   }
 

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -43,8 +43,11 @@ async function* withPeriodicHeartbeat<T>(
   let heartbeatCount = 0;
   let lastEventTimeMs = Date.now();
 
+  let heartbeatTimer: NodeJS.Timeout | undefined;
+
   try {
     while (!streamExhausted) {
+      heartbeatTimer = undefined;
       const result = await Promise.race([
         nextPromise
           .then((value) => ({ type: "stream" as const, value }))
@@ -52,13 +55,16 @@ async function* withPeriodicHeartbeat<T>(
             // Rethrow to ensure errors are not swallowed
             throw error;
           }),
-        new Promise<{ type: "heartbeat" }>((resolve) =>
-          setTimeout(
+        new Promise<{ type: "heartbeat" }>((resolve) => {
+          heartbeatTimer = setTimeout(
             () => resolve({ type: "heartbeat" }),
             LLM_HEARTBEAT_INTERVAL_MS
-          )
-        ),
+          );
+        }),
       ]);
+
+      // Clear the heartbeat timer if the stream event won the race.
+      clearTimeout(heartbeatTimer);
 
       heartbeat();
 
@@ -111,6 +117,9 @@ async function* withPeriodicHeartbeat<T>(
       lastEventTimeMs = Date.now();
     }
   } finally {
+    // Clear any pending heartbeat timer to prevent leaked closures.
+    clearTimeout(heartbeatTimer);
+
     // Ensure the underlying stream is closed on early exit (timeout, error, or break).
     // This aborts the HTTP connection to the LLM provider.
     // Wrapped in try/catch to avoid masking the original error if cleanup fails.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1773240483352259).

The agent-loop worker pods have been crashing with heap growth showing 8.9K leaked Timeouts, 214K Contexts,
and 35K Promises. The root cause is `Promise.race` patterns in `withPeriodicHeartbeat` and `tryCallMCPTool` that
create `setTimeout` timers on each loop iteration without cancelling the losing timer when the other promise
wins the race. Each leaked timer holds a closure chain (resolve function, Promise, execution Context) alive
for 10 seconds, and under high token throughput across many concurrent activities these accumulate faster than they expire.

In `withPeriodicHeartbeat`, the heartbeat `setTimeout` is now tracked and cleared both when the stream event wins
the race and in the finally block on exit. In `tryCallMCPTool`, the heartbeat timer is similarly cleared after
the notification loop exits, and `notificationStream.return()` is now called to close the `fromEvent` async
generator, which removes the EventEmitter listener and resolves the pending consumer promise that was
previously left dangling.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
