### PR TITLE
fix(msft): don't crash on json parsing failure

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -69,7 +69,7 @@ import {
   isDevelopment,
 } from "@connectors/types";
 import type { LoggerInterface } from "@dust-tt/client";
-import { normalizeError, removeNulls } from "@dust-tt/client";
+import { removeNulls } from "@dust-tt/client";
 import { Storage } from "@google-cloud/storage";
 import type { Client } from "@microsoft/microsoft-graph-client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
@@ -1753,36 +1753,38 @@ export async function microsoftGarbageCollectionActivity({
         );
         continue;
       } else if (isJSONParsingError(error)) {
-        logger.error(
-          {
-            connectorId,
-            error: error.message,
-            errorStack: error.stack,
-            chunkSize: chunk.length,
-            chunkUrls: chunk.map((req) => req.url),
-          },
-          "Batch request failed with JSON parsing error, attempting individual requests to identify problematic node"
-        );
-
-        // Try individual GET requests to identify which node is causing the issue
-        // Only for logging purpose at first
+        // Batch returned malformed JSON — try individual requests to diagnose.
+        const failedUrls: string[] = [];
         for (const req of chunk) {
           try {
             await getItem(logger, client, req.url);
-          } catch (itemError) {
-            const normalizedError = normalizeError(itemError);
-            logger.error(
-              {
-                connectorId,
-                error: normalizedError.message,
-                url: req.url,
-              },
-              "Individual request failed"
-            );
+          } catch {
+            failedUrls.push(req.url);
           }
         }
 
-        throw error;
+        if (failedUrls.length > 0) {
+          logger.warn(
+            {
+              connectorId,
+              error: error.message,
+              chunkSize: chunk.length,
+              failedUrls,
+            },
+            "Batch request failed with JSON parsing error and some individual requests also failed, skipping chunk"
+          );
+        } else {
+          logger.warn(
+            {
+              connectorId,
+              error: error.message,
+              chunkSize: chunk.length,
+              chunkUrls: chunk.map((req) => req.url),
+            },
+            "Batch request failed with JSON parsing error but all individual requests succeeded, skipping chunk"
+          );
+        }
+        continue;
       } else {
         throw error;
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

When Microsoft Graph API returns malformed JSON on batch requests during garbage collection, the activity now retries each item individually to diagnose the issue, then skips the chunk instead of re-throwing. This prevents infinite Temporal retries (we observed 4488+ attempts) caused by persistent malformed responses from Microsoft's API. 

The chunk will be retried on the next garbage collection cycle.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy connectors