### PR TITLE
feat: chrome extension tools stakes

### DIFF
--- a/extension/platforms/chrome/tools/getCurrentPageTool.ts
+++ b/extension/platforms/chrome/tools/getCurrentPageTool.ts
@@ -8,7 +8,7 @@ import type { CaptureService } from "@extension/shared/services/capture";
  * Registers the get-current-browser-page tool with the MCP server.
  * Extracts the text content of a browser tab.
  */
-export async function getCurrentPageTool({
+export async function getPageTool({
   tabId,
   captureService,
 }: {

--- a/extension/platforms/chrome/tools/getCurrentPageTool.ts
+++ b/extension/platforms/chrome/tools/getCurrentPageTool.ts
@@ -1,67 +1,45 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@extension/shared/lib/utils";
 import type { CaptureService } from "@extension/shared/services/capture";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 
 /**
  * Registers the get-current-browser-page tool with the MCP server.
  * Extracts the text content of a browser tab.
  */
-export function registerGetCurrentPageTool(
-  server: McpServer,
-  captureService: CaptureService | null
-): void {
-  server.tool(
-    "get-current-browser-page",
-    "Extracts the title, URL, and text content of a browser tab. " +
-      "Use this to read and understand what the user is viewing. " +
-      "For non-text pages (PDFs, images, etc.), use get-current-browser-page-view instead — it will attach the file directly to the conversation." +
-      "Use list-browser-tabs to discover tab IDs.",
-    {
-      tabId: z
-        .number()
-        .optional()
-        .describe(
-          "The tab ID to read. If omitted, reads the active tab. Use list-browser-tabs to get tab IDs."
-        ),
-    },
-    async ({ tabId }) => {
-      if (!captureService) {
-        return {
-          content: [{ type: "text", text: "Capture service not available." }],
-        };
-      }
+export async function getCurrentPageTool({
+  tabId,
+  captureService,
+}: {
+  tabId?: number;
+  captureService: CaptureService | null;
+}): Promise<ToolHandlerResult> {
+  if (!captureService) {
+    return new Err(new MCPError("Capture service not available."));
+  }
 
-      try {
-        const result = await captureService.handleOperation(
-          "capture-page-content",
-          { includeContent: true, includeCapture: false, tabId }
-        );
+  try {
+    const result = await captureService.handleOperation(
+      "capture-page-content",
+      { includeContent: true, includeCapture: false, tabId }
+    );
 
-        if (result.isErr()) {
-          return {
-            content: [{ type: "text", text: `Error: ${result.error.message}` }],
-          };
-        }
-
-        const { title, url, content } = result.value;
-        const parts = [`Title: ${title}`, `URL: ${url}`];
-        if (content) {
-          parts.push(`Content:\n${content}`);
-        }
-
-        return {
-          content: [{ type: "text", text: parts.join("\n") }],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to get current page: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
+    if (result.isErr()) {
+      return new Err(new MCPError(`Error: ${result.error.message}`));
     }
-  );
+
+    const { title, url, content } = result.value;
+    const parts = [`Title: ${title}`, `URL: ${url}`];
+    if (content) {
+      parts.push(`Content:\n${content}`);
+    }
+
+    return new Ok([{ type: "text", text: parts.join("\n") }]);
+  } catch (error) {
+    return new Err(
+      new MCPError(normalizeError(error).message) ??
+        "An unknown error occurred while capturing page content."
+    );
+  }
 }

--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -1,9 +1,11 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { clientFetch } from "@app/lib/egress/client";
 import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
+import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { normalizeError } from "@extension/shared/lib/utils";
 import type { CaptureService } from "@extension/shared/services/capture";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 
 // Max characters of extracted text to include inline in the tool result.
 // The full content is also indexed in the conversation JIT data source.
@@ -101,115 +103,83 @@ async function uploadPdf(
  * Registers the get-current-browser-page-view tool with the MCP server.
  * Captures a screenshot or attaches the file content of a browser tab.
  */
-export function registerGetPageViewTool(
-  server: McpServer,
-  captureService: CaptureService | null,
-  workspaceId: string
-): void {
-  server.tool(
-    "get-current-browser-page-view",
-    "Captures or attaches the content of a browser tab. " +
-      "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
-      "For image pages, returns the image directly so you can visually analyze it. " +
-      "For HTML pages, takes a screenshot for visual inspection (Drive canvas, dashboards, etc.)." +
-      "Use list-browser-tabs to discover tab IDs.",
-    {
-      tabId: z
-        .number()
-        .optional()
-        .describe(
-          "The tab ID to capture. If omitted, captures the active tab. Use list-browser-tabs to get tab IDs."
-        ),
-    },
-    async ({ tabId }) => {
-      if (!captureService) {
-        return {
-          content: [{ type: "text", text: "Capture service not available." }],
-        };
+export async function getPageViewTool({
+  tabId,
+  captureService,
+  workspaceId,
+}: {
+  tabId?: number;
+  captureService: CaptureService | null;
+  workspaceId: string;
+}): Promise<ToolHandlerResult> {
+  if (!captureService) {
+    return new Err(new MCPError("Capture service not available."));
+  }
+
+  try {
+    const result = await captureService.handleOperation(
+      "capture-page-content",
+      { includeContent: false, includeCapture: true, tabId }
+    );
+
+    if (result.isErr()) {
+      return new Err(new MCPError(`Error: ${result.error.message}`));
+    }
+
+    const { captures, fileData } = result.value;
+
+    if (fileData) {
+      const { base64, mimeType, url } = fileData;
+
+      if (mimeType === "application/pdf") {
+        const data = await uploadPdf(workspaceId, base64, mimeType, url);
+        if (data) {
+          // The MCP SDK strips non-standard fields from resource objects during
+          // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
+          // so they survive the MCP protocol round-trip. The server will move
+          // them back to the root level in mcp_actions.ts (tryCallMCPTool).
+          const resource = {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+            uri: `/api/w/${workspaceId}/files/${data.fileId}`,
+            text: data.extractedText ?? `PDF from ${url}`,
+            _meta: {
+              fileId: data.fileId,
+              title: data.fileName,
+              contentType: mimeType,
+              snippet: data.extractedText
+                ? data.extractedText.slice(0, 500)
+                : null,
+            },
+          };
+          return new Ok([{ type: "resource" as const, resource }]);
+        }
+        return new Err(
+          new MCPError(
+            "Failed to process the PDF. It may be too large or inaccessible."
+          )
+        );
       }
 
-      try {
-        const result = await captureService.handleOperation(
-          "capture-page-content",
-          { includeContent: false, includeCapture: true, tabId }
-        );
-
-        if (result.isErr()) {
-          return {
-            content: [{ type: "text", text: `Error: ${result.error.message}` }],
-          };
-        }
-
-        const { captures, fileData } = result.value;
-
-        if (fileData) {
-          const { base64, mimeType, url } = fileData;
-
-          if (mimeType === "application/pdf") {
-            const data = await uploadPdf(workspaceId, base64, mimeType, url);
-            if (data) {
-              // The MCP SDK strips non-standard fields from resource objects during
-              // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
-              // so they survive the MCP protocol round-trip. The server will move
-              // them back to the root level in mcp_actions.ts (tryCallMCPTool).
-              const resource = {
-                mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-                uri: `/api/w/${workspaceId}/files/${data.fileId}`,
-                text: data.extractedText ?? `PDF from ${url}`,
-                _meta: {
-                  fileId: data.fileId,
-                  title: data.fileName,
-                  contentType: mimeType,
-                  snippet: data.extractedText
-                    ? data.extractedText.slice(0, 500)
-                    : null,
-                },
-              };
-              return {
-                content: [{ type: "resource" as const, resource }],
-              };
-            }
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: "Failed to process the PDF. It may be too large or inaccessible.",
-                },
-              ],
-            };
-          }
-
-          // For images, return the raw image so the model can analyze it visually.
-          if (mimeType.startsWith("image/")) {
-            return {
-              content: [{ type: "image" as const, data: base64, mimeType }],
-            };
-          }
-        }
-
-        if (!captures || captures.length === 0) {
-          return {
-            content: [{ type: "text", text: "No screenshot captured." }],
-          };
-        }
-
-        return {
-          content: captures.map((dataUrl) => {
-            const [header, data] = dataUrl.split(",");
-            const mimeType = header.replace("data:", "").replace(";base64", "");
-            return { type: "image" as const, data, mimeType };
-          }),
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to capture page: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
+      // For images, return the raw image so the model can analyze it visually.
+      if (mimeType.startsWith("image/")) {
+        return new Ok([{ type: "image" as const, data: base64, mimeType }]);
       }
     }
-  );
+
+    if (!captures || captures.length === 0) {
+      return new Err(new MCPError("No screenshot captured."));
+    }
+
+    return new Ok(
+      captures.map((dataUrl) => {
+        const [header, data] = dataUrl.split(",");
+        const mimeType = header.replace("data:", "").replace(";base64", "");
+        return { type: "image" as const, data, mimeType };
+      })
+    );
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to capture page: ${normalizeError(error).message}`)
+    );
+  }
 }

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -1,7 +1,7 @@
 import { CHROME_TOOLS_METADATA } from "@app/lib/actions/mcp_client_side/metadata";
 import {
-  buildTools,
-  type ToolHandlers,
+  buildClientTools,
+  type ClientToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
 import type { CaptureService } from "@extension/shared/services/capture";
@@ -28,7 +28,7 @@ export function registerAllTools(
   workspaceId: string
 ): void {
   registerInteractWithPageTool(server);
-  const handlers: ToolHandlers<typeof CHROME_TOOLS_METADATA> = {
+  const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
     get_current_browser_page: (params) =>
       getCurrentPageTool({ ...params, captureService }),
     get_current_browser_page_view: (params) =>
@@ -41,7 +41,7 @@ export function registerAllTools(
     reload_browser_tab: (params) => reloadBrowserTabTool(params),
   };
 
-  const tools = buildTools(CHROME_TOOLS_METADATA, handlers);
+  const tools = buildClientTools(CHROME_TOOLS_METADATA, handlers);
 
   for (const tool of tools) {
     server.tool(tool.name, tool.description, tool.schema, async (params) => {

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -1,10 +1,21 @@
-import { registerGetCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
-import { registerGetPageViewTool } from "@extension/platforms/chrome/tools/getPageViewTool";
-import { registerListTabsTool } from "@extension/platforms/chrome/tools/listTabsTool";
-import { registerTabActionTools } from "@extension/platforms/chrome/tools/tabActionTools";
+import { CHROME_TOOLS_METADATA } from "@app/lib/actions/mcp_client_side/metadata";
+import {
+  buildTools,
+  type ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getPageViewTool } from "./getPageViewTool";
 import { registerInteractWithPageTool } from "./interactWithPageTool";
+import { listBrowserTabsTool } from "./listTabsTool";
+import {
+  activateBrowserTabTool,
+  closeBrowserTabTool,
+  moveBrowserTabTool,
+  openBrowserTab,
+  reloadBrowserTabTool,
+} from "./tabActionTools";
 
 /**
  * Registers all Chrome MCP tools with the server
@@ -16,9 +27,35 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  registerListTabsTool(server);
-  registerTabActionTools(server);
-  registerGetCurrentPageTool(server, captureService);
-  registerGetPageViewTool(server, captureService, workspaceId);
   registerInteractWithPageTool(server);
+  const handlers: ToolHandlers<typeof CHROME_TOOLS_METADATA> = {
+    get_current_browser_page: (params) =>
+      getCurrentPageTool({ ...params, captureService }),
+    get_current_browser_page_view: (params) =>
+      getPageViewTool({ ...params, captureService, workspaceId }),
+    list_browser_tabs: () => listBrowserTabsTool(),
+    activate_browser_tab: (params) => activateBrowserTabTool(params),
+    close_browser_tab: (params) => closeBrowserTabTool(params),
+    move_browser_tab: (params) => moveBrowserTabTool(params),
+    open_browser_tab: (params) => openBrowserTab(params),
+    reload_browser_tab: (params) => reloadBrowserTabTool(params),
+  };
+
+  const tools = buildTools(CHROME_TOOLS_METADATA, handlers);
+
+  for (const tool of tools) {
+    server.tool(tool.name, tool.description, tool.schema, async (params) => {
+      const result = await tool.handler(params);
+      if (result.isErr()) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: result.error.message }],
+        };
+      }
+      return {
+        isError: false,
+        content: result.value,
+      };
+    });
+  }
 }

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -3,11 +3,11 @@ import {
   buildClientTools,
   type ClientToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { getCurrentPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
+import { getPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getPageViewTool } from "./getPageViewTool";
-import { registerInteractWithPageTool } from "./interactWithPageTool";
+import { interactWithPageTool } from "./interactWithPageTool";
 import { listBrowserTabsTool } from "./listTabsTool";
 import {
   activateBrowserTabTool,
@@ -27,11 +27,9 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  registerInteractWithPageTool(server);
   const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
-    get_current_browser_page: (params) =>
-      getCurrentPageTool({ ...params, captureService }),
-    get_current_browser_page_view: (params) =>
+    get_browser_page: (params) => getPageTool({ ...params, captureService }),
+    get_browser_page_view: (params) =>
       getPageViewTool({ ...params, captureService, workspaceId }),
     list_browser_tabs: () => listBrowserTabsTool(),
     activate_browser_tab: (params) => activateBrowserTabTool(params),
@@ -39,6 +37,7 @@ export function registerAllTools(
     move_browser_tab: (params) => moveBrowserTabTool(params),
     open_browser_tab: (params) => openBrowserTab(params),
     reload_browser_tab: (params) => reloadBrowserTabTool(params),
+    interact_with_page: (params) => interactWithPageTool(params),
   };
 
   const tools = buildClientTools(CHROME_TOOLS_METADATA, handlers);

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -1,195 +1,127 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { Err, Ok } from "@app/types/shared/result";
 import { sendInteractWithPageMessage } from "@extension/platforms/chrome/messages";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod/v4";
 
-const inputSchema = z.object({
-  action: z
-    .enum(["get_elements", "click_element", "type_text", "delete_text"])
-    .describe("Action to perform."),
-  tab_id: z.number().describe("The ID of the tab to interact with."),
-  element_id: z
-    .string()
-    .nullish()
-    .describe(
-      "ID of the element to interact with. Required for click_element, type_text and delete_text. Must match an element returned by get_elements."
-    ),
-
-  text: z.string().nullish().describe("Text to insert when using type_text."),
-
-  textActionVariant: z
-    .enum(["replace", "append"])
-    .nullish()
-    .describe(
-      "How text should be applied when using type_text: replace existing content or append to it."
-    ),
-});
-
-export function registerInteractWithPageTool(server: McpServer): void {
-  server.tool(
-    "chrome-interact-with-page",
-    `Interact with the webpage the user is currently viewing.
-
-Available actions:
-- get_elements: retrieve the interactive and text elements on the page.
-- click_element: trigger an element's click behavior (e.g., buttons, links, toggles, menu items).
-- type_text: insert text into an editable element.
-- delete_text: deletes the text of an editable element.
-
-Important rules:
-- Use get_elements when you need to see what elements are available.
-- Use click_element for controls like buttons or links.
-- Use type_text for entering text into inputs. Or removing text with the replace option.
-
-type_text automatically focuses the element before typing.
-delete_text automatically focuses the element before deleting the text.
-For the above reasons in most cases you do NOT need to click an element before calling type_text or delete_text.
-Avoid unnecessary actions.`,
-    inputSchema.shape,
-    async (input) => {
-      if (input.action === "type_text") {
-        const elementId = input.element_id;
-        if (!elementId) {
-          return {
-            content: [{ type: "text", text: "No elementId specified" }],
-            isError: true,
-          };
-        }
-        const variant = input.textActionVariant;
-        if (!variant) {
-          return {
-            content: [{ type: "text", text: "No textActionVariant specified" }],
-            isError: true,
-          };
-        }
-
-        const typeResponse = await sendInteractWithPageMessage({
-          action: "type_text",
-          tabId: input.tab_id,
-          elementId,
-          text: input.text ?? "",
-          variant,
-        });
-        if (!typeResponse.success) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `${typeResponse.error ?? "Unexpected error when typing in element"} ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
-              },
-            ],
-            isError: true,
-          };
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Text inserted successfully. ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
-            },
-          ],
-        };
-      }
-
-      if (input.action === "delete_text") {
-        const elementId = input.element_id;
-        if (!elementId) {
-          return {
-            content: [{ type: "text", text: "No elementId specified" }],
-            isError: true,
-          };
-        }
-
-        const typeResponse = await sendInteractWithPageMessage({
-          action: "delete_text",
-          tabId: input.tab_id,
-          elementId,
-        });
-        if (!typeResponse.success) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `${typeResponse.error ?? "Unexpected error when deleting text in element"} ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
-              },
-            ],
-            isError: true,
-          };
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Text deleted successfully. ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
-            },
-          ],
-        };
-      }
-
-      if (input.action === "click_element") {
-        const elementId = input.element_id;
-        if (!elementId) {
-          return {
-            content: [{ type: "text", text: "No elementId specified" }],
-            isError: true,
-          };
-        }
-        const clickResponse = await sendInteractWithPageMessage({
-          action: "click_element",
-          tabId: input.tab_id,
-          elementId,
-        });
-
-        if (!clickResponse.success) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `${clickResponse.error ?? "Unexpected error when clicking element"} ${clickResponse.elementsDiff ? `Elements diff: ${clickResponse.elementsDiff}` : ""}`,
-              },
-            ],
-            isError: true,
-          };
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Button clicked successfully. ${clickResponse.elementsDiff ? `Elements diff: ${clickResponse.elementsDiff}` : ""}`,
-            },
-          ],
-        };
-      }
-
-      const response = await sendInteractWithPageMessage({
-        action: "get_elements",
-        tabId: input.tab_id,
-      });
-
-      if (!response) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "No response received from background script.",
-            },
-          ],
-        };
-      }
-
-      if (response.error) {
-        return {
-          content: [{ type: "text", text: `Error: ${response.error}` }],
-        };
-      }
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: response.elements,
-          },
-        ],
-      };
+export async function interactWithPageTool(input: {
+  action: "get_elements" | "click_element" | "type_text" | "delete_text";
+  tab_id: number;
+  element_id?: string | null;
+  text?: string | null;
+  textActionVariant?: "replace" | "append" | null;
+}): Promise<ToolHandlerResult> {
+  if (input.action === "type_text") {
+    const elementId = input.element_id;
+    if (!elementId) {
+      return new Err(
+        new MCPError("No elementId specified for type_text action")
+      );
     }
-  );
+    const variant = input.textActionVariant;
+    if (!variant) {
+      return new Err(
+        new MCPError("No textActionVariant specified for type_text action")
+      );
+    }
+
+    const typeResponse = await sendInteractWithPageMessage({
+      action: "type_text",
+      tabId: input.tab_id,
+      elementId,
+      text: input.text ?? "",
+      variant,
+    });
+    if (!typeResponse.success) {
+      return new Err(
+        new MCPError(
+          `${typeResponse.error ?? "Unexpected error when typing in element"} ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`
+        )
+      );
+    }
+    return new Ok([
+      {
+        type: "text",
+        text: `Text inserted successfully. ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
+      },
+    ]);
+  }
+
+  if (input.action === "delete_text") {
+    const elementId = input.element_id;
+    if (!elementId) {
+      return new Err(
+        new MCPError("No elementId specified for delete_text action")
+      );
+    }
+
+    const typeResponse = await sendInteractWithPageMessage({
+      action: "delete_text",
+      tabId: input.tab_id,
+      elementId,
+    });
+    if (!typeResponse.success) {
+      return new Err(
+        new MCPError(
+          `${typeResponse.error ?? "Unexpected error when deleting text in element"} ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`
+        )
+      );
+    }
+    return new Ok([
+      {
+        type: "text",
+        text: `Text deleted successfully. ${typeResponse.elementsDiff ? `Elements diff: ${typeResponse.elementsDiff}` : ""}`,
+      },
+    ]);
+  }
+
+  if (input.action === "click_element") {
+    const elementId = input.element_id;
+    if (!elementId) {
+      return new Err(
+        new MCPError("No elementId specified for click_element action")
+      );
+    }
+    const clickResponse = await sendInteractWithPageMessage({
+      action: "click_element",
+      tabId: input.tab_id,
+      elementId,
+    });
+
+    if (!clickResponse.success) {
+      return new Err(
+        new MCPError(
+          `${clickResponse.error ?? "Unexpected error when clicking element"} ${clickResponse.elementsDiff ? `Elements diff: ${clickResponse.elementsDiff}` : ""}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: `Button clicked successfully. ${clickResponse.elementsDiff ? `Elements diff: ${clickResponse.elementsDiff}` : ""}`,
+      },
+    ]);
+  }
+
+  const response = await sendInteractWithPageMessage({
+    action: "get_elements",
+    tabId: input.tab_id,
+  });
+
+  if (!response) {
+    return new Err(
+      new MCPError("No response received from background script.")
+    );
+  }
+
+  if (response.error) {
+    return new Err(new MCPError(`Error: ${response.error}`));
+  }
+
+  return new Ok([
+    {
+      type: "text",
+      text: response.elements,
+    },
+  ]);
 }

--- a/extension/platforms/chrome/tools/listTabsTool.ts
+++ b/extension/platforms/chrome/tools/listTabsTool.ts
@@ -1,45 +1,30 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { Err, Ok } from "@app/types/shared/result";
 import { sendListTabsMessage } from "@extension/platforms/chrome/messages";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { normalizeError } from "@extension/shared/lib/utils";
 
 /**
  * Registers the list-browser-tabs tool with the MCP server.
  * Lists all open tabs in the current browser window.
  */
-export function registerListTabsTool(server: McpServer): void {
-  server.tool(
-    "list-browser-tabs",
-    "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
-      "Use this to discover which tabs the user has open. " +
-      "Tab IDs can be passed to get-current-browser-page or get-current-browser-page-screenshot to read a specific tab.",
-    {},
-    async () => {
-      try {
-        const result = await sendListTabsMessage();
-        const tabs = result.tabs ?? [];
+export async function listBrowserTabsTool(): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendListTabsMessage();
+    const tabs = result.tabs ?? [];
 
-        if (!tabs || tabs.length === 0) {
-          return {
-            content: [{ type: "text", text: "No tabs found." }],
-          };
-        }
-
-        const lines = tabs.map(
-          (t) => `${t.active ? "* " : "  "}[${t.tabId}] ${t.title} — ${t.url}`
-        );
-
-        return {
-          content: [{ type: "text", text: lines.join("\n") }],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to list tabs: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
+    if (!tabs || tabs.length === 0) {
+      return new Err(new MCPError("No tabs found."));
     }
-  );
+
+    const lines = tabs.map(
+      (t) => `${t.active ? "* " : "  "}[${t.tabId}] ${t.title} — ${t.url}`
+    );
+
+    return new Ok([{ type: "text", text: lines.join("\n") }]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to list tabs: ${normalizeError(error).message}`)
+    );
+  }
 }

--- a/extension/platforms/chrome/tools/tabActionTools.ts
+++ b/extension/platforms/chrome/tools/tabActionTools.ts
@@ -1,199 +1,124 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { Err, Ok } from "@app/types/shared/result";
 import { sendTabActionMessage } from "@extension/platforms/chrome/messages";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import { normalizeError } from "@extension/shared/lib/utils";
 
 /**
  * Registers tab manipulation tools with the MCP server.
  */
-export function registerTabActionTools(server: McpServer): void {
-  server.tool(
-    "activate-browser-tab",
-    "Switches to the specified browser tab, making it the active tab. " +
-      "Use list-browser-tabs to discover tab IDs.",
-    {
-      tabId: z.number().describe("The tab ID to activate."),
-    },
-    async ({ tabId }) => {
-      try {
-        const result = await sendTabActionMessage({
-          type: "ACTIVATE_TAB",
-          tabId,
-        });
-        if (!result.success) {
-          return {
-            content: [
-              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
-            ],
-          };
-        }
-        return {
-          content: [{ type: "text", text: `Activated tab ${tabId}.` }],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to activate tab: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
-    }
-  );
 
-  server.tool(
-    "close-browser-tab",
-    "Closes the specified browser tab. Use list-browser-tabs to discover tab IDs.",
-    {
-      tabId: z.number().describe("The tab ID to close."),
-    },
-    async ({ tabId }) => {
-      try {
-        const result = await sendTabActionMessage({
-          type: "CLOSE_TAB",
-          tabId,
-        });
-        if (!result.success) {
-          return {
-            content: [
-              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
-            ],
-          };
-        }
-        return {
-          content: [{ type: "text", text: `Closed tab ${tabId}.` }],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to close tab: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
+export async function activateBrowserTabTool({
+  tabId,
+}: {
+  tabId: number;
+}): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendTabActionMessage({
+      type: "ACTIVATE_TAB",
+      tabId,
+    });
+    if (!result.success) {
+      return new Err(new MCPError(`Error: ${result.error ?? "Unknown"}`));
     }
-  );
+    return new Ok([{ type: "text", text: `Activated tab ${tabId}.` }]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to activate tab: ${normalizeError(error).message}`)
+    );
+  }
+}
 
-  server.tool(
-    "open-browser-tab",
-    "Opens a new browser tab with the specified URL.",
-    {
-      url: z.string().url().describe("The URL to open in a new tab."),
-    },
-    async ({ url }) => {
-      try {
-        const result = await sendTabActionMessage({ type: "OPEN_TAB", url });
-        if (!result.success) {
-          return {
-            content: [
-              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
-            ],
-          };
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Opened new tab${result.tabId ? ` (ID: ${result.tabId})` : ""} with URL: ${url}`,
-            },
-          ],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to open tab: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
+export async function closeBrowserTabTool({
+  tabId,
+}: {
+  tabId: number;
+}): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendTabActionMessage({
+      type: "CLOSE_TAB",
+      tabId,
+    });
+    if (!result.success) {
+      return new Err(new MCPError(`Error: ${result.error ?? "Unknown"}`));
     }
-  );
+    return new Ok([{ type: "text", text: `Closed tab ${tabId}.` }]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to close tab: ${normalizeError(error).message}`)
+    );
+  }
+}
 
-  server.tool(
-    "reload-browser-tab",
-    "Reloads the specified browser tab. Useful after server-side actions that modify page content. " +
-      "Use list-browser-tabs to discover tab IDs.",
-    {
-      tabId: z.number().describe("The tab ID to reload."),
-    },
-    async ({ tabId }) => {
-      try {
-        const result = await sendTabActionMessage({
-          type: "RELOAD_TAB",
-          tabId,
-        });
-        if (!result.success) {
-          return {
-            content: [
-              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
-            ],
-          };
-        }
-        return {
-          content: [{ type: "text", text: `Reloaded tab ${tabId}.` }],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to reload tab: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
+export async function openBrowserTab({
+  url,
+}: {
+  url: string;
+}): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendTabActionMessage({ type: "OPEN_TAB", url });
+    if (!result.success) {
+      return new Err(new MCPError(`Error: ${result.error ?? "Unknown"}`));
     }
-  );
+    return new Ok([
+      {
+        type: "text",
+        text: `Opened new tab${result.tabId ? ` (ID: ${result.tabId})` : ""} with URL: ${url}`,
+      },
+    ]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to open tab: ${normalizeError(error).message}`)
+    );
+  }
+}
 
-  server.tool(
-    "move-browser-tab",
-    "Moves a browser tab to a new position (index) in the tab bar. " +
-      "Use list-browser-tabs to discover tab IDs and current order.",
-    {
-      tabId: z.number().describe("The tab ID to move."),
-      index: z
-        .number()
-        .describe(
-          "The zero-based position to move the tab to. Use -1 to move to the end."
-        ),
-    },
-    async ({ tabId, index }) => {
-      try {
-        const result = await sendTabActionMessage({
-          type: "MOVE_TAB",
-          tabId,
-          index,
-        });
-        if (!result.success) {
-          return {
-            content: [
-              { type: "text", text: `Error: ${result.error ?? "Unknown"}` },
-            ],
-          };
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Moved tab ${tabId} to position ${index}.`,
-            },
-          ],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Failed to move tab: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
-      }
+export async function moveBrowserTabTool({
+  tabId,
+  index,
+}: {
+  tabId: number;
+  index: number;
+}): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendTabActionMessage({
+      type: "MOVE_TAB",
+      tabId,
+      index,
+    });
+    if (!result.success) {
+      return new Err(new MCPError(`Error: ${result.error ?? "Unknown"}`));
     }
-  );
+    return new Ok([
+      {
+        type: "text",
+        text: `Moved tab ${tabId} to position ${index}.`,
+      },
+    ]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to move tab: ${normalizeError(error).message}`)
+    );
+  }
+}
+
+export async function reloadBrowserTabTool({
+  tabId,
+}: {
+  tabId: number;
+}): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendTabActionMessage({
+      type: "RELOAD_TAB",
+      tabId,
+    });
+    if (!result.success) {
+      return new Err(new MCPError(`Error: ${result.error ?? "Unknown"}`));
+    }
+    return new Ok([{ type: "text", text: `Reloaded tab ${tabId}.` }]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to reload tab: ${normalizeError(error).message}`)
+    );
+  }
 }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -7,7 +7,6 @@ import {
 } from "@app/lib/actions/action_output_limits";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
-  DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL,
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
@@ -30,6 +29,7 @@ import {
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
   getAvailabilityOfInternalMCPServerById,
+  getClientSideToolStake,
   getInternalMCPServerNameAndWorkspaceId,
   getInternalMCPServerToolStakes,
   INTERNAL_MCP_SERVERS,
@@ -1042,6 +1042,8 @@ async function listToolsForClientSideMCPServer(
   let allTools: ClientSideMCPToolTypeWithStakeLevel[] = [];
   let nextPageCursor;
 
+  const serverId = getBaseServerId(config.clientSideMcpServerId);
+
   // Fetch all tools, handling pagination if supported by the MCP server.
   do {
     const { tools, nextCursor } = await mcpClient.listTools();
@@ -1052,7 +1054,7 @@ async function listToolsForClientSideMCPServer(
       ...extractMetadataFromTools(tools).map((tool) => ({
         ...tool,
         availability: "manual" as const,
-        stakeLevel: DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL,
+        stakeLevel: getClientSideToolStake(serverId, tool.name),
       })),
     ];
   } while (nextPageCursor);

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -2,11 +2,11 @@ import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { z } from "zod";
 
 export const CHROME_TOOLS_METADATA = createToolsRecord({
-  get_current_browser_page: {
+  get_browser_page: {
     description:
       "Extracts the title, URL, and text content of a browser tab. " +
       "Use this to read and understand what the user is viewing. " +
-      "For non-text pages (PDFs, images, etc.), use get_current_browser_page_view instead — it will attach the file directly to the conversation." +
+      "For non-text pages (PDFs, images, etc.), use get_browser_page_view instead — it will attach the file directly to the conversation." +
       "Use list_browser_tabs to discover tab IDs.",
     schema: {
       tabId: z
@@ -16,13 +16,13 @@ export const CHROME_TOOLS_METADATA = createToolsRecord({
           "The tab ID to read. If omitted, reads the active tab. Use list_browser_tabs to get tab IDs."
         ),
     },
-    stake: "low",
+    stake: "medium",
     displayLabels: {
-      running: "Getting current page content...",
+      running: "Getting page content...",
       done: "Page content retrieved",
     },
   },
-  get_current_browser_page_view: {
+  get_browser_page_view: {
     description:
       "Captures or attaches the content of a browser tab. " +
       "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
@@ -37,17 +37,17 @@ export const CHROME_TOOLS_METADATA = createToolsRecord({
           "The tab ID to capture. If omitted, captures the active tab. Use list_browser_tabs to get tab IDs."
         ),
     },
-    stake: "low",
+    stake: "medium",
     displayLabels: {
-      running: "Capturing screenshot of current page...",
-      done: "Screenshot captured",
+      running: "Attaching tab content...",
+      done: "Tab content attached",
     },
   },
   list_browser_tabs: {
     description:
       "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
       "Use this to discover which tabs the user has open. " +
-      "Tab IDs can be passed to get_current_browser_page or get_current_browser_page_view to read a specific tab.",
+      "Tab IDs can be passed to get_browser_page or get_browser_page_view to read a specific tab.",
     schema: {},
     stake: "low",
     displayLabels: {
@@ -112,7 +112,7 @@ export const CHROME_TOOLS_METADATA = createToolsRecord({
   reload_browser_tab: {
     description:
       "Reloads the specified browser tab. Useful after server-side actions that modify page content. " +
-      "Use list-browser-tabs to discover tab IDs.",
+      "Use list_browser_tabs to discover tab IDs.",
     schema: {
       tabId: z.number().describe("The tab ID to reload."),
     },
@@ -120,6 +120,54 @@ export const CHROME_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Reloading browser tab...",
       done: "Browser tab reloaded",
+    },
+  },
+  interact_with_page: {
+    description: `Interact with a browser tab of the user's browser window.
+
+Available actions:
+- get_elements: retrieve the interactive and text elements on the page.
+- click_element: trigger an element's click behavior (e.g., buttons, links, toggles, menu items).
+- type_text: insert text into an editable element.
+- delete_text: deletes the text of an editable element.
+
+Important rules:
+- Use get_elements when you need to see what elements are available.
+- Use click_element for controls like buttons or links.
+- Use type_text for entering text into inputs. Or removing text with the replace option.
+
+type_text automatically focuses the element before typing.
+delete_text automatically focuses the element before deleting the text.
+For the above reasons in most cases you do NOT need to click an element before calling type_text or delete_text.
+Avoid unnecessary actions.`,
+    schema: z.object({
+      action: z
+        .enum(["get_elements", "click_element", "type_text", "delete_text"])
+        .describe("Action to perform."),
+      tab_id: z.number().describe("The ID of the tab to interact with."),
+      element_id: z
+        .string()
+        .nullish()
+        .describe(
+          "ID of the element to interact with. Required for click_element, type_text and delete_text. Must match an element returned by get_elements."
+        ),
+
+      text: z
+        .string()
+        .nullish()
+        .describe("Text to insert when using type_text."),
+
+      textActionVariant: z
+        .enum(["replace", "append"])
+        .nullish()
+        .describe(
+          "How text should be applied when using type_text: replace existing content or append to it."
+        ),
+    }).shape,
+    stake: "medium",
+    displayLabels: {
+      running: "Interacting with page...",
+      done: "Page interaction completed",
     },
   },
 });

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -1,0 +1,125 @@
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { z } from "zod";
+
+export const CHROME_TOOLS_METADATA = createToolsRecord({
+  get_current_browser_page: {
+    description:
+      "Extracts the title, URL, and text content of a browser tab. " +
+      "Use this to read and understand what the user is viewing. " +
+      "For non-text pages (PDFs, images, etc.), use get_current_browser_page_view instead — it will attach the file directly to the conversation." +
+      "Use list_browser_tabs to discover tab IDs.",
+    schema: {
+      tabId: z
+        .number()
+        .optional()
+        .describe(
+          "The tab ID to read. If omitted, reads the active tab. Use list_browser_tabs to get tab IDs."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Getting current page content...",
+      done: "Page content retrieved",
+    },
+  },
+  get_current_browser_page_view: {
+    description:
+      "Captures or attaches the content of a browser tab. " +
+      "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
+      "For image pages, returns the image directly so you can visually analyze it. " +
+      "For HTML pages, takes a screenshot for visual inspection (Drive canvas, dashboards, etc.)." +
+      "Use list_browser_tabs to discover tab IDs.",
+    schema: {
+      tabId: z
+        .number()
+        .optional()
+        .describe(
+          "The tab ID to capture. If omitted, captures the active tab. Use list_browser_tabs to get tab IDs."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Capturing screenshot of current page...",
+      done: "Screenshot captured",
+    },
+  },
+  list_browser_tabs: {
+    description:
+      "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
+      "Use this to discover which tabs the user has open. " +
+      "Tab IDs can be passed to get_current_browser_page or get_current_browser_page_view to read a specific tab.",
+    schema: {},
+    stake: "low",
+    displayLabels: {
+      running: "Listing browser tabs...",
+      done: "Browser tabs listed",
+    },
+  },
+  activate_browser_tab: {
+    description:
+      "Switches to the specified browser tab, making it the active tab. " +
+      "Use list_browser_tabs to discover tab IDs.",
+    schema: {
+      tabId: z.number().describe("The tab ID to activate."),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Activating browser tab...",
+      done: "Browser tab activated",
+    },
+  },
+  close_browser_tab: {
+    description:
+      "Closes the specified browser tab. Use list_browser_tabs to discover tab IDs.",
+    schema: {
+      tabId: z.number().describe("The tab ID to close."),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Closing browser tab...",
+      done: "Browser tab closed",
+    },
+  },
+  open_browser_tab: {
+    description: "Opens a new browser tab with the specified URL.",
+    schema: {
+      url: z.string().url().describe("The URL to open in a new tab."),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Opening new browser tab...",
+      done: "Browser tab opened",
+    },
+  },
+  move_browser_tab: {
+    description:
+      "Moves a browser tab to a new position (index) in the tab bar. " +
+      "Use list_browser_tabs to discover tab IDs and current order.",
+    schema: {
+      tabId: z.number().describe("The tab ID to move."),
+      index: z
+        .number()
+        .describe(
+          "The zero-based position to move the tab to. Use -1 to move to the end."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Moving browser tab...",
+      done: "Browser tab moved",
+    },
+  },
+  reload_browser_tab: {
+    description:
+      "Reloads the specified browser tab. Useful after server-side actions that modify page content. " +
+      "Use list-browser-tabs to discover tab IDs.",
+    schema: {
+      tabId: z.number().describe("The tab ID to reload."),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Reloading browser tab...",
+      done: "Browser tab reloaded",
+    },
+  },
+});

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,7 +1,13 @@
 import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
-import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL,
+  type MCPToolStakeLevelType,
+  RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
+} from "@app/lib/actions/constants";
+import type {
+  ServerMetadata,
+  ToolMeta,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/agent_management/metadata";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
 import {
@@ -89,6 +95,7 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { CHROME_TOOLS_METADATA } from "../mcp_client_side/metadata";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
 export const USE_SUMMARY_SWITCH = "useSummary";
@@ -1079,6 +1086,16 @@ export const INTERNAL_MCP_SERVERS = {
   [K in InternalMCPServerNameType]: InternalMCPServerEntryBase<K>;
 };
 
+// Hardcoded stakes per client-side server (keyed by base server ID)
+export const CLIENT_SIDE_MCP_TOOL_METADATA: Record<
+  string,
+  Record<string, ToolMeta>
+> = {
+  "mcp-client-side:chrome_extension_client": Object.fromEntries(
+    Object.entries(CHROME_TOOLS_METADATA).map(([name, meta]) => [name, meta])
+  ),
+};
+
 type InternalMCPServerEntryCommon = {
   id: number;
   availability: MCPServerAvailability;
@@ -1253,6 +1270,29 @@ export function getInternalMCPServerToolStakes(
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
 
   return server.metadata.tools_stakes;
+}
+
+export function getClientSideToolStake(
+  serverId: string,
+  toolName: string
+): MCPToolStakeLevelType {
+  const toolStake = CLIENT_SIDE_MCP_TOOL_METADATA[serverId]?.[toolName]?.stake;
+  if (toolStake) {
+    return toolStake;
+  }
+  return DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL;
+}
+
+export function getClientSideToolDisplayLabels(
+  serverId: string,
+  toolName: string
+): ToolDisplayLabels | null {
+  const toolDisplayLabels =
+    CLIENT_SIDE_MCP_TOOL_METADATA[serverId]?.[toolName]?.displayLabels;
+  if (toolDisplayLabels) {
+    return toolDisplayLabels;
+  }
+  return null;
 }
 
 // TODO(2026-01-27 MCP): improve typing once all servers are migrated to the metadata pattern.

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -4,6 +4,7 @@ import {
   type MCPToolStakeLevelType,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
+import { CHROME_TOOLS_METADATA } from "@app/lib/actions/mcp_client_side/metadata";
 import type {
   ServerMetadata,
   ToolMeta,
@@ -95,7 +96,6 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { CHROME_TOOLS_METADATA } from "../mcp_client_side/metadata";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
 export const USE_SUMMARY_SWITCH = "useSummary";

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -33,6 +33,14 @@ export type ToolHandlers<T extends Record<string, { schema: ZodRawShape }>> = {
   ) => Promise<ToolHandlerResult>;
 };
 
+export type ClientToolHandlers<
+  T extends Record<string, { schema: ZodRawShape }>,
+> = {
+  [K in keyof T]: (
+    params: z.infer<z.ZodObject<T[K]["schema"]>>
+  ) => Promise<ToolHandlerResult>;
+};
+
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
@@ -45,7 +53,22 @@ export interface ToolDefinition<
   displayLabels: ToolDisplayLabels;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
-    extra?: ToolHandlerExtra
+    extra: ToolHandlerExtra
+  ) => Promise<ToolHandlerResult>;
+}
+
+interface ClientToolDefinition<
+  TName extends string = string,
+  TSchema extends ZodRawShape = ZodRawShape,
+> {
+  name: TName;
+  enableAlerting?: boolean;
+  description: string;
+  schema: TSchema;
+  stake: MCPToolStakeLevelType;
+  displayLabels: ToolDisplayLabels;
+  handler: (
+    params: z.infer<z.ZodObject<TSchema>>
   ) => Promise<ToolHandlerResult>;
 }
 
@@ -60,6 +83,19 @@ export function createToolsRecord<
   return Object.fromEntries(
     Object.entries(tools).map(([key, value]) => [key, { ...value, name: key }])
   ) as { [K in keyof T]: T[K] & { name: K } };
+}
+
+export function buildClientTools<T extends Record<string, ToolMeta>>(
+  metadata: T,
+  handlers: ClientToolHandlers<T>
+): ClientToolDefinition[] {
+  return (Object.keys(metadata) as (keyof T & string)[]).map(
+    (key) =>
+      ({
+        ...metadata[key],
+        handler: handlers[key],
+      }) as unknown as ClientToolDefinition
+  );
 }
 
 export function buildTools<T extends Record<string, ToolMeta>>(

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -45,7 +45,7 @@ export interface ToolDefinition<
   displayLabels: ToolDisplayLabels;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
-    extra: ToolHandlerExtra
+    extra?: ToolHandlerExtra
   ) => Promise<ToolHandlerResult>;
 }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1,10 +1,11 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
+  getClientSideToolDisplayLabels,
   getInternalMCPServerNameFromSId,
   getInternalMCPServerToolDisplayLabels,
+  type InternalMCPServerNameType,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
@@ -16,7 +17,10 @@ import {
 } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { isFileAuthorizationInfo } from "@app/lib/actions/types";
-import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import {
+  isLightClientSideMCPToolConfiguration,
+  isLightServerSideMCPToolConfiguration,
+} from "@app/lib/actions/types/guards";
 import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -957,10 +961,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       ? (getInternalMCPServerToolDisplayLabels(internalMCPServerName)?.[
           toolName
         ] ?? null)
-      : getDefaultRemoteDisplayLabels(
-          this.toolConfiguration.mcpServerName,
-          toolName
-        );
+      : isLightClientSideMCPToolConfiguration(this.toolConfiguration) &&
+          this.metadata.mcpServerId
+        ? getClientSideToolDisplayLabels(this.metadata.mcpServerId, toolName)
+        : getDefaultRemoteDisplayLabels(
+            this.toolConfiguration.mcpServerName,
+            toolName
+          );
 
     return {
       id: this.id,


### PR DESCRIPTION
## Description

This PR refactors Chrome extension MCP tools to use a centralized metadata configuration with stake level configuration.

- Extracts all Chrome extension tool definitions (get-current-browser-page, get-current-browser-page-view, list-browser-tabs, activate-browser-tab, close-browser-tab, open-browser-tab, move-browser-tab) into a `CHROME_TOOLS_METADATA` object with schemas, descriptions, stake levels, and display labels
- Refactors tool handlers from inline MCP server registrations to standalone exported functions that return `Result<ToolHandlerResult>` for consistency.
- Implements `getClientSideToolStake()` and `getClientSideToolDisplayLabels()` helpers
- Updates the tool registration logic in `index.ts` to use `buildTools()` pattern with centralized metadata and handler mapping
- Sets all Chrome extension tools to "low" stake level (no changes to the stake level for the moment)
- Makes `ToolHandlerExtra` parameter optional in tool handler signatures to use it for chrome extension client-side tools

## Tests

Manually

## Risks

Low - This is a refactoring that maintains the same functionality. The tool behavior remains unchanged.

## Deploy Plan

Standard deployment.
