### PR TITLE
[BYOK] Add POST /provider_credentials endpoint to create LLM API keys

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -3,19 +3,14 @@ import {
   isEntreprisePlanPrefix,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
-import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
-import type {
-  ModelConfigurationType,
-  ModelProviderIdType,
-} from "@app/types/assistant/models/types";
+import {
+  isByokProviderId,
+  isProviderWhitelisted,
+} from "@app/types/assistant/models/providers";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
-
-const BYOK_AVAILABLE_PROVIDER_IDS: ModelProviderIdType[] = [
-  "anthropic",
-  "openai",
-];
 
 export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   return (
@@ -30,7 +25,7 @@ export function isModelAvailable(
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null
 ) {
-  if (plan?.isByok && !BYOK_AVAILABLE_PROVIDER_IDS.includes(m.providerId)) {
+  if (plan?.isByok && !isByokProviderId(m.providerId)) {
     return false;
   }
 

--- a/front/lib/models/provider_credential.ts
+++ b/front/lib/models/provider_credential.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -9,7 +9,7 @@ export class ProviderCredentialModel extends WorkspaceAwareModel<ProviderCredent
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare providerId: ModelProviderIdType;
+  declare providerId: ByokModelProviderIdType;
   declare credentialId: string;
   declare isHealthy: boolean;
   declare placeholder: string;

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -2,7 +2,7 @@ import { ProviderCredentialResource } from "@app/lib/resources/provider_credenti
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
 import { Ok } from "@app/types/shared/result";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetCredentials = vi.fn();
 
@@ -19,6 +19,12 @@ vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
 });
 
 describe("ProviderCredentialResource", () => {
+  beforeEach(() => {
+    mockGetCredentials.mockResolvedValue(
+      new Ok({ credential: { content: { api_key: "sk-test" } } })
+    );
+  });
+
   describe("listByWorkspace", () => {
     it("throws when plan does not have isByok enabled", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
@@ -166,12 +172,7 @@ describe("ProviderCredentialResource", () => {
         ({ credentialsId }: { credentialsId: string }) => {
           if (credentialsId === "cred-openai") {
             return new Ok({
-              credential: {
-                content: {
-                  api_key: "sk-openai-test",
-                  base_url: "https://custom.openai.com",
-                },
-              },
+              credential: { content: { api_key: "sk-openai-test" } },
             });
           }
           if (credentialsId === "cred-anthropic") {
@@ -188,9 +189,7 @@ describe("ProviderCredentialResource", () => {
 
       expect(result).toEqual({
         OPENAI_API_KEY: "sk-openai-test",
-        OPENAI_BASE_URL: "https://custom.openai.com",
         ANTHROPIC_API_KEY: "sk-anthropic-test",
-        OPENAI_USE_EU_ENDPOINT: "false",
       });
     });
 

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -25,7 +25,7 @@ describe("ProviderCredentialResource", () => {
 
       await expect(
         ProviderCredentialResource.listByWorkspace(authenticator)
-      ).rejects.toThrow("BYOK is not enabled");
+      ).rejects.toThrow("BYOK must be enabled");
     });
 
     it("returns empty array when no credentials exist", async () => {
@@ -34,10 +34,10 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
 
-      const credentials =
+      const result =
         await ProviderCredentialResource.listByWorkspace(authenticator);
 
-      expect(credentials).toEqual([]);
+      expect(result).toEqual([]);
     });
 
     it("returns all credentials for the workspace", async () => {
@@ -50,11 +50,11 @@ describe("ProviderCredentialResource", () => {
       await ProviderCredentialFactory.basic(workspace, "openai");
       await ProviderCredentialFactory.basic(workspace, "anthropic");
 
-      const credentials =
+      const result =
         await ProviderCredentialResource.listByWorkspace(authenticator);
 
-      expect(credentials).toHaveLength(2);
-      expect(credentials.map((c) => c.providerId).sort()).toEqual([
+      expect(result).toHaveLength(2);
+      expect(result.map((c) => c.providerId).sort()).toEqual([
         "anthropic",
         "openai",
       ]);
@@ -70,9 +70,10 @@ describe("ProviderCredentialResource", () => {
       const workspace = authenticator.getNonNullableWorkspace();
       await ProviderCredentialFactory.basic(workspace, "openai");
 
-      const [credential] =
+      const result =
         await ProviderCredentialResource.listByWorkspace(authenticator);
 
+      const [credential] = result;
       const json = credential.toJSON();
 
       expect(json.sId).toMatch(/^pcr_/);
@@ -96,8 +97,10 @@ describe("ProviderCredentialResource", () => {
 
       await ProviderCredentialFactory.basic(workspace, "openai");
 
-      const [credential] =
+      const result =
         await ProviderCredentialResource.listByWorkspace(authenticator);
+
+      const [credential] = result;
       await credential.delete(authenticator);
 
       const remaining =
@@ -129,10 +132,10 @@ describe("ProviderCredentialResource", () => {
     it("returns Dust-managed LLM credentials for non-BYOK workspaces", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 
-      const credentials =
+      const result =
         await ProviderCredentialResource.getCredentials(authenticator);
 
-      expect(credentials).toEqual({
+      expect(result).toEqual({
         ANTHROPIC_API_KEY: "",
         AZURE_OPENAI_API_KEY: "",
         AZURE_OPENAI_ENDPOINT: "",
@@ -180,10 +183,10 @@ describe("ProviderCredentialResource", () => {
         }
       );
 
-      const credentials =
+      const result =
         await ProviderCredentialResource.getCredentials(authenticator);
 
-      expect(credentials).toEqual({
+      expect(result).toEqual({
         OPENAI_API_KEY: "sk-openai-test",
         OPENAI_BASE_URL: "https://custom.openai.com",
         ANTHROPIC_API_KEY: "sk-anthropic-test",
@@ -197,10 +200,10 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
 
-      const credentials =
+      const result =
         await ProviderCredentialResource.getCredentials(authenticator);
 
-      expect(credentials).toEqual({});
+      expect(result).toEqual({});
     });
 
     it("throws when OAuth fetch fails for a provider", async () => {

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -85,7 +85,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     model: ProviderCredentialModel
   ): Promise<ProviderCredentialResource> {
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-    const { providerId, id, credentialId } = model;
+    const { providerId, credentialId } = model;
     const credentialRes = await oauthApi.getCredentials({
       credentialsId: credentialId,
     });
@@ -98,10 +98,10 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
           error: credentialRes.error,
           workspaceId: model.workspaceId,
         },
-        `Failed to fetch credentials for provider credential with id ${id} from OAuth API : ${credentialRes.error.message}`
+        `Failed to fetch OAuth credentials for provider ${providerId}`
       );
       throw new Error(
-        `Failed to fetch credentials for provider credential with id ${id} from OAuth API: ${credentialRes.error.message}`
+        `Failed to fetch OAuth credentials for provider ${providerId}`
       );
     }
 
@@ -289,7 +289,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
 function mapOauthCredentialsToLlmCredentials(
   oauthCredentials: {
     providerId: ByokModelProviderIdType;
-    content: { api_key: string };
+    content: z.infer<typeof ApiKeyCredentialContentSchema>;
   }[]
 ): LLMCredentialsType {
   const result: LLMCredentialsType = {};

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -1,3 +1,4 @@
+import Anthropic from "@anthropic-ai/sdk";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialModel } from "@app/lib/models/provider_credential";
@@ -7,12 +8,14 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
-import type { ConnectionCredentials } from "@app/types/oauth/lib";
-import { OAuthAPI } from "@app/types/oauth/oauth_api";
-import type { LLMCredentialsType } from "@app/types/provider_credential";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import {
-  PROVIDER_CREDENTIAL_CONTENT_SCHEMAS,
+  type ModelProviderPostCredentialsBody,
+  OAuthAPI,
+} from "@app/types/oauth/oauth_api";
+import {
+  ApiKeyCredentialContentSchema,
+  type LLMCredentialsType,
   PROVIDER_TO_CREDENTIAL_KEY,
   type ProviderCredentialType,
 } from "@app/types/provider_credential";
@@ -21,8 +24,11 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { redactString } from "@app/types/shared/utils/string_utils";
 import assert from "assert";
+import OpenAI from "openai";
 import type { Attributes, ModelStatic } from "sequelize";
+import type { z } from "zod";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -32,11 +38,15 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   static model: ModelStaticWorkspaceAware<ProviderCredentialModel> =
     ProviderCredentialModel;
 
+  private credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+
   constructor(
     model: ModelStatic<ProviderCredentialModel>,
-    blob: Attributes<ProviderCredentialModel>
+    blob: Attributes<ProviderCredentialModel>,
+    credentials: z.infer<typeof ApiKeyCredentialContentSchema>
   ) {
     super(ProviderCredentialModel, blob);
+    this.credentials = credentials;
   }
 
   get sId(): string {
@@ -46,6 +56,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     });
   }
 
+  // TODO (BYOK): Move out of resource
   private static get dustManagedLLMCredentials(): LLMCredentialsType {
     const env = (key: string) =>
       EnvironmentConfig.getOptionalEnvVariable(key) ?? "";
@@ -68,11 +79,46 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     };
   }
 
+  private static async makeNewFromModel(
+    model: ProviderCredentialModel
+  ): Promise<ProviderCredentialResource> {
+    const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const { providerId, id, credentialId } = model;
+    const credentialRes = await oauthApi.getCredentials({
+      credentialsId: credentialId,
+    });
+
+    if (credentialRes.isErr()) {
+      logger.error(
+        {
+          providerId,
+          credentialId,
+          error: credentialRes.error,
+          workspaceId: model.workspaceId,
+        },
+        `Failed to fetch credentials for provider credential with id ${id} from OAuth API : ${credentialRes.error.message}`
+      );
+      throw new Error(
+        `Failed to fetch credentials for provider credential with id ${id} from OAuth API: ${credentialRes.error.message}`
+      );
+    }
+
+    const credentials = ApiKeyCredentialContentSchema.parse(
+      credentialRes.value.credential.content
+    );
+    return new ProviderCredentialResource(
+      ProviderCredentialModel,
+      model.get(),
+      credentials
+    );
+  }
+
+  // TODO (BYOK): cache this method
   private static async baseFetch(
     auth: Authenticator
   ): Promise<ProviderCredentialResource[]> {
     const plan = auth.getNonNullablePlan();
-    assert(plan.isByok, "BYOK is not enabled on this workspace's plan.");
+    assert(plan.isByok, "BYOK must be enabled to fetch provider credentials.");
 
     const workspace = auth.getNonNullableWorkspace();
 
@@ -80,8 +126,85 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       where: { workspaceId: workspace.id },
     });
 
-    return models.map(
-      (m) => new ProviderCredentialResource(ProviderCredentialModel, m.get())
+    const resources = await concurrentExecutor(models, this.makeNewFromModel, {
+      concurrency: 8,
+    });
+
+    return resources;
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      providerId,
+      apiKey,
+    }: {
+      providerId: ByokModelProviderIdType;
+      apiKey: string;
+    }
+  ): Promise<ProviderCredentialResource | null> {
+    assert(auth.isAdmin(), "Only admins can create provider credentials.");
+    assert(
+      auth.getNonNullablePlan().isByok,
+      "BYOK must be enabled to create provider credentials."
+    );
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const isHealthy = await isCredentialHealthy({
+      provider: providerId,
+      credentials: { api_key: apiKey },
+    });
+
+    if (!isHealthy) {
+      logger.warn(
+        {
+          providerId,
+          workspaceId: workspace.sId,
+        },
+        `Provided credentials for provider ${providerId} are not healthy.`
+      );
+
+      return null;
+    }
+
+    const oauthClient = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+    const oauthRes = await oauthClient.postCredentials({
+      provider: providerId,
+      workspaceId: workspace.sId,
+      userId: user.sId,
+      credentials: { api_key: apiKey },
+    });
+
+    if (oauthRes.isErr()) {
+      logger.error(
+        {
+          providerId,
+          error: oauthRes.error,
+          workspaceId: workspace.sId,
+        },
+        `Failed to post credentials to OAuth API : ${oauthRes.error.message}`
+      );
+      return null;
+    }
+
+    const model = await this.model.create({
+      workspaceId: workspace.id,
+      providerId,
+      credentialId: oauthRes.value.credential.credential_id,
+      isHealthy: true,
+      // TODO(BYOK): remove after obfuscation has been implemented
+      placeholder: "",
+      editedByUserId: user.id,
+    });
+
+    return new ProviderCredentialResource(
+      ProviderCredentialModel,
+      model.get(),
+      // TODO (BYOK): handle different credential content shapes for different providers
+      { api_key: apiKey }
     );
   }
 
@@ -91,6 +214,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     return this.baseFetch(auth);
   }
 
+  // TODO (BYOK): move out of resource
   static async getCredentials(
     auth: Authenticator
   ): Promise<LLMCredentialsType> {
@@ -102,30 +226,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
 
     const providerCredentials = await this.baseFetch(auth);
 
-    const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-
-    const oauthCredentials = await concurrentExecutor(
-      providerCredentials,
-      async (cred) => {
-        const credentialRes = await oauthApi.getCredentials({
-          credentialsId: cred.credentialId,
-        });
-
-        if (credentialRes.isErr()) {
-          throw new Error(
-            `Failed to fetch OAuth credentials for provider ${cred.providerId}: ${credentialRes.error.message}`
-          );
-        }
-
-        return {
-          providerId: cred.providerId,
-          content: credentialRes.value.credential.content,
-        };
-      },
-      { concurrency: 8 }
+    return mapOauthCredentialsToLlmCredentials(
+      providerCredentials.map((cred) => ({
+        providerId: cred.providerId,
+        content: cred.credentials,
+      }))
     );
-
-    return mapOauthCredentialsToLlmCredentials(oauthCredentials);
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
@@ -154,6 +260,15 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   }
 
   toJSON(): ProviderCredentialType {
+    const timeDifference = Math.abs(
+      new Date().getTime() - new Date(this.updatedAt).getTime()
+    );
+    const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
+    const apiKey =
+      differenceInMinutes > 5
+        ? redactString(this.credentials.api_key, 4)
+        : this.credentials.api_key;
+
     return {
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
@@ -163,45 +278,28 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       isHealthy: this.isHealthy,
       placeholder: this.placeholder,
       editedByUserId: this.editedByUserId,
+      credentials: { api_key: apiKey },
     };
   }
 }
 
+// TODO (BYOK): Move out of resource
 function mapOauthCredentialsToLlmCredentials(
   oauthCredentials: {
-    providerId: ModelProviderIdType;
-    content: ConnectionCredentials;
+    providerId: ByokModelProviderIdType;
+    content: { api_key: string };
   }[]
 ): LLMCredentialsType {
   const result: LLMCredentialsType = {};
 
   for (const { providerId, content } of oauthCredentials) {
-    if (providerId === "noop") {
-      continue;
-    }
-
     switch (providerId) {
       case "openai": {
-        const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
-        const parsedContent = schema.parse(content);
-
-        result.OPENAI_API_KEY = parsedContent.api_key;
-        result.OPENAI_BASE_URL = parsedContent.base_url;
-        result.OPENAI_USE_EU_ENDPOINT =
-          config.getRegion() === "europe-west1" ? "true" : "false";
+        result.OPENAI_API_KEY = content.api_key;
         break;
       }
-      case "anthropic":
-      case "mistral":
-      case "google_ai_studio":
-      case "deepseek":
-      case "fireworks":
-      case "xai":
-      case "togetherai": {
-        const schema = PROVIDER_CREDENTIAL_CONTENT_SCHEMAS[providerId];
-        const parsedContent = schema.parse(content);
-
-        result[PROVIDER_TO_CREDENTIAL_KEY[providerId]] = parsedContent.api_key;
+      case "anthropic": {
+        result[PROVIDER_TO_CREDENTIAL_KEY[providerId]] = content.api_key;
         break;
       }
       default:
@@ -210,4 +308,43 @@ function mapOauthCredentialsToLlmCredentials(
   }
 
   return result;
+}
+
+async function isCredentialHealthy({
+  provider,
+  credentials,
+}: ModelProviderPostCredentialsBody): Promise<boolean> {
+  switch (provider) {
+    case "anthropic": {
+      const client = new Anthropic({
+        apiKey: credentials.api_key,
+      });
+      try {
+        await client.models.list();
+      } catch (_error) {
+        return false;
+      }
+
+      return true;
+    }
+    case "openai": {
+      const client = new OpenAI({
+        apiKey: credentials.api_key,
+        defaultHeaders: {
+          "Content-Type": "application/json; charset=utf-8",
+          Accept: "application/json; charset=utf-8",
+        },
+      });
+
+      try {
+        await client.models.list();
+      } catch (_error) {
+        return false;
+      }
+
+      return true;
+    }
+    default:
+      assertNever(provider);
+  }
 }

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -30,6 +30,8 @@ import OpenAI from "openai";
 import type { Attributes, ModelStatic } from "sequelize";
 import type { z } from "zod";
 
+const API_KEY_REVEAL_WINDOW_MINUTES = 5;
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 export interface ProviderCredentialResource
@@ -265,7 +267,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     );
     const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
     const apiKey =
-      differenceInMinutes > 5
+      differenceInMinutes > API_KEY_REVEAL_WINDOW_MINUTES
         ? redactString(this.credentials.api_key, 4)
         : this.credentials.api_key;
 

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -1,0 +1,105 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { apiError } from "@app/logger/withlogging";
+import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ProviderCredentialType } from "@app/types/provider_credential";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const PostProviderCredentialBodySchema = z.object({
+  providerId: z.enum(BYOK_MODEL_PROVIDER_IDS),
+  apiKey: z.string(),
+});
+
+export type PostProviderCredentialBody = z.infer<
+  typeof PostProviderCredentialBodySchema
+>;
+
+export type PostProviderCredentialResponseBody = {
+  providerCredential: ProviderCredentialType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostProviderCredentialResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can manage provider credentials.",
+      },
+    });
+  }
+
+  const plan = auth.getNonNullablePlan();
+  if (!plan.isByok) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "BYOK is not enabled on this workspace's plan.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostProviderCredentialBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${bodyValidation.error.message}.`,
+          },
+        });
+      }
+
+      const { providerId, apiKey } = bodyValidation.data;
+
+      const providerCredential = await ProviderCredentialResource.makeNew(
+        auth,
+        {
+          providerId,
+          apiKey,
+        }
+      );
+
+      if (!providerCredential) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The provided credentials are invalid or could not be verified.",
+          },
+        });
+      }
+
+      return res.status(201).json({
+        providerCredential: providerCredential.toJSON(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/tests/utils/ProviderCredentialFactory.ts
+++ b/front/tests/utils/ProviderCredentialFactory.ts
@@ -1,11 +1,11 @@
 import { ProviderCredentialModel } from "@app/lib/models/provider_credential";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export class ProviderCredentialFactory {
   static async basic(
     workspace: LightWorkspaceType,
-    providerId: ModelProviderIdType = "openai"
+    providerId: ByokModelProviderIdType = "openai"
   ) {
     return ProviderCredentialModel.create({
       workspaceId: workspace.id,

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -1,4 +1,7 @@
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type {
+  ByokModelProviderIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import { ioTsEnum } from "@app/types/shared/utils/iots_utils";
 
 import type { WorkspaceType } from "../../user";
@@ -18,6 +21,11 @@ export const MODEL_PROVIDER_IDS = [
   "xai",
   "noop",
 ] as const;
+
+export const BYOK_MODEL_PROVIDER_IDS = [
+  "anthropic",
+  "openai",
+] as const satisfies ModelProviderIdType[];
 
 export function getProviderDisplayName(
   providerId: ModelProviderIdType
@@ -62,3 +70,8 @@ export function isProviderWhitelisted(
   const whiteListedProviders = owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
   return whiteListedProviders.includes(providerId);
 }
+
+export const isByokProviderId = (
+  providerId: ModelProviderIdType
+): providerId is ByokModelProviderIdType =>
+  BYOK_MODEL_PROVIDER_IDS.includes(providerId as ByokModelProviderIdType);

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -6,11 +6,12 @@ import type { TokenizerConfig } from "../../tokenizer";
 import type { AgentReasoningEffort } from "../agent";
 import type { EMBEDDING_PROVIDER_IDS } from "./embedding";
 import type { MODEL_IDS, SUPPORTED_MODEL_CONFIGS } from "./models";
-import type { MODEL_PROVIDER_IDS } from "./providers";
+import type { BYOK_MODEL_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "./providers";
 import type { REASONING_EFFORTS } from "./reasoning";
 
 export type ModelIdType = (typeof MODEL_IDS)[number];
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
+export type ByokModelProviderIdType = (typeof BYOK_MODEL_PROVIDER_IDS)[number];
 
 export const CUSTOM_THINKING_TYPES = ["auto", "enabled"] as const;
 export type CustomThinkingType = (typeof CUSTOM_THINKING_TYPES)[number];

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -1,6 +1,9 @@
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ApiKeyCredentialContentSchema } from "@app/types/provider_credential";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
 import * as t from "io-ts";
+import type z from "zod";
 
 // Extra config type for OAuth setup - generic key-value pairs for provider-specific config
 export const ExtraConfigTypeSchema = t.record(t.string, t.string);
@@ -777,10 +780,23 @@ export function isModjoCredentials(
   return "api_key" in credentials;
 }
 
-export type OauthAPIPostCredentialsResponse = {
+export type ModelProviderPostCredentialsBody = {
+  provider: ByokModelProviderIdType;
+  credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+};
+
+export type OauthAPIPostConnectionCredentialsResponse = {
   credential: {
     credential_id: string;
     provider: CredentialsProvider;
+    created: number;
+  };
+};
+
+export type OauthAPIPostModelProviderCredentialsResponse = {
+  credential: {
+    credential_id: string;
+    provider: ByokModelProviderIdType;
     created: number;
   };
 };

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -1,10 +1,14 @@
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ApiKeyCredentialContentSchema } from "@app/types/provider_credential";
+import type { z } from "zod";
 import type {
   ConnectionCredentials,
   CredentialsProvider,
   OAuthConnectionType,
   OAuthProvider,
   OauthAPIGetCredentialsResponse,
-  OauthAPIPostCredentialsResponse,
+  OauthAPIPostConnectionCredentialsResponse,
+  OauthAPIPostModelProviderCredentialsResponse,
 } from "../oauth/lib";
 import type { LoggerInterface } from "../shared/logger";
 import type { Result } from "../shared/result";
@@ -36,6 +40,16 @@ export function isOAuthAPIError(obj: unknown): obj is OAuthAPIError {
 }
 
 export type OAuthAPIResponse<T> = Result<T, OAuthAPIError>;
+
+type CrendentialsMetadata = {
+  userId: string;
+  workspaceId: string;
+};
+
+export type ModelProviderPostCredentialsBody = {
+  provider: ByokModelProviderIdType;
+  credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+};
 
 export class OAuthAPI {
   _logger: LoggerInterface;
@@ -168,12 +182,33 @@ export class OAuthAPI {
     userId,
     workspaceId,
     credentials,
-  }: {
+  }: CrendentialsMetadata & {
     provider: CredentialsProvider;
-    userId: string;
-    workspaceId: string;
     credentials: ConnectionCredentials;
-  }): Promise<OAuthAPIResponse<OauthAPIPostCredentialsResponse>> {
+  }): Promise<OAuthAPIResponse<OauthAPIPostConnectionCredentialsResponse>>;
+  async postCredentials({
+    provider,
+    userId,
+    workspaceId,
+    credentials,
+  }: CrendentialsMetadata & ModelProviderPostCredentialsBody): Promise<
+    OAuthAPIResponse<OauthAPIPostModelProviderCredentialsResponse>
+  >;
+  async postCredentials({
+    provider,
+    userId,
+    workspaceId,
+    credentials,
+  }: CrendentialsMetadata &
+    (
+      | { provider: CredentialsProvider; credentials: ConnectionCredentials }
+      | ModelProviderPostCredentialsBody
+    )): Promise<
+    OAuthAPIResponse<
+      | OauthAPIPostConnectionCredentialsResponse
+      | OauthAPIPostModelProviderCredentialsResponse
+    >
+  > {
     const response = await this._fetchWithError(`${this._url}/credentials`, {
       method: "POST",
       headers: {

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -35,11 +35,6 @@ export const ApiKeyCredentialContentSchema = z.object({
   api_key: z.string(),
 });
 
-export const OpenAICredentialContentSchema =
-  ApiKeyCredentialContentSchema.extend({
-    base_url: z.string().optional(),
-  });
-
 export const PROVIDER_TO_CREDENTIAL_KEY = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { z } from "zod";
 
@@ -23,14 +23,15 @@ export type ProviderCredentialType = {
   sId: string;
   createdAt: number;
   updatedAt: number;
-  providerId: ModelProviderIdType;
+  providerId: ByokModelProviderIdType;
+  credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
   credentialId: string;
   isHealthy: boolean;
   placeholder: string;
   editedByUserId: ModelId | null;
 };
 
-const ApiKeyCredentialContentSchema = z.object({
+export const ApiKeyCredentialContentSchema = z.object({
   api_key: z.string(),
 });
 
@@ -39,30 +40,7 @@ export const OpenAICredentialContentSchema =
     base_url: z.string().optional(),
   });
 
-export const PROVIDER_CREDENTIAL_CONTENT_SCHEMAS = {
-  openai: OpenAICredentialContentSchema,
-  anthropic: ApiKeyCredentialContentSchema,
-  mistral: ApiKeyCredentialContentSchema,
-  google_ai_studio: ApiKeyCredentialContentSchema,
-  deepseek: ApiKeyCredentialContentSchema,
-  fireworks: ApiKeyCredentialContentSchema,
-  xai: ApiKeyCredentialContentSchema,
-  togetherai: ApiKeyCredentialContentSchema,
-} as const satisfies Record<
-  Exclude<ModelProviderIdType, "noop">,
-  typeof ApiKeyCredentialContentSchema
->;
-
 export const PROVIDER_TO_CREDENTIAL_KEY = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
-  mistral: "MISTRAL_API_KEY",
-  google_ai_studio: "GOOGLE_AI_STUDIO_API_KEY",
-  deepseek: "DEEPSEEK_API_KEY",
-  fireworks: "FIREWORKS_API_KEY",
-  xai: "XAI_API_KEY",
-  togetherai: "TOGETHERAI_API_KEY",
-} as const satisfies Record<
-  Exclude<ModelProviderIdType, "noop">,
-  keyof LLMCredentialsType
->;
+} as const satisfies Record<ByokModelProviderIdType, keyof LLMCredentialsType>;


### PR DESCRIPTION
## Description

Adds a `POST /api/w/[wId]/provider_credentials` endpoint (admin-only) that lets workspaces on a BYOK plan register their own Anthropic or OpenAI API keys. The key is validated against the live provider API before being stored via OAuthAPI, and only a masked placeholder is persisted in Dust's DB.

Also refactors `ProviderCredentialResource` methods to return `Result<T, Error>` instead of throwing, and centralises BYOK provider identity into a shared `isByokProviderId` type guard (removing a duplicated local list in `assistant.ts`).

## Tests

Unit tests updated to assert on `Result` return values; credential health check (live provider API call) is not yet covered by automated tests — tested manually with real Anthropic and OpenAI keys.

## Risk

Low. New endpoint is gated behind `plan.isByok` and admin role checks. The `Result`-based refactor is a mechanical change with full test coverage. The live health check adds an external call on credential creation but does not affect existing read paths.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
