### PR TITLE
[front] fix: display correct skills for each version on Poke agent page

### DIFF
--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -65,8 +65,13 @@ export function AssistantDetailsPage() {
     );
   }
 
-  const { agentConfigurations, authors, lastVersionEditors, spaces, skills } =
-    agentDetails;
+  const {
+    agentConfigurations,
+    authors,
+    lastVersionEditors,
+    spaces,
+    skillsByVersion,
+  } = agentDetails;
 
   return (
     <div>
@@ -159,6 +164,7 @@ export function AssistantDetailsPage() {
                 const author = authors.find(
                   (user) => user.id === a.versionAuthorId
                 );
+                const versionSkills = skillsByVersion[a.version] ?? [];
                 return (
                   <ContextItem
                     key={a.version}
@@ -220,10 +226,10 @@ export function AssistantDetailsPage() {
                         </div>
                         <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
                           <div className="font-bold">Skills:</div>
-                          {skills.length === 0 ? (
+                          {versionSkills.length === 0 ? (
                             <div>No skills</div>
                           ) : (
-                            skills.map((skill) => (
+                            versionSkills.map((skill) => (
                               <div key={skill.sId}>
                                 <div className="flex items-center gap-1">
                                   {skill.name}

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -848,6 +848,77 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
+   * Batched version of listByAgentConfiguration. Performs 2 SQL queries.
+   * Does not support global agents as we rely on the ID for mapping.
+   */
+  static async listByAgentConfigurations(
+    auth: Authenticator,
+    agentConfigurations: AgentConfigurationType[]
+  ): Promise<
+    { agentConfiguration: AgentConfigurationType; skill: SkillResource }[]
+  > {
+    assert(
+      agentConfigurations.every((c) => !isGlobalAgentId(c.sId)),
+      "Global agents are not supported"
+    );
+
+    if (agentConfigurations.length === 0) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    // Fetch all agent-skill relationships for the given agents.
+    const agentSkills = await AgentSkillModel.findAll({
+      where: {
+        agentConfigurationId: agentConfigurations.map((c) => c.id),
+        workspaceId: workspace.id,
+      },
+    });
+
+    // Fetch all unique skills in one batch.
+    const allSkills = await this.fetchBySkillReferences(
+      auth,
+      agentSkills.map((s) => ({
+        customSkillId: s.customSkillId,
+        globalSkillId: s.globalSkillId,
+      }))
+    );
+
+    const skillByCustomId = new Map<ModelId, SkillResource>();
+    const skillByGlobalId = new Map<string, SkillResource>();
+    for (const skill of allSkills) {
+      if (skill.globalSId) {
+        skillByGlobalId.set(skill.globalSId, skill);
+      } else {
+        skillByCustomId.set(skill.id, skill);
+      }
+    }
+
+    // Map skills back to each config.
+    const configById = new Map(agentConfigurations.map((c) => [c.id, c]));
+    return removeNulls(
+      Object.entries(
+        groupBy(agentSkills, (s) => s.agentConfigurationId)
+      ).flatMap(([configId, refs]) => {
+        const agentConfiguration = configById.get(parseInt(configId, 10));
+        if (!agentConfiguration) {
+          return [];
+        }
+        return refs.map((ref) => {
+          if (ref.globalSkillId) {
+            const skill = skillByGlobalId.get(ref.globalSkillId);
+            return skill ? { agentConfiguration, skill } : null;
+          } else if (ref.customSkillId) {
+            const skill = skillByCustomId.get(ref.customSkillId);
+            return skill ? { agentConfiguration, skill } : null;
+          }
+        });
+      })
+    );
+  }
+
+  /**
    * Returns skill references for an agent configuration.
    * For global agents, returns references from the config's skills field.
    * For non-global agents, queries the database.

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -19,7 +19,7 @@ export type PokeGetAgentDetails = {
   authors: UserType[];
   lastVersionEditors: UserType[];
   spaces: SpaceType[];
-  skills: SkillType[];
+  skillsByVersion: Record<number, SkillType[]>;
 };
 
 async function handler(
@@ -77,17 +77,25 @@ async function handler(
       );
       const authors = await getAuthors(agentConfigurations);
 
-      const skillResources = await SkillResource.listByAgentConfiguration(
+      const allSkills = await SkillResource.listByAgentConfigurations(
         auth,
-        latestAgentConfiguration
+        agentConfigurations
       );
+
+      const skillsByVersion: Record<number, SkillType[]> = {};
+      for (const config of agentConfigurations) {
+        skillsByVersion[config.version] = [];
+      }
+      for (const { agentConfiguration, skill } of allSkills) {
+        skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
+      }
 
       return res.status(200).json({
         agentConfigurations,
         authors,
         lastVersionEditors,
         spaces: spaces.map((s) => s.toJSON()),
-        skills: skillResources.map((s) => s.toJSON(auth)),
+        skillsByVersion,
       });
 
     default:


### PR DESCRIPTION
## Description

- This PR fixes the poke page for an agent to correctly display the list of skills for each version.
- This page used to show the skills for the latest version on all versions.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
