### PR TITLE
Use batch calls to LLM API in reinforced agents

### DIFF
--- a/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
+++ b/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
@@ -9,9 +9,16 @@ export const runReinforcedAgentPlugin = createPlugin({
     description:
       "Analyze recent conversations for this agent and suggest improvements to its configuration",
     resourceTypes: ["agents"],
-    args: {},
+    args: {
+      useBatchMode: {
+        type: "boolean",
+        label: "Use batch mode",
+        description:
+          "Process conversations via batch LLM API (slower but cheaper). Uncheck to use streaming (faster but more expensive).",
+      },
+    },
   },
-  execute: async (auth, resource) => {
+  execute: async (auth, resource, args) => {
     if (!resource) {
       return new Err(new Error("Agent configuration not found"));
     }
@@ -21,6 +28,7 @@ export const runReinforcedAgentPlugin = createPlugin({
     const result = await startReinforcedAgentForAgentWorkflow({
       workspaceId: workspace.sId,
       agentConfigurationId: resource.sId,
+      useBatchMode: args.useBatchMode,
     });
 
     if (result.isErr()) {

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -1,6 +1,10 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import { runReinforcedAnalysis } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import {
+  buildReinforcedLLMParams,
+  runReinforcedAnalysis,
+} from "@app/lib/reinforced_agent/run_reinforced_analysis";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import logger from "@app/logger/logger";
 import type { AgentInstructionsSuggestionType } from "@app/types/suggestions/agent_suggestion";
@@ -36,6 +40,51 @@ You MUST call the tool. If no suggestions survive aggregation, return an empty s
 ${suggestionsSection}`;
 
   return { systemPrompt, userMessage };
+}
+
+/**
+ * Build the batch map for aggregation.
+ * Returns null if there are no pending synthetic suggestions or the agent is not found.
+ */
+export async function buildAggregationBatchMap(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<Map<string, LLMStreamParameters> | null> {
+  const syntheticSuggestions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { sources: ["synthetic"], states: ["pending"] }
+    );
+
+  if (syntheticSuggestions.length === 0) {
+    return null;
+  }
+
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "light",
+  });
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId },
+      "ReinforcedAgent: agent not found for aggregation batch"
+    );
+    return null;
+  }
+
+  const instructionsSuggestions = syntheticSuggestions
+    .map((s) => s.toJSON())
+    .filter(
+      (json): json is AgentInstructionsSuggestionType =>
+        json.kind === "instructions"
+    );
+
+  const prompt = buildAggregationPrompt(
+    agentConfig.name,
+    instructionsSuggestions
+  );
+  return new Map([["aggregation", buildReinforcedLLMParams(prompt)]]);
 }
 
 /**

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -1,3 +1,8 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import type { Authenticator } from "@app/lib/auth";
+import { runReinforcedAnalysis } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import logger from "@app/logger/logger";
 import type { AgentInstructionsSuggestionType } from "@app/types/suggestions/agent_suggestion";
 
 export function buildAggregationPrompt(
@@ -31,4 +36,72 @@ You MUST call the tool. If no suggestions survive aggregation, return an empty s
 ${suggestionsSection}`;
 
   return { systemPrompt, userMessage };
+}
+
+/**
+ * Aggregate synthetic suggestions for an agent into pending suggestions.
+ * Marks processed synthetic suggestions as approved.
+ */
+export async function aggregateSyntheticSuggestions(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<void> {
+  const syntheticSuggestions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { sources: ["synthetic"], states: ["pending"] }
+    );
+
+  if (syntheticSuggestions.length === 0) {
+    return;
+  }
+
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "light",
+  });
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId },
+      "ReinforcedAgent: agent not found for aggregation"
+    );
+    return;
+  }
+
+  const instructionsSuggestions = syntheticSuggestions
+    .map((s) => s.toJSON())
+    .filter(
+      (json): json is AgentInstructionsSuggestionType =>
+        json.kind === "instructions"
+    );
+
+  const prompt = buildAggregationPrompt(
+    agentConfig.name,
+    instructionsSuggestions
+  );
+
+  const createdCount = await runReinforcedAnalysis({
+    auth,
+    agentConfig,
+    prompt,
+    source: "reinforcement",
+    operationType: "reinforced_agent_aggregate_suggestions",
+    contextId: "n/a",
+  });
+
+  await AgentSuggestionResource.bulkUpdateState(
+    auth,
+    syntheticSuggestions,
+    "approved"
+  );
+
+  logger.info(
+    {
+      agentConfigurationId,
+      syntheticCount: syntheticSuggestions.length,
+      pendingCreated: createdCount,
+    },
+    "ReinforcedAgent: aggregated synthetic suggestions into pending"
+  );
 }

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -1,14 +1,9 @@
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import type { Authenticator } from "@app/lib/auth";
-import { runReinforcedAnalysis } from "@app/lib/reinforced_agent/run_reinforced_analysis";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
-import logger from "@app/logger/logger";
 import type { AgentInstructionsSuggestionType } from "@app/types/suggestions/agent_suggestion";
 
-function buildAggregationPrompt(
+export function buildAggregationPrompt(
   agentName: string,
   suggestions: AgentInstructionsSuggestionType[]
-): string {
+): { systemPrompt: string; userMessage: string } {
   const suggestionsSection = suggestions
     .map(
       (s, i) => `### Suggestion ${i + 1}
@@ -19,13 +14,7 @@ content: ${s.suggestion.content}`
     )
     .join("\n\n");
 
-  return `You are an AI agent improvement analyst. You have been given multiple suggestions from individual conversation analyses for the same agent. Your job is to deduplicate, merge, and prioritize them into a concise set of high-quality, actionable suggestions.
-
-## Agent: ${agentName}
-
-## Synthetic suggestions from conversation analyses
-
-${suggestionsSection}
+  const systemPrompt = `You are an AI agent improvement analyst. You have been given multiple suggestions from individual conversation analyses for the same agent. Your job is to deduplicate, merge, and prioritize them into a concise set of high-quality, actionable suggestions.
 
 ## Your task
 - Merge suggestions that address the same issue, or that target the same block
@@ -34,76 +23,12 @@ ${suggestionsSection}
 - When calling the tool, make sure there is never more than one suggestion targeting the same block (including instructions-root)
 
 You MUST call the tool. If no suggestions survive aggregation, return an empty suggestions array.`;
-}
 
-/**
- * Aggregate synthetic suggestions for an agent into pending suggestions.
- * Marks processed synthetic suggestions as approved.
- */
-export async function aggregateSyntheticSuggestions(
-  auth: Authenticator,
-  agentConfigurationId: string
-): Promise<void> {
-  // Fetch all synthetic suggestions for this agent.
-  const syntheticSuggestions =
-    await AgentSuggestionResource.listByAgentConfigurationId(
-      auth,
-      agentConfigurationId,
-      { sources: ["synthetic"], states: ["pending"] }
-    );
+  const userMessage = `## Agent: ${agentName}
 
-  if (syntheticSuggestions.length === 0) {
-    return;
-  }
+## Synthetic suggestions from conversation analyses
 
-  // Fetch agent configuration for context.
-  const [agentConfig] = await getAgentConfigurations(auth, {
-    agentIds: [agentConfigurationId],
-    variant: "light",
-  });
-  if (!agentConfig) {
-    logger.warn(
-      { agentConfigurationId },
-      "ReinforcedAgent: agent not found for aggregation"
-    );
-    return;
-  }
+${suggestionsSection}`;
 
-  // Filter to instructions suggestions using the discriminated union.
-  const instructionsSuggestions = syntheticSuggestions
-    .map((s) => s.toJSON())
-    .filter(
-      (json): json is AgentInstructionsSuggestionType =>
-        json.kind === "instructions"
-    );
-
-  const prompt = buildAggregationPrompt(
-    agentConfig.name,
-    instructionsSuggestions
-  );
-
-  const createdCount = await runReinforcedAnalysis({
-    auth,
-    agentConfig,
-    prompt,
-    source: "reinforcement",
-    operationType: "reinforced_agent_aggregate_suggestions",
-    contextId: "n/a",
-  });
-
-  // Mark all synthetic suggestions as approved (consumed by aggregation).
-  await AgentSuggestionResource.bulkUpdateState(
-    auth,
-    syntheticSuggestions,
-    "approved"
-  );
-
-  logger.info(
-    {
-      agentConfigurationId,
-      syntheticCount: syntheticSuggestions.length,
-      pendingCreated: createdCount,
-    },
-    "ReinforcedAgent: aggregated synthetic suggestions into pending"
-  );
+  return { systemPrompt, userMessage };
 }

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -1,3 +1,8 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import type { Authenticator } from "@app/lib/auth";
+import { runReinforcedAnalysis } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
 export function buildAnalysisPrompt(
@@ -40,4 +45,70 @@ ${conversationText}
 </conversation>`;
 
   return { systemPrompt, userMessage };
+}
+
+/**
+ * Analyze a single conversation for reinforcement suggestions.
+ * Creates synthetic AgentSuggestion records.
+ */
+export async function analyzeConversationForReinforcement(
+  auth: Authenticator,
+  {
+    conversationId,
+    agentConfigurationId,
+  }: {
+    conversationId: string;
+    agentConfigurationId: string;
+  }
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "full",
+  });
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId, workspaceId: owner.sId },
+      "ReinforcedAgent: agent configuration not found"
+    );
+    return;
+  }
+  if (agentConfig.id < 0) {
+    return;
+  }
+
+  const conversationRes = await getShrinkWrappedConversation(auth, {
+    conversationId,
+    includeFeedback: true,
+  });
+  if (conversationRes.isErr()) {
+    logger.warn(
+      { conversationId, error: conversationRes.error },
+      "ReinforcedAgent: conversation not found"
+    );
+    return;
+  }
+
+  const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
+
+  const createdCount = await runReinforcedAnalysis({
+    auth,
+    agentConfig,
+    prompt,
+    source: "synthetic",
+    operationType: "reinforced_agent_analyze_conversation",
+    contextId: conversationId,
+  });
+
+  if (createdCount > 0) {
+    logger.info(
+      {
+        conversationId,
+        agentConfigurationId,
+        suggestionsCreated: createdCount,
+      },
+      "ReinforcedAgent: created synthetic suggestions from conversation analysis"
+    );
+  }
 }

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -1,14 +1,9 @@
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
-import type { Authenticator } from "@app/lib/auth";
-import { runReinforcedAnalysis } from "@app/lib/reinforced_agent/run_reinforced_analysis";
-import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
-function buildAnalysisPrompt(
+export function buildAnalysisPrompt(
   agentConfig: AgentConfigurationType,
   conversationText: string
-): string {
+): { systemPrompt: string; userMessage: string } {
   const descriptionSection = agentConfig.description
     ? `Description: ${agentConfig.description}`
     : "";
@@ -16,18 +11,7 @@ function buildAnalysisPrompt(
     ? `\n### Current instructions\n${agentConfig.instructionsHtml}`
     : "";
 
-  return `You are an AI agent improvement analyst. Your job is to analyze a conversation handled by an AI agent and suggest concrete improvements to the agent's configuration.
-
-## Agent being analyzed
-Name: ${agentConfig.name}
-${descriptionSection}
-${instructionsSection}
-
-## Conversation to analyze
-
-<conversation>
-${conversationText}
-</conversation>
+  const systemPrompt = `You are an AI agent improvement analyst. Your job is to analyze a conversation handled by an AI agent and suggest concrete improvements to the agent's configuration.
 
 ## Your task
 Analyze the conversation and identify areas where the agent's instructions could be improved. Pay special attention to any user feedback (thumbs up/down and comments) as direct signals of satisfaction or dissatisfaction. Focus on:
@@ -43,73 +27,17 @@ The content must contain exactly what should go in the instructions block, with 
 It is in HTML format, so make sure to preserve any HTML tags from the original instructions.
 
 You MUST call the tool. Always call it. If no improvements are needed, return an empty suggestions array.`;
-}
 
-/**
- * Analyze a single conversation for reinforcement suggestions.
- * Creates synthetic AgentSuggestion records.
- */
-export async function analyzeConversationForReinforcement(
-  auth: Authenticator,
-  {
-    conversationId,
-    agentConfigurationId,
-  }: {
-    conversationId: string;
-    agentConfigurationId: string;
-  }
-): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
+  const userMessage = `## Agent being analyzed
+Name: ${agentConfig.name}
+${descriptionSection}
+${instructionsSection}
 
-  // Fetch agent configuration.
-  const [agentConfig] = await getAgentConfigurations(auth, {
-    agentIds: [agentConfigurationId],
-    variant: "full",
-  });
-  if (!agentConfig) {
-    logger.warn(
-      { agentConfigurationId, workspaceId: owner.sId },
-      "ReinforcedAgent: agent configuration not found"
-    );
-    return;
-  }
-  if (agentConfig.id < 0) {
-    // Skip global agents.
-    return;
-  }
+## Conversation to analyze
 
-  // Get shrink-wrapped conversation text with inline feedback.
-  const conversationRes = await getShrinkWrappedConversation(auth, {
-    conversationId,
-    includeFeedback: true,
-  });
-  if (conversationRes.isErr()) {
-    logger.warn(
-      { conversationId, error: conversationRes.error },
-      "ReinforcedAgent: conversation not found"
-    );
-    return;
-  }
+<conversation>
+${conversationText}
+</conversation>`;
 
-  const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
-
-  const createdCount = await runReinforcedAnalysis({
-    auth,
-    agentConfig,
-    prompt,
-    source: "synthetic",
-    operationType: "reinforced_agent_analyze_conversation",
-    contextId: conversationId,
-  });
-
-  if (createdCount > 0) {
-    logger.info(
-      {
-        conversationId,
-        agentConfigurationId,
-        suggestionsCreated: createdCount,
-      },
-      "ReinforcedAgent: created synthetic suggestions from conversation analysis"
-    );
-  }
+  return { systemPrompt, userMessage };
 }

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -1,7 +1,11 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import { runReinforcedAnalysis } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import {
+  buildReinforcedLLMParams,
+  runReinforcedAnalysis,
+} from "@app/lib/reinforced_agent/run_reinforced_analysis";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
@@ -45,6 +49,50 @@ ${conversationText}
 </conversation>`;
 
   return { systemPrompt, userMessage };
+}
+
+/**
+ * Build the batch map for conversation analysis.
+ * Returns null if there are no valid conversations or the agent is global.
+ */
+export async function buildConversationAnalysisBatchMap(
+  auth: Authenticator,
+  {
+    agentConfigurationId,
+    conversationIds,
+  }: {
+    agentConfigurationId: string;
+    conversationIds: string[];
+  }
+): Promise<Map<string, LLMStreamParameters> | null> {
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "full",
+  });
+  if (!agentConfig || agentConfig.id < 0) {
+    return null;
+  }
+
+  const batchMap = new Map<string, LLMStreamParameters>();
+
+  for (const conversationId of conversationIds) {
+    const conversationRes = await getShrinkWrappedConversation(auth, {
+      conversationId,
+      includeFeedback: true,
+    });
+    if (conversationRes.isErr()) {
+      logger.warn(
+        { conversationId, error: conversationRes.error },
+        "ReinforcedAgent: conversation not found, skipping in batch"
+      );
+      continue;
+    }
+
+    const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
+    batchMap.set(conversationId, buildReinforcedLLMParams(prompt));
+  }
+
+  return batchMap.size > 0 ? batchMap : null;
 }
 
 /**

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -232,3 +232,47 @@ async function createSuggestionsFromToolCall({
 
   return createdCount;
 }
+
+/**
+ * Shared helper for both analyze and aggregate phases of reinforced agents.
+ * Calls the LLM with the given prompt, parses suggestions, and creates them.
+ * Returns the number of suggestions created.
+ */
+export async function runReinforcedAnalysis({
+  auth,
+  agentConfig,
+  prompt,
+  source,
+  operationType,
+  contextId,
+}: {
+  auth: Authenticator;
+  agentConfig: LightAgentConfigurationType;
+  prompt: { systemPrompt: string; userMessage: string };
+  source: AgentSuggestionSource;
+  operationType: ReinforcedOperationType;
+  contextId: string;
+}): Promise<number> {
+  const llm = await getReinforcedLLM(auth);
+  if (!llm) {
+    logger.error(
+      { contextId },
+      `ReinforcedAgent: no whitelisted model available for ${operationType}`
+    );
+    return 0;
+  }
+
+  const events: LLMEvent[] = [];
+  for await (const event of llm.stream(buildReinforcedLLMParams(prompt))) {
+    events.push(event);
+  }
+
+  return processReinforcedEvents({
+    auth,
+    agentConfig,
+    events,
+    source,
+    operationType,
+    contextId,
+  });
+}

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -1,10 +1,15 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getLLM } from "@app/lib/api/llm";
+import type { LLM } from "@app/lib/api/llm/llm";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { getSmallWhitelistedModel } from "@app/types/assistant/assistant";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { AgentSuggestionSource } from "@app/types/suggestions/agent_suggestion";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { z } from "zod";
@@ -74,77 +79,122 @@ type ReinforcedOperationType =
   | "reinforced_agent_aggregate_suggestions";
 
 /**
- * Shared helper for both analyze and aggregate phases of reinforced agents.
- * Calls the LLM with the given prompt, parses suggestions, and creates them.
- * Returns the number of suggestions created.
+ * Build LLMStreamParameters for a reinforced analysis prompt.
+ * Used to create batch entries or for direct streaming.
  */
-export async function runReinforcedAnalysis({
+export function buildReinforcedLLMParams({
+  systemPrompt,
+  userMessage,
+}: {
+  systemPrompt: string;
+  userMessage: string;
+}): LLMStreamParameters {
+  return {
+    conversation: {
+      messages: [
+        {
+          role: "user",
+          name: "user",
+          content: [{ type: "text", text: userMessage }],
+        },
+      ],
+    },
+    prompt: systemPrompt,
+    specifications: buildSpecifications(),
+    forceToolCall: FUNCTION_NAME,
+  };
+}
+
+/**
+ * Get the LLM instance configured for reinforced agent analysis.
+ */
+export async function getReinforcedLLM(
+  auth: Authenticator
+): Promise<LLM | null> {
+  const owner = auth.workspace();
+  if (!owner) {
+    return null;
+  }
+  const model = getSmallWhitelistedModel(owner);
+  if (!model) {
+    return null;
+  }
+  const credentials = await ProviderCredentialResource.getCredentials(auth);
+  return getLLM(auth, { modelId: model.modelId, credentials });
+}
+
+/**
+ * Parse tool calls from LLM events and create suggestion records.
+ * Used to process batch results.
+ */
+export async function processReinforcedEvents({
   auth,
   agentConfig,
-  prompt,
+  events,
   source,
   operationType,
   contextId,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
-  prompt: string;
+  events: LLMEvent[];
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
 }): Promise<number> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const model = getSmallWhitelistedModel(owner);
-  if (!model) {
-    logger.warn(
-      { workspaceId: owner.sId },
-      `ReinforcedAgent: no whitelisted model available for ${operationType}`
-    );
-    return 0;
-  }
-
-  const res = await runMultiActionsAgent(
-    auth,
-    {
-      providerId: model.providerId,
-      modelId: model.modelId,
-      functionCall: FUNCTION_NAME,
-      useCache: false,
-    },
-    {
-      conversation: { messages: [] },
-      prompt,
-      specifications: buildSpecifications(),
-      forceToolCall: FUNCTION_NAME,
-    },
-    {
-      context: {
-        operationType,
-        conversationId: contextId,
-        workspaceId: owner.sId,
-      },
-    }
-  );
-
-  if (res.isErr()) {
+  const errorEvents = events.filter((e) => e.type === "error");
+  if (errorEvents.length > 0) {
     logger.error(
-      { contextId, error: res.error },
-      `ReinforcedAgent: LLM call failed for ${operationType}`
+      {
+        contextId,
+        errorCount: errorEvents.length,
+        errors: errorEvents.map((e) => normalizeError(e)),
+      },
+      `ReinforcedAgent: batch LLM errors for ${operationType}`
     );
     return 0;
   }
 
-  const action = res.value.actions?.[0];
-  if (!action?.arguments) {
+  const toolCallEvent = events.find(
+    (e) => e.type === "tool_call" && e.content.name === FUNCTION_NAME
+  );
+  if (!toolCallEvent || toolCallEvent.type !== "tool_call") {
     logger.warn(
       { contextId },
-      `ReinforcedAgent: no tool call in LLM response for ${operationType}`
+      `ReinforcedAgent: no tool call in batch result for ${operationType}`
     );
     return 0;
   }
 
-  const parsed = ReinforcedResponseSchema.safeParse(action.arguments);
+  return createSuggestionsFromToolCall({
+    auth,
+    agentConfig,
+    actionArguments: toolCallEvent.content.arguments,
+    source,
+    operationType,
+    contextId,
+  });
+}
+
+/**
+ * Shared helper: parse action arguments and create suggestion records.
+ */
+async function createSuggestionsFromToolCall({
+  auth,
+  agentConfig,
+  actionArguments,
+  source,
+  operationType,
+  contextId,
+}: {
+  auth: Authenticator;
+  agentConfig: LightAgentConfigurationType;
+  actionArguments: Record<string, unknown>;
+  source: AgentSuggestionSource;
+  operationType: ReinforcedOperationType;
+  contextId: string;
+}): Promise<number> {
+  const parsed = ReinforcedResponseSchema.safeParse(actionArguments);
   if (!parsed.success) {
     logger.warn(
       {

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -1,18 +1,16 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import {
   aggregateSyntheticSuggestions,
-  buildAggregationPrompt,
+  buildAggregationBatchMap,
 } from "@app/lib/reinforced_agent/aggregate_suggestions";
 import {
   analyzeConversationForReinforcement,
-  buildAnalysisPrompt,
+  buildConversationAnalysisBatchMap,
 } from "@app/lib/reinforced_agent/analyze_conversation";
 import {
-  buildReinforcedLLMParams,
   getReinforcedLLM,
   processReinforcedEvents,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
@@ -20,7 +18,6 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
-import type { AgentInstructionsSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import { ApplicationFailure } from "@temporalio/common";
 
 const HOURS_LOOKBACK = 24;
@@ -149,42 +146,16 @@ export async function startConversationAnalysisBatchActivity({
 }): Promise<string | null> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  const [agentConfig] = await getAgentConfigurations(auth, {
-    agentIds: [agentConfigurationId],
-    variant: "full",
+  const batchMap = await buildConversationAnalysisBatchMap(auth, {
+    agentConfigurationId,
+    conversationIds,
   });
-  if (!agentConfig || agentConfig.id < 0) {
+  if (!batchMap) {
     return null;
   }
 
   const llm = await getReinforcedLLM(auth);
   if (!llm) {
-    return null;
-  }
-
-  const batchMap = new Map<
-    string,
-    ReturnType<typeof buildReinforcedLLMParams>
-  >();
-
-  for (const conversationId of conversationIds) {
-    const conversationRes = await getShrinkWrappedConversation(auth, {
-      conversationId,
-      includeFeedback: true,
-    });
-    if (conversationRes.isErr()) {
-      logger.warn(
-        { conversationId, error: conversationRes.error },
-        "ReinforcedAgent: conversation not found, skipping in batch"
-      );
-      continue;
-    }
-
-    const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
-    batchMap.set(conversationId, buildReinforcedLLMParams(prompt));
-  }
-
-  if (batchMap.size === 0) {
     return null;
   }
 
@@ -295,26 +266,8 @@ export async function startAggregationBatchActivity({
 }): Promise<string | null> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  const syntheticSuggestions =
-    await AgentSuggestionResource.listByAgentConfigurationId(
-      auth,
-      agentConfigurationId,
-      { sources: ["synthetic"], states: ["pending"] }
-    );
-
-  if (syntheticSuggestions.length === 0) {
-    return null;
-  }
-
-  const [agentConfig] = await getAgentConfigurations(auth, {
-    agentIds: [agentConfigurationId],
-    variant: "light",
-  });
-  if (!agentConfig) {
-    logger.warn(
-      { agentConfigurationId },
-      "ReinforcedAgent: agent not found for aggregation batch"
-    );
+  const batchMap = await buildAggregationBatchMap(auth, agentConfigurationId);
+  if (!batchMap) {
     return null;
   }
 
@@ -323,20 +276,6 @@ export async function startAggregationBatchActivity({
     return null;
   }
 
-  const instructionsSuggestions = syntheticSuggestions
-    .map((s) => s.toJSON())
-    .filter(
-      (json): json is AgentInstructionsSuggestionType =>
-        json.kind === "instructions"
-    );
-
-  const prompt = buildAggregationPrompt(
-    agentConfig.name,
-    instructionsSuggestions
-  );
-
-  const batchMap = new Map([["aggregation", buildReinforcedLLMParams(prompt)]]);
-
   const batchId = await llm.sendBatchProcessing(batchMap);
 
   logger.info(
@@ -344,7 +283,6 @@ export async function startAggregationBatchActivity({
       agentConfigurationId,
       workspaceId,
       batchId,
-      syntheticCount: syntheticSuggestions.length,
     },
     "ReinforcedAgent: started aggregation batch"
   );

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -3,8 +3,14 @@ import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configurat
 import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { buildAggregationPrompt } from "@app/lib/reinforced_agent/aggregate_suggestions";
-import { buildAnalysisPrompt } from "@app/lib/reinforced_agent/analyze_conversation";
+import {
+  aggregateSyntheticSuggestions,
+  buildAggregationPrompt,
+} from "@app/lib/reinforced_agent/aggregate_suggestions";
+import {
+  analyzeConversationForReinforcement,
+  buildAnalysisPrompt,
+} from "@app/lib/reinforced_agent/analyze_conversation";
 import {
   buildReinforcedLLMParams,
   getReinforcedLLM,
@@ -87,6 +93,41 @@ export async function getRecentConversationsForAgentActivity({
     agentConfigurationId,
     updatedSince,
   });
+}
+
+/**
+ * Analyze a single conversation for a specific agent.
+ */
+export async function analyzeConversationActivity({
+  workspaceId,
+  agentConfigurationId,
+  conversationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  conversationId: string;
+}): Promise<void> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  await analyzeConversationForReinforcement(auth, {
+    conversationId,
+    agentConfigurationId,
+  });
+}
+
+/**
+ * Aggregate synthetic suggestions for a specific agent into pending suggestions.
+ */
+export async function aggregateSuggestionsActivity({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}): Promise<void> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  await aggregateSyntheticSuggestions(auth, agentConfigurationId);
 }
 
 // ---------------------------------------------------------------------------

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -1,9 +1,20 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { aggregateSyntheticSuggestions } from "@app/lib/reinforced_agent/aggregate_suggestions";
-import { analyzeConversationForReinforcement } from "@app/lib/reinforced_agent/analyze_conversation";
+import { buildAggregationPrompt } from "@app/lib/reinforced_agent/aggregate_suggestions";
+import { buildAnalysisPrompt } from "@app/lib/reinforced_agent/analyze_conversation";
+import {
+  buildReinforcedLLMParams,
+  getReinforcedLLM,
+  processReinforcedEvents,
+} from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import type { AgentInstructionsSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import { ApplicationFailure } from "@temporalio/common";
 
 const HOURS_LOOKBACK = 24;
@@ -78,37 +89,295 @@ export async function getRecentConversationsForAgentActivity({
   });
 }
 
+// ---------------------------------------------------------------------------
+// Batch activities
+// ---------------------------------------------------------------------------
+
 /**
- * Analyze a single conversation for a specific agent.
+ * Build analysis prompts for all conversations and submit them as a batch.
+ * Returns the batch ID, or null if no conversations could be prepared.
  */
-export async function analyzeConversationActivity({
+export async function startConversationAnalysisBatchActivity({
   workspaceId,
   agentConfigurationId,
-  conversationId,
+  conversationIds,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
-  conversationId: string;
-}): Promise<void> {
+  conversationIds: string[];
+}): Promise<string | null> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  await analyzeConversationForReinforcement(auth, {
-    conversationId,
-    agentConfigurationId,
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "full",
   });
+  if (!agentConfig || agentConfig.id < 0) {
+    return null;
+  }
+
+  const llm = await getReinforcedLLM(auth);
+  if (!llm) {
+    return null;
+  }
+
+  const batchMap = new Map<
+    string,
+    ReturnType<typeof buildReinforcedLLMParams>
+  >();
+
+  for (const conversationId of conversationIds) {
+    const conversationRes = await getShrinkWrappedConversation(auth, {
+      conversationId,
+      includeFeedback: true,
+    });
+    if (conversationRes.isErr()) {
+      logger.warn(
+        { conversationId, error: conversationRes.error },
+        "ReinforcedAgent: conversation not found, skipping in batch"
+      );
+      continue;
+    }
+
+    const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
+    batchMap.set(conversationId, buildReinforcedLLMParams(prompt));
+  }
+
+  if (batchMap.size === 0) {
+    return null;
+  }
+
+  const batchId = await llm.sendBatchProcessing(batchMap);
+
+  logger.info(
+    {
+      agentConfigurationId,
+      workspaceId,
+      batchId,
+      conversationCount: batchMap.size,
+    },
+    "ReinforcedAgent: started conversation analysis batch"
+  );
+
+  return batchId;
 }
 
 /**
- * Aggregate synthetic suggestions for a specific agent into pending suggestions.
+ * Check the status of a batch.
  */
-export async function aggregateSuggestionsActivity({
+export async function checkBatchStatusActivity({
+  workspaceId,
+  batchId,
+}: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<BatchStatus> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  const llm = await getReinforcedLLM(auth);
+  if (!llm) {
+    throw ApplicationFailure.nonRetryable(
+      "ReinforcedAgent: no LLM available for batch status check"
+    );
+  }
+
+  return llm.getBatchStatus(batchId);
+}
+
+/**
+ * Download batch results for conversation analysis and create suggestions.
+ */
+export async function processConversationAnalysisBatchResultActivity({
+  workspaceId,
+  agentConfigurationId,
+  batchId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  batchId: string;
+}): Promise<void> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "light",
+  });
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId },
+      "ReinforcedAgent: agent not found for batch result processing"
+    );
+    return;
+  }
+
+  const llm = await getReinforcedLLM(auth);
+  if (!llm) {
+    return;
+  }
+
+  const results = await llm.getBatchResult(batchId);
+
+  let totalCreated = 0;
+  for (const [conversationId, events] of results) {
+    const createdCount = await processReinforcedEvents({
+      auth,
+      agentConfig,
+      events,
+      source: "synthetic",
+      operationType: "reinforced_agent_analyze_conversation",
+      contextId: conversationId,
+    });
+    totalCreated += createdCount;
+  }
+
+  logger.info(
+    {
+      agentConfigurationId,
+      batchId,
+      conversationCount: results.size,
+      suggestionsCreated: totalCreated,
+    },
+    "ReinforcedAgent: processed conversation analysis batch results"
+  );
+}
+
+/**
+ * Build aggregation prompt and submit it as a batch.
+ * Returns the batch ID, or null if there are no suggestions to aggregate.
+ */
+export async function startAggregationBatchActivity({
   workspaceId,
   agentConfigurationId,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
+}): Promise<string | null> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  const syntheticSuggestions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { sources: ["synthetic"], states: ["pending"] }
+    );
+
+  if (syntheticSuggestions.length === 0) {
+    return null;
+  }
+
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "light",
+  });
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId },
+      "ReinforcedAgent: agent not found for aggregation batch"
+    );
+    return null;
+  }
+
+  const llm = await getReinforcedLLM(auth);
+  if (!llm) {
+    return null;
+  }
+
+  const instructionsSuggestions = syntheticSuggestions
+    .map((s) => s.toJSON())
+    .filter(
+      (json): json is AgentInstructionsSuggestionType =>
+        json.kind === "instructions"
+    );
+
+  const prompt = buildAggregationPrompt(
+    agentConfig.name,
+    instructionsSuggestions
+  );
+
+  const batchMap = new Map([["aggregation", buildReinforcedLLMParams(prompt)]]);
+
+  const batchId = await llm.sendBatchProcessing(batchMap);
+
+  logger.info(
+    {
+      agentConfigurationId,
+      workspaceId,
+      batchId,
+      syntheticCount: syntheticSuggestions.length,
+    },
+    "ReinforcedAgent: started aggregation batch"
+  );
+
+  return batchId;
+}
+
+/**
+ * Download aggregation batch results, create suggestions, and mark synthetic ones as approved.
+ */
+export async function processAggregationBatchResultActivity({
+  workspaceId,
+  agentConfigurationId,
+  batchId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  batchId: string;
 }): Promise<void> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  await aggregateSyntheticSuggestions(auth, agentConfigurationId);
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "light",
+  });
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId },
+      "ReinforcedAgent: agent not found for aggregation result processing"
+    );
+    return;
+  }
+
+  const llm = await getReinforcedLLM(auth);
+  if (!llm) {
+    return;
+  }
+
+  const results = await llm.getBatchResult(batchId);
+  const events = results.get("aggregation");
+
+  let createdCount = 0;
+  if (events) {
+    createdCount = await processReinforcedEvents({
+      auth,
+      agentConfig,
+      events,
+      source: "reinforcement",
+      operationType: "reinforced_agent_aggregate_suggestions",
+      contextId: "n/a",
+    });
+  }
+
+  // Mark all synthetic suggestions as approved (consumed by aggregation).
+  const syntheticSuggestions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { sources: ["synthetic"], states: ["pending"] }
+    );
+
+  await AgentSuggestionResource.bulkUpdateState(
+    auth,
+    syntheticSuggestions,
+    "approved"
+  );
+
+  logger.info(
+    {
+      agentConfigurationId,
+      batchId,
+      syntheticCount: syntheticSuggestions.length,
+      pendingCreated: createdCount,
+    },
+    "ReinforcedAgent: processed aggregation batch results"
+  );
 }

--- a/front/temporal/reinforced_agent/admin/cli.ts
+++ b/front/temporal/reinforced_agent/admin/cli.ts
@@ -12,16 +12,18 @@ import parseArgs from "minimist";
 
 function usage() {
   console.error(`Usage:
-  start                                              Start the cron workflow
-  stop                                               Stop the cron workflow
-  run-now                                            Trigger the top-level workflow immediately
-  run-workspace --workspace-id <sId>                 Run for a specific workspace
-  run-agent --workspace-id <sId> --agent-id <sId>    Run for a specific agent`);
+  start                                                              Start the cron workflow
+  stop                                                               Stop the cron workflow
+  run-now                                                            Trigger the top-level workflow immediately
+  run-workspace --workspace-id <sId> [--batch]                       Run for a specific workspace (--batch defaults to false)
+  run-agent --workspace-id <sId> --agent-id <sId> [--batch]         Run for a specific agent (--batch defaults to false)`);
 }
 
 const main = async () => {
   const argv = parseArgs(process.argv.slice(2), {
     string: ["workspace-id", "agent-id"],
+    boolean: ["batch"],
+    default: { batch: false },
   });
 
   const [command] = argv._;
@@ -50,7 +52,10 @@ const main = async () => {
         usage();
         process.exit(1);
       }
-      await startReinforcedAgentWorkspaceWorkflow({ workspaceId });
+      await startReinforcedAgentWorkspaceWorkflow({
+        workspaceId,
+        useBatchMode: argv["batch"],
+      });
       return;
     }
     case "run-agent": {
@@ -64,6 +69,7 @@ const main = async () => {
       await startReinforcedAgentForAgentWorkflow({
         workspaceId,
         agentConfigurationId: agentId,
+        useBatchMode: argv["batch"],
       });
       return;
     }

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -65,14 +65,16 @@ export async function stopReinforcedAgentWorkflow({
 
 export async function startReinforcedAgentWorkspaceWorkflow({
   workspaceId,
+  useBatchMode,
 }: {
   workspaceId: string;
+  useBatchMode: boolean;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = `reinforced-agent-workspace-${workspaceId}-manual-${Date.now()}`;
 
   await client.workflow.start(reinforcedAgentWorkspaceWorkflow, {
-    args: [{ workspaceId }],
+    args: [{ workspaceId, useBatchMode }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });
@@ -87,15 +89,17 @@ export async function startReinforcedAgentWorkspaceWorkflow({
 export async function startReinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
+  useBatchMode,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
+  useBatchMode: boolean;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = `reinforced-agent-${workspaceId}-${agentConfigurationId}-manual-${Date.now()}`;
 
   await client.workflow.start(reinforcedAgentForAgentWorkflow, {
-    args: [{ workspaceId, agentConfigurationId }],
+    args: [{ workspaceId, agentConfigurationId, useBatchMode }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -50,9 +50,9 @@ const { processAggregationBatchResultActivity } = proxyActivities<
   startToCloseTimeout: "30 minutes",
 });
 
-const BATCH_POLL_INTERVAL_FAST_MS = 60_000; // 1 minute (first 30 minutes).
-const BATCH_POLL_INTERVAL_SLOW_MS = 5 * 60_000; // 5 minutes (after 30 minutes).
-const BATCH_POLL_FAST_PHASE_DURATION_MS = 30 * 60_000; // 30 minutes.
+const BATCH_POLL_INTERVAL_MIN_MS = 30_000; // 30 seconds (linear backoff start).
+const BATCH_POLL_INTERVAL_MAX_MS = 5 * 60_000; // 5 minutes (linear backoff cap).
+const BATCH_POLL_INTERVAL_STEP_MS = 10_000; // 10 seconds (linear backoff step).
 const BATCH_TIMEOUT_MS = 6 * 60 * 60_000; // 6 hours.
 
 /**
@@ -95,7 +95,7 @@ export async function reinforcedAgentWorkspaceWorkflow({
 
 /**
  * Wait for a batch to complete.
- * Polls every minute for the first 30 minutes, then every 5 minutes.
+ * Polls with linear backoff starting at 30 seconds, adding 10 seconds each time, capped at 5 minutes.
  * Throws a non-retryable error after 6 hours.
  */
 async function waitForBatch({
@@ -106,15 +106,12 @@ async function waitForBatch({
   batchId: string;
 }): Promise<void> {
   let elapsedMs = 0;
+  let intervalMs = BATCH_POLL_INTERVAL_MIN_MS;
 
   while (elapsedMs < BATCH_TIMEOUT_MS) {
-    const intervalMs =
-      elapsedMs < BATCH_POLL_FAST_PHASE_DURATION_MS
-        ? BATCH_POLL_INTERVAL_FAST_MS
-        : BATCH_POLL_INTERVAL_SLOW_MS;
-
     await sleep(intervalMs);
     elapsedMs += intervalMs;
+    intervalMs = Math.min(intervalMs + BATCH_POLL_INTERVAL_STEP_MS, BATCH_POLL_INTERVAL_MAX_MS);
 
     const status = await checkBatchStatusActivity({ workspaceId, batchId });
     if (status === "ready") {

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -1,8 +1,10 @@
 import type * as activities from "@app/temporal/reinforced_agent/activities";
 import {
+  ApplicationFailure,
   ParentClosePolicy,
   proxyActivities,
   setHandler,
+  sleep,
   startChild,
 } from "@temporalio/workflow";
 
@@ -22,13 +24,36 @@ const { getRecentConversationsForAgentActivity } = proxyActivities<
   startToCloseTimeout: "5 minutes",
 });
 
-const { analyzeConversationActivity } = proxyActivities<typeof activities>({
+const { startConversationAnalysisBatchActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "30 minutes",
+});
+
+const { checkBatchStatusActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+const { processConversationAnalysisBatchResultActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "30 minutes",
+});
+
+const { startAggregationBatchActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
-const { aggregateSuggestionsActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
+const { processAggregationBatchResultActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "30 minutes",
 });
+
+const BATCH_POLL_INTERVAL_FAST_MS = 60_000; // 1 minute (first 30 minutes).
+const BATCH_POLL_INTERVAL_SLOW_MS = 5 * 60_000; // 5 minutes (after 30 minutes).
+const BATCH_POLL_FAST_PHASE_DURATION_MS = 30 * 60_000; // 30 minutes.
+const BATCH_TIMEOUT_MS = 6 * 60 * 60_000; // 6 hours.
 
 /**
  * Top-level workflow: find flagged workspaces and start a child workflow for each.
@@ -69,7 +94,44 @@ export async function reinforcedAgentWorkspaceWorkflow({
 }
 
 /**
- * Agent-level workflow: analyze recent conversations then aggregate suggestions.
+ * Wait for a batch to complete.
+ * Polls every minute for the first 30 minutes, then every 5 minutes.
+ * Throws a non-retryable error after 6 hours.
+ */
+async function waitForBatch({
+  workspaceId,
+  batchId,
+}: {
+  workspaceId: string;
+  batchId: string;
+}): Promise<void> {
+  let elapsedMs = 0;
+
+  while (elapsedMs < BATCH_TIMEOUT_MS) {
+    const intervalMs =
+      elapsedMs < BATCH_POLL_FAST_PHASE_DURATION_MS
+        ? BATCH_POLL_INTERVAL_FAST_MS
+        : BATCH_POLL_INTERVAL_SLOW_MS;
+
+    await sleep(intervalMs);
+    elapsedMs += intervalMs;
+
+    const status = await checkBatchStatusActivity({ workspaceId, batchId });
+    if (status === "ready") {
+      return;
+    }
+  }
+
+  throw new ApplicationFailure(
+    `Batch ${batchId} in workspace ${workspaceId} timed out after 6 hours.`,
+    "BATCH_TIMEOUT",
+    true // non-retryable
+  );
+}
+
+/**
+ * Agent-level workflow: analyze recent conversations then aggregate suggestions,
+ * using batch LLM processing.
  */
 export async function reinforcedAgentForAgentWorkflow({
   workspaceId,
@@ -83,18 +145,38 @@ export async function reinforcedAgentForAgentWorkflow({
     agentConfigurationId,
   });
 
-  // Phase 1: Analyze each conversation.
-  for (const conversationId of conversationIds) {
-    await analyzeConversationActivity({
+  // Phase 1: Batch-analyze all conversations.
+  if (conversationIds.length > 0) {
+    const analysisBatchId = await startConversationAnalysisBatchActivity({
       workspaceId,
       agentConfigurationId,
-      conversationId,
+      conversationIds,
     });
+
+    if (analysisBatchId) {
+      await waitForBatch({ workspaceId, batchId: analysisBatchId });
+
+      await processConversationAnalysisBatchResultActivity({
+        workspaceId,
+        agentConfigurationId,
+        batchId: analysisBatchId,
+      });
+    }
   }
 
-  // Phase 2: Aggregate synthetic suggestions into pending.
-  await aggregateSuggestionsActivity({
+  // Phase 2: Batch-aggregate synthetic suggestions into pending.
+  const aggregationBatchId = await startAggregationBatchActivity({
     workspaceId,
     agentConfigurationId,
   });
+
+  if (aggregationBatchId) {
+    await waitForBatch({ workspaceId, batchId: aggregationBatchId });
+
+    await processAggregationBatchResultActivity({
+      workspaceId,
+      agentConfigurationId,
+      batchId: aggregationBatchId,
+    });
+  }
 }

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -24,6 +24,14 @@ const { getRecentConversationsForAgentActivity } = proxyActivities<
   startToCloseTimeout: "5 minutes",
 });
 
+const { analyzeConversationActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
+const { aggregateSuggestionsActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
 const { startConversationAnalysisBatchActivity } = proxyActivities<
   typeof activities
 >({
@@ -68,7 +76,7 @@ export async function reinforcedAgentWorkflow(): Promise<void> {
   for (const workspaceId of workspaceIds) {
     await startChild(reinforcedAgentWorkspaceWorkflow, {
       workflowId: `reinforced-agent-workspace-${workspaceId}`,
-      args: [{ workspaceId }],
+      args: [{ workspaceId, useBatchMode: true }],
       parentClosePolicy: ParentClosePolicy.ABANDON,
     });
   }
@@ -79,15 +87,17 @@ export async function reinforcedAgentWorkflow(): Promise<void> {
  */
 export async function reinforcedAgentWorkspaceWorkflow({
   workspaceId,
+  useBatchMode,
 }: {
   workspaceId: string;
+  useBatchMode: boolean;
 }): Promise<void> {
   const agentIds = await getAgentConfigurationsActivity({ workspaceId });
 
   for (const agentConfigurationId of agentIds) {
     await startChild(reinforcedAgentForAgentWorkflow, {
       workflowId: `reinforced-agent-${workspaceId}-${agentConfigurationId}`,
-      args: [{ workspaceId, agentConfigurationId }],
+      args: [{ workspaceId, agentConfigurationId, useBatchMode }],
       parentClosePolicy: ParentClosePolicy.ABANDON,
     });
   }
@@ -111,7 +121,10 @@ async function waitForBatch({
   while (elapsedMs < BATCH_TIMEOUT_MS) {
     await sleep(intervalMs);
     elapsedMs += intervalMs;
-    intervalMs = Math.min(intervalMs + BATCH_POLL_INTERVAL_STEP_MS, BATCH_POLL_INTERVAL_MAX_MS);
+    intervalMs = Math.min(
+      intervalMs + BATCH_POLL_INTERVAL_STEP_MS,
+      BATCH_POLL_INTERVAL_MAX_MS
+    );
 
     const status = await checkBatchStatusActivity({ workspaceId, batchId });
     if (status === "ready") {
@@ -127,53 +140,72 @@ async function waitForBatch({
 }
 
 /**
- * Agent-level workflow: analyze recent conversations then aggregate suggestions,
- * using batch LLM processing.
+ * Agent-level workflow: analyze recent conversations then aggregate suggestions.
+ * Uses batch LLM processing when useBatchMode is true, sequential streaming otherwise.
  */
 export async function reinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
+  useBatchMode,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
+  useBatchMode: boolean;
 }): Promise<void> {
   const conversationIds = await getRecentConversationsForAgentActivity({
     workspaceId,
     agentConfigurationId,
   });
 
-  // Phase 1: Batch-analyze all conversations.
-  if (conversationIds.length > 0) {
-    const analysisBatchId = await startConversationAnalysisBatchActivity({
-      workspaceId,
-      agentConfigurationId,
-      conversationIds,
-    });
-
-    if (analysisBatchId) {
-      await waitForBatch({ workspaceId, batchId: analysisBatchId });
-
-      await processConversationAnalysisBatchResultActivity({
+  if (useBatchMode) {
+    // Phase 1: Batch-analyze all conversations.
+    if (conversationIds.length > 0) {
+      const analysisBatchId = await startConversationAnalysisBatchActivity({
         workspaceId,
         agentConfigurationId,
-        batchId: analysisBatchId,
+        conversationIds,
       });
+
+      if (analysisBatchId) {
+        await waitForBatch({ workspaceId, batchId: analysisBatchId });
+
+        await processConversationAnalysisBatchResultActivity({
+          workspaceId,
+          agentConfigurationId,
+          batchId: analysisBatchId,
+        });
+      }
     }
-  }
 
-  // Phase 2: Batch-aggregate synthetic suggestions into pending.
-  const aggregationBatchId = await startAggregationBatchActivity({
-    workspaceId,
-    agentConfigurationId,
-  });
-
-  if (aggregationBatchId) {
-    await waitForBatch({ workspaceId, batchId: aggregationBatchId });
-
-    await processAggregationBatchResultActivity({
+    // Phase 2: Batch-aggregate synthetic suggestions into pending.
+    const aggregationBatchId = await startAggregationBatchActivity({
       workspaceId,
       agentConfigurationId,
-      batchId: aggregationBatchId,
+    });
+
+    if (aggregationBatchId) {
+      await waitForBatch({ workspaceId, batchId: aggregationBatchId });
+
+      await processAggregationBatchResultActivity({
+        workspaceId,
+        agentConfigurationId,
+        batchId: aggregationBatchId,
+      });
+    }
+  } else {
+    // Phase 1: Analyze each conversation sequentially via streaming.
+    for (const conversationId of conversationIds) {
+      await analyzeConversationActivity({
+        workspaceId,
+        agentConfigurationId,
+        conversationId,
+      });
+    }
+
+    // Phase 2: Aggregate synthetic suggestions into pending.
+    await aggregateSuggestionsActivity({
+      workspaceId,
+      agentConfigurationId,
     });
   }
 }


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/5935

Use the new BAtch API to do the LLM calls in reinforced agents for both analysing the conversations and generating the suggestions.

The flow looks like this now:

<img width="3044" height="1646" alt="image" src="https://github.com/user-attachments/assets/7cd6f3c8-7865-434d-bbd2-89f01fd8eb63" />

Note: we currently still run all the agents workflows sequentially, so as it now takes 10 minutes to run it will be long to do a full workspace. Will handle this to run in parallel in next PRs


## Tests

Tested locally with Haiku

## Risk

low, job will be slower but 50% cheaper

## Deploy Plan

deploy front 
