### PR TITLE
Add batch processing API to google LLMs

### DIFF
--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -240,9 +240,8 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     const inlinedResponses = batch.dest?.inlinedResponses ?? [];
     const batchResult: BatchResult = new Map();
 
-    for (let i = 0; i < inlinedResponses.length; i++) {
+    for (const [i, inlinedResponse] of inlinedResponses.entries()) {
       const customId = customIds[i] ?? String(i);
-      const inlinedResponse = inlinedResponses[i];
 
       if (inlinedResponse.error || !inlinedResponse.response) {
         const errorMessage =

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -7,24 +7,31 @@ import {
   toContent,
   toTool,
 } from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
-import { streamLLMEvents } from "@app/lib/api/llm/clients/google/utils/google_to_events";
+import {
+  responseToLLMEvents,
+  streamLLMEvents,
+} from "@app/lib/api/llm/clients/google/utils/google_to_events";
 import {
   toResponseSchemaParam,
   toThinkingConfig,
   toToolConfigParam,
 } from "@app/lib/api/llm/clients/google/utils/to_thinking";
 import { LLM } from "@app/lib/api/llm/llm";
+import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { EventError } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import { ApiError, GoogleGenAI } from "@google/genai";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { ApiError, GoogleGenAI, JobState } from "@google/genai";
 import assert from "assert";
-
+import { z } from "zod";
 import { handleError } from "./utils/errors";
 
 interface GoogleGenerateContentRequestParams {
@@ -57,6 +64,29 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     });
   }
 
+  private buildGenerateContentConfig(
+    specifications: LLMStreamParameters["specifications"],
+    prompt: LLMStreamParameters["prompt"],
+    forceToolCall: LLMStreamParameters["forceToolCall"]
+  ) {
+    return {
+      temperature: this.temperature ?? undefined,
+      tools: specifications.map(toTool),
+      systemInstruction: { text: systemPromptToText(prompt) },
+      // We only need one
+      candidateCount: 1,
+      thinkingConfig: toThinkingConfig({
+        modelId: this.modelId,
+        reasoningEffort: this.reasoningEffort,
+        useNativeLightReasoning: this.modelConfig.useNativeLightReasoning,
+      }),
+      toolConfig: toToolConfigParam(specifications, forceToolCall),
+      // Structured response format
+      responseMimeType: this.responseFormat ? "application/json" : undefined,
+      responseSchema: toResponseSchemaParam(this.responseFormat),
+    };
+  }
+
   protected buildStreamRequestPayload({
     conversation,
     prompt,
@@ -86,27 +116,11 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
         await this.client.models.generateContentStream({
           model: this.modelId,
           contents,
-          config: {
-            temperature: this.temperature ?? undefined,
-            tools: payload.specifications.map(toTool),
-            systemInstruction: { text: systemPromptToText(payload.prompt) },
-            // We only need one
-            candidateCount: 1,
-            thinkingConfig: toThinkingConfig({
-              modelId: this.modelId,
-              reasoningEffort: this.reasoningEffort,
-              useNativeLightReasoning: this.modelConfig.useNativeLightReasoning,
-            }),
-            toolConfig: toToolConfigParam(
-              payload.specifications,
-              payload.forceToolCall
-            ),
-            // Structured response format
-            responseMimeType: this.responseFormat
-              ? "application/json"
-              : undefined,
-            responseSchema: toResponseSchemaParam(this.responseFormat),
-          },
+          config: this.buildGenerateContentConfig(
+            payload.specifications,
+            payload.prompt,
+            payload.forceToolCall
+          ),
         });
 
       yield* streamLLMEvents({
@@ -120,5 +134,142 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
         yield handleGenericError(err, this.metadata);
       }
     }
+  }
+
+  // Encodes the Google batch name and ordered custom IDs into a single opaque string,
+  // since Google's inline batch API returns responses in order without custom_id echo.
+  private static encodeBatchId(batchName: string, customIds: string[]): string {
+    return JSON.stringify({ batchName, customIds });
+  }
+
+  private static readonly batchIdSchema = z.object({
+    batchName: z.string(),
+    customIds: z.array(z.string()),
+  });
+
+  private static decodeBatchId(batchId: string): {
+    batchName: string;
+    customIds: string[];
+  } {
+    const result = GoogleLLM.batchIdSchema.safeParse(JSON.parse(batchId));
+    if (!result.success) {
+      throw new Error(`Invalid Google batch ID format: ${batchId}`);
+    }
+    return result.data;
+  }
+
+  /**
+   * Sends a batch to goolge to process.
+   *
+   * Note that Google does not use any custom IDs but preserve the order.
+   * To keep the ids of the processed conversations we store them stringified in the batchId string.
+   */
+  override async sendBatchProcessing(
+    conversations: Map<string, LLMStreamParameters>
+  ): Promise<string> {
+    const customIds = Array.from(conversations.keys());
+    const params = Array.from(conversations.values());
+
+    const inlinedRequests = [];
+    for (const {
+      conversation,
+      prompt,
+      specifications,
+      forceToolCall,
+    } of params) {
+      const contents = [];
+      for (const message of conversation.messages) {
+        contents.push(await toContent(message, this.modelId));
+      }
+      inlinedRequests.push({
+        contents,
+        config: this.buildGenerateContentConfig(
+          specifications,
+          prompt,
+          forceToolCall
+        ),
+      });
+    }
+
+    const batch = await this.client.batches.create({
+      model: this.modelId,
+      src: inlinedRequests,
+    });
+
+    if (!batch.name) {
+      throw new Error("Google batch job was created without a name");
+    }
+
+    return GoogleLLM.encodeBatchId(batch.name, customIds);
+  }
+
+  override async getBatchStatus(batchId: string): Promise<BatchStatus> {
+    const { batchName } = GoogleLLM.decodeBatchId(batchId);
+    const batch = await this.client.batches.get({ name: batchName });
+
+    switch (batch.state) {
+      case JobState.JOB_STATE_SUCCEEDED:
+      case JobState.JOB_STATE_PARTIALLY_SUCCEEDED:
+        return "ready";
+      case JobState.JOB_STATE_QUEUED:
+      case JobState.JOB_STATE_PENDING:
+      case JobState.JOB_STATE_RUNNING:
+      case JobState.JOB_STATE_UPDATING:
+      case JobState.JOB_STATE_CANCELLING:
+        return "computing";
+      case JobState.JOB_STATE_FAILED:
+      case JobState.JOB_STATE_CANCELLED:
+      case JobState.JOB_STATE_PAUSED:
+      case JobState.JOB_STATE_EXPIRED:
+      case JobState.JOB_STATE_UNSPECIFIED:
+        logger.warn(
+          { batchId, status: batch.state, provider: "google" },
+          "LLM Batch has been aborted"
+        );
+        return "aborted";
+      case undefined:
+        return "computing";
+      default:
+        assertNever(batch.state);
+    }
+  }
+
+  override async getBatchResult(batchId: string): Promise<BatchResult> {
+    const { batchName, customIds } = GoogleLLM.decodeBatchId(batchId);
+    const batch = await this.client.batches.get({ name: batchName });
+    const inlinedResponses = batch.dest?.inlinedResponses ?? [];
+    const batchResult: BatchResult = new Map();
+
+    for (let i = 0; i < inlinedResponses.length; i++) {
+      const customId = customIds[i] ?? String(i);
+      const inlinedResponse = inlinedResponses[i];
+
+      if (inlinedResponse.error || !inlinedResponse.response) {
+        const errorMessage =
+          inlinedResponse.error?.message ??
+          `No response for index ${i} (custom_id ${customId})`;
+        batchResult.set(customId, [
+          new EventError(
+            {
+              type: "server_error",
+              message: errorMessage,
+              isRetryable: false,
+            },
+            this.metadata
+          ),
+        ]);
+        continue;
+      }
+
+      batchResult.set(
+        customId,
+        await responseToLLMEvents({
+          response: inlinedResponse.response,
+          metadata: this.metadata,
+        })
+      );
+    }
+
+    return batchResult;
   }
 }

--- a/front/lib/api/llm/clients/google/utils/google_to_events.ts
+++ b/front/lib/api/llm/clients/google/utils/google_to_events.ts
@@ -21,6 +21,25 @@ type StateContainer = {
   thinkingSignature?: string;
 };
 
+export async function responseToLLMEvents({
+  response,
+  metadata,
+}: {
+  response: GenerateContentResponse;
+  metadata: LLMClientMetadata;
+}): Promise<LLMEvent[]> {
+  const events: LLMEvent[] = [];
+  for await (const event of streamLLMEvents({
+    generateContentResponses: (async function* () {
+      yield response;
+    })(),
+    metadata,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
 export async function* streamLLMEvents({
   generateContentResponses,
   metadata,

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -29,6 +29,7 @@ export const GEMINI_2_5_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
+  supportsBatchProcessing: true,
 };
 export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -50,6 +51,7 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
+  supportsBatchProcessing: true,
 };
 export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -71,6 +73,7 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
+  supportsBatchProcessing: true,
 };
 export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -93,6 +96,7 @@ export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
+  supportsBatchProcessing: true,
 };
 export const GEMINI_3_1_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -115,6 +119,7 @@ export const GEMINI_3_1_PRO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
+  supportsBatchProcessing: true,
 };
 export const GEMINI_3_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -136,4 +141,5 @@ export const GEMINI_3_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
+  supportsBatchProcessing: true,
 };


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/5935

Add the batch API to Google LLMs

Main diff compared to other clients is that they don't store ids of the conversations but used order based between ocnversation sent and the retrieved one.

Note: the goolge batch API is pretty unstable at the moment and can not answer for more than 24h


## Tests


Local tests
```
~/dust-hive/batch-google/front fabien/llm/batch-for-google ⇣1⇡1 *36 !1 # RUN_LLM_BATCH_TEST=true FRONT_DATABASE_URI="$FRONT_DATABASE_URI"_test NODE_ENV=test npx vitest --config lib/api/llm/tests/vite.config.js --run  lib/api/llm/tests/llmBatch.test.ts


 RUN  v4.0.18 /Users/fabiencelier/dust-hive/batch-google/front

 ✓ lib/api/llm/tests/llmBatch.test.ts (6 tests) 1053629ms
   ✓ Batch Processing Integration Tests (6)
     ✓ 'google_ai_studio' / 'gemini-2.5-pro' (2)
       ✓ 'simple math'  442844ms
       ✓ 'forced tool call'  442774ms
     ✓ 'google_ai_studio' / 'gemini-3-pro-preview' (2)
       ✓ 'simple math'  437668ms
       ✓ 'forced tool call'  427353ms
     ✓ 'google_ai_studio' / 'gemini-3.1-pro-preview' (2)
       ✓ 'simple math'  1053626ms
       ✓ 'forced tool call'  1043543ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  10:27:55
   Duration  1058.17s (transform 2.28s, setup 353ms, import 4.09s, tests 1053.63s, environment 0ms)
```

## Risk

low

## Deploy Plan

deploy front 