### PR TITLE
Auto-deploy SPA preview on PR label

### DIFF
--- a/.github/workflows/deploy-spa-preview.yaml
+++ b/.github/workflows/deploy-spa-preview.yaml
@@ -1,0 +1,104 @@
+name: Deploy SPA preview on PR label
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-app:
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy-app-preview')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy-app-preview'))
+    uses: ./.github/workflows/deploy-spa.yaml
+    with:
+      app: "app"
+      env: "prod"
+      region: "us"
+      skip_slack: true
+    secrets: inherit
+
+  deploy-poke:
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy-poke-preview')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy-poke-preview'))
+    uses: ./.github/workflows/deploy-spa.yaml
+    with:
+      app: "poke"
+      env: "prod"
+      region: "us"
+      skip_slack: true
+    secrets: inherit
+
+  comment-app:
+    needs: [deploy-app]
+    if: ${{ !failure() && !cancelled() && needs.deploy-app.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- spa-preview-app -->';
+            const body = `${marker}\n🚀 **App SPA preview deployed**\n\n${{ needs.deploy-app.outputs.preview_url }}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  comment-poke:
+    needs: [deploy-poke]
+    if: ${{ !failure() && !cancelled() && needs.deploy-poke.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- spa-preview-poke -->';
+            const body = `${marker}\n🚀 **Poke SPA preview deployed**\n\n${{ needs.deploy-poke.outputs.preview_url }}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -47,10 +47,18 @@ on:
         type: string
         default: ""
         required: false
+      skip_slack:
+        description: "Skip Slack notifications (e.g. for PR preview deploys)"
+        type: boolean
+        default: false
+        required: false
     outputs:
       version_id:
         description: "Worker version ID from versions upload"
         value: ${{ jobs.deploy.outputs.version_id }}
+      preview_url:
+        description: "Preview URL for the deployed version"
+        value: ${{ jobs.deploy.outputs.preview_url }}
 
 concurrency:
   group: deploy-spa-${{ inputs.app }}-${{ github.ref_name }}
@@ -78,6 +86,7 @@ jobs:
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   notify-start:
+    if: ${{ !inputs.skip_slack }}
     needs: [prepare]
     runs-on: ubuntu-latest
     outputs:
@@ -98,9 +107,11 @@ jobs:
 
   deploy:
     needs: [prepare, notify-start]
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       version_id: ${{ steps.extract_version.outputs.version_id }}
+      preview_url: ${{ steps.preview_url.outputs.url }}
     permissions:
       contents: read
 
@@ -120,6 +131,11 @@ jobs:
         if: ${{ github.ref_name != 'main' }}
         run: |
           SANITIZED=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-28 | sed 's/-$//')
+          # Preview aliases must start with a letter (DNS label rule).
+          if [[ "$SANITIZED" =~ ^[0-9] ]]; then
+            SANITIZED="pr-${SANITIZED}"
+            SANITIZED=$(echo "$SANITIZED" | cut -c1-28 | sed 's/-$//')
+          fi
           echo "sanitized=${SANITIZED}" >> $GITHUB_OUTPUT
 
       - name: Build SPA
@@ -211,6 +227,7 @@ jobs:
           echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Deploy Success
+        if: ${{ !inputs.skip_slack }}
         uses: ./.github/actions/slack-notify
         with:
           step: ${{ 'spa_preview_success' }}
@@ -222,7 +239,7 @@ jobs:
           preview_url: ${{ steps.preview_url.outputs.url }}
 
       - name: Notify Failure
-        if: failure()
+        if: ${{ failure() && !inputs.skip_slack }}
         uses: ./.github/actions/slack-notify
         with:
           step: "failure"


### PR DESCRIPTION
## Summary

- Add `deploy-spa-preview.yaml` workflow that auto-deploys SPA previews when a PR is labeled:
  - `deploy-app-preview` label triggers app SPA deploy
  - `deploy-poke-preview` label triggers poke SPA deploy
  - Re-deploys automatically on push (`synchronize`) while the label is present
- After deploy, posts a PR comment with the preview URL (updates existing comment on subsequent deploys instead of creating duplicates)
- Slack notifications are skipped for PR preview deploys (`skip_slack` input)
- Fix preview alias validation: prefix `pr-` when branch name starts with a digit (Cloudflare requires aliases to start with a letter)

## Changes

- **`.github/workflows/deploy-spa-preview.yaml`** (new): Label-triggered wrapper that calls `deploy-spa.yaml` with `skip_slack: true`, then posts a PR comment with the preview URL
- **`.github/workflows/deploy-spa.yaml`**: Add `skip_slack` input to gate Slack notifications; add `preview_url` output; fix branch name sanitization for numeric prefixes

## Test plan

- [x] Add `deploy-app-preview` label to a PR → verify deploy triggers and PR comment is posted
- [x] Push a new commit to the same PR → verify deploy re-triggers and comment is updated (not duplicated)
- [ ] Verify no Slack notification is sent for label-triggered deploys
- [x] Test with a branch starting with a number (e.g. `22861-merge`) → verify alias is `pr-22861-merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)