### PR TITLE
[front] chore: Bump up docker version in bust base

### DIFF
--- a/.github/workflows/sandbox-bedrock-release.yml
+++ b/.github/workflows/sandbox-bedrock-release.yml
@@ -98,6 +98,6 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           echo "## Sandbox Bedrock Release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Released **v${VERSION}**" >> $GITHUB_STEP_SUMMARY
+          echo "Released **${VERSION}**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Image: \`us-central1-docker.pkg.dev/or1g1n-186209/dust-sbx/dust-sbx-bedrock:${VERSION}\`" >> $GITHUB_STEP_SUMMARY

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -4,7 +4,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:0.2.0")
+const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.1.0")
   // Conversation files bootstrap
   // Pre-create workspace directory for faster GCS mounts.
   .runCmd(


### PR DESCRIPTION
## Description

Bumps up docker image use for bedrock
Also remove a "v" in the description that could make you trip over.

## Tests

Tested manually (rebuild)

## Risk

None

## Deploy Plan

- [ ] Deploy front