### PR TITLE
Make screenshots visible to agents

### DIFF
--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -1,4 +1,5 @@
 import { clientFetch } from "@app/lib/egress/client";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CaptureService } from "@extension/shared/services/capture";
@@ -269,8 +270,9 @@ export function registerGetPageViewTool(
 
         // Upload each screenshot and return as ToolGeneratedFile resources
         // so the agent can visually analyze them.
-        const uploadedCaptures = await Promise.all(
-          captures.map(async (dataUrl, i) => {
+        const uploadedCaptures = await concurrentExecutor(
+          captures,
+          async (dataUrl, i) => {
             const [header, data] = dataUrl.split(",");
             const mimeType = header.replace("data:", "").replace(";base64", "");
             const ext = mimeType.split("/")[1] ?? "jpg";
@@ -294,7 +296,8 @@ export function registerGetPageViewTool(
               null
             );
             return { type: "resource" as const, resource };
-          })
+          },
+          { concurrency: 8 }
         );
 
         return { content: uploadedCaptures };

--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -9,78 +9,115 @@ import { z } from "zod";
 // The full content is also indexed in the conversation JIT data source.
 const MAX_EXTRACTED_TEXT_CHARS = 100_000;
 
+type UploadError = { error: string };
+
+function base64ToBlob(base64: string, mimeType: string): Blob {
+  const binaryStr = atob(base64);
+  const bytes = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i++) {
+    bytes[i] = binaryStr.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mimeType });
+}
+
+/**
+ * Creates a file record via the Dust API and uploads the blob content.
+ * Returns the file sId on success, or an error message on failure.
+ */
+async function createAndUpload(
+  workspaceId: string,
+  blob: Blob,
+  fileName: string,
+  mimeType: string
+): Promise<{ fileId: string } | UploadError> {
+  const createRes = await clientFetch(`/api/w/${workspaceId}/files`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      contentType: mimeType,
+      fileName,
+      fileSize: blob.size,
+      useCase: "conversation",
+    }),
+  });
+
+  if (!createRes.ok) {
+    const msg = await createRes.text();
+    return { error: `Failed to create file record: ${msg}` };
+  }
+
+  const { file } = (await createRes.json()) as FileUploadRequestResponseBody;
+
+  const formData = new FormData();
+  formData.append("file", blob, fileName);
+
+  const uploadRes = await clientFetch(file.uploadUrl, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!uploadRes.ok) {
+    const msg = await uploadRes.text();
+    return { error: `Failed to upload file: ${msg}` };
+  }
+
+  return { fileId: file.sId };
+}
+
+function makeFileResource(
+  workspaceId: string,
+  fileId: string,
+  fileName: string,
+  contentType: string,
+  text: string,
+  snippet: string | null
+) {
+  return {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+    uri: `/api/w/${workspaceId}/files/${fileId}`,
+    text,
+    // The MCP SDK strips non-standard fields from resource objects during
+    // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
+    // so they survive the MCP protocol round-trip. The server will move
+    // them back to the root level in mcp_actions.ts (tryCallMCPTool).
+    _meta: { fileId, title: fileName, contentType, snippet },
+  };
+}
+
 /**
  * Uploads a PDF to the Dust file API and fetches the server-extracted text.
- * Returns the file ID, name, and extracted text, or null on failure.
+ * Returns the file ID, name, and extracted text, or an error on failure.
  */
 async function uploadPdf(
   workspaceId: string,
   base64: string,
   mimeType: string,
   pageUrl: string
-): Promise<{
-  fileId: string;
-  fileName: string;
-  extractedText: string | null;
-} | null> {
+): Promise<
+  | { fileId: string; fileName: string; extractedText: string | null }
+  | UploadError
+> {
   try {
     const urlFilename = pageUrl.split("/").pop()?.split("?")[0];
     const fileName = urlFilename || "document.pdf";
+    const blob = base64ToBlob(base64, mimeType);
 
-    // Convert base64 to Blob.
-    const binaryStr = atob(base64);
-    const bytes = new Uint8Array(binaryStr.length);
-    for (let i = 0; i < binaryStr.length; i++) {
-      bytes[i] = binaryStr.charCodeAt(i);
-    }
-    const blob = new Blob([bytes], { type: mimeType });
-
-    // Step 1: Create the file record and get the upload URL.
-    const createRes = await clientFetch(`/api/w/${workspaceId}/files`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        contentType: mimeType,
-        fileName,
-        fileSize: blob.size,
-        useCase: "conversation",
-      }),
-    });
-
-    if (!createRes.ok) {
-      console.error(
-        "[getPageViewTool] Failed to create file record:",
-        await createRes.text()
-      );
-      return null;
+    const uploaded = await createAndUpload(
+      workspaceId,
+      blob,
+      fileName,
+      mimeType
+    );
+    if ("error" in uploaded) {
+      return uploaded;
     }
 
-    const { file } = (await createRes.json()) as FileUploadRequestResponseBody;
-
-    // Step 2: Upload the file contentcreateServerForWorkspace. The server runs text extraction
-    // synchronously, so the processed version is ready when this resolves.
-    const formData = new FormData();
-    formData.append("file", blob, fileName);
-
-    const uploadRes = await clientFetch(file.uploadUrl, {
-      method: "POST",
-      body: formData,
-    });
-
-    if (!uploadRes.ok) {
-      console.error(
-        "[getPageViewTool] Failed to upload file content:",
-        await uploadRes.text()
-      );
-      return null;
-    }
-
-    // Step 3: Fetch the extracted text (processed version).
+    // Fetch the extracted text (processed version).
     // The server ran OCR-enabled text extraction during upload, so it's ready now.
     let extractedText: string | null = null;
     try {
       const textRes = await clientFetch(
-        `/api/w/${workspaceId}/files/${file.sId}?version=processed&action=view`
+        `/api/w/${workspaceId}/files/${uploaded.fileId}?version=processed&action=view`
       );
       if (textRes.ok) {
         const text = await textRes.text();
@@ -90,10 +127,47 @@ async function uploadPdf(
       console.warn("[getPageViewTool] Could not fetch extracted text:", err);
     }
 
-    return { fileId: file.sId, fileName, extractedText };
+    return { fileId: uploaded.fileId, fileName, extractedText };
   } catch (error) {
-    console.error("[getPageViewTool] Error uploading PDF:", error);
-    return null;
+    return {
+      error: `Unexpected error uploading PDF: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Uploads an image to the Dust file API.
+ * Returns the file ID and name, or an error message on failure.
+ */
+async function uploadImage(
+  workspaceId: string,
+  base64: string,
+  mimeType: string,
+  fileName: string
+): Promise<{ fileId: string; fileName: string } | UploadError> {
+  try {
+    const blob = base64ToBlob(base64, mimeType);
+
+    if (blob.size > 5 * 1024 * 1024) {
+      const sizeMb = (blob.size / (1024 * 1024)).toFixed(1);
+      return { error: `Image is too large (${sizeMb} MB, max 5 MB).` };
+    }
+
+    const uploaded = await createAndUpload(
+      workspaceId,
+      blob,
+      fileName,
+      mimeType
+    );
+    if ("error" in uploaded) {
+      return uploaded;
+    }
+
+    return { fileId: uploaded.fileId, fileName };
+  } catch (error) {
+    return {
+      error: `Unexpected error uploading image: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 }
 
@@ -140,50 +214,50 @@ export function registerGetPageViewTool(
           };
         }
 
-        const { captures, fileData } = result.value;
+        const { captures, fileData, title } = result.value;
 
         if (fileData) {
           const { base64, mimeType, url } = fileData;
 
           if (mimeType === "application/pdf") {
             const data = await uploadPdf(workspaceId, base64, mimeType, url);
-            if (data) {
-              // The MCP SDK strips non-standard fields from resource objects during
-              // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
-              // so they survive the MCP protocol round-trip. The server will move
-              // them back to the root level in mcp_actions.ts (tryCallMCPTool).
-              const resource = {
-                mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-                uri: `/api/w/${workspaceId}/files/${data.fileId}`,
-                text: data.extractedText ?? `PDF from ${url}`,
-                _meta: {
-                  fileId: data.fileId,
-                  title: data.fileName,
-                  contentType: mimeType,
-                  snippet: data.extractedText
-                    ? data.extractedText.slice(0, 500)
-                    : null,
-                },
-              };
-              return {
-                content: [{ type: "resource" as const, resource }],
-              };
+            if ("error" in data) {
+              return { content: [{ type: "text", text: data.error }] };
             }
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: "Failed to process the PDF. It may be too large or inaccessible.",
-                },
-              ],
-            };
+            const resource = makeFileResource(
+              workspaceId,
+              data.fileId,
+              data.fileName,
+              mimeType,
+              data.extractedText ?? `PDF from ${url}`,
+              data.extractedText ? data.extractedText.slice(0, 500) : null
+            );
+            return { content: [{ type: "resource" as const, resource }] };
           }
 
-          // For images, return the raw image so the model can analyze it visually.
+          // For images, upload to Dust and return as a ToolGeneratedFile resource
+          // so the agent can visually analyze it.
           if (mimeType.startsWith("image/")) {
-            return {
-              content: [{ type: "image" as const, data: base64, mimeType }],
-            };
+            const urlFilename = url.split("/").pop()?.split("?")[0];
+            const fileName = urlFilename || `image.${mimeType.split("/")[1]}`;
+            const data = await uploadImage(
+              workspaceId,
+              base64,
+              mimeType,
+              fileName
+            );
+            if ("error" in data) {
+              return { content: [{ type: "text", text: data.error }] };
+            }
+            const resource = makeFileResource(
+              workspaceId,
+              data.fileId,
+              data.fileName,
+              mimeType,
+              "",
+              null
+            );
+            return { content: [{ type: "resource" as const, resource }] };
           }
         }
 
@@ -193,13 +267,37 @@ export function registerGetPageViewTool(
           };
         }
 
-        return {
-          content: captures.map((dataUrl) => {
+        // Upload each screenshot and return as ToolGeneratedFile resources
+        // so the agent can visually analyze them.
+        const uploadedCaptures = await Promise.all(
+          captures.map(async (dataUrl, i) => {
             const [header, data] = dataUrl.split(",");
             const mimeType = header.replace("data:", "").replace(";base64", "");
-            return { type: "image" as const, data, mimeType };
-          }),
-        };
+            const ext = mimeType.split("/")[1] ?? "jpg";
+            const base = captures.length > 1 ? `${title} (${i + 1})` : title;
+            const fileName = `${base}.${ext}`;
+            const uploaded = await uploadImage(
+              workspaceId,
+              data,
+              mimeType,
+              fileName
+            );
+            if ("error" in uploaded) {
+              return { type: "text" as const, text: uploaded.error };
+            }
+            const resource = makeFileResource(
+              workspaceId,
+              uploaded.fileId,
+              uploaded.fileName,
+              mimeType,
+              "",
+              null
+            );
+            return { type: "resource" as const, resource };
+          })
+        );
+
+        return { content: uploadedCaptures };
       } catch (error) {
         return {
           content: [

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -17,16 +17,22 @@ import {
   uploadBase64ImageToFileStorage,
 } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
+import type { Content } from "@app/types/assistant/generation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type {
   FileUseCase,
   FileUseCaseMetadata,
   SupportedFileContentType,
   SupportedImageContentType,
 } from "@app/types/files";
-import { isSupportedFileContentType } from "@app/types/files";
+import {
+  isLLMVisionSupportedImageContentType,
+  isSupportedFileContentType,
+} from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { hasNullUnicodeCharacter } from "@app/types/shared/utils/string_utils";
@@ -85,14 +91,34 @@ export function hideFileFromActionOutput({
   };
 }
 
-export function rewriteContentForModel(
+export async function rewriteContentForModel(
+  auth: Authenticator,
+  model: ModelConfigurationType,
   content: CallToolResult["content"][number]
-): CallToolResult["content"][number] | null {
+): Promise<Content | null> {
   // Only render tool generated files that are supported.
   if (
     isToolGeneratedFile(content) &&
     isSupportedFileContentType(content.resource.contentType)
   ) {
+    const { contentType, fileId } = content.resource;
+
+    // For vision-supported images on vision-capable models, return an image_url block
+    // so the LLM can actually see the screenshot.
+    if (
+      isLLMVisionSupportedImageContentType(contentType) &&
+      model.supportsVision
+    ) {
+      const fileCloudStoragePath = FileResource.getCloudStoragePathForId({
+        fileId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        version: "processed",
+      });
+      const signedUrl =
+        await getPrivateUploadBucket().getSignedUrl(fileCloudStoragePath);
+      return { type: "image_url", image_url: { url: signedUrl } };
+    }
+
     const attachment = getAttachmentFromFile({
       fileId: content.resource.fileId,
       source: "agent",
@@ -121,7 +147,11 @@ export function rewriteContentForModel(
     return null;
   }
 
-  return content;
+  if (content.type === "text") {
+    return content;
+  }
+
+  return null;
 }
 
 /**

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -11,6 +11,7 @@ import {
   serializeMention,
 } from "@app/lib/mentions/format";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
@@ -86,8 +87,10 @@ export async function renderActionForMultiActionsModel(
   }
 
   const outputItems = removeNulls(
-    await Promise.all(
-      action.output?.map((c) => rewriteContentForModel(auth, model, c)) ?? []
+    await concurrentExecutor(
+      action.output ?? [],
+      (c) => rewriteContentForModel(auth, model, c),
+      { concurrency: 8 }
     )
   );
 
@@ -97,7 +100,7 @@ export async function renderActionForMultiActionsModel(
   } else if (outputItems.every((item) => isTextContent(item))) {
     output = outputItems.map((item) => item.text).join("\n");
   } else if (outputItems.some((item) => isImageContent(item))) {
-    // Return as Content[] so vision models receive the image_url blocks directly.
+    // Return as Content[] to the model so vision models receive the image_url blocks directly.
     output = outputItems;
   } else {
     output = JSON.stringify(outputItems);

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -3,7 +3,6 @@
  * These functions are used by both legacy and enhanced implementations
  */
 
-import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -24,11 +23,13 @@ import type {
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import type {
+  Content,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelMessageTypeMultiActions,
   UserMessageTypeModel,
 } from "@app/types/assistant/generation";
+import { isImageContent, isTextContent } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
 
@@ -46,9 +47,11 @@ export type Step = {
 /**
  * Renders an action result for multi-actions model
  */
-export function renderActionForMultiActionsModel(
+export async function renderActionForMultiActionsModel(
+  auth: Authenticator,
+  model: ModelConfigurationType,
   action: AgentMCPActionWithOutputType
-): FunctionMessageTypeModel {
+): Promise<FunctionMessageTypeModel> {
   if (action.status === "denied") {
     return {
       role: "function" as const,
@@ -83,14 +86,19 @@ export function renderActionForMultiActionsModel(
   }
 
   const outputItems = removeNulls(
-    action.output?.map(rewriteContentForModel) ?? []
+    await Promise.all(
+      action.output?.map((c) => rewriteContentForModel(auth, model, c)) ?? []
+    )
   );
 
-  let output;
+  let output: string | Content[];
   if (outputItems.length === 0) {
     output = "Successfully executed action, no output.";
   } else if (outputItems.every((item) => isTextContent(item))) {
     output = outputItems.map((item) => item.text).join("\n");
+  } else if (outputItems.some((item) => isImageContent(item))) {
+    // Return as Content[] so vision models receive the image_url blocks directly.
+    output = outputItems;
   } else {
     output = JSON.stringify(outputItems);
   }
@@ -106,7 +114,7 @@ export function renderActionForMultiActionsModel(
 /**
  * Processes agent message steps
  */
-export function getSteps(
+export async function getSteps(
   auth: Authenticator,
   {
     model,
@@ -121,7 +129,7 @@ export function getSteps(
     conversationId: string;
     onMissingAction: "inject-placeholder" | "skip";
   }
-): Step[] {
+): Promise<Step[]> {
   const supportedModel = getSupportedModelConfig(model);
   if (!supportedModel) {
     return [];
@@ -141,15 +149,13 @@ export function getSteps(
   for (const action of actions) {
     const stepIndex = action.step;
     stepByStepIndex[stepIndex] = stepByStepIndex[stepIndex] || emptyStep();
-    // All these calls are not async, so we're not doing a Promise.all for now but might need to
-    // be reconsidered in the future.
     stepByStepIndex[stepIndex].actions.push({
       call: {
         id: action.functionCallId,
         name: action.functionCallName,
         arguments: JSON.stringify(action.params),
       },
-      result: renderActionForMultiActionsModel(action),
+      result: await renderActionForMultiActionsModel(auth, model, action),
     });
   }
 

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -46,7 +46,7 @@ describe("renderAllMessages", () => {
         }) as UserMessageTypeModel
     );
 
-    vi.mocked(getSteps).mockReturnValue([
+    vi.mocked(getSteps).mockResolvedValue([
       {
         contents: [{ type: "text_content", value: "Agent response" }],
         actions: [],
@@ -269,7 +269,7 @@ describe("renderAllMessages", () => {
       ]);
 
       // Mock getSteps to return a step with both text_content and function_call
-      vi.mocked(getSteps).mockReturnValue([
+      vi.mocked(getSteps).mockResolvedValue([
         {
           contents: [
             { type: "text_content", value: "Agent response" },
@@ -321,7 +321,7 @@ describe("renderAllMessages", () => {
       ]);
 
       // Mock getSteps to return a step with both text_content and function_call
-      vi.mocked(getSteps).mockReturnValue([
+      vi.mocked(getSteps).mockResolvedValue([
         {
           contents: [
             { type: "text_content", value: "Agent response" },

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -162,7 +162,7 @@ export async function renderAllMessages(
 
         if (isCurrentAgentMessage) {
           // Render the current agent's messages normally with full agentic loop.
-          const steps = getSteps(auth, {
+          const steps = await getSteps(auth, {
             model,
             message: m,
             workspaceId: conversation.owner.sId,


### PR DESCRIPTION
## Description

Enables vision-capable models to see screenshots captured by the Chrome extension. Previously, screenshots from the `get-current-browser-page-view` tool were uploaded to file storage but rendered as text attachments, preventing vision models from analyzing them visually. This PR uploads screenshots as files and returns them as `image_url` content blocks when the model supports vision, allowing agents to see and analyze page screenshots.

## Tests

Manual testing with vision-capable agents capturing screenshots from browser tabs and verifying the model can visually analyze the content.

## Risk

Low. Changes are contained to the Chrome extension's page view tool and the conversation rendering layer. 

## Deploy Plan

Deploy extension and front.