### PR TITLE
Fine tune Gong connector permission profile behavior

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -109,11 +109,6 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       mimeType: INTERNAL_MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
     });
 
-    const result = await this.createGongSchedule(connector);
-    if (result.isErr()) {
-      throw result.error;
-    }
-
     return new Ok(connector.id.toString());
   }
 
@@ -417,28 +412,48 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
         await configuration.setPermissionProfileId(profileId);
 
-        logger.info(
-          {
-            connectorId: connector.id,
-            permissionProfileId: profileId,
-          },
-          "[Gong] Permission profile updated, stopping and resuming sync."
-        );
+        const scheduleId = makeGongSyncScheduleId(connector);
+        const exists = await scheduleExists({ scheduleId });
 
-        const stopResult = await this.stop({
-          reason: "Permission profile updated",
-        });
-        if (stopResult.isErr()) {
-          return stopResult;
-        }
-
-        const resumeResult = await this.resume();
-        if (resumeResult.isErr()) {
-          logger.error(
-            { connectorId: connector.id, error: resumeResult.error },
-            "[Gong] Failed to resume schedule after permission profile update"
+        if (!exists) {
+          // First save after connector creation: create the schedule.
+          logger.info(
+            {
+              connectorId: connector.id,
+              permissionProfileId: profileId,
+            },
+            "[Gong] Permission profile saved, creating sync schedule."
           );
-          return resumeResult;
+          const createResult =
+            await GongConnectorManager.createGongSchedule(connector);
+          if (createResult.isErr()) {
+            return new Err(createResult.error);
+          }
+        } else {
+          // Subsequent save: stop and resume to pick up the new profile.
+          logger.info(
+            {
+              connectorId: connector.id,
+              permissionProfileId: profileId,
+            },
+            "[Gong] Permission profile updated, stopping and resuming sync."
+          );
+
+          const stopResult = await this.stop({
+            reason: "Permission profile updated",
+          });
+          if (stopResult.isErr()) {
+            return stopResult;
+          }
+
+          const resumeResult = await this.resume();
+          if (resumeResult.isErr()) {
+            logger.error(
+              { connectorId: connector.id, error: resumeResult.error },
+              "[Gong] Failed to resume schedule after permission profile update"
+            );
+            return resumeResult;
+          }
         }
 
         return new Ok(undefined);

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -414,14 +414,32 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       }
       case PERMISSION_PROFILE_ID_CONFIG_KEY: {
         const profileId = configValue || null;
+
+        await configuration.setPermissionProfileId(profileId);
+
         logger.info(
           {
             connectorId: connector.id,
             permissionProfileId: profileId,
           },
-          "[Gong] Update permission profile."
+          "[Gong] Permission profile updated, stopping and resuming sync."
         );
-        await configuration.setPermissionProfileId(profileId);
+
+        const stopResult = await this.stop({
+          reason: "Permission profile updated",
+        });
+        if (stopResult.isErr()) {
+          return stopResult;
+        }
+
+        const resumeResult = await this.resume();
+        if (resumeResult.isErr()) {
+          logger.error(
+            { connectorId: connector.id, error: resumeResult.error },
+            "[Gong] Failed to resume schedule after permission profile update"
+          );
+          return resumeResult;
+        }
 
         return new Ok(undefined);
       }

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -112,7 +112,18 @@ function shouldSyncTranscript(
   }
 
   const { parties = [] } = metadata;
-  if (parties.some((p) => p.userId && filter.userIds.has(p.userId))) {
+  const partyUserIds = parties
+    .map((p) => p.userId)
+    .filter((id): id is string => Boolean(id));
+
+  // Include the call owner (primaryUserId) in the match check, since they
+  // may not appear in the parties array (e.g. imported calls).
+  const { primaryUserId } = metadata.metaData;
+  const candidateUserIds = primaryUserId
+    ? [...new Set([primaryUserId, ...partyUserIds])]
+    : partyUserIds;
+
+  if (candidateUserIds.some((id) => filter.userIds.has(id))) {
     return { shouldSync: true, reason: null };
   }
 

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -368,8 +368,12 @@ export function GongOptionComponent({
 
   return (
     <div className="flex flex-col space-y-4 py-2">
-      <ContentMessage title="All Gong data will sync automatically" size="lg">
-        All your Gong resources will sync automatically. Selecting items
+      <ContentMessage
+        title="All Gong data will sync automatically once you save"
+        size="lg"
+      >
+        Syncing will start once you save a participant filter selection.
+        Relevant Gong resources will then sync automatically. Selecting items
         individually is not available.
       </ContentMessage>
 

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -223,9 +223,9 @@ function PermissionProfileSelector({
     >
       <ContextItem.Description>
         <div className="text-muted-foreground dark:text-muted-foreground-night">
-          Filter calls by participant group. Only calls where at least one
-          participant is assigned to the selected profile will be synced.
-          Changing the filter only affects future syncs.
+          Filter calls by Gong permission profile. Only calls involving users
+          listed in the selected profile's "Specific Teams" section will be
+          synced. Changing the filter only affects future syncs.
         </div>
       </ContextItem.Description>
     </ContextItem>


### PR DESCRIPTION
## Description
Fine tuning the permission profile filter logic ahead of use.
Changes are:
1. Pause & restart an in progress sync if a permission filter is updated so the remainder of the in progress sync uses this selection
2. Move start of sync schedule to the save of the permission filter setting and add clarifying copy. This is to ensure the first sync doesn't pull in calls from users with sensitive content. I think this is better than doing a cleanup process like we did for the keyword search because cleaning up a ton of old transcripts in this case could require a ton of Gong API calls, but lmk what you think.
3. Improve the copy to better reflect the behavior of the setting

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Medium - it would be possible for a user to set up a connection and then never save their profile which would leave the sync in a pending state. I think this is okay with the clarifying copy I've added, but if we think this is too risky, we can rethink the approach
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front
- [ ] deploy connectors

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
