### PR TITLE
Fix logic so old suggestions marked outdated for new agents

### DIFF
--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -353,10 +353,6 @@ export async function pruneConflictingInstructionSuggestions(
     return;
   }
 
-  if (!agentConfiguration.instructionsHtml) {
-    return;
-  }
-
   const allPending = await AgentSuggestionResource.listByAgentConfigurationId(
     auth,
     agentConfiguration.sId,
@@ -392,12 +388,13 @@ export async function pruneConflictingInstructionSuggestions(
       return;
     }
 
-    // Collect all descendants of this block (child blocks that would be replaced)
-    const descendants = getDescendantBlockIds(
-      agentConfiguration.instructionsHtml,
-      targetBlockId
-    );
-    descendants.forEach((id) => allDescendantBlockIds.add(id));
+    if (agentConfiguration.instructionsHtml) {
+      const descendants = getDescendantBlockIds(
+        agentConfiguration.instructionsHtml,
+        targetBlockId
+      );
+      descendants.forEach((id) => allDescendantBlockIds.add(id));
+    }
   }
 
   const toMarkOutdated: InstructionsSuggestionResource[] = [];


### PR DESCRIPTION
## Description

* Fixing existing bug where if you overwrite a suggestion for a fresh agent, it wouldn't mark the old as outdated, which caused overlapping suggestions

## Tests

* Manually validated fix

## Risk

* None

## Deploy Plan

* Deploy front