### PR TITLE
[front] Show feedback UI only for certain global agents + improve UI for sidekick

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -56,6 +56,7 @@ import { formatTimestring } from "@app/lib/utils/timestamps";
 import {
   canShowAgentConversationActions,
   isGlobalAgentId,
+  isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
 import type {
   RichAgentMention,
@@ -548,7 +549,9 @@ export function AgentMessage({
     !isDeleted &&
     agentMessage.status !== "created" &&
     agentMessage.status !== "failed" &&
-    agentMessage.configuration.status !== "draft";
+    agentMessage.configuration.status !== "draft" &&
+    (!isGlobalAgent ||
+      isGlobalAgentWithFeedback(agentMessage.configuration.sId));
 
   const retryMessage = useRetryMessage({ owner });
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -55,7 +55,6 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import {
   canShowAgentConversationActions,
-  GLOBAL_AGENTS_SID,
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
@@ -148,7 +147,6 @@ function PrunedContextChip() {
 
 interface AgentMessageProps {
   conversationId: string;
-  isFirstMessage: boolean;
   isLastMessage: boolean;
   agentMessage: MessageTemporaryState;
   messageFeedback: FeedbackSelectorBaseProps;
@@ -166,7 +164,6 @@ interface AgentMessageProps {
 
 export function AgentMessage({
   conversationId,
-  isFirstMessage,
   isLastMessage,
   agentMessage,
   messageFeedback,
@@ -548,19 +545,13 @@ export function AgentMessage({
     !shouldStream &&
     !isAgentMessageHandingOver;
 
-  // Hide feedback for Sidekick's first message (intro/greeting).
-  const isSidekickFirstMessage =
-    isFirstMessage &&
-    agentMessage.configuration.sId === GLOBAL_AGENTS_SID.SIDEKICK;
-
   const shouldShowFeedback =
     !isDeleted &&
     agentMessage.status !== "created" &&
     agentMessage.status !== "failed" &&
     agentMessage.configuration.status !== "draft" &&
     (!isGlobalAgent ||
-      isGlobalAgentWithFeedback(agentMessage.configuration.sId)) &&
-    !isSidekickFirstMessage;
+      isGlobalAgentWithFeedback(agentMessage.configuration.sId));
 
   const retryMessage = useRetryMessage({ owner });
 
@@ -585,7 +576,7 @@ export function AgentMessage({
     [retryMessage]
   );
 
-  // Add feedback buttons first (thumbs up/down)
+  // Add feedback buttons first
   if (shouldShowFeedback) {
     messageButtons.push(
       <FeedbackSelector

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -55,6 +55,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import {
   canShowAgentConversationActions,
+  GLOBAL_AGENTS_SID,
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
@@ -147,6 +148,7 @@ function PrunedContextChip() {
 
 interface AgentMessageProps {
   conversationId: string;
+  isFirstMessage: boolean;
   isLastMessage: boolean;
   agentMessage: MessageTemporaryState;
   messageFeedback: FeedbackSelectorBaseProps;
@@ -164,6 +166,7 @@ interface AgentMessageProps {
 
 export function AgentMessage({
   conversationId,
+  isFirstMessage,
   isLastMessage,
   agentMessage,
   messageFeedback,
@@ -545,13 +548,19 @@ export function AgentMessage({
     !shouldStream &&
     !isAgentMessageHandingOver;
 
+  // Hide feedback for Sidekick's first message (intro/greeting).
+  const isSidekickFirstMessage =
+    isFirstMessage &&
+    agentMessage.configuration.sId === GLOBAL_AGENTS_SID.SIDEKICK;
+
   const shouldShowFeedback =
     !isDeleted &&
     agentMessage.status !== "created" &&
     agentMessage.status !== "failed" &&
     agentMessage.configuration.status !== "draft" &&
     (!isGlobalAgent ||
-      isGlobalAgentWithFeedback(agentMessage.configuration.sId));
+      isGlobalAgentWithFeedback(agentMessage.configuration.sId)) &&
+    !isSidekickFirstMessage;
 
   const retryMessage = useRetryMessage({ owner });
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -551,7 +551,8 @@ export function AgentMessage({
     agentMessage.status !== "failed" &&
     agentMessage.configuration.status !== "draft" &&
     (!isGlobalAgent ||
-      isGlobalAgentWithFeedback(agentMessage.configuration.sId));
+      (isGlobalAgentId(agentMessage.configuration.sId) &&
+        isGlobalAgentWithFeedback(agentMessage.configuration.sId)));
 
   const retryMessage = useRetryMessage({ owner });
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -64,7 +64,10 @@ const feedbackBaseSchema = z.object({
   isConversationShared: z.boolean().default(true),
 });
 
-function makeFeedbackSchema(thumbDirection: ThumbReaction) {
+function makeFeedbackSchema(
+  thumbDirection: ThumbReaction,
+  showPredefinedAnswers: boolean
+) {
   if (thumbDirection === "up") {
     return feedbackBaseSchema;
   }
@@ -74,13 +77,17 @@ function makeFeedbackSchema(thumbDirection: ThumbReaction) {
   return feedbackBaseSchema.refine(
     (data) => {
       const hasAnswer =
-        data.selectedAnswer.length > 0 && data.selectedAnswer !== OTHER_ANSWER;
+        showPredefinedAnswers &&
+        data.selectedAnswer.length > 0 &&
+        data.selectedAnswer !== OTHER_ANSWER;
       const hasContent = data.feedbackContent.trim().length > 0;
 
       return hasAnswer || hasContent;
     },
     {
-      message: "Please select a reason or describe the issue.",
+      message: showPredefinedAnswers
+        ? "Please select a reason or describe the issue."
+        : "Please describe the issue.",
       path: ["feedbackContent"],
     }
   );
@@ -111,7 +118,7 @@ export function FeedbackSelector({
     React.useState<ThumbReaction>("up");
 
   const form = useForm<FeedbackFormValues>({
-    resolver: zodResolver(makeFeedbackSchema(thumbDirection)),
+    resolver: zodResolver(makeFeedbackSchema(thumbDirection, showPredefinedAnswers)),
     defaultValues: feedbackBaseSchema.parse({}),
   });
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -118,7 +118,9 @@ export function FeedbackSelector({
     React.useState<ThumbReaction>("up");
 
   const form = useForm<FeedbackFormValues>({
-    resolver: zodResolver(makeFeedbackSchema(thumbDirection, showPredefinedAnswers)),
+    resolver: zodResolver(
+      makeFeedbackSchema(thumbDirection, showPredefinedAnswers)
+    ),
     defaultValues: feedbackBaseSchema.parse({}),
   });
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -1,4 +1,5 @@
 import { FeedbackSelectorPopoverContent } from "@app/components/assistant/conversation/FeedbackSelectorPopoverContent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -96,6 +97,12 @@ export function FeedbackSelector({
   agentName,
   isGlobalAgent,
 }: FeedbackSelectorProps) {
+  // "Improve this agent" would be confusing in the context of sidekick so we show "Improve @sidekick" instead
+  const improveLabel =
+    agentConfigurationId === GLOBAL_AGENTS_SID.SIDEKICK
+      ? `Improve @${agentName}`
+      : "Improve this agent";
+
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const [thumbDirection, setThumbDirection] =
     React.useState<ThumbReaction>("up");
@@ -176,7 +183,7 @@ export function FeedbackSelector({
           disabled={isSubmittingThumb}
           onClick={() => handleThumbClick("down")}
           icon={MagicIcon}
-          label="Improve this agent"
+          label={improveLabel}
           className={feedback?.thumb === "down" ? "" : "text-muted-foreground"}
         />
       </ButtonGroup>

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -294,7 +294,6 @@ export function FeedbackSelector({
                 <FeedbackSelectorPopoverContent
                   owner={owner}
                   agentConfigurationId={agentConfigurationId}
-                  agentName={agentName}
                   isGlobalAgent={isGlobalAgent}
                 />
               </div>

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -97,11 +97,14 @@ export function FeedbackSelector({
   agentName,
   isGlobalAgent,
 }: FeedbackSelectorProps) {
+  const isSidekick = agentConfigurationId === GLOBAL_AGENTS_SID.SIDEKICK;
+  // Predefined answers are not so relevant in the context of sidekick.
+  const showPredefinedAnswers = !isSidekick;
+
   // "Improve this agent" would be confusing in the context of sidekick so we show "Improve @sidekick" instead
-  const improveLabel =
-    agentConfigurationId === GLOBAL_AGENTS_SID.SIDEKICK
-      ? `Improve @${agentName}`
-      : "Improve this agent";
+  const improveLabel = isSidekick
+    ? `Improve @${agentName}`
+    : "Improve this agent";
 
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const [thumbDirection, setThumbDirection] =
@@ -217,25 +220,26 @@ export function FeedbackSelector({
 
                   {thumbDirection === "down" && (
                     <div className="mb-3 flex flex-wrap gap-2">
-                      {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => (
-                        <Button
-                          key={answer}
-                          label={answer}
-                          size="xs"
-                          variant={
-                            selectedAnswerField.field.value === answer
-                              ? "primary"
-                              : "outline"
-                          }
-                          onClick={() => {
-                            selectedAnswerField.field.onChange(
+                      {showPredefinedAnswers &&
+                        FEEDBACK_PREDEFINED_ANSWERS.map((answer) => (
+                          <Button
+                            key={answer}
+                            label={answer}
+                            size="xs"
+                            variant={
                               selectedAnswerField.field.value === answer
-                                ? ""
-                                : answer
-                            );
-                          }}
-                        />
-                      ))}
+                                ? "primary"
+                                : "outline"
+                            }
+                            onClick={() => {
+                              selectedAnswerField.field.onChange(
+                                selectedAnswerField.field.value === answer
+                                  ? ""
+                                  : answer
+                              );
+                            }}
+                          />
+                        ))}
                     </div>
                   )}
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -51,7 +51,7 @@ const OTHER_ANSWER = "Other (add details below)";
 
 const FEEDBACK_PREDEFINED_ANSWERS = [
   "Factually incorrect",
-  "Didn’t fully follow instructions",
+  "Didn’t follow instructions",
   "Don’t like the tone",
   "Wrong data sources",
   "Took too long",
@@ -223,32 +223,31 @@ export function FeedbackSelector({
                 <div>
                   <Label htmlFor="feedback-content" className="mb-2 block">
                     {thumbDirection === "down"
-                      ? "What should the agent do differently?"
+                      ? "What was the issue?"
                       : "Glad you liked it! Tell us more?"}
                   </Label>
 
-                  {thumbDirection === "down" && (
+                  {thumbDirection === "down" && showPredefinedAnswers && (
                     <div className="mb-3 flex flex-wrap gap-2">
-                      {showPredefinedAnswers &&
-                        FEEDBACK_PREDEFINED_ANSWERS.map((answer) => (
-                          <Button
-                            key={answer}
-                            label={answer}
-                            size="xs"
-                            variant={
+                      {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => (
+                        <Button
+                          key={answer}
+                          label={answer}
+                          size="xs"
+                          variant={
+                            selectedAnswerField.field.value === answer
+                              ? "primary"
+                              : "outline"
+                          }
+                          onClick={() => {
+                            selectedAnswerField.field.onChange(
                               selectedAnswerField.field.value === answer
-                                ? "primary"
-                                : "outline"
-                            }
-                            onClick={() => {
-                              selectedAnswerField.field.onChange(
-                                selectedAnswerField.field.value === answer
-                                  ? ""
-                                  : answer
-                              );
-                            }}
-                          />
-                        ))}
+                                ? ""
+                                : answer
+                            );
+                          }}
+                        />
+                      ))}
                     </div>
                   )}
 
@@ -295,6 +294,7 @@ export function FeedbackSelector({
                 <FeedbackSelectorPopoverContent
                   owner={owner}
                   agentConfigurationId={agentConfigurationId}
+                  agentName={agentName}
                   isGlobalAgent={isGlobalAgent}
                 />
               </div>

--- a/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
+++ b/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
@@ -23,7 +23,7 @@ export function FeedbackSelectorPopoverContent({
     return (
       <div className="mb-4 mt-2 flex flex-col gap-2">
         <Page.P variant="secondary">
-          Dust will use this to improve default agents.
+          Your feedback goes to the Dust team.
         </Page.P>
       </div>
     );

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -164,6 +164,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               user={context.user}
               triggeringUser={triggeringUser}
               conversationId={context.conversation.sId}
+              isFirstMessage={!prevData}
               isLastMessage={!nextData}
               agentMessage={data}
               messageFeedback={messageFeedbackWithSubmit}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -164,7 +164,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               user={context.user}
               triggeringUser={triggeringUser}
               conversationId={context.conversation.sId}
-              isFirstMessage={!prevData}
               isLastMessage={!nextData}
               agentMessage={data}
               messageFeedback={messageFeedbackWithSubmit}

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -187,6 +187,17 @@ export function isGlobalAgentId(sId: string): sId is GLOBAL_AGENTS_SID {
   return (Object.values(GLOBAL_AGENTS_SID) as string[]).includes(sId);
 }
 
+// If you want to show feedback buttons for global agents, add sId here.
+const GLOBAL_AGENTS_WITH_FEEDBACK = new Set<string>([
+  GLOBAL_AGENTS_SID.DUST,
+  GLOBAL_AGENTS_SID.DEEP_DIVE,
+  GLOBAL_AGENTS_SID.SIDEKICK,
+]);
+
+export function isGlobalAgentWithFeedback(sId: string): boolean {
+  return GLOBAL_AGENTS_WITH_FEEDBACK.has(sId);
+}
+
 const AGENT_IDS_RESTRICTED_TO_BUILDER = new Set<string>([
   GLOBAL_AGENTS_SID.SIDEKICK,
 ]);

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -188,13 +188,13 @@ export function isGlobalAgentId(sId: string): sId is GLOBAL_AGENTS_SID {
 }
 
 // If you want to show feedback buttons for global agents, add sId here.
-const GLOBAL_AGENTS_WITH_FEEDBACK = new Set<string>([
+const GLOBAL_AGENTS_WITH_FEEDBACK = new Set<GLOBAL_AGENTS_SID>([
   GLOBAL_AGENTS_SID.DUST,
   GLOBAL_AGENTS_SID.DEEP_DIVE,
   GLOBAL_AGENTS_SID.SIDEKICK,
 ]);
 
-export function isGlobalAgentWithFeedback(sId: string): boolean {
+export function isGlobalAgentWithFeedback(sId: GLOBAL_AGENTS_SID): boolean {
   return GLOBAL_AGENTS_WITH_FEEDBACK.has(sId);
 }
 


### PR DESCRIPTION
## Description
This PR is to update the feedback UI based on the discussion [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1773261007724129). We show the feedback buttons only for custom agents + selected Dust owned agents (Dust, deep-dive, sidekick for now). I also removed the predefined answers for sidekick.  

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
