### PR TITLE
Add shortcuts to attach page screenshot/content

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -931,7 +931,7 @@ const InputBarContainer = ({
                                 endComponent={
                                   <DropdownMenuShortcut
                                     shortcut={pageShortcut}
-                                    className="text-xs"
+                                    className="text-xs text-faint dark:text-faint-night"
                                   />
                                 }
                               />
@@ -948,7 +948,7 @@ const InputBarContainer = ({
                                 endComponent={
                                   <DropdownMenuShortcut
                                     shortcut={screenshotShortcut}
-                                    className="text-xs"
+                                    className="text-xs text-faint dark:text-faint-night"
                                   />
                                 }
                               />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -560,8 +560,8 @@ const InputBarContainer = ({
     return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
   }, []);
 
-  const pageShortcut = isMac ? "cmd+shift+P" : "ctrl+shift+P";
-  const screenshotShortcut = isMac ? "cmd+shift+S" : "ctrl+shift+S";
+  const pageShortcut = isMac ? "⇧⌘P" : "Ctrl+Maj+P";
+  const screenshotShortcut = isMac ? "⇧⌘S" : "Ctrl+Maj+S";
 
   useEffect(() => {
     // captureActions is defined only in the extension, so the shortcuts won't work in the web app
@@ -931,6 +931,7 @@ const InputBarContainer = ({
                                 endComponent={
                                   <DropdownMenuShortcut
                                     shortcut={pageShortcut}
+                                    className="text-xs"
                                   />
                                 }
                               />
@@ -947,6 +948,7 @@ const InputBarContainer = ({
                                 endComponent={
                                   <DropdownMenuShortcut
                                     shortcut={screenshotShortcut}
+                                    className="text-xs"
                                   />
                                 }
                               />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -49,6 +49,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
   GlobeAltIcon,
   PlusIcon,
@@ -551,6 +552,41 @@ const InputBarContainer = ({
   // When input bar animation is requested, it means the new button was clicked (removing focus from
   // the input bar), we grab it back.
   const { animate, captureActions } = useContext(InputBarContext);
+
+  const isMac = useMemo(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+  }, []);
+
+  const pageShortcut = isMac ? "cmd+shift+P" : "ctrl+shift+P";
+  const screenshotShortcut = isMac ? "cmd+shift+S" : "ctrl+shift+S";
+
+  useEffect(() => {
+    if (!captureActions) {
+      return;
+    }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMod = e.metaKey || e.ctrlKey;
+      if (!isMod || !e.shiftKey) {
+        return;
+      }
+      if (captureActions.isCapturing || fileUploaderService.isProcessingFiles) {
+        return;
+      }
+      if (e.key === "p" || e.key === "P") {
+        e.preventDefault();
+        captureActions.onCapture("text");
+      } else if (e.key === "s" || e.key === "S") {
+        e.preventDefault();
+        captureActions.onCapture("screenshot");
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [captureActions, fileUploaderService.isProcessingFiles]);
+
   useEffect(() => {
     if (animate) {
       // Schedule focus to avoid flushing during render lifecycle.
@@ -891,6 +927,11 @@ const InputBarContainer = ({
                                   fileUploaderService.isProcessingFiles
                                 }
                                 onClick={() => captureActions.onCapture("text")}
+                                endComponent={
+                                  <DropdownMenuShortcut
+                                    shortcut={pageShortcut}
+                                  />
+                                }
                               />
                               <DropdownMenuItem
                                 icon={CameraIcon}
@@ -901,6 +942,11 @@ const InputBarContainer = ({
                                 }
                                 onClick={() =>
                                   captureActions.onCapture("screenshot")
+                                }
+                                endComponent={
+                                  <DropdownMenuShortcut
+                                    shortcut={screenshotShortcut}
+                                  />
                                 }
                               />
                             </>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -564,6 +564,7 @@ const InputBarContainer = ({
   const screenshotShortcut = isMac ? "cmd+shift+S" : "ctrl+shift+S";
 
   useEffect(() => {
+    // captureActions is defined only in the extension, so the shortcuts won't work in the web app
     if (!captureActions) {
       return;
     }


### PR DESCRIPTION
## Description

**Extension only**: Adds keyboard shortcuts to quickly attach page content and screenshots in the input bar. The shortcuts use platform-appropriate modifiers (Cmd on macOS, Ctrl on Windows/Linux) combined with Shift + P/S keys:
- **Cmd/Ctrl+Shift+P**: Attach page content  
- **Cmd/Ctrl+Shift+S**: Attach page screenshot

The shortcuts are displayed next to their corresponding menu items in the attachment dropdown and are only active when capture is not already in progress and no files are being processed.

## Tests

Manually tested on macOS and verified shortcuts trigger the correct capture actions.

## Risk

Low - the keyboard event listener is scoped to the InputBarContainer component and only fires when capture is available (in extension only)

## Deploy Plan

Deploy front.