### PR TITLE
Remove the client side computation of eventId to avoid race condition

### DIFF
--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -34,7 +34,6 @@ export type EventPayload = {
  */
 class RedisHybridManager {
   private static instance: RedisHybridManager;
-  private static paddingCounter = 0;
   private subscriptionClient: RedisClientType | null = null;
   private streamAndPublishClient: RedisClientType | null = null;
   private subscribers: Map<string, Set<EventCallback>> = new Map();
@@ -197,29 +196,19 @@ class RedisHybridManager {
 
     // Try to publish the event up to MAX_PUBLISH_ATTEMPTS times to avoid losing events in case of a temporary Redis error.
     for (let i = 0; i < MAX_PUBLISH_ATTEMPTS; ++i) {
-      // Generate a unique event ID in redis expected format with a padding static counter to avoid collisions
-      // Redis expected format is: <timestamp>-<number> and eventId should be unique AND incrementing.
-      // The padding counter is used to ensure that the eventId is unique and incrementing when the timestamp is the same.
-      // We recompute the eventId for each attempt to avoid race conditions with other clients publishing events.
-      const startTime = Date.now();
-      const eventId = `${startTime}-${RedisHybridManager.paddingCounter}`;
-
-      // Increment the padding counter and wrap around to avoid overflow
-      RedisHybridManager.paddingCounter =
-        (RedisHybridManager.paddingCounter + 1) % 1000;
-
-      const eventPayload: EventPayload = {
-        id: eventId,
-        message: { payload: data },
-      };
-
       try {
-        // Publish to stream for history, set expiration on stream and publish to pub/sub in a single pipeline to avoid 3 round trips to Redis (3 => 1).
+        // Publish to stream for history, set expiration on stream and publish to pub/sub in a 2 steps to avoid 3 round trips to Redis (3 => 1).
+        const eventId = await streamAndPublishClient.xAdd(streamName, "*", {
+          payload: data,
+        });
+
+        const eventPayload: EventPayload = {
+          id: eventId,
+          message: { payload: data },
+        };
+
         // Using Promise.all is the idiomatic way to do this in node-redis https://redis.io/docs/latest/develop/clients/nodejs/transpipe/#execute-a-pipeline
         await Promise.all([
-          streamAndPublishClient.xAdd(streamName, eventId, {
-            payload: data,
-          }),
           streamAndPublishClient.expire(streamName, ttl),
           streamAndPublishClient.publish(
             pubSubChannelName,
@@ -239,7 +228,6 @@ class RedisHybridManager {
             origin,
             attempt: i + 1,
             maxAttempts: MAX_PUBLISH_ATTEMPTS,
-            eventId,
           },
           "Error publishing to Redis, retrying..."
         );


### PR DESCRIPTION
## Description

Do the xAdd separately to avoid the race condition.

## Tests

Local

## Risk

Low, similar to previous code.

## Deploy Plan

Deploy front