### PR TITLE
Reset mcp on workspace change, fix concurrency issues

### DIFF
--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -23,7 +23,7 @@ export class ChromeMcpService extends McpService {
     this.captureService = captureService;
   }
 
-  createServerForWorkspace(workspaceId: string): McpServer | null {
+  private createServerForWorkspace(workspaceId: string): McpServer | null {
     try {
       const server = new McpServer(
         {
@@ -43,7 +43,6 @@ export class ChromeMcpService extends McpService {
 
       registerAllTools(server, this.captureService, workspaceId);
 
-      this.server = server;
       return server;
     } catch (error) {
       console.error("Error creating MCP server:", error);
@@ -76,6 +75,7 @@ export class ChromeMcpService extends McpService {
 
       await server.connect(transport);
 
+      this.server = server;
       this.transport = transport;
     } catch (error) {
       console.error("Failed to connect MCP server:", error);
@@ -88,8 +88,7 @@ export class ChromeMcpService extends McpService {
     onServerIdReceived: (serverId: string) => void
   ): Promise<{ server: McpServer | null; serverId: string | undefined }> {
     try {
-      if (this.server) {
-        await this.connectServer(this.server, owner, onServerIdReceived);
+      if (this.server && this.transport) {
         return { server: this.server, serverId: this.serverId };
       }
 
@@ -99,7 +98,7 @@ export class ChromeMcpService extends McpService {
       }
 
       await this.connectServer(server, owner, onServerIdReceived);
-      return { server, serverId: this.serverId };
+      return { server: this.server, serverId: this.serverId };
     } catch (error) {
       console.error("Error getting or creating MCP server:", error);
       return { server: null, serverId: undefined };
@@ -111,9 +110,12 @@ export class ChromeMcpService extends McpService {
   }
 
   async disconnect(): Promise<void> {
-    if (this.transport) {
-      await this.transport.close();
-      this.transport = null;
+    const transport = this.transport;
+    this.transport = null;
+    this.server = null;
+    this.serverId = undefined;
+    if (transport) {
+      await transport.close();
     }
   }
 }

--- a/extension/platforms/front/services/mcp.ts
+++ b/extension/platforms/front/services/mcp.ts
@@ -31,7 +31,7 @@ export class FrontMcpService extends McpService {
    * Create an MCP server for a workspace
    * This is the core implementation that creates the workspace-scoped server
    */
-  createServerForWorkspace(): McpServer | null {
+  private createServerForWorkspace(): McpServer | null {
     try {
       const server = new McpServer(
         {
@@ -52,7 +52,6 @@ export class FrontMcpService extends McpService {
       // Register all tools with the server.
       registerAllTools(server, this.frontContext);
 
-      this.server = server;
       return server;
     } catch (error) {
       console.error("Error creating MCP server:", error);
@@ -76,7 +75,6 @@ export class FrontMcpService extends McpService {
     try {
       // If we already have a transport for this workspace, reuse it.
       if (this.transport) {
-        console.log("Transport already exists, reusing");
         return;
       }
 
@@ -93,7 +91,8 @@ export class FrontMcpService extends McpService {
       // Connect the server to the transport.
       await server.connect(transport);
 
-      // Store the transport for future reuse.
+      // Store the server and transport for future reuse.
+      this.server = server;
       this.transport = transport;
     } catch (error) {
       console.error("Failed to connect MCP server:", error);
@@ -110,38 +109,24 @@ export class FrontMcpService extends McpService {
     onServerIdReceived: (serverId: string) => void
   ): Promise<{ server: McpServer | null; serverId: string | undefined }> {
     try {
-      // Reuse existing server if we have one
-      if (this.server) {
-        // Connect if not already connected
-        await this.connectServer(this.server, owner, onServerIdReceived);
-        return {
-          server: this.server,
-          serverId: this.serverId,
-        };
+      // Reuse existing server if we have one.
+      if (this.server && this.transport) {
+        return { server: this.server, serverId: this.serverId };
       }
 
-      // Create a new server if we don't have one
+      // Create a new server if we don't have one.
       const server = this.createServerForWorkspace();
       if (!server) {
-        return {
-          server: null,
-          serverId: undefined,
-        };
+        return { server: null, serverId: undefined };
       }
 
-      // Connect the server
+      // Connect the server.
       await this.connectServer(server, owner, onServerIdReceived);
 
-      return {
-        server: server,
-        serverId: this.serverId,
-      };
+      return { server: this.server, serverId: this.serverId };
     } catch (error) {
       console.error("Error getting or creating MCP server:", error);
-      return {
-        server: null,
-        serverId: undefined,
-      };
+      return { server: null, serverId: undefined };
     }
   }
 
@@ -157,10 +142,12 @@ export class FrontMcpService extends McpService {
    * Disconnect and clean up the current server connection
    */
   async disconnect(): Promise<void> {
-    if (this.transport) {
-      await this.transport.close();
-      this.transport = null;
+    const transport = this.transport;
+    this.transport = null;
+    this.server = null;
+    this.serverId = undefined;
+    if (transport) {
+      await transport.close();
     }
-    // Note: We keep the serverId for potential reconnection.
   }
 }

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,13 +1,12 @@
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { normalizeError } from "@extension/shared/lib/utils";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
- * React hook for using MCP servers in components
- * This hook provides access to workspace-scoped MCP servers
- *
- * @returns An object with the MCP server, serverId for message payloads, and connection state
+ * React hook for using MCP servers in components.
+ * This hook provides access to workspace-scoped MCP servers and
+ * re-registers when the workspace changes.
  */
 export function useMcpServer() {
   const platform = usePlatform();
@@ -16,34 +15,32 @@ export function useMcpServer() {
   const [serverId, setServerId] = useState<string | undefined>(undefined);
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const serverRef = useRef<any>(null);
 
   const { workspace } = useExtensionAuth();
+  const workspaceId = workspace?.sId;
 
-  // Function to disconnect the server.
   const disconnectServer = useCallback(async () => {
-    if (serverRef.current) {
+    if (platform.mcp) {
       try {
-        // If the server has a disconnect method, call it.
-        if (typeof serverRef.current.disconnect === "function") {
-          await serverRef.current.disconnect();
-        }
+        await platform.mcp.disconnect();
         setIsConnected(false);
       } catch (err) {
         console.error("Error disconnecting MCP server:", err);
       }
     }
-  }, []);
+  }, [platform.mcp]);
 
-  // Create and connect to the MCP server.
   useEffect(() => {
-    // Check if the platform supports MCP.
     if (!platform.mcp) {
       setIsSupported(false);
       return;
     }
 
     setIsSupported(true);
+
+    if (!workspaceId) {
+      return;
+    }
 
     let isMounted = true;
 
@@ -52,9 +49,7 @@ export function useMcpServer() {
         if (!platform.mcp) {
           if (isMounted) {
             setIsSupported(false);
-            return;
           }
-
           return;
         }
 
@@ -64,25 +59,26 @@ export function useMcpServer() {
 
         const result = await platform.mcp.getOrCreateServer(
           workspace,
-          (serverId) => {
-            setServerId(serverId);
+          (sid) => {
+            if (isMounted) {
+              setServerId(sid);
+            }
           }
         );
-        if (!result.server) {
-          console.log("MCP server creation returned null");
-          if (isMounted) {
-            setIsSupported(false);
-            return;
-          }
+
+        if (!isMounted) {
+          return;
         }
 
-        if (isMounted) {
-          serverRef.current = result.server;
-          setServer(result.server);
-          setServerId(result.serverId);
-          setIsConnected(true);
-          setError(null);
+        if (!result.server) {
+          setIsSupported(false);
+          return;
         }
+
+        setServer(result.server);
+        setServerId(result.serverId);
+        setIsConnected(true);
+        setError(null);
       } catch (err) {
         console.error("Error setting up MCP server:", err);
         if (isMounted) {
@@ -92,18 +88,24 @@ export function useMcpServer() {
       }
     };
 
-    // Start the setup process.
-    void setupServer();
+    // Defer so that React StrictMode's synchronous mount→cleanup→mount cycle
+    // cancels the first timer before it runs, preventing duplicate registrations.
+    const timer = setTimeout(() => {
+      void setupServer();
+    }, 0);
 
-    // Cleanup function.
     return () => {
+      clearTimeout(timer);
       isMounted = false;
-      if (serverRef.current && isConnected) {
-        // Disconnect server if connected.
-        void disconnectServer();
+      if (platform.mcp) {
+        void platform.mcp.disconnect();
       }
+      setServer(null);
+      setServerId(undefined);
+      setIsConnected(false);
     };
-  }, [platform.mcp, isConnected, disconnectServer]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workspace object excluded; workspaceId triggers re-runs.
+  }, [platform.mcp, workspaceId]);
 
   return {
     server,


### PR DESCRIPTION
## Description

When switching workspaces in the extension, client-side MCP servers were not re-registered, causing "User does not have access to the client-side MCP servers" errors. The workspace switch is effectively a new login, but the MCP service kept reusing the old server/transport bound to the previous workspace.

### Changes

**`extension/shared/hooks/useMcpServer.ts`**
- Added `workspaceId` (`workspace?.sId`) to the effect dependency array so it re-runs on workspace switch
- Cleanup now calls `platform.mcp.disconnect()` to tear down the old connection
- Deferred setup with `setTimeout(0)` to prevent duplicate registrations from React StrictMode's mount→cleanup→mount cycle

**`extension/platforms/chrome/services/mcp.ts` & `extension/platforms/front/services/mcp.ts`**
- `disconnect()` now clears `this.server`, `this.transport`, and `this.serverId` synchronously before the async `transport.close()`, so `getOrCreateServer` always creates fresh state for the new workspace
- `createServerForWorkspace` no longer sets `this.server` as a side-effect; both `this.server` and `this.transport` are now set together in `connectServer` after the connection succeeds
- Made `createServerForWorkspace` private

## Tests

Manual testing: verified workspace switch properly disconnects old MCP server and registers a new one. Confirmed single registration in both dev (StrictMode) and production builds.

## Risk

Low — changes are scoped to the extension's MCP lifecycle. The core registration/transport logic is unchanged.

## Deploy Plan

Standard extension deploy.