### PR TITLE
Sidekick: change model suggestion title when change is only about reasoning level

### DIFF
--- a/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
@@ -444,14 +444,27 @@ function ModelSuggestionCard({ agentSuggestion }: ModelSuggestionCardProps) {
     void rejectSuggestion(agentSuggestion);
   };
 
+  const isReasoningOnlyChange =
+    relations.model?.modelId === modelSettingsField.value?.modelId;
+
+  const effort =
+    suggestion.reasoningEffort ?? relations.model?.defaultReasoningEffort;
+  const formattedReasoning = effort
+    ? effort.charAt(0).toUpperCase() + effort.slice(1)
+    : "Default";
+
   return (
     <ActionCardBlock
-      title={`Change model to: ${modelName}`}
+      title={
+        isReasoningOnlyChange
+          ? `Change model reasoning to: ${formattedReasoning}`
+          : `Change model to: ${modelName}`
+      }
+      acceptedTitle={`Model changed to ${modelName} with ${formattedReasoning} reasoning`}
+      rejectedTitle={`${modelName} model with ${formattedReasoning} reasoning suggestion rejected`}
       description={analysis ?? undefined}
       state={cardState}
       applyLabel="Accept"
-      acceptedTitle={`Model changed to ${modelName}`}
-      rejectedTitle={`${modelName} model suggestion rejected`}
       actionsPosition="header"
       onClickAccept={() => handleAccept(agentSuggestion)}
       onClickReject={() => handleReject(agentSuggestion)}


### PR DESCRIPTION
## Description

Title was confusing when only the reasoning was changing

<img width="450" height="180" alt="image" src="https://github.com/user-attachments/assets/0ff1a9ae-fd50-49a7-a85a-ef3ce2575265" />

Note that after the model has changed, we cannot know if the suggestion was about to the model id or to the reasoning, so we display everything all the time

<img width="420" height="125" alt="image" src="https://github.com/user-attachments/assets/e5493d6a-e950-482e-83bf-170e39e2d9a2" />
 
<img width="450" height="125" alt="image" src="https://github.com/user-attachments/assets/c0fc0eba-c423-4b5f-ba56-a658bfa4df3a" />

## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front
