### PR TITLE
Add LLM batch APi to Mistral

### DIFF
--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -6,19 +6,51 @@ import {
   toTool,
 } from "@app/lib/api/llm/clients/mistral/utils/conversation_to_mistral";
 import { handleError } from "@app/lib/api/llm/clients/mistral/utils/errors";
-import { streamLLMEvents } from "@app/lib/api/llm/clients/mistral/utils/mistral_to_events";
+import {
+  chatCompletionToLLMEvents,
+  streamLLMEvents,
+} from "@app/lib/api/llm/clients/mistral/utils/mistral_to_events";
 import { LLM } from "@app/lib/api/llm/llm";
+import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { EventError } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { Mistral } from "@mistralai/mistralai";
+import type { ChatCompletionRequest } from "@mistralai/mistralai/models/components";
+import {
+  ApiEndpoint,
+  BatchJobStatus,
+  ChatCompletionRequest$outboundSchema,
+  chatCompletionResponseFromJSON,
+} from "@mistralai/mistralai/models/components";
 import { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
 import assert from "assert";
+import { z } from "zod";
+
+const mistralBatchOutputLineSchema = z.object({
+  custom_id: z.string(),
+  response: z
+    .object({
+      status_code: z.number(),
+      body: z.unknown(),
+    })
+    .nullable()
+    .optional(),
+  error: z
+    .object({
+      code: z.string().optional(),
+      message: z.string(),
+    })
+    .nullable()
+    .optional(),
+});
 
 /**
  * Extract the request type from Mistral SDK's chat.stream method.
@@ -43,12 +75,12 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     });
   }
 
-  protected buildStreamRequestPayload({
+  private buildChatCompletionRequest({
     conversation,
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): MistralChatStreamRequest {
+  }: LLMStreamParameters): ChatCompletionRequest {
     const messages = [
       {
         role: "system" as const,
@@ -61,9 +93,17 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
       model: this.modelId,
       messages,
       temperature: this.temperature ?? undefined,
-      stream: true,
       toolChoice: toToolChoiceParam(specifications, forceToolCall),
       tools: specifications.map(toTool),
+    };
+  }
+
+  protected buildStreamRequestPayload(
+    streamParameters: LLMStreamParameters
+  ): MistralChatStreamRequest {
+    return {
+      ...this.buildChatCompletionRequest(streamParameters),
+      stream: true,
     };
   }
 
@@ -84,5 +124,110 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
         yield handleGenericError(err, this.metadata);
       }
     }
+  }
+
+  override async sendBatchProcessing(
+    conversations: Map<string, LLMStreamParameters>
+  ): Promise<string> {
+    const requests = Array.from(conversations.entries()).map(
+      ([customId, streamParams]) => ({
+        customId,
+        body: ChatCompletionRequest$outboundSchema.parse(
+          this.buildChatCompletionRequest(streamParams)
+        ),
+      })
+    );
+
+    const job = await this.client.batch.jobs.create({
+      model: this.modelId,
+      endpoint: ApiEndpoint.RootV1ChatCompletions,
+      requests,
+    });
+
+    return job.id;
+  }
+
+  override async getBatchStatus(batchId: string): Promise<BatchStatus> {
+    const job = await this.client.batch.jobs.get({ jobId: batchId });
+
+    switch (job.status) {
+      case BatchJobStatus.Success:
+        return "ready";
+      case BatchJobStatus.Failed:
+      case BatchJobStatus.TimeoutExceeded:
+      case BatchJobStatus.Cancelled:
+        return "aborted";
+      case BatchJobStatus.Queued:
+      case BatchJobStatus.Running:
+      case BatchJobStatus.CancellationRequested:
+        return "computing";
+      default:
+        assertNever(job.status);
+    }
+  }
+
+  override async getBatchResult(batchId: string): Promise<BatchResult> {
+    const job = await this.client.batch.jobs.get({ jobId: batchId });
+
+    if (!job.outputFile) {
+      throw new Error(`Mistral batch ${batchId} has no output file`);
+    }
+
+    const stream = await this.client.files.download({
+      fileId: job.outputFile,
+    });
+    const text = await new Response(stream).text();
+
+    const batchResult: BatchResult = new Map();
+
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      const parsed = mistralBatchOutputLineSchema.safeParse(
+        JSON.parse(trimmed)
+      );
+      if (!parsed.success) {
+        throw new Error(
+          `Failed to parse Mistral batch output line: ${parsed.error.message}`
+        );
+      }
+
+      const { custom_id, response, error } = parsed.data;
+
+      if (error || !response) {
+        const errorMessage =
+          error?.message ?? `No response for custom_id ${custom_id}`;
+        batchResult.set(custom_id, [
+          new EventError(
+            {
+              type: "server_error",
+              message: errorMessage,
+              isRetryable: false,
+            },
+            this.metadata
+          ),
+        ]);
+        continue;
+      }
+
+      const parsedResponse = chatCompletionResponseFromJSON(
+        JSON.stringify(response.body)
+      );
+      if (!parsedResponse.ok) {
+        throw new Error(
+          `Failed to parse Mistral batch response for custom_id ${custom_id}: ${parsedResponse.error.message}`
+        );
+      }
+
+      batchResult.set(
+        custom_id,
+        chatCompletionToLLMEvents(parsedResponse.value, this.metadata)
+      );
+    }
+
+    return batchResult;
   }
 }

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -21,6 +21,7 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { Mistral } from "@mistralai/mistralai";
 import type { ChatCompletionRequest } from "@mistralai/mistralai/models/components";
@@ -156,6 +157,10 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
       case BatchJobStatus.Failed:
       case BatchJobStatus.TimeoutExceeded:
       case BatchJobStatus.Cancelled:
+        logger.warn(
+          { batchId, status: job.status, provider: "mistral" },
+          "LLM Batch has been aborted"
+        );
         return "aborted";
       case BatchJobStatus.Queued:
       case BatchJobStatus.Running:
@@ -190,9 +195,9 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
         JSON.parse(trimmed)
       );
       if (!parsed.success) {
-        throw new Error(
-          `Failed to parse Mistral batch output line: ${parsed.error.message}`
-        );
+        const message = `Failed to parse Mistral batch output line: ${parsed.error.message}`;
+        logger.warn({ batchId, provider: "mistral" }, message);
+        throw new Error(message);
       }
 
       const { custom_id, response, error } = parsed.data;

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -16,12 +16,16 @@ import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
 import type {
+  ChatCompletionResponse,
   CompletionEvent,
   ContentChunk,
   ToolCall,
   UsageInfo,
 } from "@mistralai/mistralai/models/components";
-import { CompletionResponseStreamChoiceFinishReason } from "@mistralai/mistralai/models/components";
+import {
+  CompletionResponseStreamChoiceFinishReason,
+  FinishReason,
+} from "@mistralai/mistralai/models/components";
 import compact from "lodash/compact";
 
 export async function* streamLLMEvents({
@@ -293,4 +297,131 @@ function contentChunkToLLMEvent({
       // Only support text for now
       return null;
   }
+}
+
+/**
+ * Converts a non-streaming ChatCompletionResponse (batch result) to LLM events.
+ */
+export function chatCompletionToLLMEvents(
+  response: ChatCompletionResponse,
+  metadata: LLMClientMetadata
+): LLMEvent[] {
+  const events: LLMEvent[] = [];
+  const aggregate = new SuccessAggregate();
+
+  function addEvent(event: LLMEvent): void {
+    aggregate.add(event);
+    events.push(event);
+  }
+
+  addEvent({
+    type: "interaction_id",
+    content: { modelInteractionId: response.id },
+    metadata,
+  });
+
+  if (!response.choices || response.choices.length === 0) {
+    addEvent(
+      new EventError(
+        {
+          type: "stream_error",
+          message: "Mistral batch response has no choices",
+          isRetryable: false,
+        },
+        metadata
+      )
+    );
+    return events;
+  }
+
+  const choice = response.choices[0];
+  switch (choice.finishReason) {
+    case FinishReason.Stop:
+    case FinishReason.ToolCalls: {
+      const { content, toolCalls } = choice.message;
+      if (content) {
+        const text = batchContentToText(content);
+        if (text.length > 0) {
+          addEvent({
+            type: "text_generated",
+            content: { text },
+            metadata,
+          });
+        }
+      }
+      if (toolCalls) {
+        for (const toolCall of toolCalls) {
+          const toolEvent = toToolEvent({ toolCall, metadata });
+          if (toolEvent) {
+            addEvent(toolEvent);
+          }
+        }
+      }
+      break;
+    }
+    case FinishReason.Length:
+    case FinishReason.ModelLength: {
+      addEvent(
+        new EventError(
+          {
+            type: "maximum_length",
+            isRetryable: true,
+            message: "Maximum length reached",
+            originalError: { choice },
+          },
+          metadata
+        )
+      );
+      break;
+    }
+    case FinishReason.Error: {
+      addEvent(
+        new EventError(
+          {
+            type: "stop_error",
+            isRetryable: true,
+            message: "An error occurred during completion",
+            originalError: { choice },
+          },
+          metadata
+        )
+      );
+      break;
+    }
+    default: {
+      logger.error(
+        `Unknown Mistral batch finish reason: ${choice.finishReason}`
+      );
+      break;
+    }
+  }
+
+  addEvent(toTokenUsage({ usage: response.usage, metadata }));
+
+  addEvent({
+    type: "success",
+    aggregated: aggregate.aggregated,
+    textGenerated: aggregate.textGenerated,
+    reasoningGenerated: aggregate.reasoningGenerated,
+    toolCalls: aggregate.toolCalls,
+    metadata,
+  });
+
+  return events;
+}
+
+function batchContentToText(content: string | Array<ContentChunk>): string {
+  if (isString(content)) {
+    return content;
+  }
+  return content
+    .map((chunk) => {
+      switch (chunk.type) {
+        case "text":
+          return chunk.text;
+        default:
+          return "";
+      }
+    })
+    .join("");
 }

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -415,13 +415,6 @@ function batchContentToText(content: string | Array<ContentChunk>): string {
     return content;
   }
   return content
-    .map((chunk) => {
-      switch (chunk.type) {
-        case "text":
-          return chunk.text;
-        default:
-          return "";
-      }
-    })
+    .map((chunk) => (chunk.type == "text" ? chunk.text : ""))
     .join("");
 }

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -26,6 +26,7 @@ import {
   streamLLMEvents,
 } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 import { APIError, OpenAI, toFile } from "openai";
@@ -189,6 +190,10 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
       case "expired":
       case "cancelling":
       case "cancelled":
+        logger.warn(
+          { batchId, status: batch.status, provider: "openai" },
+          "LLM Batch has been aborted"
+        );
         return "aborted";
       default:
         assertNever(batch.status);
@@ -215,9 +220,9 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
 
       const parsed = openAIBatchOutputLineSchema.safeParse(JSON.parse(trimmed));
       if (!parsed.success) {
-        throw new Error(
-          `Failed to parse OpenAI batch output line: ${parsed.error.message}`
-        );
+        const message = `Failed to parse OpenAI batch output line: ${parsed.error.message}`;
+        logger.warn({ batchId, provider: "openai" }, message);
+        throw new Error(message);
       }
 
       const { custom_id, response, error } = parsed.data;

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -28,6 +28,7 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
+  supportsBatchProcessing: true,
 };
 export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -47,6 +48,7 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
+  supportsBatchProcessing: true,
 };
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -66,6 +68,7 @@ export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
+  supportsBatchProcessing: true,
 };
 export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -86,4 +89,5 @@ export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
+  supportsBatchProcessing: true,
 };


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/5935

Add batch API support to Mistral.
Implementation is pretty straightforward I think, similar to OpenAI and Anthropic.

## Tests

From testing it was pretty fast:

```
 RUN  v4.0.18 /Users/fabiencelier/dust-hive/batch-mistral/front

 ✓ lib/api/llm/tests/llmBatch.test.ts (8 tests) 186926ms
   ✓ Batch Processing Integration Tests (8)
     ✓ 'mistral' / 'codestral-latest' (2)
       ✓ 'simple math'  6772ms
       ✓ 'forced tool call'  6996ms
     ✓ 'mistral' / 'mistral-large-latest' (2)
       ✓ 'simple math'  186925ms
       ✓ 'forced tool call'  177047ms
     ✓ 'mistral' / 'mistral-medium' (2)
       ✓ 'simple math'  7768ms
       ✓ 'forced tool call'  7251ms
     ✓ 'mistral' / 'mistral-small-latest' (2)
       ✓ 'simple math'  7112ms
       ✓ 'forced tool call'  6961ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  12:40:43
   Duration  190.14s (transform 1.50s, setup 266ms, import 2.87s, tests 186.93s, environment 0ms)
```

## Risk

low

## Deploy Plan

deploy front