### PR TITLE
Remove header from onboarding layout

### DIFF
--- a/front/components/pages/onboarding/JoinPage.tsx
+++ b/front/components/pages/onboarding/JoinPage.tsx
@@ -92,19 +92,7 @@ export function JoinPage() {
   const { onboardingType, signInUrl, userExists, workspace } = joinData;
 
   return (
-    <OnboardingLayout
-      owner={workspace}
-      headerTitle="Welcome to Dust"
-      headerRightActions={
-        <Button
-          variant="ghost"
-          size="sm"
-          label={userExists ? "Sign in" : "Sign up"}
-          icon={LoginIcon}
-          onClick={() => (window.location.href = signInUrl)}
-        />
-      }
-    >
+    <OnboardingLayout owner={workspace}>
       <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
         <Page.Header
           title={`Hello there!`}

--- a/front/components/pages/onboarding/WelcomePage.tsx
+++ b/front/components/pages/onboarding/WelcomePage.tsx
@@ -94,11 +94,7 @@ function UserProfileStep({
   }, [formData.jobType]);
 
   return (
-    <OnboardingLayout
-      owner={owner}
-      headerTitle="Joining Dust"
-      headerRightActions={<Button label="Next" size="sm" onClick={onNext} />}
-    >
+    <OnboardingLayout owner={owner}>
       <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
         <Page.Header
           title={`Hello ${formData.firstName || "there"}!`}
@@ -213,19 +209,7 @@ function FavoritePlatformsStep({
   isSubmitting,
 }: FavoritePlatformsStepProps) {
   return (
-    <OnboardingLayout
-      owner={owner}
-      headerTitle="Joining Dust"
-      headerRightActions={
-        <Button
-          label="Next"
-          disabled={isSubmitting}
-          isLoading={isSubmitting}
-          size="sm"
-          onClick={onSubmit}
-        />
-      }
-    >
+    <OnboardingLayout owner={owner}>
       <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
         <Page.Header title="What are your favorite platforms?" />
         <p className="text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -1,18 +1,14 @@
 import { Head, Script } from "@app/lib/platform";
 import { getFaviconPath } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { BarHeader, Page } from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import type React from "react";
 
 export default function OnboardingLayout({
   owner,
-  headerTitle,
-  headerRightActions,
   children,
 }: {
   owner: LightWorkspaceType;
-  headerTitle: string;
-  headerRightActions: React.ReactNode;
   children: React.ReactNode;
 }) {
   const faviconPath = getFaviconPath();
@@ -73,7 +69,6 @@ export default function OnboardingLayout({
       </Head>
 
       <Page>
-        <BarHeader title={headerTitle} rightActions={headerRightActions} />
         {children}
       </Page>
 

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -68,9 +68,7 @@ export default function OnboardingLayout({
         />
       </Head>
 
-      <Page>
-        {children}
-      </Page>
+      <Page>{children}</Page>
 
       <Script id="google-tag-manager" strategy="afterInteractive">
         {`


### PR DESCRIPTION
## Description

Remove header from onboarding (double button) 

Before:
<img width="432" height="876" alt="Screenshot 2026-03-12 at 13 36 52" src="https://github.com/user-attachments/assets/59861829-ec6e-448e-9122-372a52c9017e" />

After:
<img width="427" height="878" alt="Screenshot 2026-03-12 at 13 37 06" src="https://github.com/user-attachments/assets/a1dc7fc3-f833-46ae-bb09-69efc4a2f713" />

## Tests

Tested locally desktop and mobile layout

## Risk

Low

## Deploy Plan

- deploy `front`