### PR TITLE
[front] Migrate deep dive to Sonnet 4.6

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -34,7 +34,7 @@ import {
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
@@ -340,10 +340,10 @@ function getModelConfig(
   } =
     prefer === "anthropic"
       ? {
-          model: CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+          model: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
           reasoningEffort: reasoning
             ? "light"
-            : CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
+            : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
         }
       : prefer === "openai"
         ? {
@@ -366,10 +366,10 @@ function getModelConfig(
             : GPT_5_4_MODEL_CONFIG.minimumReasoningEffort,
         }
       : {
-          model: CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+          model: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
           reasoningEffort: reasoning
             ? "light"
-            : CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
+            : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
         };
 
   if (isProviderWhitelisted(owner, preferredModel.model.providerId)) {
@@ -427,7 +427,7 @@ function getMaxReasoningModelConfig(owner: WorkspaceType): {
   }
   if (isProviderWhitelisted(owner, "anthropic")) {
     return {
-      modelConfiguration: CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+      modelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
       reasoningEffort: "high",
     };
   }

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -34,8 +34,8 @@ import {
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";


### PR DESCRIPTION
## Description

- Sonnet 4.5 was used on workspaces that do not have access to Opus for dust-task and the deep-dive global agent.
- This PR migrates this usage to Sonnet 4.6 and uses a medium reasoning effort when `reasoning: true`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
