### PR TITLE
Add new reinforcement column to agent_configurations

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -57,6 +57,7 @@ import type {
   AgentConfigurationType,
   AgentFetchVariant,
   AgentModelConfigurationType,
+  AgentReinforcementMode,
   AgentStatus,
   GlobalAgentContext,
   LightAgentConfigurationType,
@@ -118,6 +119,7 @@ export async function createPendingAgentConfiguration(
         reasoningEffort:
           CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
         maxStepsPerRun: 8,
+        reinforcement: "auto",
         pictureUrl: PENDING_AGENT_PLACEHOLDER_PICTURE_URL,
         workspaceId: owner.id,
         authorId: user.id,
@@ -418,6 +420,7 @@ export async function createAgentConfiguration(
     requestedSpaceIds,
     tags,
     editors,
+    reinforcement,
   }: {
     name: string;
     description: string;
@@ -432,6 +435,7 @@ export async function createAgentConfiguration(
     requestedSpaceIds: number[];
     tags: TagType[];
     editors: UserType[];
+    reinforcement?: AgentReinforcementMode;
   },
   transaction?: Transaction
 ): Promise<Result<LightAgentConfigurationType, Error>> {
@@ -603,6 +607,7 @@ export async function createAgentConfiguration(
             templateId: template?.id,
             requestedSpaceIds: requestedSpaceIds,
             responseFormat: model.responseFormat,
+            reinforcement: reinforcement ?? "auto",
           },
           {
             where: {
@@ -647,6 +652,7 @@ export async function createAgentConfiguration(
             templateId: template?.id,
             requestedSpaceIds: requestedSpaceIds,
             responseFormat: model.responseFormat,
+            reinforcement: reinforcement ?? "auto",
           },
           {
             transaction: t,
@@ -801,6 +807,7 @@ export async function createAgentConfiguration(
         SpaceResource.modelIdToSId({ id: spaceId, workspaceId: owner.id })
       ),
       tags,
+      reinforcement: reinforcement ?? "auto",
       canRead: true,
       canEdit: true,
     };

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -177,6 +177,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
         })
       ),
       tags: tags.map((t) => t.toJSON()).sort(tagsSorter),
+      reinforcement: agent.reinforcement,
       canRead: isAuthor || isMember || agent.scope === "visible",
       canEdit: isAuthor || isMember,
     };

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -6,6 +6,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type {
   AgentConfigurationScope,
   AgentReasoningEffort,
+  AgentReinforcementMode,
   AgentStatus,
   GlobalAgentStatus,
 } from "@app/types/assistant/agent";
@@ -48,6 +49,8 @@ export class AgentConfigurationModel extends WorkspaceAwareModel<AgentConfigurat
   // declare visualizationEnabled: boolean;
 
   declare templateId: ForeignKey<TemplateModel["id"]> | null;
+
+  declare reinforcement: AgentReinforcementMode;
 
   declare requestedSpaceIds: number[];
 
@@ -155,6 +158,11 @@ AgentConfigurationModel.init(
     pictureUrl: {
       type: DataTypes.TEXT,
       allowNull: false,
+    },
+    reinforcement: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "auto",
     },
     requestedSpaceIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),

--- a/front/migrations/db/migration_541.sql
+++ b/front/migrations/db/migration_541.sql
@@ -1,0 +1,2 @@
+-- Migration created on Mar 12, 2026
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "reinforcement" VARCHAR(255) NOT NULL DEFAULT 'auto';

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -119,6 +119,7 @@ async function handler(
           templateId: agentConfiguration.templateId,
           maxStepsPerRun: agentConfiguration.maxStepsPerRun,
           tags: agentConfiguration.tags,
+          reinforcement: agentConfiguration.reinforcement,
           canRead: agentConfiguration.canRead,
           canEdit: agentConfiguration.canEdit,
           editors: [],

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
@@ -48,6 +48,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/apps/[aId]", () => {
       workspaceId: workspace.id,
       authorId: user.id,
       templateId: null,
+      reinforcement: "auto",
       requestedSpaceIds: [],
       maxStepsPerRun: 8,
     });

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -54,7 +54,9 @@ export async function getAgentConfigurationsActivity({
     variant: "extra_light",
   });
 
-  return agents.filter((a) => a.id > 0).map((a) => a.sId);
+  return agents
+    .filter((a) => a.id > 0 && a.reinforcement !== "off")
+    .map((a) => a.sId);
 }
 
 /**

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -94,8 +94,7 @@ export type AgentUsageType = {
 export type AgentRecentAuthors = readonly string[];
 
 export const AGENT_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
-export type AgentReinforcementMode =
-  (typeof AGENT_REINFORCEMENT_MODES)[number];
+export type AgentReinforcementMode = (typeof AGENT_REINFORCEMENT_MODES)[number];
 
 const AGENT_REASONING_EFFORTS = ["none", "light", "medium", "high"] as const;
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -93,6 +93,10 @@ export type AgentUsageType = {
 
 export type AgentRecentAuthors = readonly string[];
 
+export const AGENT_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
+export type AgentReinforcementMode =
+  (typeof AGENT_REINFORCEMENT_MODES)[number];
+
 const AGENT_REASONING_EFFORTS = ["none", "light", "medium", "high"] as const;
 
 export const AgentReasoningEffortSchema = z.enum(AGENT_REASONING_EFFORTS);
@@ -177,6 +181,8 @@ export type LightAgentConfigurationType = {
   //
   // Example: [1,2] means (1 AND 2)
   requestedSpaceIds: string[];
+
+  reinforcement?: AgentReinforcementMode;
 
   canRead: boolean;
   canEdit: boolean;


### PR DESCRIPTION
## Description

  - Adds a reinforcement column to agent_configurations with values auto | on | off, defaulting to auto
  - Filters out agents with reinforcement: "off" in getAgentConfigurationsActivity (the reinforced agent temporal workflow)
  - auto and on are treated identically for now (reinforcement runs)
  - The field is optional on the type so global agents are unaffected

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

- Run migration to add column
- Deploy Front