### PR TITLE
[front] - feat(workspace/analytics): add CSV export to source

### DIFF
--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -6,7 +6,12 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { clientFetch } from "@app/lib/egress/client";
 import { useWorkspaceContextOrigin } from "@app/lib/swr/workspaces";
+import { Button } from "@dust-tt/sparkle";
+import { DownloadIcon } from "lucide-react";
+import { useState } from "react";
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 
 interface WorkspaceSourceChartProps {
@@ -18,6 +23,11 @@ export function WorkspaceSourceChart({
   workspaceId,
   period,
 }: WorkspaceSourceChartProps) {
+  const { hasFeature } = useFeatureFlags();
+  const showExport = hasFeature("analytics_csv_export");
+
+  const [isDownloading, setIsDownloading] = useState(false);
+
   const { contextOrigin, isContextOriginLoading, isContextOriginError } =
     useWorkspaceContextOrigin({
       workspaceId,
@@ -34,6 +44,42 @@ export function WorkspaceSourceChart({
     colorClassName: getSourceColor(d.origin),
   }));
 
+  const canDownload =
+    !isContextOriginLoading && !isContextOriginError && data.length > 0;
+
+  const handleDownload = async () => {
+    setIsDownloading(true);
+    try {
+      const response = await clientFetch(
+        `/api/w/${workspaceId}/analytics/source-export?days=${period}`
+      );
+      if (!response.ok) {
+        return;
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `dust_sources_last_${period}_days.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const controls = showExport ? (
+    <Button
+      icon={DownloadIcon}
+      variant="outline"
+      size="xs"
+      tooltip="Download CSV"
+      onClick={handleDownload}
+      disabled={!canDownload || isDownloading}
+      isLoading={isDownloading}
+    />
+  ) : undefined;
+
   return (
     <ChartContainer
       title="Source"
@@ -47,6 +93,7 @@ export function WorkspaceSourceChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
+      additionalControls={controls}
     >
       <PieChart>
         <Tooltip

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -1,4 +1,8 @@
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -48,4 +52,81 @@ export async function fetchContextOriginBreakdown(
   }));
 
   return new Ok(mapped);
+}
+
+export type ContextOriginDailyPoint = {
+  date: string;
+  origin: string;
+  messageCount: number;
+};
+
+type OriginSubBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type DailyOriginDateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  by_origin: estypes.AggregationsMultiBucketAggregateBase<OriginSubBucket>;
+};
+
+type DailyOriginAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<DailyOriginDateBucket>;
+};
+
+export async function fetchContextOriginDailyBreakdown(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<ContextOriginDailyPoint[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_date: {
+      date_histogram: {
+        field: "timestamp",
+        calendar_interval: "day",
+        time_zone: "UTC",
+      },
+      aggs: {
+        by_origin: {
+          terms: {
+            field: "context_origin",
+            size: 20,
+            missing: "unknown",
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, DailyOriginAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dateBuckets = bucketsToArray<DailyOriginDateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  const points: ContextOriginDailyPoint[] = [];
+
+  for (const dateBucket of dateBuckets) {
+    const date = formatUTCDateFromMillis(dateBucket.key);
+    const originBuckets = bucketsToArray<OriginSubBucket>(
+      dateBucket.by_origin?.buckets
+    );
+
+    for (const originBucket of originBuckets) {
+      points.push({
+        date,
+        origin: String(originBucket.key),
+        messageCount: originBucket.doc_count ?? 0,
+      });
+    }
+  }
+
+  return new Ok(points);
 }

--- a/front/pages/api/w/[wId]/analytics/source-export.ts
+++ b/front/pages/api/w/[wId]/analytics/source-export.ts
@@ -1,0 +1,97 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days: q.data.days,
+      });
+
+      const result = await fetchContextOriginDailyBreakdown(baseQuery);
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve source breakdown: ${result.error.message}`,
+          },
+        });
+      }
+
+      const rows = [...result.value].sort((a, b) => {
+        const dateCompare = a.date.localeCompare(b.date);
+        if (dateCompare !== 0) {
+          return dateCompare;
+        }
+        return a.origin.localeCompare(b.origin);
+      });
+
+      const headers = ["date", "source", "messageCount"];
+      const csvData = rows.map((row) => [
+        row.date,
+        row.origin,
+        row.messageCount,
+      ]);
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_sources_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION

## Description

This PR adds CSV export functionality to the workspace analytics source chart. When the `analytics_csv_export` feature flag is enabled, workspace admins can download daily source breakdown data as CSV files. The implementation includes:
- A download button on the `WorkspaceSourceChart` component that appears when the feature flag is enabled
- A new API endpoint `/api/w/[wId]/analytics/source-export` that generates CSV files with columns: date, source, messageCount

Data looks like this:
```
date,source,messageCount
2026-02-10,agent_copilot,42
2026-02-10,api,2918
2026-02-10,cli,17
2026-02-10,cli_programmatic,122
2026-02-10,extension,250
2026-02-10,gsheet,642
2026-02-10,project_butler,1
2026-02-10,project_kickoff,1
2026-02-10,slack,56
2026-02-10,triggered,543
2026-02-10,triggered_programmatic,2
2026-02-10,web,3505
2026-02-10,zapier,148
2026-02-11,agent_copilot,44
2026-02-11,api,76
2026-02-11,cli,1
....
```

## Tests

- [x] Locally
- [x] Front-edge

## Risk

Low. The feature is behind the `analytics_csv_export` feature flag and follows the established pattern from previous analytics CSV exports (#22006, #21357)

## Deploy Plan

Deploy front.