### PR TITLE
Add poke UI to show feedback on global agents

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -11,6 +11,7 @@ import { DataSourceSearchPage } from "@dust-tt/front/components/poke/pages/DataS
 import { DataSourceViewPage } from "@dust-tt/front/components/poke/pages/DataSourceViewPage";
 import { EmailTemplatesPage } from "@dust-tt/front/components/poke/pages/EmailTemplatesPage";
 import { FramePage } from "@dust-tt/front/components/poke/pages/FramePage";
+import { GlobalAgentFeedbacksPage } from "@dust-tt/front/components/poke/pages/GlobalAgentFeedbacksPage";
 import { GroupPage } from "@dust-tt/front/components/poke/pages/GroupPage";
 import { KillPage } from "@dust-tt/front/components/poke/pages/KillPage";
 import { LLMTracePage } from "@dust-tt/front/components/poke/pages/LLMTracePage";
@@ -72,6 +73,10 @@ export const routes: RouteObject[] = [
           { path: "pokefy", element: <PokefyPage /> },
           { path: "production-checks", element: <ProductionChecksPage /> },
           { path: "email-templates", element: <EmailTemplatesPage /> },
+          {
+            path: "global-agent-feedbacks",
+            element: <GlobalAgentFeedbacksPage />,
+          },
           { path: "templates", element: <TemplatesListPage /> },
           { path: "templates/:tId", element: <TemplateDetailPage /> },
           { path: "plugins", element: <PluginsPage /> },

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -79,6 +79,11 @@ function PokeNavbar({
             variant="ghost"
             label="Production Checks"
           />
+          <Button
+            href="/poke/global-agent-feedbacks"
+            variant="ghost"
+            label="Agent Feedbacks"
+          />
         </div>
       </div>
       <div className="items-right flex items-center gap-4">

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -1,0 +1,203 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeGlobalAgentFeedbacks } from "@app/hooks/usePokeGlobalAgentFeedbacks";
+import type { GlobalAgentFeedbackItem } from "@app/pages/api/poke/global-agent-feedbacks";
+import { Button, Chip, LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
+
+function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
+  return [
+    {
+      accessorKey: "createdAt",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Date" />
+      ),
+      cell: ({ row }) => {
+        const date = new Date(row.getValue("createdAt") as string);
+        return (
+          <span className="whitespace-nowrap">
+            {date.toLocaleDateString()} {date.toLocaleTimeString()}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "agentConfigurationId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Agent" />
+      ),
+    },
+    {
+      accessorKey: "thumbDirection",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Vote" />
+      ),
+      cell: ({ row }) => {
+        const direction = row.getValue("thumbDirection") as string;
+        return (
+          <Chip
+            color={direction === "up" ? "green" : "rose"}
+            size="xs"
+            label={direction === "up" ? "up" : "down"}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: "userName",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="User" />
+      ),
+      cell: ({ row }) => {
+        const feedback = row.original;
+        return (
+          <div>
+            <div>{feedback.userName ?? "Unknown"}</div>
+            {feedback.userEmail && (
+              <div className="text-xs text-gray-500 dark:text-muted-foreground-night">
+                {feedback.userEmail}
+              </div>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "workspaceName",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Workspace" />
+      ),
+      cell: ({ row }) => {
+        const feedback = row.original;
+        return (
+          <LinkWrapper href={`/poke/${feedback.workspaceSId}`}>
+            <span className="text-blue-600 hover:underline dark:text-blue-400">
+              {feedback.workspaceName}
+            </span>
+          </LinkWrapper>
+        );
+      },
+    },
+    {
+      accessorKey: "content",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Content" />
+      ),
+      cell: ({ row }) => {
+        const content = row.getValue("content") as string | null;
+        return <div className="max-w-md truncate">{content ?? "-"}</div>;
+      },
+    },
+    {
+      id: "link",
+      header: "Link",
+      cell: ({ row }) => {
+        const feedback = row.original;
+        if (feedback.conversationSId && feedback.workspaceSId !== "unknown") {
+          return (
+            <LinkWrapper
+              href={`/poke/${feedback.workspaceSId}/conversation/${feedback.conversationSId}`}
+            >
+              <span className="text-blue-600 hover:underline dark:text-blue-400">
+                View
+              </span>
+            </LinkWrapper>
+          );
+        }
+        return <span className="text-gray-400">-</span>;
+      },
+    },
+  ];
+}
+
+export function GlobalAgentFeedbacksPage() {
+  useSetPokePageTitle("Global Agent Feedbacks");
+
+  const [includeEmpty, setIncludeEmpty] = useState(false);
+  const [pages, setPages] = useState<number[]>([]);
+
+  const currentLastId = pages.length > 0 ? pages[pages.length - 1] : null;
+
+  const { feedbacks, hasMore, isLoading } = usePokeGlobalAgentFeedbacks({
+    includeEmpty,
+    lastId: currentLastId,
+  });
+
+  const columns = useMemo(() => makeColumns(), []);
+
+  const handleNextPage = useCallback(() => {
+    if (feedbacks.length > 0) {
+      const lastFeedback = feedbacks[feedbacks.length - 1];
+      setPages((prev) => [...prev, lastFeedback.id]);
+    }
+  }, [feedbacks]);
+
+  const handlePrevPage = useCallback(() => {
+    setPages((prev) => prev.slice(0, -1));
+  }, []);
+
+  const handleIncludeEmptyChange = useCallback(() => {
+    setIncludeEmpty((prev) => !prev);
+    setPages([]);
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div className="py-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-foreground-night">
+            Global Agent Feedbacks
+          </h1>
+          <p className="mt-1 text-sm text-gray-600 dark:text-muted-foreground-night">
+            User feedback on global agents across all workspaces.
+          </p>
+        </div>
+
+        <div className="mb-4 flex items-center gap-4">
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <input
+              type="checkbox"
+              checked={includeEmpty}
+              onChange={handleIncludeEmptyChange}
+              className="rounded"
+            />
+            Include feedback without content
+          </label>
+        </div>
+
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Spinner />
+          </div>
+        ) : (
+          <>
+            <PokeDataTable columns={columns} data={feedbacks} pageSize={25} />
+
+            <div className="mt-4 flex items-center justify-between">
+              <Button
+                variant="outline"
+                size="sm"
+                label="Previous batch"
+                onClick={handlePrevPage}
+                disabled={pages.length === 0}
+              />
+              <span className="text-sm text-gray-500 dark:text-muted-foreground-night">
+                Batch {pages.length + 1}
+                {hasMore ? " (more available)" : " (last)"}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                label="Next batch"
+                onClick={handleNextPage}
+                disabled={!hasMore}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -15,7 +15,7 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
         <PokeColumnSortableHeader column={column} label="Date" />
       ),
       cell: ({ row }) => {
-        const date = new Date(row.getValue("createdAt") as string);
+        const date = new Date(row.original.createdAt);
         return (
           <span className="whitespace-nowrap">
             {date.toLocaleDateString()} {date.toLocaleTimeString()}
@@ -35,12 +35,12 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
         <PokeColumnSortableHeader column={column} label="Vote" />
       ),
       cell: ({ row }) => {
-        const direction = row.getValue("thumbDirection") as string;
+        const { thumbDirection } = row.original;
         return (
           <Chip
-            color={direction === "up" ? "green" : "rose"}
+            color={thumbDirection === "up" ? "green" : "rose"}
             size="xs"
-            label={direction === "up" ? "up" : "down"}
+            label={thumbDirection === "up" ? "up" : "down"}
           />
         );
       },
@@ -86,7 +86,7 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
         <PokeColumnSortableHeader column={column} label="Content" />
       ),
       cell: ({ row }) => {
-        const content = row.getValue("content") as string | null;
+        const { content } = row.original;
         return <div className="max-w-md truncate">{content ?? "-"}</div>;
       },
     },

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -94,7 +94,11 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
       header: "Conversation",
       cell: ({ row }) => {
         const feedback = row.original;
-        if (feedback.conversationSId && feedback.workspaceSId !== "unknown") {
+        if (
+          feedback.isConversationShared &&
+          feedback.conversationSId &&
+          feedback.workspaceSId !== "unknown"
+        ) {
           return (
             <LinkWrapper
               href={`/poke/${feedback.workspaceSId}/conversation/${feedback.conversationSId}`}

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -5,7 +5,7 @@ import { usePokeGlobalAgentFeedbacks } from "@app/hooks/usePokeGlobalAgentFeedba
 import type { GlobalAgentFeedbackItem } from "@app/pages/api/poke/global-agent-feedbacks";
 import { Button, Chip, LinkWrapper, Spinner } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
   return [
@@ -130,21 +130,21 @@ export function GlobalAgentFeedbacksPage() {
 
   const columns = useMemo(() => makeColumns(), []);
 
-  const handleNextPage = useCallback(() => {
+  const handleNextPage = () => {
     if (feedbacks.length > 0) {
       const lastFeedback = feedbacks[feedbacks.length - 1];
       setPages((prev) => [...prev, lastFeedback.id]);
     }
-  }, [feedbacks]);
+  };
 
-  const handlePrevPage = useCallback(() => {
+  const handlePrevPage = () => {
     setPages((prev) => prev.slice(0, -1));
-  }, []);
+  };
 
-  const handleIncludeEmptyChange = useCallback(() => {
+  const handleIncludeEmptyChange = () => {
     setIncludeEmpty((prev) => !prev);
     setPages([]);
-  }, []);
+  };
 
   return (
     <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -82,17 +82,16 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
     },
     {
       accessorKey: "content",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Content" />
-      ),
+      header: "Content",
+      enableSorting: false,
       cell: ({ row }) => {
         const { content } = row.original;
-        return <div className="max-w-md truncate">{content ?? "-"}</div>;
+        return <div className="whitespace-pre-wrap">{content ?? "-"}</div>;
       },
     },
     {
       id: "link",
-      header: "Link",
+      header: "Conversation",
       cell: ({ row }) => {
         const feedback = row.original;
         if (feedback.conversationSId && feedback.workspaceSId !== "unknown") {

--- a/front/hooks/usePokeGlobalAgentFeedbacks.ts
+++ b/front/hooks/usePokeGlobalAgentFeedbacks.ts
@@ -1,0 +1,35 @@
+import { emptyArray, useFetcher } from "@app/lib/swr/swr";
+import type { GetGlobalAgentFeedbacksResponseBody } from "@app/pages/api/poke/global-agent-feedbacks";
+import type { Fetcher } from "swr";
+import useSWR from "swr";
+
+export function usePokeGlobalAgentFeedbacks({
+  includeEmpty,
+  lastId,
+}: {
+  includeEmpty: boolean;
+  lastId: number | null;
+}) {
+  const { fetcher } = useFetcher();
+  const feedbacksFetcher: Fetcher<GetGlobalAgentFeedbacksResponseBody> =
+    fetcher;
+
+  const params = new URLSearchParams();
+  if (includeEmpty) {
+    params.set("includeEmpty", "true");
+  }
+  if (lastId !== null) {
+    params.set("lastId", String(lastId));
+  }
+
+  const key = `/api/poke/global-agent-feedbacks?${params.toString()}`;
+
+  const { data, error } = useSWR(key, feedbacksFetcher);
+
+  return {
+    feedbacks: data?.feedbacks ?? emptyArray(),
+    hasMore: data?.hasMore ?? false,
+    isLoading: !error && !data,
+    isError: error,
+  };
+}

--- a/front/pages/api/poke/global-agent-feedbacks/index.ts
+++ b/front/pages/api/poke/global-agent-feedbacks/index.ts
@@ -37,6 +37,7 @@ export interface GlobalAgentFeedbackItem {
   content: string | null;
   userName: string | null;
   userEmail: string | null;
+  isConversationShared: boolean;
   workspaceSId: string;
   workspaceName: string;
   conversationSId: string | null;
@@ -158,6 +159,7 @@ async function handler(
       content: row.content,
       userName: row.user?.name ?? null,
       userEmail: row.user?.email ?? null,
+      isConversationShared: row.isConversationShared,
       workspaceSId: workspace?.sId ?? "unknown",
       workspaceName: workspace?.name ?? "Unknown",
       conversationSId: conversationById.get(row.conversationId) ?? null,

--- a/front/pages/api/poke/global-agent-feedbacks/index.ts
+++ b/front/pages/api/poke/global-agent-feedbacks/index.ts
@@ -13,6 +13,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
 
@@ -86,7 +87,7 @@ async function handler(
     where.content = { [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: "" }] };
   }
 
-  if (typeof lastId === "string") {
+  if (isString(lastId)) {
     const parsed = parseInt(lastId, 10);
     if (!isNaN(parsed)) {
       where.id = { [Op.lt]: parsed };

--- a/front/pages/api/poke/global-agent-feedbacks/index.ts
+++ b/front/pages/api/poke/global-agent-feedbacks/index.ts
@@ -1,0 +1,170 @@
+import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import {
+  AgentMessageFeedbackModel,
+  ConversationModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { apiError } from "@app/logger/withlogging";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Op } from "sequelize";
+
+const PAGE_SIZE = 500;
+
+const GLOBAL_AGENT_IDS = Object.values(GLOBAL_AGENTS_SID);
+
+// Type casts to enable cross-workspace queries for poke super-admin.
+const AgentMessageFeedbackModelWithBypass: ModelStaticWorkspaceAware<AgentMessageFeedbackModel> =
+  AgentMessageFeedbackModel;
+const ConversationModelWithBypass: ModelStaticWorkspaceAware<ConversationModel> =
+  ConversationModel;
+const MessageModelWithBypass: ModelStaticWorkspaceAware<MessageModel> =
+  MessageModel;
+
+export interface GlobalAgentFeedbackItem {
+  id: number;
+  createdAt: string;
+  agentConfigurationId: string;
+  thumbDirection: AgentMessageFeedbackDirection;
+  content: string | null;
+  userName: string | null;
+  userEmail: string | null;
+  workspaceSId: string;
+  workspaceName: string;
+  conversationSId: string | null;
+  messageSId: string | null;
+}
+
+export interface GetGlobalAgentFeedbacksResponseBody {
+  feedbacks: GlobalAgentFeedbackItem[];
+  hasMore: boolean;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetGlobalAgentFeedbacksResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const { includeEmpty, lastId } = req.query;
+
+  const where: Record<string, unknown> = {
+    agentConfigurationId: { [Op.in]: GLOBAL_AGENT_IDS },
+  };
+
+  if (includeEmpty !== "true") {
+    where.content = { [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: "" }] };
+  }
+
+  if (typeof lastId === "string") {
+    const parsed = parseInt(lastId, 10);
+    if (!isNaN(parsed)) {
+      where.id = { [Op.lt]: parsed };
+    }
+  }
+
+  // WORKSPACE_ISOLATION_BYPASS: Poke super-admin query across all workspaces
+  // to aggregate global agent feedback for internal review.
+  const feedbackRows = await AgentMessageFeedbackModelWithBypass.findAll({
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+    where,
+    include: [
+      {
+        model: UserResource.model,
+        as: "user",
+        attributes: ["name", "email"],
+      },
+    ],
+    order: [["id", "DESC"]],
+    limit: PAGE_SIZE + 1,
+  });
+
+  const hasMore = feedbackRows.length > PAGE_SIZE;
+  const rows = feedbackRows.slice(0, PAGE_SIZE);
+
+  if (rows.length === 0) {
+    return res.status(200).json({ feedbacks: [], hasMore: false });
+  }
+
+  // Batch-fetch workspace info.
+  const workspaceIds = [...new Set(rows.map((r) => r.workspaceId))];
+  const workspaces = await WorkspaceModel.findAll({
+    attributes: ["id", "sId", "name"],
+    where: { id: workspaceIds },
+  });
+  const workspaceById = new Map(workspaces.map((w) => [w.id, w]));
+
+  // Batch-fetch conversation sIds.
+  const conversationIds = [...new Set(rows.map((r) => r.conversationId))];
+  const conversations = await ConversationModelWithBypass.findAll({
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+    attributes: ["id", "sId"],
+    where: { id: conversationIds },
+  });
+  const conversationById = new Map(conversations.map((c) => [c.id, c.sId]));
+
+  // Batch-fetch message sIds.
+  const agentMessageIds = rows.map((r) => r.agentMessageId);
+  const messages = await MessageModelWithBypass.findAll({
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+    attributes: ["sId", "agentMessageId"],
+    where: { agentMessageId: agentMessageIds },
+  });
+  const messageSIdByAgentMessageId = new Map(
+    messages.map((m) => [m.agentMessageId, m.sId])
+  );
+
+  const feedbacks: GlobalAgentFeedbackItem[] = rows.map((row) => {
+    const workspace = workspaceById.get(row.workspaceId);
+    return {
+      id: row.id,
+      createdAt: row.createdAt.toISOString(),
+      agentConfigurationId: row.agentConfigurationId,
+      thumbDirection: row.thumbDirection,
+      content: row.content,
+      userName: row.user?.name ?? null,
+      userEmail: row.user?.email ?? null,
+      workspaceSId: workspace?.sId ?? "unknown",
+      workspaceName: workspace?.name ?? "Unknown",
+      conversationSId: conversationById.get(row.conversationId) ?? null,
+      messageSId: messageSIdByAgentMessageId.get(row.agentMessageId) ?? null,
+    };
+  });
+
+  return res.status(200).json({ feedbacks, hasMore });
+}
+
+export default withSessionAuthenticationForPoke(handler);


### PR DESCRIPTION
## Description

  - Add a new global Poke page ("Agent Feedbacks") to view user feedback on global agents (dust, sidekick, gpt-5, claude-4.5-sonnet, etc.) across all workspaces
  - Queries agent_message_feedback for all GLOBAL_AGENTS_SID values using workspace isolation bypass (super-admin only)
  - Uses PokeDataTable with sortable columns (Date, Agent, Vote, User, Workspace, Content) and text filtering
  - By default only shows feedback with non-empty content; checkbox to include all
  - Workspace names link to the poke workspace page; "View" links navigate to the conversation
  - Server-side cursor pagination (500 per batch), client-side table pagination (25 per page)
 
<img width="1313" height="684" alt="Screenshot 2026-03-12 at 15 45 57" src="https://github.com/user-attachments/assets/9342e4d3-0d91-44c1-b0be-b7d53b9e2335" />

## Tests

Manual

## Risk

Poke only

## Deploy Plan

Front