### PR TITLE
[connectors] fix: Slack streaming path robustness (auth name, msg_too_long, bot recipient)

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
@@ -311,7 +311,7 @@ const _webhookSlackBotInteractionsAPIHandler = async (
 
         const { status: approved, agentName, toolName } = valueValidation.right;
 
-        const text = `Agent \`@${agentName}\`'s request to use tool \`${toolName}\` was ${
+        const text = `Agent \`${agentName}\`'s request to use tool \`${toolName}\` was ${
           approved === "approved" ? "✅ approved" : "❌ rejected"
         }`;
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1012,13 +1012,24 @@ async function answerMessage(
   let streamHandler: SlackStreamHandler | undefined;
 
   if (useNativeStreaming) {
+    let streamRecipientUserId = slackUserId;
+    if (!streamRecipientUserId) {
+      const botUserIdRes = await getBotUserIdResponse(
+        slackClient,
+        connector.id
+      );
+      if (botUserIdRes.isErr()) {
+        throw botUserIdRes.error;
+      }
+      streamRecipientUserId = botUserIdRes.value;
+    }
     streamHandler = new SlackStreamHandler(slackClient, connector.id);
     streamHandler.start({
       slackChannel,
       slackMessageTs,
       slackThreadTs,
       slackTeamId,
-      slackUserId,
+      slackUserId: streamRecipientUserId,
     });
     await streamHandler.setThinking(
       mention.agentName === "dust"

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -407,7 +407,7 @@ export function makeToolAuthenticationBlock({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Agent \`@${agentName}\` requires personal authentication for \`${serverName}\``,
+        text: `Agent \`${agentName}\` requires personal authentication for \`${serverName}\``,
       },
     },
     {

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -11,9 +11,14 @@ const ACTIVE_TASK_ID = "active-task-id";
 export class SlackStreamHandler {
   private streamer: ChatStreamer | undefined;
   private hasTask = false;
+  private stopped = false;
   private channelId: string | undefined;
   private threadTs: string | undefined;
   messageTs: string | undefined;
+
+  get isStopped(): boolean {
+    return this.stopped;
+  }
 
   constructor(
     private readonly slackClient: WebClient,
@@ -52,6 +57,7 @@ export class SlackStreamHandler {
       channel_id: this.channelId,
       thread_ts: this.threadTs,
       status,
+      loading_messages: ["Thinking..."],
     });
   }
 
@@ -61,7 +67,7 @@ export class SlackStreamHandler {
     const res = await throttleWithRedis(
       RATE_LIMITS["chat.appendStream"],
       `${this.connectorId}-chat-appendStream`,
-      { canBeIgnored: true },
+      { canBeIgnored: false },
       () => this.streamer?.append(payload) ?? Promise.resolve(undefined),
       {}
     );
@@ -103,6 +109,7 @@ export class SlackStreamHandler {
 
   async stop() {
     this.hasTask = false;
+    this.stopped = true;
     await this.streamer?.stop();
   }
 }

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -386,9 +386,44 @@ async function streamAgentAnswerToSlack(
 
         answer += event.text;
 
-        if (streamHandler) {
+        // Streaming path: append text or stop if too long.
+        if (streamHandler?.isStopped) {
+          break;
+        }
+        if (streamHandler && answer.length <= MAX_SLACK_MESSAGE_LENGTH) {
           await streamHandler.appendText(event.text);
-        } else {
+          break;
+        }
+        if (streamHandler) {
+          // Message too long for streaming: stop and fall back to chat.update
+          // with truncated content + footer.
+          await streamHandler.stop();
+          const { formattedContent, footnotes } = annotateCitations(
+            answer,
+            actions
+          );
+          const slackContent = safelyPrepareAnswer(formattedContent);
+          if (slackContent) {
+            await postSlackMessageUpdate({
+              messageUpdate: {
+                text: slackContent,
+                assistantName,
+                agentConfigurations,
+                footnotes,
+              },
+              ...conversationData,
+              canBeIgnored: false,
+              extraLogs: {
+                source: "streamAgentAnswerToSlack",
+                eventType: "stream_fallback",
+              },
+            });
+          }
+          break;
+        }
+
+        // Non-streaming path: throttled chat.update.
+        {
           const { formattedContent, footnotes } = annotateCitations(
             answer,
             actions
@@ -456,7 +491,7 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        if (streamHandler) {
+        if (streamHandler && !streamHandler.isStopped) {
           await streamHandler.stop();
         }
 
@@ -579,7 +614,7 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
-        if (streamHandler) {
+        if (streamHandler && !streamHandler.isStopped) {
           await streamHandler.stop();
         }
 
@@ -620,7 +655,7 @@ async function streamAgentAnswerToSlack(
   }
 
   // Clean up stream if the event stream ended without a terminal event.
-  if (streamHandler) {
+  if (streamHandler && !streamHandler.isStopped) {
     await streamHandler.stop();
   }
 

--- a/connectors/src/connectors/slack/ratelimits.ts
+++ b/connectors/src/connectors/slack/ratelimits.ts
@@ -27,7 +27,9 @@ export const RATE_LIMITS = {
     windowInMs: 60 * 1000,
   },
   "chat.appendStream": {
-    limit: 100,
+    // Higher limit to enhance streaming UX, the numbers given by slack are 180 rpm/1000 burst at the time of writing
+    // We also use SDK's chatStream which has a buffer mechanism to reduce the number of calls.
+    limit: 160,
     windowInMs: 60 * 1000,
   },
 } satisfies Record<string, RateLimit>;


### PR DESCRIPTION
## Description
- Fix agent name display in Slack auth/validation blocks (remove extra `@` prefix that was causing @dust to be mapped to @Dust Data Sync app on slack)
- Replaced slack's default loading messages with "Thinking..." when thinking status is on
- Handle `msg_too_long` in streaming path: stop stream and fall back to `chat.update` with truncated content + footer when message exceeds 2.5k chars
- Fix `missing_recipient_user_id` for workflow/bot-triggered messages by falling back to Dust bot's own user ID
- Add `isStopped` state to `SlackStreamHandler` to guard against double-stop and enable graceful fallback
- Bump `chat.appendStream` rate limit to 160 rpm (Slack allows 180 rpm/1000 burst)

Fixes:
- https://github.com/dust-tt/tasks/issues/6522
- https://github.com/dust-tt/tasks/issues/7048