### PR TITLE
[front] - fix(triggers): change timestamp format to compact in AdminTriggersList

### DIFF
--- a/front/components/triggers/AdminTriggersList.tsx
+++ b/front/components/triggers/AdminTriggersList.tsx
@@ -214,7 +214,7 @@ export const AdminTriggersList = ({
           <DataTable.BasicCellContent
             label={formatTimestampToFriendlyDate(
               info.row.original.webhookSource.updatedAt,
-              "long"
+              "compact"
             )}
           />
         ),


### PR DESCRIPTION
## Description

This PR  updates the timestamp format in `AdminTriggersList` from 'long' to 'compact' for consistency with other tables

## Tests

Locally

## Risk

None

## Deploy Plan

Deploy front
