### PR TITLE
[Notifications] Default email digests to weekly

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   CONVERSATION_UNREAD_TRIGGER_ID,
+  DEFAULT_NOTIFICATION_DELAY,
   DEFAULT_PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION,
   isNotificationCondition,
   isNotificationPreferencesDelay,
@@ -68,7 +69,6 @@ const PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_LABELS: Record<
   never: "Never notify me",
 };
 
-const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay = "weekly";
 const DEFAULT_NOTIFICATION_CONDITION: NotificationCondition = "all_messages";
 const NOVU_SESSION_ERROR_CODE = "novu_session_initialization_failed";
 const NOVU_REQUEST_ERROR_CODE = "novu_preferences_request_failed";

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -51,6 +51,7 @@ const NOTIFICATION_PREFERENCES_DELAY_LABELS: Record<
   "30_minutes": "every 30 minutes",
   "1_hour": "every hour",
   daily: "a day",
+  weekly: "a week",
 };
 
 const NOTIFICATION_CONDITION_LABELS: Record<NotificationCondition, string> = {
@@ -67,7 +68,7 @@ const PROJECT_NEW_CONVERSATION_NOTIFICATION_CONDITION_LABELS: Record<
   never: "Never notify me",
 };
 
-const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay = "1_hour";
+const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay = "weekly";
 const DEFAULT_NOTIFICATION_CONDITION: NotificationCondition = "all_messages";
 const NOVU_SESSION_ERROR_CODE = "novu_session_initialization_failed";
 const NOVU_REQUEST_ERROR_CODE = "novu_preferences_request_failed";

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -11,6 +11,7 @@ export const NOTIFICATION_DELAY_OPTIONS = [
   "30_minutes",
   "1_hour",
   "daily",
+  "weekly",
 ] as const;
 
 export type NotificationPreferencesDelay =
@@ -39,10 +40,11 @@ export const NOTIFICATION_PREFERENCES_DELAYS: Record<
   "30_minutes": { amount: 30, unit: "minutes" },
   "1_hour": { amount: 1, unit: "hours" },
   daily: { cron: "0 6 * * *" }, // Every day at 6am
+  weekly: { cron: "0 6 * * 1" }, // Every Monday at 6am
 };
 
 export const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay =
-  isDevelopment() ? "5_minutes" : "1_hour";
+  isDevelopment() ? "5_minutes" : "weekly";
 
 export const isNotificationPreferencesDelay = (
   value: unknown


### PR DESCRIPTION
## Description
- Set the shared email digest default to `weekly` instead of `1_hour` for notification workflows that use `DEFAULT_NOTIFICATION_DELAY`.
- Add `weekly` as an explicit delay option so the account settings UI can represent and persist the new default.

## Risks
Blast radius: default email cadence for new users on conversation and project notification digests in front.
Risk: low

## Deploy Plan
- deploy front