### PR TITLE
[Email] Add admin toggle for email agents in workspace settings

### DIFF
--- a/front/components/pages/workspace/WorkspaceSettingsPage.tsx
+++ b/front/components/pages/workspace/WorkspaceSettingsPage.tsx
@@ -43,6 +43,7 @@ export function WorkspaceSettingsPage() {
         publishingRestrictionMessage={getPublishingRestrictionMessage(
           featureFlags
         )}
+        isEmailAgentsAvailable={featureFlags.includes("email_agents")}
       />
       <IntegrationsSection
         owner={owner}

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -1,16 +1,21 @@
+import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Page } from "@dust-tt/sparkle";
 
+interface CapabilitiesSectionProps {
+  owner: WorkspaceType;
+  publishingRestrictionMessage: string | null;
+  isEmailAgentsAvailable: boolean;
+}
+
 export function CapabilitiesSection({
   owner,
   publishingRestrictionMessage,
-}: {
-  owner: WorkspaceType;
-  publishingRestrictionMessage: string | null;
-}) {
+  isEmailAgentsAvailable,
+}: CapabilitiesSectionProps) {
   return (
     <Page.Vertical align="stretch" gap="md">
       <Page.H variant="h4">Capabilities</Page.H>
@@ -18,6 +23,7 @@ export function CapabilitiesSection({
         <div className="h-full border-b border-border dark:border-border-night" />
         <InteractiveContentSharingToggle owner={owner} />
         <VoiceTranscriptionToggle owner={owner} />
+        {isEmailAgentsAvailable && <EmailAgentsToggle owner={owner} />}
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability
             subElement={publishingRestrictionMessage}

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -1,4 +1,5 @@
 import { useEmailAgentsToggle } from "@app/hooks/useEmailAgentsToggle";
+import { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/email_trigger";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ActionMailAiIcon,
@@ -23,7 +24,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
         <div className="flex flex-row items-center gap-2">
           <span>
             Allow workspace members to email agents at{" "}
-            <code>AGENT_NAME@dust.team</code>
+            <code>AGENT_NAME@{ASSISTANT_EMAIL_SUBDOMAIN}</code>
           </span>
           <a
             href="https://dust-tt.notion.site/Email-Agents-32028599d94181209594fbf1402b720d"

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -1,0 +1,29 @@
+import { useEmailAgentsToggle } from "@app/hooks/useEmailAgentsToggle";
+import type { WorkspaceType } from "@app/types/user";
+import { ActionMailAiIcon, ContextItem, SliderToggle } from "@dust-tt/sparkle";
+
+interface EmailAgentsToggleProps {
+  owner: WorkspaceType;
+}
+
+export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
+  const { isEnabled, isChanging, doToggleEmailAgents } = useEmailAgentsToggle({
+    owner,
+  });
+
+  return (
+    <ContextItem
+      title="Email agents"
+      subElement="Allow triggering and interacting with agents via email"
+      visual={<ActionMailAiIcon className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={doToggleEmailAgents}
+        />
+      }
+    />
+  );
+}

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -1,6 +1,11 @@
 import { useEmailAgentsToggle } from "@app/hooks/useEmailAgentsToggle";
 import type { WorkspaceType } from "@app/types/user";
-import { ActionMailAiIcon, ContextItem, SliderToggle } from "@dust-tt/sparkle";
+import {
+  ActionMailAiIcon,
+  BookOpenIcon,
+  ContextItem,
+  SliderToggle,
+} from "@dust-tt/sparkle";
 
 interface EmailAgentsToggleProps {
   owner: WorkspaceType;
@@ -14,7 +19,22 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
   return (
     <ContextItem
       title="Email agents"
-      subElement="Allow triggering and interacting with agents via email"
+      subElement={
+        <div className="flex flex-row items-center gap-2">
+          <span>
+            Allow workspace members to email agents at{" "}
+            <code>AGENT_NAME@dust.team</code>
+          </span>
+          <a
+            href="https://dust-tt.notion.site/Email-Agents-32028599d94181209594fbf1402b720d"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-action-400 hover:text-action-500 text-sm"
+          >
+            <BookOpenIcon className="h-4 w-4" />
+          </a>
+        </div>
+      }
       visual={<ActionMailAiIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/hooks/useEmailAgentsToggle.ts
+++ b/front/hooks/useEmailAgentsToggle.ts
@@ -1,0 +1,51 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface UseEmailAgentsToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function useEmailAgentsToggle({ owner }: UseEmailAgentsToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    owner.metadata?.allowEmailAgents === true
+  );
+
+  const doToggleEmailAgents = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowEmailAgents: !isEnabled,
+        }),
+      });
+      setIsEnabled(!isEnabled);
+
+      if (!res.ok) {
+        throw new Error("Failed to update Email agents setting");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update Email agents setting",
+        description: "Could not update the Email agents setting.",
+      });
+    }
+    setIsChanging(false);
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doToggleEmailAgents,
+  };
+}

--- a/front/hooks/useEmailAgentsToggle.ts
+++ b/front/hooks/useEmailAgentsToggle.ts
@@ -1,5 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useState } from "react";
 
@@ -31,13 +32,11 @@ export function useEmailAgentsToggle({ owner }: UseEmailAgentsToggleProps) {
         throw new Error("Failed to update Email agents setting");
       }
       setIsEnabled(!isEnabled);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
     } catch (error) {
       sendNotification({
         type: "error",
         title: "Failed to update Email agents setting",
-        description: "Could not update the Email agents setting.",
+        description: normalizeError(error).message,
       });
     }
     setIsChanging(false);

--- a/front/hooks/useEmailAgentsToggle.ts
+++ b/front/hooks/useEmailAgentsToggle.ts
@@ -26,11 +26,11 @@ export function useEmailAgentsToggle({ owner }: UseEmailAgentsToggleProps) {
           allowEmailAgents: !isEnabled,
         }),
       });
-      setIsEnabled(!isEnabled);
 
       if (!res.ok) {
         throw new Error("Failed to update Email agents setting");
       }
+      setIsEnabled(!isEnabled);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
     } catch (error) {

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -65,13 +65,19 @@ async function isEmailAgentsEnabled(
     );
     return false;
   }
-  const featureFlags = await getFeatureFlags(
-    authResult.value.getNonNullableWorkspace()
-  );
+  const workspace = authResult.value.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(workspace);
   if (!featureFlags.includes("email_agents")) {
     logger.info(
       { workspaceId: authType.workspaceId },
       "[email] email_agents feature flag not enabled, skipping reply"
+    );
+    return false;
+  }
+  if (workspace.metadata?.allowEmailAgents !== true) {
+    logger.info(
+      { workspaceId: authType.workspaceId },
+      "[email] allowEmailAgents not enabled in workspace metadata, skipping reply"
     );
     return false;
   }

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -381,7 +381,10 @@ export async function userAndWorkspaceFromEmail({
   for (const w of workspaceModels) {
     const lightWorkspace = renderLightWorkspaceType({ workspace: w });
     const flags = await getFeatureFlags(lightWorkspace);
-    if (flags.includes("email_agents")) {
+    if (
+      flags.includes("email_agents") &&
+      lightWorkspace.metadata?.allowEmailAgents === true
+    ) {
       eligibleWorkspaceModels.push(w);
     }
   }

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -271,10 +271,18 @@ async function handler(
         workspace.sId
       );
 
-      const featureFlags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
+      const featureFlagWorkspace = auth.getNonNullableWorkspace();
+      const featureFlags = await getFeatureFlags(featureFlagWorkspace);
       if (!featureFlags.includes("email_agents")) {
+        await replyToError(email, {
+          type: "invalid_email_error",
+          message:
+            "Email interactions with agents are not enabled for your workspace.",
+        });
+        return;
+      }
+
+      if (workspace.metadata?.allowEmailAgents !== true) {
         await replyToError(email, {
           type: "invalid_email_error",
           message:

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -62,6 +62,10 @@ const WorkspaceVoiceTranscriptionUpdateBodySchema = t.type({
   allowVoiceTranscription: t.boolean,
 });
 
+const WorkspaceEmailAgentsUpdateBodySchema = t.type({
+  allowEmailAgents: t.boolean,
+});
+
 const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -71,6 +75,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceWorkOSUpdateBodySchema,
   WorkspaceInteractiveContentSharingUpdateBodySchema,
   WorkspaceVoiceTranscriptionUpdateBodySchema,
+  WorkspaceEmailAgentsUpdateBodySchema,
 ]);
 
 async function handler(
@@ -178,6 +183,14 @@ async function handler(
         const newMetadata = {
           ...previousMetadata,
           allowVoiceTranscription: body.allowVoiceTranscription,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("allowEmailAgents" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          allowEmailAgents: body.allowEmailAgents,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;


### PR DESCRIPTION
## Description

Adds a self-service toggle in workspace settings for admins to enable/disable email agents. The `email_agents` feature flag gates whether the toggle is **visible**. A new workspace metadata field `allowEmailAgents` (default: `false`) controls whether email actually works. Both must be true.

- New hook `useEmailAgentsToggle` and component `EmailAgentsToggle` following existing voice transcription pattern
- New `allowEmailAgents` body schema in workspace POST endpoint
- Guard checks added in webhook handler, workspace eligibility filter (`email_trigger.ts`), and reply path (`email_reply.ts`)
<img width="1455" height="435" alt="image" src="https://github.com/user-attachments/assets/b0d034c7-0445-4fc0-8334-a45c8b58ef03" />

## Risks

Blast radius: email agents feature — workspaces with `email_agents` flag will need to also enable the toggle for emails to work
Risk: low (additive change, new metadata field defaults to false, existing feature flag still required)

## Deploy Plan
- pmrr
- deploy front