### PR TITLE
Remove -worker from preview links

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -212,9 +212,9 @@ jobs:
         id: preview_url
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "url=https://${{ steps.extract_version.outputs.version_prefix }}--${{ inputs.app }}-worker.preview.dust.tt" >> $GITHUB_OUTPUT
+            echo "url=https://${{ steps.extract_version.outputs.version_prefix }}--${{ inputs.app }}.preview.dust.tt" >> $GITHUB_OUTPUT
           else
-            echo "url=https://${{ steps.branch.outputs.sanitized }}--${{ inputs.app }}-worker.preview.dust.tt" >> $GITHUB_OUTPUT
+            echo "url=https://${{ steps.branch.outputs.sanitized }}--${{ inputs.app }}.preview.dust.tt" >> $GITHUB_OUTPUT
           fi
 
       - name: Summary

--- a/preview-proxy/src/index.js
+++ b/preview-proxy/src/index.js
@@ -16,7 +16,7 @@ export default {
 
     if (separatorIndex === -1) {
       return new Response(
-        "Expected format: <branch>--<app|poke|app-worker|poke-worker>.preview.dust.tt",
+        "Expected format: <branch>--<app|poke>.preview.dust.tt",
         { status: 400 }
       );
     }
@@ -24,7 +24,7 @@ export default {
     const branch = prefix.slice(0, separatorIndex);
     const target = prefix.slice(separatorIndex + 2);
 
-    // Check if targeting Workers (suffix "-worker") or Pages (default)
+    // Check if targeting Workers (suffix "-worker") - legacy migration, removing.
     const isWorker = target.endsWith("-worker");
     const project = isWorker ? target.slice(0, -"-worker".length) : target;
     const projectName = PROJECTS[project];
@@ -36,12 +36,7 @@ export default {
     }
 
     const upstreamUrl = new URL(url);
-    if (isWorker) {
-      // Workers version preview alias: branch-app-dust-tt.dust-account.workers.dev
-      upstreamUrl.hostname = `${branch}-${projectName}.${WORKERS_SUBDOMAIN}`;
-    } else {
-      upstreamUrl.hostname = `${branch}.${projectName}.pages.dev`;
-    }
+    upstreamUrl.hostname = `${branch}-${projectName}.${WORKERS_SUBDOMAIN}`;
 
     const headers = new Headers(request.headers);
     headers.set("Host", upstreamUrl.hostname);


### PR DESCRIPTION
## Description

Remove support for pages in preview urls - app redirects to workers similarly as app-worker (which will be removed later). Update genertaed URL to remove -worker suffix.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

manually deploy proxy
