### PR TITLE
[front] enh: Add runtime + profile to sandbox img tools

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -15,6 +15,7 @@ import {
 import {
   createToolManifest,
   getSandboxImage,
+  getToolsForProvider,
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image";
@@ -152,12 +153,17 @@ export function createSandboxTools(
 
       return new Ok([{ type: "text" as const, text: output }]);
     },
-    describe_environment: async ({ format }, { auth }) => {
-      const sandboxImageResult = getSandboxImage(auth);
-      if (sandboxImageResult.isErr()) {
-        return new Err(new MCPError(sandboxImageResult.error.message));
+    describe_environment: async ({ format }, { auth, agentLoopContext }) => {
+      const providerId =
+        agentLoopContext?.runContext?.agentConfiguration.model.providerId;
+      if (!providerId) {
+        return new Err(new MCPError("Missing model provider ID"));
       }
-      const manifest = createToolManifest(sandboxImageResult.value.tools);
+      const toolsResult = getToolsForProvider(auth, providerId);
+      if (toolsResult.isErr()) {
+        return new Err(new MCPError(toolsResult.error.message));
+      }
+      const manifest = createToolManifest(toolsResult.value);
       const output =
         format === "json"
           ? toolManifestToJSON(manifest)

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -3,8 +3,48 @@ import {
   getSandboxImageFromRegistry,
 } from "@app/lib/api/sandbox/image/registry";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import type { ToolEntry, ToolProfile } from "@app/lib/api/sandbox/image/types";
 import type { Authenticator } from "@app/lib/auth";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+function providerToProfile(providerId: ModelProviderIdType): ToolProfile {
+  switch (providerId) {
+    case "openai":
+      return "openai";
+    case "google_ai_studio":
+      return "gemini";
+    case "anthropic":
+    case "mistral":
+    case "deepseek":
+    case "togetherai":
+    case "xai":
+    case "fireworks":
+    case "noop":
+      return "anthropic";
+    default:
+      assertNever(providerId);
+  }
+}
+
+export function getToolsForProvider(
+  _auth: Authenticator,
+  providerId: ModelProviderIdType
+): Result<readonly ToolEntry[], Error> {
+  const imageResult = getSandboxImageFromRegistry({ name: "dust-base" });
+  if (imageResult.isErr()) {
+    return new Err(new Error("Default sandbox image not found in registry"));
+  }
+
+  const allTools = imageResult.value.tools;
+  const profile = providerToProfile(providerId);
+
+  return new Ok(
+    allTools.filter((tool) => !tool.profile || tool.profile === profile)
+  );
+}
 
 export function getSandboxImage(
   _auth?: Authenticator
@@ -29,5 +69,7 @@ export type {
   SandboxResources,
   ToolEntry,
   ToolManifest,
+  ToolProfile,
+  ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
 export { formatSandboxImageId } from "@app/lib/api/sandbox/image/types";

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,43 +26,75 @@ SHELLEOF`)
   .runCmd("sudo touch /files/conversation/.mount-pending")
   .registerTool(
     [
-      { name: "git", description: "Version control system" },
-      { name: "jq", description: "JSON processor" },
-      { name: "pandoc", description: "Document converter" },
-      { name: "imagemagick", description: "Image manipulation" },
-      { name: "ffmpeg", description: "Media processing" },
-      { name: "lsb-release", description: "Linux distribution info" },
+      { name: "git", description: "Version control system", runtime: "system" },
+      { name: "jq", description: "JSON processor", runtime: "system" },
+      { name: "pandoc", description: "Document converter", runtime: "system" },
+      {
+        name: "imagemagick",
+        description: "Image manipulation",
+        runtime: "system",
+      },
+      { name: "ffmpeg", description: "Media processing", runtime: "system" },
+      {
+        name: "lsb-release",
+        description: "Linux distribution info",
+        runtime: "system",
+      },
     ],
     {
       installCmd:
         "sudo apt-get update && sudo apt-get install -y jq pandoc imagemagick ffmpeg lsb-release",
     }
   )
-  .registerTool({ name: "python", description: "Python interpreter" })
+  .registerTool({
+    name: "python",
+    description: "Python interpreter",
+    runtime: "python",
+  })
   .registerTool(
     [
-      { name: "pandas", description: "Data analysis library" },
-      { name: "numpy", description: "Numerical computing" },
-      { name: "matplotlib", description: "Plotting library" },
-      { name: "requests", description: "HTTP library" },
-      { name: "openpyxl", description: "Excel file support" },
-      { name: "pdfplumber", description: "PDF extraction" },
+      {
+        name: "pandas",
+        description: "Data analysis library",
+        runtime: "python",
+      },
+      { name: "numpy", description: "Numerical computing", runtime: "python" },
+      {
+        name: "matplotlib",
+        description: "Plotting library",
+        runtime: "python",
+      },
+      { name: "requests", description: "HTTP library", runtime: "python" },
+      {
+        name: "openpyxl",
+        description: "Excel file support",
+        runtime: "python",
+      },
+      { name: "pdfplumber", description: "PDF extraction", runtime: "python" },
     ],
     {
       installCmd:
         "uv pip install --python /opt/venv pandas numpy matplotlib requests openpyxl pdfplumber",
     }
   )
-  .registerTool({ name: "bun", description: "JavaScript runtime" })
+  .registerTool({
+    name: "bun",
+    description: "JavaScript runtime",
+    runtime: "node",
+  })
   .registerTool(
     [
-      { name: "typescript", description: "TypeScript compiler" },
-      { name: "tsx", description: "TypeScript executor" },
+      {
+        name: "typescript",
+        description: "TypeScript compiler",
+        runtime: "node",
+      },
+      { name: "tsx", description: "TypeScript executor", runtime: "node" },
     ],
     { installCmd: "npm install -g typescript tsx" }
   )
   .registerTool(
-    { name: "dsbx", description: "Dust CLI" },
+    { name: "dsbx", description: "Dust CLI", runtime: "system" },
     {
       installCmd:
         `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64 -o /tmp/dsbx && ` +
@@ -76,6 +108,7 @@ SHELLEOF`)
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(ALLOWLIST_NETWORK_POLICY)
   .setWorkdir("/home/user")
+  .withToolManifest()
   .register({
     imageName: "dust-base",
     tag: "0.2.2",

--- a/front/lib/api/sandbox/image/sandbox_image.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.test.ts
@@ -78,17 +78,19 @@ describe("SandboxImage.registerTool()", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool({
       name: "dsbx",
       description: "Dust CLI",
+      runtime: "system",
     });
 
     expect(image.operations).toHaveLength(0);
     expect(image.tools).toHaveLength(1);
     expect(image.tools[0].name).toBe("dsbx");
     expect(image.tools[0].description).toBe("Dust CLI");
+    expect(image.tools[0].runtime).toBe("system");
   });
 
   test("registers single tool with installCmd", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool(
-      { name: "curl", description: "HTTP client" },
+      { name: "curl", description: "HTTP client", runtime: "system" },
       { installCmd: "apt-get install -y curl" }
     );
 
@@ -99,14 +101,23 @@ describe("SandboxImage.registerTool()", () => {
     }
     expect(image.tools).toHaveLength(1);
     expect(image.tools[0].name).toBe("curl");
+    expect(image.tools[0].runtime).toBe("system");
   });
 
   test("registers multiple tools with single installCmd", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool(
       [
-        { name: "pandas", description: "Data analysis" },
-        { name: "numpy", description: "Numerical computing" },
-        { name: "matplotlib", description: "Plotting library" },
+        { name: "pandas", description: "Data analysis", runtime: "python" },
+        {
+          name: "numpy",
+          description: "Numerical computing",
+          runtime: "python",
+        },
+        {
+          name: "matplotlib",
+          description: "Plotting library",
+          runtime: "python",
+        },
       ],
       { installCmd: "pip install pandas numpy matplotlib" }
     );
@@ -124,6 +135,19 @@ describe("SandboxImage.registerTool()", () => {
       "numpy",
       "matplotlib",
     ]);
+    expect(image.tools.every((t) => t.runtime === "python")).toBe(true);
+  });
+
+  test("registers tool with profile", () => {
+    const image = SandboxImage.fromDocker("ubuntu:22.04").registerTool({
+      name: "special",
+      description: "OpenAI-only tool",
+      runtime: "system",
+      profile: "openai",
+    });
+
+    expect(image.tools).toHaveLength(1);
+    expect(image.tools[0].profile).toBe("openai");
   });
 
   test("returns new image instance", () => {
@@ -131,6 +155,7 @@ describe("SandboxImage.registerTool()", () => {
     const modified = original.registerTool({
       name: "curl",
       description: "HTTP client",
+      runtime: "system",
     });
 
     expect(modified).not.toBe(original);
@@ -240,7 +265,7 @@ describe("SandboxImage immutability", () => {
   test("chained operations preserve original instances", () => {
     const original = SandboxImage.fromDocker("ubuntu:22.04");
     const afterInstall = original.registerTool(
-      { name: "curl", description: "HTTP client" },
+      { name: "curl", description: "HTTP client", runtime: "system" },
       { installCmd: "apt-get install -y curl" }
     );
     const afterRun = afterInstall.runCmd("echo hello");
@@ -315,7 +340,11 @@ describe("SandboxImage.withToolManifest()", () => {
 
   test("chains with other operations", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04")
-      .registerTool({ name: "curl", description: "HTTP client" })
+      .registerTool({
+        name: "curl",
+        description: "HTTP client",
+        runtime: "system",
+      })
       .runCmd("echo hello")
       .withToolManifest()
       .runCmd("echo done");
@@ -328,8 +357,16 @@ describe("SandboxImage.withToolManifest()", () => {
 
   test("includes registered tools in manifest content", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04")
-      .registerTool({ name: "curl", description: "HTTP client" })
-      .registerTool({ name: "jq", description: "JSON processor" })
+      .registerTool({
+        name: "curl",
+        description: "HTTP client",
+        runtime: "system",
+      })
+      .registerTool({
+        name: "jq",
+        description: "JSON processor",
+        runtime: "system",
+      })
       .withToolManifest();
 
     if (
@@ -348,6 +385,7 @@ describe("SandboxImage.withToolManifest()", () => {
     const baseImage = SandboxImage.fromDocker("ubuntu:22.04").registerTool({
       name: "curl",
       description: "HTTP client",
+      runtime: "system",
     });
 
     const imageWithManifest = baseImage.withToolManifest();
@@ -545,7 +583,11 @@ describe("SandboxImage.register()", () => {
 
   test("chains with other operations", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04")
-      .registerTool({ name: "curl", description: "HTTP client" })
+      .registerTool({
+        name: "curl",
+        description: "HTTP client",
+        runtime: "system",
+      })
       .withResources({ vcpu: 2, memoryMb: 1024 })
       .register({ imageName: "dust-base", tag: "staging" })
       .setRunEnv({ DEBUG: "true" });

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -212,7 +212,6 @@ export class SandboxImage {
     const destPath =
       options?.path ?? `${this.workdir}/tool-manifest.${extension}`;
 
-    // Capture tools at call time, generate content lazily
     const tools = this.tools;
     const getContent = (): string => {
       const manifest = createToolManifest(tools);

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -3,7 +3,7 @@ import {
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image/tool_manifest";
-import type { ToolManifest } from "@app/lib/api/sandbox/image/types";
+import type { ToolEntry, ToolManifest } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 import { describe, expect, test } from "vitest";
 
@@ -21,29 +21,45 @@ describe("createToolManifest()", () => {
     expect(() => new Date(manifest.generatedAt)).not.toThrow();
   });
 
-  test("includes all tools", () => {
-    const tools = [
-      { name: "curl", description: "HTTP client" },
-      { name: "pandas", description: "Data analysis" },
-      { name: "custom", description: "Custom tool" },
+  test("groups tools by runtime", () => {
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+      { name: "pandas", description: "Data analysis", runtime: "python" },
+      { name: "tsx", description: "TypeScript executor", runtime: "node" },
     ];
 
     const manifest = createToolManifest(tools);
 
-    expect(manifest.tools).toHaveLength(3);
-    expect(manifest.tools.map((t) => t.name)).toEqual([
-      "curl",
-      "pandas",
-      "custom",
+    expect(manifest.tools.system).toEqual([
+      { name: "curl", description: "HTTP client" },
     ]);
+    expect(manifest.tools.python).toEqual([
+      { name: "pandas", description: "Data analysis" },
+    ]);
+    expect(manifest.tools.node).toEqual([
+      { name: "tsx", description: "TypeScript executor" },
+    ]);
+  });
+
+  test("omits empty runtime categories", () => {
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+    ];
+
+    const manifest = createToolManifest(tools);
+
+    expect(manifest.tools.system).toBeDefined();
+    expect(manifest.tools.python).toBeUndefined();
+    expect(manifest.tools.node).toBeUndefined();
   });
 });
 
 describe("toolManifestToJSON()", () => {
   test("generates valid JSON string", () => {
-    const manifest = createToolManifest([
-      { name: "curl", description: "HTTP client" },
-    ]);
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+    ];
+    const manifest = createToolManifest(tools);
 
     const jsonString = toolManifestToJSON(manifest);
 
@@ -52,24 +68,26 @@ describe("toolManifestToJSON()", () => {
   });
 
   test("includes all manifest fields", () => {
-    const manifest = createToolManifest([
-      { name: "curl", description: "HTTP client" },
-    ]);
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+    ];
+    const manifest = createToolManifest(tools);
 
     const jsonString = toolManifestToJSON(manifest);
     const parsed = JSON.parse(jsonString);
 
     expect(parsed.version).toBe("1.0");
     expect(parsed.generatedAt).toBeDefined();
-    expect(parsed.tools).toHaveLength(1);
+    expect(parsed.tools.system).toHaveLength(1);
   });
 });
 
 describe("toolManifestToYAML()", () => {
   test("generates valid YAML string", () => {
-    const manifest = createToolManifest([
-      { name: "curl", description: "HTTP client" },
-    ]);
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+    ];
+    const manifest = createToolManifest(tools);
 
     const yamlString = toolManifestToYAML(manifest);
 
@@ -79,9 +97,9 @@ describe("toolManifestToYAML()", () => {
   });
 
   test("YAML can be parsed back and matches JSON manifest", () => {
-    const tools = [
-      { name: "curl", description: "HTTP client" },
-      { name: "pandas", description: "Data analysis" },
+    const tools: ToolEntry[] = [
+      { name: "curl", description: "HTTP client", runtime: "system" },
+      { name: "pandas", description: "Data analysis", runtime: "python" },
     ];
     const manifest = createToolManifest(tools);
 

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -1,11 +1,39 @@
-import type { ToolEntry, ToolManifest } from "@app/lib/api/sandbox/image/types";
+import type {
+  ManifestToolEntry,
+  ToolEntry,
+  ToolManifest,
+  ToolRuntime,
+} from "@app/lib/api/sandbox/image/types";
+import { TOOL_RUNTIMES } from "@app/lib/api/sandbox/image/types";
 import * as yaml from "js-yaml";
 
 export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
+  const toolsByRuntime: Record<ToolRuntime, ManifestToolEntry[]> = {
+    system: [],
+    python: [],
+    node: [],
+  };
+
+  for (const tool of tools) {
+    toolsByRuntime[tool.runtime].push({
+      name: tool.name,
+      description: tool.description,
+    });
+  }
+
+  const filteredTools: Partial<
+    Record<ToolRuntime, readonly ManifestToolEntry[]>
+  > = {};
+  for (const runtime of TOOL_RUNTIMES) {
+    if (toolsByRuntime[runtime].length > 0) {
+      filteredTools[runtime] = toolsByRuntime[runtime];
+    }
+  }
+
   return {
     version: "1.0",
     generatedAt: new Date().toISOString(),
-    tools,
+    tools: filteredTools,
   };
 }
 

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -14,12 +14,24 @@ export function formatSandboxImageId(id: SandboxImageId): string {
 }
 
 // ---------------------------------------------------------------------------
+// Tool Runtime & Profile
+// ---------------------------------------------------------------------------
+
+export const TOOL_RUNTIMES = ["system", "python", "node"] as const;
+export type ToolRuntime = (typeof TOOL_RUNTIMES)[number];
+
+export const TOOL_PROFILES = ["openai", "anthropic", "gemini"] as const;
+export type ToolProfile = (typeof TOOL_PROFILES)[number];
+
+// ---------------------------------------------------------------------------
 // Tool Entry
 // ---------------------------------------------------------------------------
 
 export interface ToolEntry {
   readonly name: string;
   readonly description: string;
+  readonly runtime: ToolRuntime;
+  readonly profile?: ToolProfile;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,10 +96,17 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
 // Tool Manifest
 // ---------------------------------------------------------------------------
 
+export interface ManifestToolEntry {
+  readonly name: string;
+  readonly description: string;
+}
+
 export interface ToolManifest {
   readonly version: "1.0";
   readonly generatedAt: string;
-  readonly tools: readonly ToolEntry[];
+  readonly tools: Readonly<
+    Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>>
+  >;
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -12,11 +12,11 @@ import { buildSandboxImage } from "./e2b_template";
 function createTestImage(): SandboxImage {
   return SandboxImage.fromDocker("test-image:v1")
     .registerTool(
-      { name: "tool-a", description: "Test tool A" },
+      { name: "tool-a", description: "Test tool A", runtime: "system" },
       { installCmd: "apt-get install -y tool-a" }
     )
     .registerTool(
-      { name: "tool-b", description: "Test tool B" },
+      { name: "tool-b", description: "Test tool B", runtime: "python" },
       { installCmd: "pip install tool-b" }
     )
     .withResources({ vcpu: 2, memoryMb: 1024 })

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -27,7 +27,6 @@ import {
   Template as E2BTemplate,
 } from "e2b";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 export type DockerRegistryFactory = (imageRef: string) => TemplateBuilder;
@@ -60,13 +59,23 @@ class ContentMaterializer {
   private tempDir: string | null = null;
   private fileCount = 0;
 
-  materializeToPath(getContent: ContentGenerator): string {
+  materializeToPath(
+    getContent: ContentGenerator,
+    destFileName: string
+  ): string {
     if (!this.tempDir) {
-      this.tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sandbox-build-"));
+      // Create temp dir relative to this module (E2B resolves paths from __dirname).
+      const uniqueId = `sandbox-build-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      this.tempDir = path.join(__dirname, uniqueId);
+      fs.mkdirSync(this.tempDir, { recursive: true });
     }
-    const tempFile = path.join(this.tempDir, `content-${this.fileCount++}`);
+    // Use a subdirectory per file so E2B's directory-based copy works correctly.
+    const contentDir = path.join(this.tempDir, `content-${this.fileCount++}`);
+    fs.mkdirSync(contentDir, { recursive: true });
+    const fileName = path.basename(destFileName);
+    const tempFile = path.join(contentDir, fileName);
     fs.writeFileSync(tempFile, getContent());
-    return tempFile;
+    return path.relative(__dirname, contentDir);
   }
 
   cleanup(): void {
@@ -135,10 +144,14 @@ class E2BTemplateBuilder {
         if (op.src.type === "path") {
           this.builder = this.builder.copy(op.src.path, op.dest);
         } else {
-          const tempPath = this.materializer.materializeToPath(
-            op.src.getContent
+          // E2B copy works with directories, so we create a temp dir containing
+          // a file with the destination's filename, then copy to dest's parent.
+          const tempDir = this.materializer.materializeToPath(
+            op.src.getContent,
+            op.dest
           );
-          this.builder = this.builder.copy(tempPath, op.dest);
+          const destDir = path.dirname(op.dest);
+          this.builder = this.builder.copy(tempDir, destDir);
         }
         break;
 


### PR DESCRIPTION
## Description

### Adds the first building block of agent-centric bash profiles ✨ 

Here we focus on providing the primitives, the tool list is still TBD, (PR 3 upcoming soon)
My goal here is to make it very easy to update the tools list for a given number of providers, to enable rapid iteration.

## Tests

- Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front