### PR TITLE
[front] enh: Make sandboxes delighful for agents

### DIFF
--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -49,6 +49,8 @@ jobs:
           postgresql user: test
           postgresql password: test
           postgresql port: 5433
+      - name: Install Profile Tools
+        run: sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd
       - name: Run Tests
         working-directory: front
         env:

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -458,7 +458,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "sandbox": {
     "bash": "never_ask",
-    "describe_environment": "never_ask",
+    "describe_toolset": "never_ask",
   },
   "schedules_management": {
     "create_schedule": "high",

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -37,7 +37,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       done: "Execute command in sandbox",
     },
   },
-  describe_environment: {
+  describe_toolset: {
     description:
       "Describe the sandbox environment and list available CLI binaries and language libraries.",
     schema: {
@@ -48,8 +48,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Describing sandbox environment",
-      done: "Describe sandbox environment",
+      running: "Describing sandbox toolset",
+      done: "Describe sandbox toolset",
     },
   },
 });

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -19,6 +19,7 @@ import {
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image";
+import { wrapCommand } from "@app/lib/api/sandbox/image/profile";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -137,9 +138,16 @@ export function createSandboxTools(
         expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
       });
 
-      const execResult = await sandbox.exec(auth, command, {
+      const providerId = agentConfiguration.model.providerId;
+      // Convert timeoutMs to seconds for shell wrapper
+      const timeoutSec = timeoutMs ? Math.ceil(timeoutMs / 1000) : 60;
+      const wrappedCommand = wrapCommand(command, providerId, {
+        timeoutSec,
+      });
+
+      // No timeout at E2B level - shell wrapper handles it
+      const execResult = await sandbox.exec(auth, wrappedCommand, {
         workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
-        timeoutMs: timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
         envVars: {
           DUST_SANDBOX_TOKEN: sandboxToken,
           DUST_API_URL: `${config.getClientFacingUrl()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
@@ -153,7 +161,7 @@ export function createSandboxTools(
 
       return new Ok([{ type: "text" as const, text: output }]);
     },
-    describe_environment: async ({ format }, { auth, agentLoopContext }) => {
+    describe_toolset: async ({ format }, { auth, agentLoopContext }) => {
       const providerId =
         agentLoopContext?.runContext?.agentConfiguration.model.providerId;
       if (!providerId) {

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -1,0 +1,25 @@
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+
+export const PROFILE_DIR = "/opt/dust/profile";
+
+export interface WrapCommandOptions {
+  timeoutSec?: number;
+}
+
+function getProfileName(_providerId: ModelProviderIdType): string {
+  // Future: return provider-specific profiles
+  // e.g., if (providerId === "openai") return "openai.sh";
+  return "common.sh";
+}
+
+export function wrapCommand(
+  cmd: string,
+  providerId: ModelProviderIdType,
+  opts?: WrapCommandOptions
+): string {
+  const profile = getProfileName(providerId);
+  const timeoutSec = opts?.timeoutSec ?? 60;
+  // Escape double quotes and backslashes in command for safe embedding
+  const escapedCmd = cmd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `source ${PROFILE_DIR}/${profile} && shell "${escapedCmd}" ${timeoutSec}`;
+}

--- a/front/lib/api/sandbox/image/profile/_truncate.sh
+++ b/front/lib/api/sandbox/image/profile/_truncate.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Internal helpers: truncate output (keeps tail)
+
+_dust_truncate() {
+  local max_lines="${1:-500}"
+  local input
+  input=$(cat)
+  local line_count
+  line_count=$(echo "$input" | wc -l)
+
+  if [[ $line_count -gt $max_lines ]]; then
+    local skipped=$((line_count - max_lines))
+    echo "[... $skipped lines truncated ...]"
+    echo "$input" | tail -n "$max_lines"
+  else
+    echo "$input"
+  fi
+}
+export -f _dust_truncate
+
+_dust_truncate_chars() {
+  local max_chars=50000
+  local input
+  input=$(cat)
+  local char_count=${#input}
+
+  if [[ $char_count -gt $max_chars ]]; then
+    local output_file="/tmp/shell_output_$(date +%s%N).txt"
+    echo "$input" > "$output_file"
+    echo "[Output too long ($char_count chars). Showing last $max_chars chars only. Full output: $output_file]"
+    echo "[BEGIN TAIL]"
+    echo "${input: -$max_chars}"
+    echo "[END TAIL]"
+  else
+    echo "$input"
+  fi
+}
+export -f _dust_truncate_chars

--- a/front/lib/api/sandbox/image/profile/common.sh
+++ b/front/lib/api/sandbox/image/profile/common.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Dust Sandbox Profile - Main Entry Point
+# Sources all command files for sandbox operations
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/_truncate.sh"
+source "$SCRIPT_DIR/read_file.sh"
+source "$SCRIPT_DIR/edit_file.sh"
+source "$SCRIPT_DIR/write_file.sh"
+source "$SCRIPT_DIR/grep_files.sh"
+source "$SCRIPT_DIR/glob.sh"
+source "$SCRIPT_DIR/list_dir.sh"
+source "$SCRIPT_DIR/shell.sh"

--- a/front/lib/api/sandbox/image/profile/edit_file.sh
+++ b/front/lib/api/sandbox/image/profile/edit_file.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Edit files by replacing exact text
+# Usage: edit_file <old_text> <new_text> <path1> [path2]...
+# Errors per file if old_text matches 0 or 2+ times
+
+edit_file() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+edit_file - Replace exact text in files
+
+Usage: edit_file <old_text> <new_text> <path1> [path2]...
+
+Arguments:
+  old_text    Text to find and replace (required)
+  new_text    Replacement text (can be empty)
+  path1...    One or more files to edit (required)
+
+Output: "Edited <path>" for each successful edit
+
+Errors: Fails per-file if old_text not found or matches multiple times
+
+Examples:
+  edit_file "hello" "world" file.txt           # Replace in one file
+  edit_file "foo" "bar" a.txt b.txt c.txt      # Replace in multiple files
+  edit_file "old" "new" src/*.py               # Replace in all Python files
+  edit_file "debug" "" config.js               # Remove text
+EOF
+    return 0
+  fi
+
+  local old_text="$1"
+  local new_text="$2"
+  shift 2
+  local paths=("$@")
+
+  if [[ -z "$old_text" ]] || [[ ${#paths[@]} -eq 0 ]]; then
+    echo "Error: old_text and at least one path are required" >&2
+    echo "Usage: edit_file <old_text> <new_text> <path1> [path2]..." >&2
+    echo "Run 'edit_file --help' for more information." >&2
+    return 1
+  fi
+
+  local failed=0
+  for path in "${paths[@]}"; do
+    if [[ ! -f "$path" ]]; then
+      echo "Error: file not found: $path" >&2
+      failed=1
+      continue
+    fi
+
+    # Count occurrences using grep -F for literal matching
+    local count
+    count=$(grep -Fc "$old_text" "$path" 2>/dev/null)
+    count=${count:-0}
+
+    if [[ "$count" -eq 0 ]]; then
+      echo "Error: old_text not found in $path" >&2
+      failed=1
+      continue
+    fi
+
+    if [[ "$count" -gt 1 ]]; then
+      echo "Error: old_text matches $count times in $path, must be unique" >&2
+      failed=1
+      continue
+    fi
+
+    # Use sd for replacement (handles special characters well)
+    sd --fixed-strings "$old_text" "$new_text" "$path"
+    echo "Edited $path"
+  done
+
+  return $failed
+}
+export -f edit_file

--- a/front/lib/api/sandbox/image/profile/glob.sh
+++ b/front/lib/api/sandbox/image/profile/glob.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Find files matching a glob pattern
+# Usage: glob <pattern> [path]
+
+glob() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+glob - Find files by glob pattern
+
+Usage: glob <pattern> [path]
+
+Arguments:
+  pattern  Glob pattern, e.g., "*.py", "**/*.ts" (required)
+  path     Directory to search, default: . (optional)
+
+Output: File paths, one per line. Truncated to 200 results.
+
+Examples:
+  glob "*.txt"                # Find .txt files in current dir
+  glob "**/*.py"              # Find all Python files recursively
+  glob "*.{js,ts}" src/       # Find JS/TS files in src/
+  glob "test_*.py" tests/     # Find test files in tests/
+EOF
+    return 0
+  fi
+
+  local pattern="$1"
+  local search_path="${2:-.}"
+
+  if [[ -z "$pattern" ]]; then
+    echo "Error: pattern is required" >&2
+    echo "Usage: glob <pattern> [path]" >&2
+    echo "Run 'glob --help' for more information." >&2
+    return 1
+  fi
+
+  # fdfind on Debian/Ubuntu, fd on macOS/other systems
+  local fd_cmd
+  if command -v fdfind &>/dev/null; then
+    fd_cmd="fdfind"
+  elif command -v fd &>/dev/null; then
+    fd_cmd="fd"
+  else
+    echo "Error: fd-find not installed" >&2
+    return 1
+  fi
+
+  $fd_cmd --glob "$pattern" "$search_path" 2>/dev/null | _dust_truncate 200
+}
+export -f glob

--- a/front/lib/api/sandbox/image/profile/grep_files.sh
+++ b/front/lib/api/sandbox/image/profile/grep_files.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Search files for pattern using ripgrep
+# Usage: grep_files <pattern> [glob] [path] [max_results] [context_lines]
+
+grep_files() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+grep_files - Search files for regex pattern using ripgrep
+
+Usage: grep_files <pattern> [glob] [path] [max_results] [context_lines]
+
+Arguments:
+  pattern        Regex pattern to search for (required)
+  glob           File glob filter, e.g., "*.py" (optional)
+  path           Directory to search, default: . (optional)
+  max_results    Max lines to return, default: 200 (optional)
+  context_lines  Lines before/after each match, default: 0 (optional)
+
+Output: file:line:content format, one match per line
+
+Examples:
+  grep_files "TODO"                      # Search all files for TODO
+  grep_files "import" "*.py"             # Search Python files for imports
+  grep_files "error" "*.log" /var/log    # Search log files in /var/log
+  grep_files "func" "" "." 100 3         # Show 3 lines context, max 100 results
+EOF
+    return 0
+  fi
+
+  local pattern="$1"
+  local file_glob="$2"
+  local search_path="${3:-.}"
+  local max_results="${4:-200}"
+  local context_lines="${5:-0}"
+
+  if [[ -z "$pattern" ]]; then
+    echo "Error: pattern is required" >&2
+    echo "Usage: grep_files <pattern> [glob] [path] [max_results] [context_lines]" >&2
+    echo "Run 'grep_files --help' for more information." >&2
+    return 1
+  fi
+
+  local args=(-n --color=never)
+  if [[ -n "$file_glob" ]]; then
+    args+=(--glob "$file_glob")
+  fi
+  if [[ "$context_lines" -gt 0 ]]; then
+    args+=(-C "$context_lines")
+  fi
+
+  rg "${args[@]}" "$pattern" "$search_path" 2>/dev/null | _dust_truncate "$max_results"
+}
+export -f grep_files

--- a/front/lib/api/sandbox/image/profile/list_dir.sh
+++ b/front/lib/api/sandbox/image/profile/list_dir.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# List directory contents
+# Usage: list_dir [path] [depth]
+
+list_dir() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+list_dir - List directory contents
+
+Usage: list_dir [path] [depth]
+
+Arguments:
+  path   Directory to list, default: . (optional)
+  depth  Max depth to recurse, default: 2, max: 5 (optional)
+
+Output: File and directory paths, one per line. Limited to 200 entries.
+
+Examples:
+  list_dir                    # List current dir, depth 2
+  list_dir /home/user         # List specific directory
+  list_dir . 1                # List current dir, no recursion
+  list_dir src/ 3             # List src/ with depth 3
+EOF
+    return 0
+  fi
+
+  local path="${1:-.}"
+  local depth="${2:-2}"
+
+  # Cap depth at 5
+  if [[ "$depth" -gt 5 ]]; then
+    depth=5
+  fi
+
+  if [[ ! -d "$path" ]]; then
+    echo "Error: directory not found: $path" >&2
+    return 1
+  fi
+
+  find "$path" -maxdepth "$depth" -type f -o -type d 2>/dev/null | head -n 200
+}
+export -f list_dir

--- a/front/lib/api/sandbox/image/profile/read_file.sh
+++ b/front/lib/api/sandbox/image/profile/read_file.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Read a file with line numbers
+# Usage: read_file <path> [start_line] [end_line]
+
+read_file() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+read_file - Read file with line numbers
+
+Usage: read_file <path> [start_line] [end_line]
+
+Arguments:
+  path        File to read (required)
+  start_line  First line to read, 1-indexed, default: 1 (optional)
+  end_line    Last line to read, default: EOF (optional)
+
+Output: Numbered lines in format: '  N\tcontent'
+
+Examples:
+  read_file file.txt              # Read entire file
+  read_file file.txt 10           # Read from line 10 to EOF
+  read_file file.txt 10 20        # Read lines 10-20
+  read_file /etc/hosts 1 5        # Read first 5 lines
+EOF
+    return 0
+  fi
+
+  local path="$1"
+  local start="${2:-1}"
+  local end="$3"
+
+  if [[ -z "$path" ]]; then
+    echo "Error: path is required" >&2
+    echo "Usage: read_file <path> [start_line] [end_line]" >&2
+    echo "Run 'read_file --help' for more information." >&2
+    return 1
+  fi
+
+  if [[ ! -f "$path" ]]; then
+    echo "Error: file not found: $path" >&2
+    return 1
+  fi
+
+  if [[ -n "$end" ]]; then
+    sed -n "${start},${end}p" "$path" | nl -ba -v "$start"
+  else
+    tail -n "+${start}" "$path" | nl -ba -v "$start"
+  fi
+}
+export -f read_file

--- a/front/lib/api/sandbox/image/profile/shell.sh
+++ b/front/lib/api/sandbox/image/profile/shell.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Execute a shell command with timeout
+# Usage: shell <command> [timeout_sec]
+
+shell() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+shell - Execute shell command with timeout
+
+Usage: shell <command> [timeout_sec]
+
+Arguments:
+  command      Shell command to execute (required)
+  timeout_sec  Timeout in seconds, default: 60 (optional)
+
+Output: stdout truncated to 50000 chars; stderr preserved separately.
+        When truncated, full output is saved to /tmp/shell_output_<timestamp>.txt
+
+Examples:
+  shell "ls -la"                    # Simple command
+  shell "python script.py" 120     # Run with 2 minute timeout
+EOF
+    return 0
+  fi
+
+  local cmd="$1"
+  local timeout_sec="${2:-60}"
+
+  if [[ -z "$cmd" ]]; then
+    echo "Error: command is required" >&2
+    echo "Usage: shell <command> [timeout_sec]" >&2
+    echo "Run 'shell --help' for more information." >&2
+    return 1
+  fi
+
+  local exit_code
+  # Use timeout if available (Linux), otherwise run without timeout (macOS dev)
+  if command -v timeout &>/dev/null; then
+    timeout "${timeout_sec}s" bash -c "$cmd" | _dust_truncate_chars
+    exit_code=${PIPESTATUS[0]}
+    if [[ $exit_code -eq 124 ]]; then
+      echo "[Command timed out after ${timeout_sec}s]" >&2
+    fi
+  else
+    bash -c "$cmd" | _dust_truncate_chars
+    exit_code=${PIPESTATUS[0]}
+  fi
+
+  return $exit_code
+}
+export -f shell

--- a/front/lib/api/sandbox/image/profile/tests/_test_utils.ts
+++ b/front/lib/api/sandbox/image/profile/tests/_test_utils.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export const PROFILE_LOCAL_DIR = path.resolve(__dirname, "..");
+
+export function runBashFunction(
+  funcCall: string,
+  cwd: string
+): {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+} {
+  const profilePath = path.join(PROFILE_LOCAL_DIR, "common.sh");
+  const result = spawnSync(
+    "bash",
+    ["-c", `source "${profilePath}" && ${funcCall}`],
+    {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10000,
+    }
+  );
+  return {
+    stdout: result.stdout?.trim() ?? "",
+    stderr: result.stderr?.trim() ?? "",
+    exitCode: result.status ?? 1,
+  };
+}
+
+export function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "profile-test-"));
+}
+
+export function cleanupTempDir(tempDir: string): void {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}

--- a/front/lib/api/sandbox/image/profile/tests/edit_file.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/edit_file.test.ts
@@ -1,0 +1,107 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("edit_file", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    fs.writeFileSync(path.join(tempDir, "edit.txt"), "hello world\nfoo bar\n");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("replaces unique match", () => {
+    const filePath = path.join(tempDir, "edit.txt");
+    const { stdout, exitCode } = runBashFunction(
+      `edit_file "hello" "goodbye" "${filePath}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Edited");
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("goodbye world\nfoo bar\n");
+  });
+
+  it("errors when old_text not found", () => {
+    const filePath = path.join(tempDir, "edit.txt");
+    const { stderr, exitCode } = runBashFunction(
+      `edit_file "nonexistent" "replacement" "${filePath}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("old_text not found");
+  });
+
+  it("errors when old_text matches multiple times", () => {
+    const filePath = path.join(tempDir, "multi.txt");
+    fs.writeFileSync(filePath, "foo\nfoo\nbar\n");
+    const { stderr, exitCode } = runBashFunction(
+      `edit_file "foo" "baz" "${filePath}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("matches 2 times");
+  });
+
+  it("handles special characters", () => {
+    const filePath = path.join(tempDir, "special.txt");
+    fs.writeFileSync(filePath, 'const x = "value";\n');
+    const { exitCode } = runBashFunction(
+      `edit_file '"value"' '"newValue"' "${filePath}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe('const x = "newValue";\n');
+  });
+
+  it("edits multiple files with same replacement", () => {
+    const file1 = path.join(tempDir, "file1.txt");
+    const file2 = path.join(tempDir, "file2.txt");
+    fs.writeFileSync(file1, "hello world\n");
+    fs.writeFileSync(file2, "hello there\n");
+    const { stdout, exitCode } = runBashFunction(
+      `edit_file "hello" "goodbye" "${file1}" "${file2}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(`Edited ${file1}`);
+    expect(stdout).toContain(`Edited ${file2}`);
+    expect(fs.readFileSync(file1, "utf-8")).toBe("goodbye world\n");
+    expect(fs.readFileSync(file2, "utf-8")).toBe("goodbye there\n");
+  });
+
+  it("continues editing remaining files when one file fails", () => {
+    const file1 = path.join(tempDir, "file1.txt");
+    const file2 = path.join(tempDir, "file2.txt");
+    fs.writeFileSync(file1, "no match here\n");
+    fs.writeFileSync(file2, "hello world\n");
+    const { stdout, stderr, exitCode } = runBashFunction(
+      `edit_file "hello" "goodbye" "${file1}" "${file2}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(`old_text not found in ${file1}`);
+    expect(stdout).toContain(`Edited ${file2}`);
+    expect(fs.readFileSync(file2, "utf-8")).toBe("goodbye world\n");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("edit_file --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("edit_file <old_text> <new_text> <path1>");
+  });
+
+  it("error includes usage hint", () => {
+    const { stderr, exitCode } = runBashFunction("edit_file", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+    expect(stderr).toContain("--help");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/glob.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/glob.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("glob", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    fs.writeFileSync(path.join(tempDir, "file1.txt"), "");
+    fs.writeFileSync(path.join(tempDir, "file2.py"), "");
+    fs.mkdirSync(path.join(tempDir, "subdir"));
+    fs.writeFileSync(path.join(tempDir, "subdir", "file3.txt"), "");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("finds files matching glob pattern", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `glob "*.txt" "${tempDir}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("file1.txt");
+    expect(stdout).toContain("file3.txt");
+    expect(stdout).not.toContain("file2.py");
+  });
+
+  it("supports recursive glob", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `glob "**/*.txt" "${tempDir}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("file1.txt");
+    expect(stdout).toContain("file3.txt");
+  });
+
+  it("errors on missing pattern", () => {
+    const { stderr, exitCode } = runBashFunction("glob", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("pattern is required");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("glob --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("glob <pattern>");
+  });
+
+  it("error includes usage hint", () => {
+    const { stderr, exitCode } = runBashFunction("glob", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+    expect(stderr).toContain("--help");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/grep_files.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/grep_files.test.ts
@@ -1,0 +1,94 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("grep_files", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    fs.writeFileSync(path.join(tempDir, "file1.txt"), "hello world\n");
+    fs.writeFileSync(path.join(tempDir, "file2.txt"), "foo bar\nhello again\n");
+    fs.mkdirSync(path.join(tempDir, "subdir"));
+    fs.writeFileSync(
+      path.join(tempDir, "subdir", "file3.py"),
+      "# hello\nprint('test')\n"
+    );
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("searches for pattern in directory", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `grep_files "hello" "" "${tempDir}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("file1.txt");
+    expect(stdout).toContain("file2.txt");
+    expect(stdout).toContain("file3.py");
+  });
+
+  it("filters by glob pattern", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `grep_files "hello" "*.txt" "${tempDir}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("file1.txt");
+    expect(stdout).not.toContain("file3.py");
+  });
+
+  it("errors on missing pattern", () => {
+    const { stderr, exitCode } = runBashFunction("grep_files", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("pattern is required");
+  });
+
+  it("max_results param limits output lines", () => {
+    // Create a file with many matches
+    const lines = Array.from({ length: 50 }, (_, i) => `hello line ${i + 1}`);
+    fs.writeFileSync(path.join(tempDir, "many.txt"), lines.join("\n") + "\n");
+    const { stdout, exitCode } = runBashFunction(
+      `grep_files "hello" "*.txt" "${tempDir}" 10`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    // Should have truncation message since we have >10 results
+    expect(stdout).toContain("truncated");
+  });
+
+  it("context_lines param shows N lines before/after matches", () => {
+    fs.writeFileSync(
+      path.join(tempDir, "context.txt"),
+      "line1\nline2\nTARGET\nline4\nline5\n"
+    );
+    const { stdout, exitCode } = runBashFunction(
+      `grep_files "TARGET" "*.txt" "${tempDir}" 200 1`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("line2");
+    expect(stdout).toContain("TARGET");
+    expect(stdout).toContain("line4");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("grep_files --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("grep_files <pattern>");
+  });
+
+  it("error includes usage hint", () => {
+    const { stderr, exitCode } = runBashFunction("grep_files", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+    expect(stderr).toContain("--help");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/list_dir.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/list_dir.test.ts
@@ -1,0 +1,70 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("list_dir", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    fs.mkdirSync(path.join(tempDir, "dir1"));
+    fs.writeFileSync(path.join(tempDir, "file1.txt"), "");
+    fs.mkdirSync(path.join(tempDir, "dir1", "nested"));
+    fs.writeFileSync(path.join(tempDir, "dir1", "file2.txt"), "");
+    fs.mkdirSync(path.join(tempDir, "dir1", "nested", "deep"));
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("lists directory contents with default depth", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `list_dir "${tempDir}"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("file1.txt");
+    expect(stdout).toContain("dir1");
+    expect(stdout).toContain("nested");
+  });
+
+  it("respects depth parameter", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `list_dir "${tempDir}" 1`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("file1.txt");
+    expect(stdout).toContain("dir1");
+    expect(stdout).not.toContain("nested");
+  });
+
+  it("caps depth at 5", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `list_dir "${tempDir}" 100`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("deep");
+  });
+
+  it("errors on directory not found", () => {
+    const { stderr, exitCode } = runBashFunction(
+      `list_dir "${tempDir}/nonexistent"`,
+      tempDir
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("directory not found");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("list_dir --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("list_dir [path]");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/read_file.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/read_file.test.ts
@@ -1,0 +1,84 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("read_file", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    fs.writeFileSync(
+      path.join(tempDir, "test.txt"),
+      "line1\nline2\nline3\nline4\nline5\n"
+    );
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("reads entire file with line numbers", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `read_file "${tempDir}/test.txt"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("1\tline1");
+    expect(stdout).toContain("5\tline5");
+  });
+
+  it("reads range of lines", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `read_file "${tempDir}/test.txt" 2 4`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("2\tline2");
+    expect(stdout).toContain("4\tline4");
+    expect(stdout).not.toContain("line1");
+    expect(stdout).not.toContain("line5");
+  });
+
+  it("reads from start line to EOF", () => {
+    const { stdout, exitCode } = runBashFunction(
+      `read_file "${tempDir}/test.txt" 3`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("3\tline3");
+    expect(stdout).toContain("5\tline5");
+    expect(stdout).not.toContain("line1");
+  });
+
+  it("errors on missing path", () => {
+    const { stderr, exitCode } = runBashFunction("read_file", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("path is required");
+  });
+
+  it("errors on file not found", () => {
+    const { stderr, exitCode } = runBashFunction(
+      `read_file "${tempDir}/nonexistent.txt"`,
+      tempDir
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("file not found");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("read_file --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("read_file <path>");
+  });
+
+  it("error includes usage hint", () => {
+    const { stderr, exitCode } = runBashFunction("read_file", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+    expect(stderr).toContain("--help");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/shell.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/shell.test.ts
@@ -1,0 +1,98 @@
+import { execSync } from "child_process";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+function hasTimeoutCommand(): boolean {
+  try {
+    execSync("command -v timeout", { encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("shell", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("executes command and captures output", () => {
+    const { stdout, exitCode } = runBashFunction('shell "echo hello"', tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("hello");
+  });
+
+  it("captures stderr separately from stdout", () => {
+    const { stdout, stderr, exitCode } = runBashFunction(
+      'shell "echo error >&2"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("error");
+  });
+
+  it("captures both stdout and stderr separately", () => {
+    const { stdout, stderr, exitCode } = runBashFunction(
+      'shell "echo out && echo err >&2"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("out");
+    expect(stderr).toBe("err");
+  });
+
+  it("returns exit code from command", () => {
+    const { exitCode } = runBashFunction('shell "exit 42"', tempDir);
+    expect(exitCode).toBe(42);
+  });
+
+  it("errors on missing command", () => {
+    const { stderr, exitCode } = runBashFunction("shell", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("command is required");
+  });
+
+  it("truncates long output and saves to file", () => {
+    // seq 1 15000 produces ~90000 chars, exceeding 50000 limit
+    const { stdout } = runBashFunction('shell "seq 1 15000"', tempDir);
+    expect(stdout).toContain("[Output too long");
+    expect(stdout).toContain("[BEGIN TAIL]");
+    expect(stdout).toContain("[END TAIL]");
+    expect(stdout).toContain("/tmp/shell_output_");
+    expect(stdout).toContain("15000");
+  });
+
+  it("timeout_sec param causes timeout after N seconds", () => {
+    if (!hasTimeoutCommand()) {
+      // timeout command not available on macOS, skip
+      return;
+    }
+    // Use a 1 second timeout with a 5 second sleep
+    const { stderr, exitCode } = runBashFunction('shell "sleep 5" 1', tempDir);
+    expect(exitCode).toBe(124);
+    expect(stderr).toContain("timed out after 1s");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("shell --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("shell <command>");
+  });
+
+  it("error includes usage hint", () => {
+    const { stderr, exitCode } = runBashFunction("shell", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+    expect(stderr).toContain("--help");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/truncate.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/truncate.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("_dust_truncate", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("passes through output under limit", () => {
+    const { stdout } = runBashFunction(
+      'echo -e "line1\\nline2\\nline3" | _dust_truncate 10',
+      tempDir
+    );
+    expect(stdout).toBe("line1\nline2\nline3");
+  });
+
+  it("truncates output over limit keeping tail", () => {
+    const { stdout } = runBashFunction(
+      'echo -e "1\\n2\\n3\\n4\\n5" | _dust_truncate 3',
+      tempDir
+    );
+    expect(stdout).toContain("[... 2 lines truncated ...]");
+    expect(stdout).toContain("3\n4\n5");
+  });
+});
+
+describe("_dust_truncate_chars", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("passes through output under character limit", () => {
+    const { stdout } = runBashFunction(
+      'echo "short text" | _dust_truncate_chars',
+      tempDir
+    );
+    expect(stdout).toBe("short text");
+  });
+
+  it("truncates output over limit and writes full output to file", () => {
+    // Generate 60000 chars (exceeds 50000 limit)
+    const { stdout } = runBashFunction(
+      'head -c 60000 /dev/zero | tr "\\0" "a" | _dust_truncate_chars',
+      tempDir
+    );
+    expect(stdout).toContain(
+      "[Output too long (60000 chars). Showing last 50000 chars only."
+    );
+    expect(stdout).toContain("/tmp/shell_output_");
+    expect(stdout).toContain("[BEGIN TAIL]");
+    expect(stdout).toContain("[END TAIL]");
+  });
+
+  it("creates file with full output when truncated", () => {
+    const { stdout } = runBashFunction(
+      `
+      output=$(head -c 60000 /dev/zero | tr "\\0" "b" | _dust_truncate_chars)
+      file_path=$(echo "$output" | grep -o '/tmp/shell_output_[0-9]*\\.txt' | head -1)
+      if [[ -f "$file_path" ]]; then
+        wc -c < "$file_path" | tr -d ' '
+      else
+        echo "FILE_NOT_FOUND"
+      fi
+      `,
+      tempDir
+    );
+    expect(stdout.trim()).toBe("60001"); // 60000 chars + newline from echo
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { PROFILE_DIR, wrapCommand } from "../../profile";
+
+describe("wrapCommand", () => {
+  it("wraps command with shell function for anthropic provider", () => {
+    const result = wrapCommand("ls -la", "anthropic");
+    expect(result).toBe(`source ${PROFILE_DIR}/common.sh && shell "ls -la" 60`);
+  });
+
+  it("wraps command with shell function for openai provider", () => {
+    const result = wrapCommand("pwd", "openai");
+    expect(result).toBe(`source ${PROFILE_DIR}/common.sh && shell "pwd" 60`);
+  });
+
+  it("wraps command with shell function for google_ai_studio provider", () => {
+    const result = wrapCommand("echo hello", "google_ai_studio");
+    expect(result).toBe(
+      `source ${PROFILE_DIR}/common.sh && shell "echo hello" 60`
+    );
+  });
+
+  it("passes timeoutSec to shell wrapper", () => {
+    const result = wrapCommand("long-cmd", "anthropic", { timeoutSec: 120 });
+    expect(result).toBe(
+      `source ${PROFILE_DIR}/common.sh && shell "long-cmd" 120`
+    );
+  });
+
+  it("escapes double quotes in command", () => {
+    const result = wrapCommand('echo "hello world"', "anthropic");
+    expect(result).toBe(
+      `source ${PROFILE_DIR}/common.sh && shell "echo \\"hello world\\"" 60`
+    );
+  });
+
+  it("escapes backslashes in command", () => {
+    const result = wrapCommand("echo \\n", "anthropic");
+    expect(result).toBe(
+      `source ${PROFILE_DIR}/common.sh && shell "echo \\\\n" 60`
+    );
+  });
+});

--- a/front/lib/api/sandbox/image/profile/tests/write_file.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/write_file.test.ts
@@ -1,0 +1,71 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDir, createTempDir, runBashFunction } from "./_test_utils";
+
+describe("write_file", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  it("writes content to file", () => {
+    const filePath = path.join(tempDir, "output.txt");
+    const { stdout, exitCode } = runBashFunction(
+      `write_file "${filePath}" "hello world"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Wrote");
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("hello world");
+  });
+
+  it("creates parent directories", () => {
+    const filePath = path.join(tempDir, "nested", "deep", "file.txt");
+    const { exitCode } = runBashFunction(
+      `write_file "${filePath}" "content"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("content");
+  });
+
+  it("overwrites existing file", () => {
+    const filePath = path.join(tempDir, "existing.txt");
+    fs.writeFileSync(filePath, "old content");
+    const { exitCode } = runBashFunction(
+      `write_file "${filePath}" "new content"`,
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("new content");
+  });
+
+  it("errors on missing path", () => {
+    const { stderr, exitCode } = runBashFunction("write_file", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("path is required");
+  });
+
+  it("returns help with --help flag", () => {
+    const { stdout, exitCode } = runBashFunction("write_file --help", tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("write_file <path>");
+  });
+
+  it("error includes usage hint", () => {
+    const { stderr, exitCode } = runBashFunction("write_file", tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+    expect(stderr).toContain("--help");
+  });
+});

--- a/front/lib/api/sandbox/image/profile/write_file.sh
+++ b/front/lib/api/sandbox/image/profile/write_file.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Write content to a file (creates parent directories)
+# Usage: write_file <path> <content>
+
+write_file() {
+  if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    cat <<'EOF'
+write_file - Write content to file (creates parent directories)
+
+Usage: write_file <path> <content>
+
+Arguments:
+  path     File path to write to (required)
+  content  Content to write (can be empty)
+
+Output: "Wrote <path>" on success
+
+Examples:
+  write_file file.txt "Hello, world!"     # Write to file
+  write_file nested/dir/file.txt "data"   # Creates parent dirs
+  write_file config.json '{"key": "val"}' # Write JSON
+EOF
+    return 0
+  fi
+
+  local path="$1"
+  local content="$2"
+
+  if [[ -z "$path" ]]; then
+    echo "Error: path is required" >&2
+    echo "Usage: write_file <path> <content>" >&2
+    echo "Run 'write_file --help' for more information." >&2
+    return 1
+  fi
+
+  local dir
+  dir=$(dirname "$path")
+  if [[ ! -d "$dir" ]]; then
+    mkdir -p "$dir"
+  fi
+
+  printf '%s' "$content" > "$path"
+  echo "Wrote $path"
+}
+export -f write_file

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -1,12 +1,85 @@
+import { PROFILE_DIR } from "@app/lib/api/sandbox/image/profile";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
-import { ALLOWLIST_NETWORK_POLICY } from "@app/lib/api/sandbox/image/types";
+import {
+  ALLOWLIST_NETWORK_POLICY,
+  type ToolEntry,
+} from "@app/lib/api/sandbox/image/types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import fs from "fs";
+import path from "path";
 
 const DSBX_CLI_VERSION = "0.1.1";
+const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 
-const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.1.0")
+interface PythonLibrary {
+  name: string;
+  version: string;
+  description: string;
+}
+
+const PYTHON_LIBRARIES: PythonLibrary[] = [
+  { name: "pandas", version: "3.0.1", description: "Data analysis library" },
+  { name: "numpy", version: "2.4.3", description: "Numerical computing" },
+  { name: "scipy", version: "1.17.1", description: "Scientific computing" },
+  { name: "scikit-learn", version: "1.8.0", description: "Machine learning" },
+  { name: "statsmodels", version: "0.14.6", description: "Statistical models" },
+  { name: "pyarrow", version: "23.0.1", description: "Arrow data format" },
+  { name: "matplotlib", version: "3.10.8", description: "Plotting library" },
+  {
+    name: "seaborn",
+    version: "0.13.2",
+    description: "Statistical visualization",
+  },
+  { name: "plotly", version: "6.6.0", description: "Interactive plots" },
+  { name: "requests", version: "2.32.5", description: "HTTP library" },
+  { name: "openpyxl", version: "3.1.5", description: "Excel file support" },
+  { name: "xlsxwriter", version: "3.2.9", description: "Excel file writer" },
+  { name: "pdfplumber", version: "0.11.9", description: "PDF extraction" },
+  { name: "pypdf", version: "6.8.0", description: "PDF manipulation" },
+  { name: "reportlab", version: "4.4.10", description: "PDF generation" },
+  {
+    name: "python-docx",
+    version: "1.2.0",
+    description: "Word document support",
+  },
+  { name: "python-pptx", version: "1.0.2", description: "PowerPoint support" },
+  {
+    name: "beautifulsoup4",
+    version: "4.14.3",
+    description: "HTML/XML parsing",
+  },
+  { name: "lxml", version: "6.0.2", description: "XML processing" },
+  { name: "pillow", version: "12.1.1", description: "Image processing" },
+  { name: "sympy", version: "1.14.0", description: "Symbolic mathematics" },
+];
+
+function getPythonToolEntries(): ToolEntry[] {
+  return PYTHON_LIBRARIES.map((lib) => ({
+    name: lib.name,
+    version: lib.version,
+    description: lib.description,
+    runtime: "python" as const,
+  }));
+}
+
+function getPythonInstallCmd(): string {
+  const packages = PYTHON_LIBRARIES.map(
+    (lib) => `${lib.name}==${lib.version}`
+  ).join(" ");
+  return `uv pip install --python /opt/venv ${packages}`;
+}
+
+function getProfileContent(filename: string): () => string {
+  return () => fs.readFileSync(path.join(PROFILE_LOCAL_DIR, filename), "utf-8");
+}
+
+function getFileContent(filePath: string): () => string {
+  return () => fs.readFileSync(filePath, "utf-8");
+}
+
+const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.2.0")
   // Conversation files bootstrap
   // Pre-create workspace directory for faster GCS mounts.
   .runCmd(
@@ -24,10 +97,16 @@ SHELLEOF`)
   .runCmd("sudo chmod 755 /home/user/.bin/token-server.sh")
   // Add sentinel file to indicate when mounts are pending.
   .runCmd("sudo touch /files/conversation/.mount-pending")
+  // Hidden tools: installed but not in manifest (back profile functions)
+  .runCmd("sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd")
+  // Create profile directory and copy profile scripts
   .registerTool(
     [
       { name: "git", description: "Version control system", runtime: "system" },
+      { name: "curl", description: "HTTP client", runtime: "system" },
+      { name: "wget", description: "Network downloader", runtime: "system" },
       { name: "jq", description: "JSON processor", runtime: "system" },
+      { name: "sqlite3", description: "SQLite database", runtime: "system" },
       { name: "pandoc", description: "Document converter", runtime: "system" },
       {
         name: "imagemagick",
@@ -35,15 +114,22 @@ SHELLEOF`)
         runtime: "system",
       },
       { name: "ffmpeg", description: "Media processing", runtime: "system" },
+      { name: "unzip", description: "Archive extraction", runtime: "system" },
       {
         name: "lsb-release",
         description: "Linux distribution info",
         runtime: "system",
       },
+      {
+        name: "file",
+        description: "Determine file type",
+        runtime: "system",
+      },
     ],
     {
+      // the other tools are installed in bedrock
       installCmd:
-        "sudo apt-get update && sudo apt-get install -y jq pandoc imagemagick ffmpeg lsb-release",
+        "sudo apt-get install -y jq pandoc imagemagick ffmpeg unzip file",
     }
   )
   .registerTool({
@@ -51,32 +137,7 @@ SHELLEOF`)
     description: "Python interpreter",
     runtime: "python",
   })
-  .registerTool(
-    [
-      {
-        name: "pandas",
-        description: "Data analysis library",
-        runtime: "python",
-      },
-      { name: "numpy", description: "Numerical computing", runtime: "python" },
-      {
-        name: "matplotlib",
-        description: "Plotting library",
-        runtime: "python",
-      },
-      { name: "requests", description: "HTTP library", runtime: "python" },
-      {
-        name: "openpyxl",
-        description: "Excel file support",
-        runtime: "python",
-      },
-      { name: "pdfplumber", description: "PDF extraction", runtime: "python" },
-    ],
-    {
-      installCmd:
-        "uv pip install --python /opt/venv pandas numpy matplotlib requests openpyxl pdfplumber",
-    }
-  )
+  .registerTool(getPythonToolEntries(), { installCmd: getPythonInstallCmd() })
   .registerTool(
     [
       {
@@ -99,6 +160,77 @@ SHELLEOF`)
         "sudo mv /tmp/dsbx /opt/bin/dsbx",
     }
   )
+  // Test data file
+  .copy(
+    getFileContent("/Users/jd/Downloads/products-100000.csv"),
+    "/home/user/products-100000.csv"
+  )
+  .runCmd(`sudo mkdir -p ${PROFILE_DIR}`)
+  .copy(getProfileContent("common.sh"), `${PROFILE_DIR}/common.sh`)
+  .copy(getProfileContent("_truncate.sh"), `${PROFILE_DIR}/_truncate.sh`)
+  .copy(getProfileContent("read_file.sh"), `${PROFILE_DIR}/read_file.sh`)
+  .copy(getProfileContent("edit_file.sh"), `${PROFILE_DIR}/edit_file.sh`)
+  .copy(getProfileContent("write_file.sh"), `${PROFILE_DIR}/write_file.sh`)
+  .copy(getProfileContent("grep_files.sh"), `${PROFILE_DIR}/grep_files.sh`)
+  .copy(getProfileContent("glob.sh"), `${PROFILE_DIR}/glob.sh`)
+  .copy(getProfileContent("list_dir.sh"), `${PROFILE_DIR}/list_dir.sh`)
+  .copy(getProfileContent("shell.sh"), `${PROFILE_DIR}/shell.sh`)
+  // Profile functions (no install needed, provided by profile scripts)
+  .registerTool([
+    {
+      name: "read_file",
+      description: "Read file with line numbers",
+      usage: "read_file <path> [start] [end]",
+      returns: "Numbered lines (format: '  N\\tcontent')",
+      runtime: "system",
+    },
+    {
+      name: "edit_file",
+      description:
+        "Replace exact text in files. Fails per-file if old_text not found or matches multiple times",
+      usage: "edit_file <old_text> <new_text> <path1> [path2]...",
+      returns: "'Edited <path>' per success",
+      runtime: "system",
+    },
+    {
+      name: "write_file",
+      description: "Write content to file (creates parent directories)",
+      usage: "write_file <path> <content>",
+      returns: "'Wrote <path>' on success",
+      runtime: "system",
+    },
+    {
+      name: "grep_files",
+      description:
+        "Search files for regex pattern. context_lines adds N lines before/after each match (default 0)",
+      usage: "grep_files <pattern> [glob] [path] [max_results] [context_lines]",
+      returns:
+        "file:line:content format, truncated to max_results (default 200)",
+      runtime: "system",
+    },
+    {
+      name: "glob",
+      description: "Find files by glob pattern",
+      usage: "glob <pattern> [path]",
+      returns: "File paths, one per line. Truncated to 200 results",
+      runtime: "system",
+    },
+    {
+      name: "list_dir",
+      description: "List directory contents. depth defaults to 2, max 5",
+      usage: "list_dir [path] [depth]",
+      returns: "File/dir paths, limited to 200 entries",
+      runtime: "system",
+    },
+    {
+      name: "shell",
+      description: "Execute shell command. Combines stdout/stderr",
+      usage: "shell <command> [timeout_sec]",
+      returns:
+        "Command output, truncated to 50000 chars (full output saved to /tmp when truncated)",
+      runtime: "system",
+    },
+  ])
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(ALLOWLIST_NETWORK_POLICY)
@@ -106,7 +238,7 @@ SHELLEOF`)
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.2.2",
+    tag: "0.4.0",
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];

--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -52,6 +52,50 @@ describe("createToolManifest()", () => {
     expect(manifest.tools.python).toBeUndefined();
     expect(manifest.tools.node).toBeUndefined();
   });
+
+  test("includes version when provided", () => {
+    const tools: ToolEntry[] = [
+      {
+        name: "pandas",
+        version: "2.2.3",
+        description: "Data analysis",
+        runtime: "python",
+      },
+      { name: "curl", description: "HTTP client", runtime: "system" },
+    ];
+
+    const manifest = createToolManifest(tools);
+
+    expect(manifest.tools.python).toEqual([
+      { name: "pandas", version: "2.2.3", description: "Data analysis" },
+    ]);
+    expect(manifest.tools.system).toEqual([
+      { name: "curl", description: "HTTP client" },
+    ]);
+  });
+
+  test("includes usage and returns when provided", () => {
+    const tools: ToolEntry[] = [
+      {
+        name: "read_file",
+        description: "Read file with line numbers",
+        usage: "read_file <path> [start] [end]",
+        returns: "Numbered lines",
+        runtime: "system",
+      },
+    ];
+
+    const manifest = createToolManifest(tools);
+
+    expect(manifest.tools.system).toEqual([
+      {
+        name: "read_file",
+        description: "Read file with line numbers",
+        usage: "read_file <path> [start] [end]",
+        returns: "Numbered lines",
+      },
+    ]);
+  });
 });
 
 describe("toolManifestToJSON()", () => {

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -15,10 +15,14 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
   };
 
   for (const tool of tools) {
-    toolsByRuntime[tool.runtime].push({
+    const entry: ManifestToolEntry = {
       name: tool.name,
+      ...(tool.version && { version: tool.version }),
       description: tool.description,
-    });
+      ...(tool.usage && { usage: tool.usage }),
+      ...(tool.returns && { returns: tool.returns }),
+    };
+    toolsByRuntime[tool.runtime].push(entry);
   }
 
   const filteredTools: Partial<

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -29,7 +29,10 @@ export type ToolProfile = (typeof TOOL_PROFILES)[number];
 
 export interface ToolEntry {
   readonly name: string;
+  readonly version?: string;
   readonly description: string;
+  readonly usage?: string;
+  readonly returns?: string;
   readonly runtime: ToolRuntime;
   readonly profile?: ToolProfile;
 }
@@ -98,7 +101,10 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
 
 export interface ManifestToolEntry {
   readonly name: string;
+  readonly version?: string;
   readonly description: string;
+  readonly usage?: string;
+  readonly returns?: string;
 }
 
 export interface ToolManifest {


### PR DESCRIPTION
## Description

- Add a set of bash tool (+ tests) to make file manipulation and navigation easier for LLMs
- Wrap bash with a custom profile which is modulable enough to have provider specific profiles
- Rename describe_environment to describe_toolset => models were not using it. We might want to move this to the prompt directly to save one agent loop turn.


## Tests

- Local tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front