### PR TITLE
feat: add arguments requiring approval for extension tools

### DIFF
--- a/extension/platforms/chrome/tools/getCurrentPageTool.ts
+++ b/extension/platforms/chrome/tools/getCurrentPageTool.ts
@@ -12,7 +12,7 @@ export async function getPageTool({
   tabId,
   captureService,
 }: {
-  tabId?: number;
+  tabId: number;
   captureService: CaptureService | null;
 }): Promise<ToolHandlerResult> {
   if (!captureService) {

--- a/extension/platforms/chrome/tools/getPageViewTool.ts
+++ b/extension/platforms/chrome/tools/getPageViewTool.ts
@@ -108,7 +108,7 @@ export async function getPageViewTool({
   captureService,
   workspaceId,
 }: {
-  tabId?: number;
+  tabId: number;
   captureService: CaptureService | null;
   workspaceId: string;
 }): Promise<ToolHandlerResult> {

--- a/extension/platforms/chrome/tools/interactWithPageTool.ts
+++ b/extension/platforms/chrome/tools/interactWithPageTool.ts
@@ -5,13 +5,13 @@ import { sendInteractWithPageMessage } from "@extension/platforms/chrome/message
 
 export async function interactWithPageTool(input: {
   action: "get_elements" | "click_element" | "type_text" | "delete_text";
-  tab_id: number;
-  element_id?: string | null;
+  tabId: number;
+  elementId?: string | null;
   text?: string | null;
   textActionVariant?: "replace" | "append" | null;
 }): Promise<ToolHandlerResult> {
   if (input.action === "type_text") {
-    const elementId = input.element_id;
+    const elementId = input.elementId;
     if (!elementId) {
       return new Err(
         new MCPError("No elementId specified for type_text action")
@@ -26,7 +26,7 @@ export async function interactWithPageTool(input: {
 
     const typeResponse = await sendInteractWithPageMessage({
       action: "type_text",
-      tabId: input.tab_id,
+      tabId: input.tabId,
       elementId,
       text: input.text ?? "",
       variant,
@@ -47,7 +47,7 @@ export async function interactWithPageTool(input: {
   }
 
   if (input.action === "delete_text") {
-    const elementId = input.element_id;
+    const elementId = input.elementId;
     if (!elementId) {
       return new Err(
         new MCPError("No elementId specified for delete_text action")
@@ -56,7 +56,7 @@ export async function interactWithPageTool(input: {
 
     const typeResponse = await sendInteractWithPageMessage({
       action: "delete_text",
-      tabId: input.tab_id,
+      tabId: input.tabId,
       elementId,
     });
     if (!typeResponse.success) {
@@ -75,7 +75,7 @@ export async function interactWithPageTool(input: {
   }
 
   if (input.action === "click_element") {
-    const elementId = input.element_id;
+    const elementId = input.elementId;
     if (!elementId) {
       return new Err(
         new MCPError("No elementId specified for click_element action")
@@ -83,7 +83,7 @@ export async function interactWithPageTool(input: {
     }
     const clickResponse = await sendInteractWithPageMessage({
       action: "click_element",
-      tabId: input.tab_id,
+      tabId: input.tabId,
       elementId,
     });
 
@@ -105,7 +105,7 @@ export async function interactWithPageTool(input: {
 
   const response = await sendInteractWithPageMessage({
     action: "get_elements",
-    tabId: input.tab_id,
+    tabId: input.tabId,
   });
 
   if (!response) {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -106,6 +106,9 @@ export type ClientSideMCPToolType = Omit<
   toolServerId: string;
   type: "mcp_configuration";
   timeoutMs?: number;
+  // For "medium" stake tools: defines which arguments require per-agent approval.
+  // When present, the user must approve the specific (agent, tool, argument values) combination.
+  argumentsRequiringApproval?: string[];
 };
 
 type WithToolNameMetadata<T> = T & {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -29,6 +29,7 @@ import {
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
   getAvailabilityOfInternalMCPServerById,
+  getClientSideToolArgumentsRequiringApproval,
   getClientSideToolStake,
   getInternalMCPServerNameAndWorkspaceId,
   getInternalMCPServerToolStakes,
@@ -250,6 +251,10 @@ function makeClientSideMCPToolConfigurations(
     // of the same server name, allowing for consistent tool behavior.
     toolServerId: getBaseServerId(config.clientSideMcpServerId),
     icon: config.icon,
+    argumentsRequiringApproval: getClientSideToolArgumentsRequiringApproval(
+      config.clientSideMcpServerId,
+      tool.name
+    ),
   }));
 }
 

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -136,8 +136,8 @@ Avoid unnecessary actions.`,
       action: z
         .enum(["get_elements", "click_element", "type_text", "delete_text"])
         .describe("Action to perform."),
-      tab_id: z.number().describe("The ID of the tab to interact with."),
-      element_id: z
+      tabId: z.number().describe("The ID of the tab to interact with."),
+      elementId: z
         .string()
         .nullish()
         .describe(
@@ -156,7 +156,7 @@ Avoid unnecessary actions.`,
           "How text should be applied when using type_text: replace existing content or append to it."
         ),
     }).shape,
-    argumentsRequiringApproval: ["tab_id"],
+    argumentsRequiringApproval: ["tabId"],
     stake: "medium",
     displayLabels: {
       running: "Interacting with page...",

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -1,7 +1,7 @@
-import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createClientToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
-export const CHROME_TOOLS_METADATA = createToolsRecord({
+export const CHROME_TOOLS_METADATA = createClientToolsRecord({
   get_browser_page: {
     description:
       "Extracts the title, URL, and text content of a browser tab. " +
@@ -9,13 +9,9 @@ export const CHROME_TOOLS_METADATA = createToolsRecord({
       "For non-text pages (PDFs, images, etc.), use get_browser_page_view instead — it will attach the file directly to the conversation." +
       "Use list_browser_tabs to discover tab IDs.",
     schema: {
-      tabId: z
-        .number()
-        .optional()
-        .describe(
-          "The tab ID to read. If omitted, reads the active tab. Use list_browser_tabs to get tab IDs."
-        ),
+      tabId: z.number().describe("The tab ID to read."),
     },
+    argumentsRequiringApproval: ["tabId"],
     stake: "medium",
     displayLabels: {
       running: "Getting page content...",
@@ -30,13 +26,9 @@ export const CHROME_TOOLS_METADATA = createToolsRecord({
       "For HTML pages, takes a screenshot for visual inspection (Drive canvas, dashboards, etc.)." +
       "Use list_browser_tabs to discover tab IDs.",
     schema: {
-      tabId: z
-        .number()
-        .optional()
-        .describe(
-          "The tab ID to capture. If omitted, captures the active tab. Use list_browser_tabs to get tab IDs."
-        ),
+      tabId: z.number().describe("The tab ID to capture."),
     },
+    argumentsRequiringApproval: ["tabId"],
     stake: "medium",
     displayLabels: {
       running: "Attaching tab content...",
@@ -164,6 +156,7 @@ Avoid unnecessary actions.`,
           "How text should be applied when using type_text: replace existing content or append to it."
         ),
     }).shape,
+    argumentsRequiringApproval: ["tab_id"],
     stake: "medium",
     displayLabels: {
       running: "Interacting with page...",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -6,8 +6,8 @@ import {
 } from "@app/lib/actions/constants";
 import { CHROME_TOOLS_METADATA } from "@app/lib/actions/mcp_client_side/metadata";
 import type {
+  ClientToolMeta,
   ServerMetadata,
-  ToolMeta,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { AGENT_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/agent_management/metadata";
 import { AGENT_MEMORY_SERVER } from "@app/lib/api/actions/servers/agent_memory/metadata";
@@ -1089,7 +1089,7 @@ export const INTERNAL_MCP_SERVERS = {
 // Hardcoded stakes per client-side server (keyed by base server ID)
 export const CLIENT_SIDE_MCP_TOOL_METADATA: Record<
   string,
-  Record<string, ToolMeta>
+  Record<string, ClientToolMeta>
 > = {
   "mcp-client-side:chrome_extension_client": Object.fromEntries(
     Object.entries(CHROME_TOOLS_METADATA).map(([name, meta]) => [name, meta])
@@ -1281,6 +1281,16 @@ export function getClientSideToolStake(
     return toolStake;
   }
   return DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL;
+}
+
+export function getClientSideToolArgumentsRequiringApproval(
+  serverId: string,
+  toolName: string
+): string[] | undefined {
+  const toolArgsRequiringApproval =
+    CLIENT_SIDE_MCP_TOOL_METADATA[serverId]?.[toolName]
+      .argumentsRequiringApproval;
+  return toolArgsRequiringApproval;
 }
 
 export function getClientSideToolDisplayLabels(

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -67,6 +67,9 @@ interface ClientToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
+  argumentsRequiringApproval?: Array<
+    Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
+  >;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>
   ) => Promise<ToolHandlerResult>;
@@ -77,6 +80,11 @@ export type ToolMeta<
   TSchema extends ZodRawShape = ZodRawShape,
 > = Omit<ToolDefinition<TName, TSchema>, "handler">;
 
+export type ClientToolMeta<
+  TName extends string = string,
+  TSchema extends ZodRawShape = ZodRawShape,
+> = Omit<ClientToolDefinition<TName, TSchema>, "handler">;
+
 export function createToolsRecord<
   T extends Record<string, Omit<ToolMeta, "name">>,
 >(tools: T): { [K in keyof T]: T[K] & { name: K } } {
@@ -85,7 +93,22 @@ export function createToolsRecord<
   ) as { [K in keyof T]: T[K] & { name: K } };
 }
 
-export function buildClientTools<T extends Record<string, ToolMeta>>(
+export function createClientToolsRecord<
+  T extends {
+    [K in keyof T]: T[K] extends { schema: infer S extends ZodRawShape }
+      ? Omit<ClientToolMeta<string, S>, "name">
+      : Omit<ClientToolMeta, "name">;
+  },
+>(tools: T): { [K in keyof T]: T[K] & { name: K } } {
+  return Object.fromEntries(
+    Object.entries(tools).map(([key, value]) => [
+      key,
+      { ...(value as object), name: key },
+    ])
+  ) as { [K in keyof T]: T[K] & { name: K } };
+}
+
+export function buildClientTools<T extends Record<string, ClientToolMeta>>(
   metadata: T,
   handlers: ClientToolHandlers<T>
 ): ClientToolDefinition[] {

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -1,6 +1,5 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -56,11 +55,7 @@ export async function getExecutionStatusFromConfig(
       // Medium stake requires per-argument, per-agent approval.
       // If context is missing, we block.
       const user = auth.user();
-      if (
-        !user ||
-        !context ||
-        !isServerSideMCPToolConfiguration(actionConfiguration)
-      ) {
+      if (!user || !context) {
         return { status: "blocked_validation_required" };
       }
       const { agentId, toolInputs } = context;

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -7,7 +7,6 @@ import {
   extractArgRequiringApprovalValues,
   setUserAlwaysApprovedTool,
 } from "@app/lib/actions/tool_status";
-import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -120,10 +119,7 @@ export async function validateAction(
             id: action.agentMessageId,
           },
         });
-        if (
-          agentMessage &&
-          isLightServerSideMCPToolConfiguration(action.toolConfiguration)
-        ) {
+        if (agentMessage) {
           const argumentsRequiringApproval =
             action.toolConfiguration.argumentsRequiringApproval ?? [];
           const argsAndValues = extractArgRequiringApprovalValues(


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7019

This PR adds support for arguments requiring approval for client-side extension tools.

- Introduces `argumentsRequiringApproval` field to `ClientSideMCPToolType` and `ClientToolMeta` types
- Defines arguments requiring approval for Chrome extension tools (`tabId` for `get_browser_page`, `get_browser_page_view` and for `interact_with_page`)
- Makes `tabId` parameters required (no longer optional) for browser page tools

## Tests

Manually

## Risks

Low. The changes extend existing approval mechanisms to client-side tools without modifying core approval logic.

## Deploy Plan

Standard deployment.
