### PR TITLE
Disable agent/user details link on extension

### DIFF
--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -73,7 +73,7 @@ export const MainPage = () => {
         conversationId ? (
           <div className="flex items-center gap-2">
             <ConversationAttachmentsPopover
-              conversationId={conversationId}
+              conversation={conversation}
               owner={workspace}
             />
             <ConversationMenu

--- a/front/components/assistant/conversation/AgentHandle.tsx
+++ b/front/components/assistant/conversation/AgentHandle.tsx
@@ -1,3 +1,4 @@
+import { useClientType } from "@app/lib/context/clientType";
 import { LinkWrapper, useAppRouter } from "@app/lib/platform";
 import { cn } from "@dust-tt/sparkle";
 
@@ -16,6 +17,7 @@ export function AgentHandle({
   isDisabled = false,
 }: AgentHandleProps) {
   const router = useAppRouter();
+  const clientType = useClientType();
 
   const href = {
     pathname: router.pathname,
@@ -23,7 +25,7 @@ export function AgentHandle({
     hash: router.asPath.split("#")[1] || undefined,
   };
 
-  if (!canMention) {
+  if (!canMention || clientType === "extension") {
     return <span>{agent.name}</span>;
   }
 

--- a/front/components/assistant/conversation/UserHandle.tsx
+++ b/front/components/assistant/conversation/UserHandle.tsx
@@ -1,3 +1,4 @@
+import { useClientType } from "@app/lib/context/clientType";
 import { LinkWrapper, useAppRouter } from "@app/lib/platform";
 
 interface UserHandleProps {
@@ -9,6 +10,7 @@ interface UserHandleProps {
 
 export function UserHandle({ user }: UserHandleProps) {
   const router = useAppRouter();
+  const clientType = useClientType();
 
   const href = {
     pathname: router.pathname,
@@ -17,6 +19,10 @@ export function UserHandle({ user }: UserHandleProps) {
 
   if (!user.name) {
     return <span>Unknown User</span>;
+  }
+
+  if (clientType === "extension") {
+    return <span>{user.name}</span>;
   }
 
   return (


### PR DESCRIPTION
## Description

Disables clickable agent and user name links in the extension by checking `clientType === "extension"` in both `AgentHandle` and `UserHandle` components. When in the extension, names are rendered as plain text instead of interactive links that open detail panels.

## Tests

Manually tested in the browser extension.

## Risk

Low. Only affects the extension UI behavior, making names non-clickable.

## Deploy Plan

Deploy front and extension.