### PR TITLE
feat: tool to get info on current tab

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -636,6 +636,26 @@ chrome.runtime.onMessage.addListener(
         })();
         return true;
 
+      case "GET_CURRENT_TAB_INFO":
+        void (async () => {
+          const tabs = await chrome.tabs.query({
+            active: true,
+            currentWindow: true,
+          });
+          sendResponse({
+            success: true,
+            tabs: tabs
+              .filter((t) => t.id !== undefined && t.url)
+              .map((t) => ({
+                tabId: t.id!,
+                title: t.title || "",
+                url: t.url || "",
+                active: t.active,
+              })),
+          });
+        })();
+        return true;
+
       case "ACTIVATE_TAB":
         void (async () => {
           try {

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -45,6 +45,7 @@ export type TabInfo = {
 
 export type TabActionMessage =
   | { type: "LIST_TABS" }
+  | { type: "GET_CURRENT_TAB_INFO" }
   | { type: "ACTIVATE_TAB"; tabId: number }
   | { type: "CLOSE_TAB"; tabId: number }
   | { type: "OPEN_TAB"; url: string }
@@ -255,6 +256,12 @@ export const sendGetActiveTabMessage = (params: CaptureOptions) => {
 export const sendListTabsMessage = () => {
   return sendMessage<TabActionMessage, TabActionResponse>({
     type: "LIST_TABS",
+  });
+};
+
+export const sendGetCurrentTabInfoMessage = () => {
+  return sendMessage<TabActionMessage, TabActionResponse>({
+    type: "GET_CURRENT_TAB_INFO",
   });
 };
 

--- a/extension/platforms/chrome/tools/getCurrentTabInfo.ts
+++ b/extension/platforms/chrome/tools/getCurrentTabInfo.ts
@@ -19,10 +19,19 @@ export async function getCurrentTabInfoTool(): Promise<ToolHandlerResult> {
       return new Err(new MCPError("No active tab found."));
     }
 
+    const lines = [
+      `# Tab ID: ${currentTab.tabId}`,
+      `## Fields`,
+      `Title: ${currentTab.title}`,
+      `URL: ${currentTab.url}`,
+    ];
+
+    const resultText = lines.join("\n");
+
     return new Ok([
       {
         type: "text",
-        text: `[${currentTab.tabId}] ${currentTab.title} — ${currentTab.url}`,
+        text: resultText,
       },
     ]);
   } catch (error) {

--- a/extension/platforms/chrome/tools/getCurrentTabInfo.ts
+++ b/extension/platforms/chrome/tools/getCurrentTabInfo.ts
@@ -1,0 +1,33 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { Err, Ok } from "@app/types/shared/result";
+import { sendGetCurrentTabInfoMessage } from "@extension/platforms/chrome/messages";
+import { normalizeError } from "@extension/shared/lib/utils";
+
+export async function getCurrentTabInfoTool(): Promise<ToolHandlerResult> {
+  try {
+    const result = await sendGetCurrentTabInfoMessage();
+    const tabs = result.tabs ?? [];
+
+    if (!tabs || tabs.length === 0) {
+      return new Err(new MCPError("No tabs found."));
+    }
+
+    const currentTab = tabs.find((t) => t.active);
+
+    if (!currentTab) {
+      return new Err(new MCPError("No active tab found."));
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: `[${currentTab.tabId}] ${currentTab.title} — ${currentTab.url}`,
+      },
+    ]);
+  } catch (error) {
+    return new Err(
+      new MCPError(`Failed to list tabs: ${normalizeError(error).message}`)
+    );
+  }
+}

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -6,6 +6,7 @@ import {
 import { getPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
 import type { CaptureService } from "@extension/shared/services/capture";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getCurrentTabInfoTool } from "./getCurrentTabInfo";
 import { getPageViewTool } from "./getPageViewTool";
 import { interactWithPageTool } from "./interactWithPageTool";
 import { listBrowserTabsTool } from "./listTabsTool";
@@ -32,6 +33,7 @@ export function registerAllTools(
     get_browser_page_view: (params) =>
       getPageViewTool({ ...params, captureService, workspaceId }),
     list_browser_tabs: () => listBrowserTabsTool(),
+    get_current_tab_info: () => getCurrentTabInfoTool(),
     activate_browser_tab: (params) => activateBrowserTabTool(params),
     close_browser_tab: (params) => closeBrowserTabTool(params),
     move_browser_tab: (params) => moveBrowserTabTool(params),

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -47,6 +47,17 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tabs listed",
     },
   },
+  get_current_tab_info: {
+    description:
+      "Retrieves the tab ID, title, and URL of the currently active browser tab. " +
+      "Use this to quickly understand what the user is currently looking at without needing to list all tabs.",
+    schema: {},
+    stake: "low",
+    displayLabels: {
+      running: "Getting current tab info...",
+      done: "Current tab info retrieved",
+    },
+  },
   activate_browser_tab: {
     description:
       "Switches to the specified browser tab, making it the active tab. " +


### PR DESCRIPTION
## Description

This PR adds a new Chrome extension tool to retrieve information about the currently active browser tab.

- Implements `get_current_tab_info` tool that returns the tab ID, title, and URL of the active tab
- Registers the tool with "low" stake level requiring no user approval

## Tests

Manually

## Risks

Low risk.

## Deploy Plan

Standard deployment.