### PR TITLE
[connectors] refactor signal handling in Gong kw cleanup

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -505,11 +505,10 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
           const GONG_TRANSCRIPT_PAGE_SIZE = 100;
           const maxTranscriptId = currentMaxId + GONG_TRANSCRIPT_PAGE_SIZE;
 
-          await launchGongKeywordUpdateWorkflow(
-            connector,
+          await launchGongKeywordUpdateWorkflow(connector, {
             newKeywords,
-            maxTranscriptId
-          );
+            maxTranscriptId,
+          });
 
           // Resume the schedule with new keywords excluded
           const resumeResult = await this.resume();

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -498,15 +498,15 @@ export async function gongDeleteExcludedTranscriptsActivity({
 }: {
   connectorId: ModelId;
   excludeKeywords: string[];
-  lastId?: ModelId;
+  lastId: ModelId | null;
   maxTranscriptId: ModelId;
 }): Promise<{ hasMore: boolean; lastId: ModelId | null }> {
   const connector = await fetchGongConnector({ connectorId });
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const transcripts = await GongTranscriptResource.fetchBatch(connector, {
+    ...(lastId ? { lastId } : {}),
     limit: GARBAGE_COLLECT_BATCH_SIZE,
-    lastId,
   });
 
   if (transcripts.length === 0) {

--- a/connectors/src/connectors/gong/temporal/client.ts
+++ b/connectors/src/connectors/gong/temporal/client.ts
@@ -5,6 +5,7 @@ import {
 } from "@connectors/connectors/gong/temporal/workflows";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ModelId } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
 import { Ok } from "@dust-tt/client";
 
@@ -16,14 +17,19 @@ export function makeGongKeywordUpdateWorkflowId(
 
 export async function launchGongKeywordUpdateWorkflow(
   connector: ConnectorResource,
-  newKeywords: string[],
-  maxTranscriptId: number
+  {
+    newKeywords,
+    maxTranscriptId,
+  }: {
+    newKeywords: string[];
+    maxTranscriptId: ModelId;
+  }
 ): Promise<Result<string, Error>> {
   const client = await getTemporalClient();
   const workflowId = makeGongKeywordUpdateWorkflowId(connector);
 
   await client.workflow.signalWithStart(gongKeywordUpdateWorkflow, {
-    args: [{ connectorId: connector.id, newKeywords, maxTranscriptId }],
+    args: [{ connectorId: connector.id }],
     signal: updateExcludedKeywordsSignal,
     signalArgs: [{ newKeywords, maxTranscriptId }],
     taskQueue: QUEUE_NAME,

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -165,6 +165,7 @@ export async function gongKeywordUpdateWorkflow({
   const keywordsToProcess = new Set<string>();
   let latestMaxTranscriptId: ModelId | null = null;
   let keywordsUpdated = false;
+  let lastId: number | null = null;
 
   setHandler(
     updateExcludedKeywordsSignal,
@@ -174,6 +175,8 @@ export async function gongKeywordUpdateWorkflow({
       }
       latestMaxTranscriptId = maxTranscriptId;
       keywordsUpdated = true;
+      // Start over from the beginning to check for the new keywords.
+      lastId = null;
     }
   );
 
@@ -186,11 +189,11 @@ export async function gongKeywordUpdateWorkflow({
     const signalReceived = await condition(() => keywordsUpdated, "90 seconds");
     if (!signalReceived) {
       settled = true;
+      lastId = null;
     }
   }
 
   let hasMore = keywordsToProcess.size > 0;
-  let lastId: number | undefined = undefined;
 
   while (hasMore && latestMaxTranscriptId) {
     const result = await gongDeleteExcludedTranscriptsActivity({
@@ -201,6 +204,6 @@ export async function gongKeywordUpdateWorkflow({
     });
 
     hasMore = result.hasMore;
-    lastId = result.lastId ?? undefined;
+    lastId = result.lastId ?? null;
   }
 }

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -189,7 +189,6 @@ export async function gongKeywordUpdateWorkflow({
     const signalReceived = await condition(() => keywordsUpdated, "90 seconds");
     if (!signalReceived) {
       settled = true;
-      lastId = null;
     }
   }
 

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -159,23 +159,23 @@ export async function gongGarbageCollectWorkflow({
  */
 export async function gongKeywordUpdateWorkflow({
   connectorId,
-  newKeywords,
-  maxTranscriptId,
 }: {
   connectorId: ModelId;
-  newKeywords: string[];
-  maxTranscriptId: ModelId;
 }) {
-  let latestKeywords = newKeywords;
-  let latestMaxTranscriptId = maxTranscriptId;
-  let activeKeywords = [...newKeywords];
+  const keywordsToProcess = new Set<string>();
+  let latestMaxTranscriptId: ModelId | null = null;
   let keywordsUpdated = false;
 
-  setHandler(updateExcludedKeywordsSignal, (update) => {
-    latestKeywords = update.newKeywords;
-    latestMaxTranscriptId = update.maxTranscriptId;
-    keywordsUpdated = true;
-  });
+  setHandler(
+    updateExcludedKeywordsSignal,
+    ({ newKeywords, maxTranscriptId }) => {
+      for (const keyword of newKeywords) {
+        keywordsToProcess.add(keyword);
+      }
+      latestMaxTranscriptId = maxTranscriptId;
+      keywordsUpdated = true;
+    }
+  );
 
   // Wait for in-flight sync activities to settle after this.stop().
   // Resets the 90s wait each time a new signal arrives (meaning a new
@@ -189,29 +189,13 @@ export async function gongKeywordUpdateWorkflow({
     }
   }
 
-  // Pick up the latest keywords after the settle period
-  activeKeywords = [...latestKeywords];
-
-  let hasMore = true;
+  let hasMore = keywordsToProcess.size > 0;
   let lastId: number | undefined = undefined;
 
-  while (hasMore) {
-    if (keywordsUpdated) {
-      // Only restart from the beginning if new keywords were added.
-      // If keywords were only removed, continue from current position.
-      const hasNewKeywords = latestKeywords.some(
-        (kw) => !activeKeywords.includes(kw)
-      );
-      if (hasNewKeywords) {
-        lastId = undefined;
-      }
-      activeKeywords = [...latestKeywords];
-      keywordsUpdated = false;
-    }
-
+  while (hasMore && latestMaxTranscriptId) {
     const result = await gongDeleteExcludedTranscriptsActivity({
       connectorId,
-      excludeKeywords: activeKeywords,
+      excludeKeywords: [...keywordsToProcess],
       lastId,
       maxTranscriptId: latestMaxTranscriptId,
     });

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -203,7 +203,7 @@ export async function gongKeywordUpdateWorkflow({
     });
 
     hasMore = result.hasMore;
-    lastId = result.lastId ?? null;
+    lastId = result.lastId;
 
     // If a signal arrived during the activity, restart from the beginning.
     // The signal handler already reset lastId to null and added keywords to the set.

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -204,5 +204,12 @@ export async function gongKeywordUpdateWorkflow({
 
     hasMore = result.hasMore;
     lastId = result.lastId ?? null;
+
+    // If a signal arrived during the activity, restart from the beginning.
+    // The signal handler already reset lastId to null and added keywords to the set.
+    if (!hasMore && keywordsUpdated) {
+      hasMore = true;
+      keywordsUpdated = false;
+    }
   }
 }

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -6,7 +6,7 @@ import {
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ConnectorResource } from "@connectors/resources/connector_resource"; // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
-import { normalizeError } from "@connectors/types";
+import { type ModelId, normalizeError } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import type {
@@ -455,7 +455,7 @@ export class GongTranscriptResource extends BaseResource<GongTranscriptModel> {
       orderBy = "ASC",
     }: {
       limit: number;
-      lastId?: number;
+      lastId?: ModelId;
       orderBy?: "ASC" | "DESC";
     }
   ): Promise<GongTranscriptResource[]> {


### PR DESCRIPTION
## Description

- This PR refactors the handling of signals in the Gong keyword cleanup workflow.
- Fixes a potential bug if the cleanup takes more than 90 seconds and the keyword list is updated, in which case some of the transcripts would not be checked against the first set of kw to cleanup.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Check for running workflows.
- Deploy connectors.