### PR TITLE
[DO NOT MERGE] Add `get_host` sandbox tool with traffic access token auth

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -37,6 +37,27 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       done: "Execute command in sandbox",
     },
   },
+  get_host: {
+    description:
+      "Get the public URL for a port exposed by the sandbox. " +
+      "Use this after starting a server or service on a specific port " +
+      "to obtain an HTTPS URL that can be used to connect to it from outside the sandbox.",
+    schema: {
+      port: z
+        .number()
+        .int()
+        .min(1)
+        .max(65535)
+        .describe(
+          "The port number the service is listening on inside the sandbox."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Getting sandbox host URL",
+      done: "Get sandbox host URL",
+    },
+  },
   describe_environment: {
     description:
       "Describe the sandbox environment and list available CLI binaries and language libraries.",

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -120,6 +120,39 @@ export function createSandboxTools(
 
       return new Ok([{ type: "text" as const, text: output }]);
     },
+    get_host: async ({ port }, { auth, agentLoopContext }) => {
+      const conversation = agentLoopContext?.runContext?.conversation;
+      if (!conversation) {
+        return new Err(new MCPError("No conversation context available."));
+      }
+
+      const ensureResult = await SandboxResource.ensureActive(
+        auth,
+        conversation
+      );
+      if (ensureResult.isErr()) {
+        return new Err(new MCPError(ensureResult.error.message));
+      }
+
+      const { sandbox } = ensureResult.value;
+
+      const hostResult = await sandbox.getHost(port);
+      if (hostResult.isErr()) {
+        return new Err(new MCPError(hostResult.error.message));
+      }
+
+      const { host, trafficAccessToken } = hostResult.value;
+      const url = `https://${host}`;
+
+      const parts = [`URL: ${url}`];
+      if (trafficAccessToken) {
+        parts.push(
+          `Authentication required: include header \`e2b-traffic-access-token: ${trafficAccessToken}\` in all requests to this URL.`
+        );
+      }
+
+      return new Ok([{ type: "text" as const, text: parts.join("\n") }]);
+    },
     describe_environment: async ({ format }, { auth }) => {
       const sandboxImageResult = getSandboxImage(auth);
       if (sandboxImageResult.isErr()) {

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -141,13 +141,13 @@ export function createSandboxTools(
         return new Err(new MCPError(hostResult.error.message));
       }
 
-      const { host, trafficAccessToken } = hostResult.value;
+      const { host, accessToken } = hostResult.value;
       const url = `https://${host}`;
 
       const parts = [`URL: ${url}`];
-      if (trafficAccessToken) {
+      if (accessToken) {
         parts.push(
-          `Authentication required: include header \`e2b-traffic-access-token: ${trafficAccessToken}\` in all requests to this URL.`
+          `Authentication required: include header \`${accessToken.header}: ${accessToken.value}\` in all requests to this URL.`
         );
       }
 

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -48,8 +48,11 @@ export interface SandboxCreateConfig {
 export interface SandboxHostInfo {
   /** Public hostname (without protocol) for the sandbox port. */
   host: string;
-  /** Access token required in the `e2b-traffic-access-token` header when public traffic is restricted. */
-  trafficAccessToken?: string;
+  /** Credentials required to access the sandbox URL when public traffic is restricted. */
+  accessToken?: {
+    header: string;
+    value: string;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -42,6 +42,17 @@ export interface SandboxCreateConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Host Info
+// ---------------------------------------------------------------------------
+
+export interface SandboxHostInfo {
+  /** Public hostname (without protocol) for the sandbox port. */
+  host: string;
+  /** Access token required in the `e2b-traffic-access-token` header when public traffic is restricted. */
+  trafficAccessToken?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Execution
 // ---------------------------------------------------------------------------
 
@@ -107,6 +118,16 @@ export interface SandboxProvider {
     command: string,
     opts?: ExecOptions
   ): Promise<Result<ExecResult, Error>>;
+
+  /**
+   * Get the public hostname for a port exposed by the sandbox.
+   * The returned host can be used to reach the sandbox over HTTPS or WSS.
+   * When public traffic is restricted, includes an access token for authentication.
+   */
+  getHost(
+    providerId: string,
+    port: number
+  ): Promise<Result<SandboxHostInfo, Error>>;
 
   writeFile(providerId: string, path: string, content: Buffer): Promise<void>;
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -242,7 +242,14 @@ export class E2BSandboxProvider implements SandboxProvider {
 
     return new Ok({
       host: sandbox.getHost(port),
-      trafficAccessToken: sandbox.trafficAccessToken,
+      ...(sandbox.trafficAccessToken
+        ? {
+            accessToken: {
+              header: "e2b-traffic-access-token",
+              value: sandbox.trafficAccessToken,
+            },
+          }
+        : {}),
     });
   }
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -8,6 +8,7 @@ import type {
   FileEntry,
   SandboxCreateConfig,
   SandboxHandle,
+  SandboxHostInfo,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
@@ -28,6 +29,7 @@ const ALL_TRAFFIC = "0.0.0.0/0";
 interface E2BNetworkOpts {
   allowOut?: string[];
   denyOut?: string[];
+  allowPublicTraffic?: boolean;
 }
 
 function toE2BNetworkOpts(policy: NetworkPolicy): E2BNetworkOpts {
@@ -95,9 +97,10 @@ export class E2BSandboxProvider implements SandboxProvider {
         envs: hasEnvVars ? envVars : undefined,
         timeoutMs: SANDBOX_LIFETIME_MS,
         requestTimeoutMs: REQUEST_TIMEOUT_MS,
-        ...(config.network
-          ? { network: toE2BNetworkOpts(config.network) }
-          : {}),
+        network: {
+          ...(config.network ? toE2BNetworkOpts(config.network) : {}),
+          allowPublicTraffic: false,
+        },
       });
     } catch (err) {
       return new Err(normalizeError(err));
@@ -218,6 +221,29 @@ export class E2BSandboxProvider implements SandboxProvider {
       }
       return new Err(normalizeError(err));
     }
+  }
+
+  async getHost(
+    providerId: string,
+    port: number
+  ): Promise<Result<SandboxHostInfo, Error>> {
+    let sandbox: Sandbox;
+    try {
+      sandbox = await Sandbox.connect(providerId, {
+        ...this.connectionOpts(),
+        timeoutMs: SANDBOX_LIFETIME_MS,
+      });
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return new Err(new SandboxNotFoundError(providerId));
+      }
+      return new Err(normalizeError(err));
+    }
+
+    return new Ok({
+      host: sandbox.getHost(port),
+      trafficAccessToken: sandbox.trafficAccessToken,
+    });
   }
 
   async writeFile(

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -3,6 +3,7 @@ import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
   ExecOptions,
   ExecResult,
+  SandboxHostInfo,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
@@ -446,6 +447,18 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       logger.info({ sandbox: sandbox.toLogJSON() }, "Sandbox destroyed.");
       return new Ok(undefined);
     });
+  }
+
+  /**
+   * Get the public hostname for a port exposed by this sandbox.
+   */
+  async getHost(port: number): Promise<Result<SandboxHostInfo, Error>> {
+    const provider = getSandboxProvider();
+    if (!provider) {
+      return new Err(new Error("Sandbox provider not configured."));
+    }
+
+    return provider.getHost(this.providerId, port);
   }
 
   /**


### PR DESCRIPTION
DO NOT MERGE (security risk used for experimentation)

## Description

Add a `get_host` MCP tool to the sandbox server that lets agents retrieve the public URL for a port exposed by the sandbox. Uses the E2B SDK's `Sandbox.getHost()` to derive the correct per-sandbox domain (required for BYOC setups where the domain differs from the connection config).

Also restrict public traffic on all sandboxes (`allowPublicTraffic: false`) so that sandbox URLs require the `e2b-traffic-access-token` header. The token is returned alongside the URL in the tool output.

Without accesss token header:

<img width="528" height="210" alt="Screenshot 2026-03-12 at 18 27 10" src="https://github.com/user-attachments/assets/281dd8b2-30d6-47be-afc6-324f583a092c" />

```
spolu@spolu-box ~/dust-hive/w0 (spolu-get_sandbox_host) $ curl -H "e2b-traffic-access-token: e2513b1d99ebfed36b771633229006d97bbdca7ba57f09d22584e15b29170983" \
  https://8080-ily92r19e42svmlh08otk.e2b-dust.dev
{"random_number": 364843}%               
```

## Tests

Tested locally

## Risk

high security-wise

r? @zmarouf 
cc @fontanierh 

## Deploy Plan

- deploy `front`