### PR TITLE
Adding ability to list all canvases for a channel

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -478,6 +478,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "slack": {
     "archive_channel": "high",
     "create_channel": "high",
+    "get_channel_canvases": "never_ask",
     "invite_to_channel": "high",
     "list_messages": "never_ask",
     "list_user_groups": "never_ask",

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1132,6 +1132,91 @@ export async function executeSearchUser(
   ]);
 }
 
+type ChannelTab = {
+  type?: string;
+  data?: { file_id?: string; shared_ts?: string };
+  label?: string;
+};
+
+// This object is unfortunately not in the SDK type, but documented in the API reference.
+function hasChannelTabs(
+  ch: unknown
+): ch is { properties: { tabs: ChannelTab[] } } {
+  const p =
+    ch !== null &&
+    typeof ch === "object" &&
+    (ch as Record<string, unknown>).properties;
+  return (
+    p !== null &&
+    typeof p === "object" &&
+    Array.isArray((p as Record<string, unknown>).tabs)
+  );
+}
+
+export type ChannelCanvasInfo = {
+  canvas_id: string;
+  type: "canvas";
+  label?: string;
+};
+
+async function getChannelCanvases({
+  channelId,
+  accessToken,
+}: {
+  channelId: string;
+  accessToken: string;
+}): Promise<ChannelCanvasInfo[]> {
+  const slackClient = await getSlackClient(accessToken);
+  const res = await slackClient.conversations.info({ channel: channelId });
+  if (!res.ok || !res.channel || !hasChannelTabs(res.channel)) {
+    return [];
+  }
+  const tabs = res.channel.properties.tabs;
+
+  const canvases: ChannelCanvasInfo[] = [];
+  const seen = new Set<string>();
+  for (const tab of tabs) {
+    if (tab.type === "canvas" && tab.data?.file_id) {
+      const id = tab.data.file_id;
+      if (!seen.has(id)) {
+        seen.add(id);
+        canvases.push({ canvas_id: id, type: "canvas", label: tab.label });
+      }
+    }
+  }
+  return canvases;
+}
+
+export async function executeGetChannelCanvases({
+  channel_id,
+  accessToken,
+}: {
+  channel_id: string;
+  accessToken: string;
+}): Promise<Ok<Array<{ type: "text"; text: string }>> | Err<MCPError>> {
+  const canvases = await getChannelCanvases({
+    channelId: channel_id,
+    accessToken,
+  });
+  if (canvases.length === 0) {
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Channel ${channel_id} has no canvases. Create one with write_canvas.`,
+      },
+    ]);
+  }
+  const lines = canvases.map(
+    (c) => `- ${c.canvas_id} (${c.type}${c.label ? `, "${c.label}"` : ""})`
+  );
+  return new Ok([
+    {
+      type: "text" as const,
+      text: `Channel ${channel_id} — ${canvases.length} canvas/canvases:\n\n${lines.join("\n")}\n\nUse these canvas_id values with read_canvas or write_canvas.`,
+    },
+  ]);
+}
+
 export async function executeReadCanvas({
   canvas_id,
   section_types,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -285,6 +285,21 @@ Set search_all=true only if the user explicitly requests to search all public wo
       done: "Read Slack thread messages",
     },
   },
+  get_channel_canvases: {
+    description:
+      "List all canvas IDs for a Slack channel (from the channel's tabs). " +
+      "Use when you need to edit a channel's canvas but only have the channel ID. ",
+    schema: {
+      channel_id: z
+        .string()
+        .describe("The Slack channel ID (e.g. 'C01234ABCD')."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Getting channel canvases",
+      done: "Got channel canvases",
+    },
+  },
   read_canvas: {
     description:
       "Find sections within a Slack canvas. " +

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -12,6 +12,7 @@ import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import {
   executeArchiveChannel,
   executeCreateChannel,
+  executeGetChannelCanvases,
   executeInviteToChannel,
   executeListUserGroups,
   executePostMessage,
@@ -830,6 +831,30 @@ export function createSlackPersonalTools(
         latest,
         accessToken,
       });
+    },
+
+    get_channel_canvases: async ({ channel_id }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        return new Err(new MCPError("Access token not found"));
+      }
+
+      try {
+        return await executeGetChannelCanvases({
+          channel_id,
+          accessToken,
+        });
+      } catch (error) {
+        const authError = handleSlackAuthError(error);
+        if (authError) {
+          return authError;
+        }
+        return new Err(
+          new MCPError(
+            `Error getting channel canvases: ${normalizeError(error)}`
+          )
+        );
+      }
     },
 
     read_canvas: async (


### PR DESCRIPTION
## Description

*Ability to list all canvases related to a Slack channel


## Tests

<img width="694" height="389" alt="Screenshot 2026-03-12 at 11 05 58 AM" src="https://github.com/user-attachments/assets/a221b575-ad1f-4fca-96d8-695e74f77d7a" />

## Risk

* Low

## Deploy Plan

* Deploy front