### PR TITLE
feat: disable public traffic on E2B sandboxes by default

### DIFF
--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -28,6 +28,7 @@ const ALL_TRAFFIC = "0.0.0.0/0";
 interface E2BNetworkOpts {
   allowOut?: string[];
   denyOut?: string[];
+  allowPublicTraffic?: boolean;
 }
 
 function toE2BNetworkOpts(policy: NetworkPolicy): E2BNetworkOpts {
@@ -95,9 +96,10 @@ export class E2BSandboxProvider implements SandboxProvider {
         envs: hasEnvVars ? envVars : undefined,
         timeoutMs: SANDBOX_LIFETIME_MS,
         requestTimeoutMs: REQUEST_TIMEOUT_MS,
-        ...(config.network
-          ? { network: toE2BNetworkOpts(config.network) }
-          : {}),
+        network: {
+          ...(config.network ? toE2BNetworkOpts(config.network) : {}),
+          allowPublicTraffic: false,
+        },
       });
     } catch (err) {
       return new Err(normalizeError(err));


### PR DESCRIPTION
## Description

Strengthen networking of sandboxes.

<img width="518" height="195" alt="Screenshot 2026-03-12 at 20 05 25" src="https://github.com/user-attachments/assets/f28b5bc3-5720-466a-853e-8a3e713c30f7" />

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`