### PR TITLE
Add ability to execute commands in the background

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -456,9 +456,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_actions": "never_ask",
   },
   "sandbox": {
-    "describe_environment": "never_ask",
     "bash": "never_ask",
-    "ps": "never_ask",
+    "describe_environment": "never_ask",
   },
   "schedules_management": {
     "create_schedule": "high",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -457,7 +457,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "sandbox": {
     "describe_environment": "never_ask",
-    "execute": "never_ask",
+    "bash": "never_ask",
     "ps": "never_ask",
   },
   "schedules_management": {

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -456,8 +456,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_actions": "never_ask",
   },
   "sandbox": {
-    "bash": "never_ask",
     "describe_environment": "never_ask",
+    "execute": "never_ask",
+    "ps": "never_ask",
   },
   "schedules_management": {
     "create_schedule": "high",

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SANDBOX_TOOL_NAME = "sandbox" as const;
 
 export const SANDBOX_TOOLS_METADATA = createToolsRecord({
-  execute: {
+  bash: {
     description:
       "Execute a shell command in an isolated sandbox environment. " +
       "The sandbox is a Linux container with common tools pre-installed. " +
@@ -79,7 +79,7 @@ export const SANDBOX_SERVER = {
     instructions:
       // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
       "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
-      "Use `execute` to run commands and scripts. " +
+      "Use `bash` to run commands and scripts. " +
       "The sandbox persists for the conversation duration. " +
       "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
   },

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -7,12 +7,14 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const SANDBOX_TOOL_NAME = "sandbox" as const;
 
 export const SANDBOX_TOOLS_METADATA = createToolsRecord({
-  bash: {
+  execute: {
     description:
       "Execute a shell command in an isolated sandbox environment. " +
       "The sandbox is a Linux container with common tools pre-installed. " +
       "Use this for running scripts, installing packages, or executing code. " +
-      "The sandbox persists for the duration of the conversation.",
+      "The sandbox persists for the duration of the conversation. " +
+      "To start long-running processes (e.g. servers, or long running commands), use background mode. " +
+      "Do NOT use shell backgrounding (& or nohup) — use the background parameter instead.",
     schema: {
       command: z
         .string()
@@ -28,7 +30,15 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .max(120000)
         .optional()
         .describe(
-          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000."
+          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000. Ignored when background is true."
+        ),
+      background: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, start the command in the background and return immediately with a process ID (pid). " +
+            "Output (stdout/stderr) of background commands is NOT accessible directly. " +
+            "You MUST redirect output to a file (e.g. `cmd > /tmp/out.log 2>&1`) to read it later."
         ),
     },
     stake: "never_ask",
@@ -69,9 +79,12 @@ export const SANDBOX_SERVER = {
     instructions:
       // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
       "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
-      "Use `bash` to run commands and scripts. " +
+      "Use `execute` to run commands and scripts. " +
       "The sandbox persists for the conversation duration. " +
-      "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
+      "Common tools like Python, Node.js, and standard Unix utilities are pre-installed. " +
+      "IMPORTANT: Do NOT use shell backgrounding operators (& or nohup). " +
+      "To run long-running processes (e.g. servers), use the `background` parameter of the `execute` tool. " +
+      "When starting a background process, redirect its output to a log file (e.g. `python server.py > /tmp/server.log 2>&1`) so you can read the logs later with `cat`.",
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -14,7 +14,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       "Use this for running scripts, installing packages, or executing code. " +
       "The sandbox persists for the duration of the conversation. " +
       "To start long-running processes (e.g. servers, or long running commands), use background mode. " +
-      "Do NOT use shell backgrounding (& or nohup) — use the background parameter instead.",
+      "Do NOT use shell backgrounding (& or nohup).",
     schema: {
       command: z
         .string()
@@ -81,10 +81,7 @@ export const SANDBOX_SERVER = {
       "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
       "Use `execute` to run commands and scripts. " +
       "The sandbox persists for the conversation duration. " +
-      "Common tools like Python, Node.js, and standard Unix utilities are pre-installed. " +
-      "IMPORTANT: Do NOT use shell backgrounding operators (& or nohup). " +
-      "To run long-running processes (e.g. servers), use the `background` parameter of the `execute` tool. " +
-      "When starting a background process, redirect its output to a log file (e.g. `python server.py > /tmp/server.log 2>&1`) so you can read the logs later with `cat`.",
+      "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -19,11 +19,20 @@ import {
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image";
-import type { ExecResult } from "@app/lib/api/sandbox/provider";
+import type {
+  BackgroundExecResult,
+  ExecResult,
+} from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
+
+function isBackgroundExecResult(
+  result: ExecResult | BackgroundExecResult
+): result is BackgroundExecResult {
+  return "pid" in result && !("exitCode" in result);
+}
 
 const DEFAULT_WORKING_DIRECTORY = "/home/user";
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
@@ -82,8 +91,8 @@ export function createSandboxTools(
   _agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
-    bash: async (
-      { command, workingDirectory, timeoutMs },
+    execute: async (
+      { command, workingDirectory, timeoutMs, background },
       { auth, agentLoopContext }
     ) => {
       const conversation = agentLoopContext?.runContext?.conversation;
@@ -140,6 +149,7 @@ export function createSandboxTools(
       const execResult = await sandbox.exec(auth, command, {
         workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
         timeoutMs: timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
+        background: background ?? false,
         envVars: {
           DUST_SANDBOX_TOKEN: sandboxToken,
           DUST_API_URL: `${config.getClientFacingUrl()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
@@ -149,7 +159,18 @@ export function createSandboxTools(
         return new Err(new MCPError(execResult.error.message));
       }
 
-      const output = formatExecOutput(execResult.value);
+      const result = execResult.value;
+
+      if (isBackgroundExecResult(result)) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Process started in background (pid: ${result.pid})`,
+          },
+        ]);
+      }
+
+      const output = formatExecOutput(result);
 
       return new Ok([{ type: "text" as const, text: output }]);
     },

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -19,20 +19,11 @@ import {
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image";
-import type {
-  BackgroundExecResult,
-  ExecResult,
-} from "@app/lib/api/sandbox/provider";
+import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
-
-function isBackgroundExecResult(
-  result: ExecResult | BackgroundExecResult
-): result is BackgroundExecResult {
-  return "pid" in result && !("exitCode" in result);
-}
 
 const DEFAULT_WORKING_DIRECTORY = "/home/user";
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
@@ -146,31 +137,39 @@ export function createSandboxTools(
         expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
       });
 
-      const execResult = await sandbox.exec(auth, command, {
+      const baseOpts = {
         workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
-        timeoutMs: timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
-        background: background ?? false,
         envVars: {
           DUST_SANDBOX_TOKEN: sandboxToken,
           DUST_API_URL: `${config.getClientFacingUrl()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
         },
+      };
+
+      if (background) {
+        const execResult = await sandbox.exec(auth, command, {
+          ...baseOpts,
+          background: true,
+        });
+        if (execResult.isErr()) {
+          return new Err(new MCPError(execResult.error.message));
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Process started in background (pid: ${execResult.value.pid})`,
+          },
+        ]);
+      }
+
+      const execResult = await sandbox.exec(auth, command, {
+        ...baseOpts,
+        timeoutMs: timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
       });
       if (execResult.isErr()) {
         return new Err(new MCPError(execResult.error.message));
       }
 
-      const result = execResult.value;
-
-      if (isBackgroundExecResult(result)) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Process started in background (pid: ${result.pid})`,
-          },
-        ]);
-      }
-
-      const output = formatExecOutput(result);
+      const output = formatExecOutput(execResult.value);
 
       return new Ok([{ type: "text" as const, text: output }]);
     },

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -91,7 +91,7 @@ export function createSandboxTools(
   _agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
-    execute: async (
+    bash: async (
       { command, workingDirectory, timeoutMs, background },
       { auth, agentLoopContext }
     ) => {

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -51,13 +51,19 @@ export interface ExecResult {
   stderr: string;
 }
 
+export interface BackgroundExecResult {
+  pid: number;
+}
+
 export interface ExecOptions {
   /** Working directory for command execution. */
   workingDirectory?: string;
-  /** Timeout in milliseconds. */
+  /** Timeout in milliseconds (ignored when background is true). */
   timeoutMs?: number;
   /** Additional environment variables for this execution only. */
   envVars?: Record<string, string>;
+  /** If true, start the command in the background and return immediately with a pid. */
+  background?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -106,7 +112,7 @@ export interface SandboxProvider {
     providerId: string,
     command: string,
     opts?: ExecOptions
-  ): Promise<Result<ExecResult, Error>>;
+  ): Promise<Result<ExecResult | BackgroundExecResult, Error>>;
 
   writeFile(providerId: string, path: string, content: Buffer): Promise<void>;
 

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -55,16 +55,24 @@ export interface BackgroundExecResult {
   pid: number;
 }
 
-export interface ExecOptions {
+interface BaseExecOptions {
   /** Working directory for command execution. */
   workingDirectory?: string;
-  /** Timeout in milliseconds (ignored when background is true). */
-  timeoutMs?: number;
   /** Additional environment variables for this execution only. */
   envVars?: Record<string, string>;
-  /** If true, start the command in the background and return immediately with a pid. */
-  background?: boolean;
 }
+
+export interface ForegroundExecOptions extends BaseExecOptions {
+  /** Timeout in milliseconds. */
+  timeoutMs?: number;
+  background?: false;
+}
+
+export interface BackgroundExecOptions extends BaseExecOptions {
+  background: true;
+}
+
+export type ExecOptions = ForegroundExecOptions | BackgroundExecOptions;
 
 // ---------------------------------------------------------------------------
 // Filesystem
@@ -108,6 +116,16 @@ export interface SandboxProvider {
   sleep(providerId: string): Promise<Result<void, Error>>;
   destroy(providerId: string): Promise<Result<void, Error>>;
 
+  exec(
+    providerId: string,
+    command: string,
+    opts: BackgroundExecOptions
+  ): Promise<Result<BackgroundExecResult, Error>>;
+  exec(
+    providerId: string,
+    command: string,
+    opts?: ForegroundExecOptions
+  ): Promise<Result<ExecResult, Error>>;
   exec(
     providerId: string,
     command: string,

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -3,6 +3,7 @@ import {
   type NetworkPolicy,
 } from "@app/lib/api/sandbox/image/types";
 import type {
+  BackgroundExecResult,
   ExecOptions,
   ExecResult,
   FileEntry,
@@ -182,7 +183,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     providerId: string,
     command: string,
     opts?: ExecOptions
-  ): Promise<Result<ExecResult, Error>> {
+  ): Promise<Result<ExecResult | BackgroundExecResult, Error>> {
     let sandbox: Sandbox;
     try {
       sandbox = await Sandbox.connect(providerId, {
@@ -194,6 +195,20 @@ export class E2BSandboxProvider implements SandboxProvider {
         return new Err(new SandboxNotFoundError(providerId));
       }
       return new Err(normalizeError(err));
+    }
+
+    if (opts?.background) {
+      try {
+        const handle = await sandbox.commands.run(command, {
+          cwd: opts?.workingDirectory,
+          envs: opts?.envVars,
+          background: true,
+        });
+
+        return new Ok({ pid: handle.pid });
+      } catch (err) {
+        return new Err(normalizeError(err));
+      }
     }
 
     try {

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -3,10 +3,12 @@ import {
   type NetworkPolicy,
 } from "@app/lib/api/sandbox/image/types";
 import type {
+  BackgroundExecOptions,
   BackgroundExecResult,
   ExecOptions,
   ExecResult,
   FileEntry,
+  ForegroundExecOptions,
   SandboxCreateConfig,
   SandboxHandle,
   SandboxProvider,
@@ -179,6 +181,16 @@ export class E2BSandboxProvider implements SandboxProvider {
     return new Ok(undefined);
   }
 
+  async exec(
+    providerId: string,
+    command: string,
+    opts: BackgroundExecOptions
+  ): Promise<Result<BackgroundExecResult, Error>>;
+  async exec(
+    providerId: string,
+    command: string,
+    opts?: ForegroundExecOptions
+  ): Promise<Result<ExecResult, Error>>;
   async exec(
     providerId: string,
     command: string,

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,10 +1,12 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
+  BackgroundExecOptions,
   BackgroundExecResult,
   ExecOptions,
   ExecResult,
   FileEntry,
+  ForegroundExecOptions,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
@@ -455,6 +457,16 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   /**
    * Execute a command in this sandbox.
    */
+  async exec(
+    auth: Authenticator,
+    command: string,
+    opts: BackgroundExecOptions
+  ): Promise<Result<BackgroundExecResult, Error>>;
+  async exec(
+    auth: Authenticator,
+    command: string,
+    opts?: ForegroundExecOptions
+  ): Promise<Result<ExecResult, Error>>;
   async exec(
     auth: Authenticator,
     command: string,

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,7 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
+  BackgroundExecResult,
   ExecOptions,
   ExecResult,
   FileEntry,
@@ -458,7 +459,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     auth: Authenticator,
     command: string,
     opts?: ExecOptions
-  ): Promise<Result<ExecResult, Error>> {
+  ): Promise<Result<ExecResult | BackgroundExecResult, Error>> {
     const provider = getSandboxProvider();
     if (!provider) {
       return new Err(new Error("Sandbox provider not configured."));


### PR DESCRIPTION
## Description

Add background option to the bash command.

I would make the argument that we should rename the command to `execute` as `bash` implies availability of and proper functioning of & which is not the case with E2B interface. But that's quite nit.

## Tests

Tested locally. Do not hang on running a server (with or without `&` when background is set to true)

## Risk

None

## Deploy Plan

- deploy `front`