### PR TITLE
Do not mark as read automatically when the doNotAssociateUser is true.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -792,11 +792,13 @@ export async function postUserMessage(
 
     await ConversationResource.markAsUpdated(auth, { conversation, t });
 
-    // Mark the conversation as read for the current user.
-    await ConversationResource.markAsReadForAuthUser(auth, {
-      conversation,
-      transaction: t,
-    });
+    if (!doNotAssociateUser) {
+      // Mark the conversation as read for the current user.
+      await ConversationResource.markAsReadForAuthUser(auth, {
+        conversation,
+        transaction: t,
+      });
+    }
 
     return {
       userMessage,


### PR DESCRIPTION
## Description

Fix that the automatically generated conversations in projects (from the tool) are not used as part of the project's summary for the author.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front