### PR TITLE
[front] refactor(sandbox): move GitHub import utils in `lib/api`

### DIFF
--- a/front/lib/api/skills/detection/github/detect_skills.ts
+++ b/front/lib/api/skills/detection/github/detect_skills.ts
@@ -160,7 +160,7 @@ export async function detectSkillsFromGitHubRepo({
   octokit: InstanceType<typeof Octokit>;
   owner: string;
   repo: string;
-}): Promise<Result<GitHubDetectedSkill[], GitHubSkillDetectionError>> {
+}): Promise<Result<DetectedSkill[], GitHubSkillDetectionError>> {
   const treeResult = await fetchRepoTree(octokit, { owner, repo });
   if (treeResult.isErr()) {
     return treeResult;

--- a/front/lib/api/skills/detection/github/detect_skills.ts
+++ b/front/lib/api/skills/detection/github/detect_skills.ts
@@ -126,24 +126,41 @@ async function fetchBlobContent(
 }
 
 /**
- * Detects Agent Skills (https://agentskills.io/specification) in a GitHub
- * repository by scanning for SKILL.md files via the Git Trees API.
+ * Parses a GitHub repo URL and creates an authenticated Octokit client.
+ * Shared setup for both skill detection and import flows.
  */
-export async function detectSkillsFromGitHubRepo({
+export function initGitHubRepoClient({
   repoUrl,
   accessToken,
 }: {
   repoUrl: string;
   accessToken?: string | null;
-}): Promise<Result<DetectedSkill[], GitHubSkillDetectionError>> {
+}): Result<
+  { octokit: InstanceType<typeof Octokit>; owner: string; repo: string },
+  GitHubSkillDetectionError
+> {
   const parseResult = parseGitHubRepoUrl(repoUrl);
   if (parseResult.isErr()) {
     return parseResult;
   }
   const { owner, repo } = parseResult.value;
-
   const octokit = new Octokit(accessToken ? { auth: accessToken } : {});
+  return new Ok({ octokit, owner, repo });
+}
 
+/**
+ * Detects Agent Skills (https://agentskills.io/specification) in a GitHub
+ * repository by scanning for SKILL.md files via the Git Trees API.
+ */
+export async function detectSkillsFromGitHubRepo({
+  octokit,
+  owner,
+  repo,
+}: {
+  octokit: InstanceType<typeof Octokit>;
+  owner: string;
+  repo: string;
+}): Promise<Result<GitHubDetectedSkill[], GitHubSkillDetectionError>> {
   const treeResult = await fetchRepoTree(octokit, { owner, repo });
   if (treeResult.isErr()) {
     return treeResult;

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -1,6 +1,5 @@
 import {
   detectSkillsFromGitHubRepo,
-  fetchSkillFileAttachments,
   initGitHubRepoClient,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/detection/github/detect_skills";
@@ -8,7 +7,6 @@ import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detectio
 import type { GitHubSkillDetectionError } from "@app/lib/api/skills/detection/github/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -75,14 +73,6 @@ export async function importSkillsFromGitHub(
         return;
       }
 
-      const fileAttachments = await fetchSkillFileAttachments(auth, skill, {
-        octokit,
-        owner,
-        repo,
-      });
-
-      let skillId: string;
-
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
 
@@ -95,7 +85,6 @@ export async function importSkillsFromGitHub(
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
-          fileAttachments,
           source: "github",
           sourceMetadata: {
             repoUrl,
@@ -103,7 +92,6 @@ export async function importSkillsFromGitHub(
           },
         });
 
-        skillId = existing.sId;
         updated.push(existing);
       } else {
         let icon: string | null = null;
@@ -140,17 +128,10 @@ export async function importSkillsFromGitHub(
             },
             isDefault: false,
           },
-          { mcpServerViews: [], fileAttachments }
+          { mcpServerViews: [] }
         );
 
-        skillId = skillResource.sId;
         imported.push(skillResource);
-      }
-
-      if (fileAttachments.length > 0) {
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId,
-        });
       }
     },
     { concurrency: IMPORT_CONCURRENCY }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -54,9 +54,7 @@ export async function importSkillsFromGitHub(
   const requestedNames = new Set(names);
   const selectedSkills = detectedSkills.filter(
     (skill) =>
-      requestedNames.has(skill.name) &&
-      skill.name &&
-      skill.instructions.trim()
+      requestedNames.has(skill.name) && skill.name && skill.instructions.trim()
   );
 
   const user = auth.getNonNullableUser();
@@ -67,10 +65,7 @@ export async function importSkillsFromGitHub(
   await concurrentExecutor(
     selectedSkills,
     async (skill) => {
-      const existing = await SkillResource.fetchActiveByName(
-        auth,
-        skill.name
-      );
+      const existing = await SkillResource.fetchActiveByName(auth, skill.name);
 
       if (existing && !isSkillFromGitHubRepo(existing, { repoUrl })) {
         errors.push({
@@ -80,11 +75,11 @@ export async function importSkillsFromGitHub(
         return;
       }
 
-      const fileAttachments = await fetchSkillFileAttachments(
-        auth,
-        skill,
-        { octokit, owner, repo }
-      );
+      const fileAttachments = await fetchSkillFileAttachments(auth, skill, {
+        octokit,
+        owner,
+        repo,
+      });
 
       let skillSId: string;
 
@@ -153,11 +148,9 @@ export async function importSkillsFromGitHub(
       }
 
       if (fileAttachments.length > 0) {
-        await FileResource.bulkSetUseCaseMetadata(
-          auth,
-          fileAttachments,
-          { skillId: skillSId }
-        );
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: skillSId,
+        });
       }
     },
     { concurrency: IMPORT_CONCURRENCY }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -1,0 +1,167 @@
+import {
+  detectSkillsFromGitHubRepo,
+  fetchSkillFileAttachments,
+  initGitHubRepoClient,
+  isSkillFromGitHubRepo,
+} from "@app/lib/api/skills/detection/github/detect_skills";
+import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
+import type { GitHubSkillDetectionError } from "@app/lib/api/skills/detection/github/types";
+import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+const IMPORT_CONCURRENCY = 4;
+
+export interface ImportSkillsResult {
+  imported: SkillResource[];
+  updated: SkillResource[];
+  errors: { name: string; message: string }[];
+}
+
+/**
+ * Imports skills from a GitHub repository. Detects skills, fetches their
+ * attachments, and creates or updates SkillResource objects.
+ */
+export async function importSkillsFromGitHub(
+  auth: Authenticator,
+  {
+    repoUrl,
+    names,
+  }: {
+    repoUrl: string;
+    names: string[];
+  }
+): Promise<Result<ImportSkillsResult, GitHubSkillDetectionError>> {
+  const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
+  const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
+  if (clientResult.isErr()) {
+    return clientResult;
+  }
+  const { octokit, owner, repo } = clientResult.value;
+
+  const result = await detectSkillsFromGitHubRepo({ octokit, owner, repo });
+  if (result.isErr()) {
+    return result;
+  }
+
+  const detectedSkills = result.value;
+
+  const requestedNames = new Set(names);
+  const selectedSkills = detectedSkills.filter(
+    (skill) =>
+      requestedNames.has(skill.name) &&
+      skill.name &&
+      skill.instructions.trim()
+  );
+
+  const user = auth.getNonNullableUser();
+  const imported: SkillResource[] = [];
+  const updated: SkillResource[] = [];
+  const errors: { name: string; message: string }[] = [];
+
+  await concurrentExecutor(
+    selectedSkills,
+    async (skill) => {
+      const existing = await SkillResource.fetchActiveByName(
+        auth,
+        skill.name
+      );
+
+      if (existing && !isSkillFromGitHubRepo(existing, { repoUrl })) {
+        errors.push({
+          name: skill.name,
+          message: `A different skill named "${skill.name}" already exists.`,
+        });
+        return;
+      }
+
+      const fileAttachments = await fetchSkillFileAttachments(
+        auth,
+        skill,
+        { octokit, owner, repo }
+      );
+
+      let skillSId: string;
+
+      if (existing) {
+        const attachedKnowledge = await existing.getAttachedKnowledge(auth);
+
+        await existing.updateSkill(auth, {
+          name: skill.name,
+          agentFacingDescription: skill.description,
+          userFacingDescription: skill.description,
+          instructions: skill.instructions,
+          icon: existing.icon,
+          mcpServerViews: existing.mcpServerViews,
+          attachedKnowledge,
+          requestedSpaceIds: existing.requestedSpaceIds,
+          fileAttachments,
+          source: "github",
+          sourceMetadata: {
+            repoUrl,
+            filePath: skill.skillMdPath,
+          },
+        });
+
+        skillSId = existing.sId;
+        updated.push(existing);
+      } else {
+        let icon: string | null = null;
+        const iconResult = await getSkillIconSuggestion(auth, {
+          name: skill.name,
+          instructions: skill.instructions,
+          agentFacingDescription: skill.description,
+        });
+        if (iconResult.isOk()) {
+          icon = iconResult.value;
+        } else {
+          logger.warn(
+            { error: iconResult.error, skillName: skill.name },
+            "Failed to generate icon suggestion for imported skill"
+          );
+        }
+
+        const skillResource = await SkillResource.makeNew(
+          auth,
+          {
+            status: "active",
+            name: skill.name,
+            agentFacingDescription: skill.description,
+            userFacingDescription: skill.description,
+            instructions: skill.instructions,
+            editedBy: user.id,
+            requestedSpaceIds: [],
+            extendedSkillId: null,
+            icon,
+            source: "github",
+            sourceMetadata: {
+              repoUrl,
+              filePath: skill.skillMdPath,
+            },
+            isDefault: false,
+          },
+          { mcpServerViews: [], fileAttachments }
+        );
+
+        skillSId = skillResource.sId;
+        imported.push(skillResource);
+      }
+
+      if (fileAttachments.length > 0) {
+        await FileResource.bulkSetUseCaseMetadata(
+          auth,
+          fileAttachments,
+          { skillId: skillSId }
+        );
+      }
+    },
+    { concurrency: IMPORT_CONCURRENCY }
+  );
+
+  return new Ok({ imported, updated, errors });
+}

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -81,7 +81,7 @@ export async function importSkillsFromGitHub(
         repo,
       });
 
-      let skillSId: string;
+      let skillId: string;
 
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
@@ -103,7 +103,7 @@ export async function importSkillsFromGitHub(
           },
         });
 
-        skillSId = existing.sId;
+        skillId = existing.sId;
         updated.push(existing);
       } else {
         let icon: string | null = null;
@@ -143,13 +143,13 @@ export async function importSkillsFromGitHub(
           { mcpServerViews: [], fileAttachments }
         );
 
-        skillSId = skillResource.sId;
+        skillId = skillResource.sId;
         imported.push(skillResource);
       }
 
       if (fileAttachments.length > 0) {
         await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: skillSId,
+          skillId,
         });
       }
     },

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,6 +1,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   detectSkillsFromGitHubRepo,
+  initGitHubRepoClient,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/detection/github/detect_skills";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -62,10 +62,18 @@ async function handler(
       }
 
       const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
-      const result = await detectSkillsFromGitHubRepo({
-        repoUrl,
-        accessToken,
-      });
+      const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
+      if (clientResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: clientResult.error.message,
+          },
+        });
+      }
+
+      const result = await detectSkillsFromGitHubRepo(clientResult.value);
 
       if (result.isErr()) {
         const { error } = result;

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -1,13 +1,6 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import {
-  detectSkillsFromGitHubRepo,
-  isSkillFromGitHubRepo,
-} from "@app/lib/api/skills/detection/github/detect_skills";
-import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
-import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -17,8 +10,6 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-const IMPORT_CONCURRENCY = 4;
 
 const ImportSkillsRequestBodySchema = t.type({
   repoUrl: t.string,
@@ -75,11 +66,7 @@ async function handler(
 
       const { repoUrl, names } = bodyValidation.right;
 
-      const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
-      const result = await detectSkillsFromGitHubRepo({
-        repoUrl,
-        accessToken,
-      });
+      const result = await importSkillsFromGitHub(auth, { repoUrl, names });
       if (result.isErr()) {
         const error = result.error;
         switch (error.type) {
@@ -124,104 +111,10 @@ async function handler(
         }
       }
 
-      const requestedNames = new Set(names);
-      const selectedSkills = result.value.filter(
-        (skill) =>
-          requestedNames.has(skill.name) &&
-          skill.name &&
-          skill.instructions.trim()
-      );
-
-      const user = auth.getNonNullableUser();
-      const imported: SkillResource[] = [];
-      const updated: SkillResource[] = [];
-      const errors: { name: string; message: string }[] = [];
-
-      await concurrentExecutor(
-        selectedSkills,
-        async (skill) => {
-          const existing = await SkillResource.fetchActiveByName(
-            auth,
-            skill.name
-          );
-
-          if (existing) {
-            if (!isSkillFromGitHubRepo(existing, { repoUrl })) {
-              errors.push({
-                name: skill.name,
-                message: `A different skill named "${skill.name}" already exists.`,
-              });
-              return;
-            }
-
-            const attachedKnowledge = await existing.getAttachedKnowledge(auth);
-
-            await existing.updateSkill(auth, {
-              name: skill.name,
-              agentFacingDescription: skill.description,
-              userFacingDescription: skill.description,
-              instructions: skill.instructions,
-              icon: existing.icon,
-              mcpServerViews: existing.mcpServerViews,
-              attachedKnowledge,
-              requestedSpaceIds: existing.requestedSpaceIds,
-              source: "github",
-              sourceMetadata: {
-                repoUrl,
-                filePath: skill.skillMdPath,
-              },
-            });
-
-            updated.push(existing);
-            return;
-          }
-
-          let icon: string | null = null;
-          const iconResult = await getSkillIconSuggestion(auth, {
-            name: skill.name,
-            instructions: skill.instructions,
-            agentFacingDescription: skill.description,
-          });
-          if (iconResult.isOk()) {
-            icon = iconResult.value;
-          } else {
-            logger.warn(
-              { error: iconResult.error, skillName: skill.name },
-              "Failed to generate icon suggestion for imported skill"
-            );
-          }
-
-          const skillResource = await SkillResource.makeNew(
-            auth,
-            {
-              status: "active",
-              name: skill.name,
-              agentFacingDescription: skill.description,
-              userFacingDescription: skill.description,
-              instructions: skill.instructions,
-              editedBy: user.id,
-              requestedSpaceIds: [],
-              extendedSkillId: null,
-              icon,
-              source: "github",
-              sourceMetadata: {
-                repoUrl,
-                filePath: skill.skillMdPath,
-              },
-              isDefault: false,
-            },
-            { mcpServerViews: [] }
-          );
-
-          imported.push(skillResource);
-        },
-        { concurrency: IMPORT_CONCURRENCY }
-      );
-
       return res.status(200).json({
-        imported: imported.map((skill) => skill.toJSON(auth)),
-        updated: updated.map((skill) => skill.toJSON(auth)),
-        errors,
+        imported: result.value.imported.map((skill) => skill.toJSON(auth)),
+        updated: result.value.updated.map((skill) => skill.toJSON(auth)),
+        errors: result.value.errors,
       });
     }
 

--- a/front/scripts/detect_github_skills.ts
+++ b/front/scripts/detect_github_skills.ts
@@ -1,4 +1,7 @@
-import { detectSkillsFromGitHubRepo } from "@app/lib/api/skills/detection/github/detect_skills";
+import {
+  detectSkillsFromGitHubRepo,
+  initGitHubRepoClient,
+} from "@app/lib/api/skills/detection/github/detect_skills";
 import { makeScript } from "@app/scripts/helpers";
 
 // TODO(2026-02-25 aubin): move to a poke plugin or a CLI command if ends up being needed for debugging.
@@ -16,7 +19,16 @@ makeScript(
     },
   },
   async ({ repoUrl, accessToken }, logger) => {
-    const result = await detectSkillsFromGitHubRepo({ repoUrl, accessToken });
+    const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
+    if (clientResult.isErr()) {
+      logger.error(
+        { error: clientResult.error },
+        `Invalid URL: ${clientResult.error.message}`
+      );
+      return;
+    }
+
+    const result = await detectSkillsFromGitHubRepo(clientResult.value);
 
     if (result.isErr()) {
       logger.error(


### PR DESCRIPTION
## Description

- This PR moves the utils used to import skills from GitHub from the handler to a dedicated file in `lib/api`.
- Goal is to prepare for the addition of imports from a zip file, which will be handled in the same endpoint.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
