### PR TITLE
Mount GCS conversation files in sandbox via gcsfuse with downscoped tokens

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -9,6 +9,10 @@ import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/met
 import config from "@app/lib/api/config";
 import { generateSandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import {
+  mountConversationFiles,
+  refreshGcsToken,
+} from "@app/lib/api/sandbox/gcs/mount";
+import {
   createToolManifest,
   getSandboxImage,
   toolManifestToJSON,
@@ -17,6 +21,7 @@ import {
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/user";
@@ -95,7 +100,34 @@ export function createSandboxTools(
         return new Err(new MCPError(ensureResult.error.message));
       }
 
-      const { sandbox } = ensureResult.value;
+      const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
+
+      // Mount GCS conversation files (fire-and-forget).
+      // On fresh creation or wake-from-sleep, /tmp is empty so we need a full mount.
+      // For already-running sandboxes we just refresh the token.
+      const imageResult = getSandboxImage(auth);
+      if (imageResult.isOk()) {
+        const image = imageResult.value;
+
+        if (freshlyCreated || wokeFromSleep) {
+          void mountConversationFiles(auth, sandbox, conversation, image).catch(
+            (err) => logger.error({ err }, "GCS mount failed (fire-and-forget)")
+          );
+        } else {
+          void refreshGcsToken(auth, sandbox, conversation, image).catch(
+            (err) =>
+              logger.error(
+                { err },
+                "GCS token refresh failed (fire-and-forget)"
+              )
+          );
+        }
+      } else {
+        logger.error(
+          { err: imageResult.error },
+          "Failed to get sandbox image for GCS mount"
+        );
+      }
 
       const sandboxToken = generateSandboxExecToken(auth, {
         agentConfiguration,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -495,6 +495,9 @@ const config = {
       "SBX_GCP_ARTIFACT_REGISTRY"
     );
   },
+  getGoogleCloudProjectId: (): string => {
+    return EnvironmentConfig.getEnvVariable("GOOGLE_CLOUD_PROJECT_ID");
+  },
 };
 
 export default config;

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -1,0 +1,210 @@
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
+import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import type { Authenticator } from "@app/lib/auth";
+import fileStorageConfig from "@app/lib/file_storage/config";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const MOUNT_TIMEOUT_MS = 30_000;
+const MOUNT_POINT = "/files/conversation";
+
+/**
+ * Mount GCS conversation files into a running sandbox via gcsfuse.
+ *
+ * The mount sequence:
+ *  1. Mint a downscoped token scoped to the conversation prefix.
+ *  2. Write the token JSON to /tmp/token.json in the sandbox.
+ *  3. Start the token HTTP server (netcat loop on :9876) and wait for it.
+ *  4. Run gcsfuse with --token-url pointing to the local token server.
+ *
+ * This function is designed to be called fire-and-forget (non-blocking) after sandbox creation or
+ * wake. The .mount-pending sentinel file signals to code running in the sandbox that the mount is
+ * not yet ready.
+ */
+export async function mountConversationFiles(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  conversation: ConversationType,
+  image: SandboxImage
+): Promise<Result<void, Error>> {
+  if (!image.hasCapability("gcsfuse")) {
+    return new Ok(undefined);
+  }
+
+  const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const prefix = getConversationFilesBasePath({
+    workspaceId,
+    conversationId: conversation.sId,
+  }).replace(/\/$/, ""); // Strip trailing slash for the token condition.
+
+  const childLogger = logger.child({
+    sandboxId: sandbox.sId,
+    workspaceId,
+    conversationId: conversation.sId,
+    bucket,
+    prefix,
+  });
+
+  // 1. Mint downscoped token.
+  const tokenResult = await mintDownscopedGcsToken({ bucket, prefix });
+  if (tokenResult.isErr()) {
+    childLogger.error(
+      { err: tokenResult.error },
+      "GCS mount: failed to mint token"
+    );
+    return tokenResult;
+  }
+
+  const { accessToken, expiresInSeconds } = tokenResult.value;
+
+  const tokenJson = JSON.stringify({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: expiresInSeconds,
+  });
+
+  // 2. Write token file into the sandbox.
+  const writeResult = await sandbox.exec(
+    auth,
+    `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
+  );
+  if (writeResult.isErr()) {
+    childLogger.error(
+      { err: writeResult.error },
+      "GCS mount: failed to write token file"
+    );
+    return writeResult;
+  }
+
+  // 3. Start token server and wait until it's listening.
+  // The server script is a netcat loop baked into the template.
+  // Start in background, then verify with a separate exec (matching PoC).
+  const startResult = await sandbox.exec(
+    auth,
+    "bash /home/user/.bin/token-server.sh > /tmp/server.log 2>&1 &"
+  );
+  if (startResult.isErr()) {
+    childLogger.error(
+      { err: startResult.error },
+      "GCS mount: failed to start token server"
+    );
+    return startResult;
+  }
+
+  const checkResult = await sandbox.exec(
+    auth,
+    "sleep 1 && curl -sf http://127.0.0.1:9876 > /dev/null 2>&1"
+  );
+  if (checkResult.isErr() || checkResult.value.exitCode !== 0) {
+    const msg = "Token server not ready after 1s";
+    childLogger.error({}, msg);
+    return new Err(new Error(msg));
+  }
+
+  // 4. Mount via gcsfuse.
+  const mountCmd = buildMountCommand({ bucket, prefix });
+  const mountResult = await sandbox.exec(auth, mountCmd, {
+    timeoutMs: MOUNT_TIMEOUT_MS,
+  });
+  if (mountResult.isErr()) {
+    childLogger.error(
+      { err: mountResult.error },
+      "GCS mount: gcsfuse mount failed"
+    );
+    return mountResult;
+  }
+
+  if (mountResult.value.exitCode !== 0) {
+    const msg = `gcsfuse exited with code ${mountResult.value.exitCode}: ${mountResult.value.stderr}`;
+    childLogger.error({ stderr: mountResult.value.stderr }, msg);
+    return new Err(new Error(msg));
+  }
+
+  childLogger.info({}, "GCS mount: conversation files mounted successfully");
+  return new Ok(undefined);
+}
+
+/**
+ * Refresh the GCS token in an already-mounted sandbox.
+ *
+ * Overwrites /tmp/token.json. The token server picks it up on next request from gcsfuse.
+ * No remount needed.
+ */
+export async function refreshGcsToken(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  conversation: ConversationType,
+  image: SandboxImage
+): Promise<Result<void, Error>> {
+  if (!image.hasCapability("gcsfuse")) {
+    return new Ok(undefined);
+  }
+
+  const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const prefix = getConversationFilesBasePath({
+    workspaceId,
+    conversationId: conversation.sId,
+  }).replace(/\/$/, "");
+
+  const tokenResult = await mintDownscopedGcsToken({ bucket, prefix });
+  if (tokenResult.isErr()) {
+    return tokenResult;
+  }
+
+  const tokenJson = JSON.stringify({
+    access_token: tokenResult.value.accessToken,
+    token_type: "Bearer",
+    expires_in: tokenResult.value.expiresInSeconds,
+  });
+
+  const writeResult = await sandbox.exec(
+    auth,
+    `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
+  );
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+
+  logger.info(
+    {
+      sandboxId: sandbox.sId,
+      workspaceId,
+      conversationId: conversation.sId,
+    },
+    "GCS token refreshed"
+  );
+
+  return new Ok(undefined);
+}
+
+function buildMountCommand({
+  bucket,
+  prefix,
+}: {
+  bucket: string;
+  prefix: string;
+}): string {
+  const flags = [
+    `--token-url http://127.0.0.1:9876`,
+    `--only-dir ${prefix}`,
+    `--implicit-dirs`,
+    `-o allow_other`,
+    `--file-mode=666`,
+    `--dir-mode=777`,
+    `--kernel-list-cache-ttl-secs=60`,
+  ].join(" ");
+
+  return `timeout 30 sudo gcsfuse ${flags} ${bucket} ${MOUNT_POINT} 2>&1`;
+}
+
+function escapeSingleQuotes(s: string): string {
+  return s.replace(/'/g, "'\\''");
+}

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -200,6 +200,10 @@ function buildMountCommand({
     `--file-mode=666`,
     `--dir-mode=777`,
     `--kernel-list-cache-ttl-secs=60`,
+    // Disable HNS (Hierarchical Namespace) support. gcsfuse calls GetStorageLayout at mount time
+    // when HNS is enabled, which requires unrestricted `objects.list` on the bucket. Disabling it
+    // lets us condition `objects.list` via the objectListPrefix CAB attribute.
+    `--enable-hns=false`,
   ].join(" ");
 
   return `timeout 30 sudo gcsfuse ${flags} ${bucket} ${MOUNT_POINT} 2>&1`;

--- a/front/lib/api/sandbox/gcs/token.test.ts
+++ b/front/lib/api/sandbox/gcs/token.test.ts
@@ -1,0 +1,127 @@
+import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
+import fileStorageConfig from "@app/lib/file_storage/config";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Manual integration test for GCS downscoped token CAB rules.
+ *
+ * Requires GCP credentials (SERVICE_ACCOUNT env var or Workload Identity) and a real bucket with
+ * existing objects under the test prefix.
+ *
+ * Run manually:
+ *   MANUAL_GCS_TEST=1 npm test lib/api/sandbox/gcs/token.test.ts
+ *
+ * Skipped by default in CI / regular test runs.
+ */
+
+// Must be a prefix that contains at least one object in the bucket.
+const PREFIX = "w/ncfXXrse2l/conversations/AtDChPZB16/files";
+const GCS_API = "https://storage.googleapis.com/storage/v1";
+
+const runManual = process.env.MANUAL_GCS_TEST === "1";
+
+describe.skipIf(!runManual)("GCS downscoped token CAB", () => {
+  let accessToken: string;
+  let bucket: string;
+
+  it("mints a downscoped token", async () => {
+    bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
+    const result = await mintDownscopedGcsToken({ bucket, prefix: PREFIX });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.expiresInSeconds).toBeGreaterThan(0);
+    accessToken = result.value.accessToken;
+  });
+
+  // -- Allowed operations --
+
+  it("allows buckets.get (needed for gcsfuse mount)", async () => {
+    const res = await fetch(`${GCS_API}/b/${bucket}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows objects.list on the conversation prefix", async () => {
+    const res = await fetch(
+      `${GCS_API}/b/${bucket}/o?prefix=${encodeURIComponent(PREFIX + "/")}&maxResults=5`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect((data.items ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("allows write + read + delete on the conversation prefix", async () => {
+    const headers = { Authorization: `Bearer ${accessToken}` };
+    const objectName = `${PREFIX}/cab-test-${Date.now()}.txt`;
+    const content = `CAB test at ${new Date().toISOString()}`;
+
+    // Write.
+    const writeRes = await fetch(
+      `https://storage.googleapis.com/upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent(objectName)}`,
+      {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "text/plain" },
+        body: content,
+      }
+    );
+    expect(writeRes.status).toBe(200);
+
+    // Read back.
+    const readRes = await fetch(
+      `${GCS_API}/b/${bucket}/o/${encodeURIComponent(objectName)}?alt=media`,
+      { headers }
+    );
+    expect(readRes.status).toBe(200);
+    expect(await readRes.text()).toBe(content);
+
+    // Delete (cleanup).
+    const delRes = await fetch(
+      `${GCS_API}/b/${bucket}/o/${encodeURIComponent(objectName)}`,
+      { method: "DELETE", headers }
+    );
+    expect(delRes.status).toBe(204);
+  });
+
+  // -- Blocked operations --
+
+  it("blocks objects.list without a prefix", async () => {
+    const res = await fetch(`${GCS_API}/b/${bucket}/o?maxResults=5`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks objects.list on a different prefix", async () => {
+    const res = await fetch(`${GCS_API}/b/${bucket}/o?prefix=w/&maxResults=5`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks objects.get on a different prefix", async () => {
+    const res = await fetch(
+      `${GCS_API}/b/${bucket}/o/${encodeURIComponent("w/OTHER/conversations/fake/files/secret.txt")}?alt=media`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it("blocks objects.create on a different prefix", async () => {
+    const res = await fetch(
+      `https://storage.googleapis.com/upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent("w/OTHER/conversations/fake/files/hacked.txt")}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "text/plain",
+        },
+        body: "should not be written",
+      }
+    );
+    expect(res.ok).toBe(false);
+  });
+});

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -1,0 +1,137 @@
+import fileStorageConfig from "@app/lib/file_storage/config";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { GoogleAuth } from "google-auth-library";
+
+/**
+ * Mint downscoped GCS access tokens for sandbox gcsfuse mounts.
+ *
+ * Tokens are restricted via Credential Access Boundaries so the sandbox can only list and
+ * read/write objects under a specific conversation prefix.
+ *
+ * Auth discovery (handled automatically by google-auth-library):
+ *  - k8s (prod): Workload Identity using pod service account annotation.
+ *  - Local dev:  SERVICE_ACCOUNT env var pointing to a JSON key file.
+ */
+
+export interface DownscopedGcsToken {
+  accessToken: string;
+  expiresInSeconds: number;
+}
+
+interface StsTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+// Singleton auth client. Initialized once, reused for all token mints.
+let authClientPromise: ReturnType<GoogleAuth["getClient"]> | null = null;
+
+function getAuthClient() {
+  if (!authClientPromise) {
+    const auth = new GoogleAuth({
+      keyFilename: fileStorageConfig.getServiceAccount(),
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    });
+    authClientPromise = auth.getClient();
+  }
+  return authClientPromise;
+}
+
+/**
+ * Mint a downscoped GCS token restricted to a single conversation prefix.
+ *
+ * The token grants:
+ *  - Bucket-level metadata (buckets.get) needed by gcsfuse at mount time.
+ *  - Object list restricted to `prefix/` via the objectListPrefix API attribute.
+ *  - Object read+write restricted to `prefix/` via resource.name condition.
+ */
+export async function mintDownscopedGcsToken({
+  bucket,
+  prefix,
+}: {
+  bucket: string;
+  prefix: string;
+}): Promise<Result<DownscopedGcsToken, Error>> {
+  const client = await getAuthClient();
+  const { token: sourceToken } = await client.getAccessToken();
+
+  if (!sourceToken) {
+    return new Err(new Error("Failed to obtain source access token from GCP."));
+  }
+
+  try {
+    const response = await fetch("https://sts.googleapis.com/v1/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        subject_token: sourceToken,
+        options: JSON.stringify({
+          accessBoundary: {
+            accessBoundaryRules: buildAccessBoundaryRules(bucket, prefix),
+          },
+        }),
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return new Err(
+        new Error(`STS token exchange failed (${response.status}): ${body}`)
+      );
+    }
+
+    const data = (await response.json()) as StsTokenResponse;
+
+    return new Ok({
+      accessToken: data.access_token,
+      expiresInSeconds: data.expires_in,
+    });
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), bucket, prefix },
+      "Failed to mint downscoped GCS token"
+    );
+
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Build Credential Access Boundary rules that restrict a token to a single
+ * conversation prefix within a bucket.
+ *
+ * Two rules:
+ *
+ *  1. legacyBucketReader (unconditional) — grants buckets.get + objects.list at the bucket level.
+ *     gcsfuse needs both at mount time.
+ *     Note: legacyBucketReader does NOT include objects.get — the token cannot
+ *     read object contents, only list paths and get bucket metadata.
+ *     TODO(2026-03-12 SANDBOX): Restrict objects.list to our prefix via objectListPrefix
+ *     CAB condition once we confirm buckets.get works with it.
+ *
+ *  2. objectUser with resource.name condition — read/write scoped to prefix.
+ */
+function buildAccessBoundaryRules(bucket: string, prefix: string) {
+  const bucketResource = `//storage.googleapis.com/projects/_/buckets/${bucket}`;
+
+  return [
+    {
+      availablePermissions: ["inRole:roles/storage.legacyBucketReader"],
+      availableResource: bucketResource,
+    },
+    {
+      availablePermissions: ["inRole:roles/storage.objectUser"],
+      availableResource: bucketResource,
+      availabilityCondition: {
+        expression: `resource.name.startsWith('projects/_/buckets/${bucket}/objects/${prefix}/')`,
+      },
+    },
+  ];
+}

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -1,5 +1,4 @@
 import fileStorageConfig from "@app/lib/file_storage/config";
-import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -49,20 +48,28 @@ function getAuthClient() {
  *  - Object list restricted to `prefix/` via the objectListPrefix API attribute.
  *  - Object read+write restricted to `prefix/` via resource.name condition.
  */
-export async function mintDownscopedGcsToken({
+async function getSourceToken(): Promise<Result<string, Error>> {
+  try {
+    const client = await getAuthClient();
+    const { token } = await client.getAccessToken();
+    if (!token) {
+      return new Err(new Error("GCP auth returned no access token."));
+    }
+    return new Ok(token);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+async function exchangeToken({
   bucket,
   prefix,
+  sourceToken,
 }: {
   bucket: string;
   prefix: string;
-}): Promise<Result<DownscopedGcsToken, Error>> {
-  const client = await getAuthClient();
-  const { token: sourceToken } = await client.getAccessToken();
-
-  if (!sourceToken) {
-    return new Err(new Error("Failed to obtain source access token from GCP."));
-  }
-
+  sourceToken: string;
+}): Promise<Result<StsTokenResponse, Error>> {
   try {
     const response = await fetch("https://sts.googleapis.com/v1/token", {
       method: "POST",
@@ -87,20 +94,38 @@ export async function mintDownscopedGcsToken({
       );
     }
 
-    const data = (await response.json()) as StsTokenResponse;
-
-    return new Ok({
-      accessToken: data.access_token,
-      expiresInSeconds: data.expires_in,
-    });
+    return new Ok((await response.json()) as StsTokenResponse);
   } catch (err) {
-    logger.error(
-      { err: normalizeError(err), bucket, prefix },
-      "Failed to mint downscoped GCS token"
-    );
-
     return new Err(normalizeError(err));
   }
+}
+
+export async function mintDownscopedGcsToken({
+  bucket,
+  prefix,
+}: {
+  bucket: string;
+  prefix: string;
+}): Promise<Result<DownscopedGcsToken, Error>> {
+  const sourceTokenResult = await getSourceToken();
+  if (sourceTokenResult.isErr()) {
+    return sourceTokenResult;
+  }
+
+  const stsResult = await exchangeToken({
+    bucket,
+    prefix,
+    sourceToken: sourceTokenResult.value,
+  });
+  if (stsResult.isErr()) {
+    return stsResult;
+  }
+
+  const data = stsResult.value;
+  return new Ok({
+    accessToken: data.access_token,
+    expiresInSeconds: data.expires_in,
+  });
 }
 
 /**

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -149,8 +149,9 @@ function getStorageMountRole(): string {
  *     which is bundled in every predefined role that includes buckets.get.
  *
  *  2. legacyBucketReader with objectListPrefix condition — grants objects.list restricted to our
- *     prefix. The objectListPrefix CAB attribute is only present on list requests. buckets.get
- *     falls through to rule 1 instead.
+ *     prefix via the objectListPrefix CAB attribute. gcsfuse must be started with
+ *     --enable-hns=false to avoid the GetStorageLayout call (which requires unrestricted
+ *     objects.list and would bypass this condition).
  *
  *  3. objectUser with resource.name condition — read/write scoped to prefix.
  */

--- a/front/lib/api/sandbox/gcs/token.ts
+++ b/front/lib/api/sandbox/gcs/token.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -128,28 +129,45 @@ export async function mintDownscopedGcsToken({
   });
 }
 
+// Custom role created in dust-infra with only storage.buckets.get.
+// No predefined role grants buckets.get without also granting objects.list, and CAB does not
+// support specifying individual permissions, only roles.
+const SANDBOX_STORAGE_MOUNT_ROLE_ID = "sandbox_storage_mount";
+
+function getStorageMountRole(): string {
+  return `projects/${config.getGoogleCloudProjectId()}/roles/${SANDBOX_STORAGE_MOUNT_ROLE_ID}`;
+}
+
 /**
- * Build Credential Access Boundary rules that restrict a token to a single
- * conversation prefix within a bucket.
+ * Build Credential Access Boundary rules that restrict a token to a single conversation prefix
+ * within a bucket.
  *
- * Two rules:
+ * Three rules (evaluated with OR semantics by the STS endpoint):
  *
- *  1. legacyBucketReader (unconditional) — grants buckets.get + objects.list at the bucket level.
- *     gcsfuse needs both at mount time.
- *     Note: legacyBucketReader does NOT include objects.get — the token cannot
- *     read object contents, only list paths and get bucket metadata.
- *     TODO(2026-03-12 SANDBOX): Restrict objects.list to our prefix via objectListPrefix
- *     CAB condition once we confirm buckets.get works with it.
+ *  1. Custom role (storage.buckets.get only) — unconditional.
+ *     gcsfuse needs bucket metadata at mount time. Using a custom role avoids leaking objects.list
+ *     which is bundled in every predefined role that includes buckets.get.
  *
- *  2. objectUser with resource.name condition — read/write scoped to prefix.
+ *  2. legacyBucketReader with objectListPrefix condition — grants objects.list restricted to our
+ *     prefix. The objectListPrefix CAB attribute is only present on list requests. buckets.get
+ *     falls through to rule 1 instead.
+ *
+ *  3. objectUser with resource.name condition — read/write scoped to prefix.
  */
 function buildAccessBoundaryRules(bucket: string, prefix: string) {
   const bucketResource = `//storage.googleapis.com/projects/_/buckets/${bucket}`;
 
   return [
     {
+      availablePermissions: [`inRole:${getStorageMountRole()}`],
+      availableResource: bucketResource,
+    },
+    {
       availablePermissions: ["inRole:roles/storage.legacyBucketReader"],
       availableResource: bucketResource,
+      availabilityCondition: {
+        expression: `api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('${prefix}/')`,
+      },
     },
     {
       availablePermissions: ["inRole:roles/storage.objectUser"],

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -24,6 +24,7 @@ export type {
   NetworkMode,
   NetworkPolicy,
   Operation,
+  SandboxCapability,
   SandboxImageId,
   SandboxResources,
   ToolEntry,

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -70,6 +70,7 @@ SHELLEOF`)
         "sudo mv /tmp/dsbx /opt/bin/dsbx",
     }
   )
+  .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(ALLOWLIST_NETWORK_POLICY)
   .setWorkdir("/home/user")

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -10,6 +10,7 @@ import type {
   ManifestFormat,
   NetworkPolicy,
   Operation,
+  SandboxCapability,
   SandboxImageId,
   SandboxResources,
   ToolEntry,
@@ -32,6 +33,7 @@ interface SandboxImageState {
   network: NetworkPolicy;
   workdir: string;
   runEnv: Readonly<Record<string, string>>;
+  capabilities: ReadonlySet<SandboxCapability>;
   imageId?: SandboxImageId;
 }
 
@@ -44,6 +46,7 @@ export class SandboxImage {
   readonly workdir: string;
   readonly runEnv: Readonly<Record<string, string>>;
   readonly startupScript?: string;
+  readonly capabilities: ReadonlySet<SandboxCapability>;
   readonly imageId?: SandboxImageId;
 
   private constructor(state: SandboxImageState) {
@@ -54,6 +57,7 @@ export class SandboxImage {
     this.network = state.network;
     this.workdir = state.workdir;
     this.runEnv = state.runEnv;
+    this.capabilities = state.capabilities;
     this.imageId = state.imageId;
   }
 
@@ -66,6 +70,7 @@ export class SandboxImage {
       network: updates.network ?? this.network,
       workdir: updates.workdir ?? this.workdir,
       runEnv: updates.runEnv ?? this.runEnv,
+      capabilities: updates.capabilities ?? this.capabilities,
       imageId: updates.imageId ?? this.imageId,
     });
   }
@@ -79,6 +84,7 @@ export class SandboxImage {
       network: DEFAULT_NETWORK,
       workdir: "/home/user",
       runEnv: {},
+      capabilities: new Set(),
     });
   }
 
@@ -91,6 +97,7 @@ export class SandboxImage {
       network: DEFAULT_NETWORK,
       workdir: "/home/user",
       runEnv: {},
+      capabilities: new Set(),
     });
   }
 
@@ -170,6 +177,16 @@ export class SandboxImage {
     return this.clone({
       runEnv: { ...this.runEnv, ...vars },
     });
+  }
+
+  withCapability(cap: SandboxCapability): SandboxImage {
+    const next = new Set(this.capabilities);
+    next.add(cap);
+    return this.clone({ capabilities: next });
+  }
+
+  hasCapability(cap: SandboxCapability): boolean {
+    return this.capabilities.has(cap);
   }
 
   withResources(resources: SandboxResources): SandboxImage {

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -90,6 +90,17 @@ export interface ToolManifest {
 }
 
 // ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Declarative tags describing what a sandbox template supports.
+ * The Docker image must actually have the corresponding tooling installed. The capability tag tells
+ * orchestration it is safe to attempt the feature.
+ */
+export type SandboxCapability = "gcsfuse";
+
+// ---------------------------------------------------------------------------
 // Base Image
 // ---------------------------------------------------------------------------
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -27,8 +27,9 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 interface EnsureSandboxResult {
-  sandbox: SandboxResource;
   freshlyCreated: boolean;
+  sandbox: SandboxResource;
+  wokeFromSleep: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -309,11 +310,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           "Created new sandbox for conversation"
         );
 
-        return new Ok({ sandbox, freshlyCreated: true });
+        return new Ok({ sandbox, freshlyCreated: true, wokeFromSleep: false });
       }
 
       const { status } = existing;
       let freshlyCreated = false;
+      let wokeFromSleep = false;
 
       switch (status) {
         case "running":
@@ -333,10 +335,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
               "Failed to wake sandbox — will recreate"
             );
           } else {
-            logger.info(
-              { sandbox: existing.toLogJSON() },
-              "Woke sleeping sandbox"
-            );
+            wokeFromSleep = true;
+
             break;
           }
         }
@@ -371,7 +371,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       await existing.updateStatus("running");
       await existing.updateLastActivityAt();
-      return new Ok({ sandbox: existing, freshlyCreated });
+
+      return new Ok({ sandbox: existing, freshlyCreated, wokeFromSleep });
     });
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Design Doc [here](https://www.notion.so/dust-tt/Design-Doc-Bidirectional-File-Access-for-E2B-Sandboxes-31a28599d9418012b80ef3a81ed7fea9).

When a sandbox is created or woken from sleep, we now automatically mount the conversation's GCS file prefix into `/files/conversation/` via gcsfuse. This gives the sandbox live read/write access to conversation files without having to copy them in and out.

As discovered during the PoC phase, mounting sometimes takes time so it has been decided that the mount happens fire-and-forget after `ensureActive` returns so it doesn't block the first command execution. A `.mount-pending` sentinel file (baked into the template) is automatically replaced by `gcsfuse` once the mount succeeds, so code running in the sandbox can detect readiness. For already-running sandboxes, we refresh the GCS token on each exec to keep the mount alive across token expiry boundaries.

## How it works

We use the pod's GCP service account to get a source token, exchange it via GCP [STS](https://docs.cloud.google.com/iam/docs/downscoping-short-lived-credentials) for a downscoped token, write it to `/tmp/token.json` inside the sandbox where a netcat-based HTTP server serves it on `:9876`, then run `gcsfuse with --token-url` pointing to that local endpoint. A new `SandboxCapability` system on `SandboxImage` gates the mount, templates without the "gcsfuse" capability skip it entirely.

## Security model

The downscoped token uses three Credential Access Boundary rules:
1. Custom role `sandbox_storage_mount` (unconditional) — grants only storage.buckets.get, needed by gcsfuse at mount time. We created a custom GCP role because no predefined role provides `buckets.get` without also bundling `objects.list`.
2. `storage.legacyBucketReader` with `objectListPrefix` condition — grants `objects.list` restricted to the conversation prefix only. Uses the GCP CAB `objectListPrefix` API attribute so listing outside the conversation path returns 403.
3. `storage.objectUser` with `resource.name` condition — grants read/write/delete scoped strictly to the conversation prefix.

No GCP credentials persist in the sandbox. Tokens are short-lived (~1h) and re-minted server-side on
every creation or wake.

Verified with manual integration tests (token.test.ts)

- `buckets.get` — allowed (gcsfuse mount works)
- `objects.list` on conversation prefix — allowed
- `objects.list` without prefix — blocked (403)
- `objects.list` on different prefix — blocked (403)
- `objects.get` on different prefix — blocked (403)
- `objects.create` on different prefix — blocked (403)
- Write + read + delete on conversation prefix — allowed

## Known limitations / follow-ups

- The GCS token is accessible to user code running in the sandbox (inherent to the gcsfuse approach).
Blast radius is limited by the CAB downscoping rules above.
- Token refresh for sessions idle >1h without an exec needs further thought.

## Infra dependency

This PR requires a companion change in dust-infra to create the sandbox_storage_mount custom IAM role
in each GCP project where the private uploads bucket lives. See https://github.com/dust-tt/dust-infra/pull/684.

## Tests

Manual integration test in lib/api/sandbox/gcs/token.test.ts. Run with `MANUAL_GCS_TEST=1`. Skipped in
CI (requires real GCP credentials and bucket).

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

1. Apply terraform in dust-infra to create the custom role.
2. Ensure `GOOGLE_CLOUD_PROJECT_ID` is set in the deployment environment.
3. Deploy front — the mount activates automatically for templates with the gcsfuse capability.