### PR TITLE
feat: Add conversation files side panel with sandbox tree view

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -1,9 +1,11 @@
 import { AgentActionsPanel } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
+import { ConversationFilesPanel } from "@app/components/assistant/conversation/files_panel/ConversationFilesPanel";
 import { InteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/InteractiveContentContainer";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
 } from "@app/types/conversation_side_panel";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -29,6 +31,11 @@ export default function ConversationSidePanelContent({
           conversation={conversation}
           owner={owner}
         />
+      );
+
+    case FILES_SIDE_PANEL_TYPE:
+      return (
+        <ConversationFilesPanel conversation={conversation} owner={owner} />
       );
 
     default:

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -2,6 +2,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   SIDE_PANEL_HASH_PARAM,
   SIDE_PANEL_TYPE_HASH_PARAM,
@@ -19,12 +20,15 @@ type OpenPanelParams =
       type: "interactive_content";
       fileId: string;
       timestamp?: string;
+    }
+  | {
+      type: "files";
     };
 
 const isSupportedPanelType = (
   type: string | undefined
 ): type is ConversationSidePanelType =>
-  type === "actions" || type === "interactive_content";
+  type === "actions" || type === "interactive_content" || type === "files";
 
 interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
@@ -116,11 +120,20 @@ export function ConversationSidePanelProvider({
             : setData(params.fileId);
           break;
 
+        case FILES_SIDE_PANEL_TYPE:
+          // Toggle: if already open, close it.
+          if (currentPanel === FILES_SIDE_PANEL_TYPE) {
+            closePanel();
+            return;
+          }
+          setData("files");
+          break;
+
         default:
           assertNever(params);
       }
     },
-    [setCurrentPanel, setData, data, closePanel]
+    [setCurrentPanel, setData, data, closePanel, currentPanel]
   );
 
   // Initialize panel state from URL hash parameters

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -3,17 +3,25 @@ import {
   ConversationMenu,
   useConversationMenu,
 } from "@app/components/assistant/conversation/ConversationMenu";
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversation } from "@app/hooks/conversations";
+import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getProjectRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types/user";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
-import { ArrowLeftIcon, Breadcrumbs, Button, MoreIcon } from "@dust-tt/sparkle";
+import {
+  ArrowLeftIcon,
+  Breadcrumbs,
+  Button,
+  FolderOpenIcon,
+  MoreIcon,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
@@ -21,6 +29,14 @@ import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const { openPanel } = useConversationSidePanelContext();
+  const useSidePanelFiles = hasFeature("sidepanel_files");
+  const { attachments } = useConversationAttachments({
+    conversationId: activeConversationId,
+    owner,
+    options: { disabled: !useSidePanelFiles },
+  });
   const { conversation } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
@@ -96,6 +112,17 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             conversation={conversation}
             owner={owner}
           />
+          {useSidePanelFiles && (
+            <Button
+              size="sm"
+              label="Files"
+              isCounter={attachments.length > 0}
+              counterValue={String(attachments.length)}
+              icon={FolderOpenIcon}
+              variant="ghost"
+              onClick={() => openPanel({ type: "files" })}
+            />
+          )}
           <ConversationMenu
             activeConversationId={activeConversationId}
             conversation={conversation}

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -1,0 +1,165 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  FilePreviewSheet,
+  type MinimalFileForPreview,
+} from "@app/components/spaces/FilePreviewSheet";
+import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isInteractiveContentType } from "@app/types/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+import { FilesTab } from "./FilesTab";
+import { SandboxStatusChip } from "./SandboxStatusChip";
+import { SandboxTab } from "./SandboxTab";
+import type { ConversationAttachmentItem } from "./types";
+import { buildSandboxTree, conversationAttachmentToRow } from "./utils";
+
+interface ConversationFilesPanelProps {
+  conversation: ConversationWithoutContentType;
+  owner: LightWorkspaceType;
+}
+
+export function ConversationFilesPanel({
+  conversation,
+  owner,
+}: ConversationFilesPanelProps) {
+  const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(
+    null
+  );
+  const [showPreviewSheet, setShowPreviewSheet] = useState(false);
+  const { openPanel, closePanel } = useConversationSidePanelContext();
+
+  const { attachments, isConversationAttachmentsLoading } =
+    useConversationAttachments({
+      conversationId: conversation.sId,
+      owner,
+    });
+
+  const { sandboxFiles, sandboxStatus, isSandboxFilesLoading } =
+    useConversationSandboxFiles({
+      conversationId: conversation.sId,
+      owner,
+    });
+
+  const handleFileClick = useCallback(
+    (fileId: string, title: string, contentType: string) => {
+      if (isInteractiveContentType(contentType)) {
+        openPanel({ type: "interactive_content", fileId });
+      } else {
+        setPreviewFile({ sId: fileId, fileName: title, contentType });
+        setShowPreviewSheet(true);
+      }
+    },
+    [openPanel]
+  );
+
+  const conversationContextFiles = useMemo(() => {
+    const conversationFiles: ConversationAttachmentItem[] = [];
+    for (const f of attachments) {
+      if (!f.isInProjectContext) {
+        conversationFiles.push(f);
+      }
+    }
+    return conversationFiles.map((a) =>
+      conversationAttachmentToRow(a, handleFileClick)
+    );
+  }, [attachments, handleFileClick]);
+
+  const sandboxTree = useMemo(
+    () => buildSandboxTree(sandboxFiles),
+    [sandboxFiles]
+  );
+
+  const hasSandbox = sandboxStatus !== null;
+
+  const filesContent = (
+    <FilesTab
+      isLoading={isConversationAttachmentsLoading}
+      rows={conversationContextFiles}
+    />
+  );
+
+  if (!hasSandbox) {
+    return (
+      <>
+        <div className="flex h-full flex-col">
+          <AppLayoutTitle>
+            <div className="flex h-full items-center justify-between">
+              <span className="text-sm font-normal text-primary dark:text-primary-night">
+                Files
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={closePanel}
+                icon={XMarkIcon}
+              />
+            </div>
+          </AppLayoutTitle>
+          {filesContent}
+        </div>
+
+        <FilePreviewSheet
+          owner={owner}
+          file={previewFile}
+          isOpen={showPreviewSheet}
+          onOpenChange={setShowPreviewSheet}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex h-full flex-col">
+        <Tabs defaultValue="files" className="flex h-full flex-col">
+          <AppLayoutTitle>
+            <div className="flex h-full items-center justify-between">
+              <TabsList border={false}>
+                <TabsTrigger value="files" label="Files" />
+                <TabsTrigger value="sandbox" label="Sandbox" />
+              </TabsList>
+              <div className="flex items-center gap-2">
+                {sandboxStatus && <SandboxStatusChip status={sandboxStatus} />}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={closePanel}
+                  icon={XMarkIcon}
+                />
+              </div>
+            </div>
+          </AppLayoutTitle>
+          <TabsContent value="files" className="flex-1 overflow-hidden">
+            {filesContent}
+          </TabsContent>
+          <TabsContent value="sandbox" className="flex-1 overflow-hidden">
+            <SandboxTab
+              isLoading={isSandboxFilesLoading}
+              sandboxTree={sandboxTree}
+              onFileClick={handleFileClick}
+            />
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <FilePreviewSheet
+        owner={owner}
+        file={previewFile}
+        isOpen={showPreviewSheet}
+        onOpenChange={setShowPreviewSheet}
+      />
+    </>
+  );
+}

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -1,11 +1,20 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { FilesTab } from "@app/components/assistant/conversation/files_panel/FilesTab";
+import { SandboxStatusChip } from "@app/components/assistant/conversation/files_panel/SandboxStatusChip";
+import { SandboxTab } from "@app/components/assistant/conversation/files_panel/SandboxTab";
+import type {
+  ConversationAttachmentItem,
+  SandboxTreeNode,
+} from "@app/components/assistant/conversation/files_panel/types";
+import { conversationAttachmentToRow } from "@app/components/assistant/conversation/files_panel/utils";
 import {
   FilePreviewSheet,
   type MinimalFileForPreview,
 } from "@app/components/spaces/FilePreviewSheet";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
-import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
+import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
+import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isInteractiveContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -18,12 +27,6 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useState } from "react";
-
-import { FilesTab } from "./FilesTab";
-import { SandboxStatusChip } from "./SandboxStatusChip";
-import { SandboxTab } from "./SandboxTab";
-import type { ConversationAttachmentItem } from "./types";
-import { buildSandboxTree, conversationAttachmentToRow } from "./utils";
 
 interface ConversationFilesPanelProps {
   conversation: ConversationWithoutContentType;
@@ -46,14 +49,21 @@ export function ConversationFilesPanel({
       owner,
     });
 
-  const { sandboxFiles, sandboxStatus, isSandboxFilesLoading } =
-    useConversationSandboxFiles({
-      conversationId: conversation.sId,
-      owner,
-    });
+  const { sandboxStatus } = useConversationSandboxStatus({
+    conversationId: conversation.sId,
+    owner,
+  });
 
-  const handleFileClick = useCallback(
-    (fileId: string, title: string, contentType: string) => {
+  const openFile = useCallback(
+    ({
+      fileId,
+      title,
+      contentType,
+    }: {
+      fileId: string;
+      title: string;
+      contentType: string;
+    }) => {
       if (isInteractiveContentType(contentType)) {
         openPanel({ type: "interactive_content", fileId });
       } else {
@@ -64,6 +74,28 @@ export function ConversationFilesPanel({
     [openPanel]
   );
 
+  const handleAttachmentClick = useCallback(
+    (item: ConversationAttachmentItem) => {
+      if (isFileAttachmentType(item)) {
+        openFile(item);
+      }
+    },
+    [openFile]
+  );
+
+  const handleSandboxFileClick = useCallback(
+    (node: SandboxTreeNode) => {
+      if (node.fileId) {
+        openFile({
+          fileId: node.fileId,
+          title: node.name,
+          contentType: node.contentType,
+        });
+      }
+    },
+    [openFile]
+  );
+
   const conversationContextFiles = useMemo(() => {
     const conversationFiles: ConversationAttachmentItem[] = [];
     for (const f of attachments) {
@@ -72,14 +104,9 @@ export function ConversationFilesPanel({
       }
     }
     return conversationFiles.map((a) =>
-      conversationAttachmentToRow(a, handleFileClick)
+      conversationAttachmentToRow(a, handleAttachmentClick)
     );
-  }, [attachments, handleFileClick]);
-
-  const sandboxTree = useMemo(
-    () => buildSandboxTree(sandboxFiles),
-    [sandboxFiles]
-  );
+  }, [attachments, handleAttachmentClick]);
 
   const hasSandbox = sandboxStatus !== null;
 
@@ -146,9 +173,9 @@ export function ConversationFilesPanel({
           </TabsContent>
           <TabsContent value="sandbox" className="flex-1 overflow-hidden">
             <SandboxTab
-              isLoading={isSandboxFilesLoading}
-              sandboxTree={sandboxTree}
-              onFileClick={handleFileClick}
+              conversationId={conversation.sId}
+              owner={owner}
+              onFileClick={handleSandboxFileClick}
             />
           </TabsContent>
         </Tabs>

--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -1,0 +1,93 @@
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import { Card, CardGrid, Icon, ScrollArea, Spinner } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+import type { ConversationAttachmentRow } from "./types";
+
+interface FilesTabProps {
+  isLoading: boolean;
+  rows: ConversationAttachmentRow[];
+}
+
+function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
+  return (
+    <CardGrid>
+      {rows.map((row) => {
+        const FileIcon = getFileTypeIcon(row.contentType, row.title);
+        return (
+          <Card
+            key={row.fileId ?? row.title}
+            size="sm"
+            variant="primary"
+            onClick={row.onClick}
+          >
+            <div className="flex items-center gap-2">
+              <Icon visual={FileIcon} size="sm" className="shrink-0" />
+              <div className="min-w-0 truncate text-sm font-medium">
+                {row.title}
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+    </CardGrid>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="heading-sm pb-2 text-foreground dark:text-foreground-night">
+      {children}
+    </div>
+  );
+}
+
+export function FilesTab({ isLoading, rows }: FilesTabProps) {
+  const { attached, generated } = useMemo(() => {
+    const attached: ConversationAttachmentRow[] = [];
+    const generated: ConversationAttachmentRow[] = [];
+    for (const row of rows) {
+      if (row.source === "user") {
+        attached.push(row);
+      } else {
+        generated.push(row);
+      }
+    }
+    return { attached, generated };
+  }, [rows]);
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full items-center justify-center p-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Conversation attachments & generated content will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="flex-1 p-4">
+      <div className="flex flex-col gap-4">
+        {attached.length > 0 && (
+          <div>
+            <SectionLabel>Attached</SectionLabel>
+            <FileCards rows={attached} />
+          </div>
+        )}
+        {generated.length > 0 && (
+          <div>
+            <SectionLabel>Generated</SectionLabel>
+            <FileCards rows={generated} />
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -1,45 +1,11 @@
+import type { ConversationAttachmentRow } from "@app/components/assistant/conversation/files_panel/types";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { Card, CardGrid, Icon, ScrollArea, Spinner } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
-import type { ConversationAttachmentRow } from "./types";
-
 interface FilesTabProps {
   isLoading: boolean;
   rows: ConversationAttachmentRow[];
-}
-
-function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
-  return (
-    <CardGrid>
-      {rows.map((row) => {
-        const FileIcon = getFileTypeIcon(row.contentType, row.title);
-        return (
-          <Card
-            key={row.fileId ?? row.title}
-            size="sm"
-            variant="primary"
-            onClick={row.onClick}
-          >
-            <div className="flex items-center gap-2">
-              <Icon visual={FileIcon} size="sm" className="shrink-0" />
-              <div className="min-w-0 truncate text-sm font-medium">
-                {row.title}
-              </div>
-            </div>
-          </Card>
-        );
-      })}
-    </CardGrid>
-  );
-}
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="heading-sm pb-2 text-foreground dark:text-foreground-night">
-      {children}
-    </div>
-  );
 }
 
 export function FilesTab({ isLoading, rows }: FilesTabProps) {
@@ -89,5 +55,38 @@ export function FilesTab({ isLoading, rows }: FilesTabProps) {
         )}
       </div>
     </ScrollArea>
+  );
+}
+
+function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
+  return (
+    <CardGrid>
+      {rows.map((row) => {
+        const FileIcon = getFileTypeIcon(row.contentType, row.title);
+        return (
+          <Card
+            key={row.fileId ?? row.title}
+            size="sm"
+            variant="primary"
+            onClick={row.onClick}
+          >
+            <div className="flex items-center gap-2">
+              <Icon visual={FileIcon} size="sm" className="shrink-0" />
+              <div className="min-w-0 truncate text-sm font-medium">
+                {row.title}
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+    </CardGrid>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="heading-sm pb-2 text-foreground dark:text-foreground-night">
+      {children}
+    </div>
   );
 }

--- a/front/components/assistant/conversation/files_panel/SandboxStatusChip.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxStatusChip.tsx
@@ -1,0 +1,20 @@
+import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { Chip } from "@dust-tt/sparkle";
+
+interface SandboxStatusChipProps {
+  status: SandboxStatus;
+}
+
+export function SandboxStatusChip({ status }: SandboxStatusChipProps) {
+  switch (status) {
+    case "running":
+      return <Chip size="mini" color="success" label="Sandbox running" />;
+    case "sleeping":
+      return <Chip size="mini" color="warning" label="Sandbox sleeping" />;
+    case "deleted":
+      return <Chip size="mini" color="primary" label="Sandbox expired" />;
+    default:
+      assertNever(status);
+  }
+}

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -1,3 +1,6 @@
+import { buildSandboxTree } from "@app/components/assistant/conversation/files_panel/utils";
+import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   DocumentIcon,
   FolderIcon,
@@ -6,25 +9,35 @@ import {
   Spinner,
   Tree,
 } from "@dust-tt/sparkle";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { SandboxTreeNode } from "./types";
 
 interface SandboxTabProps {
-  isLoading: boolean;
-  sandboxTree: SandboxTreeNode[];
-  onFileClick: (fileId: string, name: string, contentType: string) => void;
+  conversationId: string;
+  owner: LightWorkspaceType;
+  onFileClick: (node: SandboxTreeNode) => void;
 }
 
 export function SandboxTab({
-  isLoading,
-  sandboxTree,
+  conversationId,
+  owner,
   onFileClick,
 }: SandboxTabProps) {
+  const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
+    conversationId,
+    owner,
+  });
+
+  const sandboxTree = useMemo(
+    () => buildSandboxTree(sandboxFiles),
+    [sandboxFiles]
+  );
+
   const renderTreeNodes = useCallback(
     (nodes: SandboxTreeNode[]) => {
       return nodes.map((node) => {
-        if (node.isDirectory) {
+        if (node.children.length > 0) {
           return (
             <Tree.Item
               key={node.path}
@@ -46,11 +59,7 @@ export function SandboxTab({
             label={node.name}
             type="leaf"
             visual={icon}
-            onItemClick={
-              node.fileId
-                ? () => onFileClick(node.fileId!, node.name, node.contentType)
-                : undefined
-            }
+            onItemClick={node.fileId ? () => onFileClick(node) : undefined}
           />
         );
       });
@@ -60,7 +69,7 @@ export function SandboxTab({
 
   return (
     <ScrollArea className="flex-1 p-4">
-      {isLoading ? (
+      {isSandboxFilesLoading ? (
         <div className="flex w-full items-center justify-center p-8">
           <Spinner />
         </div>

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -1,0 +1,76 @@
+import {
+  DocumentIcon,
+  FolderIcon,
+  ImageIcon,
+  ScrollArea,
+  Spinner,
+  Tree,
+} from "@dust-tt/sparkle";
+import { useCallback } from "react";
+
+import type { SandboxTreeNode } from "./types";
+
+interface SandboxTabProps {
+  isLoading: boolean;
+  sandboxTree: SandboxTreeNode[];
+  onFileClick: (fileId: string, name: string, contentType: string) => void;
+}
+
+export function SandboxTab({
+  isLoading,
+  sandboxTree,
+  onFileClick,
+}: SandboxTabProps) {
+  const renderTreeNodes = useCallback(
+    (nodes: SandboxTreeNode[]) => {
+      return nodes.map((node) => {
+        if (node.isDirectory) {
+          return (
+            <Tree.Item
+              key={node.path}
+              label={node.name}
+              type="node"
+              visual={FolderIcon}
+              defaultCollapsed={false}
+            >
+              {renderTreeNodes(node.children)}
+            </Tree.Item>
+          );
+        }
+        const icon = node.contentType.startsWith("image/")
+          ? ImageIcon
+          : DocumentIcon;
+        return (
+          <Tree.Item
+            key={node.path}
+            label={node.name}
+            type="leaf"
+            visual={icon}
+            onItemClick={
+              node.fileId
+                ? () => onFileClick(node.fileId!, node.name, node.contentType)
+                : undefined
+            }
+          />
+        );
+      });
+    },
+    [onFileClick]
+  );
+
+  return (
+    <ScrollArea className="flex-1 p-4">
+      {isLoading ? (
+        <div className="flex w-full items-center justify-center p-8">
+          <Spinner />
+        </div>
+      ) : sandboxTree.length > 0 ? (
+        <Tree>{renderTreeNodes(sandboxTree)}</Tree>
+      ) : (
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No files in the sandbox yet.
+        </div>
+      )}
+    </ScrollArea>
+  );
+}

--- a/front/components/assistant/conversation/files_panel/types.ts
+++ b/front/components/assistant/conversation/files_panel/types.ts
@@ -1,0 +1,21 @@
+import type { GetConversationAttachmentsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/attachments";
+
+export type ConversationAttachmentItem =
+  GetConversationAttachmentsResponseBody["attachments"][number];
+
+export type ConversationAttachmentRow = {
+  title: string;
+  contentType: string;
+  fileId: string | null;
+  source: "agent" | "user" | null;
+  onClick?: () => void;
+};
+
+export type SandboxTreeNode = {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  contentType: string;
+  fileId: string | null;
+  children: SandboxTreeNode[];
+};

--- a/front/components/assistant/conversation/files_panel/types.ts
+++ b/front/components/assistant/conversation/files_panel/types.ts
@@ -14,7 +14,6 @@ export type ConversationAttachmentRow = {
 export type SandboxTreeNode = {
   name: string;
   path: string;
-  isDirectory: boolean;
   contentType: string;
   fileId: string | null;
   children: SandboxTreeNode[];

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -2,7 +2,7 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
-import type { SandboxFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { SandboxFileEntry } from "@app/lib/api/sandbox/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type {
@@ -11,40 +11,80 @@ import type {
   SandboxTreeNode,
 } from "./types";
 
+/**
+ * Build a tree from flat GCS file entries by inferring directories from paths.
+ * The GCS prefix (e.g. "w/{wId}/conversations/{cId}/files/") is stripped so
+ * tree paths start at the sandbox working directory root.
+ */
 export function buildSandboxTree(
   entries: SandboxFileEntry[]
 ): SandboxTreeNode[] {
   const root: SandboxTreeNode[] = [];
-
-  // Sort entries so directories come before files at the same level.
-  const sorted = [...entries].sort((a, b) => {
-    if (a.isDirectory !== b.isDirectory) {
-      return a.isDirectory ? -1 : 1;
-    }
-    return a.path.localeCompare(b.path);
-  });
-
-  // Build a map of path -> node for quick parent lookup.
   const nodeMap = new Map<string, SandboxTreeNode>();
 
-  for (const entry of sorted) {
-    const node: SandboxTreeNode = {
-      name: entry.fileName,
-      path: entry.path,
-      isDirectory: entry.isDirectory,
+  // Find the common prefix to strip (everything up to and including "files/").
+  const commonPrefix =
+    entries.length > 0
+      ? entries[0].path.substring(
+          0,
+          entries[0].path.indexOf("/files/") + "/files/".length
+        )
+      : "";
+
+  for (const entry of entries) {
+    const relativePath = entry.path.startsWith(commonPrefix)
+      ? entry.path.slice(commonPrefix.length)
+      : entry.path;
+
+    if (!relativePath) {
+      continue;
+    }
+
+    const parts = relativePath.split("/");
+
+    // Ensure all ancestor directories exist as nodes.
+    let currentPath = "";
+    for (let i = 0; i < parts.length - 1; i++) {
+      currentPath = currentPath ? `${currentPath}/${parts[i]}` : parts[i];
+      if (!nodeMap.has(currentPath)) {
+        const dirNode: SandboxTreeNode = {
+          name: parts[i],
+          path: currentPath,
+          contentType: "inode/directory",
+          fileId: null,
+          children: [],
+        };
+        nodeMap.set(currentPath, dirNode);
+
+        const parentPath = currentPath.substring(
+          0,
+          currentPath.lastIndexOf("/")
+        );
+        const parent = parentPath ? nodeMap.get(parentPath) : undefined;
+        if (parent) {
+          parent.children.push(dirNode);
+        } else {
+          root.push(dirNode);
+        }
+      }
+    }
+
+    // Add the file node.
+    const fileNode: SandboxTreeNode = {
+      name: parts[parts.length - 1],
+      path: relativePath,
       contentType: entry.contentType,
       fileId: entry.fileId,
       children: [],
     };
-    nodeMap.set(entry.path, node);
+    nodeMap.set(relativePath, fileNode);
 
-    // Find parent directory path.
-    const parentPath = entry.path.substring(0, entry.path.lastIndexOf("/"));
-    const parent = nodeMap.get(parentPath);
+    const parentPath = relativePath.substring(0, relativePath.lastIndexOf("/"));
+    const parent = parentPath ? nodeMap.get(parentPath) : undefined;
     if (parent) {
-      parent.children.push(node);
+      parent.children.push(fileNode);
     } else {
-      root.push(node);
+      root.push(fileNode);
     }
   }
 
@@ -53,26 +93,26 @@ export function buildSandboxTree(
 
 export function conversationAttachmentToRow(
   item: ConversationAttachmentItem,
-  onFileClick: (fileId: string, title: string, contentType: string) => void
+  onFileClick: (item: ConversationAttachmentItem) => void
 ): ConversationAttachmentRow {
   if (isFileAttachmentType(item)) {
+    const { title, contentType, fileId, source } = item;
     return {
-      title: item.title,
-      contentType: item.contentType,
-      fileId: item.fileId,
-      source: item.source,
-      onClick: () => {
-        onFileClick(item.fileId, item.title, item.contentType);
-      },
+      title,
+      contentType,
+      fileId,
+      source,
+      onClick: () => onFileClick(item),
     };
   } else if (isContentNodeAttachmentType(item)) {
+    const { title, contentType, sourceUrl } = item;
     return {
-      title: item.title,
-      contentType: item.contentType,
+      title,
+      contentType,
       fileId: null,
       source: null,
-      onClick: item.sourceUrl
-        ? () => window.open(item.sourceUrl!, "_blank", "noopener,noreferrer")
+      onClick: sourceUrl
+        ? () => window.open(sourceUrl, "_blank", "noopener,noreferrer")
         : undefined,
     };
   } else {

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -1,0 +1,81 @@
+import {
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import type { SandboxFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+import type {
+  ConversationAttachmentItem,
+  ConversationAttachmentRow,
+  SandboxTreeNode,
+} from "./types";
+
+export function buildSandboxTree(
+  entries: SandboxFileEntry[]
+): SandboxTreeNode[] {
+  const root: SandboxTreeNode[] = [];
+
+  // Sort entries so directories come before files at the same level.
+  const sorted = [...entries].sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) {
+      return a.isDirectory ? -1 : 1;
+    }
+    return a.path.localeCompare(b.path);
+  });
+
+  // Build a map of path -> node for quick parent lookup.
+  const nodeMap = new Map<string, SandboxTreeNode>();
+
+  for (const entry of sorted) {
+    const node: SandboxTreeNode = {
+      name: entry.fileName,
+      path: entry.path,
+      isDirectory: entry.isDirectory,
+      contentType: entry.contentType,
+      fileId: entry.fileId,
+      children: [],
+    };
+    nodeMap.set(entry.path, node);
+
+    // Find parent directory path.
+    const parentPath = entry.path.substring(0, entry.path.lastIndexOf("/"));
+    const parent = nodeMap.get(parentPath);
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      root.push(node);
+    }
+  }
+
+  return root;
+}
+
+export function conversationAttachmentToRow(
+  item: ConversationAttachmentItem,
+  onFileClick: (fileId: string, title: string, contentType: string) => void
+): ConversationAttachmentRow {
+  if (isFileAttachmentType(item)) {
+    return {
+      title: item.title,
+      contentType: item.contentType,
+      fileId: item.fileId,
+      source: item.source,
+      onClick: () => {
+        onFileClick(item.fileId, item.title, item.contentType);
+      },
+    };
+  } else if (isContentNodeAttachmentType(item)) {
+    return {
+      title: item.title,
+      contentType: item.contentType,
+      fileId: null,
+      source: null,
+      onClick: item.sourceUrl
+        ? () => window.open(item.sourceUrl!, "_blank", "noopener,noreferrer")
+        : undefined,
+    };
+  } else {
+    assertNever(item);
+  }
+}

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -1,0 +1,39 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  GetConversationSandboxFilesResponseBody,
+  SandboxFileEntry,
+} from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+export function useConversationSandboxFiles({
+  conversationId,
+  owner,
+  options,
+}: {
+  conversationId?: string | null;
+  owner: LightWorkspaceType;
+  options?: { disabled?: boolean };
+}) {
+  const { fetcher } = useFetcher();
+  const sandboxFilesFetcher: Fetcher<GetConversationSandboxFilesResponseBody> =
+    fetcher;
+
+  const disabled = options?.disabled;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    conversationId && !disabled
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/sandbox/files`
+      : null,
+    sandboxFilesFetcher,
+    options
+  );
+
+  return {
+    sandboxFiles: data?.files ?? emptyArray<SandboxFileEntry>(),
+    sandboxStatus: data?.sandboxStatus ?? null,
+    isSandboxFilesLoading: !disabled && !error && !data,
+    isSandboxFilesError: error,
+    mutateSandboxFiles: mutate,
+  };
+}

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -31,7 +31,6 @@ export function useConversationSandboxFiles({
 
   return {
     sandboxFiles: data?.files ?? emptyArray<SandboxFileEntry>(),
-    sandboxStatus: data?.sandboxStatus ?? null,
     isSandboxFilesLoading: !disabled && !error && !data,
     isSandboxFilesError: error,
     mutateSandboxFiles: mutate,

--- a/front/hooks/conversations/useConversationSandboxStatus.ts
+++ b/front/hooks/conversations/useConversationSandboxStatus.ts
@@ -1,0 +1,33 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationSandboxResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+export function useConversationSandboxStatus({
+  conversationId,
+  owner,
+  options,
+}: {
+  conversationId?: string | null;
+  owner: LightWorkspaceType;
+  options?: { disabled?: boolean };
+}) {
+  const { fetcher } = useFetcher();
+  const sandboxFetcher: Fetcher<GetConversationSandboxResponseBody> = fetcher;
+
+  const disabled = options?.disabled;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    conversationId && !disabled
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/sandbox`
+      : null,
+    sandboxFetcher,
+    options
+  );
+
+  return {
+    sandboxStatus: data?.sandboxStatus ?? null,
+    isSandboxStatusLoading: !disabled && !error && !data,
+    mutateSandboxStatus: mutate,
+  };
+}

--- a/front/lib/api/sandbox/files.ts
+++ b/front/lib/api/sandbox/files.ts
@@ -2,24 +2,6 @@ import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
-import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import logger from "@app/logger/logger";
-import { FILE_FORMATS } from "@app/types/files";
-
-const SANDBOX_WORKING_DIRECTORY = "/tmp";
-
-// Reverse lookup: extension -> content type, built from FILE_FORMATS.
-const EXTENSION_TO_CONTENT_TYPE = new Map<string, string>();
-for (const [contentType, format] of Object.entries(FILE_FORMATS)) {
-  for (const ext of format.exts) {
-    EXTENSION_TO_CONTENT_TYPE.set(ext, contentType);
-  }
-}
-
-function contentTypeFromExtension(fileName: string): string {
-  const ext = fileName.slice(fileName.lastIndexOf(".")).toLowerCase();
-  return EXTENSION_TO_CONTENT_TYPE.get(ext) ?? "application/octet-stream";
-}
 
 export type SandboxFileEntry = {
   fileName: string;
@@ -28,75 +10,12 @@ export type SandboxFileEntry = {
   contentType: string;
   lastModifiedMs: number;
   fileId: string | null;
-  isDirectory: boolean;
 };
 
 /**
- * List sandbox files by querying the E2B sandbox filesystem directly.
+ * List sandbox files from GCS (mounted bucket as source of truth).
  */
-export async function listSandboxFilesFromProvider(
-  sandbox: SandboxResource
-): Promise<SandboxFileEntry[]> {
-  const result = await sandbox.listFiles(SANDBOX_WORKING_DIRECTORY, {
-    recursive: true,
-  });
-  if (result.isErr()) {
-    logger.warn(
-      { sandboxId: sandbox.sId, error: result.error.message },
-      "Failed to list sandbox files from provider"
-    );
-    return [];
-  }
-
-  const entries: SandboxFileEntry[] = [];
-
-  for (const entry of result.value) {
-    // Make the path relative to the working directory.
-    // E2B returns paths like "/tmp/scripts" or "tmp/scripts" when listing "/tmp".
-    let relativePath = entry.path;
-    // Strip leading slash for uniform handling.
-    relativePath = relativePath.replace(/^\//, "");
-    // Strip working directory prefix (e.g. "tmp/").
-    const wdName = SANDBOX_WORKING_DIRECTORY.replace(/^\//, "");
-    if (relativePath === wdName) {
-      // Skip the working directory entry itself.
-      continue;
-    }
-    if (relativePath.startsWith(`${wdName}/`)) {
-      relativePath = relativePath.slice(wdName.length + 1);
-    }
-
-    // Skip empty paths (shouldn't happen, but be safe).
-    if (!relativePath) {
-      continue;
-    }
-
-    const name = relativePath.split("/").pop() ?? "";
-    // Hide hidden files/dirs (dot-prefixed) and systemd artifacts.
-    if (name.startsWith(".") || relativePath.includes("systemd-private-")) {
-      continue;
-    }
-
-    entries.push({
-      fileName: name,
-      path: relativePath,
-      sizeBytes: entry.size,
-      contentType: entry.isDirectory
-        ? "inode/directory"
-        : contentTypeFromExtension(name),
-      lastModifiedMs: 0,
-      fileId: null,
-      isDirectory: entry.isDirectory,
-    });
-  }
-
-  return entries;
-}
-
-/**
- * List sandbox files from GCS mount path (fallback for deleted sandboxes).
- */
-export async function listSandboxFilesFromGCS(
+export async function listSandboxFiles(
   auth: Authenticator,
   conversationId: string
 ): Promise<SandboxFileEntry[]> {
@@ -136,7 +55,6 @@ export async function listSandboxFilesFromGCS(
         ? new Date(metadata.updated as string).getTime()
         : 0,
       fileId: fileResource?.sId ?? null,
-      isDirectory: false,
     };
   });
 }

--- a/front/lib/api/sandbox/files.ts
+++ b/front/lib/api/sandbox/files.ts
@@ -1,0 +1,142 @@
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { FILE_FORMATS } from "@app/types/files";
+
+const SANDBOX_WORKING_DIRECTORY = "/tmp";
+
+// Reverse lookup: extension -> content type, built from FILE_FORMATS.
+const EXTENSION_TO_CONTENT_TYPE = new Map<string, string>();
+for (const [contentType, format] of Object.entries(FILE_FORMATS)) {
+  for (const ext of format.exts) {
+    EXTENSION_TO_CONTENT_TYPE.set(ext, contentType);
+  }
+}
+
+function contentTypeFromExtension(fileName: string): string {
+  const ext = fileName.slice(fileName.lastIndexOf(".")).toLowerCase();
+  return EXTENSION_TO_CONTENT_TYPE.get(ext) ?? "application/octet-stream";
+}
+
+export type SandboxFileEntry = {
+  fileName: string;
+  path: string;
+  sizeBytes: number;
+  contentType: string;
+  lastModifiedMs: number;
+  fileId: string | null;
+  isDirectory: boolean;
+};
+
+/**
+ * List sandbox files by querying the E2B sandbox filesystem directly.
+ */
+export async function listSandboxFilesFromProvider(
+  sandbox: SandboxResource
+): Promise<SandboxFileEntry[]> {
+  const result = await sandbox.listFiles(SANDBOX_WORKING_DIRECTORY, {
+    recursive: true,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { sandboxId: sandbox.sId, error: result.error.message },
+      "Failed to list sandbox files from provider"
+    );
+    return [];
+  }
+
+  const entries: SandboxFileEntry[] = [];
+
+  for (const entry of result.value) {
+    // Make the path relative to the working directory.
+    // E2B returns paths like "/tmp/scripts" or "tmp/scripts" when listing "/tmp".
+    let relativePath = entry.path;
+    // Strip leading slash for uniform handling.
+    relativePath = relativePath.replace(/^\//, "");
+    // Strip working directory prefix (e.g. "tmp/").
+    const wdName = SANDBOX_WORKING_DIRECTORY.replace(/^\//, "");
+    if (relativePath === wdName) {
+      // Skip the working directory entry itself.
+      continue;
+    }
+    if (relativePath.startsWith(`${wdName}/`)) {
+      relativePath = relativePath.slice(wdName.length + 1);
+    }
+
+    // Skip empty paths (shouldn't happen, but be safe).
+    if (!relativePath) {
+      continue;
+    }
+
+    const name = relativePath.split("/").pop() ?? "";
+    // Hide hidden files/dirs (dot-prefixed) and systemd artifacts.
+    if (name.startsWith(".") || relativePath.includes("systemd-private-")) {
+      continue;
+    }
+
+    entries.push({
+      fileName: name,
+      path: relativePath,
+      sizeBytes: entry.size,
+      contentType: entry.isDirectory
+        ? "inode/directory"
+        : contentTypeFromExtension(name),
+      lastModifiedMs: 0,
+      fileId: null,
+      isDirectory: entry.isDirectory,
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * List sandbox files from GCS mount path (fallback for deleted sandboxes).
+ */
+export async function listSandboxFilesFromGCS(
+  auth: Authenticator,
+  conversationId: string
+): Promise<SandboxFileEntry[]> {
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId,
+  });
+
+  const bucket = getPrivateUploadBucket();
+  const gcsFiles = await bucket.getFiles({ prefix, maxResults: 200 });
+
+  // Filter out .processed.* files (internal processing artifacts).
+  const filteredFiles = gcsFiles.filter((f) => {
+    const name = f.name.split("/").pop() ?? "";
+    return !name.includes(".processed.");
+  });
+
+  const mountPaths = filteredFiles.map((f) => f.name);
+  const mountPathToFileResource = await FileResource.fetchByMountFilePaths(
+    auth,
+    mountPaths
+  );
+
+  return filteredFiles.map((gcsFile) => {
+    const fileName = gcsFile.name.split("/").pop() ?? gcsFile.name;
+    const metadata = gcsFile.metadata;
+    const fileResource = mountPathToFileResource.get(gcsFile.name) ?? null;
+
+    return {
+      fileName,
+      path: gcsFile.name,
+      sizeBytes: Number(metadata.size ?? 0),
+      contentType:
+        (metadata.contentType as string) ?? "application/octet-stream",
+      lastModifiedMs: metadata.updated
+        ? new Date(metadata.updated as string).getTime()
+        : 0,
+      fileId: fileResource?.sId ?? null,
+      isDirectory: false,
+    };
+  });
+}

--- a/front/lib/api/sandbox/files.ts
+++ b/front/lib/api/sandbox/files.ts
@@ -2,6 +2,7 @@ import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { isString } from "@app/types/shared/utils/general";
 
 export type SandboxFileEntry = {
   fileName: string;
@@ -35,24 +36,31 @@ export async function listSandboxFiles(
   });
 
   const mountPaths = filteredFiles.map((f) => f.name);
-  const mountPathToFileResource = await FileResource.fetchByMountFilePaths(
+  const fileResources = await FileResource.fetchByMountFilePaths(
     auth,
     mountPaths
   );
+  const fileResourceByMountPath = new Map<string, FileResource>();
+  for (const r of fileResources) {
+    if (r.mountFilePath) {
+      fileResourceByMountPath.set(r.mountFilePath, r);
+    }
+  }
 
   return filteredFiles.map((gcsFile) => {
     const fileName = gcsFile.name.split("/").pop() ?? gcsFile.name;
     const metadata = gcsFile.metadata;
-    const fileResource = mountPathToFileResource.get(gcsFile.name) ?? null;
+    const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
 
     return {
       fileName,
       path: gcsFile.name,
       sizeBytes: Number(metadata.size ?? 0),
-      contentType:
-        (metadata.contentType as string) ?? "application/octet-stream",
-      lastModifiedMs: metadata.updated
-        ? new Date(metadata.updated as string).getTime()
+      contentType: isString(metadata.contentType)
+        ? metadata.contentType
+        : "application/octet-stream",
+      lastModifiedMs: isString(metadata.updated)
+        ? new Date(metadata.updated).getTime()
         : 0,
       fileId: fileResource?.sId ?? null,
     };

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -233,10 +233,31 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   async listFiles(
-    _providerId: string,
-    _path: string,
-    _opts?: { recursive?: boolean }
+    providerId: string,
+    path: string,
+    opts?: { recursive?: boolean }
   ): Promise<FileEntry[]> {
-    throw new Error("listFiles is not implemented yet.");
+    let sandbox: Sandbox;
+    try {
+      sandbox = await Sandbox.connect(providerId, {
+        ...this.connectionOpts(),
+        timeoutMs: SANDBOX_LIFETIME_MS,
+      });
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        throw new SandboxNotFoundError(providerId);
+      }
+      throw normalizeError(err);
+    }
+
+    const entries = await sandbox.files.list(path, {
+      depth: opts?.recursive ? 10 : 1,
+    });
+
+    return entries.map((e) => ({
+      path: e.path,
+      size: e.size,
+      isDirectory: e.type === "dir",
+    }));
   }
 }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -302,9 +302,9 @@ export class FileResource extends BaseResource<FileModel> {
   static async fetchByMountFilePaths(
     auth: Authenticator,
     mountFilePaths: string[]
-  ): Promise<Map<string, FileResource>> {
+  ): Promise<FileResource[]> {
     if (mountFilePaths.length === 0) {
-      return new Map();
+      return [];
     }
 
     const owner = auth.getNonNullableWorkspace();
@@ -315,15 +315,7 @@ export class FileResource extends BaseResource<FileModel> {
       },
     });
 
-    const result = new Map<string, FileResource>();
-    for (const f of files) {
-      const resource = new this(this.model, f.get());
-      if (resource.mountFilePath) {
-        result.set(resource.mountFilePath, resource);
-      }
-    }
-
-    return result;
+    return files.map((f) => new this(this.model, f.get()));
   }
 
   static async deleteAllForWorkspace(auth: Authenticator) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -299,6 +299,33 @@ export class FileResource extends BaseResource<FileModel> {
     return files.map((f) => new this(this.model, f.get()));
   }
 
+  static async fetchByMountFilePaths(
+    auth: Authenticator,
+    mountFilePaths: string[]
+  ): Promise<Map<string, FileResource>> {
+    if (mountFilePaths.length === 0) {
+      return new Map();
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const files = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        mountFilePath: { [Op.in]: mountFilePaths },
+      },
+    });
+
+    const result = new Map<string, FileResource>();
+    for (const f of files) {
+      const resource = new this(this.model, f.get());
+      if (resource.mountFilePath) {
+        result.set(resource.mountFilePath, resource);
+      }
+    }
+
+    return result;
+  }
+
   static async deleteAllForWorkspace(auth: Authenticator) {
     // Delete all shareable file records.
     await this.shareableFileModel.destroy({

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -3,6 +3,7 @@ import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
   ExecOptions,
   ExecResult,
+  FileEntry,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
@@ -22,6 +23,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -472,6 +474,33 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return result;
+  }
+
+  /**
+   * List files in a directory on this sandbox.
+   */
+  async listFiles(
+    path: string,
+    opts?: { recursive?: boolean }
+  ): Promise<Result<FileEntry[], Error>> {
+    const provider = getSandboxProvider();
+    if (!provider) {
+      return new Err(new Error("Sandbox provider not configured."));
+    }
+
+    try {
+      const entries = await provider.listFiles(this.providerId, path, opts);
+      return new Ok(entries);
+    } catch (err) {
+      if (err instanceof SandboxNotFoundError) {
+        logger.error(
+          { sandbox: this.toLogJSON() },
+          "Sandbox not found at provider during listFiles — marking as deleted"
+        );
+        await this.updateStatus("deleted");
+      }
+      return new Err(normalizeError(err));
+    }
   }
 
   toLogJSON() {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files.ts
@@ -1,14 +1,11 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { SandboxFileEntry } from "@app/lib/api/sandbox/files";
 import {
-  listSandboxFilesFromGCS,
-  listSandboxFilesFromProvider,
+  listSandboxFiles,
+  type SandboxFileEntry,
 } from "@app/lib/api/sandbox/files";
 import type { Authenticator } from "@app/lib/auth";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -17,7 +14,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type { SandboxFileEntry };
 
 export type GetConversationSandboxFilesResponseBody = {
-  sandboxStatus: SandboxStatus | null;
   files: SandboxFileEntry[];
 };
 
@@ -54,27 +50,9 @@ async function handler(
     return apiErrorForConversation(req, res, conversationRes.error);
   }
 
-  const sandbox = await SandboxResource.fetchByConversationId(auth, cId);
-  if (!sandbox) {
-    return res.status(200).json({ sandboxStatus: null, files: [] });
-  }
+  const files = await listSandboxFiles(auth, cId);
 
-  let files: SandboxFileEntry[];
-
-  switch (sandbox.status) {
-    case "running":
-    case "sleeping":
-      files = await listSandboxFilesFromProvider(sandbox);
-      break;
-    case "deleted":
-      files = await listSandboxFilesFromGCS(auth, cId);
-      break;
-  }
-
-  return res.status(200).json({
-    sandboxStatus: sandbox.status,
-    files,
-  });
+  return res.status(200).json({ files });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files.ts
@@ -1,0 +1,80 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { SandboxFileEntry } from "@app/lib/api/sandbox/files";
+import {
+  listSandboxFilesFromGCS,
+  listSandboxFilesFromProvider,
+} from "@app/lib/api/sandbox/files";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type { SandboxFileEntry };
+
+export type GetConversationSandboxFilesResponseBody = {
+  sandboxStatus: SandboxStatus | null;
+  files: SandboxFileEntry[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationSandboxFilesResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId } = req.query;
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationRes = await getConversation(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const sandbox = await SandboxResource.fetchByConversationId(auth, cId);
+  if (!sandbox) {
+    return res.status(200).json({ sandboxStatus: null, files: [] });
+  }
+
+  let files: SandboxFileEntry[];
+
+  switch (sandbox.status) {
+    case "running":
+    case "sleeping":
+      files = await listSandboxFilesFromProvider(sandbox);
+      break;
+    case "deleted":
+      files = await listSandboxFilesFromGCS(auth, cId);
+      break;
+  }
+
+  return res.status(200).json({
+    sandboxStatus: sandbox.status,
+    files,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -1,0 +1,56 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetConversationSandboxResponseBody = {
+  sandboxStatus: SandboxStatus | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationSandboxResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId } = req.query;
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationRes = await getConversation(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const sandbox = await SandboxResource.fetchByConversationId(auth, cId);
+
+  return res.status(200).json({
+    sandboxStatus: sandbox?.status ?? null,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/conversation_side_panel.ts
+++ b/front/types/conversation_side_panel.ts
@@ -4,11 +4,13 @@ export const FULL_SCREEN_HASH_PARAM = "fullScreen";
 
 export const AGENT_ACTIONS_SIDE_PANEL_TYPE = "actions";
 export const INTERACTIVE_CONTENT_SIDE_PANEL_TYPE = "interactive_content";
+export const FILES_SIDE_PANEL_TYPE = "files";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SIDE_PANEL_TYPES = [
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
+  FILES_SIDE_PANEL_TYPE,
 ] as const;
 
 export type ConversationSidePanelType =

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -265,6 +265,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable default skills discovery on global agents (do not enable for customers)",
     stage: "dust_only",
   },
+  sidepanel_files: {
+    description: "Show conversation files in a side panel instead of a popover",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -732,6 +732,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "xai_feature"
   | "conversations_slack_notifications"
   | "anthropic_reasoning_token_count"
+  | "sidepanel_files"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds a new "Files" side panel to conversations, gated behind the `sidepanel_files` feature flag. The panel shows two tabs when a sandbox exists: "Generated content" displays conversation attachments as cards, and "Sandbox" displays the sandbox filesystem as an interactive tree. When there is no sandbox, only the generated content view is shown.

The existing attachments popover is left untouched so both can be compared during the transition.

New API endpoint `GET /conversations/:cId/sandbox/files` lists sandbox files either from the live E2B filesystem (running/sleeping sandboxes) or from GCS (deleted sandboxes). The response includes sandbox status for a status chip in the panel header. Server-side filtering hides dot-prefixed files and systemd artifacts, and paths are normalized relative to the working directory.

The E2B provider's `listFiles` method is implemented (was a stub), returning entries with directory info for recursive listing. A new `FileResource.fetchByMountFilePaths` method supports the GCS fallback path.

The panel UI is split into focused files under `files_panel/`: orchestrator, generated content tab (card grid), sandbox tab (tree view), status chip, shared types, and utility functions.

<kbd>
<img width="822" height="400" alt="Screenshot 2026-03-13 at 09 25 41" src="https://github.com/user-attachments/assets/a2f17810-990f-47aa-bac3-8a759ade7f28" />
</kbd>
<kbd>
<img width="852" height="415" alt="Screenshot 2026-03-13 at 09 26 18" src="https://github.com/user-attachments/assets/810579a7-6c83-47ec-9c35-7d842e5ce2e8" />
</kbd>


## Tests

- Enable `sidepanel_files` flag on a workspace
- Open a conversation with no sandbox: verify the "Files" button appears, panel opens showing generated content cards
- Open a conversation with a sandbox: verify both tabs appear, sandbox tree shows files/folders correctly, status chip reflects sandbox state
- Click a file in either tab: verify preview opens for regular files and interactive content opens in its own panel
- Verify the existing attachments popover still works independently

## Risk

Technically can't break things since behind a FF. 

## Deploy Plan

Deploy front. 