### PR TITLE
fix: tool approval ui for chrome extension tools

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -224,6 +224,8 @@ export function AgentMessage({
                 metadata: eventPayload.data.metadata,
                 stake: eventPayload.data.stake,
                 userId: eventPayload.data.userId,
+                argumentsRequiringApproval:
+                  eventPayload.data.argumentsRequiringApproval,
               },
             });
             break;

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -416,11 +416,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           agentName: agentConfiguration.name,
           icon: action.toolConfiguration.icon,
         },
-        argumentsRequiringApproval: isLightServerSideMCPToolConfiguration(
-          action.toolConfiguration
-        )
-          ? action.toolConfiguration.argumentsRequiringApproval
-          : undefined,
+        argumentsRequiringApproval:
+          action.toolConfiguration.argumentsRequiringApproval,
       };
 
       if (action.status === "blocked_authentication_required") {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -6,7 +6,6 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { ToolInputContext } from "@app/lib/actions/tool_status";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
-import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
@@ -259,11 +258,8 @@ async function createActionForTool(
               agentName: agentConfiguration.name,
               icon: actionConfiguration.icon,
             },
-            argumentsRequiringApproval: isServerSideMCPToolConfiguration(
-              actionConfiguration
-            )
-              ? actionConfiguration.argumentsRequiringApproval
-              : undefined,
+            argumentsRequiringApproval:
+              actionConfiguration.argumentsRequiringApproval,
           }
         : undefined,
   };


### PR DESCRIPTION
## Description

This PR fixes the tool approval UI for Chrome extension tools by ensuring the `argumentsRequiringApproval` property is properly propagated across all MCP tool configurations.

- Removed conditional checks that were restricting `argumentsRequiringApproval` to only server-side MCP tool configurations as client-side tools now have that option too.
- Updated `AgentMessage.tsx` to include `argumentsRequiringApproval` in event payload data
- Changed tool action creation logic in `agent_mcp_action_resource.ts` and `create_tool_actions.ts` to always include the approval requirements regardless of tool type

<img width="825" height="857" alt="Capture d’écran 2026-03-13 à 10 17 01" src="https://github.com/user-attachments/assets/e3c8efd8-d071-4cba-aacc-ecca30fd39cb" />


## Tests

Manually

## Risks

Low - This change makes the approval arguments available to Chrome extension tools.

## Deploy Plan

Standard deployment - no special considerations needed.
