### PR TITLE
Rename extension client-side MCP tools

### DIFF
--- a/extension/platforms/chrome/tools/attachPageTextTool.ts
+++ b/extension/platforms/chrome/tools/attachPageTextTool.ts
@@ -5,10 +5,10 @@ import { normalizeError } from "@extension/shared/lib/utils";
 import type { CaptureService } from "@extension/shared/services/capture";
 
 /**
- * Registers the get-current-browser-page tool with the MCP server.
+ * Registers the attach_page_text tool with the MCP server.
  * Extracts the text content of a browser tab.
  */
-export async function getPageTool({
+export async function attachPageTextTool({
   tabId,
   captureService,
 }: {

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -3,20 +3,20 @@ import {
   buildClientTools,
   type ClientToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { getPageTool } from "@extension/platforms/chrome/tools/getCurrentPageTool";
-import type { CaptureService } from "@extension/shared/services/capture";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getCurrentTabInfoTool } from "./getCurrentTabInfo";
-import { getPageViewTool } from "./getPageViewTool";
-import { interactWithPageTool } from "./interactWithPageTool";
-import { listBrowserTabsTool } from "./listTabsTool";
+import { attachPageTextTool } from "@extension/platforms/chrome/tools/attachPageTextTool";
 import {
-  activateBrowserTabTool,
   closeBrowserTabTool,
   moveBrowserTabTool,
   openBrowserTab,
   reloadBrowserTabTool,
-} from "./tabActionTools";
+  switchBrowserTabTool,
+} from "@extension/platforms/chrome/tools/tabActionTools";
+import { takeScreenshotOrAttachFileTool } from "@extension/platforms/chrome/tools/takeScreenshotOrAttachFileTool";
+import type { CaptureService } from "@extension/shared/services/capture";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getCurrentTabInfoTool } from "./getCurrentTabInfo";
+import { interactWithPageTool } from "./interactWithPageTool";
+import { listBrowserTabsTool } from "./listTabsTool";
 
 /**
  * Registers all Chrome MCP tools with the server
@@ -29,12 +29,17 @@ export function registerAllTools(
   workspaceId: string
 ): void {
   const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
-    get_browser_page: (params) => getPageTool({ ...params, captureService }),
-    get_browser_page_view: (params) =>
-      getPageViewTool({ ...params, captureService, workspaceId }),
+    attach_page_text: (params) =>
+      attachPageTextTool({ ...params, captureService }),
+    take_screenshot_or_attach_file: (params) =>
+      takeScreenshotOrAttachFileTool({
+        ...params,
+        captureService,
+        workspaceId,
+      }),
     list_browser_tabs: () => listBrowserTabsTool(),
     get_current_tab_info: () => getCurrentTabInfoTool(),
-    activate_browser_tab: (params) => activateBrowserTabTool(params),
+    switch_to_browser_tab: (params) => switchBrowserTabTool(params),
     close_browser_tab: (params) => closeBrowserTabTool(params),
     move_browser_tab: (params) => moveBrowserTabTool(params),
     open_browser_tab: (params) => openBrowserTab(params),

--- a/extension/platforms/chrome/tools/tabActionTools.ts
+++ b/extension/platforms/chrome/tools/tabActionTools.ts
@@ -4,11 +4,9 @@ import { Err, Ok } from "@app/types/shared/result";
 import { sendTabActionMessage } from "@extension/platforms/chrome/messages";
 import { normalizeError } from "@extension/shared/lib/utils";
 
-/**
- * Registers tab manipulation tools with the MCP server.
- */
+// Registers tab manipulation tools with the MCP server.
 
-export async function activateBrowserTabTool({
+export async function switchBrowserTabTool({
   tabId,
 }: {
   tabId: number;

--- a/extension/platforms/chrome/tools/takeScreenshotOrAttachFileTool.ts
+++ b/extension/platforms/chrome/tools/takeScreenshotOrAttachFileTool.ts
@@ -100,10 +100,10 @@ async function uploadPdf(
 }
 
 /**
- * Registers the get-current-browser-page-view tool with the MCP server.
+ * Registers the take_screenshot_or_attach_file tool with the MCP server.
  * Captures a screenshot or attaches the file content of a browser tab.
  */
-export async function getPageViewTool({
+export async function takeScreenshotOrAttachFileTool({
   tabId,
   captureService,
   workspaceId,

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -2,11 +2,11 @@ import { createClientToolsRecord } from "@app/lib/actions/mcp_internal_actions/t
 import { z } from "zod";
 
 export const CHROME_TOOLS_METADATA = createClientToolsRecord({
-  get_browser_page: {
+  attach_page_text: {
     description:
       "Extracts the title, URL, and text content of a browser tab. " +
       "Use this to read and understand what the user is viewing. " +
-      "For non-text pages (PDFs, images, etc.), use get_browser_page_view instead — it will attach the file directly to the conversation." +
+      "For non-text pages (PDFs, images, etc.), use take_screenshot_or_attach_file instead — it will attach the file directly to the conversation." +
       "Use list_browser_tabs to discover tab IDs.",
     schema: {
       tabId: z.number().describe("The tab ID to read."),
@@ -18,7 +18,7 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Page content retrieved",
     },
   },
-  get_browser_page_view: {
+  take_screenshot_or_attach_file: {
     description:
       "Captures or attaches the content of a browser tab. " +
       "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
@@ -39,7 +39,7 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     description:
       "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
       "Use this to discover which tabs the user has open. " +
-      "Tab IDs can be passed to get_browser_page or get_browser_page_view to read a specific tab.",
+      "Tab IDs can be passed to attach_page_text or take_screenshot_or_attach_file to read a specific tab.",
     schema: {},
     stake: "low",
     displayLabels: {
@@ -58,7 +58,7 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Current tab info retrieved",
     },
   },
-  activate_browser_tab: {
+  switch_to_browser_tab: {
     description:
       "Switches to the specified browser tab, making it the active tab. " +
       "Use list_browser_tabs to discover tab IDs.",


### PR DESCRIPTION
## Description

This PR renames Chrome extension client-side MCP tools to improve clarity and consistency. The changes affect tool names, file names, and descriptions:

- `get_browser_page` → `attach_page_text`
- `get_browser_page_view` → `take_screenshot_or_attach_file`
- `activate_browser_tab` → `switch_to_browser_tab`

The new names better reflect what each tool does and align with user-facing actions in the extension UI.

## Tests

No functional changes — this is a pure rename. Existing manual testing of Chrome extension MCP tools covers these renamed tools.

## Risk

Low. The tools are client-side only and were recently introduced. The renaming maintains the same functionality and parameter schemas.

## Deploy Plan

Deploy front + extension.