### PR TITLE
[front] - feat(RA): notification system [1/2]

### DIFF
--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -1,0 +1,157 @@
+import { getEditors } from "@app/lib/api/assistant/editors";
+import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import { getNovuClient } from "@app/lib/notifications";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
+import logger from "@app/logger/logger";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { AGENT_SUGGESTIONS_READY_TRIGGER_ID } from "@app/types/notification_preferences";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const AgentSuggestionsReadyPayloadSchema = z.object({
+  workspaceId: z.string(),
+  agentConfigurationId: z.string(),
+  agentName: z.string(),
+  suggestionCount: z.number(),
+});
+
+type AgentSuggestionsReadyPayloadType = z.infer<
+  typeof AgentSuggestionsReadyPayloadSchema
+>;
+
+export const agentSuggestionsReadyWorkflow = workflow(
+  AGENT_SUGGESTIONS_READY_TRIGGER_ID,
+  async ({ step, payload }) => {
+    await step.inApp("send-in-app", async () => {
+      const countLabel =
+        payload.suggestionCount === 1
+          ? "1 suggestion"
+          : `${payload.suggestionCount} suggestions`;
+
+      return {
+        subject: `@${payload.agentName}`,
+        body: `New improvement suggestions are ready for review (${countLabel}).`,
+        primaryAction: {
+          label: "Review",
+          redirect: {
+            url: getAgentBuilderRoute(
+              payload.workspaceId,
+              payload.agentConfigurationId
+            ),
+          },
+        },
+        data: {
+          autoDelete: true,
+        },
+      };
+    });
+  },
+  {
+    payloadSchema: AgentSuggestionsReadyPayloadSchema,
+    tags: ["admin"],
+  }
+);
+
+export const triggerAgentSuggestionsReadyNotifications = async (
+  auth: Authenticator,
+  {
+    agentConfiguration,
+    suggestionCount,
+  }: {
+    agentConfiguration: LightAgentConfigurationType;
+    suggestionCount: number;
+  }
+): Promise<Result<void, DustError<"internal_error">>> => {
+  if (suggestionCount === 0) {
+    return new Ok(undefined);
+  }
+
+  const editors = await getEditors(auth, agentConfiguration);
+
+  if (editors.length === 0) {
+    logger.info(
+      { agentConfigurationId: agentConfiguration.sId },
+      "No editors found for agent, skipping suggestions ready notification"
+    );
+    return new Ok(undefined);
+  }
+
+  try {
+    const novuClient = await getNovuClient();
+
+    const payload: AgentSuggestionsReadyPayloadType = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      agentConfigurationId: agentConfiguration.sId,
+      agentName: agentConfiguration.name,
+      suggestionCount,
+    };
+
+    const r = await novuClient.triggerBulk({
+      events: editors.map((editor) => ({
+        workflowId: AGENT_SUGGESTIONS_READY_TRIGGER_ID,
+        to: {
+          subscriberId: editor.sId,
+          email: editor.email,
+          firstName: editor.firstName ?? undefined,
+          lastName: editor.lastName ?? undefined,
+        },
+        payload,
+      })),
+    });
+
+    if (r.result.some((res) => !!res.error?.length)) {
+      const eventErrors = r.result
+        .filter((res) => !!res.error?.length)
+        .map(({ error }) => error?.join("; "))
+        .join("; ");
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: `Failed to trigger agent suggestions ready notification: ${eventErrors}`,
+      });
+    }
+  } catch (err) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: "Failed to trigger agent suggestions ready notification",
+      cause: normalizeError(err),
+    });
+  }
+
+  return new Ok(undefined);
+};
+
+/**
+ * Fire-and-forget helper to notify agent editors that reinforcement suggestions are ready.
+ * Errors are logged but don't block the caller.
+ */
+export function notifyAgentSuggestionsReady(
+  auth: Authenticator,
+  {
+    agentConfiguration,
+    suggestionCount,
+  }: {
+    agentConfiguration: LightAgentConfigurationType;
+    suggestionCount: number;
+  }
+): void {
+  void triggerAgentSuggestionsReadyNotifications(auth, {
+    agentConfiguration,
+    suggestionCount,
+  }).then((notifRes) => {
+    if (notifRes.isErr()) {
+      logger.error(
+        {
+          error: notifRes.error,
+          agentConfigurationId: agentConfiguration.sId,
+        },
+        "Failed to trigger agent suggestions ready notification"
+      );
+    }
+  });
+}

--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -44,7 +44,9 @@ export const agentSuggestionsReadyWorkflow = workflow(
             ),
           },
         },
-        data: {},
+        data: {
+          autoDelete: true,
+        },
       };
     });
   },

--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -44,9 +44,7 @@ export const agentSuggestionsReadyWorkflow = workflow(
             ),
           },
         },
-        data: {
-          autoDelete: true,
-        },
+        data: {},
       };
     });
   },

--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -9,6 +9,7 @@ import { AGENT_SUGGESTIONS_READY_TRIGGER_ID } from "@app/types/notification_pref
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import { workflow } from "@novu/framework";
 import z from "zod";
 
@@ -27,14 +28,9 @@ export const agentSuggestionsReadyWorkflow = workflow(
   AGENT_SUGGESTIONS_READY_TRIGGER_ID,
   async ({ step, payload }) => {
     await step.inApp("send-in-app", async () => {
-      const countLabel =
-        payload.suggestionCount === 1
-          ? "1 suggestion"
-          : `${payload.suggestionCount} suggestions`;
-
       return {
         subject: `@${payload.agentName}`,
-        body: `New improvement suggestions are ready for review (${countLabel}).`,
+        body: `${payload.suggestionCount} new improvement suggestion${pluralize(payload.suggestionCount)} ready for review.`,
         primaryAction: {
           label: "Review",
           redirect: {

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -1,6 +1,7 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import {
   buildReinforcedLLMParams,
   runReinforcedAnalysis,
@@ -138,6 +139,13 @@ export async function aggregateSyntheticSuggestions(
     operationType: "reinforced_agent_aggregate_suggestions",
     contextId: "n/a",
   });
+
+  if (createdCount > 0) {
+    notifyAgentSuggestionsReady(auth, {
+      agentConfiguration: agentConfig,
+      suggestionCount: createdCount,
+    });
+  }
 
   await AgentSuggestionResource.bulkUpdateState(
     auth,

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -1,4 +1,5 @@
 import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
+import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { projectNewConversationWorkflow } from "@app/lib/notifications/workflows/project-new-conversation";
@@ -13,6 +14,7 @@ export default serve({
   workflows: [
     conversationUnreadWorkflow,
     agentMessageFeedbackWorkflow,
+    agentSuggestionsReadyWorkflow,
     projectAddedAsMemberWorkflow,
     projectNewConversationWorkflow,
   ],

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -121,8 +121,11 @@ export const PROJECT_ADDED_AS_MEMBER_TRIGGER_ID =
   "project-added-as-member" as const;
 export const PROJECT_NEW_CONVERSATION_TRIGGER_ID =
   "project-new-conversation" as const;
+export const AGENT_SUGGESTIONS_READY_TRIGGER_ID =
+  "agent-suggestions-ready" as const;
 
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
-  | typeof PROJECT_NEW_CONVERSATION_TRIGGER_ID;
+  | typeof PROJECT_NEW_CONVERSATION_TRIGGER_ID
+  | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID;


### PR DESCRIPTION
## Description

This PR implements in-app notifications for agent editors when reinforcement suggestions are ready for review. When the reinforced agent background system aggregates synthetic suggestions into user-facing recommendations, editors now receive a notification linking them directly to the agent builder page. The notification uses a fire-and-forget pattern to avoid blocking the aggregation workflow.

## Tests

- [x] Locally

## Risk

Low

## Deploy Plan

Deploy front
