### PR TITLE
[MCP] Distinguish admin setup from reconnect errors

### DIFF
--- a/front/lib/actions/mcp_authentication.test.ts
+++ b/front/lib/actions/mcp_authentication.test.ts
@@ -1,0 +1,41 @@
+import {
+  getMCPServerAdminAuthenticationReason,
+  MCPServerRequiresAdminAuthenticationError,
+} from "@app/lib/actions/mcp_authentication";
+import { DustError } from "@app/lib/error";
+import { describe, expect, it } from "vitest";
+
+describe("MCP admin authentication mapping", () => {
+  it("maps a missing workspace connection to setup", () => {
+    const reason = getMCPServerAdminAuthenticationReason(
+      new DustError("connection_not_found", "Connection not found")
+    );
+    const error = new MCPServerRequiresAdminAuthenticationError(
+      "ims_test",
+      "jira",
+      undefined,
+      reason
+    );
+
+    expect(reason).toBe("setup");
+    expect(error.message).toContain("set up the workspace connection");
+  });
+
+  it("maps a broken workspace token to reconnect", () => {
+    const reason = getMCPServerAdminAuthenticationReason(
+      new DustError(
+        "mcp_access_token_error",
+        "Failed to get access token for MCP server"
+      )
+    );
+    const error = new MCPServerRequiresAdminAuthenticationError(
+      "ims_test",
+      "jira",
+      undefined,
+      reason
+    );
+
+    expect(reason).toBe("reconnect");
+    expect(error.message).toContain("reconnect the workspace connection");
+  });
+});

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -9,6 +9,8 @@ import type { OAuthConnectionType, OAuthProvider } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+export type MCPServerAdminAuthenticationReason = "setup" | "reconnect";
+
 // Dedicated function to get the connection details for an MCP server.
 // Not using the one from mcp_metadata.ts to avoid circular dependency.
 export async function getConnectionForMCPServer(
@@ -128,15 +130,24 @@ export class MCPServerRequiresAdminAuthenticationError extends Error {
   mcpServerId: string;
   provider: OAuthProvider;
   scope?: string;
+  reason: MCPServerAdminAuthenticationReason;
 
-  constructor(mcpServerId: string, provider: OAuthProvider, scope?: string) {
+  constructor(
+    mcpServerId: string,
+    provider: OAuthProvider,
+    scope?: string,
+    reason: MCPServerAdminAuthenticationReason = "setup"
+  ) {
     super(
-      `MCP server ${mcpServerId} requires your admin(s) to setup or reconnect the workspace connection on Dust.`
+      reason === "setup"
+        ? `MCP server ${mcpServerId} requires your admin(s) to set up the workspace connection on Dust.`
+        : `MCP server ${mcpServerId} requires your admin(s) to reconnect the workspace connection on Dust.`
     );
     this.name = MCPServerRequiresAdminAuthenticationErrorName;
     this.mcpServerId = mcpServerId;
     this.provider = provider;
     this.scope = scope;
+    this.reason = reason;
   }
 
   static is(
@@ -148,4 +159,10 @@ export class MCPServerRequiresAdminAuthenticationError extends Error {
       "mcpServerId" in error
     );
   }
+}
+
+export function getMCPServerAdminAuthenticationReason(
+  error: DustError<"mcp_access_token_error" | "connection_not_found">
+): MCPServerAdminAuthenticationReason {
+  return error.code === "connection_not_found" ? "setup" : "reconnect";
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/actions/constants";
 import {
   getConnectionForMCPServer,
+  getMCPServerAdminAuthenticationReason,
   MCPServerPersonalAuthenticationRequiredError,
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
@@ -282,7 +283,8 @@ async function resolveRemoteServerOAuthToken(
           new MCPServerRequiresAdminAuthenticationError(
             mcpServerId,
             provider,
-            scope
+            scope,
+            "setup"
           )
         );
       }
@@ -299,7 +301,8 @@ async function resolveRemoteServerOAuthToken(
         new MCPServerRequiresAdminAuthenticationError(
           mcpServerId,
           provider,
-          scope
+          scope,
+          getMCPServerAdminAuthenticationReason(c.error)
         )
       );
     default:
@@ -446,7 +449,7 @@ export async function connectToMCPServer(
                     oAuthUseCase: params.oAuthUseCase,
                     error: c.error,
                   },
-                  "Internal server requires workspace authentication but no connection found"
+                  "Internal server workspace authentication failed"
                 );
 
                 const scope = serverInfo.authorization.scope;
@@ -468,7 +471,8 @@ export async function connectToMCPServer(
                       new MCPServerRequiresAdminAuthenticationError(
                         params.mcpServerId,
                         serverInfo.authorization.provider,
-                        scope
+                        scope,
+                        "setup"
                       )
                     );
                   }
@@ -480,12 +484,13 @@ export async function connectToMCPServer(
                     )
                   );
                 } else if (params.oAuthUseCase === "platform_actions") {
-                  // Workspace connection required — admin must set up or reconnect.
+                  // Workspace connection required — distinguish missing setup from a broken token.
                   return new Err(
                     new MCPServerRequiresAdminAuthenticationError(
                       params.mcpServerId,
                       serverInfo.authorization.provider,
-                      scope
+                      scope,
+                      getMCPServerAdminAuthenticationReason(c.error)
                     )
                   );
                 } else {
@@ -568,7 +573,8 @@ export async function connectToMCPServer(
                 new MCPServerRequiresAdminAuthenticationError(
                   params.mcpServerId,
                   remoteMCPServer.authorization.provider,
-                  scope
+                  scope,
+                  "reconnect"
                 )
               );
             }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6591

Distinguish missing workspace MCP auth from broken workspace auth when mapping admin-facing errors.
For internal and remote servers, `connection_not_found` now points to admin setup, while `mcp_access_token_error` points to admin reconnect.

## Risks
Blast radius: MCP tool execution errors for workspace-scoped OAuth connections
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `cd front && NODE_ENV=test npm test lib/actions/mcp_authentication.test.ts`