### PR TITLE
[OAuth] Harden Jira refresh failures

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -34,21 +34,24 @@ use tracing::{error, info};
 
 use super::{credential::Credential, providers::utils::ProviderHttpRequestError};
 
-// We hold the lock for at most 20s. In case of panic preventing the lock from being released, this
-// is the maximum time the lock will be held.
-static REDIS_LOCK_TTL_SECONDS: u64 = 20;
 // Default timeout for provider token operations. Some providers may override this.
 // To ensure we don't write without holding the lock providers must comply to this timeout when
 // operating on tokens.
 pub static PROVIDER_TIMEOUT_SECONDS: u64 = 10;
+pub static ATLASSIAN_PROVIDER_TIMEOUT_SECONDS: u64 = 15;
+pub static JIRA_PROVIDER_TIMEOUT_SECONDS: u64 = 30;
+// We hold the lock long enough for the slowest provider timeout plus secret persistence.
+static REDIS_LOCK_TTL_BUFFER_SECONDS: u64 = 10;
+static REDIS_LOCK_TTL_SECONDS: u64 = JIRA_PROVIDER_TIMEOUT_SECONDS + REDIS_LOCK_TTL_BUFFER_SECONDS;
 
 /// Returns the timeout in seconds for a specific provider's token operations.
-/// Some providers (e.g., Atlassian) have slower auth servers and need longer timeouts.
+/// Some providers have slower auth servers and need longer timeouts.
 pub fn provider_timeout_seconds(provider: ConnectionProvider) -> u64 {
     match provider {
-        ConnectionProvider::Jira
-        | ConnectionProvider::Confluence
-        | ConnectionProvider::ConfluenceTools => 15,
+        ConnectionProvider::Jira => JIRA_PROVIDER_TIMEOUT_SECONDS,
+        ConnectionProvider::Confluence | ConnectionProvider::ConfluenceTools => {
+            ATLASSIAN_PROVIDER_TIMEOUT_SECONDS
+        }
         _ => PROVIDER_TIMEOUT_SECONDS,
     }
 }
@@ -107,6 +110,30 @@ impl fmt::Display for ConnectionError {
 }
 
 impl std::error::Error for ConnectionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        provider_timeout_seconds, ConnectionProvider, ATLASSIAN_PROVIDER_TIMEOUT_SECONDS,
+        JIRA_PROVIDER_TIMEOUT_SECONDS, PROVIDER_TIMEOUT_SECONDS,
+    };
+
+    #[test]
+    fn provider_timeout_seconds_uses_jira_override() {
+        assert_eq!(
+            provider_timeout_seconds(ConnectionProvider::Jira),
+            JIRA_PROVIDER_TIMEOUT_SECONDS
+        );
+        assert_eq!(
+            provider_timeout_seconds(ConnectionProvider::Confluence),
+            ATLASSIAN_PROVIDER_TIMEOUT_SECONDS
+        );
+        assert_eq!(
+            provider_timeout_seconds(ConnectionProvider::Github),
+            PROVIDER_TIMEOUT_SECONDS
+        );
+    }
+}
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -111,30 +111,6 @@ impl fmt::Display for ConnectionError {
 
 impl std::error::Error for ConnectionError {}
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        provider_timeout_seconds, ConnectionProvider, ATLASSIAN_PROVIDER_TIMEOUT_SECONDS,
-        JIRA_PROVIDER_TIMEOUT_SECONDS, PROVIDER_TIMEOUT_SECONDS,
-    };
-
-    #[test]
-    fn provider_timeout_seconds_uses_jira_override() {
-        assert_eq!(
-            provider_timeout_seconds(ConnectionProvider::Jira),
-            JIRA_PROVIDER_TIMEOUT_SECONDS
-        );
-        assert_eq!(
-            provider_timeout_seconds(ConnectionProvider::Confluence),
-            ATLASSIAN_PROVIDER_TIMEOUT_SECONDS
-        );
-        assert_eq!(
-            provider_timeout_seconds(ConnectionProvider::Github),
-            PROVIDER_TIMEOUT_SECONDS
-        );
-    }
-}
-
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionProvider {

--- a/core/src/oauth/providers/jira.rs
+++ b/core/src/oauth/providers/jira.rs
@@ -35,6 +35,23 @@ impl JiraConnectionProvider {
     pub fn new() -> Self {
         JiraConnectionProvider {}
     }
+
+    fn handle_refresh_request_error(&self, error: ProviderHttpRequestError) -> ProviderError {
+        match &error {
+            ProviderHttpRequestError::RequestFailed {
+                status, message, ..
+            } => {
+                let is_revoked = is_jira_refresh_token_revoked(*status, message);
+                info!(message, is_revoked, status, "JIRA refresh OAuth error");
+                if is_revoked {
+                    ProviderError::TokenRevokedError
+                } else {
+                    self.default_handle_provider_request_error(error)
+                }
+            }
+            _ => self.default_handle_provider_request_error(error),
+        }
+    }
 }
 
 fn is_jira_refresh_token_revoked(status: u16, message: &str) -> bool {
@@ -80,7 +97,7 @@ impl Provider for JiraConnectionProvider {
 
         let raw_json = execute_request(ConnectionProvider::Jira, req)
             .await
-            .map_err(|e| self.handle_provider_request_error(e))?;
+            .map_err(|e| self.default_handle_provider_request_error(e))?;
 
         let access_token = match raw_json["access_token"].as_str() {
             Some(token) => token,
@@ -142,7 +159,7 @@ impl Provider for JiraConnectionProvider {
 
         let raw_json = execute_request(ConnectionProvider::Jira, req)
             .await
-            .map_err(|e| self.handle_provider_request_error(e))?;
+            .map_err(|e| self.handle_refresh_request_error(e))?;
 
         let access_token = match raw_json["access_token"].as_str() {
             Some(token) => token,
@@ -193,27 +210,6 @@ impl Provider for JiraConnectionProvider {
         };
         Ok(raw_json)
     }
-
-    fn handle_provider_request_error(&self, error: ProviderHttpRequestError) -> ProviderError {
-        match &error {
-            ProviderHttpRequestError::RequestFailed {
-                status, message, ..
-            } => {
-                let is_revoked = is_jira_refresh_token_revoked(*status, message);
-                info!(message, is_revoked, status, "JIRA OAuth error");
-                if is_revoked {
-                    ProviderError::TokenRevokedError
-                } else {
-                    // Call the default implementation for non-revocation errors.
-                    self.default_handle_provider_request_error(error)
-                }
-            }
-            _ => {
-                // Call the default implementation for other cases.
-                self.default_handle_provider_request_error(error)
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -248,12 +244,25 @@ mod tests {
     fn maps_revoked_refresh_failures_to_token_revoked_error() {
         let provider = JiraConnectionProvider::new();
         let error =
-            provider.handle_provider_request_error(ProviderHttpRequestError::RequestFailed {
+            provider.handle_refresh_request_error(ProviderHttpRequestError::RequestFailed {
                 provider: ConnectionProvider::Jira,
                 status: 400,
                 message: "invalid_grant".to_string(),
             });
 
         assert!(matches!(error, ProviderError::TokenRevokedError));
+    }
+
+    #[test]
+    fn finalize_invalid_grant_stays_generic() {
+        let provider = JiraConnectionProvider::new();
+        let error =
+            provider.handle_provider_request_error(ProviderHttpRequestError::RequestFailed {
+                provider: ConnectionProvider::Jira,
+                status: 400,
+                message: "invalid_grant".to_string(),
+            });
+
+        assert!(!matches!(error, ProviderError::TokenRevokedError));
     }
 }

--- a/core/src/oauth/providers/jira.rs
+++ b/core/src/oauth/providers/jira.rs
@@ -1,8 +1,8 @@
 use crate::{
     oauth::{
         connection::{
-            Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
-            PROVIDER_TIMEOUT_SECONDS,
+            provider_timeout_seconds, Connection, ConnectionProvider, FinalizeResult, Provider,
+            ProviderError, RefreshResult,
         },
         credential::Credential,
         providers::utils::execute_request,
@@ -23,12 +23,31 @@ lazy_static! {
     static ref OAUTH_JIRA_CLIENT_SECRET: String = env::var("OAUTH_JIRA_CLIENT_SECRET").unwrap();
 }
 
+const JIRA_INVALID_GRANT_FRAGMENT: &str = "invalid_grant";
+const JIRA_INVALID_REFRESH_TOKEN_FRAGMENT: &str = "refresh_token is invalid";
+const JIRA_INVALID_REFRESH_TOKEN_WITH_SPACES_FRAGMENT: &str = "refresh token is invalid";
+const JIRA_INVALID_REFRESH_TOKEN_GENERIC_FRAGMENT: &str = "invalid refresh token";
+const JIRA_GLOBAL_REVOCATION_FRAGMENT: &str = "globally revoked";
+
 pub struct JiraConnectionProvider {}
 
 impl JiraConnectionProvider {
     pub fn new() -> Self {
         JiraConnectionProvider {}
     }
+}
+
+fn is_jira_refresh_token_revoked(status: u16, message: &str) -> bool {
+    if !matches!(status, 400 | 401 | 403) {
+        return false;
+    }
+
+    let message = message.to_lowercase();
+    message.contains(JIRA_INVALID_GRANT_FRAGMENT)
+        || message.contains(JIRA_INVALID_REFRESH_TOKEN_FRAGMENT)
+        || message.contains(JIRA_INVALID_REFRESH_TOKEN_WITH_SPACES_FRAGMENT)
+        || message.contains(JIRA_INVALID_REFRESH_TOKEN_GENERIC_FRAGMENT)
+        || message.contains(JIRA_GLOBAL_REVOCATION_FRAGMENT)
 }
 
 /// JIRA documentation: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
@@ -86,7 +105,8 @@ impl Provider for JiraConnectionProvider {
             code: code.to_string(),
             access_token: access_token.to_string(),
             access_token_expiry: Some(
-                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+                utils::now()
+                    + (expires_in - provider_timeout_seconds(ConnectionProvider::Jira)) * 1000,
             ),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
@@ -152,7 +172,8 @@ impl Provider for JiraConnectionProvider {
         Ok(RefreshResult {
             access_token: access_token.to_string(),
             access_token_expiry: Some(
-                utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
+                utils::now()
+                    + (expires_in - provider_timeout_seconds(ConnectionProvider::Jira)) * 1000,
             ),
             refresh_token: Some(final_refresh_token),
             raw_json,
@@ -177,13 +198,13 @@ impl Provider for JiraConnectionProvider {
         match &error {
             ProviderHttpRequestError::RequestFailed {
                 status, message, ..
-            } if *status == 403 => {
-                let is_revoked = message.contains("refresh_token is invalid");
-                info!(message, is_revoked, "JIRA 403 error");
+            } => {
+                let is_revoked = is_jira_refresh_token_revoked(*status, message);
+                info!(message, is_revoked, status, "JIRA OAuth error");
                 if is_revoked {
                     ProviderError::TokenRevokedError
                 } else {
-                    // Call the default implementation for other 403 errors.
+                    // Call the default implementation for non-revocation errors.
                     self.default_handle_provider_request_error(error)
                 }
             }
@@ -192,5 +213,47 @@ impl Provider for JiraConnectionProvider {
                 self.default_handle_provider_request_error(error)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_jira_refresh_token_revoked, JiraConnectionProvider};
+    use crate::oauth::{
+        connection::{ConnectionProvider, Provider, ProviderError},
+        providers::utils::ProviderHttpRequestError,
+    };
+
+    #[test]
+    fn detects_jira_revoked_refresh_token_errors() {
+        assert!(is_jira_refresh_token_revoked(400, "invalid_grant"));
+        assert!(is_jira_refresh_token_revoked(
+            403,
+            "refresh_token is invalid"
+        ));
+        assert!(is_jira_refresh_token_revoked(
+            403,
+            "Token was globally revoked"
+        ));
+        assert!(is_jira_refresh_token_revoked(401, "invalid refresh token"));
+    }
+
+    #[test]
+    fn ignores_non_revocation_errors() {
+        assert!(!is_jira_refresh_token_revoked(403, "rate limit exceeded"));
+        assert!(!is_jira_refresh_token_revoked(500, "invalid_grant"));
+    }
+
+    #[test]
+    fn maps_revoked_refresh_failures_to_token_revoked_error() {
+        let provider = JiraConnectionProvider::new();
+        let error =
+            provider.handle_provider_request_error(ProviderHttpRequestError::RequestFailed {
+                provider: ConnectionProvider::Jira,
+                status: 400,
+                message: "invalid_grant".to_string(),
+            });
+
+        assert!(matches!(error, ProviderError::TokenRevokedError));
     }
 }


### PR DESCRIPTION
## Description
Context: https://github.com/dust-tt/tasks/issues/6591
Follows https://github.com/dust-tt/dust/pull/22933

Harden Jira OAuth refresh handling in core by increasing the Jira token-operation timeout, keeping the access-token expiry buffer aligned with that timeout, and classifying more revoked refresh-token responses as `token_revoked_error` instead of generic refresh failures.

## Risks
Blast radius: Jira OAuth access-token refresh in oauth
Risk: low

## Deploy Plan
- deploy oauth

## Test
- [x] `cd core && cargo test detects_jira_revoked_refresh_token_errors`
- [x] `cd core && cargo test maps_revoked_refresh_failures_to_token_revoked_error`
- [x] `cd core && cargo test finalize_invalid_grant_stays_generic`
- [x] `cd core && cargo test ignores_non_revocation_errors`