### PR TITLE
[BYOK] Fix auto-save provider selection on toggle

### DIFF
--- a/front/components/pages/workspace/model_providers/AllProvidersToggle.tsx
+++ b/front/components/pages/workspace/model_providers/AllProvidersToggle.tsx
@@ -1,17 +1,14 @@
-import {
-  ALL_PROVIDERS_SELECTED,
-  type ProvidersSelection,
-} from "@app/types/provider_selection";
+import type { ProvidersSelection } from "@app/types/provider_selection";
 import { SliderToggle } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 interface AllProvidersToggleProps {
-  setProvidersSelection: (states: ProvidersSelection) => void;
+  onSelectAll: () => void;
   providersSelection: ProvidersSelection;
 }
 
 export function AllProvidersToggle({
-  setProvidersSelection,
+  onSelectAll,
   providersSelection,
 }: AllProvidersToggleProps) {
   const selected = useMemo(
@@ -29,9 +26,7 @@ export function AllProvidersToggle({
           size="xs"
           selected={selected}
           disabled={selected}
-          onClick={() => {
-            setProvidersSelection(ALL_PROVIDERS_SELECTED);
-          }}
+          onClick={onSelectAll}
         />
       </div>
     </div>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -6,9 +6,10 @@ import { BrainIcon, Page } from "@dust-tt/sparkle";
 
 export function ModelProvidersPage() {
   const owner = useWorkspace();
-  const { workspace, isWorkspaceValidating } = useWorkspaceDetails({ owner });
-  const { providersSelection, setProvidersSelection } =
-    useProvidersSelection(workspace);
+  const { workspace, isWorkspaceValidating, mutateWorkspace } =
+    useWorkspaceDetails({ owner });
+  const { providersSelection, setProvidersSelection, toggleProvider } =
+    useProvidersSelection(workspace, owner, mutateWorkspace);
 
   return (
     <Page.Vertical align="stretch" gap="xl">
@@ -24,6 +25,7 @@ export function ModelProvidersPage() {
             setProvidersSelection={setProvidersSelection}
             providersSelection={providersSelection}
             isWorkspaceValidating={isWorkspaceValidating}
+            onToggleProvider={toggleProvider}
           />
         )}
       </Page.Vertical>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -8,7 +8,7 @@ export function ModelProvidersPage() {
   const owner = useWorkspace();
   const { workspace, isWorkspaceValidating, mutateWorkspace } =
     useWorkspaceDetails({ owner });
-  const { providersSelection, setProvidersSelection, toggleProvider } =
+  const { providersSelection, toggleProvider, selectAllProviders } =
     useProvidersSelection(workspace, owner, mutateWorkspace);
 
   return (
@@ -22,10 +22,10 @@ export function ModelProvidersPage() {
         {workspace && (
           <ModelProvidersPageContent
             workspace={workspace}
-            setProvidersSelection={setProvidersSelection}
             providersSelection={providersSelection}
             isWorkspaceValidating={isWorkspaceValidating}
             onToggleProvider={toggleProvider}
+            onSelectAllProviders={selectAllProviders}
           />
         )}
       </Page.Vertical>

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -17,22 +17,21 @@ import type { WorkspaceType } from "@app/types/user";
 import groupBy from "lodash/groupBy";
 import mapValues from "lodash/mapValues";
 import uniqBy from "lodash/uniqBy";
-import type { Dispatch, SetStateAction } from "react";
 
 interface ModelProvidersPageContentProps {
   workspace: WorkspaceType;
-  setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
   providersSelection: ProvidersSelection;
   isWorkspaceValidating: boolean;
   onToggleProvider: (provider: ModelProviderIdType) => void;
+  onSelectAllProviders: () => void;
 }
 
 export function ModelProvidersPageContent({
   workspace,
-  setProvidersSelection,
   providersSelection,
   isWorkspaceValidating,
   onToggleProvider,
+  onSelectAllProviders,
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
@@ -65,7 +64,7 @@ export function ModelProvidersPageContent({
         <>
           <AllProvidersToggle
             providersSelection={providersSelection}
-            setProvidersSelection={setProvidersSelection}
+            onSelectAll={onSelectAllProviders}
           />
           <ProvidersToggleList
             providersSelection={providersSelection}

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -24,6 +24,7 @@ interface ModelProvidersPageContentProps {
   setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
   providersSelection: ProvidersSelection;
   isWorkspaceValidating: boolean;
+  onToggleProvider: (provider: ModelProviderIdType) => void;
 }
 
 export function ModelProvidersPageContent({
@@ -31,6 +32,7 @@ export function ModelProvidersPageContent({
   setProvidersSelection,
   providersSelection,
   isWorkspaceValidating,
+  onToggleProvider,
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
@@ -67,7 +69,7 @@ export function ModelProvidersPageContent({
           />
           <ProvidersToggleList
             providersSelection={providersSelection}
-            setProvidersSelection={setProvidersSelection}
+            onToggleProvider={onToggleProvider}
             isWorkspaceValidating={isWorkspaceValidating}
             modelsDescriptionByProvider={modelsDescriptionByProvider}
           />

--- a/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
@@ -2,31 +2,20 @@ import { ProviderToggleContextItem } from "@app/components/pages/workspace/model
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import { ContextItem } from "@dust-tt/sparkle";
-import { type Dispatch, type SetStateAction, useCallback } from "react";
 
 interface ProvidersToggleListProps {
   providersSelection: ProvidersSelection;
-  setProvidersSelection: Dispatch<SetStateAction<ProvidersSelection>>;
+  onToggleProvider: (provider: ModelProviderIdType) => void;
   isWorkspaceValidating: boolean;
   modelsDescriptionByProvider: Partial<Record<ModelProviderIdType, string>>;
 }
 
 export function ProvidersToggleList({
   providersSelection,
-  setProvidersSelection,
+  onToggleProvider,
   isWorkspaceValidating,
   modelsDescriptionByProvider,
 }: ProvidersToggleListProps) {
-  const toggleProvider = useCallback(
-    (provider: ModelProviderIdType) => {
-      setProvidersSelection((previousSelection: ProvidersSelection) => ({
-        ...previousSelection,
-        [provider]: !previousSelection[provider],
-      }));
-    },
-    [setProvidersSelection]
-  );
-
   return (
     <ContextItem.List>
       {(
@@ -40,7 +29,7 @@ export function ProvidersToggleList({
           providerId={providerId}
           description={description}
           providersSelection={providersSelection}
-          handleToggleChange={() => toggleProvider(providerId)}
+          handleToggleChange={() => onToggleProvider(providerId)}
           disabled={isWorkspaceValidating}
         />
       ))}

--- a/front/hooks/useProvidersSelection.ts
+++ b/front/hooks/useProvidersSelection.ts
@@ -35,34 +35,20 @@ export function useProvidersSelection(
     setProvidersSelection(initialProvidersSelection);
   }, [initialProvidersSelection]);
 
-  const toggleProvider = useCallback(
-    async (provider: ModelProviderIdType) => {
-      const newSelection = {
-        ...providersSelection,
-        [provider]: !providersSelection[provider],
-      };
-      const activeProviders = MODEL_PROVIDER_IDS.filter(
-        (key) => newSelection[key]
-      );
-
-      if (activeProviders.length === 0) {
-        sendNotifications({
-          type: "error",
-          title: "One provider required",
-          description:
-            "Please select at least one provider to continue with the update.",
-        });
-        return;
-      }
-
+  const saveProviders = useCallback(
+    async (
+      newSelection: ProvidersSelection,
+      previousSelection: ProvidersSelection
+    ) => {
       setProvidersSelection(newSelection);
-
       try {
         const response = await clientFetch(`/api/w/${owner.sId}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            whiteListedProviders: activeProviders,
+            whiteListedProviders: MODEL_PROVIDER_IDS.filter(
+              (key) => newSelection[key]
+            ),
             defaultEmbeddingProvider:
               workspace?.defaultEmbeddingProvider ?? null,
           }),
@@ -80,7 +66,7 @@ export function useProvidersSelection(
 
         await mutateWorkspace();
       } catch {
-        setProvidersSelection(providersSelection);
+        setProvidersSelection(previousSelection);
         sendNotifications({
           type: "error",
           title: "Update Failed",
@@ -90,12 +76,42 @@ export function useProvidersSelection(
     },
     [
       owner.sId,
-      providersSelection,
       workspace?.defaultEmbeddingProvider,
       mutateWorkspace,
       sendNotifications,
     ]
   );
 
-  return { providersSelection, setProvidersSelection, toggleProvider };
+  const toggleProvider = useCallback(
+    async (provider: ModelProviderIdType) => {
+      const newSelection = {
+        ...providersSelection,
+        [provider]: !providersSelection[provider],
+      };
+
+      if (MODEL_PROVIDER_IDS.filter((key) => newSelection[key]).length === 0) {
+        sendNotifications({
+          type: "error",
+          title: "One provider required",
+          description:
+            "Please select at least one provider to continue with the update.",
+        });
+        return;
+      }
+
+      await saveProviders(newSelection, providersSelection);
+    },
+    [providersSelection, saveProviders, sendNotifications]
+  );
+
+  const selectAllProviders = useCallback(async () => {
+    await saveProviders(ALL_PROVIDERS_SELECTED, providersSelection);
+  }, [providersSelection, saveProviders]);
+
+  return {
+    providersSelection,
+    setProvidersSelection,
+    toggleProvider,
+    selectAllProviders,
+  };
 }

--- a/front/hooks/useProvidersSelection.ts
+++ b/front/hooks/useProvidersSelection.ts
@@ -1,3 +1,5 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import {
@@ -5,12 +7,17 @@ import {
   NO_PROVIDERS_SELECTED,
   type ProvidersSelection,
 } from "@app/types/provider_selection";
-import type { WorkspaceType } from "@app/types/user";
-import { useEffect, useMemo, useState } from "react";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-export function useProvidersSelection(workspace: WorkspaceType | undefined) {
+export function useProvidersSelection(
+  workspace: WorkspaceType | undefined,
+  owner: LightWorkspaceType,
+  mutateWorkspace: () => Promise<unknown>
+) {
   const [providersSelection, setProvidersSelection] =
     useState<ProvidersSelection>(ALL_PROVIDERS_SELECTED);
+  const sendNotifications = useSendNotification();
 
   const enabledProviders: Readonly<ModelProviderIdType[]> =
     workspace?.whiteListedProviders ?? MODEL_PROVIDER_IDS;
@@ -28,5 +35,67 @@ export function useProvidersSelection(workspace: WorkspaceType | undefined) {
     setProvidersSelection(initialProvidersSelection);
   }, [initialProvidersSelection]);
 
-  return { providersSelection, setProvidersSelection };
+  const toggleProvider = useCallback(
+    async (provider: ModelProviderIdType) => {
+      const newSelection = {
+        ...providersSelection,
+        [provider]: !providersSelection[provider],
+      };
+      const activeProviders = MODEL_PROVIDER_IDS.filter(
+        (key) => newSelection[key]
+      );
+
+      if (activeProviders.length === 0) {
+        sendNotifications({
+          type: "error",
+          title: "One provider required",
+          description:
+            "Please select at least one provider to continue with the update.",
+        });
+        return;
+      }
+
+      setProvidersSelection(newSelection);
+
+      try {
+        const response = await clientFetch(`/api/w/${owner.sId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            whiteListedProviders: activeProviders,
+            defaultEmbeddingProvider:
+              workspace?.defaultEmbeddingProvider ?? null,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to update workspace providers");
+        }
+
+        sendNotifications({
+          type: "success",
+          title: "Providers Updated",
+          description: "The list of providers has been successfully updated.",
+        });
+
+        await mutateWorkspace();
+      } catch {
+        setProvidersSelection(providersSelection);
+        sendNotifications({
+          type: "error",
+          title: "Update Failed",
+          description: "An unexpected error occurred while updating providers.",
+        });
+      }
+    },
+    [
+      owner.sId,
+      providersSelection,
+      workspace?.defaultEmbeddingProvider,
+      mutateWorkspace,
+      sendNotifications,
+    ]
+  );
+
+  return { providersSelection, setProvidersSelection, toggleProvider };
 }


### PR DESCRIPTION
## Description

Wires up the missing backend save in the Model Providers settings page. Toggling a provider (individually or via "select all") now immediately POSTs the updated \`whiteListedProviders\` list to the workspace API, with optimistic state update and rollback on error.

The save logic lives in \`useProvidersSelection\`, which exposes \`toggleProvider\` and \`selectAllProviders\` instead of raw \`setProvidersSelection\`.


https://github.com/user-attachments/assets/13fd9205-3b2c-4ea2-81e2-ba363ee619d5



## Tests

Tested manually: toggling providers on/off and selecting all update the workspace correctly; deselecting the last provider is blocked with an error notification; network errors revert the UI.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy \`main\` on \`front\`