### PR TITLE
Restore rule to check @swagger docs

### DIFF
--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -83,3 +83,23 @@ jobs:
         env:
           FRONT_DATABASE_URI: "postgres://fake:fake@localhost:5432/fake"
         run: npm run build:temporal-bundles
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "22.22.0"
+      - name: Lint test filenames
+        run: npm -w front run lint:test-filenames
+      - name: Lint swagger annotations
+        run: npm -w front run lint:swagger-annotations
+      - name: Check swagger.json is up to date
+        working-directory: front
+        run: |
+          npx next-swagger-doc-cli swagger.json
+          if ! git diff --exit-code public/swagger.json; then
+            echo "Error: public/swagger.json is out of date. Run 'npm run docs' in front/ and commit the result."
+            exit 1
+          fi

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "start:worker": "USE_TEMPORAL_BUNDLES=true node dist/start_worker.js",
     "dev:worker": "./admin/dev_worker.sh",
     "lint:test-filenames": "BAD_FILES=$(find pages -type f -name '*.test.ts' | grep -E '/[^/]*(\\[|\\])[^/]*$'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: Found .test.ts files in 'pages' directory with brackets [] in their names (this can break endpoints):\"; echo \"$BAD_FILES\"; exit 1; else echo \"Filename check: OK. No .test.ts files with brackets found in 'pages'.\"; exit 0; fi",
+    "lint:swagger-annotations": "BAD_FILES=$(find pages/api/v1 -name '*.ts' ! -name '*.test.ts' | xargs grep -rL '@swagger\\|@ignoreswagger'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: The following v1 API files are missing @swagger or @ignoreswagger annotation:\"; echo \"$BAD_FILES\"; exit 1; else echo \"Swagger annotation check: OK.\"; exit 0; fi",
     "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "tsgo": "tsgo",

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -20,6 +20,11 @@ interface GetSandboxToolsResponseType {
   serverViews: MCPServerViewType[];
 }
 
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetSandboxToolsResponseType>>,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -12,6 +12,11 @@ import type { CallMCPToolResponseType } from "@dust-tt/client";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<CallMCPToolResponseType>>,

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -111,6 +111,75 @@
         }
       }
     },
+    "/api/v1/w/{wId}/assistant/agent_configurations/{sId}/export/yaml": {
+      "get": {
+        "summary": "Export agent configuration as YAML",
+        "description": "Download the agent configuration identified by {sId} as a YAML file.",
+        "tags": [
+          "Agents"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sId",
+            "required": true,
+            "description": "ID of the agent configuration",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The agent configuration as a downloadable YAML file",
+            "content": {
+              "text/yaml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "headers": {
+              "Content-Disposition": {
+                "description": "Attachment with suggested filename",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Invalid or missing parameters."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "404": {
+            "description": "Agent configuration not found."
+          },
+          "405": {
+            "description": "Method not supported. Only GET is expected."
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/assistant/agent_configurations/{sId}": {
       "get": {
         "summary": "Get agent configuration",
@@ -1491,6 +1560,11 @@
                     "type": "boolean",
                     "description": "Whether to wait for the agent to generate the initial message. If true the query will wait for the agent's answer. If false (default), the API will return a conversation ID directly and you will need to use streaming events to get the messages.",
                     "example": true
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "description": "The sId of the space (project) in which to create the conversation (optional). If not provided, the conversation is created outside projects",
+                    "example": "space_abc123"
                   }
                 }
               }
@@ -2338,6 +2412,14 @@
                   "conversationId": {
                     "type": "string",
                     "description": "Optional conversation ID for context"
+                  },
+                  "serverName": {
+                    "type": "string",
+                    "description": "Optional name of the MCP server (e.g., \"Notion\", \"GitHub\")"
+                  },
+                  "serverIcon": {
+                    "type": "string",
+                    "description": "Optional icon identifier for the MCP server"
                   }
                 }
               }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,7 +13,7 @@
 #   LEFTHOOK_EXCLUDE=ggshield-scan,package-lock-check git commit -m "message"
 #
 # Skip only linting/type-checking (front and connectors):
-#   LEFTHOOK_EXCLUDE=front-lint-test-filenames,front-typecheck,front-circular,front-docs-check,biome-format,front-biome-lint,connectors-lint-test-filenames,connectors-typecheck,connectors-biome-lint git commit -m "message"
+#   LEFTHOOK_EXCLUDE=front-lint-test-filenames,front-lint-swagger-annotations,front-typecheck,front-circular,front-docs-check,biome-format,front-biome-lint,connectors-lint-test-filenames,connectors-typecheck,connectors-biome-lint git commit -m "message"
 #
 # Skip only a project:
 #   LEFTHOOK_EXCLUDE=front git commit -m "message"
@@ -71,6 +71,12 @@ pre-commit:
       glob: "*.{js,jsx,ts,tsx}"
       root: front/
       run: npm run lint:test-filenames
+
+    front-lint-swagger-annotations:
+      tags: front
+      glob: "front/pages/api/v1/**/*.ts"
+      root: front/
+      run: npm run lint:swagger-annotations
 
     front-typecheck:
       tags: front


### PR DESCRIPTION
## Description

Restore the swagger annotation check that was previously enforced by an ESLint rule but got lost during the migration to Biome.

Adds a `lint:swagger-annotations` script that ensures every v1 API file has either a `@swagger` or `@ignoreswagger` annotation, preventing undocumented public API endpoints from slipping through.

- Add `lint:swagger-annotations` npm script in `front/package.json`
- Add a `lint` CI job in `build-and-test-front.yml` running both `lint:test-filenames` and `lint:swagger-annotations` (these were previously only run locally via lefthook)
- Add `front-lint-swagger-annotations` to lefthook pre-commit hooks
- Add `@ignoreswagger` to internal endpoints (`sandbox/tools`, `call_tool`)

## Tests

Ran `npm -w front run lint:swagger-annotations` locally — passes after adding the missing annotations.

## Risk

Low — adds lint checks only, no runtime changes.

## Deploy Plan

Standard merge to main.