### PR TITLE
[front] - fix(insights): add timezone support to charts

### DIFF
--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -14,6 +14,7 @@ import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
+import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import { formatShortDate } from "@app/lib/utils/timestamps";
 import { useMemo } from "react";
 import {
@@ -116,7 +117,13 @@ export function LatencyChart({
 
   const data = useMemo(() => {
     if (mode === "timeRange") {
-      return padSeriesToTimeRange(rawData, mode, period, zeroFactory);
+      return padSeriesToTimeRange(
+        rawData,
+        mode,
+        period,
+        zeroFactory,
+        BROWSER_TIMEZONE
+      );
     }
 
     return rawData.map((data) => ({

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -18,6 +18,7 @@ import {
   useAgentUsageMetrics,
   useAgentVersionMarkers,
 } from "@app/lib/swr/assistants";
+import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import {
   CartesianGrid,
   Line,
@@ -142,7 +143,8 @@ export function UsageMetricsChart({
     filteredData,
     mode,
     period,
-    zeroFactory
+    zeroFactory,
+    BROWSER_TIMEZONE
   );
 
   return (

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -16,6 +16,7 @@ import {
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
@@ -892,7 +893,7 @@ export function useAgentUsageMetrics({
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetUsageMetricsResponse> = fetcher;
-  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/usage-metrics?days=${days}&interval=${interval}`;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/usage-metrics?days=${days}&interval=${interval}&timezone=${encodeURIComponent(BROWSER_TIMEZONE)}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,
@@ -955,7 +956,7 @@ export function useAgentLatency({
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetLatencyResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
-  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/latency?days=${days}${versionParam}`;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/latency?days=${days}${versionParam}&timezone=${encodeURIComponent(BROWSER_TIMEZONE)}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,
@@ -986,7 +987,7 @@ export function useAgentErrorRate({
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetErrorRateResponse> = fetcher;
   const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
-  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/error_rate?days=${days}${versionParam}`;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/error_rate?days=${days}${versionParam}&timezone=${encodeURIComponent(BROWSER_TIMEZONE)}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -2,7 +2,10 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -15,6 +18,7 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
+  timezone: timezoneSchema,
 });
 
 export type GetErrorRateResponse = {
@@ -67,8 +71,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days;
-      const version = q.data.version;
+      const { days, version, timezone } = q.data;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -79,10 +82,12 @@ async function handler(
         version,
       });
 
-      const errorRateResult = await fetchMessageMetrics(baseQuery, "day", [
-        "failedMessages",
-        "errorRate",
-      ] as const);
+      const errorRateResult = await fetchMessageMetrics(
+        baseQuery,
+        "day",
+        ["failedMessages", "errorRate"] as const,
+        timezone
+      );
 
       if (errorRateResult.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -2,7 +2,10 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -15,6 +18,7 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
+  timezone: timezoneSchema,
 });
 
 export type GetLatencyResponse = {
@@ -67,7 +71,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days;
+      const { days, version, timezone } = q.data;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -75,13 +79,15 @@ async function handler(
         workspaceId: owner.sId,
         agentId: assistant.sId,
         days,
-        version: q.data.version,
+        version,
       });
 
-      const latencyResult = await fetchMessageMetrics(baseQuery, "day", [
-        "avgLatencyMs",
-        "percentilesLatencyMs",
-      ] as const);
+      const latencyResult = await fetchMessageMetrics(
+        baseQuery,
+        "day",
+        ["avgLatencyMs", "percentilesLatencyMs"] as const,
+        timezone
+      );
 
       if (latencyResult.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -5,7 +5,10 @@ import type {
   UsageMetricsInterval,
 } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -18,6 +21,7 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   interval: z.enum(["day", "week"]).optional().default("day"),
+  timezone: timezoneSchema,
 });
 
 export type GetUsageMetricsResponse = {
@@ -71,8 +75,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days;
-      const interval = q.data.interval;
+      const { days, interval, timezone } = q.data;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -85,7 +88,8 @@ async function handler(
       const usageMetricsResult = await fetchMessageMetrics(
         baseQuery,
         interval,
-        ["conversations", "activeUsers"] as const
+        ["conversations", "activeUsers"] as const,
+        timezone
       );
 
       if (usageMetricsResult.isErr()) {


### PR DESCRIPTION
## Description

This PR completes timezone support for observability charts by ensuring the frontend data padding logic respects the user's browser timezone. This is a follow-up to #22882, which fixed timezone-aware queries on the backend. The `padSeriesToTimeRange` function now receives the browser timezone as a parameter, and all observability API endpoints (`usage-metrics`, `latency`, `error_rate`) now accept and use a `timezone` query parameter to properly align chart data with the user's local time.

## Tests

- [x] Locally

## Risk

Low 

## Deploy Plan

Deploy front