### PR TITLE
Add retry logic to GCS file copy operations

### DIFF
--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -262,7 +262,7 @@ export const getBucketInstance: (
   }
   return bucketInstances.get(bucketConfig);
 };
-z;
+
 export const getPrivateUploadBucket = (options?: FileStorageOptions) =>
   getBucketInstance(config.getGcsPrivateUploadsBucket(), options);
 

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -1,7 +1,10 @@
 import config from "@app/lib/file_storage/config";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { frameContentType } from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
 import type { Bucket } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
@@ -9,6 +12,9 @@ import type formidable from "formidable";
 import fs from "fs";
 import isNumber from "lodash/isNumber";
 import { pipeline } from "stream/promises";
+
+const GCS_COPY_MAX_RETRIES = 3;
+const GCS_COPY_BASE_DELAY_MS = 500;
 
 const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
 
@@ -204,6 +210,42 @@ export class FileStorage {
     }
   }
 
+  /**
+   * Copy a file within the same bucket with retry logic.
+   *
+   * The GCS SDK's built-in autoRetry is effectively disabled for copy operations and
+   * "socket hang up" errors aren't in the SDK's retryable error list anyway.
+   * Since copy is idempotent (same source, same destination), retrying is safe.
+   */
+  async copyFile(srcPath: string, destPath: string): Promise<void> {
+    for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
+      try {
+        await this.bucket.file(srcPath).copy(this.bucket.file(destPath));
+        return;
+      } catch (err) {
+        if (attempt === GCS_COPY_MAX_RETRIES) {
+          throw err;
+        }
+
+        const delayMs = GCS_COPY_BASE_DELAY_MS * attempt ** 2;
+
+        logger.warn(
+          {
+            error: normalizeError(err),
+            srcPath,
+            destPath,
+            attempt,
+            maxRetries: GCS_COPY_MAX_RETRIES,
+            delayMs,
+          },
+          "GCS copy failed, retrying."
+        );
+
+        await setTimeoutAsync(delayMs);
+      }
+    }
+  }
+
   async deleteByPrefix(prefix: string): Promise<void> {
     await this.bucket.deleteFiles({ prefix });
   }
@@ -220,7 +262,7 @@ export const getBucketInstance: (
   }
   return bucketInstances.get(bucketConfig);
 };
-
+z;
 export const getPrivateUploadBucket = (options?: FileStorageOptions) =>
   getBucketInstance(config.getGcsPrivateUploadsBucket(), options);
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -895,13 +895,13 @@ export class FileResource extends BaseResource<FileModel> {
     const bucket = getPrivateUploadBucket();
 
     const srcOriginalPath = this.getCloudStoragePath(auth, "original");
-    await bucket.file(srcOriginalPath).copy(bucket.file(mountFilePath));
+    await bucket.copyFile(srcOriginalPath, mountFilePath);
 
     // Copy processed version only if this file type has real processing.
     if (this.getContentVersion() === "processed") {
       const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
       const processedMountPath = makeProcessedMountFileName(mountFilePath);
-      await bucket.file(srcProcessedPath).copy(bucket.file(processedMountPath));
+      await bucket.copyFile(srcProcessedPath, processedMountPath);
     }
 
     await this.update({ mountFilePath });

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -69,6 +69,7 @@ class FileStorageMock {
       uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
       uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
       fetchFileContent: vi.fn().mockResolvedValue("mock content"),
+      copyFile: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
       deleteFiles: vi.fn().mockResolvedValue(undefined),
     };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR 
- adds `copyFile` method on `FileStorage` that wraps GCS `.copy()` with retry (3 attempts, exponential backoff)
- uses it in `FileResource.setMountFilePath` instead of raw `.copy()` calls

The GCS SDK's built-in `autoRetry` is effectively disabled for copy operations: the default `RetryConditional` idempotency strategy requires `ifGenerationMatch` (which we don't pass), and socket hang up errors aren't in the SDK's retryable error list anyway.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
