### PR TITLE
[front] fix Ashby response types

### DIFF
--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -141,7 +141,7 @@ interface AshbyJobPostingUpdateDetailsProps {
   jobId: string;
   title?: string;
   descriptionHtml?: string;
-  workplaceType?: string;
+  workplaceType?: string | null;
 }
 
 function AshbyJobPostingUpdateDetails({

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -208,7 +208,7 @@ export const AshbyCandidateNoteSchema = z
         id: z.string(),
         firstName: z.string(),
         lastName: z.string(),
-        email: z.string(),
+        email: z.string().nullable(),
       })
       .optional()
       .nullable(),
@@ -556,7 +556,7 @@ export const AshbyJobPostingWorkplaceTypeSchema = z.enum([
   "OnSite",
   "Hybrid",
   "Remote",
-]);
+]).nullable();
 
 export type AshbyJobPostingWorkplaceType = z.infer<
   typeof AshbyJobPostingWorkplaceTypeSchema

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -552,11 +552,9 @@ export type AshbyJobPostingInfoResponse = z.infer<
 
 // Job posting update
 
-export const AshbyJobPostingWorkplaceTypeSchema = z.enum([
-  "OnSite",
-  "Hybrid",
-  "Remote",
-]).nullable();
+export const AshbyJobPostingWorkplaceTypeSchema = z
+  .enum(["OnSite", "Hybrid", "Remote"])
+  .nullable();
 
 export type AshbyJobPostingWorkplaceType = z.infer<
   typeof AshbyJobPostingWorkplaceTypeSchema


### PR DESCRIPTION
## Description

- Logs [here](https://app.datadoghq.eu/logs?query=%22%5BAshby%5D%20Invalid%20API%20response%20format%22&additional_filters=%5B%5D&cols=host%2Cservice&event=AwAAAZzZRG_BkBivQwAAABhBWnpaUkhxWkFBQlc4RWtyU2xzMW5BQVYAAAAkMDE5Y2Q5NTQtYWI0My00ZTNlLWJkNDAtZGI2MjhiNDc4M2ZiAAKdqA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=200152&storage=hot&stream_sort=desc&viz=stream&from_ts=1772803545221&to_ts=1773408345221&live=true)/
- This PR fixes the zod schemas we use to validate the types of the object received from the Ashby API.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
