### PR TITLE
[Knowledge] Clarify knowledge lookup method labels

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -4,6 +4,7 @@ import {
   CAPABILITY_CONFIGS,
   getInitialPageId,
   getKnowledgeDefaultValues,
+  getKnowledgeLookupMethodLabel,
 } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import {
   generateUniqueActionName,
@@ -294,7 +295,10 @@ function KnowledgeConfigurationSheetContent({
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
     if (mcpServerView && !isEditing) {
-      const processingMethodName = getMcpServerViewDisplayName(mcpServerView);
+      const processingMethodName = getKnowledgeLookupMethodLabel(
+        mcpServerView.server.name,
+        getMcpServerViewDisplayName(mcpServerView)
+      );
       const currentName = getValues("name");
       if (currentName !== processingMethodName) {
         setValue("name", processingMethodName, {
@@ -391,11 +395,9 @@ function KnowledgeConfigurationSheetContent({
     },
     {
       id: CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION,
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      title: config?.configPageTitle || "Configure Knowledge",
+      title: config?.configPageTitle ?? "Configure Knowledge",
       description:
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        config?.configPageDescription ||
+        config?.configPageDescription ??
         "Select knowledge type and configure settings",
       icon: config
         ? () => <Avatar icon={config.icon} size="md" className="mr-2" />

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -36,36 +36,13 @@ export interface CapabilityConfig {
   };
 }
 
-const KNOWLEDGE_LOOKUP_METHOD_OVERRIDES = {
-  [SEARCH_SERVER.serverInfo.name]: {
-    label: "Content search",
-    description: SEARCH_SERVER.serverInfo.description,
-  },
-  [QUERY_TABLES_V2_SERVER.serverInfo.name]: {
-    label: "Analytics (tables, spreadsheets...)",
-    description: QUERY_TABLES_V2_SERVER.serverInfo.description,
-  },
-  [INCLUDE_DATA_SERVER.serverInfo.name]: {
-    label: "Include all data",
-    description: INCLUDE_DATA_SERVER.serverInfo.description,
-  },
-  [EXTRACT_DATA_SERVER.serverInfo.name]: {
-    label: "Advanced processing",
-    description: EXTRACT_DATA_SERVER.serverInfo.description,
-  },
+const KNOWLEDGE_LOOKUP_METHOD_LABEL_OVERRIDES = {
+  [SEARCH_SERVER.serverInfo.name]: "Content search",
+  [QUERY_TABLES_V2_SERVER.serverInfo.name]:
+    "Analytics (tables, spreadsheets...)",
+  [INCLUDE_DATA_SERVER.serverInfo.name]: "Include all data",
+  [EXTRACT_DATA_SERVER.serverInfo.name]: "Advanced processing",
 } as const;
-
-export function getKnowledgeLookupMethodOverride(serverName?: string | null) {
-  if (!serverName) {
-    return null;
-  }
-
-  return (
-    KNOWLEDGE_LOOKUP_METHOD_OVERRIDES[
-      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_OVERRIDES
-    ] ?? null
-  );
-}
 
 export function getKnowledgeLookupMethodLabel(
   serverName?: string | null,
@@ -75,9 +52,12 @@ export function getKnowledgeLookupMethodLabel(
     return "";
   }
 
-  const override = getKnowledgeLookupMethodOverride(serverName);
+  const override =
+    KNOWLEDGE_LOOKUP_METHOD_LABEL_OVERRIDES[
+      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_LABEL_OVERRIDES
+    ];
   if (override) {
-    return override.label;
+    return override;
   }
 
   return fallbackLabel ?? asDisplayToolName(serverName);

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -7,10 +7,14 @@ import {
 } from "@app/components/agent_builder/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
-import { DATA_WAREHOUSE_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  DATA_WAREHOUSE_SERVER_NAME,
+  SEARCH_SERVER_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { TABLE_QUERY_V2_SERVER_NAME } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types/assistant/templates";
+import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import {
   ActionIncludeIcon,
   ActionScanIcon,
@@ -32,11 +36,36 @@ export interface CapabilityConfig {
   };
 }
 
+const INCLUDE_DATA_SERVER_NAME = "include_data";
+const EXTRACT_DATA_SERVER_NAME = "extract_data";
+
+export function getKnowledgeLookupMethodLabel(
+  serverName?: string | null,
+  fallbackLabel?: string
+) {
+  if (!serverName) {
+    return "";
+  }
+
+  switch (serverName) {
+    case SEARCH_SERVER_NAME:
+      return "Content search";
+    case TABLE_QUERY_V2_SERVER_NAME:
+      return "Analytics (tables, spreadsheets...)";
+    case INCLUDE_DATA_SERVER_NAME:
+      return "Include all data";
+    case EXTRACT_DATA_SERVER_NAME:
+      return "Advanced processing";
+    default:
+      return fallbackLabel ?? asDisplayToolName(serverName);
+  }
+}
+
 export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   search: {
     icon: MagnifyingGlassIcon,
-    configPageTitle: "Configure Search",
-    configPageDescription: "Describe what you want to search for.",
+    configPageTitle: "Configure Knowledge",
+    configPageDescription: "",
     descriptionConfig: {
       title: "What’s the data?",
       description:

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -61,6 +61,28 @@ export function getKnowledgeLookupMethodLabel(
   }
 }
 
+export function getKnowledgeLookupMethodDescription(
+  serverName?: string | null,
+  fallbackDescription?: string
+) {
+  if (!serverName) {
+    return "";
+  }
+
+  switch (serverName) {
+    case SEARCH_SERVER_NAME:
+      return "Search content whose meaning best matches your message (not suited for analytics).";
+    case TABLE_QUERY_V2_SERVER_NAME:
+      return "Query structured data like a spreadsheet or database for data analyses.";
+    case INCLUDE_DATA_SERVER_NAME:
+      return "Load complete content for full context up to memory limits. Note: won't include spreadsheet/table data.";
+    case EXTRACT_DATA_SERVER_NAME:
+      return "Parse documents to create structured datasets.";
+    default:
+      return fallbackDescription ?? "";
+  }
+}
+
 export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   search: {
     icon: MagnifyingGlassIcon,

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -55,6 +55,18 @@ const KNOWLEDGE_LOOKUP_METHOD_OVERRIDES = {
   },
 } as const;
 
+export function getKnowledgeLookupMethodOverride(serverName?: string | null) {
+  if (!serverName) {
+    return null;
+  }
+
+  return (
+    KNOWLEDGE_LOOKUP_METHOD_OVERRIDES[
+      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_OVERRIDES
+    ] ?? null
+  );
+}
+
 export function getKnowledgeLookupMethodLabel(
   serverName?: string | null,
   fallbackLabel?: string
@@ -63,34 +75,12 @@ export function getKnowledgeLookupMethodLabel(
     return "";
   }
 
-  const override =
-    KNOWLEDGE_LOOKUP_METHOD_OVERRIDES[
-      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_OVERRIDES
-    ];
+  const override = getKnowledgeLookupMethodOverride(serverName);
   if (override) {
     return override.label;
   }
 
   return fallbackLabel ?? asDisplayToolName(serverName);
-}
-
-export function getKnowledgeLookupMethodDescription(
-  serverName?: string | null,
-  fallbackDescription?: string
-) {
-  if (!serverName) {
-    return "";
-  }
-
-  const override =
-    KNOWLEDGE_LOOKUP_METHOD_OVERRIDES[
-      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_OVERRIDES
-    ];
-  if (override) {
-    return override.description;
-  }
-
-  return fallbackDescription ?? "";
 }
 
 export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -7,11 +7,11 @@ import {
 } from "@app/components/agent_builder/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
-import {
-  DATA_WAREHOUSE_SERVER_NAME,
-  SEARCH_SERVER_NAME,
-} from "@app/lib/actions/mcp_internal_actions/constants";
-import { TABLE_QUERY_V2_SERVER_NAME } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
+import { DATA_WAREHOUSE_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
+import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
+import { QUERY_TABLES_V2_SERVER } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
+import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types/assistant/templates";
 import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
@@ -36,8 +36,24 @@ export interface CapabilityConfig {
   };
 }
 
-const INCLUDE_DATA_SERVER_NAME = "include_data";
-const EXTRACT_DATA_SERVER_NAME = "extract_data";
+const KNOWLEDGE_LOOKUP_METHOD_OVERRIDES = {
+  [SEARCH_SERVER.serverInfo.name]: {
+    label: "Content search",
+    description: SEARCH_SERVER.serverInfo.description,
+  },
+  [QUERY_TABLES_V2_SERVER.serverInfo.name]: {
+    label: "Analytics (tables, spreadsheets...)",
+    description: QUERY_TABLES_V2_SERVER.serverInfo.description,
+  },
+  [INCLUDE_DATA_SERVER.serverInfo.name]: {
+    label: "Include all data",
+    description: INCLUDE_DATA_SERVER.serverInfo.description,
+  },
+  [EXTRACT_DATA_SERVER.serverInfo.name]: {
+    label: "Advanced processing",
+    description: EXTRACT_DATA_SERVER.serverInfo.description,
+  },
+} as const;
 
 export function getKnowledgeLookupMethodLabel(
   serverName?: string | null,
@@ -47,18 +63,15 @@ export function getKnowledgeLookupMethodLabel(
     return "";
   }
 
-  switch (serverName) {
-    case SEARCH_SERVER_NAME:
-      return "Content search";
-    case TABLE_QUERY_V2_SERVER_NAME:
-      return "Analytics (tables, spreadsheets...)";
-    case INCLUDE_DATA_SERVER_NAME:
-      return "Include all data";
-    case EXTRACT_DATA_SERVER_NAME:
-      return "Advanced processing";
-    default:
-      return fallbackLabel ?? asDisplayToolName(serverName);
+  const override =
+    KNOWLEDGE_LOOKUP_METHOD_OVERRIDES[
+      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_OVERRIDES
+    ];
+  if (override) {
+    return override.label;
   }
+
+  return fallbackLabel ?? asDisplayToolName(serverName);
 }
 
 export function getKnowledgeLookupMethodDescription(
@@ -69,22 +82,19 @@ export function getKnowledgeLookupMethodDescription(
     return "";
   }
 
-  switch (serverName) {
-    case SEARCH_SERVER_NAME:
-      return "Search content whose meaning best matches your message (not suited for analytics).";
-    case TABLE_QUERY_V2_SERVER_NAME:
-      return "Query structured data like a spreadsheet or database for data analyses.";
-    case INCLUDE_DATA_SERVER_NAME:
-      return "Load complete content for full context up to memory limits. Note: won't include spreadsheet/table data.";
-    case EXTRACT_DATA_SERVER_NAME:
-      return "Parse documents to create structured datasets.";
-    default:
-      return fallbackDescription ?? "";
+  const override =
+    KNOWLEDGE_LOOKUP_METHOD_OVERRIDES[
+      serverName as keyof typeof KNOWLEDGE_LOOKUP_METHOD_OVERRIDES
+    ];
+  if (override) {
+    return override.description;
   }
+
+  return fallbackDescription ?? "";
 }
 
 export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
-  search: {
+  [SEARCH_SERVER.serverInfo.name]: {
     icon: MagnifyingGlassIcon,
     configPageTitle: "Configure Knowledge",
     configPageDescription: "",
@@ -95,7 +105,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
       placeholder: "This data contains…",
     },
   },
-  include_data: {
+  [INCLUDE_DATA_SERVER.serverInfo.name]: {
     icon: ActionIncludeIcon,
     configPageTitle: "Configure Include Data",
     configPageDescription: "Set time range and describe what data to include.",
@@ -107,7 +117,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
         "Describe what data you want to include from your selected data sources...",
     },
   },
-  extract_data: {
+  [EXTRACT_DATA_SERVER.serverInfo.name]: {
     icon: ActionScanIcon,
     configPageTitle: "Configure Extract Data",
     configPageDescription:
@@ -120,7 +130,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
       maxLength: DESCRIPTION_MAX_LENGTH,
     },
   },
-  [TABLE_QUERY_V2_SERVER_NAME]: {
+  [QUERY_TABLES_V2_SERVER.serverInfo.name]: {
     icon: TableIcon,
     configPageTitle: "Configure Query Tables",
     configPageDescription:

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -1,3 +1,4 @@
+import { getKnowledgeLookupMethodLabel } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
@@ -101,9 +102,14 @@ export function ProcessingMethodSection() {
         if (sources.in.some(isNonTableDataItem)) {
           warning = (
             <>
-              <strong>{getMcpServerViewDisplayName(mcpServerView)}</strong> will
-              ignore text documents and files in your selection. Create a
-              separated knowledge tools if you need both.
+              <strong>
+                {getKnowledgeLookupMethodLabel(
+                  mcpServerView.server.name,
+                  getMcpServerViewDisplayName(mcpServerView)
+                )}
+              </strong>{" "}
+              will ignore text documents and files in your selection. Create
+              separate knowledge tools if you need both.
               <br />
               <strong>Note:</strong> When you select a folder, only tables
               directly inside it will be included. Tables in nested subfolders
@@ -116,9 +122,14 @@ export function ProcessingMethodSection() {
         if (sources.in.every(isRemoteDatabaseOrTableItem)) {
           warning = (
             <>
-              <strong>{getMcpServerViewDisplayName(mcpServerView)}</strong> will
-              ignore tables in your selection. Switch processing method if you
-              want to use your structured data.
+              <strong>
+                {getKnowledgeLookupMethodLabel(
+                  mcpServerView.server.name,
+                  getMcpServerViewDisplayName(mcpServerView)
+                )}
+              </strong>{" "}
+              will ignore tables in your selection. Switch processing method if
+              you want to use your structured data.
             </>
           );
         }
@@ -159,7 +170,7 @@ export function ProcessingMethodSection() {
   return (
     <div className="mt-2 flex flex-col space-y-4">
       <div>
-        <h3 className="mb-2 text-lg font-semibold">Processing method</h3>
+        <h3 className="mb-2 text-lg font-semibold">Knowledge lookup method</h3>
         <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           Sets the approach for finding and retrieving information from your
           data sources. Need help? Check our{" "}
@@ -180,7 +191,10 @@ export function ProcessingMethodSection() {
               isLoading={isMCPServerViewsLoading}
               label={
                 mcpServerView
-                  ? getMcpServerViewDisplayName(mcpServerView)
+                  ? getKnowledgeLookupMethodLabel(
+                      mcpServerView.server.name,
+                      getMcpServerViewDisplayName(mcpServerView)
+                    )
                   : "loading..."
               }
               icon={
@@ -199,7 +213,10 @@ export function ProcessingMethodSection() {
               serversToDisplay.map((view) => (
                 <DropdownMenuItem
                   key={view.id}
-                  label={getMcpServerViewDisplayName(view)}
+                  label={getKnowledgeLookupMethodLabel(
+                    view.server.name,
+                    getMcpServerViewDisplayName(view)
+                  )}
                   icon={getAvatar(view.server)}
                   onClick={() => onChange(view)}
                   description={getMcpServerViewDescription(view)}
@@ -210,7 +227,7 @@ export function ProcessingMethodSection() {
       </div>
 
       <span className="text-sm text-muted-foreground dark:text-muted-foreground">
-        {mcpServerView?.server.description}
+        {mcpServerView ? getMcpServerViewDescription(mcpServerView) : null}
       </span>
 
       {warningContent && (

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -105,18 +105,18 @@ export function ProcessingMethodSection() {
         if (sources.in.some(isNonTableDataItem)) {
           warning = (
             <>
-              <strong>
+              <span className="font-semibold">
                 {getKnowledgeLookupMethodLabel(
                   mcpServerView.server.name,
                   getMcpServerViewDisplayName(mcpServerView)
                 )}
-              </strong>{" "}
-              will ignore text documents and files in your selection. Create
-              separate knowledge tools if you need both.
+              </span>
+              &nbsp;will ignore text documents and files in your selection.
+              Create separate knowledge tools if you need both.
               <br />
-              <strong>Note:</strong> When you select a folder, only tables
-              directly inside it will be included. Tables in nested subfolders
-              won't be automatically added.
+              <span className="font-semibold">Note:</span>&nbsp;When you select
+              a folder, only tables directly inside it will be included. Tables
+              in nested subfolders won't be automatically added.
             </>
           );
         }
@@ -125,14 +125,14 @@ export function ProcessingMethodSection() {
         if (sources.in.every(isRemoteDatabaseOrTableItem)) {
           warning = (
             <>
-              <strong>
+              <span className="font-semibold">
                 {getKnowledgeLookupMethodLabel(
                   mcpServerView.server.name,
                   getMcpServerViewDisplayName(mcpServerView)
                 )}
-              </strong>{" "}
-              will ignore tables in your selection. Switch processing method if
-              you want to use your structured data.
+              </span>
+              &nbsp;will ignore tables in your selection. Switch processing
+              method if you want to use your structured data.
             </>
           );
         }

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -1,4 +1,7 @@
-import { getKnowledgeLookupMethodLabel } from "@app/components/agent_builder/capabilities/knowledge/utils";
+import {
+  getKnowledgeLookupMethodDescription,
+  getKnowledgeLookupMethodLabel,
+} from "@app/components/agent_builder/capabilities/knowledge/utils";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
@@ -219,7 +222,10 @@ export function ProcessingMethodSection() {
                   )}
                   icon={getAvatar(view.server)}
                   onClick={() => onChange(view)}
-                  description={getMcpServerViewDescription(view)}
+                  description={getKnowledgeLookupMethodDescription(
+                    view.server.name,
+                    getMcpServerViewDescription(view)
+                  )}
                 />
               ))}
           </DropdownMenuContent>
@@ -227,7 +233,12 @@ export function ProcessingMethodSection() {
       </div>
 
       <span className="text-sm text-muted-foreground dark:text-muted-foreground">
-        {mcpServerView ? getMcpServerViewDescription(mcpServerView) : null}
+        {mcpServerView
+          ? getKnowledgeLookupMethodDescription(
+              mcpServerView.server.name,
+              getMcpServerViewDescription(mcpServerView)
+            )
+          : null}
       </span>
 
       {warningContent && (

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -7,7 +7,10 @@ import {
 } from "@app/components/resources/resources_icons";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import {
   DATA_WAREHOUSE_SERVER_NAME,
@@ -216,7 +219,7 @@ export function ProcessingMethodSection() {
                   )}
                   icon={getAvatar(view.server)}
                   onClick={() => onChange(view)}
-                  description={view.server.description}
+                  description={getMcpServerViewDescription(view)}
                 />
               ))}
           </DropdownMenuContent>

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -1,6 +1,6 @@
 import {
-  getKnowledgeLookupMethodDescription,
   getKnowledgeLookupMethodLabel,
+  getKnowledgeLookupMethodOverride,
 } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
@@ -222,10 +222,10 @@ export function ProcessingMethodSection() {
                   )}
                   icon={getAvatar(view.server)}
                   onClick={() => onChange(view)}
-                  description={getKnowledgeLookupMethodDescription(
-                    view.server.name,
-                    getMcpServerViewDescription(view)
-                  )}
+                  description={
+                    getKnowledgeLookupMethodOverride(view.server.name)
+                      ?.description ?? getMcpServerViewDescription(view)
+                  }
                 />
               ))}
           </DropdownMenuContent>
@@ -234,10 +234,8 @@ export function ProcessingMethodSection() {
 
       <span className="text-sm text-muted-foreground dark:text-muted-foreground">
         {mcpServerView
-          ? getKnowledgeLookupMethodDescription(
-              mcpServerView.server.name,
-              getMcpServerViewDescription(mcpServerView)
-            )
+          ? (getKnowledgeLookupMethodOverride(mcpServerView.server.name)
+              ?.description ?? getMcpServerViewDescription(mcpServerView))
           : null}
       </span>
 

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -1,7 +1,4 @@
-import {
-  getKnowledgeLookupMethodLabel,
-  getKnowledgeLookupMethodOverride,
-} from "@app/components/agent_builder/capabilities/knowledge/utils";
+import { getKnowledgeLookupMethodLabel } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
@@ -10,10 +7,7 @@ import {
 } from "@app/components/resources/resources_icons";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import {
-  getMcpServerViewDescription,
-  getMcpServerViewDisplayName,
-} from "@app/lib/actions/mcp_helper";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import {
   DATA_WAREHOUSE_SERVER_NAME,
@@ -222,10 +216,7 @@ export function ProcessingMethodSection() {
                   )}
                   icon={getAvatar(view.server)}
                   onClick={() => onChange(view)}
-                  description={
-                    getKnowledgeLookupMethodOverride(view.server.name)
-                      ?.description ?? getMcpServerViewDescription(view)
-                  }
+                  description={view.server.description}
                 />
               ))}
           </DropdownMenuContent>
@@ -233,10 +224,7 @@ export function ProcessingMethodSection() {
       </div>
 
       <span className="text-sm text-muted-foreground dark:text-muted-foreground">
-        {mcpServerView
-          ? (getKnowledgeLookupMethodOverride(mcpServerView.server.name)
-              ?.description ?? getMcpServerViewDescription(mcpServerView))
-          : null}
+        {mcpServerView?.server.description}
       </span>
 
       {warningContent && (

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -63,7 +63,8 @@ export const INCLUDE_DATA_SERVER = {
   serverInfo: {
     name: "include_data",
     version: "1.0.0",
-    description: "Load complete content for full context up to memory limits.",
+    description:
+      "Load complete content for full context up to memory limits. Note: won't include spreadsheet/table data.",
     icon: "ActionTimeIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -62,7 +62,8 @@ export const SEARCH_SERVER = {
   serverInfo: {
     name: SEARCH_SERVER_NAME,
     version: "1.0.0",
-    description: "Search content to find the most relevant information.",
+    description:
+      "Search content whose meaning best matches your message (not suited for analytics).",
     icon: "ActionMagnifyingGlassIcon",
     authorization: null,
     documentationUrl: null,


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7080 (partly)
Users get confused about search / query tables etc. This makes the labels clearer.

- Clarifies the knowledge method labels in the agent builder dropdown.
- Renames the section to "Knowledge lookup method" and changes the search page header to "Configure Knowledge" without the old search-specific subtitle.
- Updates the search and include-all-data descriptions to better explain analytics limitations.

## Risks
Blast radius: agent builder knowledge configuration copy in front
Risk: low

## Deploy Plan
- deploy front