### PR TITLE
[Connectors] fix(slack): track run_agent sub-agent progress via child streams

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1039,8 +1039,7 @@ async function answerMessage(
       }
       streamRecipientUserId = botUserIdRes.value;
     }
-    streamHandler = new SlackStreamHandler(slackClient, connector.id);
-    streamHandler.start({
+    streamHandler = new SlackStreamHandler(slackClient, connector.id, {
       slackChannel,
       slackMessageTs,
       slackThreadTs,
@@ -1049,7 +1048,7 @@ async function answerMessage(
     });
     await streamHandler.setThinking(
       mention.agentName === "dust"
-        ? `is thinking...`
+        ? "is thinking..."
         : `(${mention.agentName}) is thinking...`
     );
   } else {

--- a/connectors/src/connectors/slack/chat/action_utils.ts
+++ b/connectors/src/connectors/slack/chat/action_utils.ts
@@ -1,3 +1,5 @@
+import type { TaskCardSource } from "@connectors/connectors/slack/chat/blocks";
+import { truncate } from "@connectors/types";
 import {
   type AgentActionPublicType,
   type NotificationRunAgentContent,
@@ -5,6 +7,7 @@ import {
   TOOL_RUNNING_LABEL,
   type ToolNotificationEvent,
 } from "@dust-tt/client";
+import { z } from "zod";
 
 // run_agent actions have null displayLabels due to a gap in the server-side
 // tool type system (ServerSideMCPToolType doesn't carry displayLabels).
@@ -23,6 +26,51 @@ export function getActionRunningLabel(action: AgentActionPublicType): string {
 
 export function getActionDoneLabel(action: AgentActionPublicType): string {
   return action.displayLabels?.done ?? "Done";
+}
+
+const SearchParamsSchema = z.object({ query: z.string() });
+const BrowseParamsSchema = z.object({ urls: z.array(z.string().url()) });
+const SourceResourceSchema = z.object({
+  uri: z.string().url(),
+  title: z.string(),
+});
+
+export function getActionDetails(
+  action: AgentActionPublicType
+): string | undefined {
+  const search = SearchParamsSchema.safeParse(action.params);
+  if (search.success) {
+    return search.data.query;
+  }
+  const browse = BrowseParamsSchema.safeParse(action.params);
+  if (browse.success) {
+    return browse.data.urls.map((url) => new URL(url).hostname).join(", ");
+  }
+  return undefined;
+}
+
+export function getActionSources(
+  action: AgentActionPublicType
+): TaskCardSource[] | undefined {
+  if (!action.output) {
+    return undefined;
+  }
+  const sources: TaskCardSource[] = [];
+  for (const block of action.output) {
+    if (block.type === "resource" && "resource" in block) {
+      const result = SourceResourceSchema.safeParse(block.resource);
+      if (result.success) {
+        sources.push({
+          url: result.data.uri,
+          text: truncate(result.data.title, 20),
+        });
+      }
+    }
+    if (sources.length === 3) {
+      break;
+    }
+  }
+  return sources.length > 0 ? sources : undefined;
 }
 
 export function getRunAgentNotificationOutput(

--- a/connectors/src/connectors/slack/chat/action_utils.ts
+++ b/connectors/src/connectors/slack/chat/action_utils.ts
@@ -1,0 +1,41 @@
+import {
+  type AgentActionPublicType,
+  type NotificationRunAgentContent,
+  NotificationRunAgentContentSchema,
+  TOOL_RUNNING_LABEL,
+  type ToolNotificationEvent,
+} from "@dust-tt/client";
+
+// run_agent actions have null displayLabels due to a gap in the server-side
+// tool type system (ServerSideMCPToolType doesn't carry displayLabels).
+// Fall back to the label defined in the run_agent server metadata.
+const RUN_AGENT_RUNNING_LABEL = "Running agent";
+
+export function getActionRunningLabel(action: AgentActionPublicType): string {
+  if (action.displayLabels?.running) {
+    return action.displayLabels.running;
+  }
+  if (action.internalMCPServerName === "run_agent") {
+    return RUN_AGENT_RUNNING_LABEL;
+  }
+  return TOOL_RUNNING_LABEL;
+}
+
+export function getActionDoneLabel(action: AgentActionPublicType): string {
+  return action.displayLabels?.done ?? "Done";
+}
+
+export function getRunAgentNotificationOutput(
+  event: ToolNotificationEvent
+): NotificationRunAgentContent | null {
+  if (event.action.internalMCPServerName !== "run_agent") {
+    return null;
+  }
+  const result = NotificationRunAgentContentSchema.safeParse(
+    event.notification._meta.data.output
+  );
+  if (!result.success || !result.data.agentMessageId) {
+    return null;
+  }
+  return result.data;
+}

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -13,6 +13,7 @@ import type { MessageFootnotes } from "@connectors/lib/bot/citations";
 import { makeDustAppUrl } from "@connectors/lib/bot/conversation_utils";
 import { truncate } from "@connectors/types";
 import type { LightAgentConfigurationType } from "@dust-tt/client";
+import slackifyMarkdown from "slackify-markdown";
 
 /*
  * This length threshold is set to prevent the "msg_too_long" error
@@ -29,18 +30,31 @@ function makeDividerBlock() {
   };
 }
 
-export function makeMarkdownBlock(text?: string) {
-  return text
-    ? [
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: truncate(text, MAX_SLACK_MESSAGE_LENGTH),
-          },
-        },
-      ]
-    : [];
+export function makeMarkdownBlock(text?: string, isUpload?: boolean) {
+  if (!text) {
+    return [];
+  }
+
+  // New markdown block has better support for markdown formatting,
+  // but is not supported when uploading files.
+  if (!isUpload) {
+    return [
+      {
+        type: "markdown",
+        text: truncate(text, MAX_SLACK_MESSAGE_LENGTH),
+      },
+    ];
+  }
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: truncate(slackifyMarkdown(text), MAX_SLACK_MESSAGE_LENGTH),
+      },
+    },
+  ];
 }
 
 function makeFootnotesBlock(footnotes: MessageFootnotes) {
@@ -270,7 +284,8 @@ export function makeFooterBlock({
 export function makeMessageUpdateBlocksAndText(
   conversationUrl: string | null,
   workspaceId: string,
-  messageUpdate: SlackMessageUpdate
+  messageUpdate: SlackMessageUpdate,
+  { isUpload = false } = {}
 ) {
   const { isThinking, thinkingAction, assistantName, text, footnotes } =
     messageUpdate;
@@ -285,7 +300,7 @@ export function makeMessageUpdateBlocksAndText(
         isThinking: isThinking ?? false,
         thinkingText: thinkingTextWithAction,
       }),
-      ...makeMarkdownBlock(text),
+      ...makeMarkdownBlock(text, isUpload),
       ...makeContextSectionBlocks({
         state: isThinking ? "thinking" : "answered",
         assistantName,

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -333,19 +333,49 @@ export function makeErrorBlock(
 
 export type TaskCardStatus = "pending" | "in_progress" | "complete" | "error";
 
+export interface TaskCardSource {
+  url: string;
+  text: string;
+}
+
 export interface TaskCardState {
   taskId: string;
   title: string;
   status: TaskCardStatus;
+  details?: string;
+  sources?: TaskCardSource[];
+}
+
+function makeRichTextBlock(text: string) {
+  return {
+    type: "rich_text",
+    elements: [
+      {
+        type: "rich_text_section",
+        elements: [{ type: "text", text }],
+      },
+    ],
+  };
 }
 
 function makeTaskCardBlock(t: TaskCardState) {
-  return {
+  const card: Record<string, unknown> = {
     type: "task_card",
     task_id: t.taskId,
     title: t.title,
     status: t.status,
   };
+  if (t.details) {
+    card.details = makeRichTextBlock(t.details);
+  }
+  if (t.sources && t.sources.length > 0) {
+    card.sources = t.sources.map((s) => ({
+      type: "url",
+      url: s.url,
+      text: s.text,
+    }));
+  }
+  return card;
 }
 
 export function makePlanMessage({

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -331,6 +331,58 @@ export function makeErrorBlock(
   };
 }
 
+export type TaskCardStatus = "pending" | "in_progress" | "complete" | "error";
+
+export interface TaskCardState {
+  taskId: string;
+  title: string;
+  status: TaskCardStatus;
+}
+
+function makeTaskCardBlock(t: TaskCardState) {
+  return {
+    type: "task_card",
+    task_id: t.taskId,
+    title: t.title,
+    status: t.status,
+  };
+}
+
+export function makePlanMessage({
+  planTitle,
+  tasks,
+  conversationUrl,
+  assistantName,
+  workspaceId,
+}: {
+  planTitle: string;
+  tasks: TaskCardState[];
+  conversationUrl: string | null;
+  assistantName: string;
+  workspaceId: string;
+}) {
+  return {
+    blocks: [
+      {
+        type: "plan",
+        block_id: "agent-plan",
+        title: planTitle,
+        tasks: tasks.map(makeTaskCardBlock),
+      },
+      makeDividerBlock(),
+      makeFooterBlock({
+        state: "thinking",
+        assistantName,
+        conversationUrl,
+        workspaceId,
+      }),
+    ],
+    text: planTitle,
+    mrkdwn: true,
+    unfurl_links: false,
+  };
+}
+
 /**
  * Creates Slack blocks with buttons for validating a tool execution.
  * This is used when an agent sends a tool_approve_execution event to Slack.

--- a/connectors/src/connectors/slack/chat/plan_message_handler.ts
+++ b/connectors/src/connectors/slack/chat/plan_message_handler.ts
@@ -1,6 +1,8 @@
 import {
+  getActionDetails,
   getActionDoneLabel,
   getActionRunningLabel,
+  getActionSources,
 } from "@connectors/connectors/slack/chat/action_utils";
 import {
   makePlanMessage,
@@ -9,6 +11,7 @@ import {
 } from "@connectors/connectors/slack/chat/blocks";
 import logger from "@connectors/logger/logger";
 import type {
+  AgentActionPublicType,
   AgentEvent,
   DustAPI,
   NotificationRunAgentContent,
@@ -94,8 +97,18 @@ export class PlanMessageHandler {
     await this.slackClient.chat.delete({ channel: this.slackChannelId, ts });
   }
 
-  setDefaultTask(title: string, status: TaskCardState["status"]): void {
-    this.taskCards.set("default", { taskId: "default", title, status });
+  setDefaultTask(
+    title: string,
+    status: TaskCardState["status"],
+    action?: AgentActionPublicType
+  ): void {
+    this.taskCards.set("default", {
+      taskId: "default",
+      title,
+      status,
+      details: action ? getActionDetails(action) : undefined,
+      sources: action ? getActionSources(action) : undefined,
+    });
   }
 
   private async handleChildStreamEvent(
@@ -106,13 +119,24 @@ export class PlanMessageHandler {
       case "tool_params":
       case "tool_notification": {
         const label = getActionRunningLabel(event.action);
-        this.taskCards.set(taskId, { taskId, title: label, status: "in_progress" });
+        this.taskCards.set(taskId, {
+          taskId,
+          title: label,
+          status: "in_progress",
+          details: getActionDetails(event.action),
+        });
         await this.upsertPlanMessage(label);
         return "continue";
       }
       case "agent_action_success": {
         const label = getActionDoneLabel(event.action);
-        this.taskCards.set(taskId, { taskId, title: label, status: "complete" });
+        this.taskCards.set(taskId, {
+          taskId,
+          title: label,
+          status: "complete",
+          details: getActionDetails(event.action),
+          sources: getActionSources(event.action),
+        });
         await this.upsertPlanMessage(label);
         return "continue";
       }

--- a/connectors/src/connectors/slack/chat/plan_message_handler.ts
+++ b/connectors/src/connectors/slack/chat/plan_message_handler.ts
@@ -1,0 +1,185 @@
+import {
+  getActionDoneLabel,
+  getActionRunningLabel,
+} from "@connectors/connectors/slack/chat/action_utils";
+import {
+  makePlanMessage,
+  type TaskCardState,
+  // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+} from "@connectors/connectors/slack/chat/blocks";
+import logger from "@connectors/logger/logger";
+import type {
+  AgentEvent,
+  DustAPI,
+  NotificationRunAgentContent,
+} from "@dust-tt/client";
+import type { WebClient } from "@slack/web-api";
+
+// Match the SDK defaults (sdks/js/src/index.ts DEFAULT_MAX_RECONNECT_ATTEMPTS / DEFAULT_RECONNECT_DELAY).
+const CHILD_STREAM_MAX_RECONNECT_ATTEMPTS = 10;
+const CHILD_STREAM_RECONNECT_DELAY_MS = 5_000;
+
+interface PlanMessageHandlerParams {
+  dustAPI: DustAPI;
+  slackClient: WebClient;
+  slackChannelId: string;
+  slackMessageTs: string;
+  conversationUrl: string | null;
+  assistantName: string;
+  workspaceId: string;
+}
+
+export class PlanMessageHandler {
+  private readonly dustAPI: DustAPI;
+  private readonly slackClient: WebClient;
+  private readonly slackChannelId: string;
+  private readonly slackMessageTs: string;
+  private readonly conversationUrl: string | null;
+  private readonly assistantName: string;
+  private readonly workspaceId: string;
+
+  private readonly taskCards = new Map<string, TaskCardState>();
+  private planMessageTs: string | undefined;
+  private readonly childStreamControllers = new Map<string, AbortController>();
+
+  constructor({
+    dustAPI,
+    slackClient,
+    slackChannelId,
+    slackMessageTs,
+    conversationUrl,
+    assistantName,
+    workspaceId,
+  }: PlanMessageHandlerParams) {
+    this.dustAPI = dustAPI;
+    this.slackClient = slackClient;
+    this.slackChannelId = slackChannelId;
+    this.slackMessageTs = slackMessageTs;
+    this.conversationUrl = conversationUrl;
+    this.assistantName = assistantName;
+    this.workspaceId = workspaceId;
+  }
+
+  async upsertPlanMessage(title: string): Promise<void> {
+    const payload = makePlanMessage({
+      planTitle: title,
+      tasks: [...this.taskCards.values()],
+      conversationUrl: this.conversationUrl,
+      assistantName: this.assistantName,
+      workspaceId: this.workspaceId,
+    });
+
+    if (this.planMessageTs) {
+      await this.slackClient.chat.update({
+        ...payload,
+        channel: this.slackChannelId,
+        ts: this.planMessageTs,
+      });
+    } else {
+      const res = await this.slackClient.chat.postMessage({
+        ...payload,
+        channel: this.slackChannelId,
+        thread_ts: this.slackMessageTs,
+      });
+      this.planMessageTs = res.ts;
+    }
+  }
+
+  async deletePlanMessage(): Promise<void> {
+    if (!this.planMessageTs) {
+      return;
+    }
+    const ts = this.planMessageTs;
+    this.planMessageTs = undefined;
+    await this.slackClient.chat.delete({ channel: this.slackChannelId, ts });
+  }
+
+  setDefaultTask(title: string, status: TaskCardState["status"]): void {
+    this.taskCards.set("default", { taskId: "default", title, status });
+  }
+
+  private async handleChildStreamEvent(
+    taskId: string,
+    event: AgentEvent
+  ): Promise<"continue" | "complete" | "error"> {
+    switch (event.type) {
+      case "tool_params":
+      case "tool_notification": {
+        const label = getActionRunningLabel(event.action);
+        this.taskCards.set(taskId, { taskId, title: label, status: "in_progress" });
+        await this.upsertPlanMessage(label);
+        return "continue";
+      }
+      case "agent_action_success": {
+        const label = getActionDoneLabel(event.action);
+        this.taskCards.set(taskId, { taskId, title: label, status: "complete" });
+        await this.upsertPlanMessage(label);
+        return "continue";
+      }
+      case "agent_message_success":
+      case "agent_generation_cancelled":
+        return "complete";
+      case "agent_error":
+        return "error";
+      default:
+        return "continue";
+    }
+  }
+
+  async startChildStream(output: NotificationRunAgentContent): Promise<void> {
+    if (!output.agentMessageId) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const { conversationId, agentMessageId } = output;
+    this.childStreamControllers.set(conversationId, controller);
+
+    // One task card per child agent, keyed by conversationId. Run in background.
+    void this.runChildStream(conversationId, agentMessageId, controller);
+  }
+
+  private async runChildStream(
+    conversationId: string,
+    agentMessageId: string,
+    controller: AbortController
+  ): Promise<void> {
+    const streamRes = await this.dustAPI.streamAgentMessageEvents({
+      conversation: { sId: conversationId },
+      agentMessage: { sId: agentMessageId },
+      signal: controller.signal,
+      options: {
+        maxReconnectAttempts: CHILD_STREAM_MAX_RECONNECT_ATTEMPTS,
+        reconnectDelay: CHILD_STREAM_RECONNECT_DELAY_MS,
+        autoReconnect: true,
+      },
+    });
+    if (streamRes.isErr()) {
+      logger.error(
+        { conversationId, error: streamRes.error },
+        "Failed to open child agent stream"
+      );
+      return;
+    }
+
+    try {
+      for await (const event of streamRes.value.eventStream) {
+        const result = await this.handleChildStreamEvent(conversationId, event);
+        if (result === "complete" || result === "error") {
+          break;
+        }
+      }
+    } catch {
+      // AbortError or stream failure — handled by cleanup.
+    } finally {
+      this.childStreamControllers.delete(conversationId);
+    }
+  }
+
+  abortAllChildStreams(): void {
+    for (const [, controller] of this.childStreamControllers) {
+      controller.abort();
+    }
+    this.childStreamControllers.clear();
+  }
+}

--- a/connectors/src/connectors/slack/chat/plan_message_handler.ts
+++ b/connectors/src/connectors/slack/chat/plan_message_handler.ts
@@ -169,8 +169,8 @@ export class PlanMessageHandler {
     controller: AbortController
   ): Promise<void> {
     const streamRes = await this.dustAPI.streamAgentMessageEvents({
-      conversation: { sId: conversationId },
-      agentMessage: { sId: agentMessageId },
+      conversationId,
+      agentMessageId,
       signal: controller.signal,
       options: {
         maxReconnectAttempts: CHILD_STREAM_MAX_RECONNECT_ATTEMPTS,

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -3,16 +3,11 @@ import { throttleWithRedis } from "@connectors/lib/throttle";
 import type { ChatStreamer, WebClient } from "@slack/web-api";
 import type { ChatAppendStreamArguments } from "@slack/web-api/dist/types/request/chat";
 
-// Single task id reused for every task so only the latest is visible.
-// Later, if we adapt the tool call output a bit further, we can use this
-// to show multiple tasks in a single plan block (see: https://docs.slack.dev/reference/block-kit/blocks/plan-block).
-const ACTIVE_TASK_ID = "active-task-id";
-
 export class SlackStreamHandler {
-  private streamer: ChatStreamer | undefined;
-  private hasTask = false;
+  private streamer: ChatStreamer;
   private stopped = false;
-  private channelId: string | undefined;
+  private channelId: string;
+  private slackMessageTs: string;
   private threadTs: string | undefined;
   messageTs: string | undefined;
 
@@ -22,23 +17,23 @@ export class SlackStreamHandler {
 
   constructor(
     private readonly slackClient: WebClient,
-    private readonly connectorId: number
-  ) {}
-
-  public start({
-    slackChannel,
-    slackMessageTs,
-    slackThreadTs,
-    slackTeamId,
-    slackUserId,
-  }: {
-    slackChannel: string;
-    slackMessageTs: string;
-    slackThreadTs?: string;
-    slackTeamId: string;
-    slackUserId?: string;
-  }) {
+    private readonly connectorId: number,
+    {
+      slackChannel,
+      slackMessageTs,
+      slackThreadTs,
+      slackTeamId,
+      slackUserId,
+    }: {
+      slackChannel: string;
+      slackMessageTs: string;
+      slackThreadTs?: string;
+      slackTeamId: string;
+      slackUserId: string;
+    }
+  ) {
     this.channelId = slackChannel;
+    this.slackMessageTs = slackMessageTs;
     this.threadTs = slackThreadTs;
     this.streamer = this.slackClient.chatStream({
       channel: slackChannel,
@@ -50,12 +45,9 @@ export class SlackStreamHandler {
   }
 
   async setThinking(status: string) {
-    if (!this.channelId || !this.threadTs) {
-      return;
-    }
     await this.slackClient.assistant.threads.setStatus({
       channel_id: this.channelId,
-      thread_ts: this.threadTs,
+      thread_ts: this.threadTs ?? this.slackMessageTs,
       status,
       loading_messages: ["Thinking..."],
     });
@@ -68,7 +60,7 @@ export class SlackStreamHandler {
       RATE_LIMITS["chat.appendStream"],
       `${this.connectorId}-chat-appendStream`,
       { canBeIgnored: false },
-      () => this.streamer?.append(payload) ?? Promise.resolve(undefined),
+      () => this.streamer.append(payload),
       {}
     );
     if (!this.messageTs && res?.ts) {
@@ -76,40 +68,15 @@ export class SlackStreamHandler {
     }
   }
 
-  async startTask(title: string) {
-    this.hasTask = true;
-    await this.append({
-      chunks: [
-        {
-          type: "task_update",
-          id: ACTIVE_TASK_ID,
-          title,
-          status: "in_progress",
-        },
-      ],
-    });
-  }
-
   async appendText(text: string) {
-    if (this.hasTask) {
-      this.hasTask = false;
-      await this.append({
-        chunks: [
-          {
-            type: "task_update",
-            id: ACTIVE_TASK_ID,
-            title: "Done",
-            status: "complete",
-          },
-        ],
-      });
-    }
     await this.append({ markdown_text: text });
   }
 
   async stop() {
-    this.hasTask = false;
     this.stopped = true;
-    await this.streamer?.stop();
+    const res = await this.streamer.stop();
+    if (!this.messageTs && res?.ts) {
+      this.messageTs = res.ts;
+    }
   }
 }

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -445,24 +445,21 @@ async function streamAgentAnswerToSlack(
             answer,
             actions
           );
-          const slackContent = safelyPrepareAnswer(formattedContent);
-          // If the answer cannot be prepared safely, skip processing these tokens.
-          if (slackContent) {
-            await postSlackMessageUpdate({
-              messageUpdate: {
-                text: slackContent,
-                assistantName,
-                agentConfigurations,
-                footnotes,
-              },
-              ...conversationData,
-              canBeIgnored: false,
-              extraLogs: {
-                source: "streamAgentAnswerToSlack",
-                eventType: "stream_fallback",
-              },
-            });
-          }
+
+          await postSlackMessageUpdate({
+            messageUpdate: {
+              text: formattedContent,
+              assistantName,
+              agentConfigurations,
+              footnotes,
+            },
+            ...conversationData,
+            canBeIgnored: false,
+            extraLogs: {
+              source: "streamAgentAnswerToSlack",
+              eventType: "stream_fallback",
+            },
+          });
           break;
         }
 
@@ -534,9 +531,9 @@ async function streamAgentAnswerToSlack(
           filesUploaded = await getFilesFromDust(files, dustAPI);
         }
 
-        const slackContent = slackifyMarkdown(
-          normalizeContentForSlack(formattedContent)
-        );
+        const slackContent = streamHandler
+          ? formattedContent
+          : slackifyMarkdown(normalizeContentForSlack(formattedContent));
 
         if (streamHandler && !streamHandler.isStopped) {
           await streamHandler.stop();
@@ -757,7 +754,8 @@ async function deleteAndRepostMessageWithFiles({
     ...makeMessageUpdateBlocksAndText(
       conversationUrl,
       connector.workspaceId,
-      messageUpdate
+      messageUpdate,
+      { isUpload: true }
     ),
     channel_id: slackChannelId,
     file_uploads: uploadedFiles,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -1,13 +1,19 @@
-// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
-import type { SlackMessageUpdate } from "@connectors/connectors/slack/chat/blocks";
+import {
+  getActionDoneLabel,
+  getActionRunningLabel,
+  getRunAgentNotificationOutput,
+} from "@connectors/connectors/slack/chat/action_utils";
 import {
   MAX_SLACK_MESSAGE_LENGTH,
   makeAssistantSelectionBlock,
   makeMessageUpdateBlocksAndText,
   makeToolAuthenticationBlock,
   makeToolValidationBlock,
+  type SlackMessageUpdate,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/blocks";
+// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+import { PlanMessageHandler } from "@connectors/connectors/slack/chat/plan_message_handler";
 import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
 import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
@@ -30,14 +36,7 @@ import type {
   Result,
   UserMessageType,
 } from "@dust-tt/client";
-import {
-  assertNever,
-  DustAPI,
-  Err,
-  Ok,
-  removeNulls,
-  TOOL_RUNNING_LABEL,
-} from "@dust-tt/client";
+import { assertNever, DustAPI, Err, Ok, removeNulls } from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import * as t from "io-ts";
 import throttle from "lodash/throttle";
@@ -47,12 +46,6 @@ const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
 const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
 const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 400;
 
-function getActionRunningLabel(action: AgentActionPublicType): string {
-  return action.displayLabels?.running ?? TOOL_RUNNING_LABEL;
-}
-
-// Dynamic throttling: longer messages get less frequent updates to reduce UX disruption when the content is expanded.
-// Posting an update on an expanded message will collapse it, frequent updates prevent users from reading the content.
 const getThrottleDelay = (textLength: number): number => {
   if (textLength >= SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
     return SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS;
@@ -207,7 +200,26 @@ async function streamAgentAnswerToSlack(
 
   const { streamHandler } = conversationData;
 
-  // Old path: lodash throttle for chat.update.
+  const conversationUrl = makeConversationUrl(
+    connector.workspaceId,
+    conversation.sId
+  );
+
+  // -- Plan message + child stream tracking --
+  // Only used when native streaming (streamHandler) is enabled.
+
+  const planHandler = streamHandler
+    ? new PlanMessageHandler({
+        dustAPI,
+        slackClient,
+        slackChannelId,
+        slackMessageTs,
+        conversationUrl,
+        assistantName,
+        workspaceId: connector.workspaceId,
+      })
+    : null;
+
   let currentThrottleDelay = SLACK_MESSAGE_UPDATE_THROTTLE_MS;
   let throttledPostSlackMessageUpdate = throttle(
     postSlackMessageUpdate,
@@ -218,8 +230,24 @@ async function streamAgentAnswerToSlack(
     switch (event.type) {
       case "tool_params":
       case "tool_notification": {
-        if (streamHandler) {
-          await streamHandler.startTask(getActionRunningLabel(event.action));
+        const isRunAgent = event.action.internalMCPServerName === "run_agent";
+
+        // For run_agent, skip tool_params and early notifications:
+        // the child stream handles progress.
+        if (isRunAgent && event.type === "tool_notification") {
+          const output = getRunAgentNotificationOutput(event);
+          if (output) {
+            await planHandler?.startChildStream(output);
+          }
+          break;
+        }
+
+        // For all other tools, rotate a single default task card.
+        const thinkingAction = getActionRunningLabel(event.action);
+
+        if (planHandler) {
+          planHandler.setDefaultTask(thinkingAction, "in_progress");
+          await planHandler.upsertPlanMessage(thinkingAction);
         } else {
           await throttledPostSlackMessageUpdate({
             messageUpdate: {
@@ -227,7 +255,7 @@ async function streamAgentAnswerToSlack(
               assistantName,
               agentConfigurations,
               text: answer,
-              thinkingAction: getActionRunningLabel(event.action),
+              thinkingAction,
             },
             ...conversationData,
             canBeIgnored: true,
@@ -237,7 +265,6 @@ async function streamAgentAnswerToSlack(
             },
           });
         }
-
         break;
       }
 
@@ -316,8 +343,9 @@ async function streamAgentAnswerToSlack(
           };
         }
 
-        if (streamHandler) {
-          await streamHandler.startTask("Waiting for authentication…");
+        if (planHandler) {
+          planHandler.setDefaultTask("Waiting for authentication…", "pending");
+          await planHandler.upsertPlanMessage("Waiting for authentication…");
         } else {
           await throttledPostSlackMessageUpdate({
             messageUpdate: {
@@ -357,6 +385,8 @@ async function streamAgentAnswerToSlack(
         );
       }
       case "agent_error": {
+        planHandler?.abortAllChildStreams();
+        await planHandler?.deletePlanMessage();
         return new Err(
           new Error(
             `Agent message error: code: ${event.error.code} message: ${event.error.message}`
@@ -375,6 +405,14 @@ async function streamAgentAnswerToSlack(
           );
           pendingPersonalAuth = null;
         }
+
+        // Mark default task complete (for non-run_agent tools).
+        if (planHandler && event.action.internalMCPServerName !== "run_agent") {
+          const doneLabel = getActionDoneLabel(event.action);
+          planHandler.setDefaultTask(doneLabel, "complete");
+          await planHandler.upsertPlanMessage(doneLabel);
+        }
+
         actions.push(event.action);
         break;
       }
@@ -398,11 +436,13 @@ async function streamAgentAnswerToSlack(
           // Message too long for streaming: stop and fall back to chat.update
           // with truncated content + footer.
           await streamHandler.stop();
+          await planHandler?.deletePlanMessage();
           const { formattedContent, footnotes } = annotateCitations(
             answer,
             actions
           );
           const slackContent = safelyPrepareAnswer(formattedContent);
+          // If the answer cannot be prepared safely, skip processing these tokens.
           if (slackContent) {
             await postSlackMessageUpdate({
               messageUpdate: {
@@ -469,6 +509,9 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_message_success": {
+        planHandler?.abortAllChildStreams();
+        await planHandler?.deletePlanMessage();
+
         const finalAnswer = event.message.content ?? "";
         const actions = event.message.actions;
         const messageId = event.message.sId; // Get the message ID
@@ -614,6 +657,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
+        planHandler?.abortAllChildStreams();
+        await planHandler?.deletePlanMessage();
         if (streamHandler && !streamHandler.isStopped) {
           await streamHandler.stop();
         }
@@ -659,7 +704,9 @@ async function streamAgentAnswerToSlack(
     }
   }
 
-  // Clean up stream if the event stream ended without a terminal event.
+  // Clean up if the event stream ended without a terminal event.
+  planHandler?.abortAllChildStreams();
+  await planHandler?.deletePlanMessage();
   if (streamHandler && !streamHandler.isStopped) {
     await streamHandler.stop();
   }

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -246,7 +246,11 @@ async function streamAgentAnswerToSlack(
         const thinkingAction = getActionRunningLabel(event.action);
 
         if (planHandler) {
-          planHandler.setDefaultTask(thinkingAction, "in_progress");
+          planHandler.setDefaultTask(
+            thinkingAction,
+            "in_progress",
+            event.action
+          );
           await planHandler.upsertPlanMessage(thinkingAction);
         } else {
           await throttledPostSlackMessageUpdate({
@@ -409,7 +413,7 @@ async function streamAgentAnswerToSlack(
         // Mark default task complete (for non-run_agent tools).
         if (planHandler && event.action.internalMCPServerName !== "run_agent") {
           const doneLabel = getActionDoneLabel(event.action);
-          planHandler.setDefaultTask(doneLabel, "complete");
+          planHandler.setDefaultTask(doneLabel, "complete", event.action);
           await planHandler.upsertPlanMessage(doneLabel);
         }
 

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -6,6 +6,7 @@ import {
 import {
   MAX_SLACK_MESSAGE_LENGTH,
   makeAssistantSelectionBlock,
+  makeMarkdownBlock,
   makeMessageUpdateBlocksAndText,
   makeToolAuthenticationBlock,
   makeToolValidationBlock,
@@ -959,7 +960,7 @@ async function postThreadFollowUpMessages(
   for (let i = 0; i < followUpMessages.length; i++) {
     const threadResponse = await slackClient.chat.postMessage({
       channel: slackChannelId,
-      text: followUpMessages[i] || "",
+      blocks: makeMarkdownBlock(followUpMessages[i] || ""),
       thread_ts: threadTs,
     });
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -158,7 +158,7 @@ function isTransientHttpStatus(status: number): boolean {
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 const DEFAULT_RECONNECT_DELAY = 5000;
 
-type AgentEvent =
+export type AgentEvent =
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | AgentContextPrunedEvent
@@ -1036,8 +1036,8 @@ export class DustAPI {
     signal,
     options,
   }: {
-    conversation: ConversationPublicType;
-    agentMessage: AgentMessagePublicType;
+    conversation: Pick<ConversationPublicType, "sId">;
+    agentMessage: Pick<AgentMessagePublicType, "sId">;
     signal?: AbortSignal;
     options: {
       maxReconnectAttempts: number;

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1018,8 +1018,8 @@ export class DustAPI {
 
     const agentMessage = agentMessages[0];
     return this.streamAgentMessageEvents({
-      conversation,
-      agentMessage,
+      conversationId: conversation.sId,
+      agentMessageId: agentMessage.sId,
       signal,
       options: {
         maxReconnectAttempts:
@@ -1031,13 +1031,13 @@ export class DustAPI {
   }
 
   async streamAgentMessageEvents({
-    conversation,
-    agentMessage,
+    conversationId,
+    agentMessageId,
     signal,
     options,
   }: {
-    conversation: Pick<ConversationPublicType, "sId">;
-    agentMessage: Pick<AgentMessagePublicType, "sId">;
+    conversationId: string;
+    agentMessageId: string;
     signal?: AbortSignal;
     options: {
       maxReconnectAttempts: number;
@@ -1064,7 +1064,7 @@ export class DustAPI {
     ];
 
     const createRequest = async (lastId?: string | null) => {
-      let path = `assistant/conversations/${conversation.sId}/messages/${agentMessage.sId}/events`;
+      let path = `assistant/conversations/${conversationId}/messages/${agentMessageId}/events`;
       if (lastId) {
         path += `?lastEventId=${lastId}`;
       }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1244,14 +1244,19 @@ const NotificationToolApproveBubbleUpContentSchema = z.object({
   metadata: MCPValidationMetadataSchema,
 });
 
-const NotificationRunAgentContentSchema = z.object({
+export const NotificationRunAgentContentSchema = z.object({
   type: z.literal("run_agent"),
   childAgentId: z.string(),
   conversationId: z.string(),
+  agentMessageId: z.string().nullable().optional(),
   query: z.string(),
   childConversationUrl: z.string().nullable().optional(),
   childConversationEventsUrl: z.string().nullable().optional(),
 });
+
+export type NotificationRunAgentContent = z.infer<
+  typeof NotificationRunAgentContentSchema
+>;
 
 const NotificationRunAgentChainOfThoughtSchema = z.object({
   type: z.literal("run_agent_chain_of_thought"),


### PR DESCRIPTION
## Description

### Problem

When `run_agent` executes, child agent events are published on a separate per-message stream, not the parent conversation stream. The Slack bot was never subscribed to it, so sub-agent tool progress was invisible — causing long silent gaps and eventually a 5-min stream timeout error.

### Solution

On each `run_agent` notification that carries a child `agentMessageId`, we now open a subscription to the child's message stream and surface progress in a new plan block message (deleted when the parent agent produces tokens).

Using a separate message rather than the existing chat stream sidesteps the timeout entirely, as the chat stream itself only opens on the first token.
> _`chatStream()` in the constructor just creates a local ChatStreamer object, the actual chat.startStream API call fires on the first `append()`._

### Other improvements

- Replaced unique task block with a plan block that regroup multiple tasks. The plan block shows only the latest running task (ie. latest tool call). When running sub agents, each one gets its own task block (scoped by conversation id).

- Task blocks are enriched with search queries / visited hostnames and up to 3 clickable result links from the action output.

- Plan block also includes footer blocks, allowing to access conversation on Dust when the stream is ongoing

- Response messages also switch to Slack's native markdown block type for better table, divider and code block support; `filesUploadV2` keeps a mrkdwn fallback since it doesn't support the new block type.

Fixes: https://github.com/dust-tt/tasks/issues/7033

## Risk

The `{ type: "markdown" }` block switch in `makeMarkdownBlock` affects all `chat.update` calls including the non-streaming path (workspaces without native streaming).

Tested locally but there could be other edge cases 

## Test
![Screen Recording 2026-04-07 at 13 57 09](https://github.com/user-attachments/assets/d384798b-9a4c-4953-ae2b-ec1afc563fc7)

Tested image generation, long running deep dives, tool call approval, tool auth.
Also tested with the split message feature flag.


