### PR TITLE
Add swagger annotations and update rules

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -439,13 +439,17 @@ class Conversation extends Model { }
 class ConversationModel extends Model { }
 ```
 
-### [BACK12] Endpoint backward compatibility
+### [BACK12] No breaking changes in API endpoints
 
-When updating an existing endpoint and its expected payload, ensure backward compatibility with
-clients. Schemas must be append-only, we never remove fields, and when adding a new field, it must
-be optional and accept `undefined` as a value even if the latest client code always sends a value.
+**Public API (`pages/api/v1/`):** Breaking changes are never allowed. External consumers depend on
+a stable contract. Schemas must be append-only: never remove fields. When adding a new field, it
+must be optional and accept `undefined` as a value even if the latest client code always sends a
+value.
 
-This prevents breaking clients who are still running an older version.
+**Private API (`pages/api/`):** Breaking changes are acceptable only after enough time has passed
+to be confident that no old clients are still deployed. Until then, follow the same backward
+compatibility rules as the public API. When introducing a breaking change, first deploy the
+updated client code, wait for all old clients to cycle out, then clean up the old contract.
 
 Example:
 
@@ -463,38 +467,7 @@ interface UpdateResourceBody {
 }
 ```
 
-### [BACK13] Foreign key must be indexed
-
-When adding a foreign key `B.a` on table `B` to a deletable object from table `A` (pretty much all
-objects in the context of scrubbing a workspace) make sure to add an index on `B.a` to avoid table
-scans when deleting objects from table `A`.
-
-```
-AgentMCPActionModel.belongsTo(AgentMessageModel, {
-  foreignKey: { name: "agentMessageId", allowNull: false },
-  as: "agentMessage",
-});
-
-AgentMessageModel.hasMany(AgentMCPActionModel, {
-  foreignKey: { name: "agentMessageId", allowNull: false },
-});
-
-// Must be accompanied above in the model definition by index:
-
-{
-  fields: ["agentMessageId"],
-  concurrently: true,
-}
-```
-
-### [BACK14] No breaking changes in PRIVATE API endpoints
-
-Breaking changes in PRIVATE API endpoints are prohibited. The PRIVATE API serves multiple clients
-(web app, browser extensions, etc.) that may be running different versions. Breaking
-changes can cause crashes or data corruption for users who haven't updated to the latest version.
-
-All changes to PRIVATE API endpoints must be backward compatible. Follow these steps based on the
-type of change:
+Follow these steps based on the type of change:
 
 **1. Deleting an endpoint:**
 
@@ -536,6 +509,45 @@ type of change:
   - Do NOT remove enum values immediately
   - First: Update all client code to stop relying on the removed value
   - Stop returning the enum value from backend only after a period of time
+
+### [BACK13] Foreign key must be indexed
+
+When adding a foreign key `B.a` on table `B` to a deletable object from table `A` (pretty much all
+objects in the context of scrubbing a workspace) make sure to add an index on `B.a` to avoid table
+scans when deleting objects from table `A`.
+
+```
+AgentMCPActionModel.belongsTo(AgentMessageModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+  as: "agentMessage",
+});
+
+AgentMessageModel.hasMany(AgentMCPActionModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+});
+
+// Must be accompanied above in the model definition by index:
+
+{
+  fields: ["agentMessageId"],
+  concurrently: true,
+}
+```
+
+### [BACK14] Keep Swagger documentation in sync with API schema changes
+
+Any change to the schema of a public or private API endpoint — including deeply nested objects in
+request or response bodies — must be reflected in the existing Swagger documentation. This applies
+to adding, removing, or modifying fields at any level of nesting.
+
+In particular, check and update the following files when modifying API schemas:
+
+- `pages/api/swagger_private_schemas.ts` for private API shared schemas
+- `pages/api/v1/w/[wId]/swagger_schemas.ts` for public API shared schemas
+- The `@swagger` annotation in the endpoint file itself
+
+Every endpoint must have either `@swagger` (with proper documentation) or `@ignoreswagger` 
+(for internal/undocumented endpoints). This is enforced by the `lint:swagger-annotations` check.
 
 ## MCP
 

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,7 @@
     "start:worker": "USE_TEMPORAL_BUNDLES=true node dist/start_worker.js",
     "dev:worker": "./admin/dev_worker.sh",
     "lint:test-filenames": "BAD_FILES=$(find pages -type f -name '*.test.ts' | grep -E '/[^/]*(\\[|\\])[^/]*$'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: Found .test.ts files in 'pages' directory with brackets [] in their names (this can break endpoints):\"; echo \"$BAD_FILES\"; exit 1; else echo \"Filename check: OK. No .test.ts files with brackets found in 'pages'.\"; exit 0; fi",
-    "lint:swagger-annotations": "BAD_FILES=$(find pages/api/v1 -name '*.ts' ! -name '*.test.ts' | xargs grep -rL '@swagger\\|@ignoreswagger'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: The following v1 API files are missing @swagger or @ignoreswagger annotation:\"; echo \"$BAD_FILES\"; exit 1; else echo \"Swagger annotation check: OK.\"; exit 0; fi",
+    "lint:swagger-annotations": "BAD_FILES=$(find pages/api -name '*.ts' ! -name '*.test.ts' | xargs grep -rL '@swagger\\|@ignoreswagger'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: The following API files are missing @swagger or @ignoreswagger annotation:\"; echo \"$BAD_FILES\"; exit 1; else echo \"Swagger annotation check: OK.\"; exit 0; fi",
     "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "tsgo": "tsgo",

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   PRESTOP_GRACE_PERIOD_MS,
   PRESTOP_LB_PROPAGATION_MS,

--- a/front/pages/api/academy/chat.ts
+++ b/front/pages/api/academy/chat.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import Anthropic from "@anthropic-ai/sdk";
 import config from "@app/lib/api/config";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";

--- a/front/pages/api/academy/progress/backfill.ts
+++ b/front/pages/api/academy/progress/backfill.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { fetchUserFromSession } from "@app/lib/iam/users";

--- a/front/pages/api/academy/progress/courses.ts
+++ b/front/pages/api/academy/progress/courses.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyQuizAttemptResource } from "@app/lib/resources/academy_quiz_attempt_resource";

--- a/front/pages/api/academy/progress/index.ts
+++ b/front/pages/api/academy/progress/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyQuizAttemptResource } from "@app/lib/resources/academy_quiz_attempt_resource";

--- a/front/pages/api/academy/progress/visit.ts
+++ b/front/pages/api/academy/progress/visit.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyChapterVisitResource } from "@app/lib/resources/academy_chapter_visit_resource";

--- a/front/pages/api/app-status.ts
+++ b/front/pages/api/app-status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { AppStatus } from "@app/lib/api/status";
 import {
   getDustStatusMemoized,

--- a/front/pages/api/auth-context.ts
+++ b/front/pages/api/auth-context.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/auth/login.ts
+++ b/front/pages/api/auth/login.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { NextApiRequest, NextApiResponse } from "next";
 
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing

--- a/front/pages/api/blog/preview.ts
+++ b/front/pages/api/blog/preview.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { createAndLogMembership } from "@app/lib/api/signup";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/customers/preview.ts
+++ b/front/pages/api/customers/preview.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/debug/profiler.ts
+++ b/front/pages/api/debug/profiler.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import inspector from "node:inspector/promises";
 import config from "@app/lib/api/config";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";

--- a/front/pages/api/doc.ts
+++ b/front/pages/api/doc.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSwagger } from "next-swagger-doc";
 
 const swaggerHandler = withSwagger({
@@ -8,6 +9,6 @@ const swaggerHandler = withSwagger({
       version: "0.1.0",
     },
   },
-  apiFolder: "pages/api",
+  apiFolder: "pages/api/v1",
 });
 export default swaggerHandler();

--- a/front/pages/api/email/validate-action.ts
+++ b/front/pages/api/email/validate-action.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   getActionContextForEmailValidation,
   validateActionFromEmail,

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type {
   EmailAttachment,
   EmailTriggerError,

--- a/front/pages/api/enrichment/company.ts
+++ b/front/pages/api/enrichment/company.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { fetchUsersFromWorkOSWithEmails } from "@app/lib/api/workos/user";
 import { untrustedFetch } from "@app/lib/egress/server";

--- a/front/pages/api/geo/location.ts
+++ b/front/pages/api/geo/location.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { resolveCountryCode } from "@app/lib/geo/country-detection";
 import { isGDPRCountry } from "@app/lib/geo/eu-detection";
 import logger from "@app/logger/logger";

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { NextApiRequest, NextApiResponse } from "next";
 

--- a/front/pages/api/healthz/ready.ts
+++ b/front/pages/api/healthz/ready.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 import { isInShutdown } from "@app/lib/shutdown_signal";
 import { getStatsDClient } from "@app/lib/utils/statsd";

--- a/front/pages/api/healthz/startup.ts
+++ b/front/pages/api/healthz/startup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { getStatsDClient } from "@app/lib/utils/statsd";

--- a/front/pages/api/home/contact/submit.ts
+++ b/front/pages/api/home/contact/submit.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type {
   ContactFormData,
   ContactSubmitResponse,

--- a/front/pages/api/home/ebook/download.ts
+++ b/front/pages/api/home/ebook/download.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
 import { createHmac } from "crypto";

--- a/front/pages/api/home/ebook/submit.ts
+++ b/front/pages/api/home/ebook/submit.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import type {
   EbookFormData,

--- a/front/pages/api/home/partner/submit.ts
+++ b/front/pages/api/home/partner/submit.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { TrackingParamsSchema } from "@app/lib/api/hubspot/contactFormSchema";
 import { submitToHubSpotPartnerForm } from "@app/lib/api/hubspot/hubspot";
 import type {

--- a/front/pages/api/invitations.ts
+++ b/front/pages/api/invitations.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { fetchInvitationsFromOtherRegion } from "@app/lib/api/regions/lookup";

--- a/front/pages/api/kill.ts
+++ b/front/pages/api/kill.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { makeEnterpriseConnectionInitiateLoginUrl } from "@app/lib/api/enterprise_connection";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import {
   handleLookupInvitations,

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";

--- a/front/pages/api/oauth/[provider]/finalize.ts
+++ b/front/pages/api/oauth/[provider]/finalize.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { finalizeConnection } from "@app/lib/api/oauth";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/poke/admin.ts
+++ b/front/pages/api/poke/admin.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/auth-context.ts
+++ b/front/pages/api/poke/auth-context.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/cache.ts
+++ b/front/pages/api/poke/cache.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { runOnRedis, runOnRedisCache } from "@app/lib/api/redis";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/connectors/[connectorId]/redirect.ts
+++ b/front/pages/api/poke/connectors/[connectorId]/redirect.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/global-agent-feedbacks/index.ts
+++ b/front/pages/api/poke/global-agent-feedbacks/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/kill.ts
+++ b/front/pages/api/poke/kill.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/plugins/[pluginId]/async-args.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/async-args.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";

--- a/front/pages/api/poke/plugins/[pluginId]/manifest.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/manifest.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import type { PluginResponse } from "@app/lib/api/poke/types";

--- a/front/pages/api/poke/plugins/index.ts
+++ b/front/pages/api/poke/plugins/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import type { PluginListItem } from "@app/lib/api/poke/types";

--- a/front/pages/api/poke/plugins/runs.ts
+++ b/front/pages/api/poke/plugins/runs.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/production-checks/[checkName]/history.ts
+++ b/front/pages/api/poke/production-checks/[checkName]/history.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import {
   getCheckHistoryRuns,

--- a/front/pages/api/poke/production-checks/index.ts
+++ b/front/pages/api/poke/production-checks/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getCheckSummaries } from "@app/lib/api/poke/production_checks";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/production-checks/run.ts
+++ b/front/pages/api/poke/production-checks/run.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/region.ts
+++ b/front/pages/api/poke/region.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { config, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";

--- a/front/pages/api/poke/search.ts
+++ b/front/pages/api/poke/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { config as regionConfig } from "@app/lib/api/regions/config";

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { config as regionConfig } from "@app/lib/api/regions/config";

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   archiveAgentConfiguration,
   getAgentConfiguration,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   getAgentConfiguration,
   restoreAgentConfiguration,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAuthors } from "@app/lib/api/assistant/editors";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { timezoneSchema } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/poke/workspaces/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/programmatic-cost.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { GetWorkspaceProgrammaticCostResponse } from "@app/lib/api/analytics/programmatic_cost";
 import { handleProgrammaticCostRequest } from "@app/lib/api/analytics/programmatic_cost";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/apps/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/auth-context.ts
+++ b/front/pages/api/poke/workspaces/[wId]/auth-context.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/credits/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/data_retention.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_retention.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { DataRetentionConfig } from "@app/lib/data_retention";

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/query.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/query.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 /* eslint-disable dust/enforce-client-types-in-public-api */
 // Disabling because POKE but should probably be refactored to use internal types.
 

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/downgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/downgrade.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/dsync.ts
+++ b/front/pages/api/poke/workspaces/[wId]/dsync.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getWorkOSOrganizationDSyncDirectories } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/groups/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { setInternalWorkspaceSegmentation } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/[iId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import type { HandleMembershipInvitationResult } from "@app/lib/api/invitation";
 import { handleMembershipInvitations } from "@app/lib/api/invitation";

--- a/front/pages/api/poke/workspaces/[wId]/invitations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/llm-traces/[runId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/llm-traces/[runId].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { fetchLLMTrace, isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/memberships.ts
+++ b/front/pages/api/poke/workspaces/[wId]/memberships.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { getMembers } from "@app/lib/api/workspace";

--- a/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { WorkspaceDatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { fetchWorkspaceDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { revokeAndTrackMembership } from "@app/lib/api/membership";
 import { getUserForWorkspace } from "@app/lib/api/user";

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import {

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/registry/[type]/lookup.ts
+++ b/front/pages/api/registry/[type]/lookup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { isManaged } from "@app/lib/data_sources";

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { lookupShareToken } from "@app/lib/api/regions/lookup";

--- a/front/pages/api/sse/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/sse/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,1 +1,2 @@
+/** @ignoreswagger */
 export { default } from "@app/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events";

--- a/front/pages/api/sse/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/sse/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,1 +1,2 @@
+/** @ignoreswagger */
 export { default } from "@app/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events";

--- a/front/pages/api/sse/v1/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/sse/v1/w/[wId]/mcp/requests.ts
@@ -1,1 +1,2 @@
+/** @ignoreswagger */
 export { default } from "@app/pages/api/v1/w/[wId]/mcp/requests";

--- a/front/pages/api/sse/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/sse/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,1 +1,2 @@
+/** @ignoreswagger */
 export { default } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/events";

--- a/front/pages/api/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,1 +1,2 @@
+/** @ignoreswagger */
 export { default } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events";

--- a/front/pages/api/sse/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/sse/w/[wId]/mcp/requests.ts
@@ -1,1 +1,2 @@
+/** @ignoreswagger */
 export { default } from "@app/pages/api/w/[wId]/mcp/requests";

--- a/front/pages/api/stripe/portal.ts
+++ b/front/pages/api/stripe/portal.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import apiConfig from "@app/lib/api/config";
 import {
   sendAdminSubscriptionPaymentFailedEmail,

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -1,0 +1,1393 @@
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     PrivateUser:
+ *       type: object
+ *       description: Authenticated user with their workspaces and subscriber hash.
+ *       required:
+ *         - sId
+ *         - id
+ *         - createdAt
+ *         - username
+ *         - email
+ *         - firstName
+ *         - fullName
+ *         - workspaces
+ *       properties:
+ *         sId:
+ *           type: string
+ *           description: Unique string identifier for the user
+ *         id:
+ *           type: integer
+ *           description: Numeric model identifier
+ *         createdAt:
+ *           type: integer
+ *           description: Unix timestamp of user creation
+ *         provider:
+ *           type: string
+ *           nullable: true
+ *           enum: [auth0, github, google, okta, samlp, waad]
+ *           description: Authentication provider
+ *         username:
+ *           type: string
+ *         email:
+ *           type: string
+ *         firstName:
+ *           type: string
+ *         lastName:
+ *           type: string
+ *           nullable: true
+ *         fullName:
+ *           type: string
+ *         image:
+ *           type: string
+ *           nullable: true
+ *           description: URL of the user's profile image
+ *         lastLoginAt:
+ *           type: integer
+ *           nullable: true
+ *         workspaces:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateWorkspace'
+ *         selectedWorkspace:
+ *           type: string
+ *           description: sId of the currently selected workspace
+ *         origin:
+ *           type: string
+ *           description: How the user joined (e.g. invitation, provisioned)
+ *         subscriberHash:
+ *           type: string
+ *           nullable: true
+ *           description: Hash used for Intercom identity verification
+ *     PrivateWorkspace:
+ *       type: object
+ *       description: Workspace as returned by the private API, includes SSO and provider settings.
+ *       required:
+ *         - id
+ *         - sId
+ *         - name
+ *         - role
+ *       properties:
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         name:
+ *           type: string
+ *         role:
+ *           type: string
+ *           enum: [admin, builder, user, none]
+ *         segmentation:
+ *           type: string
+ *           nullable: true
+ *         whiteListedProviders:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             type: string
+ *           description: Allowed model provider IDs
+ *         defaultEmbeddingProvider:
+ *           type: string
+ *           nullable: true
+ *         ssoEnforced:
+ *           type: boolean
+ *         metadata:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *     PrivateConversation:
+ *       type: object
+ *       description: Conversation without content, used in list responses.
+ *       required:
+ *         - id
+ *         - created
+ *         - updated
+ *         - sId
+ *         - depth
+ *       properties:
+ *         id:
+ *           type: integer
+ *         created:
+ *           type: integer
+ *           description: Unix timestamp of creation
+ *         updated:
+ *           type: integer
+ *           description: Unix timestamp of last update
+ *         unread:
+ *           type: boolean
+ *         lastReadMs:
+ *           type: integer
+ *           nullable: true
+ *         actionRequired:
+ *           type: boolean
+ *           description: Whether the conversation requires user action
+ *         hasError:
+ *           type: boolean
+ *         sId:
+ *           type: string
+ *         title:
+ *           type: string
+ *           nullable: true
+ *         spaceId:
+ *           type: string
+ *           nullable: true
+ *           description: ID of the space the conversation belongs to (for project conversations)
+ *         triggerId:
+ *           type: string
+ *           nullable: true
+ *         depth:
+ *           type: integer
+ *           description: Conversation depth (for agent handover chains)
+ *         metadata:
+ *           type: object
+ *           additionalProperties: true
+ *         requestedSpaceIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *     PrivateFullConversation:
+ *       type: object
+ *       description: Full conversation including content, owner, and visibility.
+ *       allOf:
+ *         - $ref: '#/components/schemas/PrivateConversation'
+ *         - type: object
+ *           properties:
+ *             owner:
+ *               $ref: '#/components/schemas/PrivateWorkspace'
+ *             visibility:
+ *               type: string
+ *               enum: [unlisted, deleted, test]
+ *             branchId:
+ *               type: string
+ *               nullable: true
+ *             content:
+ *               type: array
+ *               description: Array of message arrays (versions/retries)
+ *               items:
+ *                 type: array
+ *                 items:
+ *                   oneOf:
+ *                     - $ref: '#/components/schemas/PrivateUserMessage'
+ *                     - $ref: '#/components/schemas/PrivateAgentMessage'
+ *                     - $ref: '#/components/schemas/PrivateContentFragment'
+ *     PrivateUserMessage:
+ *       type: object
+ *       description: A user message in a conversation.
+ *       required:
+ *         - type
+ *         - sId
+ *         - content
+ *         - version
+ *         - rank
+ *         - created
+ *       properties:
+ *         id:
+ *           type: integer
+ *         type:
+ *           type: string
+ *           enum: [user_message]
+ *         sId:
+ *           type: string
+ *         created:
+ *           type: integer
+ *         visibility:
+ *           type: string
+ *           enum: [visible, deleted]
+ *         version:
+ *           type: integer
+ *         rank:
+ *           type: integer
+ *         user:
+ *           type: object
+ *           nullable: true
+ *           description: The user who sent the message
+ *           properties:
+ *             sId:
+ *               type: string
+ *             username:
+ *               type: string
+ *             fullName:
+ *               type: string
+ *             image:
+ *               type: string
+ *               nullable: true
+ *         mentions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateMention'
+ *         richMentions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateRichMentionWithStatus'
+ *         content:
+ *           type: string
+ *         context:
+ *           $ref: '#/components/schemas/PrivateUserMessageContext'
+ *         reactions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateReaction'
+ *     PrivateAgentMessage:
+ *       type: object
+ *       description: An agent message in a conversation.
+ *       required:
+ *         - type
+ *         - sId
+ *         - version
+ *         - rank
+ *         - status
+ *         - parentMessageId
+ *       properties:
+ *         id:
+ *           type: integer
+ *         agentMessageId:
+ *           type: integer
+ *         type:
+ *           type: string
+ *           enum: [agent_message]
+ *         sId:
+ *           type: string
+ *         created:
+ *           type: integer
+ *         completedTs:
+ *           type: integer
+ *           nullable: true
+ *         visibility:
+ *           type: string
+ *           enum: [visible, deleted]
+ *         version:
+ *           type: integer
+ *         rank:
+ *           type: integer
+ *         parentMessageId:
+ *           type: string
+ *         parentAgentMessageId:
+ *           type: string
+ *           nullable: true
+ *           description: If handover, the agent message that summoned this agent
+ *         status:
+ *           type: string
+ *           enum: [created, succeeded, failed, cancelled]
+ *         content:
+ *           type: string
+ *           nullable: true
+ *         chainOfThought:
+ *           type: string
+ *           nullable: true
+ *         error:
+ *           type: object
+ *           nullable: true
+ *           properties:
+ *             code:
+ *               type: string
+ *             message:
+ *               type: string
+ *             metadata:
+ *               type: object
+ *               nullable: true
+ *         configuration:
+ *           $ref: '#/components/schemas/PrivateLightAgentConfiguration'
+ *         actions:
+ *           type: array
+ *           items:
+ *             type: object
+ *           description: MCP actions executed by the agent
+ *         contents:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               step:
+ *                 type: integer
+ *               content:
+ *                 type: object
+ *         skipToolsValidation:
+ *           type: boolean
+ *         richMentions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateRichMentionWithStatus'
+ *         completionDurationMs:
+ *           type: integer
+ *           nullable: true
+ *         reactions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateReaction'
+ *     PrivateLightAgentMessage:
+ *       type: object
+ *       description: A lighter agent message used in paginated message list responses.
+ *       required:
+ *         - type
+ *         - sId
+ *         - version
+ *         - rank
+ *         - status
+ *         - parentMessageId
+ *         - configuration
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_message]
+ *         sId:
+ *           type: string
+ *         created:
+ *           type: integer
+ *         completedTs:
+ *           type: integer
+ *           nullable: true
+ *         visibility:
+ *           type: string
+ *           enum: [visible, deleted]
+ *         version:
+ *           type: integer
+ *         rank:
+ *           type: integer
+ *         parentMessageId:
+ *           type: string
+ *         parentAgentMessageId:
+ *           type: string
+ *           nullable: true
+ *         status:
+ *           type: string
+ *           enum: [created, succeeded, failed, cancelled]
+ *         content:
+ *           type: string
+ *           nullable: true
+ *         chainOfThought:
+ *           type: string
+ *           nullable: true
+ *         error:
+ *           type: object
+ *           nullable: true
+ *           properties:
+ *             code:
+ *               type: string
+ *             message:
+ *               type: string
+ *             metadata:
+ *               type: object
+ *               nullable: true
+ *         configuration:
+ *           type: object
+ *           description: Minimal agent configuration info
+ *           properties:
+ *             sId:
+ *               type: string
+ *             name:
+ *               type: string
+ *             pictureUrl:
+ *               type: string
+ *             status:
+ *               type: string
+ *             canRead:
+ *               type: boolean
+ *         citations:
+ *           type: object
+ *           additionalProperties:
+ *             $ref: '#/components/schemas/PrivateCitation'
+ *         generatedFiles:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               fileId:
+ *                 type: string
+ *               title:
+ *                 type: string
+ *               contentType:
+ *                 type: string
+ *               publicUrl:
+ *                 type: string
+ *         richMentions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateRichMentionWithStatus'
+ *         completionDurationMs:
+ *           type: integer
+ *           nullable: true
+ *         reactions:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateReaction'
+ *     PrivateCitation:
+ *       type: object
+ *       properties:
+ *         title:
+ *           type: string
+ *         description:
+ *           type: string
+ *         href:
+ *           type: string
+ *         provider:
+ *           type: string
+ *         contentType:
+ *           type: string
+ *     PrivateContentFragment:
+ *       type: object
+ *       description: A content fragment (file or content node attachment) in a conversation.
+ *       required:
+ *         - type
+ *         - sId
+ *         - title
+ *         - contentType
+ *         - contentFragmentType
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [content_fragment]
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         created:
+ *           type: integer
+ *         visibility:
+ *           type: string
+ *           enum: [visible, deleted]
+ *         version:
+ *           type: integer
+ *         rank:
+ *           type: integer
+ *         title:
+ *           type: string
+ *         contentType:
+ *           type: string
+ *           description: MIME type of the content
+ *         sourceUrl:
+ *           type: string
+ *           nullable: true
+ *         context:
+ *           type: object
+ *           properties:
+ *             username:
+ *               type: string
+ *               nullable: true
+ *             fullName:
+ *               type: string
+ *               nullable: true
+ *             email:
+ *               type: string
+ *               nullable: true
+ *             profilePictureUrl:
+ *               type: string
+ *               nullable: true
+ *         contentFragmentId:
+ *           type: string
+ *         contentFragmentVersion:
+ *           type: string
+ *           enum: [superseded, latest]
+ *         contentFragmentType:
+ *           type: string
+ *           enum: [file, content_node]
+ *           description: Whether this is a file upload or a content node reference
+ *         expiredReason:
+ *           type: string
+ *           nullable: true
+ *           enum: [data_source_deleted]
+ *         fileId:
+ *           type: string
+ *           nullable: true
+ *           description: Present for file content fragments
+ *         snippet:
+ *           type: string
+ *           nullable: true
+ *         textUrl:
+ *           type: string
+ *           nullable: true
+ *         textBytes:
+ *           type: integer
+ *           nullable: true
+ *         nodeId:
+ *           type: string
+ *           nullable: true
+ *           description: Present for content node fragments
+ *         nodeDataSourceViewId:
+ *           type: string
+ *           nullable: true
+ *     PrivateLightAgentConfiguration:
+ *       type: object
+ *       description: Agent configuration as returned by the private list endpoint.
+ *       required:
+ *         - id
+ *         - sId
+ *         - version
+ *         - name
+ *         - description
+ *         - pictureUrl
+ *         - status
+ *         - scope
+ *         - model
+ *         - maxStepsPerRun
+ *         - tags
+ *       properties:
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         version:
+ *           type: integer
+ *         versionCreatedAt:
+ *           type: string
+ *           nullable: true
+ *         versionAuthorId:
+ *           type: integer
+ *           nullable: true
+ *         name:
+ *           type: string
+ *         description:
+ *           type: string
+ *         instructions:
+ *           type: string
+ *           nullable: true
+ *         pictureUrl:
+ *           type: string
+ *         status:
+ *           type: string
+ *           description: Agent status
+ *           enum: [active, archived, draft, pending, disabled_by_admin, disabled_missing_datasource, disabled_free_workspace]
+ *         scope:
+ *           type: string
+ *           enum: [global, visible, hidden]
+ *         userFavorite:
+ *           type: boolean
+ *         model:
+ *           type: object
+ *           properties:
+ *             providerId:
+ *               type: string
+ *             modelId:
+ *               type: string
+ *             temperature:
+ *               type: number
+ *             reasoningEffort:
+ *               type: string
+ *               enum: [none, light, medium, high]
+ *         maxStepsPerRun:
+ *           type: integer
+ *         tags:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               sId:
+ *                 type: string
+ *               name:
+ *                 type: string
+ *         templateId:
+ *           type: string
+ *           nullable: true
+ *         requestedGroupIds:
+ *           type: array
+ *           items:
+ *             type: array
+ *             items:
+ *               type: string
+ *         requestedSpaceIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *         canRead:
+ *           type: boolean
+ *         canEdit:
+ *           type: boolean
+ *         lastAuthors:
+ *           type: array
+ *           description: Optional, returned when withAuthors query param is set
+ *           items:
+ *             type: string
+ *         editors:
+ *           type: array
+ *           description: Optional, returned when withEditors query param is set
+ *           items:
+ *             type: object
+ *             properties:
+ *               sId:
+ *                 type: string
+ *               fullName:
+ *                 type: string
+ *               image:
+ *                 type: string
+ *                 nullable: true
+ *         usage:
+ *           type: object
+ *           description: Optional, returned when withUsage query param is set
+ *           properties:
+ *             messageCount:
+ *               type: integer
+ *             conversationCount:
+ *               type: integer
+ *             userCount:
+ *               type: integer
+ *             timePeriodSec:
+ *               type: integer
+ *         feedbacks:
+ *           type: object
+ *           description: Optional, returned when withFeedbacks query param is set
+ *           properties:
+ *             up:
+ *               type: integer
+ *             down:
+ *               type: integer
+ *     PrivateFileWithUploadUrl:
+ *       type: object
+ *       description: File record with a pre-signed upload URL.
+ *       required:
+ *         - sId
+ *         - id
+ *         - fileName
+ *         - fileSize
+ *         - contentType
+ *         - status
+ *         - useCase
+ *         - uploadUrl
+ *       properties:
+ *         sId:
+ *           type: string
+ *         id:
+ *           type: string
+ *         contentType:
+ *           type: string
+ *         fileName:
+ *           type: string
+ *         fileSize:
+ *           type: integer
+ *         version:
+ *           type: integer
+ *         status:
+ *           type: string
+ *           enum: [created, failed, ready]
+ *         useCase:
+ *           type: string
+ *           enum: [conversation, avatar, tool_output, upsert_document, folders_document, upsert_table, project_context, skill_attachment]
+ *         uploadUrl:
+ *           type: string
+ *           description: Pre-signed URL for uploading the file content
+ *         downloadUrl:
+ *           type: string
+ *         publicUrl:
+ *           type: string
+ *     PrivateSpace:
+ *       type: object
+ *       description: A space in the workspace.
+ *       required:
+ *         - sId
+ *         - name
+ *         - kind
+ *         - groupIds
+ *         - isRestricted
+ *         - managementMode
+ *       properties:
+ *         sId:
+ *           type: string
+ *         name:
+ *           type: string
+ *         kind:
+ *           type: string
+ *           enum: [global, system, conversations, regular, project]
+ *         groupIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *         isRestricted:
+ *           type: boolean
+ *         managementMode:
+ *           type: string
+ *           enum: [manual, group]
+ *         createdAt:
+ *           type: integer
+ *         updatedAt:
+ *           type: integer
+ *     PrivateProject:
+ *       type: object
+ *       description: A project space with additional metadata.
+ *       allOf:
+ *         - $ref: '#/components/schemas/PrivateSpace'
+ *         - type: object
+ *           properties:
+ *             description:
+ *               type: string
+ *               nullable: true
+ *             isMember:
+ *               type: boolean
+ *             archivedAt:
+ *               type: integer
+ *               nullable: true
+ *     PrivateDataSourceView:
+ *       type: object
+ *       description: A view on a data source within a space.
+ *       required:
+ *         - sId
+ *         - id
+ *         - category
+ *         - kind
+ *         - spaceId
+ *         - dataSource
+ *       properties:
+ *         sId:
+ *           type: string
+ *         id:
+ *           type: integer
+ *         category:
+ *           type: string
+ *           enum: [managed, folder, website, apps]
+ *         kind:
+ *           type: string
+ *           enum: [default, custom]
+ *         spaceId:
+ *           type: string
+ *         createdAt:
+ *           type: integer
+ *         updatedAt:
+ *           type: integer
+ *         parentsIn:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             type: string
+ *           description: List of parent IDs included in this view, null if the full data source is used
+ *         dataSource:
+ *           $ref: '#/components/schemas/PrivateDataSource'
+ *         editedByUser:
+ *           type: object
+ *           nullable: true
+ *           properties:
+ *             editedAt:
+ *               type: integer
+ *               nullable: true
+ *             fullName:
+ *               type: string
+ *               nullable: true
+ *             imageUrl:
+ *               type: string
+ *               nullable: true
+ *             email:
+ *               type: string
+ *               nullable: true
+ *             userId:
+ *               type: string
+ *               nullable: true
+ *     PrivateDataSource:
+ *       type: object
+ *       description: A data source in the workspace.
+ *       required:
+ *         - sId
+ *         - id
+ *         - name
+ *       properties:
+ *         sId:
+ *           type: string
+ *         id:
+ *           type: integer
+ *         createdAt:
+ *           type: integer
+ *         name:
+ *           type: string
+ *         description:
+ *           type: string
+ *           nullable: true
+ *         assistantDefaultSelected:
+ *           type: boolean
+ *         dustAPIProjectId:
+ *           type: string
+ *         dustAPIDataSourceId:
+ *           type: string
+ *         connectorId:
+ *           type: string
+ *           nullable: true
+ *         connectorProvider:
+ *           type: string
+ *           nullable: true
+ *     PrivateMentionSuggestion:
+ *       type: object
+ *       description: A rich mention suggestion for agents or users.
+ *       required:
+ *         - id
+ *         - type
+ *         - label
+ *         - pictureUrl
+ *         - description
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: Agent sId or user sId
+ *         type:
+ *           type: string
+ *           enum: [agent, user]
+ *         label:
+ *           type: string
+ *           description: Display name
+ *         pictureUrl:
+ *           type: string
+ *         description:
+ *           type: string
+ *           description: Agent description or user email
+ *         userFavorite:
+ *           type: boolean
+ *           description: Whether the agent is a user favorite (agent mentions only)
+ *     PrivateFeatureFlags:
+ *       type: object
+ *       description: Workspace feature flags response.
+ *       required:
+ *         - feature_flags
+ *       properties:
+ *         feature_flags:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: List of enabled feature flag names for the workspace
+ *     PrivateExtensionConfig:
+ *       type: object
+ *       description: Extension configuration for the workspace.
+ *       required:
+ *         - blacklistedDomains
+ *       properties:
+ *         blacklistedDomains:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: Domains where the extension should not activate
+ *     PrivateFeedback:
+ *       type: object
+ *       description: User feedback on an agent message.
+ *       required:
+ *         - id
+ *         - sId
+ *         - messageId
+ *         - agentMessageId
+ *         - userId
+ *         - thumbDirection
+ *         - agentConfigurationId
+ *         - agentConfigurationVersion
+ *         - isConversationShared
+ *         - dismissed
+ *         - createdAt
+ *       properties:
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         agentMessageId:
+ *           type: integer
+ *         userId:
+ *           type: integer
+ *         thumbDirection:
+ *           type: string
+ *           enum: [up, down]
+ *         content:
+ *           type: string
+ *           nullable: true
+ *           description: Optional text feedback from the user
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         agentConfigurationId:
+ *           type: string
+ *         agentConfigurationVersion:
+ *           type: integer
+ *         isConversationShared:
+ *           type: boolean
+ *         dismissed:
+ *           type: boolean
+ *     PrivateMention:
+ *       type: object
+ *       description: A mention in a message (agent or user).
+ *       properties:
+ *         configurationId:
+ *           type: string
+ *           description: Agent configuration sId (for agent mentions)
+ *         type:
+ *           type: string
+ *           enum: [user]
+ *           description: Present only for user mentions
+ *         userId:
+ *           type: string
+ *           description: User sId (for user mentions)
+ *     PrivateRichMentionWithStatus:
+ *       type: object
+ *       description: A rich mention with approval status, used in message responses.
+ *       required:
+ *         - id
+ *         - type
+ *         - label
+ *         - pictureUrl
+ *         - description
+ *         - dismissed
+ *         - status
+ *       properties:
+ *         id:
+ *           type: string
+ *         type:
+ *           type: string
+ *           enum: [agent, user]
+ *         label:
+ *           type: string
+ *         pictureUrl:
+ *           type: string
+ *         description:
+ *           type: string
+ *         userFavorite:
+ *           type: boolean
+ *         dismissed:
+ *           type: boolean
+ *         status:
+ *           type: string
+ *           enum: [pending_conversation_access, pending_project_membership, approved, rejected, user_restricted_by_conversation_access, agent_restricted_by_space_usage]
+ *     PrivateUserMessageContext:
+ *       type: object
+ *       description: Context metadata for a user message.
+ *       required:
+ *         - username
+ *         - timezone
+ *         - origin
+ *       properties:
+ *         username:
+ *           type: string
+ *         fullName:
+ *           type: string
+ *           nullable: true
+ *         email:
+ *           type: string
+ *           nullable: true
+ *         profilePictureUrl:
+ *           type: string
+ *           nullable: true
+ *         timezone:
+ *           type: string
+ *         origin:
+ *           type: string
+ *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, zapier, zendesk, onboarding_conversation, project_butler]
+ *     PrivateReaction:
+ *       type: object
+ *       description: A reaction on a message.
+ *       required:
+ *         - emoji
+ *         - users
+ *       properties:
+ *         emoji:
+ *           type: string
+ *         users:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 nullable: true
+ *               username:
+ *                 type: string
+ *               fullName:
+ *                 type: string
+ *                 nullable: true
+ *     PrivateConversationEvent:
+ *       type: object
+ *       description: Server-Sent Event for conversation-level streaming. Discriminated on the `type` field.
+ *       discriminator:
+ *         propertyName: type
+ *       oneOf:
+ *         - $ref: '#/components/schemas/PrivateUserMessageNewEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentMessageNewEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentMessageDoneEvent'
+ *         - $ref: '#/components/schemas/PrivateConversationTitleEvent'
+ *         - $ref: '#/components/schemas/PrivateButlerSuggestionCreatedEvent'
+ *         - $ref: '#/components/schemas/PrivateButlerThinkingEvent'
+ *         - $ref: '#/components/schemas/PrivateButlerDoneEvent'
+ *     PrivateUserMessageNewEvent:
+ *       type: object
+ *       required: [type, created, messageId, message]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [user_message_new]
+ *         created:
+ *           type: integer
+ *         messageId:
+ *           type: string
+ *         message:
+ *           $ref: '#/components/schemas/PrivateUserMessage'
+ *     PrivateAgentMessageNewEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, message]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_message_new]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         message:
+ *           $ref: '#/components/schemas/PrivateAgentMessage'
+ *     PrivateAgentMessageDoneEvent:
+ *       type: object
+ *       required: [type, created, conversationId, configurationId, messageId, status]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_message_done]
+ *         created:
+ *           type: integer
+ *         conversationId:
+ *           type: string
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         status:
+ *           type: string
+ *           enum: [success, error]
+ *     PrivateConversationTitleEvent:
+ *       type: object
+ *       required: [type, created, title]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [conversation_title]
+ *         created:
+ *           type: integer
+ *         title:
+ *           type: string
+ *     PrivateButlerSuggestionCreatedEvent:
+ *       type: object
+ *       required: [type, created, suggestion]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [butler_suggestion_created]
+ *         created:
+ *           type: integer
+ *         suggestion:
+ *           type: object
+ *           description: Butler suggestion details
+ *     PrivateButlerThinkingEvent:
+ *       type: object
+ *       required: [type, created]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [butler_thinking]
+ *         created:
+ *           type: integer
+ *     PrivateButlerDoneEvent:
+ *       type: object
+ *       required: [type, created]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [butler_done]
+ *         created:
+ *           type: integer
+ *     PrivateAgentMessageEvent:
+ *       type: object
+ *       description: Server-Sent Event for agent message streaming. Discriminated on the `type` field. Each event also includes a `step` integer.
+ *       discriminator:
+ *         propertyName: type
+ *       oneOf:
+ *         - $ref: '#/components/schemas/PrivateGenerationTokensEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentActionSuccessEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentMessageSuccessEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentErrorEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentGenerationCancelledEvent'
+ *         - $ref: '#/components/schemas/PrivateToolErrorEvent'
+ *         - $ref: '#/components/schemas/PrivateToolParamsEvent'
+ *         - $ref: '#/components/schemas/PrivateToolApproveExecutionEvent'
+ *         - $ref: '#/components/schemas/PrivateToolNotificationEvent'
+ *         - $ref: '#/components/schemas/PrivateToolPersonalAuthRequiredEvent'
+ *         - $ref: '#/components/schemas/PrivateToolFileAuthRequiredEvent'
+ *         - $ref: '#/components/schemas/PrivateAgentContextPrunedEvent'
+ *     PrivateGenerationTokensEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, text, classification]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [generation_tokens]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         text:
+ *           type: string
+ *           description: The token(s) generated in this chunk
+ *         classification:
+ *           type: string
+ *           enum: [tokens, chain_of_thought, opening_delimiter, closing_delimiter]
+ *         delimiterClassification:
+ *           type: string
+ *           description: Present when classification is opening_delimiter or closing_delimiter
+ *         step:
+ *           type: integer
+ *     PrivateAgentActionSuccessEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, action]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_action_success]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         action:
+ *           type: object
+ *           description: The MCP action that completed successfully
+ *         step:
+ *           type: integer
+ *     PrivateAgentMessageSuccessEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, message, runIds]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_message_success]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         message:
+ *           $ref: '#/components/schemas/PrivateAgentMessage'
+ *         runIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *         step:
+ *           type: integer
+ *     PrivateAgentErrorEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, error]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_error]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         error:
+ *           type: object
+ *           properties:
+ *             code:
+ *               type: string
+ *             message:
+ *               type: string
+ *         runIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *         step:
+ *           type: integer
+ *     PrivateAgentGenerationCancelledEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_generation_cancelled]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         step:
+ *           type: integer
+ *     PrivateToolErrorEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, conversationId, error, isLastBlockingEventForStep]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_error]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         conversationId:
+ *           type: string
+ *         error:
+ *           type: object
+ *           properties:
+ *             code:
+ *               type: string
+ *             message:
+ *               type: string
+ *         isLastBlockingEventForStep:
+ *           type: boolean
+ *         step:
+ *           type: integer
+ *     PrivateToolParamsEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, action]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_params]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         action:
+ *           type: object
+ *           description: The MCP action with its parameters
+ *         runIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *         step:
+ *           type: integer
+ *     PrivateToolApproveExecutionEvent:
+ *       type: object
+ *       description: Sent when a tool requires user approval before execution.
+ *       required: [type, created, conversationId, messageId, actionId, configurationId, inputs]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_approve_execution]
+ *         created:
+ *           type: integer
+ *         conversationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         actionId:
+ *           type: string
+ *         configurationId:
+ *           type: string
+ *         inputs:
+ *           type: object
+ *           additionalProperties: true
+ *         stake:
+ *           type: string
+ *           description: Risk level of the tool execution
+ *         isLastBlockingEventForStep:
+ *           type: boolean
+ *         metadata:
+ *           type: object
+ *         step:
+ *           type: integer
+ *     PrivateToolNotificationEvent:
+ *       type: object
+ *       description: Progress notification from a running tool.
+ *       required: [type, created, configurationId, conversationId, messageId, action, notification]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_notification]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         conversationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         action:
+ *           type: object
+ *           description: The MCP action producing the notification
+ *         notification:
+ *           type: object
+ *           description: Progress notification content
+ *         step:
+ *           type: integer
+ *     PrivateToolPersonalAuthRequiredEvent:
+ *       type: object
+ *       description: Sent when a tool requires personal OAuth authentication.
+ *       required: [type, created, conversationId, messageId, actionId, configurationId, authError]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_personal_auth_required]
+ *         created:
+ *           type: integer
+ *         conversationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         actionId:
+ *           type: string
+ *         configurationId:
+ *           type: string
+ *         authError:
+ *           type: object
+ *           properties:
+ *             mcpServerId:
+ *               type: string
+ *             provider:
+ *               type: string
+ *             scope:
+ *               type: string
+ *             toolName:
+ *               type: string
+ *             message:
+ *               type: string
+ *         step:
+ *           type: integer
+ *     PrivateToolFileAuthRequiredEvent:
+ *       type: object
+ *       description: Sent when a tool requires file access authorization (e.g., Google Drive).
+ *       required: [type, created, conversationId, messageId, actionId, configurationId, fileAuthError]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_file_auth_required]
+ *         created:
+ *           type: integer
+ *         conversationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         actionId:
+ *           type: string
+ *         configurationId:
+ *           type: string
+ *         fileAuthError:
+ *           type: object
+ *           properties:
+ *             fileId:
+ *               type: string
+ *             fileName:
+ *               type: string
+ *             connectionId:
+ *               type: string
+ *             mimeType:
+ *               type: string
+ *             toolName:
+ *               type: string
+ *             message:
+ *               type: string
+ *         step:
+ *           type: integer
+ *     PrivateAgentContextPrunedEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [agent_context_pruned]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         step:
+ *           type: integer
+ */

--- a/front/pages/api/templates/[tId]/index.ts
+++ b/front/pages/api/templates/[tId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/templates/index.ts
+++ b/front/pages/api/templates/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -1,3 +1,74 @@
+/**
+ * @swagger
+ * /api/user:
+ *   get:
+ *     summary: Get current user
+ *     description: Returns the authenticated user with their workspaces and subscriber hash.
+ *     tags:
+ *       - Private User
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The authenticated user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   $ref: '#/components/schemas/PrivateUser'
+ *       404:
+ *         description: User not found
+ *   patch:
+ *     summary: Update current user
+ *     description: Update the authenticated user's profile (name, job type, favorite platforms, image).
+ *     tags:
+ *       - Private User
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - firstName
+ *               - lastName
+ *             properties:
+ *               firstName:
+ *                 type: string
+ *               lastName:
+ *                 type: string
+ *               jobType:
+ *                 type: string
+ *               imageUrl:
+ *                 type: string
+ *                 nullable: true
+ *               favoritePlatforms:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               emailProvider:
+ *                 type: string
+ *               workspaceId:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: User updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       400:
+ *         description: Invalid request body
+ *       404:
+ *         description: User not found
+ */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";

--- a/front/pages/api/w/[wId]/analytics/active-users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/analytics/active-users.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";

--- a/front/pages/api/w/[wId]/analytics/agents-export.ts
+++ b/front/pages/api/w/[wId]/analytics/agents-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/analytics/overview.ts
+++ b/front/pages/api/w/[wId]/analytics/overview.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost-export.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { handleProgrammaticCostExportRequest } from "@app/lib/api/analytics/programmatic_cost_export";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { GetWorkspaceProgrammaticCostResponse } from "@app/lib/api/analytics/programmatic_cost";
 import { handleProgrammaticCostRequest } from "@app/lib/api/analytics/programmatic_cost";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/analytics/skill-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";

--- a/front/pages/api/w/[wId]/analytics/skills.ts
+++ b/front/pages/api/w/[wId]/analytics/skills.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";

--- a/front/pages/api/w/[wId]/analytics/source-export.ts
+++ b/front/pages/api/w/[wId]/analytics/source-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/analytics/source.ts
+++ b/front/pages/api/w/[wId]/analytics/source.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/analytics/tool-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";

--- a/front/pages/api/w/[wId]/analytics/tools.ts
+++ b/front/pages/api/w/[wId]/analytics/tools.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchAvailableTools } from "@app/lib/api/assistant/observability/tool_usage";

--- a/front/pages/api/w/[wId]/analytics/top-agents.ts
+++ b/front/pages/api/w/[wId]/analytics/top-agents.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/analytics/top-users.ts
+++ b/front/pages/api/w/[wId]/analytics/top-users.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/analytics/usage-metrics-export.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type {
   MessageMetricsPoint,

--- a/front/pages/api/w/[wId]/analytics/users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/users-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   buildAgentAnalyticsBaseQuery,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   getAgentConfiguration,
   updateAgentPermissions,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { exportAgentConfigurationAsYAML } from "@app/lib/api/assistant/configuration/yaml_export";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks/[fId].ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks/[fId].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getMessageConversationId } from "@app/lib/api/assistant/conversation";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   getAgentConfiguration,
   listsAgentConfigurationVersions,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   archiveAgentConfiguration,
   getAgentConfiguration,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { AgentMcpConfigurationSummary } from "@app/lib/api/assistant/mcp_configurations";
 import { listAgentMcpConfigurationsForAgent } from "@app/lib/api/assistant/mcp_configurations";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { DatasourceRetrievalDocuments } from "@app/lib/api/assistant/observability/datasource_retrieval_documents";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { FeedbackDistributionPoint } from "@app/lib/api/assistant/observability/feedback_distribution";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { generateAgentObservabilitySummary } from "@app/lib/api/assistant/observability/summary";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolExecutionByVersion } from "@app/lib/api/assistant/observability/tool_execution";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolStepIndexByStep } from "@app/lib/api/assistant/observability/tool_step_index";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   getAgentConfiguration,
   restoreAgentConfiguration,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/subscribers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/subscribers.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   getAgentConfiguration,
   updateAgentConfigurationScope,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   archiveAgentConfiguration,
   getAgentConfigurations,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -1,3 +1,120 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/agent_configurations:
+ *   get:
+ *     summary: List agent configurations
+ *     description: Returns all agent configurations in the workspace.
+ *     tags:
+ *       - Private Agents
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: view
+ *         required: false
+ *         description: Filter agents by view
+ *         schema:
+ *           type: string
+ *           enum: [all, list, favorites, published, admin_internal, global, workspace]
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         description: Maximum number of results to return
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: withUsage
+ *         required: false
+ *         description: Include usage statistics
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *       - in: query
+ *         name: withAuthors
+ *         required: false
+ *         description: Include recent authors
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *       - in: query
+ *         name: withFeedbacks
+ *         required: false
+ *         description: Include feedback counts
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *       - in: query
+ *         name: withEditors
+ *         required: false
+ *         description: Include editors list
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *       - in: query
+ *         name: sort
+ *         required: false
+ *         description: Sort order
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 agentConfigurations:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateLightAgentConfiguration'
+ *       401:
+ *         description: Unauthorized
+ *   post:
+ *     summary: Create an agent configuration
+ *     description: Creates a new agent configuration in the workspace.
+ *     tags:
+ *       - Private Agents
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - assistant
+ *             properties:
+ *               assistant:
+ *                 type: object
+ *                 description: Agent configuration to create
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 agentConfiguration:
+ *                   $ref: '#/components/schemas/PrivateLightAgentConfiguration'
+ *       401:
+ *         description: Unauthorized
+ */
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import type {
   MCPServerConfigurationType,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentSIdFromName } from "@app/lib/api/assistant/configuration/helpers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentSIdFromName } from "@app/lib/api/assistant/configuration/helpers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   GENERIC_ERROR_MESSAGE,
   generateCronRule,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getWebhookFilterGeneration } from "@app/lib/api/assistant/configuration/triggers/webhook_filter";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
 import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 
 import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/template.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/template.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TemplateResource } from "@app/lib/resources/template_resource";

--- a/front/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getBuilderSuggestions } from "@app/lib/api/assistant/suggestions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/butler_suggestions/[sId].ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/butler_suggestions/[sId].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,3 +1,56 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/cancel:
+ *   post:
+ *     summary: Cancel message generation
+ *     description: Cancels the generation of messages in a conversation.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - action
+ *               - messageIds
+ *             properties:
+ *               action:
+ *                 type: string
+ *                 enum: [cancel]
+ *               messageIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: Unauthorized
+ */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -1,3 +1,70 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/content_fragment:
+ *   post:
+ *     summary: Create a content fragment
+ *     description: Post a new content fragment to an existing conversation.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *               - content
+ *               - contentType
+ *               - context
+ *             properties:
+ *               title:
+ *                 type: string
+ *               content:
+ *                 type: string
+ *               contentType:
+ *                 type: string
+ *                 description: MIME type of the content
+ *               url:
+ *                 type: string
+ *                 nullable: true
+ *               context:
+ *                 type: object
+ *                 properties:
+ *                   profilePictureUrl:
+ *                     type: string
+ *                     nullable: true
+ *               fileId:
+ *                 type: string
+ *                 nullable: true
+ *     responses:
+ *       200:
+ *         description: Successfully created content fragment
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 contentFragment:
+ *                   $ref: '#/components/schemas/PrivateContentFragment'
+ *       401:
+ *         description: Unauthorized
+ */
 import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,3 +1,38 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/events:
+ *   get:
+ *     summary: Stream conversation events
+ *     description: Stream real-time conversation events using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.
+ *     tags:
+ *       - Private Events
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: |
+ *           SSE event stream. Each event is sent as `data: {json}\n\n`.
+ *           Events are discriminated by the `type` field.
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateConversationEvent'
+ *       401:
+ *         description: Unauthorized
+ */
 // This endpoint is redirected (307) to /api/sse/w/[wId]/assistant/conversations/[cId]/events
 // via middleware. The /api/sse/ prefix allows the ingress to route SSE traffic to front-sse pods.
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,3 +1,41 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/feedbacks:
+ *   get:
+ *     summary: Get conversation feedbacks
+ *     description: Retrieve all feedbacks for a conversation submitted by the authenticated user.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved feedbacks
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 feedbacks:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateFeedback'
+ *       401:
+ *         description: Unauthorized
+ */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,3 +1,121 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}:
+ *   get:
+ *     summary: Get a conversation
+ *     description: Retrieve a specific conversation by its ID.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved conversation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 conversation:
+ *                   $ref: '#/components/schemas/PrivateConversation'
+ *       401:
+ *         description: Unauthorized
+ *   delete:
+ *     summary: Delete or leave a conversation
+ *     description: Delete a conversation or leave it if it is shared.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully deleted or left conversation
+ *       401:
+ *         description: Unauthorized
+ *   patch:
+ *     summary: Update a conversation
+ *     description: Update a conversation's title, mark it as read, or move it to a different space.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             oneOf:
+ *               - type: object
+ *                 required:
+ *                   - title
+ *                 properties:
+ *                   title:
+ *                     type: string
+ *               - type: object
+ *                 required:
+ *                   - read
+ *                 properties:
+ *                   read:
+ *                     type: boolean
+ *                     enum: [true]
+ *               - type: object
+ *                 required:
+ *                   - spaceId
+ *                 properties:
+ *                   spaceId:
+ *                     type: string
+ *     responses:
+ *       200:
+ *         description: Successfully updated conversation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: Unauthorized
+ */
 import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { suggestionsOfMentions } from "@app/lib/api/assistant/conversation/mention_suggestions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,3 +1,61 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit:
+ *   post:
+ *     summary: Edit a message
+ *     description: Edit the content and mentions of an existing user message in a conversation.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - content
+ *               - mentions
+ *             properties:
+ *               content:
+ *                 type: string
+ *               mentions:
+ *                 type: array
+ *                 items:
+ *                   $ref: '#/components/schemas/PrivateMention'
+ *     responses:
+ *       200:
+ *         description: Successfully edited message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   $ref: '#/components/schemas/PrivateUserMessage'
+ *       401:
+ *         description: Unauthorized
+ */
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,3 +1,44 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/events:
+ *   get:
+ *     summary: Stream message events
+ *     description: Stream real-time events for a specific agent message using Server-Sent Events (SSE). Only available for agent messages. This endpoint is redirected to /api/sse/ for SSE traffic routing.
+ *     tags:
+ *       - Private Events
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: |
+ *           SSE event stream. Each event is sent as `data: {json}\n\n`.
+ *           Events are discriminated by the `type` field. Each event payload also includes a `step` integer.
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateAgentMessageEvent'
+ *       401:
+ *         description: Unauthorized
+ */
 // This endpoint is redirected (307) to /api/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events
 // via middleware. The /api/sse/ prefix allows the ingress to route SSE traffic to front-sse pods.
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -1,3 +1,100 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/feedbacks:
+ *   post:
+ *     summary: Submit message feedback
+ *     description: Create or update feedback (thumbs up/down) for a specific agent message.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - thumbDirection
+ *             properties:
+ *               thumbDirection:
+ *                 type: string
+ *                 enum: [up, down]
+ *               feedbackContent:
+ *                 type: string
+ *                 nullable: true
+ *               isConversationShared:
+ *                 type: boolean
+ *     responses:
+ *       200:
+ *         description: Successfully submitted feedback
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: Unauthorized
+ *   delete:
+ *     summary: Delete message feedback
+ *     description: Remove the authenticated user's feedback for a specific agent message.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully deleted feedback
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: Unauthorized
+ */
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -1,3 +1,90 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}:
+ *   get:
+ *     summary: Get a message
+ *     description: Retrieve a specific message by its ID within a conversation.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   oneOf:
+ *                     - $ref: '#/components/schemas/PrivateUserMessage'
+ *                     - $ref: '#/components/schemas/PrivateAgentMessage'
+ *                     - $ref: '#/components/schemas/PrivateContentFragment'
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Message or conversation not found
+ *   delete:
+ *     summary: Delete a message
+ *     description: Soft-delete a user or agent message from a conversation.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully deleted message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Message or conversation not found
+ */
 import {
   softDeleteAgentMessage,
   softDeleteUserMessage,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   dismissMention,
   validateUserMention,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,3 +1,45 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/retry:
+ *   post:
+ *     summary: Retry an agent message
+ *     description: Retry generating an agent message response, optionally retrying only blocked actions.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         description: ID of the message
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retried message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   $ref: '#/components/schemas/PrivateAgentMessage'
+ *       401:
+ *         description: Unauthorized
+ */
 import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/skills.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -1,3 +1,123 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages:
+ *   get:
+ *     summary: List messages in a conversation
+ *     description: Retrieve a paginated list of messages for a specific conversation.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved messages
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 messages:
+ *                   type: array
+ *                   items:
+ *                     oneOf:
+ *                       - $ref: '#/components/schemas/PrivateUserMessage'
+ *                       - $ref: '#/components/schemas/PrivateLightAgentMessage'
+ *                       - $ref: '#/components/schemas/PrivateContentFragment'
+ *                 hasMore:
+ *                   type: boolean
+ *                 lastValue:
+ *                   type: integer
+ *                   nullable: true
+ *       401:
+ *         description: Unauthorized
+ *   post:
+ *     summary: Post a message to a conversation
+ *     description: Post a new user message to an existing conversation, triggering agent responses.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - content
+ *               - context
+ *               - mentions
+ *             properties:
+ *               content:
+ *                 type: string
+ *               mentions:
+ *                 type: array
+ *                 items:
+ *                   $ref: '#/components/schemas/PrivateMention'
+ *               context:
+ *                 type: object
+ *                 properties:
+ *                   timezone:
+ *                     type: string
+ *                   profilePictureUrl:
+ *                     type: string
+ *                     nullable: true
+ *                   origin:
+ *                     type: string
+ *                     nullable: true
+ *                   clientSideMCPServerIds:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *               skipToolsValidation:
+ *                 type: boolean
+ *     responses:
+ *       200:
+ *         description: Successfully posted message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   $ref: '#/components/schemas/PrivateUserMessage'
+ *                 contentFragments:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateContentFragment'
+ *                 agentMessages:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateAgentMessage'
+ *       401:
+ *         description: Unauthorized
+ */
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { isSidekickConversation } from "@app/lib/api/actions/servers/helpers";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -1,3 +1,87 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/participants:
+ *   get:
+ *     summary: Get conversation participants
+ *     description: Returns the participants of a specific conversation.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 participants:
+ *                   type: object
+ *                   properties:
+ *                     agents:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           configurationId:
+ *                             type: string
+ *                           configurationName:
+ *                             type: string
+ *                     users:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           username:
+ *                             type: string
+ *                           fullName:
+ *                             type: string
+ *                             nullable: true
+ *                           pictureUrl:
+ *                             type: string
+ *                             nullable: true
+ *       401:
+ *         description: Unauthorized
+ *   post:
+ *     summary: Add a participant to a conversation
+ *     description: Adds the authenticated user as a participant to a specific conversation.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Successfully added participant
+ *       401:
+ *         description: Unauthorized
+ */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getLastUserMessage } from "@app/lib/api/assistant/conversation";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";

--- a/front/pages/api/w/[wId]/assistant/conversations/bulk-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/bulk-actions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -1,3 +1,129 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations:
+ *   get:
+ *     summary: List conversations
+ *     description: Retrieve a paginated list of conversations for the authenticated user in the workspace.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved conversations
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 conversations:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateConversation'
+ *                 hasMore:
+ *                   type: boolean
+ *                 lastValue:
+ *                   type: string
+ *                   nullable: true
+ *       401:
+ *         description: Unauthorized
+ *   post:
+ *     summary: Create a conversation
+ *     description: Create a new conversation, optionally with an initial user message and content fragments.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 nullable: true
+ *               visibility:
+ *                 type: string
+ *                 enum: [unlisted, deleted, test]
+ *               spaceId:
+ *                 type: string
+ *                 nullable: true
+ *               message:
+ *                 type: object
+ *                 properties:
+ *                   content:
+ *                     type: string
+ *                   mentions:
+ *                     type: array
+ *                     items:
+ *                       $ref: '#/components/schemas/PrivateMention'
+ *                   context:
+ *                     type: object
+ *                     properties:
+ *                       timezone:
+ *                         type: string
+ *                       profilePictureUrl:
+ *                         type: string
+ *                         nullable: true
+ *                       origin:
+ *                         type: string
+ *                         nullable: true
+ *                       clientSideMCPServerIds:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                       selectedMCPServerViewIds:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                       selectedSkillIds:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *               contentFragments:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *               metadata:
+ *                 type: object
+ *                 nullable: true
+ *               skipToolsValidation:
+ *                 type: boolean
+ *     responses:
+ *       200:
+ *         description: Successfully created conversation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 conversation:
+ *                   $ref: '#/components/schemas/PrivateFullConversation'
+ *                 message:
+ *                   $ref: '#/components/schemas/PrivateUserMessage'
+ *                 contentFragments:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateContentFragment'
+ *       401:
+ *         description: Unauthorized
+ */
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import {
   createConversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/search.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/semantic_search.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/semantic_search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { searchProjectConversations } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { createOnboardingConversationIfNeeded } from "@app/lib/api/assistant/onboarding";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { upsertGlobalAgentSettings } from "@app/lib/api/assistant/global_agents/global_agents";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/mentions/parse.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/parse.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
@@ -1,3 +1,61 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/mentions/suggestions:
+ *   get:
+ *     summary: Get mention suggestions
+ *     description: Returns mention suggestions for the workspace.
+ *     tags:
+ *       - Private Mentions
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: query
+ *         required: false
+ *         description: Search query to filter suggestions
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: select
+ *         required: false
+ *         description: Filter by type (agents, users, or both)
+ *         schema:
+ *           type: string
+ *           enum: [agents, users]
+ *       - in: query
+ *         name: current
+ *         required: false
+ *         description: Whether to include only current mentions
+ *         schema:
+ *           type: string
+ *           enum: ["true", "false"]
+ *       - in: query
+ *         name: spaceId
+ *         required: false
+ *         description: Filter suggestions by space
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 suggestions:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateMentionSuggestion'
+ *       401:
+ *         description: Unauthorized
+ */
 import { suggestionsOfMentions } from "@app/lib/api/assistant/conversation/mention_suggestions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
 import {
   buildInitialActions,

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { SkillDescriptionSuggestionInputs } from "@app/lib/api/skills/description_suggestion";
 import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
+++ b/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";

--- a/front/pages/api/w/[wId]/credits/index.ts
+++ b/front/pages/api/w/[wId]/credits/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getInvoicePaymentUrl } from "@app/lib/plans/stripe";

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/data_source_views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";

--- a/front/pages/api/w/[wId]/data_source_views/tags/search.ts
+++ b/front/pages/api/w/[wId]/data_source_views/tags/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type {
   UpsertDocumentArgs,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_status.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { syncNotionUrls } from "@app/lib/api/poke/plugins/data_sources/notion_url_sync";
 import { runOnRedis } from "@app/lib/api/redis";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 // Public API types are okay to use here because it's front/connectors communication.
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/data_sources/bot-data-sources.ts
+++ b/front/pages/api/w/[wId]/data_sources/bot-data-sources.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";

--- a/front/pages/api/w/[wId]/data_sources/request_access.ts
+++ b/front/pages/api/w/[wId]/data_sources/request_access.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";

--- a/front/pages/api/w/[wId]/domains.ts
+++ b/front/pages/api/w/[wId]/domains.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   generateWorkOSAdminPortalUrl,

--- a/front/pages/api/w/[wId]/dsync.ts
+++ b/front/pages/api/w/[wId]/dsync.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   deleteWorkOSOrganizationDSyncConnection,

--- a/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getDustAppSecret } from "@app/lib/api/dust_app_secrets";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   getDustAppSecret,

--- a/front/pages/api/w/[wId]/extension/config.ts
+++ b/front/pages/api/w/[wId]/extension/config.ts
@@ -1,3 +1,30 @@
+/**
+ * @swagger
+ * /api/w/{wId}/extension/config:
+ *   get:
+ *     summary: Get extension configuration
+ *     description: Returns the extension configuration for the workspace, including blacklisted domains.
+ *     tags:
+ *       - Private Extension
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Extension configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateExtensionConfig'
+ *       401:
+ *         description: Unauthorized
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";

--- a/front/pages/api/w/[wId]/feature-flags.ts
+++ b/front/pages/api/w/[wId]/feature-flags.ts
@@ -1,3 +1,30 @@
+/**
+ * @swagger
+ * /api/w/{wId}/feature-flags:
+ *   get:
+ *     summary: Get workspace feature flags
+ *     description: Returns the list of enabled feature flags for the workspace.
+ *     tags:
+ *       - Private Workspace
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of feature flags
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PrivateFeatureFlags'
+ *       401:
+ *         description: Unauthorized
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { PDF_FOOTER_HTML } from "@app/lib/api/files/pdf_footer";

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -1,3 +1,124 @@
+/**
+ * @swagger
+ * /api/w/{wId}/files/{fileId}:
+ *   get:
+ *     summary: Get or download a file
+ *     description: View or download a file. Use query parameters `version` (original, processed, public) and `action` (view, download).
+ *     tags:
+ *       - Private Files
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: fileId
+ *         required: true
+ *         description: ID of the file
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: version
+ *         required: false
+ *         description: File version to retrieve
+ *         schema:
+ *           type: string
+ *           enum: [original, processed, public]
+ *       - in: query
+ *         name: action
+ *         required: false
+ *         description: Action to perform
+ *         schema:
+ *           type: string
+ *           enum: [view, download]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: File content or redirect to download URL
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       302:
+ *         description: Redirect to signed download URL
+ *       404:
+ *         description: File not found
+ *   post:
+ *     summary: Upload file content
+ *     description: Process and store the uploaded file content.
+ *     tags:
+ *       - Private Files
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: fileId
+ *         required: true
+ *         description: ID of the file
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       200:
+ *         description: File processed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 file:
+ *                   $ref: '#/components/schemas/PrivateFileWithUploadUrl'
+ *       403:
+ *         description: Permission denied
+ *       404:
+ *         description: File not found
+ *   delete:
+ *     summary: Delete a file
+ *     description: Delete a file from the workspace.
+ *     tags:
+ *       - Private Files
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: fileId
+ *         required: true
+ *         description: ID of the file
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       204:
+ *         description: File deleted
+ *       403:
+ *         description: Permission denied
+ *       404:
+ *         description: File not found
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";

--- a/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/w/[wId]/files/[fileId]/signed-url.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/signed-url.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -1,3 +1,58 @@
+/**
+ * @swagger
+ * /api/w/{wId}/files:
+ *   post:
+ *     summary: Create a file upload
+ *     description: Creates a file record and returns a pre-signed upload URL. The file content should then be uploaded to the returned URL.
+ *     tags:
+ *       - Private Files
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - contentType
+ *               - fileName
+ *               - fileSize
+ *               - useCase
+ *             properties:
+ *               contentType:
+ *                 type: string
+ *               fileName:
+ *                 type: string
+ *               fileSize:
+ *                 type: number
+ *               useCase:
+ *                 type: string
+ *                 enum: [conversation, folders_document, avatar, upsert_document, upsert_table, project_context, skill_attachment]
+ *               useCaseMetadata:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: File record created with upload URL
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 file:
+ *                   $ref: '#/components/schemas/PrivateFileWithUploadUrl'
+ *       400:
+ *         description: Invalid request
+ *       429:
+ *         description: Rate limit exceeded
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";

--- a/front/pages/api/w/[wId]/google_drive/search_for_authorization.ts
+++ b/front/pages/api/w/[wId]/google_drive/search_for_authorization.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { updateWorkOSOrganizationName } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/join.ts
+++ b/front/pages/api/w/[wId]/join.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { fetchUsersFromWorkOSWithEmails } from "@app/lib/api/workos/user";

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { KeyResource } from "@app/lib/resources/key_resource";

--- a/front/pages/api/w/[wId]/keys/[id]/index.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { invalidateKeyCapCache } from "@app/lib/api/programmatic_usage/key_cap";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/labs/request_access.ts
+++ b/front/pages/api/w/[wId]/labs/request_access.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/labs/transcripts/connector.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/connector.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getDataSources } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { CustomResourceIconType } from "@app/components/resources/resources_icons";
 import {
   getServerTypeAndIdFromSId,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/mcp/available.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getInternalServerCredentialPolicy } from "@app/lib/actions/mcp_server_connection_credential_policies";

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";

--- a/front/pages/api/w/[wId]/mcp/heartbeat.ts
+++ b/front/pages/api/w/[wId]/mcp/heartbeat.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { updateMCPServerHeartbeat } from "@app/lib/api/actions/mcp/client_side_registry";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { isCustomResourceIconType } from "@app/components/resources/resources_icons";
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";

--- a/front/pages/api/w/[wId]/mcp/register.ts
+++ b/front/pages/api/w/[wId]/mcp/register.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   MCPServerInstanceLimitError,
   registerMCPServer,

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";

--- a/front/pages/api/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/w/[wId]/mcp/requests.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { getMCPEventsForServer } from "@app/lib/api/assistant/mcp_events";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/mcp/results.ts
+++ b/front/pages/api/w/[wId]/mcp/results.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { publishMCPResults } from "@app/lib/api/assistant/mcp_events";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/mcp/usage.ts
+++ b/front/pages/api/w/[wId]/mcp/usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type { MCPServersUsageByAgent } from "@app/lib/api/agent_actions";
 import { getToolsUsage } from "@app/lib/api/agent_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {

--- a/front/pages/api/w/[wId]/me/approvals.ts
+++ b/front/pages/api/w/[wId]/me/approvals.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/me/pending-invitations.ts
+++ b/front/pages/api/w/[wId]/me/pending-invitations.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";

--- a/front/pages/api/w/[wId]/me/triggers.ts
+++ b/front/pages/api/w/[wId]/me/triggers.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { revokeAndTrackMembership } from "@app/lib/api/membership";
 import { getUserForWorkspace } from "@app/lib/api/user";

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/members/lookup.ts
+++ b/front/pages/api/w/[wId]/members/lookup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";

--- a/front/pages/api/w/[wId]/members/me/agent_favorite.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_favorite.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { searchMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import {
   REASONING_MODEL_CONFIGS,
   USED_MODEL_CONFIGS,

--- a/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
+++ b/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { createConnectionAndGetSetupUrl } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";

--- a/front/pages/api/w/[wId]/provisioning-status.ts
+++ b/front/pages/api/w/[wId]/provisioning-status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { handleSearch, SearchRequestBody } from "@app/lib/api/search";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/search/tools/upload.ts
+++ b/front/pages/api/w/[wId]/search/tools/upload.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {

--- a/front/pages/api/w/[wId]/seats/availability.ts
+++ b/front/pages/api/w/[wId]/seats/availability.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/seats/count.ts
+++ b/front/pages/api/w/[wId]/seats/count.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";

--- a/front/pages/api/w/[wId]/services/transcribe/index.ts
+++ b/front/pages/api/w/[wId]/services/transcribe/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { findAgentsInMessage } from "@app/lib/utils/find_agents_in_message";

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";

--- a/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";

--- a/front/pages/api/w/[wId]/skills/[sId]/restore.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   detectSkillsFromGitHubRepo,

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/skills/similar.ts
+++ b/front/pages/api/w/[wId]/skills/similar.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getDatasetHash } from "@app/lib/api/datasets";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getDatasets } from "@app/lib/api/datasets";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { softDeleteApp } from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { getRun } from "@app/lib/api/run";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -1,3 +1,140 @@
+/**
+ * @swagger
+ * /api/w/{wId}/spaces/{spaceId}/data_source_views/{dsvId}:
+ *   get:
+ *     summary: Get a data source view
+ *     description: Returns the details of a specific data source view.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: dsvId
+ *         required: true
+ *         description: ID of the data source view
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 dataSourceView:
+ *                   $ref: '#/components/schemas/PrivateDataSourceView'
+ *                 connector:
+ *                   type: object
+ *                   nullable: true
+ *                   description: Connector details if the data source is managed
+ *       401:
+ *         description: Unauthorized
+ *   patch:
+ *     summary: Update a data source view
+ *     description: Updates a specific data source view.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: dsvId
+ *         required: true
+ *         description: ID of the data source view
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               parentsIn:
+ *                 type: array
+ *                 nullable: true
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 dataSourceView:
+ *                   $ref: '#/components/schemas/PrivateDataSourceView'
+ *                 connector:
+ *                   type: object
+ *                   nullable: true
+ *       401:
+ *         description: Unauthorized
+ *   delete:
+ *     summary: Delete a data source view
+ *     description: Deletes a specific data source view.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: dsvId
+ *         required: true
+ *         description: ID of the data source view
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: force
+ *         required: false
+ *         description: Force deletion even if the view is in use
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       204:
+ *         description: Successfully deleted data source view
+ *       401:
+ *         description: Unauthorized
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getFlattenedContentNodesOfViewTypeForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -1,3 +1,109 @@
+/**
+ * @swagger
+ * /api/w/{wId}/spaces/{spaceId}/data_source_views:
+ *   get:
+ *     summary: List data source views
+ *     description: Returns all data source views in a specific space.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: category
+ *         required: false
+ *         description: Filter by data source view category
+ *         schema:
+ *           type: string
+ *           enum: [managed, folder, website, apps]
+ *       - in: query
+ *         name: withDetails
+ *         required: false
+ *         description: Include usage and connector details (requires category)
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *       - in: query
+ *         name: includeEditedBy
+ *         required: false
+ *         description: Include editedByUser information
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 dataSourceViews:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateDataSourceView'
+ *       401:
+ *         description: Unauthorized
+ *   post:
+ *     summary: Create a data source view
+ *     description: Creates a new data source view in a specific space.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - dataSourceId
+ *             properties:
+ *               dataSourceId:
+ *                 type: string
+ *               parentsIn:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       201:
+ *         description: Successfully created data source view
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 dataSourceView:
+ *                   $ref: '#/components/schemas/PrivateDataSourceView'
+ *       401:
+ *         description: Unauthorized
+ */
 import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
 import {
   getDataSourcesUsageByCategory,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { upsertDocument } from "@app/lib/api/data_sources";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { upsertTable } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,3 +1,174 @@
+/**
+ * @swagger
+ * /api/w/{wId}/spaces/{spaceId}:
+ *   get:
+ *     summary: Get a space
+ *     description: Returns the details of a specific space including categories, members, and permissions.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: includeAllMembers
+ *         required: false
+ *         description: Include all members (including inactive)
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 space:
+ *                   allOf:
+ *                     - $ref: '#/components/schemas/PrivateSpace'
+ *                     - type: object
+ *                       properties:
+ *                         categories:
+ *                           type: object
+ *                           additionalProperties:
+ *                             type: object
+ *                             properties:
+ *                               count:
+ *                                 type: integer
+ *                               usage:
+ *                                 type: object
+ *                                 properties:
+ *                                   count:
+ *                                     type: integer
+ *                                   agents:
+ *                                     type: array
+ *                                     items:
+ *                                       type: object
+ *                         canWrite:
+ *                           type: boolean
+ *                         canRead:
+ *                           type: boolean
+ *                         isMember:
+ *                           type: boolean
+ *                         isEditor:
+ *                           type: boolean
+ *                         members:
+ *                           type: array
+ *                           items:
+ *                             type: object
+ *                         description:
+ *                           type: string
+ *                           nullable: true
+ *                         archivedAt:
+ *                           type: integer
+ *                           nullable: true
+ *       401:
+ *         description: Unauthorized
+ *   patch:
+ *     summary: Update a space
+ *     description: Updates the properties of a specific space.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               content:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     dataSourceId:
+ *                       type: string
+ *                     parentsIn:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 space:
+ *                   $ref: '#/components/schemas/PrivateSpace'
+ *       401:
+ *         description: Unauthorized
+ *   delete:
+ *     summary: Delete a space
+ *     description: Deletes a specific space from the workspace.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: force
+ *         required: false
+ *         description: Force deletion even if space is in use
+ *         schema:
+ *           type: string
+ *           enum: ["true"]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 space:
+ *                   $ref: '#/components/schemas/PrivateSpace'
+ *       401:
+ *         description: Unauthorized
+ */
 import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { searchProjectConversations } from "@app/lib/api/projects";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/status.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/check-name.ts
+++ b/front/pages/api/w/[wId]/spaces/check-name.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -1,3 +1,107 @@
+/**
+ * @swagger
+ * /api/w/{wId}/spaces:
+ *   get:
+ *     summary: List spaces
+ *     description: Returns all spaces in the workspace.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: role
+ *         required: false
+ *         description: Filter by role (e.g. admin to list all workspace spaces)
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: kind
+ *         required: false
+ *         description: Filter by space kind (e.g. system)
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 spaces:
+ *                   type: array
+ *                   items:
+ *                     oneOf:
+ *                       - $ref: '#/components/schemas/PrivateSpace'
+ *                       - $ref: '#/components/schemas/PrivateProject'
+ *       401:
+ *         description: Unauthorized
+ *   post:
+ *     summary: Create a space
+ *     description: Creates a new space in the workspace.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - isRestricted
+ *               - name
+ *               - spaceKind
+ *               - managementMode
+ *             properties:
+ *               isRestricted:
+ *                 type: boolean
+ *               name:
+ *                 type: string
+ *               spaceKind:
+ *                 type: string
+ *                 enum: [regular, project]
+ *               managementMode:
+ *                 type: string
+ *                 enum: [manual, group]
+ *               memberIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Required when managementMode is manual
+ *               groupIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Required when managementMode is group
+ *     responses:
+ *       201:
+ *         description: Successfully created space
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 space:
+ *                   $ref: '#/components/schemas/PrivateSpace'
+ *       401:
+ *         description: Unauthorized
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";

--- a/front/pages/api/w/[wId]/spaces/projects-lookup.ts
+++ b/front/pages/api/w/[wId]/spaces/projects-lookup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/search_projects.ts
+++ b/front/pages/api/w/[wId]/spaces/search_projects.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects";

--- a/front/pages/api/w/[wId]/sso.ts
+++ b/front/pages/api/w/[wId]/sso.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   deleteWorkOSOrganizationSSOConnection,

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {

--- a/front/pages/api/w/[wId]/subscriptions/pricing.ts
+++ b/front/pages/api/w/[wId]/subscriptions/pricing.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/subscriptions/status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/subscriptions/trial-info.ts
+++ b/front/pages/api/w/[wId]/subscriptions/trial-info.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getStripeSubscription } from "@app/lib/plans/stripe";

--- a/front/pages/api/w/[wId]/tags/[tId]/index.ts
+++ b/front/pages/api/w/[wId]/tags/[tId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";

--- a/front/pages/api/w/[wId]/tags/index.ts
+++ b/front/pages/api/w/[wId]/tags/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getWorkspaceTagSuggestions } from "@app/lib/api/assistant/tag_manager";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/tags/usage/index.ts
+++ b/front/pages/api/w/[wId]/tags/usage/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";

--- a/front/pages/api/w/[wId]/trial-message-usage.ts
+++ b/front/pages/api/w/[wId]/trial-message-usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/trial/start.ts
+++ b/front/pages/api/w/[wId]/trial/start.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {

--- a/front/pages/api/w/[wId]/verification/start.ts
+++ b/front/pages/api/w/[wId]/verification/start.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { startVerification } from "@app/lib/api/workspace_verification";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/verification/validate.ts
+++ b/front/pages/api/w/[wId]/verification/validate.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { validateVerification } from "@app/lib/api/workspace_verification";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/verified-domains.ts
+++ b/front/pages/api/w/[wId]/verified-domains.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";

--- a/front/pages/api/w/[wId]/verify.ts
+++ b/front/pages/api/w/[wId]/verify.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { resolveCountryCode } from "@app/lib/geo/country-detection";

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { deleteWebhookSource } from "@app/lib/api/webhook_source";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getWebhookSourcesUsage } from "@app/lib/api/agent_triggers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";

--- a/front/pages/api/w/[wId]/webhook_sources/service-data.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/service-data.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import type {
   CustomResourceIconType,
   InternalAllowedIconType,

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/api/w/[wId]/welcome.ts
+++ b/front/pages/api/w/[wId]/welcome.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";

--- a/front/pages/api/w/[wId]/workspace-analytics.ts
+++ b/front/pages/api/w/[wId]/workspace-analytics.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {

--- a/front/pages/api/website/session-status.ts
+++ b/front/pages/api/website/session-status.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { getSession } from "@app/lib/auth";
 import { getUserFromSession } from "@app/lib/iam/session";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -1,3 +1,111 @@
+/**
+ * @swagger
+ * /api/workos/login:
+ *   get:
+ *     summary: Initiate WorkOS login
+ *     description: Redirects to WorkOS AuthKit for authentication. Supports PKCE flow for extensions.
+ *     tags:
+ *       - Private Authentication
+ *     security: []
+ *     parameters:
+ *       - in: query
+ *         name: redirect_uri
+ *         required: false
+ *         description: Custom redirect URI (used by extensions for PKCE flow)
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: code_challenge
+ *         required: false
+ *         description: PKCE code challenge
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: code_challenge_method
+ *         required: false
+ *         description: PKCE code challenge method (S256)
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Login page HTML
+ *       302:
+ *         description: Redirect to WorkOS authorization URL
+ *       400:
+ *         description: Bad request
+ * /api/workos/authenticate:
+ *   post:
+ *     summary: Exchange code or refresh token
+ *     description: Exchanges an authorization code or refresh token for access tokens via WorkOS.
+ *     tags:
+ *       - Private Authentication
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                 type: string
+ *               grant_type:
+ *                 type: string
+ *                 enum: [refresh_token]
+ *               refresh_token:
+ *                 type: string
+ *               code_verifier:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Authentication result with tokens
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 accessToken:
+ *                   type: string
+ *                 refreshToken:
+ *                   type: string
+ *                 user:
+ *                   type: object
+ *                 expiresIn:
+ *                   type: integer
+ *                   description: Token expiry in seconds
+ *       400:
+ *         description: Invalid request
+ * /api/workos/revoke-session:
+ *   post:
+ *     summary: Revoke a session
+ *     description: Revokes a WorkOS session by session ID. Used by the Chrome extension for logout.
+ *     tags:
+ *       - Private Authentication
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - session_id
+ *             properties:
+ *               session_id:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Session revoked successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       400:
+ *         description: Invalid session_id
+ */
 import config from "@app/lib/api/config";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {

--- a/front/pages/api/workos/actions/[actionSecret].ts
+++ b/front/pages/api/workos/actions/[actionSecret].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import {

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import config from "@app/lib/api/config";
 import {
   getClientIpFromHeaders,

--- a/front/pages/api/workspace-lookup.ts
+++ b/front/pages/api/workspace-lookup.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { fetchRevokedWorkspace } from "@app/lib/api/user";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -19,7 +19,215 @@
       "description": "Dust.tt API (europe-west1)"
     }
   ],
+  "tags": [
+    {
+      "name": "Agents",
+      "description": "Agent configurations"
+    },
+    {
+      "name": "Apps",
+      "description": "Dust apps"
+    },
+    {
+      "name": "Conversations",
+      "description": "Conversations"
+    },
+    {
+      "name": "DatasourceViews",
+      "description": "Data source views"
+    },
+    {
+      "name": "Datasources",
+      "description": "Data sources"
+    },
+    {
+      "name": "Feedbacks",
+      "description": "Message feedbacks"
+    },
+    {
+      "name": "MCP",
+      "description": "MCP servers"
+    },
+    {
+      "name": "Mentions",
+      "description": "Mentions"
+    },
+    {
+      "name": "Search",
+      "description": "Search"
+    },
+    {
+      "name": "Tools",
+      "description": "Tools"
+    },
+    {
+      "name": "Triggers",
+      "description": "Triggers"
+    },
+    {
+      "name": "Spaces",
+      "description": "Spaces"
+    },
+    {
+      "name": "Workspace",
+      "description": "Workspace"
+    },
+    {
+      "name": "Private User",
+      "description": "Private API - User"
+    },
+    {
+      "name": "Private Authentication",
+      "description": "Private API - Authentication (WorkOS)"
+    },
+    {
+      "name": "Private Agents",
+      "description": "Private API - Agent configurations"
+    },
+    {
+      "name": "Private Conversations",
+      "description": "Private API - Conversations"
+    },
+    {
+      "name": "Private Messages",
+      "description": "Private API - Messages"
+    },
+    {
+      "name": "Private Events",
+      "description": "Private API - SSE event streams"
+    },
+    {
+      "name": "Private Files",
+      "description": "Private API - File uploads"
+    },
+    {
+      "name": "Private Mentions",
+      "description": "Private API - Mention suggestions"
+    },
+    {
+      "name": "Private Spaces",
+      "description": "Private API - Spaces and data source views"
+    },
+    {
+      "name": "Private Extension",
+      "description": "Private API - Extension configuration"
+    },
+    {
+      "name": "Private Workspace",
+      "description": "Private API - Workspace settings"
+    }
+  ],
   "paths": {
+    "/api/user": {
+      "get": {
+        "summary": "Get current user",
+        "description": "Returns the authenticated user with their workspaces and subscriber hash.",
+        "tags": [
+          "Private User"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The authenticated user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "$ref": "#/components/schemas/PrivateUser"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update current user",
+        "description": "Update the authenticated user's profile (name, job type, favorite platforms, image).",
+        "tags": [
+          "Private User"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "firstName",
+                  "lastName"
+                ],
+                "properties": {
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "jobType": {
+                    "type": "string"
+                  },
+                  "imageUrl": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "favoritePlatforms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "emailProvider": {
+                    "type": "string"
+                  },
+                  "workspaceId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/assistant/agent_configurations": {
       "get": {
         "summary": "List agents",
@@ -5084,10 +5292,5455 @@
           }
         }
       }
+    },
+    "/api/w/{wId}/assistant/agent_configurations": {
+      "get": {
+        "summary": "List agent configurations",
+        "description": "Returns all agent configurations in the workspace.",
+        "tags": [
+          "Private Agents"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "view",
+            "required": false,
+            "description": "Filter agents by view",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "list",
+                "favorites",
+                "published",
+                "admin_internal",
+                "global",
+                "workspace"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "Maximum number of results to return",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "withUsage",
+            "required": false,
+            "description": "Include usage statistics",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "withAuthors",
+            "required": false,
+            "description": "Include recent authors",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "withFeedbacks",
+            "required": false,
+            "description": "Include feedback counts",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "withEditors",
+            "required": false,
+            "description": "Include editors list",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "description": "Sort order",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agentConfigurations": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateLightAgentConfiguration"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an agent configuration",
+        "description": "Creates a new agent configuration in the workspace.",
+        "tags": [
+          "Private Agents"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "assistant"
+                ],
+                "properties": {
+                  "assistant": {
+                    "type": "object",
+                    "description": "Agent configuration to create"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agentConfiguration": {
+                      "$ref": "#/components/schemas/PrivateLightAgentConfiguration"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/cancel": {
+      "post": {
+        "summary": "Cancel message generation",
+        "description": "Cancels the generation of messages in a conversation.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "action",
+                  "messageIds"
+                ],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "cancel"
+                    ]
+                  },
+                  "messageIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/content_fragment": {
+      "post": {
+        "summary": "Create a content fragment",
+        "description": "Post a new content fragment to an existing conversation.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title",
+                  "content",
+                  "contentType",
+                  "context"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "description": "MIME type of the content"
+                  },
+                  "url": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "context": {
+                    "type": "object",
+                    "properties": {
+                      "profilePictureUrl": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "fileId": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created content fragment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "contentFragment": {
+                      "$ref": "#/components/schemas/PrivateContentFragment"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/events": {
+      "get": {
+        "summary": "Stream conversation events",
+        "description": "Stream real-time conversation events using Server-Sent Events (SSE). This endpoint is redirected to /api/sse/ for SSE traffic routing.",
+        "tags": [
+          "Private Events"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE event stream. Each event is sent as `data: {json}\\n\\n`.\nEvents are discriminated by the `type` field.\n",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateConversationEvent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/feedbacks": {
+      "get": {
+        "summary": "Get conversation feedbacks",
+        "description": "Retrieve all feedbacks for a conversation submitted by the authenticated user.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved feedbacks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "feedbacks": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateFeedback"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}": {
+      "get": {
+        "summary": "Get a conversation",
+        "description": "Retrieve a specific conversation by its ID.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "conversation": {
+                      "$ref": "#/components/schemas/PrivateConversation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete or leave a conversation",
+        "description": "Delete a conversation or leave it if it is shared.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted or left conversation"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a conversation",
+        "description": "Update a conversation's title, mark it as read, or move it to a different space.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "title"
+                    ],
+                    "properties": {
+                      "title": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "read"
+                    ],
+                    "properties": {
+                      "read": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "spaceId"
+                    ],
+                    "properties": {
+                      "spaceId": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
+      "post": {
+        "summary": "Edit a message",
+        "description": "Edit the content and mentions of an existing user message in a conversation.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "content",
+                  "mentions"
+                ],
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "mentions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PrivateMention"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully edited message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "#/components/schemas/PrivateUserMessage"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/events": {
+      "get": {
+        "summary": "Stream message events",
+        "description": "Stream real-time events for a specific agent message using Server-Sent Events (SSE). Only available for agent messages. This endpoint is redirected to /api/sse/ for SSE traffic routing.",
+        "tags": [
+          "Private Events"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE event stream. Each event is sent as `data: {json}\\n\\n`.\nEvents are discriminated by the `type` field. Each event payload also includes a `step` integer.\n",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateAgentMessageEvent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/feedbacks": {
+      "post": {
+        "summary": "Submit message feedback",
+        "description": "Create or update feedback (thumbs up/down) for a specific agent message.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "thumbDirection"
+                ],
+                "properties": {
+                  "thumbDirection": {
+                    "type": "string",
+                    "enum": [
+                      "up",
+                      "down"
+                    ]
+                  },
+                  "feedbackContent": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "isConversationShared": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully submitted feedback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete message feedback",
+        "description": "Remove the authenticated user's feedback for a specific agent message.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted feedback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}": {
+      "get": {
+        "summary": "Get a message",
+        "description": "Retrieve a specific message by its ID within a conversation.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/PrivateUserMessage"
+                        },
+                        {
+                          "$ref": "#/components/schemas/PrivateAgentMessage"
+                        },
+                        {
+                          "$ref": "#/components/schemas/PrivateContentFragment"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Message or conversation not found"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a message",
+        "description": "Soft-delete a user or agent message from a conversation.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully deleted message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Message or conversation not found"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/retry": {
+      "post": {
+        "summary": "Retry an agent message",
+        "description": "Retry generating an agent message response, optionally retrying only blocked actions.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "description": "ID of the message",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retried message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "#/components/schemas/PrivateAgentMessage"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages": {
+      "get": {
+        "summary": "List messages in a conversation",
+        "description": "Retrieve a paginated list of messages for a specific conversation.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/PrivateUserMessage"
+                          },
+                          {
+                            "$ref": "#/components/schemas/PrivateLightAgentMessage"
+                          },
+                          {
+                            "$ref": "#/components/schemas/PrivateContentFragment"
+                          }
+                        ]
+                      }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    },
+                    "lastValue": {
+                      "type": "integer",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Post a message to a conversation",
+        "description": "Post a new user message to an existing conversation, triggering agent responses.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "content",
+                  "context",
+                  "mentions"
+                ],
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "mentions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PrivateMention"
+                    }
+                  },
+                  "context": {
+                    "type": "object",
+                    "properties": {
+                      "timezone": {
+                        "type": "string"
+                      },
+                      "profilePictureUrl": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "origin": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "clientSideMCPServerIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "skipToolsValidation": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully posted message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "#/components/schemas/PrivateUserMessage"
+                    },
+                    "contentFragments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateContentFragment"
+                      }
+                    },
+                    "agentMessages": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateAgentMessage"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/participants": {
+      "get": {
+        "summary": "Get conversation participants",
+        "description": "Returns the participants of a specific conversation.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "participants": {
+                      "type": "object",
+                      "properties": {
+                        "agents": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "configurationId": {
+                                "type": "string"
+                              },
+                              "configurationName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "users": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "username": {
+                                "type": "string"
+                              },
+                              "fullName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "pictureUrl": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a participant to a conversation",
+        "description": "Adds the authenticated user as a participant to a specific conversation.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully added participant"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations": {
+      "get": {
+        "summary": "List conversations",
+        "description": "Retrieve a paginated list of conversations for the authenticated user in the workspace.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved conversations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "conversations": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateConversation"
+                      }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    },
+                    "lastValue": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a conversation",
+        "description": "Create a new conversation, optionally with an initial user message and content fragments.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "visibility": {
+                    "type": "string",
+                    "enum": [
+                      "unlisted",
+                      "deleted",
+                      "test"
+                    ]
+                  },
+                  "spaceId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "message": {
+                    "type": "object",
+                    "properties": {
+                      "content": {
+                        "type": "string"
+                      },
+                      "mentions": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/PrivateMention"
+                        }
+                      },
+                      "context": {
+                        "type": "object",
+                        "properties": {
+                          "timezone": {
+                            "type": "string"
+                          },
+                          "profilePictureUrl": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "origin": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "clientSideMCPServerIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "selectedMCPServerViewIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "selectedSkillIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "contentFragments": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "nullable": true
+                  },
+                  "skipToolsValidation": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "conversation": {
+                      "$ref": "#/components/schemas/PrivateFullConversation"
+                    },
+                    "message": {
+                      "$ref": "#/components/schemas/PrivateUserMessage"
+                    },
+                    "contentFragments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateContentFragment"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/mentions/suggestions": {
+      "get": {
+        "summary": "Get mention suggestions",
+        "description": "Returns mention suggestions for the workspace.",
+        "tags": [
+          "Private Mentions"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "description": "Search query to filter suggestions",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "select",
+            "required": false,
+            "description": "Filter by type (agents, users, or both)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "agents",
+                "users"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "description": "Whether to include only current mentions",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "spaceId",
+            "required": false,
+            "description": "Filter suggestions by space",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "suggestions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateMentionSuggestion"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/extension/config": {
+      "get": {
+        "summary": "Get extension configuration",
+        "description": "Returns the extension configuration for the workspace, including blacklisted domains.",
+        "tags": [
+          "Private Extension"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Extension configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateExtensionConfig"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/feature-flags": {
+      "get": {
+        "summary": "Get workspace feature flags",
+        "description": "Returns the list of enabled feature flags for the workspace.",
+        "tags": [
+          "Private Workspace"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of feature flags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateFeatureFlags"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/files/{fileId}": {
+      "get": {
+        "summary": "Get or download a file",
+        "description": "View or download a file. Use query parameters `version` (original, processed, public) and `action` (view, download).",
+        "tags": [
+          "Private Files"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "description": "ID of the file",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "description": "File version to retrieve",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "original",
+                "processed",
+                "public"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "description": "Action to perform",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "view",
+                "download"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content or redirect to download URL",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Redirect to signed download URL"
+          },
+          "404": {
+            "description": "File not found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Upload file content",
+        "description": "Process and store the uploaded file content.",
+        "tags": [
+          "Private Files"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "description": "ID of the file",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "File processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "$ref": "#/components/schemas/PrivateFileWithUploadUrl"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "File not found"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a file",
+        "description": "Delete a file from the workspace.",
+        "tags": [
+          "Private Files"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "description": "ID of the file",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "File deleted"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "404": {
+            "description": "File not found"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/files": {
+      "post": {
+        "summary": "Create a file upload",
+        "description": "Creates a file record and returns a pre-signed upload URL. The file content should then be uploaded to the returned URL.",
+        "tags": [
+          "Private Files"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "contentType",
+                  "fileName",
+                  "fileSize",
+                  "useCase"
+                ],
+                "properties": {
+                  "contentType": {
+                    "type": "string"
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "fileSize": {
+                    "type": "number"
+                  },
+                  "useCase": {
+                    "type": "string",
+                    "enum": [
+                      "conversation",
+                      "folders_document",
+                      "avatar",
+                      "upsert_document",
+                      "upsert_table",
+                      "project_context",
+                      "skill_attachment"
+                    ]
+                  },
+                  "useCaseMetadata": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "File record created with upload URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "$ref": "#/components/schemas/PrivateFileWithUploadUrl"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/spaces/{spaceId}/data_source_views/{dsvId}": {
+      "get": {
+        "summary": "Get a data source view",
+        "description": "Returns the details of a specific data source view.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dsvId",
+            "required": true,
+            "description": "ID of the data source view",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dataSourceView": {
+                      "$ref": "#/components/schemas/PrivateDataSourceView"
+                    },
+                    "connector": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Connector details if the data source is managed"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a data source view",
+        "description": "Updates a specific data source view.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dsvId",
+            "required": true,
+            "description": "ID of the data source view",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "parentsIn": {
+                    "type": "array",
+                    "nullable": true,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dataSourceView": {
+                      "$ref": "#/components/schemas/PrivateDataSourceView"
+                    },
+                    "connector": {
+                      "type": "object",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a data source view",
+        "description": "Deletes a specific data source view.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dsvId",
+            "required": true,
+            "description": "ID of the data source view",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "description": "Force deletion even if the view is in use",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted data source view"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/spaces/{spaceId}/data_source_views": {
+      "get": {
+        "summary": "List data source views",
+        "description": "Returns all data source views in a specific space.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "description": "Filter by data source view category",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "managed",
+                "folder",
+                "website",
+                "apps"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "withDetails",
+            "required": false,
+            "description": "Include usage and connector details (requires category)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeEditedBy",
+            "required": false,
+            "description": "Include editedByUser information",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dataSourceViews": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateDataSourceView"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a data source view",
+        "description": "Creates a new data source view in a specific space.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "dataSourceId"
+                ],
+                "properties": {
+                  "dataSourceId": {
+                    "type": "string"
+                  },
+                  "parentsIn": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created data source view",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dataSourceView": {
+                      "$ref": "#/components/schemas/PrivateDataSourceView"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/spaces/{spaceId}": {
+      "get": {
+        "summary": "Get a space",
+        "description": "Returns the details of a specific space including categories, members, and permissions.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeAllMembers",
+            "required": false,
+            "description": "Include all members (including inactive)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "space": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/PrivateSpace"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "categories": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "object",
+                                "properties": {
+                                  "count": {
+                                    "type": "integer"
+                                  },
+                                  "usage": {
+                                    "type": "object",
+                                    "properties": {
+                                      "count": {
+                                        "type": "integer"
+                                      },
+                                      "agents": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "canWrite": {
+                              "type": "boolean"
+                            },
+                            "canRead": {
+                              "type": "boolean"
+                            },
+                            "isMember": {
+                              "type": "boolean"
+                            },
+                            "isEditor": {
+                              "type": "boolean"
+                            },
+                            "members": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "description": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "archivedAt": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a space",
+        "description": "Updates the properties of a specific space.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "dataSourceId": {
+                          "type": "string"
+                        },
+                        "parentsIn": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "space": {
+                      "$ref": "#/components/schemas/PrivateSpace"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a space",
+        "description": "Deletes a specific space from the workspace.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "description": "Force deletion even if space is in use",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true"
+              ]
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "space": {
+                      "$ref": "#/components/schemas/PrivateSpace"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/spaces": {
+      "get": {
+        "summary": "List spaces",
+        "description": "Returns all spaces in the workspace.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "description": "Filter by role (e.g. admin to list all workspace spaces)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "description": "Filter by space kind (e.g. system)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "spaces": {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/PrivateSpace"
+                          },
+                          {
+                            "$ref": "#/components/schemas/PrivateProject"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a space",
+        "description": "Creates a new space in the workspace.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "isRestricted",
+                  "name",
+                  "spaceKind",
+                  "managementMode"
+                ],
+                "properties": {
+                  "isRestricted": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "spaceKind": {
+                    "type": "string",
+                    "enum": [
+                      "regular",
+                      "project"
+                    ]
+                  },
+                  "managementMode": {
+                    "type": "string",
+                    "enum": [
+                      "manual",
+                      "group"
+                    ]
+                  },
+                  "memberIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Required when managementMode is manual"
+                  },
+                  "groupIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Required when managementMode is group"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created space",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "space": {
+                      "$ref": "#/components/schemas/PrivateSpace"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/workos/login": {
+      "get": {
+        "summary": "Initiate WorkOS login",
+        "description": "Redirects to WorkOS AuthKit for authentication. Supports PKCE flow for extensions.",
+        "tags": [
+          "Private Authentication"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false,
+            "description": "Custom redirect URI (used by extensions for PKCE flow)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code_challenge",
+            "required": false,
+            "description": "PKCE code challenge",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code_challenge_method",
+            "required": false,
+            "description": "PKCE code challenge method (S256)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Login page HTML"
+          },
+          "302": {
+            "description": "Redirect to WorkOS authorization URL"
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    },
+    "/api/workos/authenticate": {
+      "post": {
+        "summary": "Exchange code or refresh token",
+        "description": "Exchanges an authorization code or refresh token for access tokens via WorkOS.",
+        "tags": [
+          "Private Authentication"
+        ],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "grant_type": {
+                    "type": "string",
+                    "enum": [
+                      "refresh_token"
+                    ]
+                  },
+                  "refresh_token": {
+                    "type": "string"
+                  },
+                  "code_verifier": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authentication result with tokens",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "accessToken": {
+                      "type": "string"
+                    },
+                    "refreshToken": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object"
+                    },
+                    "expiresIn": {
+                      "type": "integer",
+                      "description": "Token expiry in seconds"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/api/workos/revoke-session": {
+      "post": {
+        "summary": "Revoke a session",
+        "description": "Revokes a WorkOS session by session ID. Used by the Chrome extension for logout.",
+        "tags": [
+          "Private Authentication"
+        ],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "session_id"
+                ],
+                "properties": {
+                  "session_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session revoked successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid session_id"
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "PrivateUser": {
+        "type": "object",
+        "description": "Authenticated user with their workspaces and subscriber hash.",
+        "required": [
+          "sId",
+          "id",
+          "createdAt",
+          "username",
+          "email",
+          "firstName",
+          "fullName",
+          "workspaces"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string",
+            "description": "Unique string identifier for the user"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Numeric model identifier"
+          },
+          "createdAt": {
+            "type": "integer",
+            "description": "Unix timestamp of user creation"
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "auth0",
+              "github",
+              "google",
+              "okta",
+              "samlp",
+              "waad"
+            ],
+            "description": "Authentication provider"
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "nullable": true,
+            "description": "URL of the user's profile image"
+          },
+          "lastLoginAt": {
+            "type": "integer",
+            "nullable": true
+          },
+          "workspaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateWorkspace"
+            }
+          },
+          "selectedWorkspace": {
+            "type": "string",
+            "description": "sId of the currently selected workspace"
+          },
+          "origin": {
+            "type": "string",
+            "description": "How the user joined (e.g. invitation, provisioned)"
+          },
+          "subscriberHash": {
+            "type": "string",
+            "nullable": true,
+            "description": "Hash used for Intercom identity verification"
+          }
+        }
+      },
+      "PrivateWorkspace": {
+        "type": "object",
+        "description": "Workspace as returned by the private API, includes SSO and provider settings.",
+        "required": [
+          "id",
+          "sId",
+          "name",
+          "role"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "builder",
+              "user",
+              "none"
+            ]
+          },
+          "segmentation": {
+            "type": "string",
+            "nullable": true
+          },
+          "whiteListedProviders": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "Allowed model provider IDs"
+          },
+          "defaultEmbeddingProvider": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssoEnforced": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          }
+        }
+      },
+      "PrivateConversation": {
+        "type": "object",
+        "description": "Conversation without content, used in list responses.",
+        "required": [
+          "id",
+          "created",
+          "updated",
+          "sId",
+          "depth"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "created": {
+            "type": "integer",
+            "description": "Unix timestamp of creation"
+          },
+          "updated": {
+            "type": "integer",
+            "description": "Unix timestamp of last update"
+          },
+          "unread": {
+            "type": "boolean"
+          },
+          "lastReadMs": {
+            "type": "integer",
+            "nullable": true
+          },
+          "actionRequired": {
+            "type": "boolean",
+            "description": "Whether the conversation requires user action"
+          },
+          "hasError": {
+            "type": "boolean"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "spaceId": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the space the conversation belongs to (for project conversations)"
+          },
+          "triggerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "depth": {
+            "type": "integer",
+            "description": "Conversation depth (for agent handover chains)"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "requestedSpaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PrivateFullConversation": {
+        "type": "object",
+        "description": "Full conversation including content, owner, and visibility.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PrivateConversation"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "$ref": "#/components/schemas/PrivateWorkspace"
+              },
+              "visibility": {
+                "type": "string",
+                "enum": [
+                  "unlisted",
+                  "deleted",
+                  "test"
+                ]
+              },
+              "branchId": {
+                "type": "string",
+                "nullable": true
+              },
+              "content": {
+                "type": "array",
+                "description": "Array of message arrays (versions/retries)",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/PrivateUserMessage"
+                      },
+                      {
+                        "$ref": "#/components/schemas/PrivateAgentMessage"
+                      },
+                      {
+                        "$ref": "#/components/schemas/PrivateContentFragment"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "PrivateUserMessage": {
+        "type": "object",
+        "description": "A user message in a conversation.",
+        "required": [
+          "type",
+          "sId",
+          "content",
+          "version",
+          "rank",
+          "created"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "user_message"
+            ]
+          },
+          "sId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "visible",
+              "deleted"
+            ]
+          },
+          "version": {
+            "type": "integer"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "user": {
+            "type": "object",
+            "nullable": true,
+            "description": "The user who sent the message",
+            "properties": {
+              "sId": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              },
+              "fullName": {
+                "type": "string"
+              },
+              "image": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "mentions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateMention"
+            }
+          },
+          "richMentions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateRichMentionWithStatus"
+            }
+          },
+          "content": {
+            "type": "string"
+          },
+          "context": {
+            "$ref": "#/components/schemas/PrivateUserMessageContext"
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateReaction"
+            }
+          }
+        }
+      },
+      "PrivateAgentMessage": {
+        "type": "object",
+        "description": "An agent message in a conversation.",
+        "required": [
+          "type",
+          "sId",
+          "version",
+          "rank",
+          "status",
+          "parentMessageId"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "agentMessageId": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_message"
+            ]
+          },
+          "sId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "completedTs": {
+            "type": "integer",
+            "nullable": true
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "visible",
+              "deleted"
+            ]
+          },
+          "version": {
+            "type": "integer"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "parentMessageId": {
+            "type": "string"
+          },
+          "parentAgentMessageId": {
+            "type": "string",
+            "nullable": true,
+            "description": "If handover, the agent message that summoned this agent"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "succeeded",
+              "failed",
+              "cancelled"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "chainOfThought": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object",
+                "nullable": true
+              }
+            }
+          },
+          "configuration": {
+            "$ref": "#/components/schemas/PrivateLightAgentConfiguration"
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "MCP actions executed by the agent"
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "step": {
+                  "type": "integer"
+                },
+                "content": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "skipToolsValidation": {
+            "type": "boolean"
+          },
+          "richMentions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateRichMentionWithStatus"
+            }
+          },
+          "completionDurationMs": {
+            "type": "integer",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateReaction"
+            }
+          }
+        }
+      },
+      "PrivateLightAgentMessage": {
+        "type": "object",
+        "description": "A lighter agent message used in paginated message list responses.",
+        "required": [
+          "type",
+          "sId",
+          "version",
+          "rank",
+          "status",
+          "parentMessageId",
+          "configuration"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_message"
+            ]
+          },
+          "sId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "completedTs": {
+            "type": "integer",
+            "nullable": true
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "visible",
+              "deleted"
+            ]
+          },
+          "version": {
+            "type": "integer"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "parentMessageId": {
+            "type": "string"
+          },
+          "parentAgentMessageId": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "succeeded",
+              "failed",
+              "cancelled"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "nullable": true
+          },
+          "chainOfThought": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object",
+                "nullable": true
+              }
+            }
+          },
+          "configuration": {
+            "type": "object",
+            "description": "Minimal agent configuration info",
+            "properties": {
+              "sId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "pictureUrl": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "canRead": {
+                "type": "boolean"
+              }
+            }
+          },
+          "citations": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PrivateCitation"
+            }
+          },
+          "generatedFiles": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fileId": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "contentType": {
+                  "type": "string"
+                },
+                "publicUrl": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "richMentions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateRichMentionWithStatus"
+            }
+          },
+          "completionDurationMs": {
+            "type": "integer",
+            "nullable": true
+          },
+          "reactions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateReaction"
+            }
+          }
+        }
+      },
+      "PrivateCitation": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateContentFragment": {
+        "type": "object",
+        "description": "A content fragment (file or content node attachment) in a conversation.",
+        "required": [
+          "type",
+          "sId",
+          "title",
+          "contentType",
+          "contentFragmentType"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "content_fragment"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "visible",
+              "deleted"
+            ]
+          },
+          "version": {
+            "type": "integer"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "MIME type of the content"
+          },
+          "sourceUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "context": {
+            "type": "object",
+            "properties": {
+              "username": {
+                "type": "string",
+                "nullable": true
+              },
+              "fullName": {
+                "type": "string",
+                "nullable": true
+              },
+              "email": {
+                "type": "string",
+                "nullable": true
+              },
+              "profilePictureUrl": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "contentFragmentId": {
+            "type": "string"
+          },
+          "contentFragmentVersion": {
+            "type": "string",
+            "enum": [
+              "superseded",
+              "latest"
+            ]
+          },
+          "contentFragmentType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "content_node"
+            ],
+            "description": "Whether this is a file upload or a content node reference"
+          },
+          "expiredReason": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "data_source_deleted"
+            ]
+          },
+          "fileId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Present for file content fragments"
+          },
+          "snippet": {
+            "type": "string",
+            "nullable": true
+          },
+          "textUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "textBytes": {
+            "type": "integer",
+            "nullable": true
+          },
+          "nodeId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Present for content node fragments"
+          },
+          "nodeDataSourceViewId": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "PrivateLightAgentConfiguration": {
+        "type": "object",
+        "description": "Agent configuration as returned by the private list endpoint.",
+        "required": [
+          "id",
+          "sId",
+          "version",
+          "name",
+          "description",
+          "pictureUrl",
+          "status",
+          "scope",
+          "model",
+          "maxStepsPerRun",
+          "tags"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "versionCreatedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "versionAuthorId": {
+            "type": "integer",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string",
+            "nullable": true
+          },
+          "pictureUrl": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "description": "Agent status",
+            "enum": [
+              "active",
+              "archived",
+              "draft",
+              "pending",
+              "disabled_by_admin",
+              "disabled_missing_datasource",
+              "disabled_free_workspace"
+            ]
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "global",
+              "visible",
+              "hidden"
+            ]
+          },
+          "userFavorite": {
+            "type": "boolean"
+          },
+          "model": {
+            "type": "object",
+            "properties": {
+              "providerId": {
+                "type": "string"
+              },
+              "modelId": {
+                "type": "string"
+              },
+              "temperature": {
+                "type": "number"
+              },
+              "reasoningEffort": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "light",
+                  "medium",
+                  "high"
+                ]
+              }
+            }
+          },
+          "maxStepsPerRun": {
+            "type": "integer"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "templateId": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedGroupIds": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "requestedSpaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "canRead": {
+            "type": "boolean"
+          },
+          "canEdit": {
+            "type": "boolean"
+          },
+          "lastAuthors": {
+            "type": "array",
+            "description": "Optional, returned when withAuthors query param is set",
+            "items": {
+              "type": "string"
+            }
+          },
+          "editors": {
+            "type": "array",
+            "description": "Optional, returned when withEditors query param is set",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sId": {
+                  "type": "string"
+                },
+                "fullName": {
+                  "type": "string"
+                },
+                "image": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "usage": {
+            "type": "object",
+            "description": "Optional, returned when withUsage query param is set",
+            "properties": {
+              "messageCount": {
+                "type": "integer"
+              },
+              "conversationCount": {
+                "type": "integer"
+              },
+              "userCount": {
+                "type": "integer"
+              },
+              "timePeriodSec": {
+                "type": "integer"
+              }
+            }
+          },
+          "feedbacks": {
+            "type": "object",
+            "description": "Optional, returned when withFeedbacks query param is set",
+            "properties": {
+              "up": {
+                "type": "integer"
+              },
+              "down": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "PrivateFileWithUploadUrl": {
+        "type": "object",
+        "description": "File record with a pre-signed upload URL.",
+        "required": [
+          "sId",
+          "id",
+          "fileName",
+          "fileSize",
+          "contentType",
+          "status",
+          "useCase",
+          "uploadUrl"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "fileSize": {
+            "type": "integer"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "failed",
+              "ready"
+            ]
+          },
+          "useCase": {
+            "type": "string",
+            "enum": [
+              "conversation",
+              "avatar",
+              "tool_output",
+              "upsert_document",
+              "folders_document",
+              "upsert_table",
+              "project_context",
+              "skill_attachment"
+            ]
+          },
+          "uploadUrl": {
+            "type": "string",
+            "description": "Pre-signed URL for uploading the file content"
+          },
+          "downloadUrl": {
+            "type": "string"
+          },
+          "publicUrl": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateSpace": {
+        "type": "object",
+        "description": "A space in the workspace.",
+        "required": [
+          "sId",
+          "name",
+          "kind",
+          "groupIds",
+          "isRestricted",
+          "managementMode"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "global",
+              "system",
+              "conversations",
+              "regular",
+              "project"
+            ]
+          },
+          "groupIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "isRestricted": {
+            "type": "boolean"
+          },
+          "managementMode": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "group"
+            ]
+          },
+          "createdAt": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateProject": {
+        "type": "object",
+        "description": "A project space with additional metadata.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PrivateSpace"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "isMember": {
+                "type": "boolean"
+              },
+              "archivedAt": {
+                "type": "integer",
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
+      "PrivateDataSourceView": {
+        "type": "object",
+        "description": "A view on a data source within a space.",
+        "required": [
+          "sId",
+          "id",
+          "category",
+          "kind",
+          "spaceId",
+          "dataSource"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "managed",
+              "folder",
+              "website",
+              "apps"
+            ]
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "default",
+              "custom"
+            ]
+          },
+          "spaceId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer"
+          },
+          "parentsIn": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "List of parent IDs included in this view, null if the full data source is used"
+          },
+          "dataSource": {
+            "$ref": "#/components/schemas/PrivateDataSource"
+          },
+          "editedByUser": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "editedAt": {
+                "type": "integer",
+                "nullable": true
+              },
+              "fullName": {
+                "type": "string",
+                "nullable": true
+              },
+              "imageUrl": {
+                "type": "string",
+                "nullable": true
+              },
+              "email": {
+                "type": "string",
+                "nullable": true
+              },
+              "userId": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "PrivateDataSource": {
+        "type": "object",
+        "description": "A data source in the workspace.",
+        "required": [
+          "sId",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "assistantDefaultSelected": {
+            "type": "boolean"
+          },
+          "dustAPIProjectId": {
+            "type": "string"
+          },
+          "dustAPIDataSourceId": {
+            "type": "string"
+          },
+          "connectorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "connectorProvider": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "PrivateMentionSuggestion": {
+        "type": "object",
+        "description": "A rich mention suggestion for agents or users.",
+        "required": [
+          "id",
+          "type",
+          "label",
+          "pictureUrl",
+          "description"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Agent sId or user sId"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "user"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "Display name"
+          },
+          "pictureUrl": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "description": "Agent description or user email"
+          },
+          "userFavorite": {
+            "type": "boolean",
+            "description": "Whether the agent is a user favorite (agent mentions only)"
+          }
+        }
+      },
+      "PrivateFeatureFlags": {
+        "type": "object",
+        "description": "Workspace feature flags response.",
+        "required": [
+          "feature_flags"
+        ],
+        "properties": {
+          "feature_flags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of enabled feature flag names for the workspace"
+          }
+        }
+      },
+      "PrivateExtensionConfig": {
+        "type": "object",
+        "description": "Extension configuration for the workspace.",
+        "required": [
+          "blacklistedDomains"
+        ],
+        "properties": {
+          "blacklistedDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Domains where the extension should not activate"
+          }
+        }
+      },
+      "PrivateFeedback": {
+        "type": "object",
+        "description": "User feedback on an agent message.",
+        "required": [
+          "id",
+          "sId",
+          "messageId",
+          "agentMessageId",
+          "userId",
+          "thumbDirection",
+          "agentConfigurationId",
+          "agentConfigurationVersion",
+          "isConversationShared",
+          "dismissed",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "agentMessageId": {
+            "type": "integer"
+          },
+          "userId": {
+            "type": "integer"
+          },
+          "thumbDirection": {
+            "type": "string",
+            "enum": [
+              "up",
+              "down"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional text feedback from the user"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "agentConfigurationId": {
+            "type": "string"
+          },
+          "agentConfigurationVersion": {
+            "type": "integer"
+          },
+          "isConversationShared": {
+            "type": "boolean"
+          },
+          "dismissed": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PrivateMention": {
+        "type": "object",
+        "description": "A mention in a message (agent or user).",
+        "properties": {
+          "configurationId": {
+            "type": "string",
+            "description": "Agent configuration sId (for agent mentions)"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "user"
+            ],
+            "description": "Present only for user mentions"
+          },
+          "userId": {
+            "type": "string",
+            "description": "User sId (for user mentions)"
+          }
+        }
+      },
+      "PrivateRichMentionWithStatus": {
+        "type": "object",
+        "description": "A rich mention with approval status, used in message responses.",
+        "required": [
+          "id",
+          "type",
+          "label",
+          "pictureUrl",
+          "description",
+          "dismissed",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "user"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "pictureUrl": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "userFavorite": {
+            "type": "boolean"
+          },
+          "dismissed": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending_conversation_access",
+              "pending_project_membership",
+              "approved",
+              "rejected",
+              "user_restricted_by_conversation_access",
+              "agent_restricted_by_space_usage"
+            ]
+          }
+        }
+      },
+      "PrivateUserMessageContext": {
+        "type": "object",
+        "description": "Context metadata for a user message.",
+        "required": [
+          "username",
+          "timezone",
+          "origin"
+        ],
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "profilePictureUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "origin": {
+            "type": "string",
+            "enum": [
+              "web",
+              "project_kickoff",
+              "extension",
+              "agent_sidekick",
+              "api",
+              "cli",
+              "cli_programmatic",
+              "email",
+              "excel",
+              "gsheet",
+              "make",
+              "n8n",
+              "powerpoint",
+              "raycast",
+              "slack",
+              "slack_workflow",
+              "teams",
+              "transcript",
+              "triggered_programmatic",
+              "triggered",
+              "zapier",
+              "zendesk",
+              "onboarding_conversation",
+              "project_butler"
+            ]
+          }
+        }
+      },
+      "PrivateReaction": {
+        "type": "object",
+        "description": "A reaction on a message.",
+        "required": [
+          "emoji",
+          "users"
+        ],
+        "properties": {
+          "emoji": {
+            "type": "string"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "userId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "username": {
+                  "type": "string"
+                },
+                "fullName": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "PrivateConversationEvent": {
+        "type": "object",
+        "description": "Server-Sent Event for conversation-level streaming. Discriminated on the `type` field.",
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PrivateUserMessageNewEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentMessageNewEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentMessageDoneEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateConversationTitleEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateButlerSuggestionCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateButlerThinkingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateButlerDoneEvent"
+          }
+        ]
+      },
+      "PrivateUserMessageNewEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "messageId",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "user_message_new"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PrivateUserMessage"
+          }
+        }
+      },
+      "PrivateAgentMessageNewEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_message_new"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PrivateAgentMessage"
+          }
+        }
+      },
+      "PrivateAgentMessageDoneEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "conversationId",
+          "configurationId",
+          "messageId",
+          "status"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_message_done"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "success",
+              "error"
+            ]
+          }
+        }
+      },
+      "PrivateConversationTitleEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "title"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "conversation_title"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateButlerSuggestionCreatedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "suggestion"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "butler_suggestion_created"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "suggestion": {
+            "type": "object",
+            "description": "Butler suggestion details"
+          }
+        }
+      },
+      "PrivateButlerThinkingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "butler_thinking"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateButlerDoneEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "butler_done"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateAgentMessageEvent": {
+        "type": "object",
+        "description": "Server-Sent Event for agent message streaming. Discriminated on the `type` field. Each event also includes a `step` integer.",
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PrivateGenerationTokensEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentActionSuccessEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentMessageSuccessEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentGenerationCancelledEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateToolErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateToolParamsEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateToolApproveExecutionEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateToolNotificationEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateToolPersonalAuthRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateToolFileAuthRequiredEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateAgentContextPrunedEvent"
+          }
+        ]
+      },
+      "PrivateGenerationTokensEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "text",
+          "classification"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "generation_tokens"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string",
+            "description": "The token(s) generated in this chunk"
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "tokens",
+              "chain_of_thought",
+              "opening_delimiter",
+              "closing_delimiter"
+            ]
+          },
+          "delimiterClassification": {
+            "type": "string",
+            "description": "Present when classification is opening_delimiter or closing_delimiter"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateAgentActionSuccessEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "action"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_action_success"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "action": {
+            "type": "object",
+            "description": "The MCP action that completed successfully"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateAgentMessageSuccessEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "message",
+          "runIds"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_message_success"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PrivateAgentMessage"
+          },
+          "runIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateAgentErrorEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "error"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_error"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          "runIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateAgentGenerationCancelledEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_generation_cancelled"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolErrorEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "conversationId",
+          "error",
+          "isLastBlockingEventForStep"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_error"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          "isLastBlockingEventForStep": {
+            "type": "boolean"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolParamsEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "action"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_params"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "action": {
+            "type": "object",
+            "description": "The MCP action with its parameters"
+          },
+          "runIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolApproveExecutionEvent": {
+        "type": "object",
+        "description": "Sent when a tool requires user approval before execution.",
+        "required": [
+          "type",
+          "created",
+          "conversationId",
+          "messageId",
+          "actionId",
+          "configurationId",
+          "inputs"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_approve_execution"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "actionId": {
+            "type": "string"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "stake": {
+            "type": "string",
+            "description": "Risk level of the tool execution"
+          },
+          "isLastBlockingEventForStep": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolNotificationEvent": {
+        "type": "object",
+        "description": "Progress notification from a running tool.",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "conversationId",
+          "messageId",
+          "action",
+          "notification"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_notification"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "action": {
+            "type": "object",
+            "description": "The MCP action producing the notification"
+          },
+          "notification": {
+            "type": "object",
+            "description": "Progress notification content"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolPersonalAuthRequiredEvent": {
+        "type": "object",
+        "description": "Sent when a tool requires personal OAuth authentication.",
+        "required": [
+          "type",
+          "created",
+          "conversationId",
+          "messageId",
+          "actionId",
+          "configurationId",
+          "authError"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_personal_auth_required"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "actionId": {
+            "type": "string"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "authError": {
+            "type": "object",
+            "properties": {
+              "mcpServerId": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "scope": {
+                "type": "string"
+              },
+              "toolName": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolFileAuthRequiredEvent": {
+        "type": "object",
+        "description": "Sent when a tool requires file access authorization (e.g., Google Drive).",
+        "required": [
+          "type",
+          "created",
+          "conversationId",
+          "messageId",
+          "actionId",
+          "configurationId",
+          "fileAuthError"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_file_auth_required"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "actionId": {
+            "type": "string"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "fileAuthError": {
+            "type": "object",
+            "properties": {
+              "fileId": {
+                "type": "string"
+              },
+              "fileName": {
+                "type": "string"
+              },
+              "connectionId": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "toolName": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateAgentContextPrunedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent_context_pruned"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
       "Section": {
         "type": "object",
         "description": "A section of a document that can contain nested sections",
@@ -6263,6 +11916,5 @@
         "description": "Your DUST API key is a Bearer token."
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/front/swagger.json
+++ b/front/swagger.json
@@ -21,6 +21,32 @@
         "url": "https://eu.dust.tt",
         "description": "Dust.tt API (europe-west1)"
       }
+    ],
+    "tags": [
+      { "name": "Agents", "description": "Agent configurations" },
+      { "name": "Apps", "description": "Dust apps" },
+      { "name": "Conversations", "description": "Conversations" },
+      { "name": "DatasourceViews", "description": "Data source views" },
+      { "name": "Datasources", "description": "Data sources" },
+      { "name": "Feedbacks", "description": "Message feedbacks" },
+      { "name": "MCP", "description": "MCP servers" },
+      { "name": "Mentions", "description": "Mentions" },
+      { "name": "Search", "description": "Search" },
+      { "name": "Tools", "description": "Tools" },
+      { "name": "Triggers", "description": "Triggers" },
+      { "name": "Spaces", "description": "Spaces" },
+      { "name": "Workspace", "description": "Workspace" },
+      { "name": "Private User", "description": "Private API - User" },
+      { "name": "Private Authentication", "description": "Private API - Authentication (WorkOS)" },
+      { "name": "Private Agents", "description": "Private API - Agent configurations" },
+      { "name": "Private Conversations", "description": "Private API - Conversations" },
+      { "name": "Private Messages", "description": "Private API - Messages" },
+      { "name": "Private Events", "description": "Private API - SSE event streams" },
+      { "name": "Private Files", "description": "Private API - File uploads" },
+      { "name": "Private Mentions", "description": "Private API - Mention suggestions" },
+      { "name": "Private Spaces", "description": "Private API - Spaces and data source views" },
+      { "name": "Private Extension", "description": "Private API - Extension configuration" },
+      { "name": "Private Workspace", "description": "Private API - Workspace settings" }
     ]
   }
 }


### PR DESCRIPTION
## Description

Add `@ignoreswagger` annotations to all private API endpoints and non-documented files (~400 files) so they pass the new `lint:swagger-annotations` check.

Also updates `CODING_RULES.md`:
- Merge BACK12 and BACK14 into a single rule `[BACK12] No breaking changes in API endpoints`, distinguishing between public API (never break) and private API (can break once old clients are no longer deployed)
- Add `[BACK14] Keep Swagger documentation in sync with API schema changes` — any schema change (including deeply nested objects) must be reflected in swagger annotations and shared schema files

## Tests

Ran `npm -w front run lint:swagger-annotations` locally — all files pass.

## Risk

Low — only adds comment annotations and updates documentation rules, no runtime changes.

## Deploy Plan

Standard merge to main.