### PR TITLE
[Front] feat(byok): add Redis caching for provider credentials baseFetch

### DIFF
--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -1,8 +1,58 @@
-import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
-import { Ok } from "@app/types/shared/result";
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisCacheClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      del: vi.fn().mockImplementation((keyOrKeys: string | string[]) => {
+        const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+        keys.forEach((key) => inMemoryCache.delete(key));
+        return Promise.resolve(keys.length);
+      }),
+    })
+  ),
+}));
+
+vi.mock("@app/lib/utils/cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/utils/cache")>();
+  return {
+    ...actual,
+    cacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(
+          fn: CacheableFunction<JsonSerializable<T>, Args>,
+          resolver: (...args: Args) => string
+        ) => {
+          return async (...args: Args): Promise<JsonSerializable<T>> => {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            const cached = inMemoryCache.get(key);
+            if (cached) {
+              return JSON.parse(cached) as JsonSerializable<T>;
+            }
+            const result = await fn(...args);
+            inMemoryCache.set(key, JSON.stringify(result));
+            return result;
+          };
+        }
+      ),
+    invalidateCacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(
+          fn: CacheableFunction<JsonSerializable<T>, Args>,
+          resolver: (...args: Args) => string
+        ) => {
+          return async (...args: Args): Promise<void> => {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            inMemoryCache.delete(key);
+          };
+        }
+      ),
+  };
+});
 
 const mockGetCredentials = vi.fn();
 
@@ -18,11 +68,21 @@ vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
   };
 });
 
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { ProviderCredentialFactory } from "@app/tests/utils/ProviderCredentialFactory";
+import { Ok } from "@app/types/shared/result";
+
+function getCacheKey(workspaceId: number): string {
+  return `cacheWithRedis-_baseFetchUncached-provider_credentials:workspaceId:${workspaceId}`;
+}
+
 describe("ProviderCredentialResource", () => {
   beforeEach(() => {
     mockGetCredentials.mockResolvedValue(
       new Ok({ credential: { content: { api_key: "sk-test" } } })
     );
+    inMemoryCache.clear();
   });
 
   describe("listByWorkspace", () => {
@@ -224,6 +284,104 @@ describe("ProviderCredentialResource", () => {
       ).rejects.toThrow(
         "Failed to fetch OAuth credentials for provider openai"
       );
+    });
+  });
+
+  describe("baseFetch caching", () => {
+    it("populates cache on first call", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+      const cacheKey = getCacheKey(workspace.id);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+      await ProviderCredentialResource.listByWorkspace(authenticator);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    });
+
+    it("serves from cache on second call", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      const result1 =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+      const result2 =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+
+      expect(result1.map((r) => r.toJSON())).toEqual(
+        result2.map((r) => r.toJSON())
+      );
+      // OAuthAPI should only be called once (for the first fetch)
+      expect(mockGetCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it("invalidates cache after delete", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+      const cacheKey = getCacheKey(workspace.id);
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      await ProviderCredentialResource.listByWorkspace(authenticator);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const [credential] =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+      await credential.delete(authenticator);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+
+    it("invalidates cache after deleteAllForWorkspace", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+      const cacheKey = getCacheKey(workspace.id);
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      await ProviderCredentialResource.listByWorkspace(authenticator);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      await ProviderCredentialResource.deleteAllForWorkspace(authenticator);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+
+    it("returns fresh data after cache invalidation", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      const result1 =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+      expect(result1).toHaveLength(1);
+
+      // Delete and verify cache is invalidated
+      await result1[0].delete(authenticator);
+
+      // Next call should hit DB again and return empty
+      const result2 =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+      expect(result2).toHaveLength(0);
     });
   });
 });

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -7,6 +7,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import {
@@ -19,6 +20,7 @@ import {
   PROVIDER_TO_CREDENTIAL_KEY,
   type ProviderCredentialType,
 } from "@app/types/provider_credential";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -31,6 +33,19 @@ import type { Attributes, ModelStatic } from "sequelize";
 import type { z } from "zod";
 
 const API_KEY_REVEAL_WINDOW_MINUTES = 5;
+
+type CachedProviderCredential = {
+  id: number;
+  workspaceId: number;
+  providerId: ByokModelProviderIdType;
+  credentialId: string;
+  isHealthy: boolean;
+  placeholder: string;
+  editedByUserId: number | null;
+  createdAt: number;
+  updatedAt: number;
+  credentials: { api_key: string };
+};
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -115,7 +130,70 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     );
   }
 
-  // TODO (BYOK): cache this method
+  private static readonly providerCredentialCacheKeyResolver = (
+    workspaceModelId: ModelId
+  ) => `provider_credentials:workspaceId:${workspaceModelId}`;
+
+  private static async _baseFetchUncached(
+    workspaceModelId: ModelId
+  ): Promise<CachedProviderCredential[]> {
+    const models = await ProviderCredentialResource.model.findAll({
+      where: { workspaceId: workspaceModelId },
+    });
+
+    const resources = await concurrentExecutor(
+      models,
+      ProviderCredentialResource.makeNewFromModel,
+      { concurrency: 8 }
+    );
+
+    return resources.map((r) => ({
+      id: r.id,
+      workspaceId: r.workspaceId,
+      providerId: r.providerId,
+      credentialId: r.credentialId,
+      isHealthy: r.isHealthy,
+      placeholder: r.placeholder,
+      editedByUserId: r.editedByUserId,
+      createdAt: r.createdAt.getTime(),
+      updatedAt: r.updatedAt.getTime(),
+      credentials: r.credentials,
+    }));
+  }
+
+  // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
+  private static baseFetchCached = cacheWithRedis(
+    ProviderCredentialResource._baseFetchUncached,
+    ProviderCredentialResource.providerCredentialCacheKeyResolver,
+    { cacheNullValues: false }
+  );
+
+  private static invalidateProviderCredentialCache = invalidateCacheWithRedis(
+    ProviderCredentialResource._baseFetchUncached,
+    ProviderCredentialResource.providerCredentialCacheKeyResolver
+  );
+
+  private static fromCachedData(
+    data: CachedProviderCredential
+  ): ProviderCredentialResource {
+    const blob: Attributes<ProviderCredentialModel> = {
+      id: data.id,
+      workspaceId: data.workspaceId,
+      providerId: data.providerId,
+      credentialId: data.credentialId,
+      isHealthy: data.isHealthy,
+      placeholder: data.placeholder,
+      editedByUserId: data.editedByUserId,
+      createdAt: new Date(data.createdAt),
+      updatedAt: new Date(data.updatedAt),
+    };
+    return new ProviderCredentialResource(
+      ProviderCredentialModel,
+      blob,
+      data.credentials
+    );
+  }
+
   private static async baseFetch(
     auth: Authenticator
   ): Promise<ProviderCredentialResource[]> {
@@ -123,16 +201,9 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     assert(plan.isByok, "BYOK must be enabled to fetch provider credentials.");
 
     const workspace = auth.getNonNullableWorkspace();
+    const cached = await this.baseFetchCached(workspace.id);
 
-    const models = await this.model.findAll({
-      where: { workspaceId: workspace.id },
-    });
-
-    const resources = await concurrentExecutor(models, this.makeNewFromModel, {
-      concurrency: 8,
-    });
-
-    return resources;
+    return cached.map(this.fromCachedData);
   }
 
   static async makeNew(
@@ -202,6 +273,8 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       editedByUserId: user.id,
     });
 
+    await this.invalidateProviderCredentialCache(workspace.id);
+
     return new ProviderCredentialResource(
       ProviderCredentialModel,
       model.get(),
@@ -242,18 +315,25 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     await ProviderCredentialModel.destroy({
       where: { workspaceId: workspace.id },
     });
+
+    await this.invalidateProviderCredentialCache(workspace.id);
   }
 
   async delete(
     auth: Authenticator
   ): Promise<Result<number | undefined, Error>> {
     try {
+      const workspace = auth.getNonNullableWorkspace();
       const affectedCount = await this.model.destroy({
         where: {
           id: this.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
+          workspaceId: workspace.id,
         },
       });
+
+      await ProviderCredentialResource.invalidateProviderCredentialCache(
+        workspace.id
+      );
 
       return new Ok(affectedCount);
     } catch (error) {

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -16,6 +16,7 @@ import {
 } from "@app/types/oauth/oauth_api";
 import {
   ApiKeyCredentialContentSchema,
+  type ApiKeyCredentialsType,
   type LLMCredentialsType,
   PROVIDER_TO_CREDENTIAL_KEY,
   type ProviderCredentialType,
@@ -30,21 +31,20 @@ import { redactString } from "@app/types/shared/utils/string_utils";
 import assert from "assert";
 import OpenAI from "openai";
 import type { Attributes, ModelStatic } from "sequelize";
-import type { z } from "zod";
 
 const API_KEY_REVEAL_WINDOW_MINUTES = 5;
 
 type CachedProviderCredential = {
-  id: number;
-  workspaceId: number;
+  id: ModelId;
+  workspaceId: ModelId;
   providerId: ByokModelProviderIdType;
   credentialId: string;
   isHealthy: boolean;
   placeholder: string;
-  editedByUserId: number | null;
+  editedByUserId: ModelId | null;
   createdAt: number;
   updatedAt: number;
-  credentials: { api_key: string };
+  credentials: ApiKeyCredentialsType;
 };
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -55,12 +55,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   static model: ModelStaticWorkspaceAware<ProviderCredentialModel> =
     ProviderCredentialModel;
 
-  private credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+  private credentials: ApiKeyCredentialsType;
 
   constructor(
     model: ModelStatic<ProviderCredentialModel>,
     blob: Attributes<ProviderCredentialModel>,
-    credentials: z.infer<typeof ApiKeyCredentialContentSchema>
+    credentials: ApiKeyCredentialsType
   ) {
     super(ProviderCredentialModel, blob);
     this.credentials = credentials;
@@ -369,7 +369,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
 function mapOauthCredentialsToLlmCredentials(
   oauthCredentials: {
     providerId: ByokModelProviderIdType;
-    content: z.infer<typeof ApiKeyCredentialContentSchema>;
+    content: ApiKeyCredentialsType;
   }[]
 ): LLMCredentialsType {
   const result: LLMCredentialsType = {};

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -1,9 +1,8 @@
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
-import type { ApiKeyCredentialContentSchema } from "@app/types/provider_credential";
+import type { ApiKeyCredentialsType } from "@app/types/provider_credential";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
 import * as t from "io-ts";
-import type z from "zod";
 
 // Extra config type for OAuth setup - generic key-value pairs for provider-specific config
 export const ExtraConfigTypeSchema = t.record(t.string, t.string);
@@ -782,7 +781,7 @@ export function isModjoCredentials(
 
 export type ModelProviderPostCredentialsBody = {
   provider: ByokModelProviderIdType;
-  credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+  credentials: ApiKeyCredentialsType;
 };
 
 export type OauthAPIPostConnectionCredentialsResponse = {

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -1,6 +1,5 @@
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
-import type { ApiKeyCredentialContentSchema } from "@app/types/provider_credential";
-import type { z } from "zod";
+import type { ApiKeyCredentialsType } from "@app/types/provider_credential";
 import type {
   ConnectionCredentials,
   CredentialsProvider,
@@ -48,7 +47,7 @@ type CrendentialsMetadata = {
 
 export type ModelProviderPostCredentialsBody = {
   provider: ByokModelProviderIdType;
-  credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+  credentials: ApiKeyCredentialsType;
 };
 
 export class OAuthAPI {

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -24,7 +24,7 @@ export type ProviderCredentialType = {
   createdAt: number;
   updatedAt: number;
   providerId: ByokModelProviderIdType;
-  credentials: z.infer<typeof ApiKeyCredentialContentSchema>;
+  credentials: ApiKeyCredentialsType;
   credentialId: string;
   isHealthy: boolean;
   placeholder: string;
@@ -34,6 +34,10 @@ export type ProviderCredentialType = {
 export const ApiKeyCredentialContentSchema = z.object({
   api_key: z.string(),
 });
+
+export type ApiKeyCredentialsType = z.infer<
+  typeof ApiKeyCredentialContentSchema
+>;
 
 export const PROVIDER_TO_CREDENTIAL_KEY = {
   openai: "OPENAI_API_KEY",


### PR DESCRIPTION
## Description

Cache `baseFetch` in `ProviderCredentialResource` using `cacheWithRedis`, following the same pattern as other resources (SubscriptionResource, WorkspaceResource, etc.).

This avoids hitting the DB + OAuthAPI on every call of `getCredentials` by byok workspaces

Cache is invalidated on create, delete, and bulk delete. No TTL — relies on Redis LFU eviction.

Closes: https://github.com/dust-tt/tasks/issues/6964