### PR TITLE
[BYOK] Add provider credential configuration and edit flow

### DIFF
--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -34,6 +34,9 @@ pub enum CredentialProvider {
     Databricks,
     UkgReady,
     Vanta,
+    // BYOK model providers
+    Openai,
+    Anthropic,
 }
 
 impl From<ConnectionProvider> for CredentialProvider {
@@ -259,6 +262,12 @@ impl Credential {
             }
             CredentialProvider::Vanta => {
                 vec!["client_id", "client_secret"]
+            }
+            CredentialProvider::Openai => {
+                vec!["api_key"]
+            }
+            CredentialProvider::Anthropic => {
+                vec!["api_key"]
             }
         };
 

--- a/front/components/pages/workspace/model_providers/EmbeddingModelSelect.tsx
+++ b/front/components/pages/workspace/model_providers/EmbeddingModelSelect.tsx
@@ -32,7 +32,7 @@ export function EmbeddingModelSelect({ workspace }: EmbeddingModelSelectProps) {
       <div className="flex items-center justify-between">
         <div className="font-semibold">Embedding Provider:</div>
         <DropdownMenu>
-          <DropdownMenuTrigger disabled>
+          <DropdownMenuTrigger asChild disabled>
             <Button
               disabled
               tooltip="Please contact us if you are willing to change this setting."

--- a/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
+++ b/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
@@ -1,0 +1,101 @@
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
+import {
+  ContextItem,
+  Hoverable,
+  Icon,
+  Input,
+  Page,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+import { useState } from "react";
+
+const PROVIDER_ID_TO_DOCS_LINK: Record<ByokModelProviderIdType, string> = {
+  openai: "https://developers.openai.com/api/docs/quickstart",
+  anthropic: "https://platform.claude.com/docs/en/api/overview",
+};
+
+interface ProviderInfoProps {
+  providerId: ByokModelProviderIdType;
+  logo: ComponentType;
+}
+
+function ProviderInfo({ providerId, logo }: ProviderInfoProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Page.H variant="h6">Provider</Page.H>
+      <ContextItem
+        title={PRETTIFIED_PROVIDER_NAMES[providerId]}
+        visual={<Icon visual={logo} size="md" />}
+        className="p-0"
+      >
+        <ContextItem.Description>
+          <Hoverable
+            href={PROVIDER_ID_TO_DOCS_LINK[providerId]}
+            target="_blank"
+            variant="highlight"
+            className="font-normal text-sm"
+          >
+            Documentation
+          </Hoverable>
+        </ContextItem.Description>
+      </ContextItem>
+    </div>
+  );
+}
+
+interface KeyConfigurationSheetProps {
+  providerId: ByokModelProviderIdType;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  logo: ComponentType;
+}
+
+export function KeyConfigurationSheet({
+  providerId,
+  isOpen,
+  onOpenChange,
+  logo,
+}: KeyConfigurationSheetProps) {
+  const [apiKey, setApiKey] = useState("");
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>
+            Configure {PRETTIFIED_PROVIDER_NAMES[providerId]} API key
+          </SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <ProviderInfo providerId={providerId} logo={logo} />
+          <div className="flex flex-col gap-2">
+            <Page.H variant="h6">Api key</Page.H>
+            <Input
+              placeholder="Type an API Key"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+            />
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => onOpenChange(false),
+          }}
+          rightButtonProps={{
+            label: "Save",
+            onClick: () => {},
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
+++ b/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
@@ -1,4 +1,4 @@
-import { useCreateProviderCredential } from "@app/lib/swr/provider_credentials";
+import { useProviderCredentialActions } from "@app/lib/swr/provider_credentials";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -58,6 +58,7 @@ interface KeyConfigurationSheetProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   logo: ComponentType;
+  apiKey: string | undefined;
 }
 
 export function KeyConfigurationSheet({
@@ -66,15 +67,20 @@ export function KeyConfigurationSheet({
   isOpen,
   onOpenChange,
   logo,
+  apiKey: initialApiKey,
 }: KeyConfigurationSheetProps) {
-  const [apiKey, setApiKey] = useState("");
+  const [apiKey, setApiKey] = useState(initialApiKey ?? "");
   const [isSaving, setIsSaving] = useState(false);
 
-  const { createProviderCredential } = useCreateProviderCredential({ owner });
+  const { saveProviderCredential } = useProviderCredentialActions({ owner });
 
   const handleSave = async () => {
     setIsSaving(true);
-    const result = await createProviderCredential({ providerId, apiKey });
+    const result = await saveProviderCredential({
+      providerId,
+      apiKey,
+      isNew: initialApiKey === undefined,
+    });
     setIsSaving(false);
 
     if (result) {

--- a/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
+++ b/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
@@ -1,6 +1,9 @@
+import { useCreateProviderCredential } from "@app/lib/swr/provider_credentials";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
+  Button,
   ContextItem,
   Hoverable,
   Icon,
@@ -9,7 +12,6 @@ import {
   Sheet,
   SheetContainer,
   SheetContent,
-  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@dust-tt/sparkle";
@@ -51,6 +53,7 @@ function ProviderInfo({ providerId, logo }: ProviderInfoProps) {
 }
 
 interface KeyConfigurationSheetProps {
+  owner: LightWorkspaceType;
   providerId: ByokModelProviderIdType;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -58,15 +61,40 @@ interface KeyConfigurationSheetProps {
 }
 
 export function KeyConfigurationSheet({
+  owner,
   providerId,
   isOpen,
   onOpenChange,
   logo,
 }: KeyConfigurationSheetProps) {
   const [apiKey, setApiKey] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const { createProviderCredential } = useCreateProviderCredential({ owner });
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    const result = await createProviderCredential({ providerId, apiKey });
+    setIsSaving(false);
+
+    if (result) {
+      setApiKey("");
+      onOpenChange(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (isSaving) {
+      return;
+    }
+    if (!open) {
+      setApiKey("");
+    }
+    onOpenChange(open);
+  };
 
   return (
-    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       <SheetContent>
         <SheetHeader>
           <SheetTitle>
@@ -81,20 +109,25 @@ export function KeyConfigurationSheet({
               placeholder="Type an API Key"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
+              disabled={isSaving}
             />
           </div>
         </SheetContainer>
-        <SheetFooter
-          leftButtonProps={{
-            label: "Cancel",
-            variant: "outline",
-            onClick: () => onOpenChange(false),
-          }}
-          rightButtonProps={{
-            label: "Save",
-            onClick: () => {},
-          }}
-        />
+        <div className="flex flex-none flex-col gap-2">
+          <div className="flex items-center justify-between border-t border-border p-3 dark:border-border-night">
+            <Button
+              label="Cancel"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSaving}
+            />
+            <Button
+              label="Save"
+              onClick={handleSave}
+              disabled={!apiKey.trim() || isSaving}
+            />
+          </div>
+        </div>
       </SheetContent>
     </Sheet>
   );

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -58,6 +58,7 @@ export function ModelProvidersPageContent({
     <div className="flex flex-col gap-8">
       {plan.isByok ? (
         <ProvidersConfigurationList
+          owner={workspace}
           modelsDescriptionByProvider={modelsDescriptionByProvider}
         />
       ) : (

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -11,11 +11,13 @@ interface ProviderConfigurationContextItemProps {
   owner: LightWorkspaceType;
   providerId: ByokModelProviderIdType;
   description: string;
+  isLoading: boolean;
 }
 export function ProviderConfigurationContextItem({
   owner,
   providerId,
   description,
+  isLoading,
 }: ProviderConfigurationContextItemProps) {
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
@@ -28,11 +30,13 @@ export function ProviderConfigurationContextItem({
         title={PRETTIFIED_PROVIDER_NAMES[providerId]}
         visual={<Icon visual={LogoComponent} size="lg" />}
         action={
-          <Button
-            label="Configure"
-            variant="outline"
-            onClick={() => setIsSheetOpen(true)}
-          />
+          !isLoading && (
+            <Button
+              label="Configure"
+              variant="outline"
+              onClick={() => setIsSheetOpen(true)}
+            />
+          )
         }
       >
         <ContextItem.Description>

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -3,14 +3,17 @@ import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
+import type { LightWorkspaceType } from "@app/types/user";
 import { Button, ContextItem, Icon } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface ProviderConfigurationContextItemProps {
+  owner: LightWorkspaceType;
   providerId: ByokModelProviderIdType;
   description: string;
 }
 export function ProviderConfigurationContextItem({
+  owner,
   providerId,
   description,
 }: ProviderConfigurationContextItemProps) {
@@ -39,6 +42,7 @@ export function ProviderConfigurationContextItem({
         </ContextItem.Description>
       </ContextItem>
       <KeyConfigurationSheet
+        owner={owner}
         providerId={providerId}
         isOpen={isSheetOpen}
         onOpenChange={setIsSheetOpen}

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -70,7 +70,7 @@ export function ProviderConfigurationContextItem({
           </span>
         </ContextItem.Description>
         {apiKey && (
-          <div className="font-mono text-lg mt-4 text-foreground dark:text-foreground-night">
+          <div className="font-mono text-lg mt-4 text-foreground dark:text-foreground-night truncate">
             {apiKey}
           </div>
         )}

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -1,11 +1,13 @@
+import { KeyConfigurationSheet } from "@app/components/pages/workspace/model_providers/KeyConfigurationSheet";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import { Button, ContextItem, Icon } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface ProviderConfigurationContextItemProps {
-  providerId: ModelProviderIdType;
+  providerId: ByokModelProviderIdType;
   description: string;
 }
 export function ProviderConfigurationContextItem({
@@ -14,19 +16,34 @@ export function ProviderConfigurationContextItem({
 }: ProviderConfigurationContextItemProps) {
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   return (
-    <ContextItem
-      key={providerId}
-      title={PRETTIFIED_PROVIDER_NAMES[providerId]}
-      visual={<Icon visual={LogoComponent} size="lg" />}
-      action={<Button label="Configure" variant="outline" />}
-    >
-      <ContextItem.Description>
-        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {description}
-        </span>
-      </ContextItem.Description>
-    </ContextItem>
+    <>
+      <ContextItem
+        key={providerId}
+        title={PRETTIFIED_PROVIDER_NAMES[providerId]}
+        visual={<Icon visual={LogoComponent} size="lg" />}
+        action={
+          <Button
+            label="Configure"
+            variant="outline"
+            onClick={() => setIsSheetOpen(true)}
+          />
+        }
+      >
+        <ContextItem.Description>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {description}
+          </span>
+        </ContextItem.Description>
+      </ContextItem>
+      <KeyConfigurationSheet
+        providerId={providerId}
+        isOpen={isSheetOpen}
+        onOpenChange={setIsSheetOpen}
+        logo={LogoComponent}
+      />
+    </>
   );
 }

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -7,17 +7,44 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { Button, ContextItem, Icon } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+interface ConfigureButtonProps {
+  isLoading: boolean;
+  apiKey: string | undefined;
+  openConfigurationSheet: () => void;
+}
+
+function ProviderConfigurationActions({
+  isLoading,
+  apiKey,
+  openConfigurationSheet,
+}: ConfigureButtonProps) {
+  const configureLabel = apiKey ? "Edit" : "Configure";
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Button
+      label={configureLabel}
+      variant="outline"
+      onClick={openConfigurationSheet}
+    />
+  );
+}
+
 interface ProviderConfigurationContextItemProps {
   owner: LightWorkspaceType;
   providerId: ByokModelProviderIdType;
   description: string;
   isLoading: boolean;
+  apiKey: string | undefined;
 }
 export function ProviderConfigurationContextItem({
   owner,
   providerId,
   description,
   isLoading,
+  apiKey,
 }: ProviderConfigurationContextItemProps) {
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
@@ -30,13 +57,11 @@ export function ProviderConfigurationContextItem({
         title={PRETTIFIED_PROVIDER_NAMES[providerId]}
         visual={<Icon visual={LogoComponent} size="lg" />}
         action={
-          !isLoading && (
-            <Button
-              label="Configure"
-              variant="outline"
-              onClick={() => setIsSheetOpen(true)}
-            />
-          )
+          <ProviderConfigurationActions
+            isLoading={isLoading}
+            apiKey={apiKey}
+            openConfigurationSheet={() => setIsSheetOpen(true)}
+          />
         }
       >
         <ContextItem.Description>
@@ -44,13 +69,20 @@ export function ProviderConfigurationContextItem({
             {description}
           </span>
         </ContextItem.Description>
+        {apiKey && (
+          <div className="font-mono text-lg mt-4 text-foreground dark:text-foreground-night">
+            {apiKey}
+          </div>
+        )}
       </ContextItem>
+
       <KeyConfigurationSheet
         owner={owner}
         providerId={providerId}
         isOpen={isSheetOpen}
         onOpenChange={setIsSheetOpen}
         logo={LogoComponent}
+        apiKey={apiKey}
       />
     </>
   );

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -33,7 +33,7 @@ export function ProvidersConfigurationList({
           providerId={providerId}
           description={description}
           isLoading={isProviderCredentialsLoading}
-          apiKey={credentialsByProvider[providerId]?.placeholder}
+          apiKey={credentialsByProvider[providerId]?.credentials.api_key}
         />
       ))}
     </ContextItem.List>

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -3,6 +3,7 @@ import { useProviderCredentials } from "@app/lib/swr/provider_credentials";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ContextItem } from "@dust-tt/sparkle";
+import keyBy from "lodash/keyBy";
 
 interface ProvidersConfigurationListProps {
   owner: LightWorkspaceType;
@@ -13,7 +14,10 @@ export function ProvidersConfigurationList({
   owner,
   modelsDescriptionByProvider,
 }: ProvidersConfigurationListProps) {
-  const { isProviderCredentialsLoading } = useProviderCredentials({ owner });
+  const { isProviderCredentialsLoading, providerCredentials } =
+    useProviderCredentials({ owner });
+
+  const credentialsByProvider = keyBy(providerCredentials, "providerId");
 
   return (
     <ContextItem.List>
@@ -29,6 +33,7 @@ export function ProvidersConfigurationList({
           providerId={providerId}
           description={description}
           isLoading={isProviderCredentialsLoading}
+          apiKey={credentialsByProvider[providerId]?.placeholder}
         />
       ))}
     </ContextItem.List>

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -1,4 +1,5 @@
 import { ProviderConfigurationContextItem } from "@app/components/pages/workspace/model_providers/ProviderConfigurationContextItem";
+import { useProviderCredentials } from "@app/lib/swr/provider_credentials";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ContextItem } from "@dust-tt/sparkle";
@@ -12,6 +13,8 @@ export function ProvidersConfigurationList({
   owner,
   modelsDescriptionByProvider,
 }: ProvidersConfigurationListProps) {
+  const { isProviderCredentialsLoading } = useProviderCredentials({ owner });
+
   return (
     <ContextItem.List>
       {(
@@ -25,6 +28,7 @@ export function ProvidersConfigurationList({
           owner={owner}
           providerId={providerId}
           description={description}
+          isLoading={isProviderCredentialsLoading}
         />
       ))}
     </ContextItem.List>

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -1,12 +1,15 @@
 import { ProviderConfigurationContextItem } from "@app/components/pages/workspace/model_providers/ProviderConfigurationContextItem";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import type { LightWorkspaceType } from "@app/types/user";
 import { ContextItem } from "@dust-tt/sparkle";
 
 interface ProvidersConfigurationListProps {
+  owner: LightWorkspaceType;
   modelsDescriptionByProvider: Partial<Record<ByokModelProviderIdType, string>>;
 }
 
 export function ProvidersConfigurationList({
+  owner,
   modelsDescriptionByProvider,
 }: ProvidersConfigurationListProps) {
   return (
@@ -19,6 +22,7 @@ export function ProvidersConfigurationList({
       ).map(([providerId, description]) => (
         <ProviderConfigurationContextItem
           key={providerId}
+          owner={owner}
           providerId={providerId}
           description={description}
         />

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -1,9 +1,9 @@
 import { ProviderConfigurationContextItem } from "@app/components/pages/workspace/model_providers/ProviderConfigurationContextItem";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { ContextItem } from "@dust-tt/sparkle";
 
 interface ProvidersConfigurationListProps {
-  modelsDescriptionByProvider: Partial<Record<ModelProviderIdType, string>>;
+  modelsDescriptionByProvider: Partial<Record<ByokModelProviderIdType, string>>;
 }
 
 export function ProvidersConfigurationList({
@@ -13,7 +13,7 @@ export function ProvidersConfigurationList({
     <ContextItem.List>
       {(
         Object.entries(modelsDescriptionByProvider) as [
-          ModelProviderIdType,
+          ByokModelProviderIdType,
           string,
         ][]
       ).map(([providerId, description]) => (

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -318,36 +318,27 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       return null;
     }
 
-    await this.model.update(
-      {
-        credentialId: oauthRes.value.credential.credential_id,
-        isHealthy: true,
-        editedByUserId: user.id,
-      },
-      { where: { id: this.id, workspaceId: workspace.id } }
-    );
+    const oldCredentialId = this.credentialId;
 
-    const updatedModel = await this.model.findOne({
-      where: { id: this.id, workspaceId: workspace.id },
+    const [affectedCount] = await this.update({
+      credentialId: oauthRes.value.credential.credential_id,
+      isHealthy: true,
+      editedByUserId: user.id,
     });
 
-    if (!updatedModel) {
+    if (affectedCount === 0) {
       await oauthClient.deleteCredentials({
         credentialsId: oauthRes.value.credential.credential_id,
       });
 
-      throw new Error("Failed to re-fetch updated provider credential.");
+      throw new Error("Failed to update provider credential.");
     }
 
     await oauthClient.deleteCredentials({
-      credentialsId: this.credentialId,
+      credentialsId: oldCredentialId,
     });
 
-    return new ProviderCredentialResource(
-      ProviderCredentialModel,
-      updatedModel.get(),
-      { api_key: apiKey }
-    );
+    return this;
   }
 
   static async listByWorkspace(

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -184,6 +184,20 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     return cached.map(this.fromCachedData);
   }
 
+  static async findByProvider(
+    auth: Authenticator,
+    providerId: ByokModelProviderIdType
+  ): Promise<ProviderCredentialResource | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const model = await this.model.findOne({
+      where: { workspaceId: workspace.id, providerId },
+    });
+    if (!model) {
+      return null;
+    }
+    return this.makeNewFromModel(model);
+  }
+
   static async makeNew(
     auth: Authenticator,
     {
@@ -257,6 +271,72 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       ProviderCredentialModel,
       model.get(),
       // TODO (BYOK): handle different credential content shapes for different providers
+      { api_key: apiKey }
+    );
+  }
+
+  async updateApiKey(
+    auth: Authenticator,
+    { apiKey }: { apiKey: string }
+  ): Promise<ProviderCredentialResource | null> {
+    assert(auth.isAdmin(), "Only admins can update provider credentials.");
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const isHealthy = await isCredentialHealthy({
+      provider: this.providerId,
+      credentials: { api_key: apiKey },
+    });
+
+    if (!isHealthy) {
+      logger.warn(
+        { providerId: this.providerId, workspaceId: workspace.sId },
+        `Provided credentials for provider ${this.providerId} are not healthy.`
+      );
+      return null;
+    }
+
+    const oauthClient = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const oauthRes = await oauthClient.postCredentials({
+      provider: this.providerId,
+      workspaceId: workspace.sId,
+      userId: user.sId,
+      credentials: { api_key: apiKey },
+    });
+
+    if (oauthRes.isErr()) {
+      logger.error(
+        {
+          providerId: this.providerId,
+          error: oauthRes.error,
+          workspaceId: workspace.sId,
+        },
+        `Failed to post credentials to OAuth API : ${oauthRes.error.message}`
+      );
+      return null;
+    }
+
+    await this.model.update(
+      {
+        credentialId: oauthRes.value.credential.credential_id,
+        isHealthy: true,
+        editedByUserId: user.id,
+      },
+      { where: { id: this.id, workspaceId: workspace.id } }
+    );
+
+    const updatedModel = await this.model.findOne({
+      where: { id: this.id, workspaceId: workspace.id },
+    });
+
+    if (!updatedModel) {
+      throw new Error("Failed to re-fetch updated provider credential.");
+    }
+
+    return new ProviderCredentialResource(
+      ProviderCredentialModel,
+      updatedModel.get(),
       { api_key: apiKey }
     );
   }

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -188,6 +188,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     auth: Authenticator,
     providerId: ByokModelProviderIdType
   ): Promise<ProviderCredentialResource | null> {
+    const plan = auth.getNonNullablePlan();
+    assert(
+      plan.isByok,
+      "BYOK must be enabled to fetch a provider's credentials."
+    );
+
     const workspace = auth.getNonNullableWorkspace();
     const model = await this.model.findOne({
       where: { workspaceId: workspace.id, providerId },
@@ -280,6 +286,8 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     { apiKey }: { apiKey: string }
   ): Promise<ProviderCredentialResource | null> {
     assert(auth.isAdmin(), "Only admins can update provider credentials.");
+    const plan = auth.getNonNullablePlan();
+    assert(plan.isByok, "BYOK must be enabled to update provider credentials.");
 
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -29,7 +29,7 @@ import assert from "assert";
 import OpenAI from "openai";
 import type { Attributes, ModelStatic } from "sequelize";
 
-const API_KEY_REVEAL_WINDOW_MINUTES = 5;
+const API_KEY_REVEAL_WINDOW_MINUTES = 2;
 
 type CachedProviderCredential = {
   id: ModelId;

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -403,7 +403,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     const differenceInMinutes = Math.ceil(timeDifference / (1000 * 60));
     const apiKey =
       differenceInMinutes > API_KEY_REVEAL_WINDOW_MINUTES
-        ? redactString(this._credentials.api_key, 4)
+        ? redactString(this._credentials.api_key.slice(-20), 4)
         : this._credentials.api_key;
 
     return {

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -299,22 +299,6 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
 
     const oauthClient = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
-    const deleteRes = await oauthClient.deleteCredentials({
-      credentialsId: this.credentialId,
-    });
-
-    if (deleteRes.isErr()) {
-      logger.error(
-        {
-          providerId: this.providerId,
-          error: deleteRes.error,
-          workspaceId: workspace.sId,
-        },
-        `Failed to delete old credentials from OAuth API: ${deleteRes.error.message}`
-      );
-      return null;
-    }
-
     const oauthRes = await oauthClient.postCredentials({
       provider: this.providerId,
       workspaceId: workspace.sId,
@@ -348,8 +332,16 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     });
 
     if (!updatedModel) {
+      await oauthClient.deleteCredentials({
+        credentialsId: oauthRes.value.credential.credential_id,
+      });
+
       throw new Error("Failed to re-fetch updated provider credential.");
     }
+
+    await oauthClient.deleteCredentials({
+      credentialsId: this.credentialId,
+    });
 
     return new ProviderCredentialResource(
       ProviderCredentialModel,

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -298,6 +298,23 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     }
 
     const oauthClient = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+    const deleteRes = await oauthClient.deleteCredentials({
+      credentialsId: this.credentialId,
+    });
+
+    if (deleteRes.isErr()) {
+      logger.error(
+        {
+          providerId: this.providerId,
+          error: deleteRes.error,
+          workspaceId: workspace.sId,
+        },
+        `Failed to delete old credentials from OAuth API: ${deleteRes.error.message}`
+      );
+      return null;
+    }
+
     const oauthRes = await oauthClient.postCredentials({
       provider: this.providerId,
       workspaceId: workspace.sId,

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -184,7 +184,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     return cached.map(this.fromCachedData);
   }
 
-  static async findByProvider(
+  static async fetchByProvider(
     auth: Authenticator,
     providerId: ByokModelProviderIdType
   ): Promise<ProviderCredentialResource | null> {

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -1,7 +1,13 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { getErrorFromResponse } from "@app/lib/swr/swr";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type {
+  GetProviderCredentialsResponseBody,
   PostProviderCredentialBody,
   PostProviderCredentialResponseBody,
 } from "@app/pages/api/w/[wId]/provider_credentials";
@@ -9,6 +15,30 @@ import type { ByokModelProviderIdType } from "@app/types/assistant/models/types"
 import type { ProviderCredentialType } from "@app/types/provider_credential";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+export function useProviderCredentials({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const providerCredentialsFetcher: Fetcher<GetProviderCredentialsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/provider_credentials`,
+    providerCredentialsFetcher
+  );
+
+  return {
+    providerCredentials:
+      data?.providerCredentials ?? emptyArray<ProviderCredentialType>(),
+    isProviderCredentialsLoading: !error && !data,
+    isProviderCredentialsError: !!error,
+    mutateProviderCredentials: mutate,
+  };
+}
 
 export function useCreateProviderCredential({
   owner,

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -13,6 +13,7 @@ import type {
 } from "@app/pages/api/w/[wId]/provider_credentials";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ProviderCredentialType } from "@app/types/provider_credential";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
@@ -59,17 +60,27 @@ export function useProviderCredentialActions({
       apiKey: string;
       isNew?: boolean;
     }): Promise<ProviderCredentialType | null> => {
-      const response = await clientFetch(
-        `/api/w/${owner.sId}/provider_credentials`,
-        {
-          method: isNew ? "POST" : "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            providerId,
-            apiKey,
-          } satisfies PostProviderCredentialBody),
-        }
-      );
+      let response: Response;
+      try {
+        response = await clientFetch(
+          `/api/w/${owner.sId}/provider_credentials`,
+          {
+            method: isNew ? "POST" : "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              providerId,
+              apiKey,
+            } satisfies PostProviderCredentialBody),
+          }
+        );
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to save API key",
+          description: normalizeError(e).message,
+        });
+        return null;
+      }
 
       if (!response.ok) {
         const error = await getErrorFromResponse(response);

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -40,25 +40,27 @@ export function useProviderCredentials({
   };
 }
 
-export function useCreateProviderCredential({
+export function useProviderCredentialActions({
   owner,
 }: {
   owner: LightWorkspaceType;
 }) {
   const sendNotification = useSendNotification();
 
-  const createProviderCredential = useCallback(
+  const saveProviderCredential = useCallback(
     async ({
       providerId,
       apiKey,
+      isNew = true,
     }: {
       providerId: ByokModelProviderIdType;
       apiKey: string;
+      isNew?: boolean;
     }): Promise<ProviderCredentialType | null> => {
       const response = await clientFetch(
         `/api/w/${owner.sId}/provider_credentials`,
         {
-          method: "POST",
+          method: isNew ? "POST" : "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             providerId,
@@ -90,5 +92,5 @@ export function useCreateProviderCredential({
     [owner.sId, sendNotification]
   );
 
-  return { createProviderCredential };
+  return { saveProviderCredential };
 }

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -27,7 +27,7 @@ export function useProviderCredentials({
   const providerCredentialsFetcher: Fetcher<GetProviderCredentialsResponseBody> =
     fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
     `/api/w/${owner.sId}/provider_credentials`,
     providerCredentialsFetcher
   );
@@ -35,7 +35,7 @@ export function useProviderCredentials({
   return {
     providerCredentials:
       data?.providerCredentials ?? emptyArray<ProviderCredentialType>(),
-    isProviderCredentialsLoading: !error && !data,
+    isProviderCredentialsLoading: isLoading,
     isProviderCredentialsError: !!error,
     mutateProviderCredentials: mutate,
   };

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -16,6 +16,7 @@ import type { ProviderCredentialType } from "@app/types/provider_credential";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
+import { useSWRConfig } from "swr";
 
 export function useProviderCredentials({
   owner,
@@ -46,6 +47,7 @@ export function useProviderCredentialActions({
   owner: LightWorkspaceType;
 }) {
   const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
 
   const saveProviderCredential = useCallback(
     async ({
@@ -87,9 +89,11 @@ export function useProviderCredentialActions({
         description: "Your API key has been configured successfully.",
       });
 
+      await mutate(`/api/w/${owner.sId}/provider_credentials`);
+
       return data.providerCredential;
     },
-    [owner.sId, sendNotification]
+    [owner.sId, sendNotification, mutate]
   );
 
   return { saveProviderCredential };

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -1,0 +1,64 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
+import type {
+  PostProviderCredentialBody,
+  PostProviderCredentialResponseBody,
+} from "@app/pages/api/w/[wId]/provider_credentials";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ProviderCredentialType } from "@app/types/provider_credential";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback } from "react";
+
+export function useCreateProviderCredential({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const createProviderCredential = useCallback(
+    async ({
+      providerId,
+      apiKey,
+    }: {
+      providerId: ByokModelProviderIdType;
+      apiKey: string;
+    }): Promise<ProviderCredentialType | null> => {
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/provider_credentials`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            providerId,
+            apiKey,
+          } satisfies PostProviderCredentialBody),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to save API key",
+          description: error.message,
+        });
+        return null;
+      }
+
+      const data: PostProviderCredentialResponseBody = await response.json();
+
+      sendNotification({
+        type: "success",
+        title: "API key saved",
+        description: "Your API key has been configured successfully.",
+      });
+
+      return data.providerCredential;
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return { createProviderCredential };
+}

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -85,10 +85,7 @@ async function handler(
 
       const providerCredential = await ProviderCredentialResource.makeNew(
         auth,
-        {
-          providerId,
-          apiKey,
-        }
+        { providerId, apiKey }
       );
 
       if (!providerCredential) {
@@ -107,13 +104,62 @@ async function handler(
       });
     }
 
+    case "PATCH": {
+      const bodyValidation = PostProviderCredentialBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${bodyValidation.error.message}.`,
+          },
+        });
+      }
+
+      const { providerId, apiKey } = bodyValidation.data;
+
+      const existing = await ProviderCredentialResource.findByProvider(
+        auth,
+        providerId
+      );
+
+      if (!existing) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "provider_not_found",
+            message: `No credential found for provider ${providerId}.`,
+          },
+        });
+      }
+
+      const providerCredential = await existing.updateApiKey(auth, { apiKey });
+
+      if (!providerCredential) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The provided credentials are invalid or could not be verified.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        providerCredential: providerCredential.toJSON(),
+      });
+    }
+
     default:
       return apiError(req, res, {
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
           message:
-            "The method passed is not supported, GET or POST is expected.",
+            "The method passed is not supported, GET, POST or PATCH is expected.",
         },
       });
   }

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -18,6 +18,10 @@ export type PostProviderCredentialBody = z.infer<
   typeof PostProviderCredentialBodySchema
 >;
 
+export type GetProviderCredentialsResponseBody = {
+  providerCredentials: ProviderCredentialType[];
+};
+
 export type PostProviderCredentialResponseBody = {
   providerCredential: ProviderCredentialType;
 };
@@ -25,7 +29,9 @@ export type PostProviderCredentialResponseBody = {
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<PostProviderCredentialResponseBody>
+    WithAPIErrorResponse<
+      GetProviderCredentialsResponseBody | PostProviderCredentialResponseBody
+    >
   >,
   auth: Authenticator
 ): Promise<void> {
@@ -52,6 +58,15 @@ async function handler(
   }
 
   switch (req.method) {
+    case "GET": {
+      const providerCredentials =
+        await ProviderCredentialResource.listByWorkspace(auth);
+
+      return res.status(200).json({
+        providerCredentials: providerCredentials.map((c) => c.toJSON()),
+      });
+    }
+
     case "POST": {
       const bodyValidation = PostProviderCredentialBodySchema.safeParse(
         req.body
@@ -97,7 +112,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
         },
       });
   }

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -120,7 +120,7 @@ async function handler(
 
       const { providerId, apiKey } = bodyValidation.data;
 
-      const existing = await ProviderCredentialResource.findByProvider(
+      const existing = await ProviderCredentialResource.fetchByProvider(
         auth,
         providerId
       );

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -343,7 +343,7 @@ export class OAuthAPI {
       }
     } else {
       const err = json?.error;
-      const res = json?.response;
+      const jsonResponse = json?.response;
 
       if (err && isOAuthAPIError(err)) {
         this._logger.error(
@@ -357,8 +357,8 @@ export class OAuthAPI {
           "OAuthAPI error"
         );
         return new Err(err);
-      } else if (res) {
-        return new Ok(res);
+      } else if (jsonResponse) {
+        return new Ok(jsonResponse);
       } else {
         const err: OAuthAPIError = {
           code: "unexpected_response_format",

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -236,6 +236,27 @@ export class OAuthAPI {
     return this._resultFromResponse(response);
   }
 
+  async deleteCredentials({
+    credentialsId,
+  }: {
+    credentialsId: string;
+  }): Promise<OAuthAPIResponse<void>> {
+    const res = await this._fetchWithError(
+      `${this._url}/credentials/${credentialsId}`,
+      { method: "DELETE" }
+    );
+    if (res.isErr()) {
+      return res;
+    }
+    if (!res.value.response.ok) {
+      return new Err({
+        code: "delete_credentials_error",
+        message: `Failed to delete credentials: HTTP ${res.value.response.status}`,
+      });
+    }
+    return new Ok(undefined);
+  }
+
   private async _fetchWithError(
     url: string,
     init?: RequestInit


### PR DESCRIPTION
## Description

Adds the ability for workspace admins to configure and edit BYOK (Bring Your Own Key) provider API keys (OpenAI, Anthropic) from the workspace settings page. Introduces a \`KeyConfigurationSheet\` for key entry, a \`GET /provider_credentials\` endpoint to list existing keys, a \`POST\` endpoint to create, and a \`PATCH\` endpoint to update — backed by \`findByProvider\` and \`updateApiKey\` on \`ProviderCredentialResource\`.

<img width="1228" height="1001" alt="image" src="https://github.com/user-attachments/assets/9e912de2-23c3-49ec-8d91-05b60ee0dc8b" />


## Tests

Tested manually: configured a new key, verified it saves and displays; edited an existing key, verified the PATCH path updates correctly without hitting the unique constraint.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy \`main\` on \`front\`