### PR TITLE
[Microsoft] Clear stale full-sync progress on incremental sync

### DIFF
--- a/connectors/migrations/20260313_clear_microsoft_first_sync_progress.ts
+++ b/connectors/migrations/20260313_clear_microsoft_first_sync_progress.ts
@@ -1,0 +1,36 @@
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+import { makeScript } from "scripts/helpers";
+import { Op } from "sequelize";
+
+makeScript({}, async ({ execute }, logger) => {
+  const where = {
+    type: "microsoft",
+    [Op.and]: [
+      { firstSyncProgress: { [Op.not]: null } },
+      { firstSyncProgress: { [Op.ne]: "" } },
+    ],
+  };
+
+  const connectorsCount = await ConnectorModel.count({ where });
+  logger.info(
+    { connectorsCount },
+    "Found microsoft connectors with non-null firstSyncProgress"
+  );
+
+  if (!execute) {
+    logger.info("Dry run mode. Pass -e to clear firstSyncProgress.");
+    return;
+  }
+
+  const [updatedCount] = await ConnectorModel.update(
+    {
+      firstSyncProgress: "",
+    },
+    { where }
+  );
+
+  logger.info(
+    { updatedCount },
+    "Cleared firstSyncProgress on microsoft connectors"
+  );
+});

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -39,7 +39,12 @@ const {
   heartbeatTimeout: "5 minutes",
 });
 
-const { reportInitialSyncProgress, syncSucceeded, syncStarted } =
+const {
+  clearInitialSyncProgress,
+  reportInitialSyncProgress,
+  syncSucceeded,
+  syncStarted,
+} =
   proxyActivities<typeof sync_status>({
     startToCloseTimeout: "10 minutes",
   });
@@ -87,6 +92,7 @@ export async function fullSyncWorkflow({
 
   if (startSyncTs === undefined) {
     startSyncTs = new Date().getTime();
+    await clearInitialSyncProgress(connectorId);
   }
 
   // Temp to clean up the running workflows state
@@ -164,9 +170,16 @@ export async function fullSyncWorkflow({
     });
   }
 
+  const hasPendingNodeUpdates =
+    nodeIdsToSync.length > 0 || nodeIdsToDelete.length > 0;
+
   await syncSucceeded(connectorId);
 
-  if (nodeIdsToSync.length > 0 || nodeIdsToDelete.length > 0) {
+  if (!hasPendingNodeUpdates) {
+    await clearInitialSyncProgress(connectorId);
+  }
+
+  if (hasPendingNodeUpdates) {
     await continueAsNew<typeof fullSyncWorkflow>({
       connectorId,
       nodeIdsToSync,

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -44,10 +44,9 @@ const {
   reportInitialSyncProgress,
   syncSucceeded,
   syncStarted,
-} =
-  proxyActivities<typeof sync_status>({
-    startToCloseTimeout: "10 minutes",
-  });
+} = proxyActivities<typeof sync_status>({
+  startToCloseTimeout: "10 minutes",
+});
 
 export async function fullSyncWorkflow({
   connectorId,
@@ -196,6 +195,7 @@ export async function incrementalSyncWorkflow({
 }: {
   connectorId: ModelId;
 }) {
+  await clearInitialSyncProgress(connectorId);
   await syncStarted(connectorId);
   const nodeIdsToSync = await getRootNodesToSync(connectorId);
   const groupedItems = await groupRootItemsByDriveId(nodeIdsToSync);
@@ -218,6 +218,7 @@ export async function incrementalSyncWorkflowV2({
 }) {
   const fullSyncRunning = await isMicrosoftFullSyncRunning(connectorId);
   if (!fullSyncRunning) {
+    await clearInitialSyncProgress(connectorId);
     await syncStarted(connectorId);
   }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7086

Clears stale `firstSyncProgress` when a Microsoft full sync starts and when it fully completes, so later incremental syncs do not reuse an old `Synced N files` label in the sync chip.

Adds a one-off connectors migration to blank existing stale Microsoft `firstSyncProgress` values.

## Risks
Blast radius: Microsoft connector sync status and the one-off cleanup of stale progress labels.
Risk: low

## Deploy Plan
- deploy connectors
- run `cd connectors && npx tsx migrations/20260313_clear_microsoft_first_sync_progress.ts -e`