### PR TITLE
Improve parallelism in reinforced-agent workflows

### DIFF
--- a/front/temporal/reinforced_agent/worker.ts
+++ b/front/temporal/reinforced_agent/worker.ts
@@ -13,7 +13,6 @@ import {
   OpenTelemetryActivityOutboundInterceptor,
 } from "@temporalio/interceptors-opentelemetry/lib/worker";
 import { Worker } from "@temporalio/worker";
-import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
 
@@ -35,19 +34,6 @@ export async function runReinforcedAgentWorker() {
     maxConcurrentActivityTaskExecutions: 8,
     connection,
     namespace,
-    bundlerOptions: {
-      // Update the webpack config to use aliases from our tsconfig.json. This let us import code
-      // in the workflows and activities files using the @app/ prefix.
-      // In particular, it let us used concurrentExecutor
-      webpackConfigHook: (config) => {
-        const plugins = config.resolve?.plugins ?? [];
-
-        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
-        return config;
-      },
-      // We need to ignore some modules that are not available in Temporal environment.
-      ignoreModules: ["child_process", "crypto", "stream"],
-    },
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/reinforced_agent/worker.ts
+++ b/front/temporal/reinforced_agent/worker.ts
@@ -13,6 +13,7 @@ import {
   OpenTelemetryActivityOutboundInterceptor,
 } from "@temporalio/interceptors-opentelemetry/lib/worker";
 import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
 
@@ -31,9 +32,22 @@ export async function runReinforcedAgentWorker() {
     activities,
     taskQueue: QUEUE_NAME,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions: 8,
     connection,
     namespace,
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json. This let us import code
+      // in the workflows and activities files using the @app/ prefix.
+      // In particular, it let us used concurrentExecutor
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
+      // We need to ignore some modules that are not available in Temporal environment.
+      ignoreModules: ["child_process", "crypto", "stream"],
+    },
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -7,34 +7,8 @@ import {
   sleep,
   startChild,
 } from "@temporalio/workflow";
-
+import { concurrentExecutor } from "../utils";
 import { runSignal } from "./signals";
-
-/**
- * Temporal-workflow-safe concurrent executor (inlined to avoid @app/ imports
- * that require bundlerOptions with TsconfigPathsPlugin).
- */
-async function concurrentExecutor<T, V>(
-  items: T[] | readonly T[],
-  iterator: (item: T, idx: number) => Promise<V>,
-  { concurrency }: { concurrency: number }
-): Promise<V[]> {
-  const results: V[] = new Array(items.length);
-  const queue = items.map((item, index) => ({ item, index }));
-
-  async function worker() {
-    let work;
-    while ((work = queue.shift())) {
-      results[work.index] = await iterator(work.item, work.index);
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
-  );
-
-  return results;
-}
 
 const { getFlaggedWorkspacesActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -1,4 +1,3 @@
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type * as activities from "@app/temporal/reinforced_agent/activities";
 import {
   ApplicationFailure,
@@ -10,6 +9,32 @@ import {
 } from "@temporalio/workflow";
 
 import { runSignal } from "./signals";
+
+/**
+ * Temporal-workflow-safe concurrent executor (inlined to avoid @app/ imports
+ * that require bundlerOptions with TsconfigPathsPlugin).
+ */
+async function concurrentExecutor<T, V>(
+  items: T[] | readonly T[],
+  iterator: (item: T, idx: number) => Promise<V>,
+  { concurrency }: { concurrency: number }
+): Promise<V[]> {
+  const results: V[] = new Array(items.length);
+  const queue = items.map((item, index) => ({ item, index }));
+
+  async function worker() {
+    let work;
+    while ((work = queue.shift())) {
+      results[work.index] = await iterator(work.item, work.index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+
+  return results;
+}
 
 const { getFlaggedWorkspacesActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -1,3 +1,4 @@
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type * as activities from "@app/temporal/reinforced_agent/activities";
 import {
   ApplicationFailure,
@@ -58,6 +59,14 @@ const { processAggregationBatchResultActivity } = proxyActivities<
   startToCloseTimeout: "30 minutes",
 });
 
+// Note on concurrency: we can reach (WORKSPACE_CONCURRENCY x AGENT_CONCURRENCY) simulateneous workflows
+// and it may be way higher than the worker's maxConcurrentActivityTaskExecutions but this is OK
+// as a lot of the time will be spent waiting for the batch to finish so many workflows should not
+// have any activity running.
+const WORKSPACE_CONCURRENCY = 8;
+const AGENT_CONCURRENCY = 8;
+const CONVERSATION_ANALYSIS_CONCURRENCY = 4;
+
 const BATCH_POLL_INTERVAL_MIN_MS = 30_000; // 30 seconds (linear backoff start).
 const BATCH_POLL_INTERVAL_MAX_MS = 5 * 60_000; // 5 minutes (linear backoff cap).
 const BATCH_POLL_INTERVAL_STEP_MS = 10_000; // 10 seconds (linear backoff step).
@@ -73,13 +82,16 @@ export async function reinforcedAgentWorkflow(): Promise<void> {
 
   const workspaceIds = await getFlaggedWorkspacesActivity();
 
-  for (const workspaceId of workspaceIds) {
-    await startChild(reinforcedAgentWorkspaceWorkflow, {
-      workflowId: `reinforced-agent-workspace-${workspaceId}`,
-      args: [{ workspaceId, useBatchMode: true }],
-      parentClosePolicy: ParentClosePolicy.ABANDON,
-    });
-  }
+  await concurrentExecutor(
+    workspaceIds,
+    (workspaceId) =>
+      startChild(reinforcedAgentWorkspaceWorkflow, {
+        workflowId: `reinforced-agent-workspace-${workspaceId}`,
+        args: [{ workspaceId, useBatchMode: true }],
+        parentClosePolicy: ParentClosePolicy.ABANDON,
+      }),
+    { concurrency: WORKSPACE_CONCURRENCY }
+  );
 }
 
 /**
@@ -94,13 +106,16 @@ export async function reinforcedAgentWorkspaceWorkflow({
 }): Promise<void> {
   const agentIds = await getAgentConfigurationsActivity({ workspaceId });
 
-  for (const agentConfigurationId of agentIds) {
-    await startChild(reinforcedAgentForAgentWorkflow, {
-      workflowId: `reinforced-agent-${workspaceId}-${agentConfigurationId}`,
-      args: [{ workspaceId, agentConfigurationId, useBatchMode }],
-      parentClosePolicy: ParentClosePolicy.ABANDON,
-    });
-  }
+  await concurrentExecutor(
+    agentIds,
+    (agentConfigurationId) =>
+      startChild(reinforcedAgentForAgentWorkflow, {
+        workflowId: `reinforced-agent-${workspaceId}-${agentConfigurationId}`,
+        args: [{ workspaceId, agentConfigurationId, useBatchMode }],
+        parentClosePolicy: ParentClosePolicy.ABANDON,
+      }),
+    { concurrency: AGENT_CONCURRENCY }
+  );
 }
 
 /**
@@ -193,14 +208,17 @@ export async function reinforcedAgentForAgentWorkflow({
       });
     }
   } else {
-    // Phase 1: Analyze each conversation sequentially via streaming.
-    for (const conversationId of conversationIds) {
-      await analyzeConversationActivity({
-        workspaceId,
-        agentConfigurationId,
-        conversationId,
-      });
-    }
+    // Phase 1: Analyze all conversations in parallel via streaming.
+    await concurrentExecutor(
+      conversationIds,
+      (conversationId) =>
+        analyzeConversationActivity({
+          workspaceId,
+          agentConfigurationId,
+          conversationId,
+        }),
+      { concurrency: CONVERSATION_ANALYSIS_CONCURRENCY }
+    );
 
     // Phase 2: Aggregate synthetic suggestions into pending.
     await aggregateSuggestionsActivity({

--- a/front/temporal/utils.ts
+++ b/front/temporal/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Temporal-workflow-safe concurrent executor (inlined to avoid @app/ imports
+ * that require bundlerOptions with TsconfigPathsPlugin).
+ */
+export async function concurrentExecutor<T, V>(
+  items: T[] | readonly T[],
+  iterator: (item: T, idx: number) => Promise<V>,
+  { concurrency }: { concurrency: number }
+): Promise<V[]> {
+  const results: V[] = new Array(items.length);
+  const queue = items.map((item, index) => ({ item, index }));
+
+  async function worker() {
+    let work;
+    while ((work = queue.shift())) {
+      results[work.index] = await iterator(work.item, work.index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+
+  return results;
+}


### PR DESCRIPTION
## Description

Increase the parallelism for each workflow layer.
I realize that most of the time will be spent in waiting for the `checkBatchStatusActivity` to succeed, but often the worflow will be sleeping so it won't take a full activity slot and we can actually have a lot of workflow waiting for a query result at the same time.
We will need to check with more volume how it behaves.

## Tests

tested locally, and I do see all the conversation being processed in parallel when batching is not used.

This is what happens without LLM batching

<img width="3036" height="620" alt="image" src="https://github.com/user-attachments/assets/61842d38-4c94-400c-a329-30bfe067155d" />


## Risk

low

## Deploy Plan

deploy front