### PR TITLE
[front] - feat(poke): add timezone selection to usage chart

### DIFF
--- a/front/components/poke/analytics/PokeWorkspaceUsageChart.tsx
+++ b/front/components/poke/analytics/PokeWorkspaceUsageChart.tsx
@@ -13,7 +13,16 @@ import {
   usePokeWorkspaceActiveUsersMetrics,
   usePokeWorkspaceUsageMetrics,
 } from "@app/poke/swr/analytics";
-import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import {
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 import {
   CartesianGrid,
@@ -26,6 +35,22 @@ import {
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
 type UsageDisplayMode = "activity" | "users";
+
+const COMMON_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Kolkata",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
 
 function getLineType(
   period: ObservabilityTimeRangeType
@@ -228,12 +253,14 @@ export function PokeWorkspaceUsageChart({
   period,
 }: PokeWorkspaceUsageChartProps) {
   const [displayMode, setDisplayMode] = useState<UsageDisplayMode>("activity");
+  const [timezone, setTimezone] = useState("UTC");
 
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     usePokeWorkspaceUsageMetrics({
       workspaceId,
       days: period,
       interval: "day",
+      timezone,
       disabled: !workspaceId || displayMode === "users",
     });
 
@@ -244,6 +271,7 @@ export function PokeWorkspaceUsageChart({
   } = usePokeWorkspaceActiveUsersMetrics({
     workspaceId,
     days: period,
+    timezone,
     disabled: !workspaceId || displayMode !== "users",
   });
 
@@ -253,14 +281,16 @@ export function PokeWorkspaceUsageChart({
     usageMetrics,
     "timeRange",
     period,
-    zeroFactory
+    zeroFactory,
+    timezone
   );
 
   const activeUsersData = padSeriesToTimeRange<ActiveUsersMetricsDatum>(
     activeUsersMetrics,
     "timeRange",
     period,
-    activeUsersZeroFactory
+    activeUsersZeroFactory,
+    timezone
   ).map((point) => ({
     ...point,
     dau: toPercentage(point.dau, point.memberCount),
@@ -279,18 +309,38 @@ export function PokeWorkspaceUsageChart({
   const description = getDescriptionForMode(displayMode, period);
 
   const controls = (
-    <ButtonsSwitchList defaultValue={displayMode} size="xs">
-      <ButtonsSwitch
-        value="activity"
-        label="Activity"
-        onClick={() => setDisplayMode("activity")}
-      />
-      <ButtonsSwitch
-        value="users"
-        label="Users"
-        onClick={() => setDisplayMode("users")}
-      />
-    </ButtonsSwitchList>
+    <div className="flex items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button label={timezone} variant="outline" size="xs" isSelect />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup value={timezone}>
+            {COMMON_TIMEZONES.map((tz) => (
+              <DropdownMenuRadioItem
+                key={tz}
+                value={tz}
+                onClick={() => setTimezone(tz)}
+              >
+                {tz}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ButtonsSwitchList defaultValue={displayMode} size="xs">
+        <ButtonsSwitch
+          value="activity"
+          label="Activity"
+          onClick={() => setDisplayMode("activity")}
+        />
+        <ButtonsSwitch
+          value="users"
+          label="Users"
+          onClick={() => setDisplayMode("users")}
+        />
+      </ButtonsSwitchList>
+    </div>
   );
 
   return (

--- a/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { timezoneSchema } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -12,6 +13,7 @@ import { z } from "zod";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  timezone: timezoneSchema,
 });
 
 async function handler(
@@ -46,8 +48,11 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { days: queryDays } = req.query;
-      const q = QuerySchema.safeParse({ days: queryDays });
+      const { days: queryDays, timezone: queryTimezone } = req.query;
+      const q = QuerySchema.safeParse({
+        days: queryDays,
+        timezone: queryTimezone,
+      });
       if (!q.success) {
         return apiError(req, res, {
           status_code: 400,
@@ -58,9 +63,9 @@ async function handler(
         });
       }
 
-      const { days } = q.data;
+      const { days, timezone } = q.data;
 
-      const result = await fetchActiveUsersMetrics(owner, days);
+      const result = await fetchActiveUsersMetrics(owner, days, timezone);
 
       if (result.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -1,6 +1,9 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -15,6 +18,7 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   interval: z.enum(["day", "week"]).optional().default("day"),
+  timezone: timezoneSchema,
 });
 
 async function handler(
@@ -49,10 +53,15 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { days: queryDays, interval: queryInterval } = req.query;
+      const {
+        days: queryDays,
+        interval: queryInterval,
+        timezone: queryTimezone,
+      } = req.query;
       const q = QuerySchema.safeParse({
         days: queryDays,
         interval: queryInterval,
+        timezone: queryTimezone,
       });
       if (!q.success) {
         return apiError(req, res, {
@@ -64,7 +73,7 @@ async function handler(
         });
       }
 
-      const { days, interval } = q.data;
+      const { days, interval, timezone } = q.data;
 
       const baseQuery = buildAgentAnalyticsBaseQuery({
         workspaceId: owner.sId,
@@ -74,7 +83,8 @@ async function handler(
       const usageMetricsResult = await fetchMessageMetrics(
         baseQuery,
         interval,
-        ["conversations", "activeUsers"] as const
+        ["conversations", "activeUsers"] as const,
+        timezone
       );
 
       if (usageMetricsResult.isErr()) {

--- a/front/poke/swr/analytics.ts
+++ b/front/poke/swr/analytics.ts
@@ -8,16 +8,18 @@ export function usePokeWorkspaceUsageMetrics({
   workspaceId,
   days = DEFAULT_PERIOD_DAYS,
   interval = "day",
+  timezone = "UTC",
   disabled,
 }: {
   workspaceId: string;
   days?: number;
   interval?: "day" | "week";
+  timezone?: string;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceUsageMetricsResponse> = fetcher;
-  const key = `/api/poke/workspaces/${workspaceId}/analytics/usage-metrics?days=${days}&interval=${interval}`;
+  const key = `/api/poke/workspaces/${workspaceId}/analytics/usage-metrics?days=${days}&interval=${interval}&timezone=${encodeURIComponent(timezone)}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,
@@ -35,15 +37,17 @@ export function usePokeWorkspaceUsageMetrics({
 export function usePokeWorkspaceActiveUsersMetrics({
   workspaceId,
   days = DEFAULT_PERIOD_DAYS,
+  timezone = "UTC",
   disabled,
 }: {
   workspaceId: string;
   days?: number;
+  timezone?: string;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetWorkspaceActiveUsersResponse> = fetcher;
-  const key = `/api/poke/workspaces/${workspaceId}/analytics/active-users?days=${days}`;
+  const key = `/api/poke/workspaces/${workspaceId}/analytics/active-users?days=${days}&timezone=${encodeURIComponent(timezone)}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,


### PR DESCRIPTION
## Description

Adds a timezone selector dropdown to Poke workspace analytics charts, allowing admins to view usage data in different timezones. This completes timezone support for Poke analytics following recent backend timezone-aware query fixes. The dropdown includes 13 common timezones (UTC, major US zones, European capitals, and Asia-Pacific locations) and dynamically updates both the active users and usage metrics charts when the timezone selection changes. The selected timezone is passed as a query parameter to existing Poke API endpoints (`/api/poke/workspaces/[wId]/analytics/usage-metrics` and `/api/poke/workspaces/[wId]/analytics/active-users`) and used by `padSeriesToTimeRange` to ensure chart data padding respects the selected timezone.

## Tests

Manually tested locally with different timezone selections.

## Risk

Low. Adds new UI controls and extends existing Poke API endpoints with optional timezone parameter. Does not modify core analytics logic.

## Deploy Plan

Deploy front
