### PR TITLE
[front] feat: add UI for making skills discoverable

### DIFF
--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -36,6 +36,7 @@ export const skillBuilderFormSchema = z.object({
   tools: z.array(actionSchema),
   icon: z.string().nullable(),
   extendedSkillId: z.string().nullable(),
+  isDefault: z.boolean(),
   fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),
 });

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -58,9 +58,8 @@ export function SkillBuilderIsDefaultSection() {
           <DialogHeader hideButton>
             <DialogTitle>Allow agents to discover this skill?</DialogTitle>
             <DialogDescription>
-              Agents with{" "}
-              <span className="font-semibold">Discover Skills</span> will be
-              able to find and enable this skill on their own.
+              Agents with <span className="font-semibold">Discover Skills</span>{" "}
+              will be able to find and enable this skill on their own.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -1,0 +1,81 @@
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import {
+  CheckboxWithText,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  InformationCircleIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+export function SkillBuilderIsDefaultSection() {
+  const { watch, setValue } = useFormContext<SkillBuilderFormData>();
+  const isDefault = watch("isDefault");
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  const handleCheckboxChange = (checked: boolean) => {
+    if (checked) {
+      setShowConfirmDialog(true);
+    } else {
+      setValue("isDefault", false, { shouldDirty: true });
+    }
+  };
+
+  const handleConfirm = () => {
+    setValue("isDefault", true, { shouldDirty: true });
+    setShowConfirmDialog(false);
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-1.5">
+        <CheckboxWithText
+          checked={isDefault}
+          onCheckedChange={handleCheckboxChange}
+          text="Allow agents to discover this skill"
+        />
+        <Tooltip
+          label="Agents with the Discover Skills tool will be able to find and enable this skill on their own."
+          trigger={
+            <InformationCircleIcon className="text-muted-foreground dark:text-muted-foreground-night h-4 w-4" />
+          }
+        />
+      </div>
+      <Dialog
+        open={showConfirmDialog}
+        onOpenChange={(open) => {
+          if (!open) {
+            setShowConfirmDialog(false);
+          }
+        }}
+      >
+        <DialogContent size="md" isAlertDialog>
+          <DialogHeader hideButton>
+            <DialogTitle>Allow agents to discover this skill?</DialogTitle>
+            <DialogDescription>
+              Agents with{" "}
+              <span className="font-semibold">Discover Skills</span> will be
+              able to find and enable this skill on their own.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+            }}
+            rightButtonProps={{
+              label: "Confirm",
+              variant: "highlight",
+              onClick: handleConfirm,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -1,6 +1,6 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import {
-  CheckboxWithText,
+  Checkbox,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -33,12 +33,15 @@ export function SkillBuilderIsDefaultSection() {
 
   return (
     <>
-      <div className="flex items-center gap-1.5">
-        <CheckboxWithText
+      <div className="flex items-center gap-2">
+        <Checkbox
           checked={isDefault}
           onCheckedChange={handleCheckboxChange}
-          text="Allow agents to discover this skill"
+          size="sm"
         />
+        <span className="text-sm text-foreground dark:text-foreground-night">
+          Allow agents to discover this skill
+        </span>
         <Tooltip
           label="Agents with the Discover Skills tool will be able to find and enable this skill on their own."
           trigger={
@@ -57,7 +60,7 @@ export function SkillBuilderIsDefaultSection() {
         <DialogContent size="md" isAlertDialog>
           <DialogHeader hideButton>
             <DialogTitle>Allow agents to discover this skill?</DialogTitle>
-            <DialogDescription>
+            <DialogDescription className="pt-4">
               Agents with <span className="font-semibold">Discover Skills</span>{" "}
               will be able to find and enable this skill on their own.
             </DialogDescription>

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -35,8 +35,12 @@ export function SkillBuilderSettingsSection() {
         </div>
       </div>
       {hasFeature("discover_skills") && (
-        <Collapsible>
-          <CollapsibleTrigger label="Advanced" variant="secondary" />
+        <Collapsible defaultOpen>
+          <CollapsibleTrigger variant="secondary">
+            <span className="text-base text-foreground dark:text-foreground-night">
+              Advanced
+            </span>
+          </CollapsibleTrigger>
           <CollapsibleContent>
             <div className="pt-3">
               <SkillBuilderIsDefaultSection />

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -1,8 +1,9 @@
 import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
- import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/SkillBuilderIsDefaultSection";
+import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/SkillBuilderIsDefaultSection";
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   Collapsible,
   CollapsibleContent,
@@ -11,6 +12,8 @@ import {
 } from "@dust-tt/sparkle";
 
 export function SkillBuilderSettingsSection() {
+  const { hasFeature } = useFeatureFlags();
+
   return (
     <div className="space-y-5">
       <h2 className="heading-lg text-foreground dark:text-foreground-night">
@@ -31,14 +34,16 @@ export function SkillBuilderSettingsSection() {
           <SkillEditorsSheet />
         </div>
       </div>
-      <Collapsible>
-        <CollapsibleTrigger label="Advanced" variant="secondary" />
-        <CollapsibleContent>
-          <div className="pt-3">
-            <SkillBuilderIsDefaultSection />
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+      {hasFeature("discover_skills") && (
+        <Collapsible>
+          <CollapsibleTrigger label="Advanced" variant="secondary" />
+          <CollapsibleContent>
+            <div className="pt-3">
+              <SkillBuilderIsDefaultSection />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -1,8 +1,14 @@
 import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
+ import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/SkillBuilderIsDefaultSection";
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
-import { Label } from "@dust-tt/sparkle";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Label,
+} from "@dust-tt/sparkle";
 
 export function SkillBuilderSettingsSection() {
   return (
@@ -25,6 +31,14 @@ export function SkillBuilderSettingsSection() {
           <SkillEditorsSheet />
         </div>
       </div>
+      <Collapsible>
+        <CollapsibleTrigger label="Advanced" variant="secondary" />
+        <CollapsibleContent>
+          <div className="pt-3">
+            <SkillBuilderIsDefaultSection />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -20,6 +20,7 @@ export function transformSkillTypeToFormData(
     fileAttachments: skill.fileAttachments,
     icon: skill.icon ?? null,
     extendedSkillId: skill.extendedSkillId,
+    isDefault: skill.isDefault,
   };
 }
 
@@ -43,5 +44,6 @@ export function getDefaultSkillFormData({
     fileAttachments: [],
     icon: null,
     extendedSkillId,
+    isDefault: false,
   };
 }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -42,6 +42,7 @@ export async function submitSkillBuilderForm({
         instructions: formData.instructions,
         icon: formData.icon,
         extendedSkillId: formData.extendedSkillId,
+        isDefault: formData.isDefault,
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1722,6 +1722,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       fileAttachments,
       icon,
       instructions,
+      isDefault,
       mcpServerViews,
       name,
       requestedSpaceIds,
@@ -1735,6 +1736,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       fileAttachments?: FileResource[];
       icon: string | null;
       instructions: string;
+      isDefault?: boolean;
       mcpServerViews: MCPServerViewResource[];
       name: string;
       requestedSpaceIds: ModelId[];
@@ -1767,6 +1769,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
           ...(sourceMetadata ? { sourceMetadata } : {}),
+          ...(isDefault !== undefined ? { isDefault } : {}),
         },
         transaction
       );
@@ -2368,6 +2371,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       })),
       canWrite: this.canWrite(auth),
       isExtendable: this.isExtendable,
+      isDefault: this.isDefault,
       extendedSkillId: this.extendedSkillId,
     };
   }

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -62,6 +62,7 @@ const PatchSkillRequestBodySchema = t.intersection([
   // TODO(2026-03-02): make mandatory once always sent by the client.
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
+    isDefault: t.boolean,
   }),
 ]);
 
@@ -318,6 +319,7 @@ async function handler(
         fileAttachments: files,
         icon: body.icon,
         instructions: body.instructions,
+        isDefault: body.isDefault,
         mcpServerViews,
         name,
         requestedSpaceIds,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -35,6 +35,7 @@ export type SkillType = {
   }[];
   canWrite: boolean;
   isExtendable: boolean;
+  isDefault: boolean;
   extendedSkillId: string | null;
 };
 


### PR DESCRIPTION
## Description

- This PR adds a setting in Skill Builder to set a skill as "default" (makes them discoverable via `discover_skills`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
