### PR TITLE
[front] enh: fromSandbox -> fromSandboxImage

### DIFF
--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -75,10 +75,6 @@ function getProfileContent(filename: string): () => string {
   return () => fs.readFileSync(path.join(PROFILE_LOCAL_DIR, filename), "utf-8");
 }
 
-function getFileContent(filePath: string): () => string {
-  return () => fs.readFileSync(filePath, "utf-8");
-}
-
 const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.2.0")
   // Conversation files bootstrap
   // Pre-create workspace directory for faster GCS mounts.
@@ -159,11 +155,6 @@ SHELLEOF`)
         "chmod +x /tmp/dsbx && " +
         "sudo mv /tmp/dsbx /opt/bin/dsbx",
     }
-  )
-  // Test data file
-  .copy(
-    getFileContent("/Users/jd/Downloads/products-100000.csv"),
-    "/home/user/products-100000.csv"
   )
   .runCmd(`sudo mkdir -p ${PROFILE_DIR}`)
   .copy(getProfileContent("common.sh"), `${PROFILE_DIR}/common.sh`)

--- a/front/lib/api/sandbox/image/sandbox_image.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.test.ts
@@ -1,53 +1,109 @@
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
-import type { SandboxImageId } from "@app/lib/api/sandbox/image/types";
 import { describe, expect, test } from "vitest";
 
-describe("SandboxImage.fromSandbox()", () => {
-  test("creates image with sandbox base", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
+describe("SandboxImage.fromSandboxImage()", () => {
+  test("clones image preserving baseImage", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const cloned = SandboxImage.fromSandboxImage(original);
 
-    expect(image.baseImage.type).toBe("sandbox");
-    if (image.baseImage.type === "sandbox") {
-      expect(image.baseImage.id).toEqual(id);
-    }
+    expect(cloned.baseImage).toEqual(original.baseImage);
   });
 
-  test("starts with empty operations and tools", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
+  test("clones image preserving operations", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04")
+      .runCmd("echo hello")
+      .runCmd("echo world");
+    const cloned = SandboxImage.fromSandboxImage(original);
 
-    expect(image.operations).toHaveLength(0);
-    expect(image.tools).toHaveLength(0);
+    expect(cloned.operations).toHaveLength(2);
+    expect(cloned.operations).toEqual(original.operations);
   });
 
-  test("has default resources", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
+  test("clones image preserving tools", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04").registerTool({
+      name: "curl",
+      description: "HTTP client",
+      runtime: "system",
+    });
+    const cloned = SandboxImage.fromSandboxImage(original);
 
-    expect(image.resources.vcpu).toBe(1);
-    expect(image.resources.memoryMb).toBe(512);
+    expect(cloned.tools).toHaveLength(1);
+    expect(cloned.tools).toEqual(original.tools);
   });
 
-  test("has default network policy", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
+  test("clones image preserving resources", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04").withResources({
+      vcpu: 4,
+      memoryMb: 8192,
+    });
+    const cloned = SandboxImage.fromSandboxImage(original);
 
-    expect(image.network.mode).toBe("deny_all");
+    expect(cloned.resources).toEqual({ vcpu: 4, memoryMb: 8192 });
   });
 
-  test("has default workdir", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
+  test("clones image preserving network policy", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04").withNetwork({
+      mode: "deny_all",
+      allowlist: ["example.com"],
+    });
+    const cloned = SandboxImage.fromSandboxImage(original);
 
-    expect(image.workdir).toBe("/home/user");
+    expect(cloned.network).toEqual({
+      mode: "deny_all",
+      allowlist: ["example.com"],
+    });
   });
 
-  test("has empty runEnv by default", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
+  test("clones image preserving workdir", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04").setWorkdir("/app");
+    const cloned = SandboxImage.fromSandboxImage(original);
 
-    expect(image.runEnv).toEqual({});
+    expect(cloned.workdir).toBe("/app");
+  });
+
+  test("clones image preserving runEnv", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04").setRunEnv({
+      FOO: "bar",
+    });
+    const cloned = SandboxImage.fromSandboxImage(original);
+
+    expect(cloned.runEnv).toEqual({ FOO: "bar" });
+  });
+
+  test("clones image preserving capabilities", () => {
+    const original =
+      SandboxImage.fromDocker("ubuntu:22.04").withCapability("gcsfuse");
+    const cloned = SandboxImage.fromSandboxImage(original);
+
+    expect(cloned.hasCapability("gcsfuse")).toBe(true);
+  });
+
+  test("clones image preserving imageId", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04").register({
+      imageName: "dust-base",
+      tag: "production",
+    });
+    const cloned = SandboxImage.fromSandboxImage(original);
+
+    expect(cloned.imageId).toEqual({
+      imageName: "dust-base",
+      tag: "production",
+    });
+  });
+
+  test("returns new instance (not same reference)", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const cloned = SandboxImage.fromSandboxImage(original);
+
+    expect(cloned).not.toBe(original);
+  });
+
+  test("modifications to clone do not affect original", () => {
+    const original = SandboxImage.fromDocker("ubuntu:22.04");
+    const cloned = SandboxImage.fromSandboxImage(original).runCmd("echo hello");
+
+    expect(original.operations).toHaveLength(0);
+    expect(cloned.operations).toHaveLength(1);
   });
 });
 
@@ -600,13 +656,6 @@ describe("SandboxImage.register()", () => {
 
   test("has undefined imageId by default", () => {
     const image = SandboxImage.fromDocker("ubuntu:22.04");
-
-    expect(image.imageId).toBeUndefined();
-  });
-
-  test("has undefined imageId from sandbox base by default", () => {
-    const id: SandboxImageId = { imageName: "dust-base", tag: "staging" };
-    const image = SandboxImage.fromSandbox(id);
 
     expect(image.imageId).toBeUndefined();
   });

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -75,17 +75,8 @@ export class SandboxImage {
     });
   }
 
-  static fromSandbox(id: SandboxImageId): SandboxImage {
-    return new SandboxImage({
-      baseImage: { type: "sandbox", id },
-      operations: [],
-      tools: [],
-      resources: DEFAULT_RESOURCES,
-      network: DEFAULT_NETWORK,
-      workdir: "/home/user",
-      runEnv: {},
-      capabilities: new Set(),
-    });
+  static fromSandboxImage(image: SandboxImage): SandboxImage {
+    return image.clone({});
   }
 
   static fromDocker(imageRef: string): SandboxImage {

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -130,6 +130,4 @@ export type SandboxCapability = "gcsfuse";
 // Base Image
 // ---------------------------------------------------------------------------
 
-export type BaseImage =
-  | { readonly type: "sandbox"; readonly id: SandboxImageId }
-  | { readonly type: "docker"; readonly imageRef: string };
+export type BaseImage = { readonly type: "docker"; readonly imageRef: string };

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -102,29 +102,9 @@ class E2BTemplateBuilder {
 
   static fromSandboxImage(
     image: SandboxImage,
-    options?: { dockerRegistryFactory?: DockerRegistryFactory }
+    options: { dockerRegistryFactory: DockerRegistryFactory }
   ): E2BTemplateBuilder {
-    const baseImage = image.baseImage;
-    let builder: TemplateBuilder;
-
-    switch (baseImage.type) {
-      case "sandbox":
-        builder = E2BTemplate().fromTemplate(
-          formatSandboxImageId(baseImage.id)
-        );
-        break;
-      case "docker":
-        if (!options?.dockerRegistryFactory) {
-          throw new Error(
-            "dockerRegistryFactory is required for docker images"
-          );
-        }
-        builder = options.dockerRegistryFactory(baseImage.imageRef);
-        break;
-      default:
-        return assertNever(baseImage);
-    }
-
+    const builder = options.dockerRegistryFactory(image.baseImage.imageRef);
     const e2bBuilder = new E2BTemplateBuilder(builder);
 
     for (const op of image.operations) {
@@ -270,9 +250,15 @@ export async function buildSandboxImage(
     "Building E2B sandbox image"
   );
 
+  if (!buildConfig?.dockerRegistryFactory) {
+    return new Err(
+      new Error("dockerRegistryFactory is required to build sandbox images")
+    );
+  }
+
   try {
     const e2bBuilder = E2BTemplateBuilder.fromSandboxImage(image, {
-      dockerRegistryFactory: buildConfig?.dockerRegistryFactory,
+      dockerRegistryFactory: buildConfig.dockerRegistryFactory,
     });
 
     const result = await e2bBuilder.build(imageId, {


### PR DESCRIPTION
## Description

At this point, `fromSandbox` is quite useless, as you loose all the tools, the capabilities and anything you introduced in the parent image. 

That's because we're leveraging E2B caching layers. Since the build-time itself is quite irrelevant (compared to other parallel tasks in the CI/CD), it's not a big upside.

So big downside (to the point of making the child image close to useless), small upside.
Thus I decided to drop it, in favour of fromSandboxImage, which simply returns a .clone() behind the doors.


## Tests

- Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front