### PR TITLE
[front] Add Claydar website tracking script

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -139,6 +139,10 @@ class MyDocument extends Document {
               })();
             `}
           </Script>
+          <Script
+            src="https://static.claydar.com/init.v1.js?id=clmYho8v0U"
+            strategy="afterInteractive"
+          />
         </body>
       </Html>
     );

--- a/front/pages/api/t/pv.ts
+++ b/front/pages/api/t/pv.ts
@@ -1,3 +1,7 @@
+/**
+ * @ignoreswagger
+ * Internal server-side pageview tracking endpoint.
+ */
 import config from "@app/lib/api/config";
 import { DUST_COOKIES_ACCEPTED } from "@app/lib/cookies";
 import type { SessionWithUser } from "@app/lib/iam/provider";


### PR DESCRIPTION
## Description

Adds the Claydar (Clay website tracking) script to `_document.tsx` to enable website visitor tracking and de-anonymization. This allows identifying companies visiting the website, tracking page engagement, and triggering personalized GTM plays based on web intent signals.

## Tests

Manually verified the script loads correctly in the browser.

## Risk

Low. The script is added alongside existing tracking scripts (Datadog RUM, GTM) and does not affect critical functionality.

## Deploy Plan

Deploy front.