### PR TITLE
Fix sendBeacon in extension

### DIFF
--- a/front/hooks/useServerPageView.ts
+++ b/front/hooks/useServerPageView.ts
@@ -1,3 +1,5 @@
+import config from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { DUST_ANONYMOUS_ID_COOKIE } from "@app/lib/utils/anonymous_id";
 import { useEffect, useRef } from "react";
@@ -34,12 +36,11 @@ export function useServerPageView() {
 
       if (typeof navigator.sendBeacon === "function") {
         navigator.sendBeacon(
-          "/api/t/pv",
+          `${config.getApiBaseUrl()}/api/t/pv`,
           new Blob([body], { type: "application/json" })
         );
       } else {
-        // eslint-disable-next-line no-restricted-globals
-        void fetch("/api/t/pv", {
+        void clientFetch("/api/t/pv", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body,


### PR DESCRIPTION
## Description

Fixes page view tracking in the browser extension by ensuring `navigator.sendBeacon` uses the full API URL instead of a relative path. In the extension context, relative paths like `/api/t/pv` don't resolve correctly, causing page views to fail silently. The fix uses `config.getApiBaseUrl()` to construct the full URL for `sendBeacon` and switches the fallback from plain `fetch` to `clientFetch` for consistency with other extension API calls.

## Tests

Manually verified that page view tracking works in the browser extension context.

## Risk

Low. This only affects the `useServerPageView` hook introduced in PR #22689, which is used for analytics tracking. The change aligns with the pattern already established in PRs #22306 and #22482 for handling extension API calls.

## Deploy Plan

Deploy front.