### PR TITLE
[front] feat: display discoverable skills in skill details

### DIFF
--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -43,14 +43,15 @@ export function SkillInfoTab({
   const [knowledgeItems, setKnowledgeItems] = useState<KnowledgeItem[]>([]);
   const { hasFeature } = useFeatureFlags();
 
-  const isDiscoverSkills = skill.sId === "discover_skills";
+  const showDiscoverableSkills =
+    skill.sId === "discover_skills" && hasFeature("discover_skills");
 
   const { skills: discoverableSkills, isSkillsLoading: isDiscoverableLoading } =
     useSkills({
       owner,
       status: "active",
       isDefault: true,
-      disabled: !isDiscoverSkills,
+      disabled: !showDiscoverableSkills,
     });
 
   const shouldLoadSpaces = skill.requestedSpaceIds.length > 0;
@@ -93,7 +94,7 @@ export function SkillInfoTab({
     knowledgeItems.length > 0 ||
     (hasFeature("sandbox_tools") && skill.fileAttachments.length > 0) ||
     sortedMCPServerViews.length > 0 ||
-    isDiscoverSkills ||
+    showDiscoverableSkills ||
     shouldLoadSpaces;
 
   return (
@@ -177,7 +178,7 @@ export function SkillInfoTab({
         </div>
       )}
 
-      {isDiscoverSkills && (
+      {showDiscoverableSkills && (
         <div className="flex flex-col gap-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Discoverable Skills

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -194,7 +194,7 @@ export function SkillInfoTab({
                 return (
                   <Tooltip
                     key={s.sId}
-                    label={s.userFacingDescription || s.name}
+                    label={s.userFacingDescription}
                     trigger={
                       <div className="flex flex-row items-center gap-2">
                         <SkillAvatar size="xs" />

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -9,7 +9,9 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
@@ -40,6 +42,16 @@ export function SkillInfoTab({
 }: SkillInfoTabProps) {
   const [knowledgeItems, setKnowledgeItems] = useState<KnowledgeItem[]>([]);
   const { hasFeature } = useFeatureFlags();
+
+  const isDiscoverSkills = skill.sId === "discover_skills";
+
+  const { skills: discoverableSkills, isSkillsLoading: isDiscoverableLoading } =
+    useSkills({
+      owner,
+      status: "active",
+      isDefault: true,
+      disabled: !isDiscoverSkills,
+    });
 
   const shouldLoadSpaces = skill.requestedSpaceIds.length > 0;
   const { spaces: spacesFromHook, isSpacesLoading } = useSpaces({
@@ -81,6 +93,7 @@ export function SkillInfoTab({
     knowledgeItems.length > 0 ||
     (hasFeature("sandbox_tools") && skill.fileAttachments.length > 0) ||
     sortedMCPServerViews.length > 0 ||
+    isDiscoverSkills ||
     shouldLoadSpaces;
 
   return (
@@ -161,6 +174,38 @@ export function SkillInfoTab({
               />
             ))}
           </div>
+        </div>
+      )}
+
+      {isDiscoverSkills && (
+        <div className="flex flex-col gap-4">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Discoverable Skills
+          </div>
+          {isDiscoverableLoading ? (
+            <div className="flex flex-row items-center gap-2">
+              <Spinner size="xs" />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              {discoverableSkills.map((s) => {
+                const SkillAvatar = getSkillAvatarIcon(s.icon);
+                return (
+                  <Tooltip
+                    key={s.sId}
+                    label={s.userFacingDescription || s.name}
+                    trigger={
+                      <div className="flex flex-row items-center gap-2">
+                        <SkillAvatar size="xs" />
+                        <div className="truncate">{s.name}</div>
+                      </div>
+                    }
+                    tooltipTriggerAsChild
+                  />
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
 

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -29,9 +29,10 @@ export function ImportFromRepositoryTab({
   const { detectedSkills, isDetecting, detectError, triggerDetect } =
     useDetectSkillsFromRepo({ owner });
 
-  // Pre-select all importable skills when detection completes.
+  // Pre-select all importable skills when detection completes. detectedSkills come
+  // from an async SWR hook (useDetectSkillsFromRepo), so the values don't exist at
+  // form initialization time and can't be provided as defaultValues.
   useEffect(() => {
-    // Using a setValue instead of have a controller to run this once at detection time.
     setValue(
       "selectedSkillNames",
       detectedSkills

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -980,15 +980,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       limit,
       globalSpaceOnly,
       onlyCustom,
+      isDefault,
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
       onlyCustom?: boolean;
+      isDefault?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
-      where: { status },
+      where: { status, ...(isDefault !== undefined ? { isDefault } : {}) },
       ...(limit ? { limit } : {}),
       onlyCustom,
     });

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -102,11 +102,13 @@ export function useSkills({
   disabled,
   status,
   globalSpaceOnly,
+  isDefault,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
+  isDefault?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetSkillsResponseBody> = fetcher;
@@ -117,6 +119,9 @@ export function useSkills({
   }
   if (globalSpaceOnly) {
     queryParams.set("globalSpaceOnly", "true");
+  }
+  if (isDefault) {
+    queryParams.set("isDefault", "true");
   }
   const queryString = queryParams.toString();
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -98,7 +98,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { withRelations, status, globalSpaceOnly } = req.query;
+      const { withRelations, status, globalSpaceOnly, isDefault } = req.query;
 
       const statusValidation = SkillStatusSchema.decode(status);
       if (isLeft(statusValidation)) {
@@ -115,6 +115,7 @@ async function handler(
       const skills = await SkillResource.listByWorkspace(auth, {
         status: skillStatus,
         globalSpaceOnly: globalSpaceOnly === "true",
+        isDefault: isDefault === "true" ? true : undefined,
       });
 
       if (withRelations === "true") {


### PR DESCRIPTION
## Description

- This PR adds a section in the Skill info sheet only for the discover skills skill that shows the skills that can be discovered.

<img width="516" height="513" alt="Screenshot 2026-03-16 at 10 03 14 AM" src="https://github.com/user-attachments/assets/3ac4affb-a6a3-40ba-9d24-e65c350fa75c" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
