### PR TITLE
[front] - fix(charts): timezones aware

### DIFF
--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -137,11 +137,11 @@ export function findVersionMarkerForDate(
   return null;
 }
 
-const truncateToMidnightUTC = (timestamp: number): number => {
+function truncateToMidnightUTC(timestamp: number): number {
   const date = new Date(timestamp);
   date.setUTCHours(0, 0, 0, 0);
   return date.getTime();
-};
+}
 
 // Filters a generic time-series of points with a `timestamp` number to the
 // selected version window determined by version markers. If no selection or
@@ -185,13 +185,20 @@ export function filterTimeSeriesByVersionWindow<
   });
 }
 
-export function getTimeRangeBounds(
+// Generates an array of midnight timestamps for each day in the range,
+// stepping via moment to respect DST transitions.
+export function getDayTimestamps(
   periodDays: number,
   timezone: string
-): [number, number] {
-  const now = moment.tz(timezone).startOf("day");
-  const start = now.clone().subtract(periodDays, "days");
-  return [start.valueOf(), now.valueOf()];
+): number[] {
+  const startOfTomorrow = moment.tz(timezone).add(1, "day").startOf("day");
+  const cursor = startOfTomorrow.clone().subtract(periodDays, "days");
+  const timestamps: number[] = [];
+  while (cursor.isBefore(startOfTomorrow)) {
+    timestamps.push(cursor.valueOf());
+    cursor.add(1, "day");
+  }
+  return timestamps;
 }
 
 // Pads a time-series with zero-value points at the selected time-range bounds
@@ -212,22 +219,14 @@ export function padSeriesToTimeRange<T extends { timestamp: number }>(
     }));
   }
 
-  const [startTime, endTime] = getTimeRangeBounds(periodDays, tz);
-
   const byTimestamp = new Map<number, T>(pts.map((p) => [p.timestamp, p]));
+  const dayTimestamps = getDayTimestamps(periodDays, tz);
 
-  const dayMs = 24 * 60 * 60 * 1000;
-  const numDays = Math.floor((endTime - startTime) / dayMs) + 1;
-
-  const out = [];
-  for (let i = 0; i < numDays; i++) {
-    const timestamp = startTime + i * dayMs;
+  return dayTimestamps.map((timestamp) => {
     const point = byTimestamp.get(timestamp) ?? zeroFactory(timestamp);
-    const formattedPoint = {
+    return {
       ...point,
       date: formatShortDate(point.timestamp),
     };
-    out.push(formattedPoint);
-  }
-  return out;
+  });
 }

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -1,8 +1,8 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
+  getDayTimestamps,
   getIndexedColor,
-  getTimeRangeBounds,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
@@ -69,12 +69,12 @@ function getSkillSelectorLabel(selectedSkills: string[]): string {
 
 interface SkillUsageTooltipProps extends TooltipContentProps<number, string> {
   displayMode: SkillUsageDisplayMode;
-  skillsForChart: string[];
+  skillsWithData: string[];
 }
 
 function SkillUsageTooltip({
   displayMode,
-  skillsForChart,
+  skillsWithData,
   active,
   payload,
 }: SkillUsageTooltipProps) {
@@ -95,14 +95,14 @@ function SkillUsageTooltip({
   const title = point.date ?? formatShortDate(point.timestamp);
   const label = displayMode === "users" ? "users" : "executions";
 
-  const values = skillsForChart.map((skill) => point.values[skill] ?? 0);
-  const rows = skillsForChart.map((skill, idx) => ({
+  const values = skillsWithData.map((skill) => point.values[skill] ?? 0);
+  const rows = skillsWithData.map((skill, idx) => ({
     label: skill,
     value: values[idx].toLocaleString(),
-    colorClassName: getIndexedColor(skill, skillsForChart),
+    colorClassName: getIndexedColor(skill, skillsWithData),
   }));
 
-  if (skillsForChart.length > 1) {
+  if (skillsWithData.length > 1) {
     const total = values.reduce((sum, v) => sum + v, 0);
     rows.push({
       label: `Total ${label}`,
@@ -141,37 +141,35 @@ export function WorkspaceSkillUsageChart({
     }
   }, [availableSkills, selectedSkills.length]);
 
-  const skillsToFetch = selectedSkills;
-
   const skill1Usage = useWorkspaceSkillUsage({
     workspaceId,
     days: period,
-    skillName: skillsToFetch[0],
-    disabled: !workspaceId || !skillsToFetch[0],
+    skillName: selectedSkills[0],
+    disabled: !workspaceId || !selectedSkills[0],
   });
   const skill2Usage = useWorkspaceSkillUsage({
     workspaceId,
     days: period,
-    skillName: skillsToFetch[1],
-    disabled: !workspaceId || !skillsToFetch[1],
+    skillName: selectedSkills[1],
+    disabled: !workspaceId || !selectedSkills[1],
   });
   const skill3Usage = useWorkspaceSkillUsage({
     workspaceId,
     days: period,
-    skillName: skillsToFetch[2],
-    disabled: !workspaceId || !skillsToFetch[2],
+    skillName: selectedSkills[2],
+    disabled: !workspaceId || !selectedSkills[2],
   });
   const skill4Usage = useWorkspaceSkillUsage({
     workspaceId,
     days: period,
-    skillName: skillsToFetch[3],
-    disabled: !workspaceId || !skillsToFetch[3],
+    skillName: selectedSkills[3],
+    disabled: !workspaceId || !selectedSkills[3],
   });
   const skill5Usage = useWorkspaceSkillUsage({
     workspaceId,
     days: period,
-    skillName: skillsToFetch[4],
-    disabled: !workspaceId || !skillsToFetch[4],
+    skillName: selectedSkills[4],
+    disabled: !workspaceId || !selectedSkills[4],
   });
 
   const skillUsages = useMemo(
@@ -197,10 +195,8 @@ export function WorkspaceSkillUsageChart({
     isSkillsLoading || (skillsWithData.length === 0 && !allSkillsSettled);
 
   const hasError = skillUsages.some(
-    (s, i) => skillsToFetch[i] && s.isSkillUsageError
+    (s, i) => selectedSkills[i] && s.isSkillUsageError
   );
-
-  const skillsForChart = skillsWithData;
 
   const data = useMemo((): SkillUsageChartPoint[] => {
     if (skillsWithData.length === 0) {
@@ -210,17 +206,11 @@ export function WorkspaceSkillUsageChart({
     const valueKey = displayMode === "users" ? "uniqueUsers" : "executionCount";
 
     const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const [startTimeMs, endTimeMs] = getTimeRangeBounds(
-      period,
-      browserTimezone
-    );
-    const dayMs = 24 * 60 * 60 * 1000;
-    const numDays = Math.floor((endTimeMs - startTimeMs) / dayMs) + 1;
+    const dayTimestamps = getDayTimestamps(period, browserTimezone);
 
     const points: SkillUsageChartPoint[] = [];
 
-    for (let i = 0; i < numDays; i++) {
-      const timestamp = startTimeMs + i * dayMs;
+    for (const timestamp of dayTimestamps) {
       const values: Record<string, number> = {};
 
       skillsWithData.forEach((skill) => {
@@ -251,10 +241,10 @@ export function WorkspaceSkillUsageChart({
     }
   };
 
-  const legendItems: LegendItem[] = skillsForChart.map((skill) => ({
+  const legendItems: LegendItem[] = skillsWithData.map((skill) => ({
     key: skill,
     label: skill,
-    colorClassName: getIndexedColor(skill, skillsForChart),
+    colorClassName: getIndexedColor(skill, skillsWithData),
   }));
 
   const skillSelector = (
@@ -363,7 +353,7 @@ export function WorkspaceSkillUsageChart({
             <SkillUsageTooltip
               {...props}
               displayMode={displayMode}
-              skillsForChart={skillsForChart}
+              skillsWithData={skillsWithData}
             />
           )}
           cursor={false}
@@ -375,14 +365,14 @@ export function WorkspaceSkillUsageChart({
             boxShadow: "none",
           }}
         />
-        {skillsForChart.map((skill) => (
+        {skillsWithData.map((skill) => (
           <Line
             key={skill}
             type={period === 7 || period === 14 ? "linear" : "monotone"}
             strokeWidth={2}
             dataKey={(point: SkillUsageChartPoint) => point.values[skill] ?? 0}
             name={skill}
-            className={getIndexedColor(skill, skillsForChart)}
+            className={getIndexedColor(skill, skillsWithData)}
             stroke="currentColor"
             dot={false}
           />

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -1,8 +1,8 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
+  getDayTimestamps,
   getIndexedColor,
-  getTimeRangeBounds,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
@@ -56,12 +56,12 @@ function getToolSelectorLabel(selectedTools: string[]): string {
 
 interface ToolUsageTooltipProps extends TooltipContentProps<number, string> {
   displayMode: ToolUsageDisplayMode;
-  toolsForChart: string[];
+  toolsWithData: string[];
 }
 
 function ToolUsageTooltip({
   displayMode,
-  toolsForChart,
+  toolsWithData,
   active,
   payload,
 }: ToolUsageTooltipProps) {
@@ -78,14 +78,14 @@ function ToolUsageTooltip({
   const title = point.date ?? formatShortDate(point.timestamp);
   const label = displayMode === "users" ? "users" : "executions";
 
-  const values = toolsForChart.map((tool) => point.values[tool] ?? 0);
-  const rows = toolsForChart.map((tool, idx) => ({
+  const values = toolsWithData.map((tool) => point.values[tool] ?? 0);
+  const rows = toolsWithData.map((tool, idx) => ({
     label: asDisplayToolName(tool),
     value: values[idx].toLocaleString(),
-    colorClassName: getIndexedColor(tool, toolsForChart),
+    colorClassName: getIndexedColor(tool, toolsWithData),
   }));
 
-  if (toolsForChart.length > 1) {
+  if (toolsWithData.length > 1) {
     const total = values.reduce((sum, v) => sum + v, 0);
     rows.push({
       label: `Total ${label}`,
@@ -124,37 +124,35 @@ export function WorkspaceToolUsageChart({
     }
   }, [availableTools, selectedTools.length]);
 
-  const toolsToFetch = selectedTools;
-
   const tool1Usage = useWorkspaceToolUsage({
     workspaceId,
     days: period,
-    serverName: toolsToFetch[0],
-    disabled: !workspaceId || !toolsToFetch[0],
+    serverName: selectedTools[0],
+    disabled: !workspaceId || !selectedTools[0],
   });
   const tool2Usage = useWorkspaceToolUsage({
     workspaceId,
     days: period,
-    serverName: toolsToFetch[1],
-    disabled: !workspaceId || !toolsToFetch[1],
+    serverName: selectedTools[1],
+    disabled: !workspaceId || !selectedTools[1],
   });
   const tool3Usage = useWorkspaceToolUsage({
     workspaceId,
     days: period,
-    serverName: toolsToFetch[2],
-    disabled: !workspaceId || !toolsToFetch[2],
+    serverName: selectedTools[2],
+    disabled: !workspaceId || !selectedTools[2],
   });
   const tool4Usage = useWorkspaceToolUsage({
     workspaceId,
     days: period,
-    serverName: toolsToFetch[3],
-    disabled: !workspaceId || !toolsToFetch[3],
+    serverName: selectedTools[3],
+    disabled: !workspaceId || !selectedTools[3],
   });
   const tool5Usage = useWorkspaceToolUsage({
     workspaceId,
     days: period,
-    serverName: toolsToFetch[4],
-    disabled: !workspaceId || !toolsToFetch[4],
+    serverName: selectedTools[4],
+    disabled: !workspaceId || !selectedTools[4],
   });
 
   const toolUsages = useMemo(
@@ -175,10 +173,8 @@ export function WorkspaceToolUsageChart({
   const isLoading = isToolsLoading || toolsWithData.length === 0;
 
   const hasError = toolUsages.some(
-    (t, i) => toolsToFetch[i] && t.isToolUsageError
+    (t, i) => selectedTools[i] && t.isToolUsageError
   );
-
-  const toolsForChart = toolsWithData;
 
   const data = useMemo((): ToolUsageChartPoint[] => {
     if (toolsWithData.length === 0) {
@@ -188,14 +184,11 @@ export function WorkspaceToolUsageChart({
     const valueKey = displayMode === "users" ? "uniqueUsers" : "executionCount";
 
     const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const [startTime, endTime] = getTimeRangeBounds(period, browserTimezone);
-    const dayMs = 24 * 60 * 60 * 1000;
-    const numDays = Math.floor((endTime - startTime) / dayMs) + 1;
+    const dayTimestamps = getDayTimestamps(period, browserTimezone);
 
     const points: ToolUsageChartPoint[] = [];
 
-    for (let i = 0; i < numDays; i++) {
-      const timestamp = startTime + i * dayMs;
+    for (const timestamp of dayTimestamps) {
       const values: Record<string, number> = {};
 
       toolsWithData.forEach((tool) => {
@@ -226,10 +219,10 @@ export function WorkspaceToolUsageChart({
     }
   };
 
-  const legendItems: LegendItem[] = toolsForChart.map((tool) => ({
+  const legendItems: LegendItem[] = toolsWithData.map((tool) => ({
     key: tool,
     label: asDisplayToolName(tool),
-    colorClassName: getIndexedColor(tool, toolsForChart),
+    colorClassName: getIndexedColor(tool, toolsWithData),
   }));
 
   const toolSelector = (
@@ -335,7 +328,7 @@ export function WorkspaceToolUsageChart({
             <ToolUsageTooltip
               {...props}
               displayMode={displayMode}
-              toolsForChart={toolsForChart}
+              toolsWithData={toolsWithData}
             />
           )}
           cursor={false}
@@ -347,14 +340,14 @@ export function WorkspaceToolUsageChart({
             boxShadow: "none",
           }}
         />
-        {toolsForChart.map((tool) => (
+        {toolsWithData.map((tool) => (
           <Line
             key={tool}
             type={period === 7 || period === 14 ? "linear" : "monotone"}
             strokeWidth={2}
             dataKey={(point: ToolUsageChartPoint) => point.values[tool] ?? 0}
             name={asDisplayToolName(tool)}
-            className={getIndexedColor(tool, toolsForChart)}
+            className={getIndexedColor(tool, toolsWithData)}
             stroke="currentColor"
             dot={false}
           />


### PR DESCRIPTION
## Description

Fixes DST-related bugs in workspace skill and tool usage charts by introducing proper timezone-aware timestamp generation. This is a follow-up to #22882 and #22942 which added timezone support to analytics queries.

Previously, `padSeriesToTimeRange` and chart components used simple millisecond arithmetic (`timestamp + dayMs * i`) to generate daily timestamps, which fails during DST transitions. This caused charts to skip or duplicate days depending on the user's timezone.

This PR introduces `getDayTimestamps()` which uses `moment-timezone` to step through calendar days, ensuring each generated timestamp represents midnight in the user's browser timezone regardless of DST.

## Tests

- [x] Locally
- [x] Front-edge

## Risk

Low

## Deploy Plan

Deploy front