### PR TITLE
Add filtering for events in branch not accessible by users.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -31,6 +31,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitMessage } from "@app/hooks/useSubmitMessage";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
+import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
@@ -42,18 +43,8 @@ import {
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
 import type {
-  AgentGenerationCancelledEvent,
-  AgentMessageDoneEvent,
-} from "@app/types/assistant/agent";
-import type {
-  AgentMessageNewEvent,
-  ButlerDoneEvent,
-  ButlerSuggestionCreatedEvent,
-  ButlerThinkingEvent,
-  ConversationTitleEvent,
   ConversationWithoutContentType,
   LightMessageType,
-  UserMessageNewEvent,
 } from "@app/types/assistant/conversation";
 import { isUserMessageTypeWithContentFragments } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -234,7 +225,6 @@ export const ConversationViewer = ({
     messages,
     setSize,
     size,
-    mutateMessages,
   } = useConversationMessages({
     conversationId,
     workspaceId: owner.sId,
@@ -440,15 +430,7 @@ export const ConversationViewer = ({
     (eventStr: string) => {
       const eventPayload: {
         eventId: string;
-        data:
-          | UserMessageNewEvent
-          | AgentMessageNewEvent
-          | AgentMessageDoneEvent
-          | AgentGenerationCancelledEvent
-          | ConversationTitleEvent
-          | ButlerSuggestionCreatedEvent
-          | ButlerThinkingEvent
-          | ButlerDoneEvent;
+        data: ConversationEvents;
       } = JSON.parse(eventStr);
       const event = eventPayload.data;
 
@@ -543,10 +525,6 @@ export const ConversationViewer = ({
             }
             break;
 
-          case "agent_generation_cancelled":
-            void mutateMessages();
-            break;
-
           case "conversation_title":
             void debouncedMarkAsRead(conversationId);
             void mutateConversation(
@@ -623,7 +601,6 @@ export const ConversationViewer = ({
       mutateConversationAttachments,
       mutateConversationParticipants,
       mutateConversations,
-      mutateMessages,
       user.sId,
     ]
   );

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1,6 +1,7 @@
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import {
   editUserMessage,
+  isConversationEventAllowedForAuth,
   postNewContentFragment,
   postUserMessage,
   retryAgentMessage,
@@ -33,6 +34,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
   ConversationType,
+  UserMessageNewEvent,
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import {
@@ -2608,5 +2610,228 @@ describe("postNewContentFragment", () => {
       // Verify getContentFragmentBlob was not called since the data source view check failed first
       expect(getContentFragmentBlob).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("isConversationEventAllowedForAuth", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let otherAuth: Authenticator;
+  let branchSId: string;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    const user = setup.user;
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      title: "Branch test conversation",
+      requestedSpaceIds: [],
+    });
+
+    const baseUserMessage = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: "Base message",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+
+    const baseMessage = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 0,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: baseUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const branch = await ConversationBranchModel.create({
+      workspaceId: workspace.id,
+      state: "open",
+      previousMessageId: baseMessage.id,
+      conversationId: conversation.id,
+      userId: user.id,
+    });
+    branchSId = makeSId("conversation_branch", {
+      id: branch.id,
+      workspaceId: workspace.id,
+    });
+  });
+
+  it("returns true for agent_message_done event", async () => {
+    const event = {
+      type: "agent_message_done" as const,
+      created: Date.now(),
+      conversationId: "conv-1",
+      configurationId: "config-1",
+      messageId: "msg-1",
+      status: "success" as const,
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for butler_suggestion_created event", async () => {
+    const event = {
+      type: "butler_suggestion_created" as const,
+      created: Date.now(),
+      suggestion: {
+        sId: "suggestion-1",
+        createdAt: 1,
+        updatedAt: 1,
+        sourceMessageSId: "msg-1",
+        resultMessageSId: null,
+        status: "pending" as const,
+        suggestionType: "rename_title" as const,
+        metadata: { suggestedTitle: "New title" },
+      },
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for butler_done event", async () => {
+    const event = {
+      type: "butler_done" as const,
+      created: Date.now(),
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for butler_thinking event", async () => {
+    const event = {
+      type: "butler_thinking" as const,
+      created: Date.now(),
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for conversation_title event", async () => {
+    const event = {
+      type: "conversation_title" as const,
+      created: Date.now(),
+      title: "New title",
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for user_message_new when message has no branchId", async () => {
+    const event: UserMessageNewEvent = {
+      type: "user_message_new",
+      created: Date.now(),
+      messageId: "msg-1",
+      message: {
+        branchId: null,
+        contentFragments: [],
+      } as unknown as UserMessageNewEvent["message"],
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for user_message_new when branch exists and auth can read it", async () => {
+    const event: UserMessageNewEvent = {
+      type: "user_message_new",
+      created: Date.now(),
+      messageId: "msg-1",
+      message: {
+        branchId: branchSId,
+        contentFragments: [],
+      } as unknown as UserMessageNewEvent["message"],
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns false for user_message_new when branch exists but auth cannot read it", async () => {
+    const event: UserMessageNewEvent = {
+      type: "user_message_new",
+      created: Date.now(),
+      messageId: "msg-1",
+      message: {
+        branchId: branchSId,
+        contentFragments: [],
+      } as unknown as UserMessageNewEvent["message"],
+    };
+    const result = await isConversationEventAllowedForAuth(otherAuth, {
+      event,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false for user_message_new when branchId does not exist", async () => {
+    const event: UserMessageNewEvent = {
+      type: "user_message_new",
+      created: Date.now(),
+      messageId: "msg-1",
+      message: {
+        branchId: makeSId("conversation_branch", {
+          id: 999999,
+          workspaceId: workspace.id,
+        }),
+        contentFragments: [],
+      } as unknown as UserMessageNewEvent["message"],
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(false);
+  });
+
+  it("returns true for agent_message_new when message has no branchId", async () => {
+    const event = {
+      type: "agent_message_new" as const,
+      created: Date.now(),
+      configurationId: "config-1",
+      messageId: "msg-1",
+      message: { branchId: null } as AgentMessageType,
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns true for agent_message_new when branch exists and auth can read it", async () => {
+    const event = {
+      type: "agent_message_new" as const,
+      created: Date.now(),
+      configurationId: "config-1",
+      messageId: "msg-1",
+      message: { branchId: branchSId } as AgentMessageType,
+    };
+    const result = await isConversationEventAllowedForAuth(auth, { event });
+    expect(result).toBe(true);
+  });
+
+  it("returns false for agent_message_new when branch exists but auth cannot read it", async () => {
+    const event = {
+      type: "agent_message_new" as const,
+      created: Date.now(),
+      configurationId: "config-1",
+      messageId: "msg-1",
+      message: { branchId: branchSId } as AgentMessageType,
+    };
+    const result = await isConversationEventAllowedForAuth(otherAuth, {
+      event,
+    });
+    expect(result).toBe(false);
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -33,6 +33,7 @@ import {
   publishAgentMessagesEvents,
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
+import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
@@ -292,6 +293,16 @@ export async function getConversationMessageType(
 
   if (!message) {
     return null;
+  }
+
+  if (message.branchSId) {
+    const branch = await ConversationBranchResource.fetchById(
+      auth,
+      message.branchSId
+    );
+    if (!branch || !branch.canRead(auth)) {
+      return null;
+    }
   }
 
   if (message.userMessageId) {
@@ -2108,4 +2119,36 @@ async function isMessagesLimitReached(
     isLimitReached,
     limitType: isLimitReached ? "plan_message_limit_exceeded" : null,
   };
+}
+
+export async function isConversationEventAllowedForAuth(
+  auth: Authenticator,
+  {
+    event,
+  }: {
+    event: ConversationEvents;
+  }
+): Promise<boolean> {
+  const type = event.type;
+  switch (type) {
+    case "user_message_new":
+    case "agent_message_new":
+      if (event.message.branchId) {
+        // It's okay to fetch the branch here because theses events are only sent once per message.
+        const branch = await ConversationBranchResource.fetchById(
+          auth,
+          event.message.branchId
+        );
+        return !!branch && branch.canRead(auth);
+      }
+      return true;
+    case "agent_message_done":
+    case "butler_suggestion_created":
+    case "butler_done":
+    case "butler_thinking":
+    case "conversation_title":
+      return true;
+    default:
+      assertNever(type);
+  }
 }

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -90,7 +90,7 @@ async function _getConversation<V extends "light" | "full">(
 
   if (branchId) {
     const branch = await ConversationBranchResource.fetchById(auth, branchId);
-    if (!branch) {
+    if (!branch || !branch.canRead(auth)) {
       return new Err(new ConversationError("branch_not_found"));
     }
 

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,5 +1,6 @@
 import type { AgentActionRunningEvents } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
@@ -14,11 +15,6 @@ import type {
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
 } from "@app/types/assistant/agent";
-import type {
-  AgentMessageNewEvent,
-  ButlerSuggestionCreatedEvent,
-  UserMessageNewEvent,
-} from "@app/types/assistant/conversation";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
 
 export async function* getConversationEvents({
@@ -32,11 +28,7 @@ export async function* getConversationEvents({
 }): AsyncGenerator<
   {
     eventId: string;
-    data:
-      | UserMessageNewEvent
-      | AgentMessageNewEvent
-      | AgentGenerationCancelledEvent
-      | ButlerSuggestionCreatedEvent;
+    data: ConversationEvents;
   },
   void
 > {

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -199,8 +199,8 @@ const getConversationDetails = async ({
     .flat()
     .find((msg) => msg.sId === payload.messageId);
   if (!message) {
-    // Message doesn't exist at all - unexpected.
-    throw new Error(`Message not found: ${payload.messageId}`);
+    // Message doesn't exist at all - could be true if it's in a branch.
+    return new Err(new ConversationError("message_not_found"));
   }
   if (message.visibility === "deleted") {
     // Message was deleted during workflow delay - expected.

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -1,6 +1,7 @@
 // This endpoint is redirected (307) to /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events
 // via middleware. The /api/sse/ prefix allows the ingress to route SSE traffic to front-sse pods.
 
+import { isConversationEventAllowedForAuth } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
@@ -127,7 +128,19 @@ async function handler(
 
       for await (const event of eventStream) {
         // Butler suggestions are internal events, not exposed via the public API.
-        if (event.data.type === "butler_suggestion_created") {
+        if (
+          event.data.type === "butler_suggestion_created" ||
+          event.data.type === "butler_done" ||
+          event.data.type === "butler_thinking"
+        ) {
+          continue;
+        }
+
+        // Some events are targetted toward a specific user.
+        const isAllowed = await isConversationEventAllowedForAuth(auth, {
+          event: event.data,
+        });
+        if (!isAllowed) {
           continue;
         }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -36,6 +36,7 @@
 // This endpoint is redirected (307) to /api/sse/w/[wId]/assistant/conversations/[cId]/events
 // via middleware. The /api/sse/ prefix allows the ingress to route SSE traffic to front-sse pods.
 
+import { isConversationEventAllowedForAuth } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -115,6 +116,14 @@ async function handler(
       let backpressureCount = 0;
 
       for await (const event of eventStream) {
+        // Some events are targetted toward a specific user.
+        const isAllowed = await isConversationEventAllowedForAuth(auth, {
+          event: event.data,
+        });
+        if (!isAllowed) {
+          continue;
+        }
+
         const writeSuccessful = res.write(`data: ${JSON.stringify(event)}\n\n`);
         if (!writeSuccessful) {
           backpressureCount++;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1524,7 +1524,7 @@ const ConversationEventTypeSchema = z.object({
   data: z.union([
     UserMessageNewEventSchema,
     AgentMessageNewEventSchema,
-    AgentGenerationCancelledEventSchema,
+    AgentMessageDoneEventSchema,
     ConversationTitleEventSchema,
   ]),
 });


### PR DESCRIPTION
## Description

Add filtering system before sending conversation events to avoid letting other users know about a message in a branch they don't have access to.
Improved our typing along the way as we did some mistakes.

## Tests

Added + local

## Risk

Low

## Deploy Plan

Deploy front / front-sse