### PR TITLE
Update template view to use CompactAssistantCard as designed

### DIFF
--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -4,7 +4,7 @@ import type {
   TemplateTagCodeType,
   TemplateTagsType,
 } from "@app/types/assistant/templates";
-import { CardGrid, ContextItem, LargeAssistantCard } from "@dust-tt/sparkle";
+import { CardGrid, CompactAssistantCard, ContextItem } from "@dust-tt/sparkle";
 
 interface AgentTemplateGridProps {
   templates: AssistantTemplateListType[];
@@ -48,32 +48,21 @@ export function AgentTemplateGrid({
                 title={templateTagsMapping[tagName].label}
                 hasBorder={false}
               />
-              {hasSidekick ? (
-                <CardGrid>
-                  {templatesForTag.map((template) => (
-                    <LargeAssistantCard
-                      key={template.sId}
-                      title={template.handle}
-                      pictureUrl={template.pictureUrl}
-                      description={template.userFacingDescription ?? ""}
-                      onClick={() => onTemplateClick(template.sId)}
-                      variant="secondary"
-                    />
-                  ))}
-                </CardGrid>
-              ) : (
-                <div className="grid grid-cols-2 gap-2">
-                  {templatesForTag.map((template) => (
-                    <LargeAssistantCard
-                      key={template.sId}
-                      title={template.handle}
-                      pictureUrl={template.pictureUrl}
-                      description={template.userFacingDescription ?? ""}
-                      onClick={() => openTemplateModal(template.sId)}
-                    />
-                  ))}
-                </div>
-              )}
+              <CardGrid>
+                {templatesForTag.map((template) => (
+                  <CompactAssistantCard
+                    key={template.sId}
+                    title={template.handle}
+                    pictureUrl={template.pictureUrl}
+                    description={template.userFacingDescription ?? ""}
+                    onClick={() =>
+                      hasSidekick
+                        ? onTemplateClick(template.sId)
+                        : openTemplateModal(template.sId)
+                    }
+                  />
+                ))}
+              </CardGrid>
             </div>
           );
         })

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -134,3 +134,51 @@ export const LargeAssistantCard = React.forwardRef<
   );
 });
 LargeAssistantCard.displayName = "LargeAssistantCard";
+
+interface CompactAssistantCardProps extends BaseAssistantCardProps {}
+
+export const CompactAssistantCard = React.forwardRef<
+  HTMLDivElement,
+  CompactAssistantCardProps
+>(
+  (
+    {
+      className,
+      onClick,
+      title,
+      description,
+      pictureUrl,
+      variant = "secondary",
+    },
+    ref
+  ) => {
+    return (
+      <Card
+        ref={ref}
+        size="md"
+        className={cn(
+          "s-cursor-pointer s-flex s-flex-col s-items-start s-gap-1",
+          className
+        )}
+        onClick={onClick}
+        variant={variant}
+      >
+        <Avatar visual={pictureUrl} size="sm" />
+        <div className="s-min-w-0">
+          <h3 className="s-heading-base s-line-clamp-1 s-text-foreground dark:s-text-foreground-night">
+            {title}
+          </h3>
+          <p
+            className={cn(
+              "s-line-clamp-3 s-text-sm",
+              "s-text-muted-foreground dark:s-text-muted-foreground-night"
+            )}
+          >
+            {description}
+          </p>
+        </div>
+      </Card>
+    );
+  }
+);
+CompactAssistantCard.displayName = "CompactAssistantCard";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -8,6 +8,7 @@ export { AspectRatio } from "./AspectRatio";
 export {
   AssistantCard,
   AssistantCardMore,
+  CompactAssistantCard,
   LargeAssistantCard,
 } from "./AssistantCard";
 export { AttachmentChip } from "./AttachmentChip";

--- a/sparkle/src/stories/AssistantCard.stories.tsx
+++ b/sparkle/src/stories/AssistantCard.stories.tsx
@@ -5,6 +5,7 @@ import {
   AssistantCard,
   AssistantCardMore,
   CardGrid,
+  CompactAssistantCard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -34,6 +35,33 @@ const ddMenu = (
 
 export const AssistantCardExample = () => (
   <div className="s-flex s-flex-col s-gap-4">
+    <h2>Compact</h2>
+    <CardGrid>
+      <CompactAssistantCard
+        title={"analyst"}
+        description={
+          "Self-service analytics agent for SQL queries, spreadsheets, data warehouses, and visualizations."
+        }
+        pictureUrl={"https://dust.tt/static/droidavatar/Droid_Lime_3.jpg"}
+        onClick={() => console.log("clicked")}
+      />
+      <CompactAssistantCard
+        title={"codingBuddy"}
+        description={
+          "Assistant for code beginners. Get help writing code and getting started."
+        }
+        pictureUrl={"https://dust.tt/static/droidavatar/Droid_Yellow_3.jpg"}
+        onClick={() => console.log("clicked")}
+      />
+      <CompactAssistantCard
+        title={"supportExpert"}
+        description={
+          "Find solutions from best-in-class tickets and internal procedures."
+        }
+        pictureUrl={"https://dust.tt/static/droidavatar/Droid_Pink_4.jpg"}
+        onClick={() => console.log("clicked")}
+      />
+    </CardGrid>
     <h2>List</h2>
     <div className="s-grid s-grid-cols-2 s-gap-4">
       <LargeAssistantCard


### PR DESCRIPTION
## Description
Made new `CompactAssistantCard` that has an Avatar, three line clamp, and horizontal stacked formatting
Removed stylistic variation for hasSidekick vs not, leaving the branched onClick logic
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="920" height="772" alt="Screenshot 2026-03-13 at 5 00 20 PM" src="https://github.com/user-attachments/assets/8ed6586a-c7bd-4e0f-a03e-ba491fdc59de" />
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
