### PR TITLE
Gong connector updates - revert schedule start change, add small delay instead

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -109,6 +109,11 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       mimeType: INTERNAL_MIME_TYPES.GONG.TRANSCRIPT_FOLDER,
     });
 
+    const result = await this.createGongSchedule(connector);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
     return new Ok(connector.id.toString());
   }
 
@@ -412,48 +417,28 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
 
         await configuration.setPermissionProfileId(profileId);
 
-        const scheduleId = makeGongSyncScheduleId(connector);
-        const exists = await scheduleExists({ scheduleId });
+        logger.info(
+          {
+            connectorId: connector.id,
+            permissionProfileId: profileId,
+          },
+          "[Gong] Permission profile updated, stopping and resuming sync."
+        );
 
-        if (!exists) {
-          // First save after connector creation: create the schedule.
-          logger.info(
-            {
-              connectorId: connector.id,
-              permissionProfileId: profileId,
-            },
-            "[Gong] Permission profile saved, creating sync schedule."
+        const stopResult = await this.stop({
+          reason: "Permission profile updated",
+        });
+        if (stopResult.isErr()) {
+          return stopResult;
+        }
+
+        const resumeResult = await this.resume();
+        if (resumeResult.isErr()) {
+          logger.error(
+            { connectorId: connector.id, error: resumeResult.error },
+            "[Gong] Failed to resume schedule after permission profile update"
           );
-          const createResult =
-            await GongConnectorManager.createGongSchedule(connector);
-          if (createResult.isErr()) {
-            return new Err(createResult.error);
-          }
-        } else {
-          // Subsequent save: stop and resume to pick up the new profile.
-          logger.info(
-            {
-              connectorId: connector.id,
-              permissionProfileId: profileId,
-            },
-            "[Gong] Permission profile updated, stopping and resuming sync."
-          );
-
-          const stopResult = await this.stop({
-            reason: "Permission profile updated",
-          });
-          if (stopResult.isErr()) {
-            return stopResult;
-          }
-
-          const resumeResult = await this.resume();
-          if (resumeResult.isErr()) {
-            logger.error(
-              { connectorId: connector.id, error: resumeResult.error },
-              "[Gong] Failed to resume schedule after permission profile update"
-            );
-            return resumeResult;
-          }
+          return resumeResult;
         }
 
         return new Ok(undefined);

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -55,6 +55,8 @@ const PERMISSION_PROFILES_CONFIG_KEY = "gongPermissionProfiles";
 
 const EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY = "gongExcludeTitleKeywords";
 
+const FIRST_SYNC_DELAY_MS = 15 * 60 * 1000;
+
 // This function generates a connector-wise unique schedule ID for the Gong sync.
 // The IDs of the workflows spawned by this schedule will follow the pattern:
 //   gong-sync-${connectorId}-workflow-${isoFormatDate}
@@ -145,7 +147,12 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       },
       scheduleId: makeGongSyncScheduleId(connector),
       policies: SCHEDULE_POLICIES,
-      spec: SCHEDULE_SPEC,
+      spec: {
+        ...SCHEDULE_SPEC,
+        // Delay the first sync to give users time to configure settings
+        // (e.g. permission profile) before the initial sync starts.
+        startAt: new Date(Date.now() + FIRST_SYNC_DELAY_MS),
+      },
     });
   }
 

--- a/connectors/src/lib/temporal_schedules.ts
+++ b/connectors/src/lib/temporal_schedules.ts
@@ -97,8 +97,12 @@ export async function createSchedule({
       },
     });
 
-    // Trigger the schedule to start the workflow immediately.
-    await scheduleHandle.trigger();
+    // Trigger the schedule to start the workflow immediately, unless a
+    // startAt delay was specified (in which case we let the schedule fire
+    // on its own after the delay).
+    if (!spec.startAt) {
+      await scheduleHandle.trigger();
+    }
   } catch (error) {
     logger.error(
       {

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -368,12 +368,8 @@ export function GongOptionComponent({
 
   return (
     <div className="flex flex-col space-y-4 py-2">
-      <ContentMessage
-        title="All Gong data will sync automatically once you save"
-        size="lg"
-      >
-        Syncing will start once you save a participant filter selection.
-        Relevant Gong resources will then sync automatically. Selecting items
+      <ContentMessage title="All Gong data will sync automatically" size="lg">
+        All your Gong resources will sync automatically. Selecting items
         individually is not available.
       </ContentMessage>
 


### PR DESCRIPTION
## Description
This PR can be reviewed commit by commit 
1. Reverts the change we made to help a customer setup their Gong config with a specific permission profile
2. Instead, adds a 15 min delay to the first sync (in addition to already existent 30 min jigger) that will allow any settings the user sets up at the time they create the connection to be captured in every sync. This, paired with our copy about the permission profile only applying to future syncs is sufficient to solve the first sync issue imo
Note: I won't squash this merge to preserve commit history

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front
- [ ] deploy connectors

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
