### PR TITLE
Extend the reinforced agents to process tools and skills suggestions

### DIFF
--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -44,12 +44,12 @@ export const InstructionsSuggestionSchema = z.object({
     .describe("The type of modification to perform on the target block"),
 });
 
-const ToolsSuggestionSchema = z.object({
+export const ToolsSuggestionSchema = z.object({
   action: z.enum(["add", "remove"]).describe("The action to perform"),
   toolId: z.string().describe("The tool/server identifier"),
 });
 
-const SkillsSuggestionSchema = z.object({
+export const SkillsSuggestionSchema = z.object({
   action: z.enum(["add", "remove"]).describe("The action to perform"),
   skillId: z.string().describe("The skill identifier"),
 });

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -26,7 +26,7 @@ const KNOWLEDGE_CATEGORIES = ["managed", "folder", "website"] as const;
 
 // Suggestion tool schemas
 
-const InstructionsSuggestionSchema = z.object({
+export const InstructionsSuggestionSchema = z.object({
   analysis: z
     .string()
     .optional()

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -58,6 +58,7 @@ import { isContentFragmentType } from "@app/types/content_fragment";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { CoreAPI } from "@app/types/core/core_api";
 import { isJobType } from "@app/types/job_type";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
@@ -189,8 +190,6 @@ type InstructionSuggestionInput = z.infer<typeof InstructionsSuggestionSchema>;
 /**
  * Shared logic for creating instruction suggestions. Used by both the
  * suggest_prompt_edits MCP handler and reinforced agent analysis.
- * Returns the created suggestions, or an empty array if limits are exceeded
- * or the agent configuration is not found.
  */
 export async function createInstructionSuggestions({
   auth,
@@ -202,7 +201,9 @@ export async function createInstructionSuggestions({
   agentConfigurationId: string;
   suggestions: InstructionSuggestionInput[];
   source: AgentSuggestionSource;
-}): Promise<{ sId: string; kind: string; targetBlockId: string }[]> {
+}): Promise<
+  Result<{ sId: string; kind: string; targetBlockId: string }[], string>
+> {
   // Check pending suggestion limit before proceeding.
   const pendingInstructions =
     await AgentSuggestionResource.listByAgentConfigurationId(
@@ -217,11 +218,7 @@ export async function createInstructionSuggestions({
     currentPendingCount: pendingInstructions.length,
   });
   if (!limitCheck.allowed) {
-    logger.warn(
-      { agentConfigurationId },
-      `createInstructionSuggestions: ${limitCheck.errorMessage}`
-    );
-    return [];
+    return new Err(limitCheck.errorMessage);
   }
 
   // Fetch the latest version of the agent configuration (full variant needed
@@ -232,11 +229,9 @@ export async function createInstructionSuggestions({
   });
 
   if (!agentConfiguration) {
-    logger.warn(
-      { agentConfigurationId },
-      "createInstructionSuggestions: agent configuration not found"
+    return new Err(
+      `Agent configuration not found: ${agentConfigurationId}`
     );
-    return [];
   }
 
   const createdSuggestions: {
@@ -272,7 +267,7 @@ export async function createInstructionSuggestions({
     createdSuggestions
   );
 
-  return createdSuggestions;
+  return new Ok(createdSuggestions);
 }
 
 type ToolsSuggestionInput = z.infer<typeof ToolsSuggestionSchema> & {
@@ -293,7 +288,7 @@ export async function createToolsSuggestions({
   agentConfigurationId: string;
   suggestions: ToolsSuggestionInput[];
   source: AgentSuggestionSource;
-}): Promise<{ sId: string; kind: string }[]> {
+}): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Fetch pending suggestions and mark duplicates (same toolId) as outdated.
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
@@ -316,11 +311,7 @@ export async function createToolsSuggestions({
     currentPendingCount: remainingPending.length,
   });
   if (!limitCheck.allowed) {
-    logger.warn(
-      { agentConfigurationId },
-      `createToolsSuggestions: ${limitCheck.errorMessage}`
-    );
-    return [];
+    return new Err(limitCheck.errorMessage);
   }
 
   const agentConfiguration = await getAgentConfiguration(auth, {
@@ -329,11 +320,9 @@ export async function createToolsSuggestions({
   });
 
   if (!agentConfiguration) {
-    logger.warn(
-      { agentConfigurationId },
-      "createToolsSuggestions: agent configuration not found"
+    return new Err(
+      `Agent configuration not found: ${agentConfigurationId}`
     );
-    return [];
   }
 
   const createdSuggestions: { sId: string; kind: string }[] = [];
@@ -355,7 +344,7 @@ export async function createToolsSuggestions({
     createdSuggestions.push({ sId: created.sId, kind: created.kind });
   }
 
-  return createdSuggestions;
+  return new Ok(createdSuggestions);
 }
 
 type SkillsSuggestionInput = z.infer<typeof SkillsSuggestionSchema> & {
@@ -376,7 +365,7 @@ export async function createSkillsSuggestions({
   agentConfigurationId: string;
   suggestions: SkillsSuggestionInput[];
   source: AgentSuggestionSource;
-}): Promise<{ sId: string; kind: string }[]> {
+}): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Fetch pending suggestions and mark duplicates (same skillId) as outdated.
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
@@ -400,11 +389,7 @@ export async function createSkillsSuggestions({
     currentPendingCount: remainingPending.length,
   });
   if (!limitCheck.allowed) {
-    logger.warn(
-      { agentConfigurationId },
-      `createSkillsSuggestions: ${limitCheck.errorMessage}`
-    );
-    return [];
+    return new Err(limitCheck.errorMessage);
   }
 
   const agentConfiguration = await getAgentConfiguration(auth, {
@@ -413,11 +398,9 @@ export async function createSkillsSuggestions({
   });
 
   if (!agentConfiguration) {
-    logger.warn(
-      { agentConfigurationId },
-      "createSkillsSuggestions: agent configuration not found"
+    return new Err(
+      `Agent configuration not found: ${agentConfigurationId}`
     );
-    return [];
   }
 
   const createdSuggestions: { sId: string; kind: string }[] = [];
@@ -438,7 +421,7 @@ export async function createSkillsSuggestions({
     createdSuggestions.push({ sId: created.sId, kind: created.kind });
   }
 
-  return createdSuggestions;
+  return new Ok(createdSuggestions);
 }
 
 import {
@@ -895,23 +878,20 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     try {
-      const createdSuggestions = await createInstructionSuggestions({
+      const result = await createInstructionSuggestions({
         auth,
         agentConfigurationId,
         suggestions: params.suggestions,
         source: "sidekick",
       });
 
-      if (createdSuggestions.length === 0) {
+      if (result.isErr()) {
         return new Err(
-          new MCPError(
-            "No suggestions were created. The pending limit may have been reached or the agent configuration was not found.",
-            { tracked: false }
-          )
+          new MCPError(result.error, { tracked: false })
         );
       }
 
-      const directives = createdSuggestions.map(
+      const directives = result.value.map(
         (s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`
       );
 
@@ -992,23 +972,20 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     try {
-      const createdSuggestions = await createToolsSuggestions({
+      const result = await createToolsSuggestions({
         auth,
         agentConfigurationId,
         suggestions: params.suggestions,
         source: "sidekick",
       });
 
-      if (createdSuggestions.length === 0) {
+      if (result.isErr()) {
         return new Err(
-          new MCPError(
-            "No suggestions were created. The pending limit may have been reached or the agent configuration was not found.",
-            { tracked: false }
-          )
+          new MCPError(result.error, { tracked: false })
         );
       }
 
-      const directives = createdSuggestions.map(
+      const directives = result.value.map(
         (s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`
       );
 
@@ -1193,23 +1170,20 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     try {
-      const createdSuggestions = await createSkillsSuggestions({
+      const result = await createSkillsSuggestions({
         auth,
         agentConfigurationId,
         suggestions: params.suggestions,
         source: "sidekick",
       });
 
-      if (createdSuggestions.length === 0) {
+      if (result.isErr()) {
         return new Err(
-          new MCPError(
-            "No suggestions were created. The pending limit may have been reached or the agent configuration was not found.",
-            { tracked: false }
-          )
+          new MCPError(result.error, { tracked: false })
         );
       }
 
-      const directives = createdSuggestions.map(
+      const directives = result.value.map(
         (s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`
       );
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -319,7 +319,8 @@ export async function createToolsSuggestions({
   );
   if (missingToolIds.length > 0) {
     return new Err(
-      `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}.`
+      `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}. ` +
+        `Check <workspace_context> for valid tool IDs.`
     );
   }
 
@@ -436,7 +437,8 @@ export async function createSkillsSuggestions({
   );
   if (missingSkillIds.length > 0) {
     return new Err(
-      `The following skill ID(s) are invalid or not accessible: ${missingSkillIds.join(", ")}.`
+      `The following skill ID(s) are invalid or not accessible: ${missingSkillIds.join(", ")}. ` +
+        `Check <workspace_context> for valid skill IDs.`
     );
   }
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -204,6 +204,16 @@ export async function createInstructionSuggestions({
 }): Promise<
   Result<{ sId: string; kind: string; targetBlockId: string }[], string>
 > {
+  // Reject batches where multiple suggestions target the same block.
+  const targetBlockIds = suggestions.map((s) => s.targetBlockId);
+  const uniqueTargetBlockIds = new Set(targetBlockIds);
+  if (uniqueTargetBlockIds.size !== targetBlockIds.length) {
+    return new Err(
+      "Multiple suggestions target the same block ID. Use a single suggestion per block." +
+        `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`
+    );
+  }
+
   // Check pending suggestion limit before proceeding.
   const pendingInstructions =
     await AgentSuggestionResource.listByAgentConfigurationId(
@@ -287,6 +297,52 @@ export async function createToolsSuggestions({
   suggestions: ToolsSuggestionInput[];
   source: AgentSuggestionSource;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
+  // Reject batches where multiple suggestions target the same tool.
+  const suggestionToolIds = suggestions.map((s) => s.toolId);
+  const uniqueToolIds = new Set(suggestionToolIds);
+  if (uniqueToolIds.size !== suggestionToolIds.length) {
+    const duplicates = [
+      ...new Set(
+        suggestionToolIds.filter(
+          (id, i) => suggestionToolIds.indexOf(id) !== i
+        )
+      ),
+    ];
+    return new Err(
+      `Multiple suggestions target the same tool ID: ${duplicates.join(", ")}. Use a single suggestion per tool.`
+    );
+  }
+
+  // Validate that all tool IDs exist and are accessible.
+  const tools = await MCPServerViewResource.fetchByIds(
+    auth,
+    suggestionToolIds
+  );
+  const foundToolIds = new Set(tools.map((t) => t.sId));
+  const missingToolIds = suggestionToolIds.filter(
+    (id) => !foundToolIds.has(id)
+  );
+  if (missingToolIds.length > 0) {
+    return new Err(
+      `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}.`
+    );
+  }
+
+  // Reject knowledge tools — they should be suggested via suggest_knowledge.
+  const knowledgeTools = tools.filter((t) => {
+    const json = t.toJSON();
+    return json !== null && isToolWithKnowledge(json);
+  });
+  if (knowledgeTools.length > 0) {
+    const knowledgeToolNames = knowledgeTools
+      .map((t) => `${t.sId} (${t.toJSON()?.server.name ?? "unknown"})`)
+      .join(", ");
+    return new Err(
+      `The following ID(s) are knowledge tools, not regular tools: ${knowledgeToolNames}. ` +
+        `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`
+    );
+  }
+
   // Fetch pending suggestions and mark duplicates (same toolId) as outdated.
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
@@ -295,12 +351,11 @@ export async function createToolsSuggestions({
       { states: ["pending"], kind: "tools" }
     );
 
-  const toolIds = new Set(suggestions.map((s) => s.toolId));
-
   const remainingPending = await markDuplicateSuggestionsAsOutdated(
     auth,
     pendingSuggestions,
-    (s) => isToolsSuggestion(s.suggestion) && toolIds.has(s.suggestion.toolId)
+    (s) =>
+      isToolsSuggestion(s.suggestion) && uniqueToolIds.has(s.suggestion.toolId)
   );
 
   const limitCheck = canAddPendingSuggestions({
@@ -362,6 +417,34 @@ export async function createSkillsSuggestions({
   suggestions: SkillsSuggestionInput[];
   source: AgentSuggestionSource;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
+  // Reject batches where multiple suggestions target the same skill.
+  const suggestionSkillIds = suggestions.map((s) => s.skillId);
+  const uniqueSkillIds = new Set(suggestionSkillIds);
+  if (uniqueSkillIds.size !== suggestionSkillIds.length) {
+    const duplicates = [
+      ...new Set(
+        suggestionSkillIds.filter(
+          (id, i) => suggestionSkillIds.indexOf(id) !== i
+        )
+      ),
+    ];
+    return new Err(
+      `Multiple suggestions target the same skill ID: ${duplicates.join(", ")}. Use a single suggestion per skill.`
+    );
+  }
+
+  // Validate that all skill IDs exist and are accessible.
+  const skills = await SkillResource.fetchByIds(auth, suggestionSkillIds);
+  const foundSkillIds = new Set(skills.map((s) => s.sId));
+  const missingSkillIds = suggestionSkillIds.filter(
+    (id) => !foundSkillIds.has(id)
+  );
+  if (missingSkillIds.length > 0) {
+    return new Err(
+      `The following skill ID(s) are invalid or not accessible: ${missingSkillIds.join(", ")}.`
+    );
+  }
+
   // Fetch pending suggestions and mark duplicates (same skillId) as outdated.
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
@@ -370,13 +453,12 @@ export async function createSkillsSuggestions({
       { states: ["pending"], kind: "skills" }
     );
 
-  const skillIds = new Set(suggestions.map((s) => s.skillId));
-
   const remainingPending = await markDuplicateSuggestionsAsOutdated(
     auth,
     pendingSuggestions,
     (s) =>
-      isSkillsSuggestion(s.suggestion) && skillIds.has(s.suggestion.skillId)
+      isSkillsSuggestion(s.suggestion) &&
+      uniqueSkillIds.has(s.suggestion.skillId)
   );
 
   const limitCheck = canAddPendingSuggestions({
@@ -858,19 +940,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    // Reject batches where multiple suggestions target the same block.
-    const targetBlockIds = params.suggestions.map((s) => s.targetBlockId);
-    const uniqueTargetBlockIds = new Set(targetBlockIds);
-    if (uniqueTargetBlockIds.size !== targetBlockIds.length) {
-      return new Err(
-        new MCPError(
-          "Multiple suggestions target the same block ID. Use a single suggestion per block." +
-            `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`,
-          { tracked: false }
-        )
-      );
-    }
-
     try {
       const result = await createInstructionSuggestions({
         auth,
@@ -911,53 +980,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
-        )
-      );
-    }
-
-    // Reject batches where multiple suggestions target the same tool.
-    const toolIds = params.suggestions.map((s) => s.toolId);
-    const uniqueToolIds = new Set(toolIds);
-    if (uniqueToolIds.size !== toolIds.length) {
-      const duplicates = [
-        ...new Set(toolIds.filter((id, i) => toolIds.indexOf(id) !== i)),
-      ];
-      return new Err(
-        new MCPError(
-          `Multiple suggestions target the same tool ID: ${duplicates.join(", ")}. Use a single suggestion per tool.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    // Validate that all tool IDs exist and are accessible.
-    const tools = await MCPServerViewResource.fetchByIds(auth, toolIds);
-    const foundToolIds = new Set(tools.map((t) => t.sId));
-    const missingToolIds = toolIds.filter((id) => !foundToolIds.has(id));
-    if (missingToolIds.length > 0) {
-      return new Err(
-        new MCPError(
-          `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}. ` +
-            `Check <workspace_context> for valid tool IDs.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    // Reject knowledge tools — they should be suggested via suggest_knowledge.
-    const knowledgeTools = tools.filter((t) => {
-      const json = t.toJSON();
-      return json !== null && isToolWithKnowledge(json);
-    });
-    if (knowledgeTools.length > 0) {
-      const knowledgeToolNames = knowledgeTools
-        .map((t) => `${t.sId} (${t.toJSON()?.server.name ?? "unknown"})`)
-        .join(", ");
-      return new Err(
-        new MCPError(
-          `The following ID(s) are knowledge tools, not regular tools: ${knowledgeToolNames}. ` +
-            `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`,
           { tracked: false }
         )
       );
@@ -1125,35 +1147,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
-        )
-      );
-    }
-
-    // Reject batches where multiple suggestions target the same skill.
-    const skillIds = params.suggestions.map((s) => s.skillId);
-    const uniqueSkillIds = new Set(skillIds);
-    if (uniqueSkillIds.size !== skillIds.length) {
-      const duplicates = [
-        ...new Set(skillIds.filter((id, i) => skillIds.indexOf(id) !== i)),
-      ];
-      return new Err(
-        new MCPError(
-          `Multiple suggestions target the same skill ID: ${duplicates.join(", ")}. Use a single suggestion per skill.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    // Validate that all skill IDs exist and are accessible.
-    const skills = await SkillResource.fetchByIds(auth, skillIds);
-    const foundSkillIds = new Set(skills.map((s) => s.sId));
-    const missingSkillIds = skillIds.filter((id) => !foundSkillIds.has(id));
-    if (missingSkillIds.length > 0) {
-      return new Err(
-        new MCPError(
-          `The following skill ID(s) are invalid or not accessible: ${missingSkillIds.join(", ")}. ` +
-            `Check <workspace_context> for valid skill IDs.`,
           { tracked: false }
         )
       );

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -229,9 +229,7 @@ export async function createInstructionSuggestions({
   });
 
   if (!agentConfiguration) {
-    return new Err(
-      `Agent configuration not found: ${agentConfigurationId}`
-    );
+    return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
   const createdSuggestions: {
@@ -320,9 +318,7 @@ export async function createToolsSuggestions({
   });
 
   if (!agentConfiguration) {
-    return new Err(
-      `Agent configuration not found: ${agentConfigurationId}`
-    );
+    return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
   const createdSuggestions: { sId: string; kind: string }[] = [];
@@ -398,9 +394,7 @@ export async function createSkillsSuggestions({
   });
 
   if (!agentConfiguration) {
-    return new Err(
-      `Agent configuration not found: ${agentConfigurationId}`
-    );
+    return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
   const createdSuggestions: { sId: string; kind: string }[] = [];
@@ -886,9 +880,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error, { tracked: false })
-        );
+        return new Err(new MCPError(result.error, { tracked: false }));
       }
 
       const directives = result.value.map(
@@ -980,9 +972,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error, { tracked: false })
-        );
+        return new Err(new MCPError(result.error, { tracked: false }));
       }
 
       const directives = result.value.map(
@@ -1178,9 +1168,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(
-          new MCPError(result.error, { tracked: false })
-        );
+        return new Err(new MCPError(result.error, { tracked: false }));
       }
 
       const directives = result.value.map(

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -10,7 +10,10 @@ import {
   MAX_PENDING_SUB_AGENT_SUGGESTIONS,
   MAX_PENDING_TOOLS_SUGGESTIONS,
 } from "@app/lib/api/actions/servers/agent_sidekick_context/constants";
-import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import {
+  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,
+  type InstructionsSuggestionSchema,
+} from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import { getAgentConfigurationIdFromContext } from "@app/lib/api/actions/servers/agent_sidekick_helpers";
 import { pruneConflictingInstructionSuggestions } from "@app/lib/api/assistant/agent_suggestion_pruning";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -58,6 +61,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type {
+  AgentSuggestionSource,
   AgentSuggestionState,
   KnowledgeSuggestionType,
   SubAgentSuggestionType,
@@ -178,6 +182,97 @@ async function markDuplicateSuggestionsAsOutdated(
   return remaining;
 }
 
+type InstructionSuggestionInput = z.infer<typeof InstructionsSuggestionSchema>;
+
+/**
+ * Shared logic for creating instruction suggestions. Used by both the
+ * suggest_prompt_edits MCP handler and reinforced agent analysis.
+ * Returns the created suggestions, or an empty array if limits are exceeded
+ * or the agent configuration is not found.
+ */
+export async function createInstructionSuggestions({
+  auth,
+  agentConfigurationId,
+  suggestions,
+  source,
+}: {
+  auth: Authenticator;
+  agentConfigurationId: string;
+  suggestions: InstructionSuggestionInput[];
+  source: AgentSuggestionSource;
+}): Promise<{ sId: string; kind: string; targetBlockId: string }[]> {
+  // Check pending suggestion limit before proceeding.
+  const pendingInstructions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { states: ["pending"], kind: "instructions" }
+    );
+
+  const limitCheck = canAddPendingSuggestions({
+    kind: "instructions",
+    newPendingCount: suggestions.length,
+    currentPendingCount: pendingInstructions.length,
+  });
+  if (!limitCheck.allowed) {
+    logger.warn(
+      { agentConfigurationId },
+      `createInstructionSuggestions: ${limitCheck.errorMessage}`
+    );
+    return [];
+  }
+
+  // Fetch the latest version of the agent configuration (full variant needed
+  // for instructionsHtml used in conflict pruning).
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "full",
+  });
+
+  if (!agentConfiguration) {
+    logger.warn(
+      { agentConfigurationId },
+      "createInstructionSuggestions: agent configuration not found"
+    );
+    return [];
+  }
+
+  const createdSuggestions: {
+    sId: string;
+    kind: string;
+    targetBlockId: string;
+  }[] = [];
+
+  for (const suggestion of suggestions) {
+    const { analysis, ...suggestionData } = suggestion;
+    const created = await AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "instructions",
+        suggestion: suggestionData,
+        analysis: analysis ?? null,
+        state: "pending",
+        source,
+      }
+    );
+
+    createdSuggestions.push({
+      sId: created.sId,
+      kind: created.kind,
+      targetBlockId: suggestionData.targetBlockId,
+    });
+  }
+
+  await pruneConflictingInstructionSuggestions(
+    auth,
+    agentConfiguration,
+    createdSuggestions
+  );
+
+  return createdSuggestions;
+}
+
 import {
   formatAvailableModels,
   formatAvailableSkills,
@@ -188,6 +283,7 @@ import {
   listAvailableSkills,
   listAvailableTools,
 } from "@app/lib/api/assistant/workspace_capabilities";
+import type { z } from "zod";
 
 /**
  * Lists all knowledge data source views across all spaces the user has access to.
@@ -630,85 +726,41 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    // Check pending suggestion limit before proceeding.
-    const pendingInstructions =
-      await AgentSuggestionResource.listByAgentConfigurationId(
+    try {
+      const createdSuggestions = await createInstructionSuggestions({
         auth,
         agentConfigurationId,
-        { states: ["pending"], kind: "instructions" }
-      );
+        suggestions: params.suggestions,
+        source: "sidekick",
+      });
 
-    const limitCheck = canAddPendingSuggestions({
-      kind: "instructions",
-      newPendingCount: params.suggestions.length,
-      currentPendingCount: pendingInstructions.length,
-    });
-    if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
-    }
-
-    // Fetch the latest version of the agent configuration (full variant needed
-    // for instructionsHtml used in conflict pruning).
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: agentConfigurationId,
-      variant: "full",
-    });
-
-    if (!agentConfiguration) {
-      return new Err(
-        new MCPError(`Agent configuration not found: ${agentConfigurationId}`, {
-          tracked: false,
-        })
-      );
-    }
-
-    const createdSuggestions: { sId: string; targetBlockId: string }[] = [];
-    const directives: string[] = [];
-
-    for (const suggestion of params.suggestions) {
-      try {
-        const { analysis, ...suggestionData } = suggestion;
-        const created = await AgentSuggestionResource.createSuggestionForAgent(
-          auth,
-          agentConfiguration,
-          {
-            kind: "instructions",
-            suggestion: suggestionData,
-            analysis: analysis ?? null,
-            state: "pending",
-            source: "sidekick",
-          }
-        );
-
-        createdSuggestions.push({
-          sId: created.sId,
-          targetBlockId: suggestionData.targetBlockId,
-        });
-        directives.push(
-          `:agent_suggestion[]{sId=${created.sId} kind=${created.kind}}`
-        );
-      } catch (error) {
+      if (createdSuggestions.length === 0) {
         return new Err(
           new MCPError(
-            `Failed to create suggestion: ${normalizeError(error).message}`,
+            "No suggestions were created. The pending limit may have been reached or the agent configuration was not found.",
             { tracked: false }
           )
         );
       }
+
+      const directives = createdSuggestions.map(
+        (s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`
+      );
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: directives.join("\n\n"),
+        },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(
+          `Failed to create suggestion: ${normalizeError(error).message}`,
+          { tracked: false }
+        )
+      );
     }
-
-    await pruneConflictingInstructionSuggestions(
-      auth,
-      agentConfiguration,
-      createdSuggestions
-    );
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text: directives.join("\n\n"),
-      },
-    ]);
   },
 
   suggest_tools: async (params, { auth, agentLoopContext }) => {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -13,6 +13,8 @@ import {
 import {
   AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,
   type InstructionsSuggestionSchema,
+  type SkillsSuggestionSchema,
+  type ToolsSuggestionSchema,
 } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import { getAgentConfigurationIdFromContext } from "@app/lib/api/actions/servers/agent_sidekick_helpers";
 import { pruneConflictingInstructionSuggestions } from "@app/lib/api/assistant/agent_suggestion_pruning";
@@ -269,6 +271,172 @@ export async function createInstructionSuggestions({
     agentConfiguration,
     createdSuggestions
   );
+
+  return createdSuggestions;
+}
+
+type ToolsSuggestionInput = z.infer<typeof ToolsSuggestionSchema> & {
+  analysis?: string;
+};
+
+/**
+ * Shared logic for creating tools suggestions. Used by both the
+ * suggest_tools MCP handler and reinforced agent analysis.
+ */
+export async function createToolsSuggestions({
+  auth,
+  agentConfigurationId,
+  suggestions,
+  source,
+}: {
+  auth: Authenticator;
+  agentConfigurationId: string;
+  suggestions: ToolsSuggestionInput[];
+  source: AgentSuggestionSource;
+}): Promise<{ sId: string; kind: string }[]> {
+  // Fetch pending suggestions and mark duplicates (same toolId) as outdated.
+  const pendingSuggestions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { states: ["pending"], kind: "tools" }
+    );
+
+  const toolIds = new Set(suggestions.map((s) => s.toolId));
+
+  const remainingPending = await markDuplicateSuggestionsAsOutdated(
+    auth,
+    pendingSuggestions,
+    (s) => isToolsSuggestion(s.suggestion) && toolIds.has(s.suggestion.toolId)
+  );
+
+  const limitCheck = canAddPendingSuggestions({
+    kind: "tools",
+    newPendingCount: suggestions.length,
+    currentPendingCount: remainingPending.length,
+  });
+  if (!limitCheck.allowed) {
+    logger.warn(
+      { agentConfigurationId },
+      `createToolsSuggestions: ${limitCheck.errorMessage}`
+    );
+    return [];
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
+
+  if (!agentConfiguration) {
+    logger.warn(
+      { agentConfigurationId },
+      "createToolsSuggestions: agent configuration not found"
+    );
+    return [];
+  }
+
+  const createdSuggestions: { sId: string; kind: string }[] = [];
+
+  for (const { action, toolId, analysis } of suggestions) {
+    const suggestion: ToolsSuggestionType = { action, toolId };
+    const created = await AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "tools",
+        suggestion,
+        analysis: analysis ?? null,
+        state: "pending",
+        source,
+      }
+    );
+
+    createdSuggestions.push({ sId: created.sId, kind: created.kind });
+  }
+
+  return createdSuggestions;
+}
+
+type SkillsSuggestionInput = z.infer<typeof SkillsSuggestionSchema> & {
+  analysis?: string;
+};
+
+/**
+ * Shared logic for creating skills suggestions. Used by both the
+ * suggest_skills MCP handler and reinforced agent analysis.
+ */
+export async function createSkillsSuggestions({
+  auth,
+  agentConfigurationId,
+  suggestions,
+  source,
+}: {
+  auth: Authenticator;
+  agentConfigurationId: string;
+  suggestions: SkillsSuggestionInput[];
+  source: AgentSuggestionSource;
+}): Promise<{ sId: string; kind: string }[]> {
+  // Fetch pending suggestions and mark duplicates (same skillId) as outdated.
+  const pendingSuggestions =
+    await AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      { states: ["pending"], kind: "skills" }
+    );
+
+  const skillIds = new Set(suggestions.map((s) => s.skillId));
+
+  const remainingPending = await markDuplicateSuggestionsAsOutdated(
+    auth,
+    pendingSuggestions,
+    (s) =>
+      isSkillsSuggestion(s.suggestion) && skillIds.has(s.suggestion.skillId)
+  );
+
+  const limitCheck = canAddPendingSuggestions({
+    kind: "skills",
+    newPendingCount: suggestions.length,
+    currentPendingCount: remainingPending.length,
+  });
+  if (!limitCheck.allowed) {
+    logger.warn(
+      { agentConfigurationId },
+      `createSkillsSuggestions: ${limitCheck.errorMessage}`
+    );
+    return [];
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
+
+  if (!agentConfiguration) {
+    logger.warn(
+      { agentConfigurationId },
+      "createSkillsSuggestions: agent configuration not found"
+    );
+    return [];
+  }
+
+  const createdSuggestions: { sId: string; kind: string }[] = [];
+
+  for (const { action, skillId, analysis } of suggestions) {
+    const created = await AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "skills",
+        suggestion: { action, skillId },
+        analysis: analysis ?? null,
+        state: "pending",
+        source,
+      }
+    );
+
+    createdSuggestions.push({ sId: created.sId, kind: created.kind });
+  }
 
   return createdSuggestions;
 }
@@ -823,83 +991,41 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    // Fetch pending suggestions and mark duplicates (same toolId) as outdated.
-    const pendingSuggestions =
-      await AgentSuggestionResource.listByAgentConfigurationId(
+    try {
+      const createdSuggestions = await createToolsSuggestions({
         auth,
         agentConfigurationId,
-        { states: ["pending"], kind: "tools" }
-      );
+        suggestions: params.suggestions,
+        source: "sidekick",
+      });
 
-    const remainingPending = await markDuplicateSuggestionsAsOutdated(
-      auth,
-      pendingSuggestions,
-      (s) =>
-        isToolsSuggestion(s.suggestion) &&
-        uniqueToolIds.has(s.suggestion.toolId)
-    );
-
-    // Check pending suggestion limit after marking duplicates as outdated.
-    const limitCheck = canAddPendingSuggestions({
-      kind: "tools",
-      newPendingCount: params.suggestions.length,
-      currentPendingCount: remainingPending.length,
-    });
-    if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
-    }
-
-    // Fetch the latest version of the agent configuration.
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: agentConfigurationId,
-      variant: "light",
-    });
-
-    if (!agentConfiguration) {
-      return new Err(
-        new MCPError(`Agent configuration not found: ${agentConfigurationId}`, {
-          tracked: false,
-        })
-      );
-    }
-
-    const directives: string[] = [];
-
-    for (const { action, toolId, analysis } of params.suggestions) {
-      try {
-        const suggestion: ToolsSuggestionType = { action, toolId };
-        const createdSuggestion =
-          await AgentSuggestionResource.createSuggestionForAgent(
-            auth,
-            agentConfiguration,
-            {
-              kind: "tools",
-              suggestion,
-              analysis: analysis ?? null,
-              state: "pending",
-              source: "sidekick",
-            }
-          );
-
-        directives.push(
-          `:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`
-        );
-      } catch (error) {
+      if (createdSuggestions.length === 0) {
         return new Err(
           new MCPError(
-            `Failed to create suggestion: ${normalizeError(error).message}`,
+            "No suggestions were created. The pending limit may have been reached or the agent configuration was not found.",
             { tracked: false }
           )
         );
       }
-    }
 
-    return new Ok([
-      {
-        type: "text" as const,
-        text: directives.join("\n\n"),
-      },
-    ]);
+      const directives = createdSuggestions.map(
+        (s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`
+      );
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: directives.join("\n\n"),
+        },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(
+          `Failed to create suggestion: ${normalizeError(error).message}`,
+          { tracked: false }
+        )
+      );
+    }
   },
 
   suggest_sub_agent: async (params, { auth, agentLoopContext }) => {
@@ -1066,82 +1192,41 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    // Fetch pending suggestions and mark duplicates (same skillId) as outdated.
-    const pendingSuggestions =
-      await AgentSuggestionResource.listByAgentConfigurationId(
+    try {
+      const createdSuggestions = await createSkillsSuggestions({
         auth,
         agentConfigurationId,
-        { states: ["pending"], kind: "skills" }
-      );
+        suggestions: params.suggestions,
+        source: "sidekick",
+      });
 
-    const remainingPending = await markDuplicateSuggestionsAsOutdated(
-      auth,
-      pendingSuggestions,
-      (s) =>
-        isSkillsSuggestion(s.suggestion) &&
-        uniqueSkillIds.has(s.suggestion.skillId)
-    );
-
-    // Check pending suggestion limit after marking duplicates as outdated.
-    const limitCheck = canAddPendingSuggestions({
-      kind: "skills",
-      newPendingCount: params.suggestions.length,
-      currentPendingCount: remainingPending.length,
-    });
-    if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
-    }
-
-    // Fetch the latest version of the agent configuration.
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: agentConfigurationId,
-      variant: "light",
-    });
-
-    if (!agentConfiguration) {
-      return new Err(
-        new MCPError(`Agent configuration not found: ${agentConfigurationId}`, {
-          tracked: false,
-        })
-      );
-    }
-
-    const directives: string[] = [];
-
-    for (const { action, skillId, analysis } of params.suggestions) {
-      try {
-        const createdSuggestion =
-          await AgentSuggestionResource.createSuggestionForAgent(
-            auth,
-            agentConfiguration,
-            {
-              kind: "skills",
-              suggestion: { action, skillId },
-              analysis: analysis ?? null,
-              state: "pending",
-              source: "sidekick",
-            }
-          );
-
-        directives.push(
-          `:agent_suggestion[]{sId=${createdSuggestion.sId} kind=${createdSuggestion.kind}}`
-        );
-      } catch (error) {
+      if (createdSuggestions.length === 0) {
         return new Err(
           new MCPError(
-            `Failed to create suggestion: ${normalizeError(error).message}`,
+            "No suggestions were created. The pending limit may have been reached or the agent configuration was not found.",
             { tracked: false }
           )
         );
       }
-    }
 
-    return new Ok([
-      {
-        type: "text" as const,
-        text: directives.join("\n\n"),
-      },
-    ]);
+      const directives = createdSuggestions.map(
+        (s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`
+      );
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: directives.join("\n\n"),
+        },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(
+          `Failed to create suggestion: ${normalizeError(error).message}`,
+          { tracked: false }
+        )
+      );
+    }
   },
 
   suggest_model: async (params, { auth, agentLoopContext }) => {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -303,9 +303,7 @@ export async function createToolsSuggestions({
   if (uniqueToolIds.size !== suggestionToolIds.length) {
     const duplicates = [
       ...new Set(
-        suggestionToolIds.filter(
-          (id, i) => suggestionToolIds.indexOf(id) !== i
-        )
+        suggestionToolIds.filter((id, i) => suggestionToolIds.indexOf(id) !== i)
       ),
     ];
     return new Err(
@@ -314,10 +312,7 @@ export async function createToolsSuggestions({
   }
 
   // Validate that all tool IDs exist and are accessible.
-  const tools = await MCPServerViewResource.fetchByIds(
-    auth,
-    suggestionToolIds
-  );
+  const tools = await MCPServerViewResource.fetchByIds(auth, suggestionToolIds);
   const foundToolIds = new Set(tools.map((t) => t.sId));
   const missingToolIds = suggestionToolIds.filter(
     (id) => !foundToolIds.has(id)

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -9,7 +9,22 @@ import {
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { AgentInstructionsSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import type {
+  AgentInstructionsSuggestionType,
+  AgentSkillsSuggestionType,
+  AgentToolsSuggestionType,
+} from "@app/types/suggestions/agent_suggestion";
+
+type ReinforcedSuggestionType =
+  | AgentInstructionsSuggestionType
+  | AgentToolsSuggestionType
+  | AgentSkillsSuggestionType;
+
+const REINFORCED_SUGGESTION_KINDS = new Set([
+  "instructions",
+  "tools",
+  "skills",
+]);
 
 interface AggregationContext {
   agentConfig: LightAgentConfigurationType;
@@ -17,14 +32,13 @@ interface AggregationContext {
   prompt: { systemPrompt: string; userMessage: string };
 }
 
-function toInstructionsSuggestions(
+function toReinforcedSuggestions(
   suggestions: AgentSuggestionResource[]
-): AgentInstructionsSuggestionType[] {
+): ReinforcedSuggestionType[] {
   return suggestions
     .map((s) => s.toJSON())
-    .filter(
-      (json): json is AgentInstructionsSuggestionType =>
-        json.kind === "instructions"
+    .filter((json): json is ReinforcedSuggestionType =>
+      REINFORCED_SUGGESTION_KINDS.has(json.kind)
     );
 }
 
@@ -65,40 +79,52 @@ async function loadAggregationContext(
       }
     );
 
-  const existingInstructions = toInstructionsSuggestions(existingSuggestions);
+  const existingReinforced = toReinforcedSuggestions(existingSuggestions);
 
   const prompt = buildAggregationPrompt(
     agentConfig.name,
-    toInstructionsSuggestions(syntheticSuggestions),
+    toReinforcedSuggestions(syntheticSuggestions),
     {
-      pending: existingInstructions.filter((s) => s.state === "pending"),
-      rejected: existingInstructions.filter((s) => s.state === "rejected"),
+      pending: existingReinforced.filter((s) => s.state === "pending"),
+      rejected: existingReinforced.filter((s) => s.state === "rejected"),
     }
   );
 
   return { agentConfig, syntheticSuggestions, prompt };
 }
 
-function formatSuggestions(
-  suggestions: AgentInstructionsSuggestionType[]
-): string {
-  return suggestions
-    .map(
-      (s, i) => `### Suggestion ${i + 1}
-kind: ${s.kind}
+function formatSuggestion(s: ReinforcedSuggestionType): string {
+  switch (s.kind) {
+    case "instructions":
+      return `kind: instructions
 targetBlockId: ${s.suggestion.targetBlockId}
 analysis: ${s.analysis ?? "N/A"}
-content: ${s.suggestion.content}`
-    )
+content: ${s.suggestion.content}`;
+    case "tools":
+      return `kind: tools
+action: ${s.suggestion.action}
+toolId: ${s.suggestion.toolId}
+analysis: ${s.analysis ?? "N/A"}`;
+    case "skills":
+      return `kind: skills
+action: ${s.suggestion.action}
+skillId: ${s.suggestion.skillId}
+analysis: ${s.analysis ?? "N/A"}`;
+  }
+}
+
+function formatSuggestions(suggestions: ReinforcedSuggestionType[]): string {
+  return suggestions
+    .map((s, i) => `### Suggestion ${i + 1}\n${formatSuggestion(s)}`)
     .join("\n\n");
 }
 
 export function buildAggregationPrompt(
   agentName: string,
-  syntheticSuggestions: AgentInstructionsSuggestionType[],
+  syntheticSuggestions: ReinforcedSuggestionType[],
   existingSuggestions: {
-    pending: AgentInstructionsSuggestionType[];
-    rejected: AgentInstructionsSuggestionType[];
+    pending: ReinforcedSuggestionType[];
+    rejected: ReinforcedSuggestionType[];
   }
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = `You are an AI agent improvement analyst. You have been given multiple suggestions from individual conversation analyses for the same agent. Your job is to deduplicate, merge, and prioritize them into a concise set of high-quality, actionable suggestions.
@@ -107,12 +133,17 @@ export function buildAggregationPrompt(
 - Merge suggestions that address the same issue, or that target the same block
 - Keep only the most impactful suggestions (max 5)
 - In the analysis, mention how many conversations support each suggestion
-- When calling the tool, make sure there is never more than one suggestion targeting the same block (including instructions-root)
+- When calling suggest_prompt_edits, make sure there is never more than one suggestion targeting the same block (including instructions-root)
 - Do NOT create suggestions that are too similar to existing pending suggestions (listed below) — they are already being reviewed
 - Do NOT create suggestions that are too similar to previously rejected suggestions (listed below) — they will get rejected again
-- It is perfectly fine to return an empty suggestions array if there is nothing new to say
+- It is perfectly fine to return empty suggestions arrays if there is nothing new to say
 
-You MUST call the tool. If no suggestions survive aggregation, return an empty suggestions array.`;
+You have three tools available:
+- suggest_prompt_edits: For instruction changes.
+- suggest_tools: For suggesting tools to add or remove.
+- suggest_skills: For suggesting skills to add or remove.
+
+You MUST call at least one tool. If no suggestions survive aggregation, call suggest_prompt_edits with an empty suggestions array.`;
 
   let userMessage = `## Agent: ${agentName}
 

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -29,13 +29,12 @@ Analyze the conversation and identify areas where the agent's instructions could
 - Tone or style improvements based on user reactions and feedback
 - Specific instructions that could prevent repeated mistakes
 
-Only suggest changes to the instructions (kind: 'instructions'). Use targetBlockId 'instructions-root' for top-level instruction changes,
-and the actual block ID for nested instructions.
+You have three tools available:
+- suggest_prompt_edits: For instruction changes. Use targetBlockId 'instructions-root' for top-level instruction changes, and the actual block ID for nested instructions. The content must contain exactly what should go in the instructions block, with no explanation about why it should be there (that belongs in the analysis). It is in HTML format, so make sure to preserve any HTML tags from the original instructions.
+- suggest_tools: For suggesting tools to add or remove from the agent. Use the tool's sId as toolId.
+- suggest_skills: For suggesting skills to add or remove from the agent. Use the skill's sId as skillId.
 
-The content must contain exactly what should go in the instructions block, with no explanation about why it should be there (that belongs in the analysis).
-It is in HTML format, so make sure to preserve any HTML tags from the original instructions.
-
-You MUST call the tool. Always call it. If no improvements are needed, return an empty suggestions array.`;
+You MUST call at least one tool. If no improvements are needed, call suggest_prompt_edits with an empty suggestions array.`;
 
   const userMessage = `## Agent being analyzed
 Name: ${agentConfig.name}

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -29,6 +29,8 @@ Analyze the conversation and identify areas where the agent's instructions could
 - Tone or style improvements based on user reactions and feedback
 - Specific instructions that could prevent repeated mistakes
 
+For each suggestion, always include an 'analysis' field explaining why this change would improve the agent.
+
 You have three tools available:
 - suggest_prompt_edits: For instruction changes. Use targetBlockId 'instructions-root' for top-level instruction changes, and the actual block ID for nested instructions. The content must contain exactly what should go in the instructions block, with no explanation about why it should be there (that belongs in the analysis). It is in HTML format, so make sure to preserve any HTML tags from the original instructions.
 - suggest_tools: For suggesting tools to add or remove from the agent. Use the tool's sId as toolId.

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -1,75 +1,35 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import { createInstructionSuggestions } from "@app/lib/api/actions/servers/agent_sidekick_context/tools";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { getSmallWhitelistedModel } from "@app/types/assistant/assistant";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { AgentSuggestionSource } from "@app/types/suggestions/agent_suggestion";
-import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
-const ReinforcedSuggestionSchema = z.object({
-  kind: z.string(),
-  content: z.string(),
-  targetBlockId: z.string(),
-  analysis: z.string(),
-});
+const TOOL_NAME =
+  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.name;
 
-const ReinforcedResponseSchema = z.object({
-  suggestions: z.array(ReinforcedSuggestionSchema),
-});
-
-const FUNCTION_NAME = "add_suggestions";
+const SuggestPromptEditsInputSchema = z.object(
+  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.schema
+);
 
 function buildSpecifications(): AgentActionSpecification[] {
   return [
     {
-      name: FUNCTION_NAME,
-      description: "Add structured suggestions that improve the agent.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          suggestions: {
-            type: "array",
-            description:
-              "A list of concrete, actionable suggestions to improve the agent.",
-            items: {
-              type: "object",
-              properties: {
-                kind: {
-                  type: "string",
-                  enum: ["instructions"],
-                  description: "The type of suggestion.",
-                },
-                content: {
-                  type: "string",
-                  description:
-                    "The full HTML content for the instructions block.",
-                },
-                targetBlockId: {
-                  type: "string",
-                  description:
-                    "The data-block-id of the block to modify. " +
-                    "Use 'instructions-root' for top-level instructions.",
-                },
-                analysis: {
-                  type: "string",
-                  description:
-                    "A short explanation of why this suggestion would improve the agent.",
-                },
-              },
-              required: ["kind", "content", "targetBlockId", "analysis"],
-            },
-          },
-        },
-        required: ["suggestions"],
-      },
+      name: TOOL_NAME,
+      description:
+        AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.description,
+      inputSchema: zodToJsonSchema(SuggestPromptEditsInputSchema) as JSONSchema,
     },
   ];
 }
@@ -101,7 +61,7 @@ export function buildReinforcedLLMParams({
     },
     prompt: systemPrompt,
     specifications: buildSpecifications(),
-    forceToolCall: FUNCTION_NAME,
+    forceToolCall: TOOL_NAME,
   };
 }
 
@@ -158,7 +118,7 @@ export async function processReinforcedEvents({
   }
 
   const toolCallEvent = events.find(
-    (e) => e.type === "tool_call" && e.content.name === FUNCTION_NAME
+    (e) => e.type === "tool_call" && e.content.name === TOOL_NAME
   );
   if (!toolCallEvent || toolCallEvent.type !== "tool_call") {
     logger.warn(
@@ -196,7 +156,7 @@ async function createSuggestionsFromToolCall({
   operationType: ReinforcedOperationType;
   contextId: string;
 }): Promise<number> {
-  const parsed = ReinforcedResponseSchema.safeParse(actionArguments);
+  const parsed = SuggestPromptEditsInputSchema.safeParse(actionArguments);
   if (!parsed.success) {
     logger.warn(
       {
@@ -211,28 +171,14 @@ async function createSuggestionsFromToolCall({
 
   const { suggestions } = parsed.data;
 
-  let createdCount = 0;
-  for (const suggestion of suggestions) {
-    if (suggestion.kind !== "instructions") {
-      continue;
-    }
+  const created = await createInstructionSuggestions({
+    auth,
+    agentConfigurationId: agentConfig.sId,
+    suggestions,
+    source,
+  });
 
-    await AgentSuggestionResource.createSuggestionForAgent(auth, agentConfig, {
-      kind: "instructions",
-      suggestion: {
-        content: suggestion.content,
-        targetBlockId:
-          suggestion.targetBlockId || INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
-        type: "replace",
-      },
-      analysis: suggestion.analysis,
-      state: "pending",
-      source,
-    });
-    createdCount++;
-  }
-
-  return createdCount;
+  return created.length;
 }
 
 /**

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -198,13 +198,20 @@ async function createSuggestionsFromToolCall({
         );
         return 0;
       }
-      const created = await createInstructionSuggestions({
+      const result = await createInstructionSuggestions({
         auth,
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
       });
-      return created.length;
+      if (result.isErr()) {
+        logger.warn(
+          { agentConfigurationId: agentConfig.sId, contextId, toolName },
+          `ReinforcedAgent: ${result.error}`
+        );
+        return 0;
+      }
+      return result.value.length;
     }
 
     case "suggest_tools": {
@@ -221,13 +228,20 @@ async function createSuggestionsFromToolCall({
         );
         return 0;
       }
-      const created = await createToolsSuggestions({
+      const result = await createToolsSuggestions({
         auth,
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
       });
-      return created.length;
+      if (result.isErr()) {
+        logger.warn(
+          { agentConfigurationId: agentConfig.sId, contextId, toolName },
+          `ReinforcedAgent: ${result.error}`
+        );
+        return 0;
+      }
+      return result.value.length;
     }
 
     case "suggest_skills": {
@@ -244,13 +258,20 @@ async function createSuggestionsFromToolCall({
         );
         return 0;
       }
-      const created = await createSkillsSuggestions({
+      const result = await createSkillsSuggestions({
         auth,
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
       });
-      return created.length;
+      if (result.isErr()) {
+        logger.warn(
+          { agentConfigurationId: agentConfig.sId, contextId, toolName },
+          `ReinforcedAgent: ${result.error}`
+        );
+        return 0;
+      }
+      return result.value.length;
     }
 
     default:

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -1,6 +1,10 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
-import { createInstructionSuggestions } from "@app/lib/api/actions/servers/agent_sidekick_context/tools";
+import {
+  createInstructionSuggestions,
+  createSkillsSuggestions,
+  createToolsSuggestions,
+} from "@app/lib/api/actions/servers/agent_sidekick_context/tools";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -16,22 +20,32 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const TOOL_NAME =
-  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.name;
+const SUPPORTED_TOOLS = [
+  "suggest_prompt_edits",
+  "suggest_tools",
+  "suggest_skills",
+] as const;
 
-const SuggestPromptEditsInputSchema = z.object(
-  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.schema
-);
+type SupportedToolName = (typeof SUPPORTED_TOOLS)[number];
+
+const TOOL_SCHEMAS: Record<SupportedToolName, z.ZodObject<z.ZodRawShape>> = {
+  suggest_prompt_edits: z.object(
+    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.schema
+  ),
+  suggest_tools: z.object(
+    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_tools.schema
+  ),
+  suggest_skills: z.object(
+    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_skills.schema
+  ),
+};
 
 function buildSpecifications(): AgentActionSpecification[] {
-  return [
-    {
-      name: TOOL_NAME,
-      description:
-        AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.description,
-      inputSchema: zodToJsonSchema(SuggestPromptEditsInputSchema) as JSONSchema,
-    },
-  ];
+  return SUPPORTED_TOOLS.map((toolName) => ({
+    name: AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[toolName].name,
+    description: AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[toolName].description,
+    inputSchema: zodToJsonSchema(TOOL_SCHEMAS[toolName]) as JSONSchema,
+  }));
 }
 
 type ReinforcedOperationType =
@@ -61,7 +75,6 @@ export function buildReinforcedLLMParams({
     },
     prompt: systemPrompt,
     specifications: buildSpecifications(),
-    forceToolCall: TOOL_NAME,
   };
 }
 
@@ -87,7 +100,8 @@ export async function getReinforcedLLM(
 
 /**
  * Parse tool calls from LLM events and create suggestion records.
- * Used to process batch results.
+ * Handles multiple tool calls across suggest_prompt_edits, suggest_tools,
+ * and suggest_skills.
  */
 export async function processReinforcedEvents({
   auth,
@@ -117,10 +131,11 @@ export async function processReinforcedEvents({
     return 0;
   }
 
-  const toolCallEvent = events.find(
-    (e) => e.type === "tool_call" && e.content.name === TOOL_NAME
+  const supportedToolNames = new Set<string>(SUPPORTED_TOOLS);
+  const toolCallEvents = events.filter(
+    (e) => e.type === "tool_call" && supportedToolNames.has(e.content.name)
   );
-  if (!toolCallEvent || toolCallEvent.type !== "tool_call") {
+  if (toolCallEvents.length === 0) {
     logger.warn(
       { contextId },
       `ReinforcedAgent: no tool call in batch result for ${operationType}`
@@ -128,22 +143,32 @@ export async function processReinforcedEvents({
     return 0;
   }
 
-  return createSuggestionsFromToolCall({
-    auth,
-    agentConfig,
-    actionArguments: toolCallEvent.content.arguments,
-    source,
-    operationType,
-    contextId,
-  });
+  let totalCreated = 0;
+  for (const event of toolCallEvents) {
+    if (event.type !== "tool_call") {
+      continue;
+    }
+    totalCreated += await createSuggestionsFromToolCall({
+      auth,
+      agentConfig,
+      toolName: event.content.name,
+      actionArguments: event.content.arguments,
+      source,
+      operationType,
+      contextId,
+    });
+  }
+
+  return totalCreated;
 }
 
 /**
- * Shared helper: parse action arguments and create suggestion records.
+ * Dispatch a tool call to the appropriate suggestion creation function.
  */
 async function createSuggestionsFromToolCall({
   auth,
   agentConfig,
+  toolName,
   actionArguments,
   source,
   operationType,
@@ -151,34 +176,90 @@ async function createSuggestionsFromToolCall({
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
+  toolName: string;
   actionArguments: Record<string, unknown>;
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
 }): Promise<number> {
-  const parsed = SuggestPromptEditsInputSchema.safeParse(actionArguments);
-  if (!parsed.success) {
-    logger.warn(
-      {
+  switch (toolName) {
+    case "suggest_prompt_edits": {
+      const parsed =
+        TOOL_SCHEMAS.suggest_prompt_edits.safeParse(actionArguments);
+      if (!parsed.success) {
+        logger.warn(
+          {
+            agentConfigurationId: agentConfig.sId,
+            contextId,
+            toolName,
+            error: parsed.error,
+          },
+          `ReinforcedAgent: invalid LLM response shape for ${operationType}`
+        );
+        return 0;
+      }
+      const created = await createInstructionSuggestions({
+        auth,
         agentConfigurationId: agentConfig.sId,
-        contextId,
-        error: parsed.error,
-      },
-      `ReinforcedAgent: invalid LLM response shape for ${operationType}`
-    );
-    return 0;
+        suggestions: parsed.data.suggestions,
+        source,
+      });
+      return created.length;
+    }
+
+    case "suggest_tools": {
+      const parsed = TOOL_SCHEMAS.suggest_tools.safeParse(actionArguments);
+      if (!parsed.success) {
+        logger.warn(
+          {
+            agentConfigurationId: agentConfig.sId,
+            contextId,
+            toolName,
+            error: parsed.error,
+          },
+          `ReinforcedAgent: invalid LLM response shape for ${operationType}`
+        );
+        return 0;
+      }
+      const created = await createToolsSuggestions({
+        auth,
+        agentConfigurationId: agentConfig.sId,
+        suggestions: parsed.data.suggestions,
+        source,
+      });
+      return created.length;
+    }
+
+    case "suggest_skills": {
+      const parsed = TOOL_SCHEMAS.suggest_skills.safeParse(actionArguments);
+      if (!parsed.success) {
+        logger.warn(
+          {
+            agentConfigurationId: agentConfig.sId,
+            contextId,
+            toolName,
+            error: parsed.error,
+          },
+          `ReinforcedAgent: invalid LLM response shape for ${operationType}`
+        );
+        return 0;
+      }
+      const created = await createSkillsSuggestions({
+        auth,
+        agentConfigurationId: agentConfig.sId,
+        suggestions: parsed.data.suggestions,
+        source,
+      });
+      return created.length;
+    }
+
+    default:
+      logger.warn(
+        { agentConfigurationId: agentConfig.sId, contextId, toolName },
+        `ReinforcedAgent: unexpected tool name for ${operationType}`
+      );
+      return 0;
   }
-
-  const { suggestions } = parsed.data;
-
-  const created = await createInstructionSuggestions({
-    auth,
-    agentConfigurationId: agentConfig.sId,
-    suggestions,
-    source,
-  });
-
-  return created.length;
 }
 
 /**


### PR DESCRIPTION
## Description

- Extend the reinforced agent pipeline to process tools and skills suggestions in addition to instructions
- Reuse sidekick tool schemas and creation functions (createInstructionSuggestions, createToolsSuggestions, createSkillsSuggestions) instead of duplicating logic

Node that as it stands, it's not actually able to make tools/skills suggestion because it doesn't have the list of available tools/skills. I'll tackle this in a separate PR.

Review notes: the diff is a little big, but can be broken down as follows:
- First, in agent_sidekick_context/tools/index.ts, the change is to factor out reusable helpers (`createInstructionSuggestions`, etc...) from `suggest_prompt_edits`, `suggest_tools` and `suggest_skill` to create the suggestions. And then those helpers are used both in the existing tools and in the Reinforced logic.
- Then there is the logic in run_reinforced_analysis.ts to use those helpers. Plus the fact that we go from just instructions to adding tools and skills, so a bunch of logic for that
- The rest is mostly straightforward and is about assing skills/tools support.

## Tests

It's reusing a lot of shared code which has test coverage.

## Risk

Need to make sure we don't break sidekick since we're refactoring some code. All the tests passed and I did some manual testing.

## Deploy Plan

Front.