### PR TITLE
[front] Add file-based skill detection and import endpoints

### DIFF
--- a/front/lib/api/skills/detection/file_detection.ts
+++ b/front/lib/api/skills/detection/file_detection.ts
@@ -1,0 +1,59 @@
+import { parseSkillMarkdown } from "@app/lib/api/skills/detection/parsing";
+import type { DetectedSkill } from "@app/lib/api/skills/detection/types";
+import { detectSkillsFromZip } from "@app/lib/api/skills/detection/zip/detect_skills";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type formidable from "formidable";
+import { readFileSync } from "fs";
+
+const ACCEPTED_EXTENSIONS = new Set([".zip", ".skill", ".md"]);
+
+interface FileDetectionError {
+  message: string;
+}
+
+/**
+ * Parses uploaded files (via formidable) and extracts detected skills.
+ * Supports .md (standalone SKILL.md), .zip and .skill (ZIP archives).
+ */
+export function detectSkillsFromUploadedFiles(
+  uploadedFiles: formidable.File[]
+): Result<DetectedSkill[], FileDetectionError> {
+  const allDetectedSkills: DetectedSkill[] = [];
+
+  for (const file of uploadedFiles) {
+    const filename = file.originalFilename ?? "";
+    const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
+
+    if (!ACCEPTED_EXTENSIONS.has(ext)) {
+      return new Err({
+        message: `Unsupported file type "${ext}". Accepted: .md, .zip, .skill`,
+      });
+    }
+
+    const buffer = readFileSync(file.filepath);
+
+    if (ext === ".zip" || ext === ".skill") {
+      const result = detectSkillsFromZip({ zipBuffer: buffer });
+      if (result.isErr()) {
+        return new Err({ message: result.error.message });
+      }
+      allDetectedSkills.push(...result.value);
+    } else {
+      // .md file — treat as a standalone SKILL.md.
+      const content = buffer.toString("utf-8");
+      const parsed = parseSkillMarkdown(content);
+      if (parsed.name) {
+        allDetectedSkills.push({
+          name: parsed.name,
+          skillMdPath: filename,
+          description: parsed.description,
+          instructions: parsed.instructions,
+          attachments: [],
+        });
+      }
+    }
+  }
+
+  return new Ok(allDetectedSkills);
+}

--- a/front/lib/api/skills/detection/import_skills_from_files.ts
+++ b/front/lib/api/skills/detection/import_skills_from_files.ts
@@ -1,0 +1,126 @@
+import { detectSkillsFromUploadedFiles } from "@app/lib/api/skills/detection/file_detection";
+import type { ImportSkillsResult } from "@app/lib/api/skills/detection/github/import_skills";
+import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import type { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type formidable from "formidable";
+
+const IMPORT_CONCURRENCY = 4;
+
+interface FileImportError {
+  type: "invalid_files";
+  message: string;
+}
+
+/**
+ * Imports skills from uploaded files. Detects skills from the files,
+ * then creates or updates SkillResource objects.
+ */
+export async function importSkillsFromFiles(
+  auth: Authenticator,
+  {
+    uploadedFiles,
+    names,
+  }: {
+    uploadedFiles: formidable.File[];
+    names: string[];
+  }
+): Promise<Result<ImportSkillsResult, FileImportError>> {
+  const detectResult = detectSkillsFromUploadedFiles(uploadedFiles);
+  if (detectResult.isErr()) {
+    return new Err({
+      type: "invalid_files",
+      message: detectResult.error.message,
+    });
+  }
+
+  const detectedSkills = detectResult.value;
+
+  const requestedNames = new Set(names);
+  const selectedSkills = detectedSkills.filter(
+    (skill) =>
+      requestedNames.has(skill.name) && skill.name && skill.instructions.trim()
+  );
+
+  const user = auth.getNonNullableUser();
+  const imported: SkillResource[] = [];
+  const updated: SkillResource[] = [];
+  const errors: { name: string; message: string }[] = [];
+
+  await concurrentExecutor(
+    selectedSkills,
+    async (skill) => {
+      const existing = await SkillResource.fetchActiveByName(auth, skill.name);
+
+      if (existing && existing.source !== "local_file") {
+        errors.push({
+          name: skill.name,
+          message: `A different skill named "${skill.name}" already exists.`,
+        });
+        return;
+      }
+
+      if (existing) {
+        const attachedKnowledge = await existing.getAttachedKnowledge(auth);
+
+        await existing.updateSkill(auth, {
+          name: skill.name,
+          agentFacingDescription: skill.description,
+          userFacingDescription: skill.description,
+          instructions: skill.instructions,
+          icon: existing.icon,
+          mcpServerViews: existing.mcpServerViews,
+          attachedKnowledge,
+          requestedSpaceIds: existing.requestedSpaceIds,
+          source: "local_file",
+          sourceMetadata: undefined,
+        });
+
+        updated.push(existing);
+      } else {
+        let icon: string | null = null;
+        const iconResult = await getSkillIconSuggestion(auth, {
+          name: skill.name,
+          instructions: skill.instructions,
+          agentFacingDescription: skill.description,
+        });
+        if (iconResult.isOk()) {
+          icon = iconResult.value;
+        } else {
+          logger.warn(
+            { error: iconResult.error, skillName: skill.name },
+            "Failed to generate icon suggestion for imported skill"
+          );
+        }
+
+        const skillResource = await SkillResource.makeNew(
+          auth,
+          {
+            status: "active",
+            name: skill.name,
+            agentFacingDescription: skill.description,
+            userFacingDescription: skill.description,
+            instructions: skill.instructions,
+            editedBy: user.id,
+            requestedSpaceIds: [],
+            extendedSkillId: null,
+            icon,
+            source: "local_file",
+            sourceMetadata: null,
+            isDefault: false,
+          },
+          { mcpServerViews: [] }
+        );
+
+        imported.push(skillResource);
+      }
+    },
+    { concurrency: IMPORT_CONCURRENCY }
+  );
+
+  return new Ok({ imported, updated, errors });
+}

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -1,11 +1,13 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { detectSkillsFromUploadedFiles } from "@app/lib/api/skills/detection/file_detection";
 import {
   detectSkillsFromGitHubRepo,
   initGitHubRepoClient,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/detection/github/detect_skills";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
+import type { DetectedSkill } from "@app/lib/api/skills/detection/types";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
@@ -15,11 +17,40 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
+import formidable from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
 
 export type DetectSkillsResponseBody = {
   skills: DetectedSkillSummary[];
 };
+
+function isMultipartRequest(req: NextApiRequest): boolean {
+  const contentType = req.headers["content-type"] ?? "";
+  return contentType.startsWith("multipart/");
+}
+
+function parseJsonBody(req: NextApiRequest): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
 
 async function handler(
   req: NextApiRequest,
@@ -46,83 +77,131 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "invalid_request_error",
-            message: "Skill import from GitHub is not supported.",
+            message: "Skill import is not supported.",
           },
         });
       }
 
-      const { repoUrl } = req.body;
+      let detectedSkills: DetectedSkill[];
+      let repoUrl: string | null = null;
 
-      if (!isString(repoUrl)) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "repoUrl is required and must be a string.",
-          },
+      if (isMultipartRequest(req)) {
+        // File-based detection.
+        const form = formidable({
+          multiples: true,
+          maxFileSize: 5 * 1024 * 1024,
         });
-      }
+        const [, files] = await form.parse(req);
+        const uploadedFiles = files.files;
 
-      const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
-      const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
-      if (clientResult.isErr()) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: clientResult.error.message,
-          },
-        });
-      }
-
-      const result = await detectSkillsFromGitHubRepo(clientResult.value);
-
-      if (result.isErr()) {
-        const { error } = result;
-
-        switch (error.type) {
-          case "invalid_url":
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: error.message,
-              },
-            });
-          case "not_found":
-            return apiError(req, res, {
-              status_code: 404,
-              api_error: {
-                type: "invalid_request_error",
-                message: error.message,
-              },
-            });
-          case "auth_error":
-            return apiError(req, res, {
-              status_code: 401,
-              api_error: {
-                type: "invalid_request_error",
-                message: error.message,
-              },
-            });
-          case "github_api_error":
-            logger.error(
-              { error, workspaceId: owner.sId },
-              "Error detecting skills from GitHub repo"
-            );
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "invalid_request_error",
-                message: error.message,
-              },
-            });
-          default:
-            assertNever(error);
+        if (!uploadedFiles || uploadedFiles.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "No files uploaded.",
+            },
+          });
         }
-      }
 
-      const detectedSkills = result.value;
+        const result = detectSkillsFromUploadedFiles(uploadedFiles);
+        if (result.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
+        }
+        detectedSkills = result.value;
+      } else {
+        // GitHub-based detection.
+        const body = await parseJsonBody(req);
+        const bodyRepoUrl =
+          body &&
+          typeof body === "object" &&
+          "repoUrl" in body &&
+          isString(body.repoUrl)
+            ? body.repoUrl
+            : undefined;
+
+        if (!bodyRepoUrl) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "repoUrl is required and must be a string.",
+            },
+          });
+        }
+
+        repoUrl = bodyRepoUrl;
+
+        const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
+        const clientResult = initGitHubRepoClient({
+          repoUrl,
+          accessToken,
+        });
+        if (clientResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: clientResult.error.message,
+            },
+          });
+        }
+
+        const result = await detectSkillsFromGitHubRepo(clientResult.value);
+
+        if (result.isErr()) {
+          const { error } = result;
+
+          switch (error.type) {
+            case "invalid_url":
+              return apiError(req, res, {
+                status_code: 400,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: error.message,
+                },
+              });
+            case "not_found":
+              return apiError(req, res, {
+                status_code: 404,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: error.message,
+                },
+              });
+            case "auth_error":
+              return apiError(req, res, {
+                status_code: 401,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: error.message,
+                },
+              });
+            case "github_api_error":
+              logger.error(
+                { error, workspaceId: owner.sId },
+                "Error detecting skills from GitHub repo"
+              );
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "invalid_request_error",
+                  message: error.message,
+                },
+              });
+            default:
+              assertNever(error);
+          }
+        }
+
+        detectedSkills = result.value;
+      }
 
       if (detectedSkills.length === 0) {
         return apiError(req, res, {
@@ -130,7 +209,7 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message:
-              "No skills found in this repository. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
+              "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).",
           },
         });
       }
@@ -151,11 +230,25 @@ async function handler(
             };
           }
 
+          if (repoUrl && isSkillFromGitHubRepo(existing, { repoUrl })) {
+            return {
+              name: skill.name,
+              status: "skill_already_exists",
+              existingSkillId: existing.sId,
+            };
+          }
+
+          if (!repoUrl && existing.source === "local_file") {
+            return {
+              name: skill.name,
+              status: "skill_already_exists",
+              existingSkillId: existing.sId,
+            };
+          }
+
           return {
             name: skill.name,
-            status: isSkillFromGitHubRepo(existing, { repoUrl })
-              ? "skill_already_exists"
-              : "name_conflict",
+            status: "name_conflict",
             existingSkillId: existing.sId,
           };
         },

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { importSkillsFromFiles } from "@app/lib/api/skills/detection/import_skills_from_files";
 import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -7,21 +8,43 @@ import { apiError } from "@app/logger/withlogging";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
+import { isString } from "@app/types/shared/utils/general";
+import formidable from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const ImportSkillsRequestBodySchema = t.type({
-  repoUrl: t.string,
-  names: t.array(t.string),
-});
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
 
 export type ImportSkillsResponseBody = {
   imported: SkillType[];
   updated: SkillType[];
   errors: { name: string; message: string }[];
 };
+
+function isMultipartRequest(req: NextApiRequest): boolean {
+  const contentType = req.headers["content-type"] ?? "";
+  return contentType.startsWith("multipart/");
+}
+
+function parseJsonBody(req: NextApiRequest): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
 
 async function handler(
   req: NextApiRequest,
@@ -48,26 +71,96 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "invalid_request_error",
-            message: "Skill import from GitHub is not supported.",
+            message: "Skill import is not supported.",
           },
         });
       }
 
-      const bodyValidation = ImportSkillsRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      if (isMultipartRequest(req)) {
+        // File-based import.
+        const form = formidable({
+          multiples: true,
+          maxFileSize: 5 * 1024 * 1024,
+        });
+        const [fields, files] = await form.parse(req);
+        const uploadedFiles = files.files;
+
+        const fieldNames = fields.names;
+        if (!fieldNames || fieldNames.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "names field is required.",
+            },
+          });
+        }
+
+        if (!uploadedFiles || uploadedFiles.length === 0) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "No files uploaded.",
+            },
+          });
+        }
+
+        const result = await importSkillsFromFiles(auth, {
+          uploadedFiles,
+          names: fieldNames,
+        });
+        if (result.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
+        }
+
+        return res.status(200).json({
+          imported: result.value.imported.map((skill) => skill.toJSON(auth)),
+          updated: result.value.updated.map((skill) => skill.toJSON(auth)),
+          errors: result.value.errors,
+        });
+      }
+
+      // GitHub-based import.
+      const body = await parseJsonBody(req);
+
+      if (
+        !body ||
+        typeof body !== "object" ||
+        !("repoUrl" in body) ||
+        !("names" in body)
+      ) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: "Invalid request body: repoUrl and names are required.",
           },
         });
       }
 
-      const { repoUrl, names } = bodyValidation.right;
+      const { repoUrl: rawRepoUrl, names: rawNames } = body;
+      if (!isString(rawRepoUrl) || !Array.isArray(rawNames)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid request body: repoUrl must be a string and names must be an array.",
+          },
+        });
+      }
 
-      const result = await importSkillsFromGitHub(auth, { repoUrl, names });
+      const result = await importSkillsFromGitHub(auth, {
+        repoUrl: rawRepoUrl,
+        names: rawNames.filter(isString),
+      });
       if (result.isErr()) {
         const error = result.error;
         switch (error.type) {


### PR DESCRIPTION
## Summary
- Add multipart/form-data support to `/api/w/[wId]/skills/detect` and `/api/w/[wId]/skills/import` endpoints
- Content-type dispatching: multipart requests route to file detection, JSON to existing GitHub detection
- New `file_detection.ts` handles .md, .zip, and .skill file parsing
- New `import_skills_from_files.ts` (parallel to `import_skills.ts` for GitHub) handles the file import flow with `local_file` source type
- Existing GitHub import path is fully preserved (backward compatible)

## Test plan
- [ ] Verify existing GitHub skill detection still works via JSON POST to `/detect`
- [ ] Verify existing GitHub skill import still works via JSON POST to `/import`
- [ ] Test file detection with multipart POST containing .md files
- [ ] Test file detection with multipart POST containing .zip files
- [ ] Test file import with multipart POST containing files + names field
- [ ] Verify conflict detection: `local_file` source allows update, other sources show name_conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)