### PR TITLE
[front] Add file upload tab for skill import

### DIFF
--- a/front/components/skills/ImportFromFilesTab.tsx
+++ b/front/components/skills/ImportFromFilesTab.tsx
@@ -1,0 +1,243 @@
+import { DetectedSkillsList } from "@app/components/skills/DetectedSkillsList";
+import { isImportableSkillStatus } from "@app/lib/skill_detection";
+import {
+  useDetectSkillsFromFiles,
+  useImportSkillsFromFiles,
+} from "@app/lib/swr/skill_configurations";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  cn,
+  ContentMessage,
+  DropzoneOverlay,
+  Hoverable,
+  InformationCircleIcon,
+  PlusIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const ACCEPTED_FILE_TYPES = ".md,.zip";
+
+interface ImportFromFilesTabProps {
+  owner: LightWorkspaceType;
+  onStateChange: (state: {
+    selectedCount: number;
+    isDetecting: boolean;
+    isImporting: boolean;
+  }) => void;
+  onImportSuccess: () => void;
+  registerImportHandler: (handler: () => Promise<void>) => void;
+}
+
+export function ImportFromFilesTab({
+  owner,
+  onStateChange,
+  onImportSuccess,
+  registerImportHandler,
+}: ImportFromFilesTabProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
+  const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
+
+  const { detectedSkills, isDetecting, detectError, triggerDetect } =
+    useDetectSkillsFromFiles({ owner });
+  const { importSkillsFromFiles, isImporting } = useImportSkillsFromFiles({
+    owner,
+  });
+
+  // Pre-select all importable skills when detection completes.
+  useEffect(() => {
+    const initial = new Set<string>();
+    for (const skill of detectedSkills) {
+      if (isImportableSkillStatus(skill.status)) {
+        initial.add(skill.name);
+      }
+    }
+    setSelectedNames(initial);
+  }, [detectedSkills]);
+
+  // Report state to parent.
+  useEffect(() => {
+    onStateChange({
+      selectedCount: selectedNames.size,
+      isDetecting,
+      isImporting,
+    });
+  }, [selectedNames.size, isDetecting, isImporting, onStateChange]);
+
+  // Register import handler with parent.
+  const handleImport = useCallback(async () => {
+    if (selectedNames.size === 0) {
+      return;
+    }
+    const result = await importSkillsFromFiles(uploadedFiles, [
+      ...selectedNames,
+    ]);
+    if (result.successCount > 0) {
+      onImportSuccess();
+    }
+  }, [selectedNames, uploadedFiles, importSkillsFromFiles, onImportSuccess]);
+
+  useEffect(() => {
+    registerImportHandler(handleImport);
+  }, [handleImport, registerImportHandler]);
+
+  const handleFilesSelected = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+      setUploadedFiles(files);
+      void triggerDetect(files);
+    },
+    [triggerDetect]
+  );
+
+  const toggleSkill = useCallback((name: string) => {
+    setSelectedNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      handleFilesSelected(Array.from(e.dataTransfer.files));
+    },
+    [handleFilesSelected]
+  );
+
+  return (
+    <div className="flex flex-col gap-4 pt-2">
+      <SkillFileDropzone
+        onDrop={handleDrop}
+        onFileInputChange={(e) => {
+          handleFilesSelected(Array.from(e.target.files ?? []));
+        }}
+        fileInputRef={fileInputRef}
+        disabled={isImporting}
+        isLoading={isDetecting}
+      />
+      <DetectedSkillsList
+        detectedSkills={detectedSkills}
+        selectedNames={selectedNames}
+        toggleSkill={toggleSkill}
+        isDetecting={isDetecting}
+        detectError={detectError}
+      />
+      <FileRequirements />
+    </div>
+  );
+}
+
+interface SkillFileDropzoneProps {
+  onDrop: (e: React.DragEvent) => void;
+  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  disabled: boolean;
+  isLoading: boolean;
+}
+
+function SkillFileDropzone({
+  onDrop,
+  onFileInputChange,
+  fileInputRef,
+  disabled,
+  isLoading,
+}: SkillFileDropzoneProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col items-center gap-3 overflow-hidden rounded-xl",
+        "border-2 border-dashed border-border bg-muted-background px-4 py-6",
+        "transition-colors dark:border-border-night dark:bg-muted-background-night"
+      )}
+      onDragOver={(e) => {
+        e.preventDefault();
+        if (!isLoading) {
+          setIsDragOver(true);
+        }
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={(e) => {
+        setIsDragOver(false);
+        if (!isLoading) {
+          onDrop(e);
+        }
+      }}
+    >
+      <DropzoneOverlay
+        isDragActive={isDragOver}
+        title="Drop files here"
+        description="Upload .md, .zip or .skill files"
+      />
+      {isLoading ? (
+        <>
+          <Spinner size="md" />
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Detecting skills...
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Drag and drop or click to upload
+          </p>
+          <input
+            className="hidden"
+            type="file"
+            accept={ACCEPTED_FILE_TYPES}
+            ref={fileInputRef}
+            multiple
+            onChange={onFileInputChange}
+          />
+          <Button
+            label="Upload files"
+            icon={PlusIcon}
+            variant="primary"
+            size="sm"
+            disabled={disabled}
+            onClick={() => fileInputRef.current?.click()}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function FileRequirements() {
+  return (
+    <ContentMessage
+      title="File requirements"
+      icon={InformationCircleIcon}
+      variant="outline"
+      size="lg"
+    >
+      <ul className="list-disc pl-4 text-sm">
+        <li>The imported .zip or file must include a SKILL.md file</li>
+        <li>
+          This file must contain the skill name and description formatted in
+          YAML
+        </li>
+      </ul>
+      Read more about importing skills&nbsp;
+      <Hoverable
+        variant="highlight"
+        href="https://agentskills.io/specification"
+        target="_blank"
+      >
+        here
+      </Hoverable>
+      .
+    </ContentMessage>
+  );
+}

--- a/front/components/skills/ImportSkillsDialog.tsx
+++ b/front/components/skills/ImportSkillsDialog.tsx
@@ -1,3 +1,4 @@
+import { ImportFromFilesTab } from "@app/components/skills/ImportFromFilesTab";
 import { ImportFromRepositoryTab } from "@app/components/skills/ImportFromRepositoryTab";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -16,9 +17,12 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useRef, useState } from "react";
 
-type ImportTab = "repository";
+type ImportTab = "repository" | "files";
 
-const IMPORT_TABS: readonly string[] = ["repository"] satisfies ImportTab[];
+const IMPORT_TABS: readonly string[] = [
+  "repository",
+  "files",
+] satisfies ImportTab[];
 
 function isImportTab(value: string): value is ImportTab {
   return IMPORT_TABS.includes(value);
@@ -37,6 +41,7 @@ interface ImportSkillsDialogProps {
 
 const TAB_DESCRIPTION: Record<ImportTab, string> = {
   repository: "Enter a GitHub repository URL to detect skills.",
+  files: "Upload .md, .zip or .skill files to import skills.",
 };
 
 export function ImportSkillsDialog({
@@ -98,9 +103,18 @@ export function ImportSkillsDialog({
           >
             <TabsList>
               <TabsTrigger value="repository" label="Repository" />
+              <TabsTrigger value="files" label="Files" />
             </TabsList>
             <TabsContent value="repository">
               <ImportFromRepositoryTab
+                owner={owner}
+                onStateChange={setTabState}
+                onImportSuccess={onClose}
+                registerImportHandler={registerImportHandler}
+              />
+            </TabsContent>
+            <TabsContent value="files">
+              <ImportFromFilesTab
                 owner={owner}
                 onStateChange={setTabState}
                 onImportSuccess={onClose}

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -500,3 +500,151 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
 
   return { importSkills, isImporting };
 }
+
+export function useDetectSkillsFromFiles({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const [detectedSkills, setDetectedSkills] = useState<DetectedSkillSummary[]>(
+    []
+  );
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [detectError, setDetectError] = useState<string | null>(null);
+
+  const triggerDetect = useCallback(
+    async (files: File[]) => {
+      setIsDetecting(true);
+      setDetectError(null);
+      setDetectedSkills([]);
+
+      const formData = new FormData();
+      for (const file of files) {
+        formData.append("files", file);
+      }
+
+      try {
+        const res = await clientFetch(`/api/w/${owner.sId}/skills/detect`, {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          setDetectError(errorData.message);
+          return;
+        }
+
+        const data: DetectSkillsResponseBody = await res.json();
+        setDetectedSkills(data.skills);
+      } catch (err) {
+        setDetectError(
+          isAPIErrorResponse(err)
+            ? err.error.message
+            : "Failed to detect skills from the uploaded files."
+        );
+      } finally {
+        setIsDetecting(false);
+      }
+    },
+    [owner.sId]
+  );
+
+  return {
+    detectedSkills,
+    isDetecting,
+    detectError,
+    triggerDetect,
+  };
+}
+
+export function useImportSkillsFromFiles({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isImporting, setIsImporting] = useState(false);
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+      disabled: true,
+    });
+
+  const importSkillsFromFiles = useCallback(
+    async (files: File[], names: string[]) => {
+      setIsImporting(true);
+      try {
+        const formData = new FormData();
+        for (const file of files) {
+          formData.append("files", file);
+        }
+        for (const name of names) {
+          formData.append("names", name);
+        }
+
+        const res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errorData.message,
+          });
+          return { successCount: 0, errors: [errorData.message] };
+        }
+
+        const data: ImportSkillsResponseBody = await res.json();
+
+        void mutateActiveSkills();
+
+        const importedCount = data.imported.length;
+        const updatedCount = data.updated.length;
+        const successCount = importedCount + updatedCount;
+        const errors = data.errors.map((e) => e.message);
+
+        if (successCount > 0) {
+          const parts: string[] = [];
+          if (importedCount > 0) {
+            parts.push(
+              `${importedCount} skill${pluralize(importedCount)} imported`
+            );
+          }
+          if (updatedCount > 0) {
+            parts.push(
+              `${updatedCount} skill${pluralize(updatedCount)} updated`
+            );
+          }
+          if (errors.length > 0) {
+            parts.push(
+              `${errors.length} skill${pluralize(errors.length)} failed`
+            );
+          }
+          sendNotification({
+            type: "success",
+            title: "Import successful",
+            description: parts.join(", ") + ".",
+          });
+        } else {
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errors[0] ?? "Failed to import skills.",
+          });
+        }
+
+        return { successCount, errors };
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [owner.sId, mutateActiveSkills, sendNotification]
+  );
+
+  return { importSkillsFromFiles, isImporting };
+}


### PR DESCRIPTION
## Summary
- Add a "Files" tab to the import skills dialog with drag-and-drop file upload
- New `ImportFromFilesTab` component with dropzone UI, file requirements info, and skill selection
- New `useDetectSkillsFromFiles` and `useImportSkillsFromFiles` SWR hooks (sends FormData to detect/import endpoints)
- Same selection/import flow as the repository tab (pre-selects importable skills, shared `DetectedSkillsList`)

**Depends on:**
- #22920 (tabs refactor — base branch)
- #22985 (backend file endpoints)

## Test plan
- [ ] Open import dialog, switch to "Files" tab
- [ ] Upload a .md file — verify skill detection and selection
- [ ] Upload a .zip file — verify multiple skills detected
- [ ] Drag and drop files — verify dropzone works
- [ ] Select/deselect skills and import — verify success notification
- [ ] Verify "Repository" tab still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)