### PR TITLE
[front] - feat(analytics): download tool usage

### DIFF
--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -7,6 +7,8 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   useWorkspaceTools,
   useWorkspaceToolUsage,
@@ -23,6 +25,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
+import { DownloadIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   CartesianGrid,
@@ -106,6 +109,10 @@ export function WorkspaceToolUsageChart({
   workspaceId,
   period,
 }: WorkspaceToolUsageChartProps) {
+  const { hasFeature } = useFeatureFlags();
+  const showExport = hasFeature("analytics_csv_export");
+  const [isDownloading, setIsDownloading] = useState(false);
+
   const [displayMode, setDisplayMode] =
     useState<ToolUsageDisplayMode>("executions");
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
@@ -263,6 +270,41 @@ export function WorkspaceToolUsageChart({
     </DropdownMenu>
   );
 
+  const canDownload = !isToolsLoading && !hasError && data.length > 0;
+
+  const handleDownload = async () => {
+    setIsDownloading(true);
+    try {
+      const response = await clientFetch(
+        `/api/w/${workspaceId}/analytics/tool-usage-export?days=${period}`
+      );
+      if (!response.ok) {
+        return;
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `dust_tool_usage_last_${period}_days.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const downloadButton = showExport ? (
+    <Button
+      icon={DownloadIcon}
+      variant="outline"
+      size="xs"
+      tooltip="Download CSV"
+      onClick={handleDownload}
+      disabled={!canDownload || isDownloading}
+      isLoading={isDownloading}
+    />
+  ) : undefined;
+
   const modeSelector = (
     <ButtonsSwitchList defaultValue={displayMode} size="xs">
       <ButtonsSwitch
@@ -293,6 +335,7 @@ export function WorkspaceToolUsageChart({
         <div className="flex items-center gap-2">
           {toolSelector}
           {modeSelector}
+          {downloadButton}
         </div>
       }
     >

--- a/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
@@ -1,0 +1,135 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  fetchAvailableSkills,
+  fetchSkillUsageMetrics,
+} from "@app/lib/api/assistant/observability/skill_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+interface SkillUsageExportRow {
+  date: string;
+  skillName: string;
+  executions: number;
+  uniqueUsers: number;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days: q.data.days,
+      });
+
+      const skillsResult = await fetchAvailableSkills(baseQuery);
+      if (skillsResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve available skills: ${skillsResult.error.message}`,
+          },
+        });
+      }
+
+      const skills = skillsResult.value;
+      const rows: SkillUsageExportRow[] = [];
+
+      for (const skill of skills) {
+        const usageResult = await fetchSkillUsageMetrics(
+          baseQuery,
+          skill.skillName
+        );
+        if (usageResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`,
+            },
+          });
+        }
+
+        for (const point of usageResult.value) {
+          rows.push({
+            date: point.date,
+            skillName: skill.skillName,
+            executions: point.executionCount,
+            uniqueUsers: point.uniqueUsers,
+          });
+        }
+      }
+
+      rows.sort((a, b) => {
+        const dateCompare = a.date.localeCompare(b.date);
+        if (dateCompare !== 0) {
+          return dateCompare;
+        }
+        return a.skillName.localeCompare(b.skillName);
+      });
+
+      const headers: (keyof SkillUsageExportRow)[] = [
+        "date",
+        "skillName",
+        "executions",
+        "uniqueUsers",
+      ];
+      const csvData = rows.map((row) => headers.map((h) => row[h]));
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_skill_usage_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   fetchAvailableSkills,

--- a/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
@@ -1,3 +1,4 @@
+/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   fetchAvailableTools,

--- a/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
@@ -1,9 +1,8 @@
-/** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
-  fetchAvailableSkills,
-  fetchSkillUsageMetrics,
-} from "@app/lib/api/assistant/observability/skill_usage";
+  fetchAvailableTools,
+  fetchToolUsageMetrics,
+} from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -17,9 +16,9 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
 
-interface SkillUsageExportRow {
+interface ToolUsageExportRow {
   date: string;
-  skillName: string;
+  toolName: string;
   executions: number;
   uniqueUsers: number;
 }
@@ -59,31 +58,31 @@ async function handler(
         days: q.data.days,
       });
 
-      const skillsResult = await fetchAvailableSkills(baseQuery);
-      if (skillsResult.isErr()) {
+      const toolsResult = await fetchAvailableTools(baseQuery);
+      if (toolsResult.isErr()) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve available skills: ${skillsResult.error.message}`,
+            message: `Failed to retrieve available tools: ${toolsResult.error.message}`,
           },
         });
       }
 
-      const skills = skillsResult.value;
-      const rows: SkillUsageExportRow[] = [];
+      const tools = toolsResult.value;
+      const rows: ToolUsageExportRow[] = [];
 
-      for (const skill of skills) {
-        const usageResult = await fetchSkillUsageMetrics(
+      for (const tool of tools) {
+        const usageResult = await fetchToolUsageMetrics(
           baseQuery,
-          skill.skillName
+          tool.serverName
         );
         if (usageResult.isErr()) {
           return apiError(req, res, {
             status_code: 500,
             api_error: {
               type: "internal_server_error",
-              message: `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`,
+              message: `Failed to retrieve tool usage for ${tool.serverName}: ${usageResult.error.message}`,
             },
           });
         }
@@ -91,7 +90,7 @@ async function handler(
         for (const point of usageResult.value) {
           rows.push({
             date: point.date,
-            skillName: skill.skillName,
+            toolName: tool.serverName,
             executions: point.executionCount,
             uniqueUsers: point.uniqueUsers,
           });
@@ -103,12 +102,12 @@ async function handler(
         if (dateCompare !== 0) {
           return dateCompare;
         }
-        return a.skillName.localeCompare(b.skillName);
+        return a.toolName.localeCompare(b.toolName);
       });
 
-      const headers: (keyof SkillUsageExportRow)[] = [
+      const headers: (keyof ToolUsageExportRow)[] = [
         "date",
-        "skillName",
+        "toolName",
         "executions",
         "uniqueUsers",
       ];
@@ -118,7 +117,7 @@ async function handler(
       res.setHeader("Content-Type", "text/csv");
       res.setHeader(
         "Content-Disposition",
-        `attachment; filename="dust_skill_usage_last_${q.data.days}_days.csv"`
+        `attachment; filename="dust_tool_usage_last_${q.data.days}_days.csv"`
       );
       return res.status(200).send(csv);
     }


### PR DESCRIPTION
## Description

This PR adds CSV export functionality for workspace tool usage analytics. When the `analytics_csv_export` feature flag is enabled, workspace admins can download tool usage data as CSV files from the workspace analytics page. The implementation follows the established pattern from previous analytics exports (#22006, #22891) and includes a new API endpoint `/api/w/[wId]/analytics/skill-usage-export` that generates CSV files with daily metrics (date, skillName, executions, uniqueUsers) for the selected time period. A download button is added to the `WorkspaceToolUsageChart` component that fetches the data and triggers a file download.

## Tests

- [x] Locally

## Risk

Low. The feature is behind the `analytics_csv_export` feature flag and follows the established pattern from previous analytics CSV exports.

## Deploy Plan

Deploy front
