### PR TITLE
fix(bigquery): sequentialize the sync

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -297,65 +297,62 @@ export const fetchTree = async ({
   fetchTablesDescription: boolean;
   logger: Logger;
 }): Promise<Result<RemoteDBTree, Error>> => {
-  const databases = await fetchDatabases({ credentials });
+  const databases = await fetchDatabases({ credentials, logger });
 
-  const tree = {
-    databases: await concurrentExecutor(
-      databases,
-      async (db) => {
-        const schemasRes = await fetchDatasets({
-          credentials,
-          database: db,
-          logger,
+  // Process projects and schemas sequentially so that only one dataset's
+  // worth of BigQuery SDK responses lives in memory at a time.
+  // With multi-project support, concurrent fetching across all projects
+  // can accumulate thousands of getMetadata responses and OOM the worker.
+  const treeDBs: RemoteDBTree["databases"] = [];
+
+  for (const db of databases) {
+    const schemasRes = await fetchDatasets({
+      credentials,
+      database: db,
+      logger,
+    });
+    if (schemasRes.isErr()) {
+      throw schemasRes.error;
+    }
+
+    const schemas: RemoteDBTree["databases"][number]["schemas"] = [];
+
+    for (const schema of schemasRes.value) {
+      const tablesRes = await fetchTables({
+        credentials,
+        dataset: schema,
+        fetchTablesDescription,
+        logger,
+      });
+      if (tablesRes.isErr()) {
+        throw tablesRes.error;
+      }
+      const tables = tablesRes.value;
+
+      // Do not store if too many tables, the sync will be too long and it's quite likely that these are useless tables.
+      if (tables.length > MAX_TABLES_PER_SCHEMA) {
+        logger.warn(
+          `[BigQuery] Skipping schema ${schema.name} with ${tables.length} tables because it has more than ${MAX_TABLES_PER_SCHEMA} tables.`
+        );
+        schemas.push({
+          name:
+            schema.name +
+            ` (sync skipped: exceeded ${MAX_TABLES_PER_SCHEMA} tables limit)`,
+          database_name: db.name,
+          tables: [],
         });
-        if (schemasRes.isErr()) {
-          throw schemasRes.error;
-        }
-        const schemas = schemasRes.value;
-        return {
-          ...db,
-          schemas: await concurrentExecutor(
-            schemas,
-            async (schema) => {
-              const tablesRes = await fetchTables({
-                credentials,
-                dataset: schema,
-                fetchTablesDescription,
-                logger,
-              });
-              if (tablesRes.isErr()) {
-                throw tablesRes.error;
-              }
-              const tables = tablesRes.value;
+      } else {
+        schemas.push({
+          ...schema,
+          tables,
+        });
+      }
+    }
 
-              // Do not store if too many tables, the sync will be too long and it's quite likely that these are useless tables.
-              if (tables.length > MAX_TABLES_PER_SCHEMA) {
-                logger.warn(
-                  `[BigQuery] Skipping schema ${schema.name} with ${tables.length} tables because it has more than ${MAX_TABLES_PER_SCHEMA} tables.`
-                );
-                return {
-                  name:
-                    schema.name +
-                    ` (sync skipped: exceeded ${MAX_TABLES_PER_SCHEMA} tables limit)`,
-                  database_name: db.name,
-                  tables: [],
-                };
-              }
+    treeDBs.push({ ...db, schemas });
+  }
 
-              return {
-                ...schema,
-                tables,
-              };
-            },
-            { concurrency: 2 }
-          ),
-        };
-      },
-      { concurrency: 2 }
-    ),
-  };
-
-  return new Ok(tree);
+  return new Ok({ databases: treeDBs });
 };
 
 // BigQuery is read-only as we force the readonly scope when creating the client.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

 **Problem**

Since #22757 added support for multiple BigQuery projects, `fetchTree` enumerates all GCP projects visible to the service account via `listAccessibleProjects()`. Previously it only synced the single project from the credentials.

For large organizations (e.g. with connector 23235), the service account can see many projects, each with dozens of datasets and hundreds of tables. `fetchTree` was using `concurrentExecutor` with concurrency 2 at both the project and schema levels, meaning multiple projects' datasets were being fetched in parallel, each with multiple schemas' `table.getMetadata()` calls running concurrently. The BigQuery SDK response objects from all these concurrent calls accumulate in memory and exhaust the V8 heap:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

This crashes the `connectors-worker-deployment` pods, which also run the intercom and snowflake workers, taking them down as collateral. As of now, all 4 pods have accumulated 9–15 restarts, with 100% of pre-crash logs being BigQuery `table.getMetadata` calls from connector 23235.

  **Fix**

Changed `fetchTree` to process projects and schemas sequentially instead of concurrently. This ensures only one dataset's worth of BigQuery SDK getMetadata responses lives in memory at a time, letting the GC reclaim intermediate objects between iterations.

The final tree object itself (~5000 table entries with name + description) is small (~1MB). The problem is the concurrent accumulation of heavy BigQuery SDK response objects during the parallel fetch phase.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low-ish, make the connector a bit slower

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy connectors