### PR TITLE
[front] Add file upload tab for skill import

### DIFF
--- a/front/components/skills/import/ImportFromFilesTab.tsx
+++ b/front/components/skills/import/ImportFromFilesTab.tsx
@@ -1,0 +1,203 @@
+import { DetectedSkillsList } from "@app/components/skills/import/DetectedSkillsList";
+import type { ImportFormValues } from "@app/components/skills/import/formSchema";
+import { isImportableSkillStatus } from "@app/lib/skill_detection";
+import { useDetectSkillsFromFiles } from "@app/lib/swr/skill_configurations";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  cn,
+  ContentMessage,
+  DropzoneOverlay,
+  Hoverable,
+  InformationCircleIcon,
+  PlusIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+const ACCEPTED_FILE_TYPES = ".md,.zip";
+
+interface ImportFromFilesTabProps {
+  owner: LightWorkspaceType;
+  onDetectingChange: (isDetecting: boolean) => void;
+  onDetectedCountChange: (count: number) => void;
+  onFilesChange: (files: File[]) => void;
+  isImporting: boolean;
+}
+
+export function ImportFromFilesTab({
+  owner,
+  onDetectingChange,
+  onDetectedCountChange,
+  onFilesChange,
+  isImporting,
+}: ImportFromFilesTabProps) {
+  const { setValue } = useFormContext<ImportFormValues>();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { detectedSkills, isDetecting, detectError, triggerDetect } =
+    useDetectSkillsFromFiles({ owner });
+
+  // Pre-select all importable skills when detection completes.
+  useEffect(() => {
+    setValue(
+      "selectedSkillNames",
+      detectedSkills
+        .filter((skill) => isImportableSkillStatus(skill.status))
+        .map((skill) => skill.name)
+    );
+  }, [detectedSkills, setValue]);
+
+  useEffect(() => {
+    onDetectingChange(isDetecting);
+  }, [isDetecting, onDetectingChange]);
+
+  useEffect(() => {
+    onDetectedCountChange(detectedSkills.length);
+  }, [detectedSkills.length, onDetectedCountChange]);
+
+  const handleFilesSelected = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+      onFilesChange(files);
+      void triggerDetect(files);
+    },
+    [triggerDetect, onFilesChange]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      handleFilesSelected(Array.from(e.dataTransfer.files));
+    },
+    [handleFilesSelected]
+  );
+
+  return (
+    <div className="flex flex-col gap-3 pt-4">
+      <SkillFileDropzone
+        onDrop={handleDrop}
+        onFileInputChange={(e) => {
+          handleFilesSelected(Array.from(e.target.files ?? []));
+        }}
+        fileInputRef={fileInputRef}
+        disabled={isImporting}
+        isLoading={isDetecting}
+      />
+      <DetectedSkillsList
+        detectedSkills={detectedSkills}
+        isDetecting={isDetecting}
+        detectError={detectError}
+      />
+      <FileRequirements />
+    </div>
+  );
+}
+
+interface SkillFileDropzoneProps {
+  onDrop: (e: React.DragEvent) => void;
+  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  disabled: boolean;
+  isLoading: boolean;
+}
+
+function SkillFileDropzone({
+  onDrop,
+  onFileInputChange,
+  fileInputRef,
+  disabled,
+  isLoading,
+}: SkillFileDropzoneProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col items-center gap-3 overflow-hidden rounded-xl",
+        "border-2 border-dashed border-border bg-muted-background px-4 py-6",
+        "transition-colors dark:border-border-night dark:bg-muted-background-night"
+      )}
+      onDragOver={(e) => {
+        e.preventDefault();
+        if (!isLoading) {
+          setIsDragOver(true);
+        }
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={(e) => {
+        setIsDragOver(false);
+        if (!isLoading) {
+          onDrop(e);
+        }
+      }}
+    >
+      <DropzoneOverlay
+        isDragActive={isDragOver}
+        title="Drop files here"
+        description="Upload .md, .zip or .skill files"
+      />
+      {isLoading ? (
+        <>
+          <Spinner size="md" />
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Detecting skills...
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Drag and drop or click to upload
+          </p>
+          <input
+            className="hidden"
+            type="file"
+            accept={ACCEPTED_FILE_TYPES}
+            ref={fileInputRef}
+            multiple
+            onChange={onFileInputChange}
+          />
+          <Button
+            label="Upload files"
+            icon={PlusIcon}
+            variant="primary"
+            size="sm"
+            disabled={disabled}
+            onClick={() => fileInputRef.current?.click()}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function FileRequirements() {
+  return (
+    <ContentMessage
+      title="File requirements"
+      icon={InformationCircleIcon}
+      variant="outline"
+      size="lg"
+    >
+      <ul className="list-disc pl-4 text-sm">
+        <li>The imported .zip or file must include a SKILL.md file</li>
+        <li>
+          This file must contain the skill name and description formatted in
+          YAML
+        </li>
+      </ul>
+      Read more about importing skills&nbsp;
+      <Hoverable
+        variant="highlight"
+        href="https://agentskills.io/specification"
+        target="_blank"
+      >
+        here
+      </Hoverable>
+      .
+    </ContentMessage>
+  );
+}

--- a/front/components/skills/import/ImportSkillsDialog.tsx
+++ b/front/components/skills/import/ImportSkillsDialog.tsx
@@ -6,8 +6,12 @@ import {
   importFormSchema,
   isImportType,
 } from "@app/components/skills/import/formSchema";
+import { ImportFromFilesTab } from "@app/components/skills/import/ImportFromFilesTab";
 import { ImportFromRepositoryTab } from "@app/components/skills/import/ImportFromRepositoryTab";
-import { useImportSkills } from "@app/lib/swr/skill_configurations";
+import {
+  useImportSkills,
+  useImportSkillsFromFiles,
+} from "@app/lib/swr/skill_configurations";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -24,7 +28,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { FormProvider, useController, useForm } from "react-hook-form";
 
 interface ImportSkillsDialogProps {
@@ -34,6 +38,7 @@ interface ImportSkillsDialogProps {
 
 const TAB_DESCRIPTION: Record<ImportType, string> = {
   repository: "Enter a GitHub repository URL to detect skills.",
+  files: "Upload .md, .zip or .skill files to import skills.",
 };
 
 export function ImportSkillsDialog({
@@ -65,19 +70,47 @@ export function ImportSkillsDialog({
     name: "selectedSkillNames",
   });
 
-  const { importSkills, isImporting } = useImportSkills({ owner });
+  const uploadedFilesRef = useRef<File[]>([]);
+
+  const { importSkills, isImporting: isImportingFromRepo } = useImportSkills({
+    owner,
+  });
+  const { importSkillsFromFiles, isImporting: isImportingFromFiles } =
+    useImportSkillsFromFiles({ owner });
+
+  const isImporting = isImportingFromRepo || isImportingFromFiles;
 
   const onSubmit = useCallback(
     async (data: ImportFormValues) => {
       if (data.selectedSkillNames.length === 0) {
         return;
       }
-      const result = await importSkills(data.repoUrl, data.selectedSkillNames);
-      if (result.successCount > 0) {
+
+      let successCount = 0;
+      switch (data.importType) {
+        case "repository": {
+          const result = await importSkills(
+            data.repoUrl,
+            data.selectedSkillNames
+          );
+          successCount = result.successCount;
+          break;
+        }
+        case "files": {
+          const result = await importSkillsFromFiles(
+            uploadedFilesRef.current,
+            data.selectedSkillNames
+          );
+          successCount = result.successCount;
+          break;
+        }
+      }
+
+      if (successCount > 0) {
         onClose();
       }
     },
-    [importSkills, onClose]
+    [importSkills, importSkillsFromFiles, onClose]
   );
 
   const selectedCount = selectedSkillNamesField.value.length;
@@ -115,12 +148,24 @@ export function ImportSkillsDialog({
             >
               <TabsList>
                 <TabsTrigger value="repository" label="Repository" />
+                <TabsTrigger value="files" label="Files" />
               </TabsList>
               <TabsContent value="repository">
                 <ImportFromRepositoryTab
                   owner={owner}
                   onDetectingChange={setIsDetecting}
                   onDetectedCountChange={setDetectedCount}
+                  isImporting={isImporting}
+                />
+              </TabsContent>
+              <TabsContent value="files">
+                <ImportFromFilesTab
+                  owner={owner}
+                  onDetectingChange={setIsDetecting}
+                  onDetectedCountChange={setDetectedCount}
+                  onFilesChange={(files) => {
+                    uploadedFilesRef.current = files;
+                  }}
                   isImporting={isImporting}
                 />
               </TabsContent>

--- a/front/components/skills/import/formSchema.ts
+++ b/front/components/skills/import/formSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const IMPORT_TYPES = ["repository"] as const;
+export const IMPORT_TYPES = ["repository", "files"] as const;
 
 export type ImportType = (typeof IMPORT_TYPES)[number];
 
@@ -8,12 +8,17 @@ export function isImportType(value: string): value is ImportType {
   return IMPORT_TYPES.includes(value as ImportType);
 }
 
-export const importFormSchema = z.object({
-  importType: z.enum(IMPORT_TYPES),
-  repoUrl: z.string().min(1, "A repository URL is required"),
-  selectedSkillNames: z
-    .array(z.string())
-    .min(1, "Select at least one skill to import"),
-});
+export const importFormSchema = z
+  .object({
+    importType: z.enum(IMPORT_TYPES),
+    repoUrl: z.string(),
+    selectedSkillNames: z
+      .array(z.string())
+      .min(1, "Select at least one skill to import"),
+  })
+  .refine(
+    (data) => data.importType !== "repository" || data.repoUrl.length > 0,
+    { message: "A repository URL is required", path: ["repoUrl"] }
+  );
 
 export type ImportFormValues = z.infer<typeof importFormSchema>;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -500,3 +500,146 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
 
   return { importSkills, isImporting };
 }
+
+export function useDetectSkillsFromFiles({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const [detectedSkills, setDetectedSkills] = useState<DetectedSkillSummary[]>(
+    []
+  );
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [detectError, setDetectError] = useState<string | null>(null);
+
+  const triggerDetect = useCallback(
+    async (files: File[]) => {
+      setIsDetecting(true);
+      setDetectError(null);
+      setDetectedSkills([]);
+
+      const formData = new FormData();
+      for (const file of files) {
+        formData.append("files", file);
+      }
+
+      try {
+        const res = await clientFetch(`/api/w/${owner.sId}/skills/detect`, {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          setDetectError(errorData.message);
+          return;
+        }
+
+        const data: DetectSkillsResponseBody = await res.json();
+        setDetectedSkills(data.skills);
+      } catch (err) {
+        setDetectError(
+          isAPIErrorResponse(err)
+            ? err.error.message
+            : "Failed to detect skills from the uploaded files."
+        );
+      } finally {
+        setIsDetecting(false);
+      }
+    },
+    [owner.sId]
+  );
+
+  return { detectedSkills, isDetecting, detectError, triggerDetect };
+}
+
+export function useImportSkillsFromFiles({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isImporting, setIsImporting] = useState(false);
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+      disabled: true,
+    });
+
+  const importSkillsFromFiles = useCallback(
+    async (files: File[], names: string[]) => {
+      setIsImporting(true);
+      try {
+        const formData = new FormData();
+        for (const file of files) {
+          formData.append("files", file);
+        }
+        for (const name of names) {
+          formData.append("names", name);
+        }
+
+        const res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errorData.message,
+          });
+          return { successCount: 0, errors: [errorData.message] };
+        }
+
+        const data: ImportSkillsResponseBody = await res.json();
+
+        void mutateActiveSkills();
+
+        const importedCount = data.imported.length;
+        const updatedCount = data.updated.length;
+        const successCount = importedCount + updatedCount;
+        const errors = data.errors.map((e) => e.message);
+
+        if (successCount > 0) {
+          const parts: string[] = [];
+          if (importedCount > 0) {
+            parts.push(
+              `${importedCount} skill${pluralize(importedCount)} imported`
+            );
+          }
+          if (updatedCount > 0) {
+            parts.push(
+              `${updatedCount} skill${pluralize(updatedCount)} updated`
+            );
+          }
+          if (errors.length > 0) {
+            parts.push(
+              `${errors.length} skill${pluralize(errors.length)} failed`
+            );
+          }
+          sendNotification({
+            type: "success",
+            title: "Import successful",
+            description: parts.join(", ") + ".",
+          });
+        } else {
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errors[0] ?? "Failed to import skills.",
+          });
+        }
+
+        return { successCount, errors };
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [owner.sId, mutateActiveSkills, sendNotification]
+  );
+
+  return { importSkillsFromFiles, isImporting };
+}


### PR DESCRIPTION
## Summary
- Add a "Files" tab to the import skills dialog with drag-and-drop file upload
- New `ImportFromFilesTab` component with dropzone UI, file requirements info, and skill detection
- New `useDetectSkillsFromFiles` and `useImportSkillsFromFiles` SWR hooks (sends FormData to detect/import endpoints)
- Updated `formSchema.ts` to support `"files"` import type with conditional `repoUrl` validation
- Same selection/import flow as the repository tab via shared `react-hook-form` context

**Depends on:** #22985 (backend file endpoints)

## Test plan
- [ ] Open import dialog, switch to "Files" tab
- [ ] Upload a .md file — verify skill detection and selection
- [ ] Upload a .zip file — verify multiple skills detected
- [ ] Drag and drop files — verify dropzone works
- [ ] Select/deselect skills and import — verify success notification
- [ ] Verify "Repository" tab still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)