### PR TITLE
Simplify safeLazy: remove retries, add canReload and SafeSuspense

### DIFF
--- a/front/components/SuspensedCodeEditor.tsx
+++ b/front/components/SuspensedCodeEditor.tsx
@@ -1,7 +1,8 @@
-import { safeLazy } from "@dust-tt/sparkle";
+import { isNavigationLocked } from "@app/lib/navigation-lock";
+import { SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import type { TextareaCodeEditorProps } from "@uiw/react-textarea-code-editor";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { Suspense } from "react";
+import React from "react";
 
 function CodeEditorFallback() {
   return (
@@ -9,16 +10,18 @@ function CodeEditorFallback() {
   );
 }
 
-const CodeEditor = safeLazy(() =>
-  import("@uiw/react-textarea-code-editor").then((mod) => ({
-    default: mod.default,
-  }))
+const CodeEditor = safeLazy(
+  () =>
+    import("@uiw/react-textarea-code-editor").then((mod) => ({
+      default: mod.default,
+    })),
+  { canReload: () => !isNavigationLocked() }
 );
 
 export function SuspensedCodeEditor(props: TextareaCodeEditorProps) {
   return (
-    <Suspense fallback={<CodeEditorFallback />}>
+    <SafeSuspense fallback={<CodeEditorFallback />}>
       <CodeEditor {...props} />
-    </Suspense>
+    </SafeSuspense>
   );
 }

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -1,22 +1,25 @@
 import { FeedbacksSection } from "@app/components/agent_builder/FeedbacksSection";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { TabContentChildSectionLayout } from "@app/components/agent_builder/observability/TabContentChildSectionLayout";
+import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { useAgentAnalytics } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   HandThumbDownIcon,
   HandThumbUpIcon,
+  SafeSuspense,
   safeLazy,
   ValueCard,
 } from "@dust-tt/sparkle";
-import { Suspense } from "react";
 
-const FeedbackDistributionChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/FeedbackDistributionChart"
-  ).then((mod) => ({
-    default: mod.FeedbackDistributionChart,
-  }))
+const FeedbackDistributionChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/FeedbackDistributionChart"
+    ).then((mod) => ({
+      default: mod.FeedbackDistributionChart,
+    })),
+  { canReload: () => !isNavigationLocked() }
 );
 
 function ChartFallback() {
@@ -76,13 +79,13 @@ export function AgentFeedback({
       </TabContentChildSectionLayout>
 
       <TabContentChildSectionLayout title="Charts">
-        <Suspense fallback={<ChartFallback />}>
+        <SafeSuspense fallback={<ChartFallback />}>
           <FeedbackDistributionChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={allowReactions}
           />
-        </Suspense>
+        </SafeSuspense>
       </TabContentChildSectionLayout>
 
       {allowReactions && (

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -1,5 +1,6 @@
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { TabContentChildSectionLayout } from "@app/components/agent_builder/observability/TabContentChildSectionLayout";
+import { isNavigationLocked } from "@app/lib/navigation-lock";
 import {
   useAgentAnalytics,
   useAgentObservabilitySummary,
@@ -10,62 +11,78 @@ import {
   CardGrid,
   ContentMessage,
   LoadingBlock,
+  SafeSuspense,
   Spinner,
   safeLazy,
   ValueCard,
 } from "@dust-tt/sparkle";
-import { Suspense } from "react";
 
 // Dynamic imports for chart components to exclude recharts from server bundle
 
-const DatasourceRetrievalTreemapChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart"
-  ).then((mod) => ({
-    default: mod.DatasourceRetrievalTreemapChart,
-  }))
+const canReload = () => !isNavigationLocked();
+
+const DatasourceRetrievalTreemapChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart"
+    ).then((mod) => ({
+      default: mod.DatasourceRetrievalTreemapChart,
+    })),
+  { canReload }
 );
-const LatencyChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/LatencyChart"
-  ).then((mod) => ({
-    default: mod.LatencyChart,
-  }))
+const LatencyChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/LatencyChart"
+    ).then((mod) => ({
+      default: mod.LatencyChart,
+    })),
+  { canReload }
 );
-const SourceChart = safeLazy(() =>
-  import("@app/components/agent_builder/observability/charts/SourceChart").then(
-    (mod) => ({
+const SourceChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/SourceChart"
+    ).then((mod) => ({
       default: mod.SourceChart,
-    })
-  )
+    })),
+  { canReload }
 );
-const SkillUsageChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/SkillUsageChart"
-  ).then((mod) => ({
-    default: mod.SkillUsageChart,
-  }))
+const SkillUsageChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/SkillUsageChart"
+    ).then((mod) => ({
+      default: mod.SkillUsageChart,
+    })),
+  { canReload }
 );
-const ToolUsageChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/ToolUsageChart"
-  ).then((mod) => ({
-    default: mod.ToolUsageChart,
-  }))
+const ToolUsageChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/ToolUsageChart"
+    ).then((mod) => ({
+      default: mod.ToolUsageChart,
+    })),
+  { canReload }
 );
-const ToolExecutionTimeChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/ToolExecutionTimeChart"
-  ).then((mod) => ({
-    default: mod.ToolExecutionTimeChart,
-  }))
+const ToolExecutionTimeChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/ToolExecutionTimeChart"
+    ).then((mod) => ({
+      default: mod.ToolExecutionTimeChart,
+    })),
+  { canReload }
 );
-const UsageMetricsChart = safeLazy(() =>
-  import(
-    "@app/components/agent_builder/observability/charts/UsageMetricsChart"
-  ).then((mod) => ({
-    default: mod.UsageMetricsChart,
-  }))
+const UsageMetricsChart = safeLazy(
+  () =>
+    import(
+      "@app/components/agent_builder/observability/charts/UsageMetricsChart"
+    ).then((mod) => ({
+      default: mod.UsageMetricsChart,
+    })),
+  { canReload }
 );
 
 function ChartFallback() {
@@ -204,55 +221,55 @@ export function AgentObservability({
       </TabContentChildSectionLayout>
 
       <TabContentChildSectionLayout title="Details">
-        <Suspense fallback={<ChartFallback />}>
+        <SafeSuspense fallback={<ChartFallback />}>
           <UsageMetricsChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
-        <Suspense fallback={<ChartFallback />}>
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
           <SourceChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
-        <Suspense fallback={<ChartFallback />}>
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
           <LatencyChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
-        <Suspense fallback={<ChartFallback />}>
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
           <DatasourceRetrievalTreemapChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
-        <Suspense fallback={<ChartFallback />}>
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
           <ToolUsageChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
-        <Suspense fallback={<ChartFallback />}>
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
           <SkillUsageChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
-        <Suspense fallback={<ChartFallback />}>
+        </SafeSuspense>
+        <SafeSuspense fallback={<ChartFallback />}>
           <ToolExecutionTimeChart
             workspaceId={owner.sId}
             agentConfigurationId={agentConfigurationId}
             isCustomAgent={isCustomAgent}
           />
-        </Suspense>
+        </SafeSuspense>
       </TabContentChildSectionLayout>
     </div>
   );

--- a/sparkle/src/lib/SafeSuspense.tsx
+++ b/sparkle/src/lib/SafeSuspense.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import * as React from "react";
+import { Suspense } from "react";
+
+import { ChunkLoadError } from "./safeLazy";
+
+interface SafeSuspenseProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+interface ChunkLoadErrorBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+interface ChunkLoadErrorBoundaryState {
+  hasChunkError: boolean;
+}
+
+/**
+ * Error boundary that only catches ChunkLoadError (thrown by safeLazy).
+ * All other errors are re-thrown to be handled by a parent error boundary.
+ */
+class ChunkLoadErrorBoundary extends React.Component<
+  ChunkLoadErrorBoundaryProps,
+  ChunkLoadErrorBoundaryState
+> {
+  constructor(props: ChunkLoadErrorBoundaryProps) {
+    super(props);
+    this.state = { hasChunkError: false };
+  }
+
+  static getDerivedStateFromError(
+    error: Error
+  ): ChunkLoadErrorBoundaryState | null {
+    if (error instanceof ChunkLoadError) {
+      return { hasChunkError: true };
+    }
+    return null;
+  }
+
+  componentDidCatch(error: Error) {
+    if (!(error instanceof ChunkLoadError)) {
+      throw error;
+    }
+  }
+
+  render() {
+    if (this.state.hasChunkError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * Combines Suspense + ErrorBoundary for lazy-loaded components.
+ *
+ * On loading: renders the fallback.
+ * On ChunkLoadError (e.g. chunk load failure while navigation is locked):
+ *   renders the same fallback with a "failed to load" message overlay.
+ * Other errors are not caught and propagate to parent error boundaries.
+ */
+export function SafeSuspense({ children, fallback }: SafeSuspenseProps) {
+  return (
+    <ChunkLoadErrorBoundary
+      fallback={
+        <div className="s-relative">
+          {fallback}
+          <div className="s-absolute s-inset-0 s-flex s-items-center s-justify-center">
+            <p className="s-text-sm s-text-muted-foreground">
+              Failed to load. Please reload the page.
+            </p>
+          </div>
+        </div>
+      }
+    >
+      <Suspense fallback={fallback}>{children}</Suspense>
+    </ChunkLoadErrorBoundary>
+  );
+}

--- a/sparkle/src/lib/index.ts
+++ b/sparkle/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * as avatarUtils from "./avatar/utils";
 export * from "./reportToDatadog";
+export * from "./SafeSuspense";
 export * from "./safeLazy";
 export * from "./utils";

--- a/sparkle/src/lib/safeLazy.ts
+++ b/sparkle/src/lib/safeLazy.ts
@@ -5,6 +5,13 @@ import { reportToDatadog } from "./reportToDatadog";
 export const FORCE_RELOAD_SESSION_KEY = "force_reload_at";
 export const FORCE_RELOAD_INTERVAL_MS = 10_000;
 
+export class ChunkLoadError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
+    this.name = "ChunkLoadError";
+  }
+}
+
 /**
  * Try to extract the chunk URL from the dynamic import error message.
  * Vite typically produces messages like:
@@ -16,19 +23,42 @@ function extractChunkUrl(error: unknown): string | null {
   return match ? match[0] : null;
 }
 
+interface ProbeResult {
+  summary: string;
+  /** True when the chunk is definitively gone (404, or served as wrong content type). */
+  chunkGone: boolean;
+}
+
 /**
- * Probe the chunk URL to gather diagnostic info for error reporting.
- * Returns a short summary string (never throws).
+ * Probe the chunk URL to gather diagnostic info and determine failure type.
+ * A chunk is considered gone when:
+ * - It returns 404 (Workers / standard static servers)
+ * - It returns 200 but with non-JS content type (e.g. HTML from SPA fallback)
+ * Never throws.
  */
-async function probeChunk(url: string): Promise<string> {
+async function probeChunk(url: string): Promise<ProbeResult> {
   try {
     const res = await fetch(url, { method: "HEAD", cache: "no-store" });
     const ct = res.headers.get("content-type") ?? "unknown";
     const cfRay = res.headers.get("cf-ray") ?? "none";
-    return `probe: status=${res.status}, content-type=${ct}, cf-ray=${cfRay}`;
+    const isJs = ct.includes("javascript");
+    return {
+      summary: `probe: status=${res.status}, content-type=${ct}, cf-ray=${cfRay}`,
+      chunkGone: res.status === 404 || (res.ok && !isJs),
+    };
   } catch (probeError) {
-    return `probe: network error (${probeError instanceof Error ? probeError.message : String(probeError)})`;
+    return {
+      summary: `probe: network error (${probeError instanceof Error ? probeError.message : String(probeError)})`,
+      chunkGone: false,
+    };
   }
+}
+
+const RETRY_DELAY_MS = 1_500;
+const MAX_RETRIES = 2;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -40,21 +70,17 @@ async function probeChunk(url: string): Promise<string> {
  *
  * To avoid infinite reload loops, reuses the same "force_reload_at" sessionStorage
  * key as the SWR reload guard and skips the reload if one happened within the last
- * 60 seconds.
+ * 10 seconds.
  */
-const RETRY_DELAY_MS = 1_500;
-const MAX_RETRIES = 2;
 
-/**
- * Wait for a given number of milliseconds.
- */
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+interface SafeLazyOptions {
+  canReload?: () => boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function safeLazy<T extends ComponentType<any>>(
-  factory: () => Promise<{ default: T }>
+  factory: () => Promise<{ default: T }>,
+  options?: SafeLazyOptions
 ) {
   return lazy(async () => {
     // In Next.js (detected via __NEXT_DATA__), let the framework handle errors.
@@ -62,7 +88,6 @@ export function safeLazy<T extends ComponentType<any>>(
 
     let lastError: unknown;
 
-    // Attempt the import with retries before resorting to a full page reload.
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
         return await factory();
@@ -73,23 +98,51 @@ export function safeLazy<T extends ComponentType<any>>(
           throw error;
         }
 
+        // Probe the chunk to determine if it's a 404 (chunk gone after deploy)
+        // or a transient error (network hiccup) worth retrying.
+        const chunkUrl = extractChunkUrl(error);
+        const probe = chunkUrl
+          ? await probeChunk(chunkUrl)
+          : {
+              summary: `unknown error: ${error instanceof Error ? error.message : String(error)}`,
+              chunkGone: false,
+            };
+
+        // 404 = chunk is gone (new deploy), no point retrying.
+        if (probe.chunkGone) {
+          break;
+        }
+
+        // Transient error: retry after a delay.
         if (attempt < MAX_RETRIES) {
           reportToDatadog(error, {
             source: "safeLazy",
             event: "retry",
             attempt: attempt + 1,
-            maxAttempts: MAX_RETRIES + 1,
+            probe: probe.summary,
           });
           await delay(RETRY_DELAY_MS);
         }
       }
     }
 
-    // All retries exhausted — enrich the error with diagnostic information.
+    // All retries exhausted or chunk is gone — build diagnostic.
     const chunkUrl = extractChunkUrl(lastError);
-    const probeInfo = chunkUrl ? await probeChunk(chunkUrl) : "no URL found";
+    const probe = chunkUrl
+      ? await probeChunk(chunkUrl)
+      : { summary: "no URL found", chunkGone: false };
     const online = navigator.onLine ? "online" : "offline";
-    const diagnostic = `[safeLazy] ${lastError instanceof Error ? lastError.message : String(lastError)} | ${probeInfo} | navigator=${online}`;
+    const diagnostic = `[safeLazy] ${lastError instanceof Error ? lastError.message : String(lastError)} | ${probe.summary} | navigator=${online}`;
+
+    // If the caller prevents reload (e.g. unsaved work), throw immediately.
+    if (options?.canReload && !options.canReload()) {
+      reportToDatadog(lastError, {
+        source: "safeLazy",
+        event: "reload_blocked",
+        diagnostic,
+      });
+      throw new ChunkLoadError(diagnostic, lastError);
+    }
 
     // Guard against continuous reload loops.
     const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
@@ -99,10 +152,15 @@ export function safeLazy<T extends ComponentType<any>>(
       !Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS;
 
     if (!shouldReload) {
-      throw new Error(diagnostic, { cause: lastError });
+      reportToDatadog(lastError, {
+        source: "safeLazy",
+        event: "reload_skipped",
+        diagnostic,
+      });
+      throw new ChunkLoadError(diagnostic, lastError);
     }
 
-    // In SPA (Vite), reload to fetch fresh assets.
+    // Reload to fetch fresh assets after a deploy.
     reportToDatadog(lastError, {
       source: "safeLazy",
       event: "reload",


### PR DESCRIPTION
## Summary

Simplifies `safeLazy` chunk error handling now that we're on Cloudflare Workers (proper 404s for missing assets), and adds safety mechanisms for navigation-locked contexts.

- **Smart retry logic**: Probe the failed chunk URL to determine failure type. If the chunk is gone (404 or non-JS content type from SPA fallback), skip retries and go straight to reload. Only retry on transient errors (network hiccups, timeouts).
- **`canReload` option**: Callers can pass a callback (e.g. `() => !isNavigationLocked()`) to prevent auto-reload when the user has unsaved work. Throws `ChunkLoadError` instead.
- **`ChunkLoadError` class**: Specific error type so error boundaries can distinguish chunk failures from other errors.
- **`SafeSuspense` component** (sparkle): Combines `Suspense` + `ChunkLoadErrorBoundary` that only catches `ChunkLoadError`. Shows the loading fallback with a "Failed to load" message overlay. Other errors propagate normally.
- **Datadog events**: `retry` (transient error, retrying), `reload_blocked` (canReload returned false), `reload_skipped` (loop guard), `reload` (reloading page).

## Changes

- **`sparkle/src/lib/safeLazy.ts`**: Add `ChunkLoadError`, `canReload` option, smart probe-based retry (skip on 404/wrong content-type, retry on transient), Datadog events
- **`sparkle/src/lib/SafeSuspense.tsx`** (new): `SafeSuspense` with `ChunkLoadErrorBoundary`
- **`sparkle/src/lib/index.ts`**: Export `SafeSuspense`
- **`front/components/SuspensedCodeEditor.tsx`**: Use `SafeSuspense`, pass `canReload`
- **`front/components/observability/AgentObservability.tsx`**: Same for all 7 chart lazy imports
- **`front/components/observability/AgentFeedback.tsx`**: Same for FeedbackDistributionChart

## Test plan

- [x] Lazy-loaded components still load normally (charts, code editor)
- [x] Block asset in devtools → page reloads (no retries for 404)
- [ ] Throttle network to simulate transient failure → retries succeed
- [x] Chunk failure with navigation lock active → shows "Failed to load" fallback, no reload
- [ ] Non-chunk errors propagate to parent error boundaries (not caught by SafeSuspense)

🤖 Generated with [Claude Code](https://claude.com/claude-code)