### PR TITLE
Remove gzip compression on GCS file uploads for gcsfuse compatibility

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -714,7 +714,6 @@ export class FileResource extends BaseResource<FileModel> {
       .file(this.getCloudStoragePath(auth, version))
       .createWriteStream({
         resumable: false,
-        gzip: true,
         contentType: overrideContentType ?? this.contentType,
       });
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We mount GCS file paths into sandboxes via `gcsfuse`. Files were uploaded with `gzip: true`, which sets `Content-Encoding: gzip` on the GCS object.

When reading through the GCS API (e.g. `createReadStream`, `download`), Google transparently decompresses, so the app never noticed. But `gcsfuse` serves raw stored bytes without decompression (confirmed limitation), meaning sandboxes saw gzipped content instead of the actual file.

Why removing gzip is safe:
- The storage/bandwidth savings from gzip are negligible for our file sizes (user uploads: CSVs, images, text files)
- The only use case where gzip savings could matter is upsert queue files, but these are not a valid use of the file system and will be moved outside of `FileResource` in the near future
- Existing gzipped files continue to work fine through the API (transparent decompression on read)
- New files are stored uncompressed and work correctly with both the API and `gcsfuse`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Will monitor the GCS failures rate. It's safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
