### PR TITLE
Revalidate file panel data on conversation events

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -42,6 +42,9 @@ import {
   useCancelMessage,
   usePostOnboardingFollowUp,
 } from "@app/hooks/conversations";
+import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
+import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
 import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -189,6 +192,22 @@ export function AgentMessage({
   const { enqueueBlockedAction, removeAllBlockedActionsForMessage } =
     useBlockedActionsContext();
 
+  const { mutateConversationAttachments } = useConversationAttachments({
+    conversationId,
+    owner,
+    options: { disabled: true },
+  });
+  const { mutateSandboxStatus } = useConversationSandboxStatus({
+    conversationId,
+    owner,
+    options: { disabled: true },
+  });
+  const { mutateSandboxFiles } = useConversationSandboxFiles({
+    conversationId,
+    owner,
+    options: { disabled: true },
+  });
+
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
     VirtuosoMessageListContext
@@ -294,6 +313,11 @@ export function AgentMessage({
             const action = eventPayload.data.action;
             if (action.generatedFiles.length > 0) {
               window.dispatchEvent(new ConversationAttachmentsUpdatedEvent());
+              void mutateConversationAttachments();
+            }
+            if (action.internalMCPServerName === "sandbox") {
+              void mutateSandboxStatus();
+              void mutateSandboxFiles();
             }
             break;
           }
@@ -313,6 +337,9 @@ export function AgentMessage({
         sId,
         removeAllBlockedActionsForMessage,
         conversationId,
+        mutateConversationAttachments,
+        mutateSandboxStatus,
+        mutateSandboxFiles,
       ]
     ),
     streamId: `message-${sId}`,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -22,6 +22,9 @@ import {
   useConversationParticipants,
   useConversations,
 } from "@app/hooks/conversations";
+import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
+import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useConversationEvents } from "@app/hooks/useConversationEvents";
 import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotification";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -131,6 +134,22 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const sendNotification = useSendNotification();
+
+  const { mutateConversationAttachments } = useConversationAttachments({
+    conversationId,
+    owner,
+    options: { disabled: true },
+  });
+  const { mutateSandboxStatus } = useConversationSandboxStatus({
+    conversationId,
+    owner,
+    options: { disabled: true },
+  });
+  const { mutateSandboxFiles } = useConversationSandboxFiles({
+    conversationId,
+    owner,
+    options: { disabled: true },
+  });
 
   const {
     conversation,
@@ -456,6 +475,7 @@ export const ConversationViewer = ({
 
               if (userMessage.contentFragments.length > 0) {
                 window.dispatchEvent(new ConversationAttachmentsUpdatedEvent());
+                void mutateConversationAttachments();
               }
             }
             break;
@@ -538,6 +558,9 @@ export const ConversationViewer = ({
             );
 
             window.dispatchEvent(new AgentMessageCompletedEvent());
+            void mutateConversationAttachments();
+            void mutateSandboxStatus();
+            void mutateSandboxFiles();
             break;
           case "butler_thinking":
             setIsButlerThinking(true);
@@ -566,9 +589,12 @@ export const ConversationViewer = ({
       conversationId,
       debouncedMarkAsRead,
       mutateConversation,
+      mutateConversationAttachments,
       mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
+      mutateSandboxFiles,
+      mutateSandboxStatus,
       user.sId,
     ]
   );

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -19,15 +19,15 @@ export function useConversationSandboxFiles({
   const sandboxFilesFetcher: Fetcher<GetConversationSandboxFilesResponseBody> =
     fetcher;
 
-  const disabled = options?.disabled;
-
   const { data, error, mutate } = useSWRWithDefaults(
-    conversationId && !disabled
+    conversationId
       ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/sandbox/files`
       : null,
     sandboxFilesFetcher,
     options
   );
+
+  const disabled = options?.disabled;
 
   return {
     sandboxFiles: data?.files ?? emptyArray<SandboxFileEntry>(),

--- a/front/hooks/conversations/useConversationSandboxStatus.ts
+++ b/front/hooks/conversations/useConversationSandboxStatus.ts
@@ -15,15 +15,15 @@ export function useConversationSandboxStatus({
   const { fetcher } = useFetcher();
   const sandboxFetcher: Fetcher<GetConversationSandboxResponseBody> = fetcher;
 
-  const disabled = options?.disabled;
-
   const { data, error, mutate } = useSWRWithDefaults(
-    conversationId && !disabled
+    conversationId
       ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/sandbox`
       : null,
     sandboxFetcher,
     options
   );
+
+  const disabled = options?.disabled;
 
   return {
     sandboxStatus: data?.sandboxStatus ?? null,


### PR DESCRIPTION
## Description

Revalidates attachments, sandbox status, and sandbox files in the file panel when conversation data changes, without requiring a page refresh or tab focus.

Instead of listening to custom DOM events (AgentMessageCompletedEvent, ConversationAttachmentsUpdatedEvent) and calling mutate() from consumer components, we call SWR  mutate directly from the SSE event handlers that already know when data changes. AgentMessage revalidates sandbox status and files on agent_action_success when the sandbox tool is used, and attachments when any action generates files. ConversationViewer revalidates attachments on user_message_new (content fragments) and agent_message_done. The hooks are imported with disabled: true so they don't fetch, only provide the mutate function.

Also fixes a bug in the sandbox SWR hooks where disabled: true was checked in the key condition before useSWRWithDefaults, nulling the key and making mutate() a no-op. The key is now always passed through and useSWRWithDefaults handles the disabled logic internally, consistent with every other hook in the codebase.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 