### PR TITLE
[front] fix: include files in skill import from GitHub

### DIFF
--- a/front/lib/api/files/use_cases/skill_attachment.ts
+++ b/front/lib/api/files/use_cases/skill_attachment.ts
@@ -66,14 +66,10 @@ const SKILL_ATTACHMENT_CONTENT_TYPES = [
 export type SkillAttachmentContentType =
   (typeof SKILL_ATTACHMENT_CONTENT_TYPES)[number];
 
-const SUPPORTED_CONTENT_TYPES = new Set<SkillAttachmentContentType>(
-  SKILL_ATTACHMENT_CONTENT_TYPES
-);
-
 export function isSupportedForSkillAttachment(
   contentType: AllSupportedFileContentType
 ): contentType is SkillAttachmentContentType {
-  return SUPPORTED_CONTENT_TYPES.has(contentType as SkillAttachmentContentType);
+  return SKILL_ATTACHMENT_CONTENT_TYPES.some((ct) => ct === contentType);
 }
 
 export function getSkillAttachmentContentType(

--- a/front/lib/api/files/use_cases/skill_attachment.ts
+++ b/front/lib/api/files/use_cases/skill_attachment.ts
@@ -1,6 +1,9 @@
+import type { FileEntry } from "@app/lib/api/skills/detection/types";
 import type { AllSupportedFileContentType } from "@app/types/files";
+import { FILE_FORMATS, isSupportedFileContentType } from "@app/types/files";
+import path from "path";
 
-const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
+const SKILL_ATTACHMENT_CONTENT_TYPES = [
   // Images (used as-is, no resize for skill attachments).
   "image/jpeg",
   "image/png",
@@ -58,10 +61,37 @@ const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
   "text/x-perl",
   "text/x-perl-script",
   "message/rfc822",
-]);
+] as const satisfies readonly AllSupportedFileContentType[];
+
+export type SkillAttachmentContentType =
+  (typeof SKILL_ATTACHMENT_CONTENT_TYPES)[number];
+
+const SUPPORTED_CONTENT_TYPES = new Set<SkillAttachmentContentType>(
+  SKILL_ATTACHMENT_CONTENT_TYPES
+);
 
 export function isSupportedForSkillAttachment(
   contentType: AllSupportedFileContentType
-): boolean {
-  return SUPPORTED_CONTENT_TYPES.has(contentType);
+): contentType is SkillAttachmentContentType {
+  return SUPPORTED_CONTENT_TYPES.has(contentType as SkillAttachmentContentType);
+}
+
+export function getSkillAttachmentContentType(
+  entry: FileEntry
+): SkillAttachmentContentType | null {
+  const ext = path.extname(entry.path).toLowerCase();
+  if (!ext) {
+    return null;
+  }
+  for (const [key, format] of Object.entries(FILE_FORMATS)) {
+    if (
+      format.exts.some((e) => e === ext) &&
+      // Type guards to validate the type of key (lost because of the Object.entries).
+      isSupportedFileContentType(key) &&
+      isSupportedForSkillAttachment(key)
+    ) {
+      return key;
+    }
+  }
+  return null;
 }

--- a/front/lib/api/files/use_cases/skill_attachment.ts
+++ b/front/lib/api/files/use_cases/skill_attachment.ts
@@ -1,6 +1,6 @@
 import type { FileEntry } from "@app/lib/api/skills/detection/types";
 import type { AllSupportedFileContentType } from "@app/types/files";
-import { FILE_FORMATS, isSupportedFileContentType } from "@app/types/files";
+import { FILE_FORMATS } from "@app/types/files";
 import path from "path";
 
 const SKILL_ATTACHMENT_CONTENT_TYPES = [
@@ -79,14 +79,9 @@ export function getSkillAttachmentContentType(
   if (!ext) {
     return null;
   }
-  for (const [key, format] of Object.entries(FILE_FORMATS)) {
-    if (
-      format.exts.some((e) => e === ext) &&
-      // Type guards to validate the type of key (lost because of the Object.entries).
-      isSupportedFileContentType(key) &&
-      isSupportedForSkillAttachment(key)
-    ) {
-      return key;
+  for (const contentType of SKILL_ATTACHMENT_CONTENT_TYPES) {
+    if (FILE_FORMATS[contentType].exts.some((e) => ext === e)) {
+      return contentType;
     }
   }
   return null;

--- a/front/lib/api/skills/detection/github/detect_skills.ts
+++ b/front/lib/api/skills/detection/github/detect_skills.ts
@@ -1,5 +1,10 @@
-import { findGitHubSkillDirectories } from "@app/lib/api/skills/detection/github/parsing";
+import {
+  collectGitHubAttachments,
+  findGitHubSkillDirectories,
+} from "@app/lib/api/skills/detection/github/parsing";
 import type {
+  GitHubDetectedSkill,
+  GitHubFileEntry,
   GitHubSkillDetectionError,
   GitHubSkillDirectory,
   GitHubTreeEntry,
@@ -8,14 +13,7 @@ import {
   GitHubBlobResponseSchema,
   GitHubTreeResponseSchema,
 } from "@app/lib/api/skills/detection/github/types";
-import {
-  collectAttachments,
-  parseSkillMarkdown,
-} from "@app/lib/api/skills/detection/parsing";
-import type {
-  DetectedSkill,
-  FileEntry,
-} from "@app/lib/api/skills/detection/types";
+import { parseSkillMarkdown } from "@app/lib/api/skills/detection/parsing";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { parseGitHubRepoUrl } from "@app/lib/skill_detection";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -86,9 +84,9 @@ async function fetchRepoTree(
 }
 
 /**
- * Fetches a blob's content from GitHub and returns it as a UTF-8 string.
+ * Fetches a blob's raw base64 content from GitHub.
  */
-async function fetchBlobContent(
+export async function fetchBlobContent(
   octokit: InstanceType<typeof Octokit>,
   {
     owner,
@@ -122,7 +120,7 @@ async function fetchBlobContent(
     });
   }
 
-  return new Ok(Buffer.from(parsed.data.content, "base64").toString("utf-8"));
+  return new Ok(parsed.data.content);
 }
 
 /**
@@ -160,7 +158,7 @@ export async function detectSkillsFromGitHubRepo({
   octokit: InstanceType<typeof Octokit>;
   owner: string;
   repo: string;
-}): Promise<Result<DetectedSkill[], GitHubSkillDetectionError>> {
+}): Promise<Result<GitHubDetectedSkill[], GitHubSkillDetectionError>> {
   const treeResult = await fetchRepoTree(octokit, { owner, repo });
   if (treeResult.isErr()) {
     return treeResult;
@@ -172,21 +170,27 @@ export async function detectSkillsFromGitHubRepo({
     return new Ok([]);
   }
 
-  const skills = await concurrentExecutor(
+  const results = await concurrentExecutor(
     skillDirs,
     async (skillDir) =>
-      buildDetectedSkill({ octokit, owner, repo, skillDir, fileEntries }),
+      buildDetectedSkill({
+        octokit,
+        owner,
+        repo,
+        skillDir,
+        fileEntries,
+      }),
     { concurrency: FETCH_CONCURRENCY }
   );
 
-  const detectedSkills: DetectedSkill[] = [];
-  for (const result of skills) {
+  const skills: GitHubDetectedSkill[] = [];
+  for (const result of results) {
     if (result.isOk()) {
-      detectedSkills.push(result.value);
+      skills.push(result.value);
     }
   }
 
-  return new Ok(detectedSkills.filter((s) => s.name.length > 0));
+  return new Ok(skills.filter((s) => s.name.length > 0));
 }
 
 async function buildDetectedSkill({
@@ -200,8 +204,8 @@ async function buildDetectedSkill({
   owner: string;
   repo: string;
   skillDir: GitHubSkillDirectory;
-  fileEntries: FileEntry[];
-}): Promise<Result<DetectedSkill, GitHubSkillDetectionError>> {
+  fileEntries: GitHubFileEntry[];
+}): Promise<Result<GitHubDetectedSkill, GitHubSkillDetectionError>> {
   const blobResult = await fetchBlobContent(octokit, {
     owner,
     repo,
@@ -219,14 +223,16 @@ async function buildDetectedSkill({
     );
     return blobResult;
   }
-  const parsed = parseSkillMarkdown(blobResult.value);
+  const parsed = parseSkillMarkdown(
+    Buffer.from(blobResult.value, "base64").toString("utf-8")
+  );
 
   return new Ok({
     name: parsed.name,
     skillMdPath: skillDir.skillMdPath,
     description: parsed.description,
     instructions: parsed.instructions,
-    attachments: collectAttachments(fileEntries, skillDir),
+    attachments: collectGitHubAttachments(fileEntries, skillDir),
   });
 }
 

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -81,10 +81,17 @@ export async function importSkillsFromGitHub(
         return;
       }
 
+      const skillDirPath = path.dirname(skill.skillMdPath);
       const uploadResults = await concurrentExecutor(
         skill.attachments,
         (attachment) =>
-          uploadAttachment(auth, { octokit, owner, repo, attachment }),
+          uploadAttachment(auth, {
+            octokit,
+            owner,
+            repo,
+            attachment,
+            skillDirPath,
+          }),
         { concurrency: IMPORT_CONCURRENCY }
       );
 
@@ -167,11 +174,13 @@ async function uploadAttachment(
     owner,
     repo,
     attachment,
+    skillDirPath,
   }: {
     octokit: InstanceType<typeof Octokit>;
     owner: string;
     repo: string;
     attachment: GitHubDetectedSkillAttachment;
+    skillDirPath: string;
   }
 ): Promise<FileResource | null> {
   const blobResult = await fetchBlobContent(octokit, {
@@ -187,7 +196,7 @@ async function uploadAttachment(
     return null;
   }
 
-  const fileName = path.basename(attachment.path);
+  const fileName = path.relative(skillDirPath, attachment.path);
 
   const uploadResult = await uploadBase64DataToFileStorage(auth, {
     base64: blobResult.value,

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -1,17 +1,25 @@
+import { uploadBase64DataToFileStorage } from "@app/lib/api/files/upload";
 import {
   detectSkillsFromGitHubRepo,
+  fetchBlobContent,
   initGitHubRepoClient,
   isSkillFromGitHubRepo,
 } from "@app/lib/api/skills/detection/github/detect_skills";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
-import type { GitHubSkillDetectionError } from "@app/lib/api/skills/detection/github/types";
+import type {
+  GitHubDetectedSkill,
+  GitHubDetectedSkillAttachment,
+  GitHubSkillDetectionError,
+} from "@app/lib/api/skills/detection/github/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import type { Octokit } from "@octokit/core";
 
 const IMPORT_CONCURRENCY = 4;
 
@@ -73,6 +81,13 @@ export async function importSkillsFromGitHub(
         return;
       }
 
+      const fileAttachments = await fetchSkillFileAttachments(auth, {
+        octokit,
+        owner,
+        repo,
+        skill,
+      });
+
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
 
@@ -85,6 +100,7 @@ export async function importSkillsFromGitHub(
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
+          fileAttachments,
           source: "github",
           sourceMetadata: {
             repoUrl,
@@ -128,7 +144,7 @@ export async function importSkillsFromGitHub(
             },
             isDefault: false,
           },
-          { mcpServerViews: [] }
+          { mcpServerViews: [], fileAttachments }
         );
 
         imported.push(skillResource);
@@ -138,4 +154,93 @@ export async function importSkillsFromGitHub(
   );
 
   return new Ok({ imported, updated, errors });
+}
+
+async function fetchSkillFileAttachments(
+  auth: Authenticator,
+  {
+    octokit,
+    owner,
+    repo,
+    skill,
+  }: {
+    octokit: InstanceType<typeof Octokit>;
+    owner: string;
+    repo: string;
+    skill: GitHubDetectedSkill;
+  }
+): Promise<FileResource[]> {
+  const uploadableAttachments = skill.attachments.filter((a) => {
+    if (!a.contentType) {
+      logger.info(
+        { path: a.path, skillName: skill.name },
+        "Skipping unsupported attachment during GitHub skill import."
+      );
+      return false;
+    }
+    return true;
+  });
+
+  if (uploadableAttachments.length === 0) {
+    return [];
+  }
+
+  const results = await concurrentExecutor(
+    uploadableAttachments,
+    (attachment) =>
+      uploadAttachment(auth, { octokit, owner, repo, attachment }),
+    { concurrency: IMPORT_CONCURRENCY }
+  );
+
+  return results.filter((r): r is FileResource => r !== null);
+}
+
+async function uploadAttachment(
+  auth: Authenticator,
+  {
+    octokit,
+    owner,
+    repo,
+    attachment,
+  }: {
+    octokit: InstanceType<typeof Octokit>;
+    owner: string;
+    repo: string;
+    attachment: GitHubDetectedSkillAttachment;
+  }
+): Promise<FileResource | null> {
+  if (!attachment.contentType) {
+    return null;
+  }
+
+  const blobResult = await fetchBlobContent(octokit, {
+    owner,
+    repo,
+    fileSha: attachment.sha,
+  });
+  if (blobResult.isErr()) {
+    logger.error(
+      { error: blobResult.error, path: attachment.path, owner, repo },
+      "Failed to fetch attachment blob from GitHub."
+    );
+    return null;
+  }
+
+  const fileName = attachment.path.split("/").pop() ?? attachment.path;
+
+  const uploadResult = await uploadBase64DataToFileStorage(auth, {
+    base64: blobResult.value,
+    contentType: attachment.contentType,
+    fileName,
+    useCase: "skill_attachment",
+  });
+  if (uploadResult.isErr()) {
+    logger.error(
+      { error: uploadResult.error, path: attachment.path },
+      "Failed to upload attachment to file storage."
+    );
+    return null;
+  }
+
+  return uploadResult.value;
 }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -23,11 +23,11 @@ import path from "path";
 
 const IMPORT_CONCURRENCY = 4;
 
-export interface ImportSkillsResult {
+type ImportSkillsResult = {
   imported: SkillResource[];
   updated: SkillResource[];
   errors: { name: string; message: string }[];
-}
+};
 
 /**
  * Imports skills from a GitHub repository. Detects skills, fetches their

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -19,6 +19,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { Octokit } from "@octokit/core";
+import path from "path";
 
 const IMPORT_CONCURRENCY = 4;
 
@@ -186,7 +187,7 @@ async function uploadAttachment(
     return null;
   }
 
-  const fileName = attachment.path.split("/").pop() ?? attachment.path;
+  const fileName = path.basename(attachment.path);
 
   const uploadResult = await uploadBase64DataToFileStorage(auth, {
     base64: blobResult.value,

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -12,7 +12,7 @@ import type {
 } from "@app/lib/api/skills/detection/github/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -119,6 +119,10 @@ export async function importSkillsFromGitHub(
           },
         });
 
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: existing.sId,
+        });
+
         updated.push(existing);
       } else {
         let icon: string | null = null;
@@ -157,6 +161,10 @@ export async function importSkillsFromGitHub(
           },
           { mcpServerViews: [], fileAttachments }
         );
+
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: skillResource.sId,
+        });
 
         imported.push(skillResource);
       }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -7,7 +7,6 @@ import {
 } from "@app/lib/api/skills/detection/github/detect_skills";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
 import type {
-  GitHubDetectedSkill,
   GitHubDetectedSkillAttachment,
   GitHubSkillDetectionError,
 } from "@app/lib/api/skills/detection/github/types";
@@ -81,12 +80,16 @@ export async function importSkillsFromGitHub(
         return;
       }
 
-      const fileAttachments = await fetchSkillFileAttachments(auth, {
-        octokit,
-        owner,
-        repo,
-        skill,
-      });
+      const uploadResults = await concurrentExecutor(
+        skill.attachments,
+        (attachment) =>
+          uploadAttachment(auth, { octokit, owner, repo, attachment }),
+        { concurrency: IMPORT_CONCURRENCY }
+      );
+
+      const fileAttachments = uploadResults.filter(
+        (r): r is FileResource => r !== null
+      );
 
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
@@ -156,45 +159,6 @@ export async function importSkillsFromGitHub(
   return new Ok({ imported, updated, errors });
 }
 
-async function fetchSkillFileAttachments(
-  auth: Authenticator,
-  {
-    octokit,
-    owner,
-    repo,
-    skill,
-  }: {
-    octokit: InstanceType<typeof Octokit>;
-    owner: string;
-    repo: string;
-    skill: GitHubDetectedSkill;
-  }
-): Promise<FileResource[]> {
-  const uploadableAttachments = skill.attachments.filter((a) => {
-    if (!a.contentType) {
-      logger.info(
-        { path: a.path, skillName: skill.name },
-        "Skipping unsupported attachment during GitHub skill import."
-      );
-      return false;
-    }
-    return true;
-  });
-
-  if (uploadableAttachments.length === 0) {
-    return [];
-  }
-
-  const results = await concurrentExecutor(
-    uploadableAttachments,
-    (attachment) =>
-      uploadAttachment(auth, { octokit, owner, repo, attachment }),
-    { concurrency: IMPORT_CONCURRENCY }
-  );
-
-  return results.filter((r): r is FileResource => r !== null);
-}
-
 async function uploadAttachment(
   auth: Authenticator,
   {
@@ -209,10 +173,6 @@ async function uploadAttachment(
     attachment: GitHubDetectedSkillAttachment;
   }
 ): Promise<FileResource | null> {
-  if (!attachment.contentType) {
-    return null;
-  }
-
   const blobResult = await fetchBlobContent(octokit, {
     owner,
     repo,

--- a/front/lib/api/skills/detection/github/parsing.ts
+++ b/front/lib/api/skills/detection/github/parsing.ts
@@ -1,41 +1,69 @@
 import type {
+  GitHubDetectedSkillAttachment,
+  GitHubFileEntry,
   GitHubSkillDirectory,
   GitHubTreeEntry,
 } from "@app/lib/api/skills/detection/github/types";
 import { findSkillDirectories } from "@app/lib/api/skills/detection/parsing";
-import type { FileEntry } from "@app/lib/api/skills/detection/types";
+import type { SkillDirectory } from "@app/lib/api/skills/detection/types";
 
 /**
  * Scans a GitHub tree for directories containing skill.md or SKILL.md.
  * Enriches the shared SkillDirectory with the blob SHA for content fetching.
- * Also returns the computed fileEntries so callers don't need to rebuild them.
  */
 export function findGitHubSkillDirectories(tree: GitHubTreeEntry[]): {
   skillDirs: GitHubSkillDirectory[];
-  fileEntries: FileEntry[];
+  fileEntries: GitHubFileEntry[];
 } {
-  const shaByPath = new Map<string, string>();
-  const fileEntries: FileEntry[] = [];
+  const fileEntries: GitHubFileEntry[] = [];
   for (const entry of tree) {
     if (entry.type === "blob") {
-      shaByPath.set(entry.path, entry.sha);
       fileEntries.push({
         path: entry.path,
         isFile: true,
         sizeBytes: entry.size ?? 0,
+        sha: entry.sha,
       });
     }
   }
 
   const baseDirs = findSkillDirectories(fileEntries);
 
+  const entriesByPath = new Map(fileEntries.map((e) => [e.path, e]));
   const skillDirs: GitHubSkillDirectory[] = [];
   for (const dir of baseDirs) {
-    const sha = shaByPath.get(dir.skillMdPath);
-    if (sha) {
-      skillDirs.push({ ...dir, skillMdSha: sha });
+    const entry = entriesByPath.get(dir.skillMdPath);
+    if (entry) {
+      skillDirs.push({ ...dir, skillMdSha: entry.sha });
     }
   }
 
   return { skillDirs, fileEntries };
+}
+
+/**
+ * Collects attachment files for a skill directory, enriched with blob SHAs.
+ */
+export function collectGitHubAttachments(
+  fileEntries: GitHubFileEntry[],
+  skillDir: SkillDirectory
+): GitHubDetectedSkillAttachment[] {
+  const dirPrefix = skillDir.dirPath + "/";
+  const attachments: GitHubDetectedSkillAttachment[] = [];
+
+  for (const entry of fileEntries) {
+    if (!entry.path.startsWith(dirPrefix)) {
+      continue;
+    }
+    if (entry.path === skillDir.skillMdPath) {
+      continue;
+    }
+    attachments.push({
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
+      sha: entry.sha,
+    });
+  }
+
+  return attachments;
 }

--- a/front/lib/api/skills/detection/github/parsing.ts
+++ b/front/lib/api/skills/detection/github/parsing.ts
@@ -23,7 +23,6 @@ export function findGitHubSkillDirectories(tree: GitHubTreeEntry[]): {
     if (entry.type === "blob") {
       fileEntries.push({
         path: entry.path,
-        isFile: true,
         sizeBytes: entry.size ?? 0,
         sha: entry.sha,
       });

--- a/front/lib/api/skills/detection/github/parsing.ts
+++ b/front/lib/api/skills/detection/github/parsing.ts
@@ -4,7 +4,10 @@ import type {
   GitHubSkillDirectory,
   GitHubTreeEntry,
 } from "@app/lib/api/skills/detection/github/types";
-import { findSkillDirectories } from "@app/lib/api/skills/detection/parsing";
+import {
+  collectAttachments,
+  findSkillDirectories,
+} from "@app/lib/api/skills/detection/parsing";
 import type { SkillDirectory } from "@app/lib/api/skills/detection/types";
 
 /**
@@ -48,22 +51,13 @@ export function collectGitHubAttachments(
   fileEntries: GitHubFileEntry[],
   skillDir: SkillDirectory
 ): GitHubDetectedSkillAttachment[] {
-  const dirPrefix = skillDir.dirPath + "/";
-  const attachments: GitHubDetectedSkillAttachment[] = [];
+  const entriesByPath = new Map(fileEntries.map((e) => [e.path, e]));
 
-  for (const entry of fileEntries) {
-    if (!entry.path.startsWith(dirPrefix)) {
-      continue;
+  return collectAttachments(fileEntries, skillDir).flatMap((attachment) => {
+    const entry = entriesByPath.get(attachment.path);
+    if (!entry) {
+      return [];
     }
-    if (entry.path === skillDir.skillMdPath) {
-      continue;
-    }
-    attachments.push({
-      path: entry.path,
-      sizeBytes: entry.sizeBytes,
-      sha: entry.sha,
-    });
-  }
-
-  return attachments;
+    return [{ ...attachment, sha: entry.sha }];
+  });
 }

--- a/front/lib/api/skills/detection/github/types.ts
+++ b/front/lib/api/skills/detection/github/types.ts
@@ -12,21 +12,21 @@ export type GitHubSkillDetectionError =
   | { type: "not_found"; message: string }
   | { type: "github_api_error"; message: string };
 
-export interface GitHubFileEntry extends FileEntry {
+export type GitHubFileEntry = FileEntry & {
   sha: string;
-}
+};
 
-export interface GitHubSkillDirectory extends SkillDirectory {
+export type GitHubSkillDirectory = SkillDirectory & {
   skillMdSha: string;
-}
+};
 
-export interface GitHubDetectedSkillAttachment extends DetectedSkillAttachment {
+export type GitHubDetectedSkillAttachment = DetectedSkillAttachment & {
   sha: string;
-}
+};
 
-export interface GitHubDetectedSkill extends DetectedSkill {
+export type GitHubDetectedSkill = DetectedSkill & {
   attachments: GitHubDetectedSkillAttachment[];
-}
+};
 
 const GitHubTreeEntrySchema = z
   .object({

--- a/front/lib/api/skills/detection/github/types.ts
+++ b/front/lib/api/skills/detection/github/types.ts
@@ -1,4 +1,9 @@
-import type { SkillDirectory } from "@app/lib/api/skills/detection/types";
+import type {
+  DetectedSkill,
+  DetectedSkillAttachment,
+  FileEntry,
+  SkillDirectory,
+} from "@app/lib/api/skills/detection/types";
 import { z } from "zod";
 
 export type GitHubSkillDetectionError =
@@ -7,8 +12,20 @@ export type GitHubSkillDetectionError =
   | { type: "not_found"; message: string }
   | { type: "github_api_error"; message: string };
 
+export interface GitHubFileEntry extends FileEntry {
+  sha: string;
+}
+
 export interface GitHubSkillDirectory extends SkillDirectory {
   skillMdSha: string;
+}
+
+export interface GitHubDetectedSkillAttachment extends DetectedSkillAttachment {
+  sha: string;
+}
+
+export interface GitHubDetectedSkill extends DetectedSkill {
+  attachments: GitHubDetectedSkillAttachment[];
 }
 
 const GitHubTreeEntrySchema = z

--- a/front/lib/api/skills/detection/parsing.test.ts
+++ b/front/lib/api/skills/detection/parsing.test.ts
@@ -105,7 +105,6 @@ describe("findSkillDirectories", () => {
     const dirs = findSkillDirectories(entries);
     expect(dirs).toHaveLength(1);
   });
-
 });
 
 describe("collectAttachments", () => {

--- a/front/lib/api/skills/detection/parsing.test.ts
+++ b/front/lib/api/skills/detection/parsing.test.ts
@@ -133,8 +133,8 @@ describe("collectAttachments", () => {
     });
 
     expect(attachments).toEqual([
-      { path: "helper.py", sizeBytes: 500 },
-      { path: "data/config.json", sizeBytes: 200 },
+      { path: "skills/foo/helper.py", sizeBytes: 500 },
+      { path: "skills/foo/data/config.json", sizeBytes: 200 },
     ]);
   });
 

--- a/front/lib/api/skills/detection/parsing.test.ts
+++ b/front/lib/api/skills/detection/parsing.test.ts
@@ -124,8 +124,16 @@ describe("collectAttachments", () => {
     });
 
     expect(attachments).toEqual([
-      { path: "skills/foo/helper.py", sizeBytes: 500 },
-      { path: "skills/foo/data/config.json", sizeBytes: 200 },
+      {
+        path: "skills/foo/helper.py",
+        sizeBytes: 500,
+        contentType: "text/x-python",
+      },
+      {
+        path: "skills/foo/data/config.json",
+        sizeBytes: 200,
+        contentType: "application/json",
+      },
     ]);
   });
 

--- a/front/lib/api/skills/detection/parsing.test.ts
+++ b/front/lib/api/skills/detection/parsing.test.ts
@@ -68,9 +68,9 @@ Some instructions.`;
 describe("findSkillDirectories", () => {
   test("finds SKILL.md in subdirectories", () => {
     const entries: FileEntry[] = [
-      { path: "skills/foo/SKILL.md", isFile: true, sizeBytes: 100 },
-      { path: "skills/bar/skill.md", isFile: true, sizeBytes: 200 },
-      { path: "skills/baz/README.md", isFile: true, sizeBytes: 50 },
+      { path: "skills/foo/SKILL.md", sizeBytes: 100 },
+      { path: "skills/bar/skill.md", sizeBytes: 200 },
+      { path: "skills/baz/README.md", sizeBytes: 50 },
     ];
 
     const dirs = findSkillDirectories(entries);
@@ -87,8 +87,8 @@ describe("findSkillDirectories", () => {
 
   test("skips SKILL.md at the root", () => {
     const entries: FileEntry[] = [
-      { path: "SKILL.md", isFile: true, sizeBytes: 100 },
-      { path: "sub/SKILL.md", isFile: true, sizeBytes: 100 },
+      { path: "SKILL.md", sizeBytes: 100 },
+      { path: "sub/SKILL.md", sizeBytes: 100 },
     ];
 
     const dirs = findSkillDirectories(entries);
@@ -98,32 +98,23 @@ describe("findSkillDirectories", () => {
 
   test("deduplicates directories with both skill.md and SKILL.md", () => {
     const entries: FileEntry[] = [
-      { path: "skills/foo/SKILL.md", isFile: true, sizeBytes: 100 },
-      { path: "skills/foo/skill.md", isFile: true, sizeBytes: 100 },
+      { path: "skills/foo/SKILL.md", sizeBytes: 100 },
+      { path: "skills/foo/skill.md", sizeBytes: 100 },
     ];
 
     const dirs = findSkillDirectories(entries);
     expect(dirs).toHaveLength(1);
   });
 
-  test("skips directory entries", () => {
-    const entries: FileEntry[] = [
-      { path: "skills/foo", isFile: false, sizeBytes: 0 },
-      { path: "skills/foo/SKILL.md", isFile: true, sizeBytes: 100 },
-    ];
-
-    const dirs = findSkillDirectories(entries);
-    expect(dirs).toHaveLength(1);
-  });
 });
 
 describe("collectAttachments", () => {
   const entries: FileEntry[] = [
-    { path: "skills/foo/SKILL.md", isFile: true, sizeBytes: 100 },
-    { path: "skills/foo/helper.py", isFile: true, sizeBytes: 500 },
-    { path: "skills/foo/data/config.json", isFile: true, sizeBytes: 200 },
-    { path: "skills/bar/SKILL.md", isFile: true, sizeBytes: 100 },
-    { path: "other/file.txt", isFile: true, sizeBytes: 50 },
+    { path: "skills/foo/SKILL.md", sizeBytes: 100 },
+    { path: "skills/foo/helper.py", sizeBytes: 500 },
+    { path: "skills/foo/data/config.json", sizeBytes: 200 },
+    { path: "skills/bar/SKILL.md", sizeBytes: 100 },
+    { path: "other/file.txt", sizeBytes: 50 },
   ];
 
   test("collects files in the skill directory excluding SKILL.md", () => {

--- a/front/lib/api/skills/detection/parsing.ts
+++ b/front/lib/api/skills/detection/parsing.ts
@@ -89,10 +89,6 @@ export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
   const seenDirs = new Set<string>();
 
   for (const entry of entries) {
-    if (!entry.isFile) {
-      continue;
-    }
-
     const filename = entry.path.split("/").pop() ?? "";
     if (filename.toLowerCase() !== SKILL_MD_FILENAME) {
       continue;
@@ -125,9 +121,6 @@ export function collectAttachments(
   const attachments: DetectedSkillAttachment[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile) {
-      continue;
-    }
     if (!entry.path.startsWith(dirPrefix)) {
       continue;
     }

--- a/front/lib/api/skills/detection/parsing.ts
+++ b/front/lib/api/skills/detection/parsing.ts
@@ -5,6 +5,7 @@ import type {
   SkillDirectory,
 } from "@app/lib/api/skills/detection/types";
 import * as yaml from "js-yaml";
+import path from "path";
 import { z } from "zod";
 
 const SKILL_MD_FILENAME = "skill.md";
@@ -89,8 +90,7 @@ export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
   const seenDirs = new Set<string>();
 
   for (const entry of entries) {
-    const filename = entry.path.split("/").pop() ?? "";
-    if (filename.toLowerCase() !== SKILL_MD_FILENAME) {
+    if (path.basename(entry.path).toLowerCase() !== SKILL_MD_FILENAME) {
       continue;
     }
 

--- a/front/lib/api/skills/detection/parsing.ts
+++ b/front/lib/api/skills/detection/parsing.ts
@@ -133,8 +133,7 @@ export function collectAttachments(
     if (entry.path === skillDir.skillMdPath) {
       continue;
     }
-    const relativePath = entry.path.slice(dirPrefix.length);
-    attachments.push({ path: relativePath, sizeBytes: entry.sizeBytes });
+    attachments.push({ path: entry.path, sizeBytes: entry.sizeBytes });
   }
 
   return attachments;

--- a/front/lib/api/skills/detection/parsing.ts
+++ b/front/lib/api/skills/detection/parsing.ts
@@ -1,3 +1,4 @@
+import { getSkillAttachmentContentType } from "@app/lib/api/files/use_cases/skill_attachment";
 import type {
   DetectedSkillAttachment,
   FileEntry,
@@ -133,7 +134,14 @@ export function collectAttachments(
     if (entry.path === skillDir.skillMdPath) {
       continue;
     }
-    attachments.push({ path: entry.path, sizeBytes: entry.sizeBytes });
+    const contentType = getSkillAttachmentContentType(entry);
+    if (contentType) {
+      attachments.push({
+        path: entry.path,
+        sizeBytes: entry.sizeBytes,
+        contentType,
+      });
+    }
   }
 
   return attachments;

--- a/front/lib/api/skills/detection/types.ts
+++ b/front/lib/api/skills/detection/types.ts
@@ -1,6 +1,9 @@
+import type { SkillAttachmentContentType } from "@app/lib/api/files/use_cases/skill_attachment";
+
 export interface DetectedSkillAttachment {
   path: string;
   sizeBytes: number;
+  contentType: SkillAttachmentContentType;
 }
 
 export interface DetectedSkill {

--- a/front/lib/api/skills/detection/types.ts
+++ b/front/lib/api/skills/detection/types.ts
@@ -25,6 +25,5 @@ export interface SkillDirectory {
  */
 export interface FileEntry {
   path: string;
-  isFile: boolean;
   sizeBytes: number;
 }

--- a/front/lib/api/skills/detection/types.ts
+++ b/front/lib/api/skills/detection/types.ts
@@ -1,29 +1,25 @@
 import type { SkillAttachmentContentType } from "@app/lib/api/files/use_cases/skill_attachment";
 
-export interface DetectedSkillAttachment {
+export type DetectedSkillAttachment = {
   path: string;
   sizeBytes: number;
   contentType: SkillAttachmentContentType;
-}
+};
 
-export interface DetectedSkill {
+export type DetectedSkill = {
   name: string;
   skillMdPath: string;
   description: string;
   instructions: string;
   attachments: DetectedSkillAttachment[];
-}
+};
 
-export interface SkillDirectory {
+export type SkillDirectory = {
   dirPath: string;
   skillMdPath: string;
-}
+};
 
-/**
- * Minimal file-entry shape consumed by the shared skill-detection helpers.
- * Both GitHub tree entries and ZIP entries can be adapted to this interface.
- */
-export interface FileEntry {
+export type FileEntry = {
   path: string;
   sizeBytes: number;
-}
+};

--- a/front/lib/api/skills/detection/zip/detect_skills.test.ts
+++ b/front/lib/api/skills/detection/zip/detect_skills.test.ts
@@ -56,8 +56,8 @@ describe("detectSkillsFromZip", () => {
     if (result.isOk()) {
       expect(result.value[0].attachments).toHaveLength(2);
       expect(result.value[0].attachments.map((a) => a.path).sort()).toEqual([
-        "data/config.json",
-        "helper.py",
+        "foo/data/config.json",
+        "foo/helper.py",
       ]);
     }
   });

--- a/front/lib/api/skills/detection/zip/detect_skills.ts
+++ b/front/lib/api/skills/detection/zip/detect_skills.ts
@@ -111,7 +111,7 @@ export function detectSkillsFromZip({
 
   const fileEntries = entries
     .filter((e) => !e.isDirectory)
-    .map((e) => ({ path: e.path, isFile: true, sizeBytes: e.sizeBytes }));
+    .map((e) => ({ path: e.path, sizeBytes: e.sizeBytes }));
 
   const skillDirs = findSkillDirectories(fileEntries);
   if (skillDirs.length === 0) {

--- a/front/lib/api/skills/detection/zip/types.ts
+++ b/front/lib/api/skills/detection/zip/types.ts
@@ -3,9 +3,9 @@ export type ZipSkillDetectionError = {
   message: string;
 };
 
-export interface ZipEntry {
+export type ZipEntry = {
   path: string;
   originalEntryName: string;
   sizeBytes: number;
   isDirectory: boolean;
-}
+};


### PR DESCRIPTION
## Description

- Downloads the attached files when importing a skill from a GitHub repository.
- Also refactors the approach to rely on absolute paths within the repo.
- Recap of the approach: we use the Tree API from GitHub for both the detection and the import. This API returns a bunch of path + sha. This sha is the one we need to download the blob. Both the import and detection flows fetch the tree and download the skill markdown file + parse it. In the detection flow we also fetch the blobs for the attached files.
- Will refactor into a base class once we have enough different types of input to know precisely what interface we need.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
