### PR TITLE
[front] - feat(WorkspaceSkillUsage): download data

### DIFF
--- a/front/components/workspace/analytics/CsvDownloadButton.tsx
+++ b/front/components/workspace/analytics/CsvDownloadButton.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@dust-tt/sparkle";
+import { DownloadIcon } from "lucide-react";
+
+interface CsvDownloadButtonProps {
+  showExport: boolean;
+  isDownloading: boolean;
+  disabled: boolean;
+  handleDownload: () => void;
+}
+
+export function CsvDownloadButton({
+  showExport,
+  isDownloading,
+  disabled,
+  handleDownload,
+}: CsvDownloadButtonProps) {
+  if (!showExport) {
+    return null;
+  }
+
+  return (
+    <Button
+      icon={DownloadIcon}
+      variant="outline"
+      size="xs"
+      tooltip="Download CSV"
+      onClick={handleDownload}
+      disabled={disabled}
+      isLoading={isDownloading}
+    />
+  );
+}

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -7,6 +7,8 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import {
   useWorkspaceSkills,
   useWorkspaceSkillUsage,
@@ -286,6 +288,12 @@ export function WorkspaceSkillUsageChart({
     </DropdownMenu>
   );
 
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/skill-usage-export?days=${period}`,
+    filename: `dust_skill_usage_last_${period}_days.csv`,
+    disabled: isSkillsLoading || hasError || data.length === 0,
+  });
+
   const modeSelector = (
     <ButtonsSwitchList defaultValue={displayMode} size="xs">
       <ButtonsSwitch
@@ -318,6 +326,7 @@ export function WorkspaceSkillUsageChart({
         <div className="flex items-center gap-2">
           {skillSelector}
           {modeSelector}
+          <CsvDownloadButton {...csvDownload} />
         </div>
       }
     >

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -6,12 +6,9 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { useWorkspaceContextOrigin } from "@app/lib/swr/workspaces";
-import { Button } from "@dust-tt/sparkle";
-import { DownloadIcon } from "lucide-react";
-import { useState } from "react";
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 
 interface WorkspaceSourceChartProps {
@@ -23,11 +20,6 @@ export function WorkspaceSourceChart({
   workspaceId,
   period,
 }: WorkspaceSourceChartProps) {
-  const { hasFeature } = useFeatureFlags();
-  const showExport = hasFeature("analytics_csv_export");
-
-  const [isDownloading, setIsDownloading] = useState(false);
-
   const { contextOrigin, isContextOriginLoading, isContextOriginError } =
     useWorkspaceContextOrigin({
       workspaceId,
@@ -44,41 +36,14 @@ export function WorkspaceSourceChart({
     colorClassName: getSourceColor(d.origin),
   }));
 
-  const canDownload =
-    !isContextOriginLoading && !isContextOriginError && data.length > 0;
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/source-export?days=${period}`,
+    filename: `dust_sources_last_${period}_days.csv`,
+    disabled:
+      isContextOriginLoading || isContextOriginError || data.length === 0,
+  });
 
-  const handleDownload = async () => {
-    setIsDownloading(true);
-    try {
-      const response = await clientFetch(
-        `/api/w/${workspaceId}/analytics/source-export?days=${period}`
-      );
-      if (!response.ok) {
-        return;
-      }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `dust_sources_last_${period}_days.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } finally {
-      setIsDownloading(false);
-    }
-  };
-
-  const controls = showExport ? (
-    <Button
-      icon={DownloadIcon}
-      variant="outline"
-      size="xs"
-      tooltip="Download CSV"
-      onClick={handleDownload}
-      disabled={!canDownload || isDownloading}
-      isLoading={isDownloading}
-    />
-  ) : undefined;
+  const controls = <CsvDownloadButton {...csvDownload} />;
 
   return (
     <ChartContainer

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -7,8 +7,8 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import {
   useWorkspaceTools,
   useWorkspaceToolUsage,
@@ -25,7 +25,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import { DownloadIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
   CartesianGrid,
@@ -109,10 +108,6 @@ export function WorkspaceToolUsageChart({
   workspaceId,
   period,
 }: WorkspaceToolUsageChartProps) {
-  const { hasFeature } = useFeatureFlags();
-  const showExport = hasFeature("analytics_csv_export");
-  const [isDownloading, setIsDownloading] = useState(false);
-
   const [displayMode, setDisplayMode] =
     useState<ToolUsageDisplayMode>("executions");
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
@@ -270,40 +265,11 @@ export function WorkspaceToolUsageChart({
     </DropdownMenu>
   );
 
-  const canDownload = !isToolsLoading && !hasError && data.length > 0;
-
-  const handleDownload = async () => {
-    setIsDownloading(true);
-    try {
-      const response = await clientFetch(
-        `/api/w/${workspaceId}/analytics/tool-usage-export?days=${period}`
-      );
-      if (!response.ok) {
-        return;
-      }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `dust_tool_usage_last_${period}_days.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } finally {
-      setIsDownloading(false);
-    }
-  };
-
-  const downloadButton = showExport ? (
-    <Button
-      icon={DownloadIcon}
-      variant="outline"
-      size="xs"
-      tooltip="Download CSV"
-      onClick={handleDownload}
-      disabled={!canDownload || isDownloading}
-      isLoading={isDownloading}
-    />
-  ) : undefined;
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/tool-usage-export?days=${period}`,
+    filename: `dust_tool_usage_last_${period}_days.csv`,
+    disabled: isToolsLoading || hasError || data.length === 0,
+  });
 
   const modeSelector = (
     <ButtonsSwitchList defaultValue={displayMode} size="xs">
@@ -335,7 +301,7 @@ export function WorkspaceToolUsageChart({
         <div className="flex items-center gap-2">
           {toolSelector}
           {modeSelector}
-          {downloadButton}
+          <CsvDownloadButton {...csvDownload} />
         </div>
       }
     >

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -1,19 +1,13 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { LinkWrapper } from "@app/lib/platform";
 import { useWorkspaceTopAgents } from "@app/lib/swr/workspaces";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
-import {
-  Button,
-  DataTable,
-  ScrollableDataTable,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { DataTable, ScrollableDataTable, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { DownloadIcon } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 interface TopAgentRowData {
   agentId: string;
@@ -103,32 +97,6 @@ export function WorkspaceTopAgentsTable({
       disabled: !workspaceId,
     });
 
-  const { hasFeature } = useFeatureFlags();
-  const showExport = hasFeature("analytics_csv_export");
-
-  const [isDownloading, setIsDownloading] = useState(false);
-
-  const handleDownload = useCallback(async () => {
-    setIsDownloading(true);
-    try {
-      const response = await clientFetch(
-        `/api/w/${workspaceId}/analytics/agents-export?days=${period}`
-      );
-      if (!response.ok) {
-        return;
-      }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `dust_agents_last_${period}_days.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } finally {
-      setIsDownloading(false);
-    }
-  }, [workspaceId, period]);
-
   const columns = useMemo(() => makeColumns(workspaceId), [workspaceId]);
 
   const rows = useMemo<TopAgentRowData[]>(() => {
@@ -141,8 +109,11 @@ export function WorkspaceTopAgentsTable({
     }));
   }, [topAgents]);
 
-  const canDownload =
-    !isTopAgentsLoading && !isTopAgentsError && rows.length > 0;
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/agents-export?days=${period}`,
+    filename: `dust_agents_last_${period}_days.csv`,
+    disabled: isTopAgentsLoading || isTopAgentsError || rows.length === 0,
+  });
 
   function renderTableContent() {
     if (isTopAgentsLoading) {
@@ -186,17 +157,7 @@ export function WorkspaceTopAgentsTable({
             Top 100 agents with the most messages over the last {period} days.
           </p>
         </div>
-        {showExport && (
-          <Button
-            icon={DownloadIcon}
-            variant="outline"
-            size="xs"
-            tooltip="Download CSV"
-            onClick={handleDownload}
-            disabled={!canDownload || isDownloading}
-            isLoading={isDownloading}
-          />
-        )}
+        <CsvDownloadButton {...csvDownload} />
       </div>
       {renderTableContent()}
     </div>

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -1,16 +1,10 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { useWorkspaceTopUsers } from "@app/lib/swr/workspaces";
-import {
-  Button,
-  DataTable,
-  ScrollableDataTable,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { DataTable, ScrollableDataTable, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { DownloadIcon } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 interface TopUserRowData {
   userId: string;
@@ -87,32 +81,6 @@ export function WorkspaceTopUsersTable({
     }
   );
 
-  const { hasFeature } = useFeatureFlags();
-  const showExport = hasFeature("analytics_csv_export");
-
-  const [isDownloading, setIsDownloading] = useState(false);
-
-  const handleDownload = useCallback(async () => {
-    setIsDownloading(true);
-    try {
-      const response = await clientFetch(
-        `/api/w/${workspaceId}/analytics/users-export?days=${period}`
-      );
-      if (!response.ok) {
-        return;
-      }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `dust_users_last_${period}_days.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } finally {
-      setIsDownloading(false);
-    }
-  }, [workspaceId, period]);
-
   const rows = useMemo<TopUserRowData[]>(() => {
     return topUsers.map((user) => ({
       userId: user.userId,
@@ -123,7 +91,11 @@ export function WorkspaceTopUsersTable({
     }));
   }, [topUsers]);
 
-  const canDownload = !isTopUsersLoading && !isTopUsersError && rows.length > 0;
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/users-export?days=${period}`,
+    filename: `dust_users_last_${period}_days.csv`,
+    disabled: isTopUsersLoading || isTopUsersError || rows.length === 0,
+  });
 
   function renderTableContent() {
     if (isTopUsersLoading) {
@@ -167,17 +139,7 @@ export function WorkspaceTopUsersTable({
             Top 100 users with the most messages over the last {period} days.
           </p>
         </div>
-        {showExport && (
-          <Button
-            icon={DownloadIcon}
-            variant="outline"
-            size="xs"
-            tooltip="Download CSV"
-            onClick={handleDownload}
-            disabled={!canDownload || isDownloading}
-            isLoading={isDownloading}
-          />
-        )}
+        <CsvDownloadButton {...csvDownload} />
       </div>
       {renderTableContent()}
     </div>

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -8,17 +8,16 @@ import { padSeriesToTimeRange } from "@app/components/agent_builder/observabilit
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import {
   BROWSER_TIMEZONE,
   useWorkspaceActiveUsersMetrics,
   useWorkspaceUsageMetrics,
 } from "@app/lib/swr/workspaces";
 import { formatShortDate } from "@app/lib/utils/timestamps";
-import { Button, ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
-import { DownloadIcon } from "lucide-react";
-import { useCallback, useState } from "react";
+import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { useState } from "react";
 import {
   CartesianGrid,
   Line,
@@ -232,35 +231,6 @@ export function WorkspaceUsageChart({
   period,
 }: WorkspaceUsageChartProps) {
   const [displayMode, setDisplayMode] = useState<UsageDisplayMode>("activity");
-  const { hasFeature } = useFeatureFlags();
-  const showExport = hasFeature("analytics_csv_export");
-  const [isDownloading, setIsDownloading] = useState(false);
-
-  const handleDownload = useCallback(async () => {
-    setIsDownloading(true);
-    try {
-      const endpoint =
-        displayMode === "activity"
-          ? `/api/w/${workspaceId}/analytics/usage-metrics-export?days=${period}`
-          : `/api/w/${workspaceId}/analytics/active-users-export?days=${period}`;
-      const response = await clientFetch(endpoint);
-      if (!response.ok) {
-        return;
-      }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download =
-        displayMode === "activity"
-          ? `dust_activity_last_${period}_days.csv`
-          : `dust_active_users_last_${period}_days.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } finally {
-      setIsDownloading(false);
-    }
-  }, [workspaceId, period, displayMode]);
 
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useWorkspaceUsageMetrics({
@@ -313,7 +283,17 @@ export function WorkspaceUsageChart({
 
   const description = getDescriptionForMode(displayMode, period);
 
-  const canDownload = !isLoading && !isError && data.length > 0;
+  const csvDownload = useDownloadCsv({
+    url:
+      displayMode === "activity"
+        ? `/api/w/${workspaceId}/analytics/usage-metrics-export?days=${period}`
+        : `/api/w/${workspaceId}/analytics/active-users-export?days=${period}`,
+    filename:
+      displayMode === "activity"
+        ? `dust_activity_last_${period}_days.csv`
+        : `dust_active_users_last_${period}_days.csv`,
+    disabled: isLoading || isError || data.length === 0,
+  });
 
   const controls = (
     <div className="flex items-center gap-2">
@@ -329,17 +309,7 @@ export function WorkspaceUsageChart({
           onClick={() => setDisplayMode("users")}
         />
       </ButtonsSwitchList>
-      {showExport && (
-        <Button
-          icon={DownloadIcon}
-          variant="outline"
-          size="xs"
-          tooltip="Download CSV"
-          onClick={handleDownload}
-          disabled={!canDownload || isDownloading}
-          isLoading={isDownloading}
-        />
-      )}
+      <CsvDownloadButton {...csvDownload} />
     </div>
   );
 

--- a/front/hooks/useDownloadCsv.ts
+++ b/front/hooks/useDownloadCsv.ts
@@ -1,0 +1,45 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { clientFetch } from "@app/lib/egress/client";
+import { useCallback, useState } from "react";
+
+interface UseDownloadCsvOptions {
+  url: string;
+  filename: string;
+  disabled?: boolean;
+}
+
+export function useDownloadCsv({
+  url,
+  filename,
+  disabled,
+}: UseDownloadCsvOptions) {
+  const { hasFeature } = useFeatureFlags();
+  const showExport = hasFeature("analytics_csv_export");
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = useCallback(async () => {
+    setIsDownloading(true);
+    try {
+      const response = await clientFetch(url);
+      if (!response.ok) {
+        return;
+      }
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(objectUrl);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [url, filename]);
+
+  return {
+    showExport,
+    isDownloading,
+    disabled: !!disabled,
+    handleDownload,
+  };
+}

--- a/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
@@ -1,0 +1,136 @@
+/** @ignoreswagger */
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  fetchAvailableSkills,
+  fetchSkillUsageMetrics,
+} from "@app/lib/api/assistant/observability/skill_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+interface SkillUsageExportRow {
+  date: string;
+  skillName: string;
+  executions: number;
+  uniqueUsers: number;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days: q.data.days,
+      });
+
+      const skillsResult = await fetchAvailableSkills(baseQuery);
+      if (skillsResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve available skills: ${skillsResult.error.message}`,
+          },
+        });
+      }
+
+      const skills = skillsResult.value;
+      const rows: SkillUsageExportRow[] = [];
+
+      for (const skill of skills) {
+        const usageResult = await fetchSkillUsageMetrics(
+          baseQuery,
+          skill.skillName
+        );
+        if (usageResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`,
+            },
+          });
+        }
+
+        for (const point of usageResult.value) {
+          rows.push({
+            date: point.date,
+            skillName: skill.skillName,
+            executions: point.executionCount,
+            uniqueUsers: point.uniqueUsers,
+          });
+        }
+      }
+
+      rows.sort((a, b) => {
+        const dateCompare = a.date.localeCompare(b.date);
+        if (dateCompare !== 0) {
+          return dateCompare;
+        }
+        return a.skillName.localeCompare(b.skillName);
+      });
+
+      const headers: (keyof SkillUsageExportRow)[] = [
+        "date",
+        "skillName",
+        "executions",
+        "uniqueUsers",
+      ];
+      const csvData = rows.map((row) => headers.map((h) => row[h]));
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_skill_usage_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Refactors CSV download functionality across workspace analytics components to eliminate code duplication. Extracts the download logic into a reusable `useDownloadCsv` hook and `CsvDownloadButton` component, replacing duplicate implementations in `WorkspaceUsageChart`, `WorkspaceTopAgentsTable`, `WorkspaceTopUsersTable`, `WorkspaceSourceChart`, `WorkspaceToolUsageChart`, and `WorkspaceSkillUsageChart`. The refactoring centralizes feature flag checks, download state management, and file fetching logic in a single place.

## Tests

- [x] Locally

## Risk

Low

## Deploy Plan

Deploy front
