### PR TITLE
[front] feat: show all default skills on `default` tab of Manage Skills page

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -140,7 +140,17 @@ export function ManageSkillsPage() {
     return {
       active: sortedActiveSkills,
       editable_by_me: sortedActiveSkills.filter((s) => s.canWrite),
-      default: sortedActiveSkills.filter((s) => !s.relations.editors),
+       default: sortedActiveSkills
+        .filter((s) => s.isDefault)
+        .sort((a, b) => {
+          // Display first the skills that have no editor (Dust-managed ones).
+          const aNoEditors = a.relations.editors === null;
+          const bNoEditors = b.relations.editors === null;
+          if (aNoEditors !== bNoEditors) {
+            return aNoEditors ? -1 : 1;
+          }
+          return a.name.localeCompare(b.name);
+        }),
       archived: sortedArchivedSkills,
       search: activeSkills
         .filter((s) =>

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -141,7 +141,7 @@ export function ManageSkillsPage() {
       active: sortedActiveSkills,
       editable_by_me: sortedActiveSkills.filter((s) => s.canWrite),
       default: sortedActiveSkills
-        .filter((s) => s.isDefault)
+        .filter((s) => s.isDefault || s.relations.editors === null)
         .sort((a, b) => {
           // Display first the skills that have no editor (Dust-managed ones).
           const aNoEditors = a.relations.editors === null;

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -149,6 +149,7 @@ export function ManageSkillsPage() {
           if (aNoEditors !== bNoEditors) {
             return aNoEditors ? -1 : 1;
           }
+          // Fallback to a name sort.
           return a.name.localeCompare(b.name);
         }),
       archived: sortedArchivedSkills,

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -140,7 +140,7 @@ export function ManageSkillsPage() {
     return {
       active: sortedActiveSkills,
       editable_by_me: sortedActiveSkills.filter((s) => s.canWrite),
-       default: sortedActiveSkills
+      default: sortedActiveSkills
         .filter((s) => s.isDefault)
         .sort((a, b) => {
           // Display first the skills that have no editor (Dust-managed ones).


### PR DESCRIPTION
## Description

- This PR displays all default skills, including ones that were set to default by users to make them discoverable, in the `default` tab of the Manage skills page.
- Sorts the skills by showing the Dust-managed ones first, then the custom ones by name.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
