### PR TITLE
feat: checked and value status for interact with page tool

### DIFF
--- a/extension/platforms/chrome/interactWithPage.ts
+++ b/extension/platforms/chrome/interactWithPage.ts
@@ -9,6 +9,8 @@ type ElementSnapshot = {
   role: string;
   name: string;
   inputType: string | null;
+  value?: string;
+  checked?: boolean;
   coords: { x: number; y: number };
 };
 
@@ -18,6 +20,8 @@ type DustWindow = {
     CONTENT: string[];
     getElementName: (el: HTMLElement) => string;
     highlightElement: (el: HTMLElement) => void;
+    getElementCheckedStatus: (el: HTMLElement) => boolean | null;
+    getElementValue: (el: HTMLElement) => string | null;
   };
   __dustElementMap: Record<string, WeakRef<HTMLElement>>;
   __dustElementSnapshots: Record<string, ElementSnapshot>;
@@ -75,7 +79,13 @@ export async function getPageElements(
     args: [tab.id],
     func: (tabId: number) => {
       const w = window as unknown as DustWindow;
-      const { selector, CONTENT, getElementName } = w.__dustUtils;
+      const {
+        selector,
+        CONTENT,
+        getElementName,
+        getElementCheckedStatus,
+        getElementValue,
+      } = w.__dustUtils;
 
       // Initialize maps only if they don't exist yet — preserve existing IDs
       if (!w.__dustElementMap) {
@@ -120,6 +130,8 @@ export async function getPageElements(
         }
 
         const tag = el.tagName.toLowerCase();
+        const checked = getElementCheckedStatus(el);
+        const value = getElementValue(el);
 
         // Reuse existing ID if this DOM node was already tracked
         const existingId = domNodeToId.get(el);
@@ -143,6 +155,8 @@ export async function getPageElements(
           role: el.getAttribute("role") ?? tag,
           name: getElementName(el),
           inputType: el.getAttribute("type"),
+          ...(checked !== null ? { checked } : {}),
+          ...(value !== null ? { value } : {}),
           coords: {
             x: Math.round(rect.x + rect.width / 2 + window.scrollX),
             y: Math.round(rect.y + rect.height / 2 + window.scrollY),
@@ -513,7 +527,13 @@ export async function getPageElementsDiff(
         return JSON.stringify({ added: [], edited: [], deleted: [] });
       }
 
-      const { selector, CONTENT, getElementName } = w.__dustUtils;
+      const {
+        selector,
+        CONTENT,
+        getElementName,
+        getElementCheckedStatus,
+        getElementValue,
+      } = w.__dustUtils;
       const {
         __dustElementMap: elementMap,
         __dustElementSnapshots: snapshots,
@@ -552,12 +572,17 @@ export async function getPageElementsDiff(
         }
 
         const tag = el.tagName.toLowerCase();
+        const checked = getElementCheckedStatus(el);
+        const value = getElementValue(el);
+
         const current: Omit<ElementSnapshot, "elementId"> = {
           tag,
           type: CONTENT.includes(tag) ? "content" : "interactive",
           role: el.getAttribute("role") ?? tag,
           name: getElementName(el),
           inputType: el.getAttribute("type"),
+          ...(checked !== null ? { checked } : {}),
+          ...(value !== null ? { value } : {}),
           coords: {
             x: Math.round(rect.x + rect.width / 2 + window.scrollX),
             y: Math.round(rect.y + rect.height / 2 + window.scrollY),
@@ -572,7 +597,9 @@ export async function getPageElementsDiff(
           const changed =
             prev.role !== current.role ||
             prev.name !== current.name ||
-            prev.inputType !== current.inputType;
+            prev.inputType !== current.inputType ||
+            prev.checked !== current.checked ||
+            prev.value !== current.value;
 
           if (changed) {
             const editedElement: ElementSnapshot = {

--- a/extension/platforms/chrome/pageUtils.ts
+++ b/extension/platforms/chrome/pageUtils.ts
@@ -184,7 +184,66 @@ export async function ensureDustPageUtils(
         }, 100);
       };
 
-      w.__dustUtils = { selector, CONTENT, getElementName, highlightElement };
+      const getElementCheckedStatus = (el: HTMLElement): boolean | null => {
+        if (!el) {
+          return null;
+        }
+
+        // Native checkbox / radio
+        if (
+          el instanceof HTMLInputElement &&
+          (el.type === "checkbox" || el.type === "radio")
+        ) {
+          return el.checked;
+        }
+
+        // ARIA-based custom checkboxes, switches, menu items
+        const ariaChecked = el.getAttribute("aria-checked");
+        if (ariaChecked !== null) {
+          return ariaChecked === "true";
+        }
+
+        return null;
+      };
+
+      const getElementValue = (el: HTMLElement): string | null => {
+        if (!el) {
+          return null;
+        }
+
+        // Select — return the human-readable label of the selected option
+        if (el instanceof HTMLSelectElement) {
+          return el.options[el.selectedIndex]?.text?.trim() || null;
+        }
+
+        // Input — exclude types where value is not meaningful as text
+        if (el instanceof HTMLInputElement) {
+          if (
+            el.type === "checkbox" ||
+            el.type === "radio" ||
+            el.type === "password"
+          ) {
+            return null;
+          }
+          return el.value?.trim() || null;
+        }
+
+        // Textarea
+        if (el instanceof HTMLTextAreaElement) {
+          return el.value?.trim() || null;
+        }
+
+        return null;
+      };
+
+      w.__dustUtils = {
+        selector,
+        CONTENT,
+        getElementName,
+        highlightElement,
+        getElementCheckedStatus,
+        getElementValue,
+      };
     },
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7100

This PR adds the ability to track the checked status and value of interactive elements in the "interact with page" tool for the Chrome extension.

- Added `getElementCheckedStatus()` function to detect checked state for checkboxes, radio buttons, and ARIA-based custom checkboxes
- Added `getElementValue()` function to extract values from select elements, input fields, and textareas
- Extended `ElementSnapshot` type to include optional `checked` and `value` properties
- Updated both element capturing and diff tracking to monitor changes to these new properties

## Tests

Manually

## Risk

Low. The changes are additive and only enhance the data captured for page elements without modifying existing behavior.

## Deploy Plan

Standard deployment.
