### PR TITLE
[front] fix: allow viewing agent details on poke for global agents

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -79,7 +79,6 @@ async function handler(
       );
       const authors = await getAuthors(agentConfigurations);
 
-
       // `SkillResource.listByAgentConfigurations` only works for custom agents, as global agents are not versioned.
       const skillsByVersion: Record<number, SkillType[]> = {};
       if (isGlobalAgentId(aId)) {
@@ -87,8 +86,8 @@ async function handler(
           auth,
           latestAgentConfiguration
         );
-        skillsByVersion[latestAgentConfiguration.version] = allSkills.map(
-          (s) => s.toJSON(auth)
+        skillsByVersion[latestAgentConfiguration.version] = allSkills.map((s) =>
+          s.toJSON(auth)
         );
       } else {
         const allSkills = await SkillResource.listByAgentConfigurations(
@@ -102,7 +101,6 @@ async function handler(
           skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
         }
       }
-
 
       return res.status(200).json({
         agentConfigurations,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -90,14 +90,14 @@ async function handler(
           s.toJSON(auth)
         );
       } else {
-        const allSkills = await SkillResource.listByAgentConfigurations(
+        const skillsByAgent = await SkillResource.listByAgentConfigurations(
           auth,
           agentConfigurations
         );
         for (const config of agentConfigurations) {
           skillsByVersion[config.version] = [];
         }
-        for (const { agentConfiguration, skill } of allSkills) {
+        for (const { agentConfiguration, skill } of skillsByAgent) {
           skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
         }
       }

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -8,6 +8,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -78,18 +79,30 @@ async function handler(
       );
       const authors = await getAuthors(agentConfigurations);
 
-      const allSkills = await SkillResource.listByAgentConfigurations(
-        auth,
-        agentConfigurations
-      );
 
+      // `SkillResource.listByAgentConfigurations` only works for custom agents, as global agents are not versioned.
       const skillsByVersion: Record<number, SkillType[]> = {};
-      for (const config of agentConfigurations) {
-        skillsByVersion[config.version] = [];
+      if (isGlobalAgentId(aId)) {
+        const allSkills = await SkillResource.listByAgentConfiguration(
+          auth,
+          latestAgentConfiguration
+        );
+        skillsByVersion[latestAgentConfiguration.version] = allSkills.map(
+          (s) => s.toJSON(auth)
+        );
+      } else {
+        const allSkills = await SkillResource.listByAgentConfigurations(
+          auth,
+          agentConfigurations
+        );
+        for (const config of agentConfigurations) {
+          skillsByVersion[config.version] = [];
+        }
+        for (const { agentConfiguration, skill } of allSkills) {
+          skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
+        }
       }
-      for (const { agentConfiguration, skill } of allSkills) {
-        skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
-      }
+
 
       return res.status(200).json({
         agentConfigurations,


### PR DESCRIPTION
## Description

- This PR fixes the Poke page for displaying details on an agent for global ones.
- https://github.com/dust-tt/dust/pull/22856 added an assert that preventing listing per-version skills (global agents are not versioned per se).

## Tests

- Tested locally.

## Risk

- Low, poke-only.

## Deploy Plan

- Deploy front.