### PR TITLE
[BYOK] Invalidate provider credential cache on update

### DIFF
--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -346,6 +346,10 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       credentialsId: oldCredentialId,
     });
 
+    await ProviderCredentialResource.invalidateProviderCredentialCache(
+      workspace.id
+    );
+
     return this;
   }
 


### PR DESCRIPTION
## Description

Invalidates the Redis cache for provider credentials when `updateApiKey` is called, ensuring stale credentials are not served after an update. The cache was already invalidated on create and delete, but the update path was missing.

## Tests

Tested manually.

## Risk

Low — additive fix aligning cache invalidation behavior with existing create/delete paths.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`