### PR TITLE
fix: highlight current conversation in extension

### DIFF
--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -6,6 +6,7 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { useConversation } from "@app/hooks/conversations/useConversation";
+import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { getProjectRoute } from "@app/lib/utils/router";
@@ -14,7 +15,6 @@ import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
 import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
 import { useMemo } from "react";
-import { useParams } from "react-router-dom";
 import { ConversationContainer } from "../components/conversation/ConversationContainer";
 
 export const MainPage = () => {
@@ -24,20 +24,7 @@ export const MainPage = () => {
   const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
   const shortcut = isMac ? "⇧⌘E" : "⇧+Ctrl+E";
 
-  // Parse conversation ID from catch-all path
-  const params = useParams();
-  const conversationId = useMemo(() => {
-    if (!params["*"]) {
-      return null;
-    }
-    const match = params["*"].match(/conversation\/([^/]+)/);
-    const isNewConversation = match && match[1] === "new";
-    const isSpaceConversation = match && match[1] === "space";
-    if (isNewConversation || isSpaceConversation) {
-      return null;
-    }
-    return match ? match[1] : null;
-  }, [params]);
+  const conversationId = useActiveConversationId();
 
   const { conversation, isConversationLoading, conversationError } =
     useConversation({

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -25,8 +25,10 @@ export const routes = [
         path: "/w/:wId/conversation/space/:spaceId",
         element: <ProjectMainPage />,
       },
-      // Keep catch-all route last. This will handle both root path and /conversations/:conversationId
-      // Since we catch all, we will need to manually handle the conversationId in the MainPage component.
+      {
+        path: "/w/:wId/conversation/:cId",
+        element: <MainPage />,
+      },
       {
         path: "*",
         element: <MainPage />,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7107

This PR fixes the highlighting of the current conversation in the extension by properly extracting the conversation ID from the URL.

The highlight logic depends on `useActiveConversationId`, which relies on `usePathParams` to extract the conversation ID from the route. Previously, the extension only used a catch-all route (`*`), which meant the path parameter was never properly captured, causing `useActiveConversationId` to always return `null` and preventing the current conversation from being highlighted.

- Adds an explicit route for `/w/:wId/conversation/:cId` to properly capture the `:cId` path parameter
- Replaces manual conversation ID parsing logic with the existing `useActiveConversationId` hook (which now works correctly)

## Tests

Manually

## Risks

Low risk. The new route is added alongside the catch-all route.

## Deploy Plan

Standard deployment. No special considerations needed.
