### PR TITLE
[front] Add category-based grouping to ConversationFilesPanel

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -23,8 +23,6 @@ import {
   useConversations,
 } from "@app/hooks/conversations";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
-import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
-import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useConversationEvents } from "@app/hooks/useConversationEvents";
 import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotification";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -136,16 +134,6 @@ export const ConversationViewer = ({
   const sendNotification = useSendNotification();
 
   const { mutateConversationAttachments } = useConversationAttachments({
-    conversationId,
-    owner,
-    options: { disabled: true },
-  });
-  const { mutateSandboxStatus } = useConversationSandboxStatus({
-    conversationId,
-    owner,
-    options: { disabled: true },
-  });
-  const { mutateSandboxFiles } = useConversationSandboxFiles({
     conversationId,
     owner,
     options: { disabled: true },
@@ -559,8 +547,6 @@ export const ConversationViewer = ({
 
             window.dispatchEvent(new AgentMessageCompletedEvent());
             void mutateConversationAttachments();
-            void mutateSandboxStatus();
-            void mutateSandboxFiles();
             break;
           case "butler_thinking":
             setIsButlerThinking(true);
@@ -593,8 +579,6 @@ export const ConversationViewer = ({
       mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
-      mutateSandboxFiles,
-      mutateSandboxStatus,
       user.sId,
     ]
   );

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -96,25 +96,18 @@ export function ConversationFilesPanel({
     [openFile]
   );
 
-  const conversationContextFiles = useMemo(() => {
-    const conversationFiles: ConversationAttachmentItem[] = [];
-    for (const f of attachments) {
-      if (!f.isInProjectContext) {
-        conversationFiles.push(f);
-      }
-    }
-    return conversationFiles.map((a) =>
-      conversationAttachmentToRow(a, handleAttachmentClick)
-    );
-  }, [attachments, handleAttachmentClick]);
+  const fileRows = useMemo(
+    () =>
+      attachments.map((a) =>
+        conversationAttachmentToRow(a, handleAttachmentClick)
+      ),
+    [attachments, handleAttachmentClick]
+  );
 
   const hasSandbox = sandboxStatus !== null;
 
   const filesContent = (
-    <FilesTab
-      isLoading={isConversationAttachmentsLoading}
-      rows={conversationContextFiles}
-    />
+    <FilesTab isLoading={isConversationAttachmentsLoading} rows={fileRows} />
   );
 
   if (!hasSandbox) {

--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -1,6 +1,18 @@
-import type { ConversationAttachmentRow } from "@app/components/assistant/conversation/files_panel/types";
+import type {
+  ConversationAttachmentRow,
+  FilePanelCategory,
+} from "@app/components/assistant/conversation/files_panel/types";
+import { CATEGORY_CONFIG } from "@app/components/assistant/conversation/files_panel/utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import { Card, CardGrid, Icon, ScrollArea, Spinner } from "@dust-tt/sparkle";
+import {
+  Card,
+  CardGrid,
+  Icon,
+  ScrollArea,
+  SpaceClosedIcon,
+  Spinner,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 interface FilesTabProps {
@@ -9,17 +21,17 @@ interface FilesTabProps {
 }
 
 export function FilesTab({ isLoading, rows }: FilesTabProps) {
-  const { attached, generated } = useMemo(() => {
-    const attached: ConversationAttachmentRow[] = [];
-    const generated: ConversationAttachmentRow[] = [];
+  const groupedByCategory = useMemo(() => {
+    const groups = new Map<FilePanelCategory, ConversationAttachmentRow[]>();
     for (const row of rows) {
-      if (row.source === "user") {
-        attached.push(row);
+      const existing = groups.get(row.category);
+      if (existing) {
+        existing.push(row);
       } else {
-        generated.push(row);
+        groups.set(row.category, [row]);
       }
     }
-    return { attached, generated };
+    return groups;
   }, [rows]);
 
   if (isLoading) {
@@ -41,18 +53,18 @@ export function FilesTab({ isLoading, rows }: FilesTabProps) {
   return (
     <ScrollArea className="flex-1 p-4">
       <div className="flex flex-col gap-4">
-        {attached.length > 0 && (
-          <div>
-            <SectionLabel>Attached</SectionLabel>
-            <FileCards rows={attached} />
-          </div>
-        )}
-        {generated.length > 0 && (
-          <div>
-            <SectionLabel>Generated</SectionLabel>
-            <FileCards rows={generated} />
-          </div>
-        )}
+        {CATEGORY_CONFIG.map(({ value, label }) => {
+          const categoryRows = groupedByCategory.get(value);
+          if (!categoryRows || categoryRows.length === 0) {
+            return null;
+          }
+          return (
+            <div key={value}>
+              <SectionLabel>{label}</SectionLabel>
+              <FileCards rows={categoryRows} />
+            </div>
+          );
+        })}
       </div>
     </ScrollArea>
   );
@@ -72,9 +84,24 @@ function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
           >
             <div className="flex items-center gap-2">
               <Icon visual={FileIcon} size="sm" className="shrink-0" />
-              <div className="min-w-0 truncate text-sm font-medium">
+              <div className="min-w-0 flex-1 truncate text-sm font-medium">
                 {row.title}
               </div>
+              {row.isInProjectContext && (
+                <Tooltip
+                  tooltipTriggerAsChild
+                  label="Saved to Project"
+                  trigger={
+                    <span className="inline-flex shrink-0">
+                      <Icon
+                        visual={SpaceClosedIcon}
+                        size="xs"
+                        className="text-muted-foreground dark:text-muted-foreground-night"
+                      />
+                    </span>
+                  }
+                />
+              )}
             </div>
           </Card>
         );

--- a/front/components/assistant/conversation/files_panel/types.ts
+++ b/front/components/assistant/conversation/files_panel/types.ts
@@ -3,11 +3,25 @@ import type { GetConversationAttachmentsResponseBody } from "@app/pages/api/w/[w
 export type ConversationAttachmentItem =
   GetConversationAttachmentsResponseBody["attachments"][number];
 
+export type FilePanelCategory =
+  | "frame"
+  | "slideshow"
+  | "document"
+  | "pdf"
+  | "table"
+  | "code"
+  | "image"
+  | "audio"
+  | "knowledge"
+  | "other";
+
 export type ConversationAttachmentRow = {
   title: string;
   contentType: string;
   fileId: string | null;
   source: "agent" | "user" | null;
+  category: FilePanelCategory;
+  isInProjectContext: boolean;
   onClick?: () => void;
 };
 

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -1,15 +1,112 @@
+import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
 import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { SandboxFileEntry } from "@app/lib/api/sandbox/files";
+import {
+  frameSlideshowContentType,
+  isInteractiveContentType,
+} from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type {
   ConversationAttachmentItem,
   ConversationAttachmentRow,
+  FilePanelCategory,
   SandboxTreeNode,
 } from "./types";
+
+/**
+ * Category display configuration, ordered by priority.
+ */
+export const CATEGORY_CONFIG: {
+  value: FilePanelCategory;
+  label: string;
+}[] = [
+  { value: "frame", label: "Frames" },
+  { value: "slideshow", label: "Slideshows" },
+  { value: "document", label: "Documents" },
+  { value: "pdf", label: "PDFs" },
+  { value: "table", label: "Tables" },
+  { value: "code", label: "Code" },
+  { value: "image", label: "Images" },
+  { value: "audio", label: "Audio" },
+  { value: "knowledge", label: "Knowledge" },
+  { value: "other", label: "Other" },
+];
+
+export function getFilePanelCategory(
+  item: ConversationAttachmentItem
+): FilePanelCategory {
+  if (isContentNodeAttachmentType(item)) {
+    return "knowledge";
+  }
+
+  if (isInteractiveContentType(item.contentType)) {
+    return item.contentType === frameSlideshowContentType
+      ? "slideshow"
+      : "frame";
+  }
+
+  const previewConfig = getFilePreviewConfig(item.contentType);
+
+  switch (previewConfig.category) {
+    case "pdf":
+      return "pdf";
+    case "image":
+      return "image";
+    case "audio":
+      return "audio";
+    case "delimited":
+      return "table";
+    case "code":
+      return "code";
+    case "viewer":
+    case "markdown":
+    case "text":
+      return "document";
+    case "frame":
+      return "frame";
+    default:
+      return "other";
+  }
+}
+
+export function conversationAttachmentToRow(
+  item: ConversationAttachmentItem,
+  onFileClick: (item: ConversationAttachmentItem) => void
+): ConversationAttachmentRow {
+  const category = getFilePanelCategory(item);
+
+  if (isFileAttachmentType(item)) {
+    const { title, contentType, fileId, source, isInProjectContext } = item;
+    return {
+      title,
+      contentType,
+      fileId,
+      source,
+      category,
+      isInProjectContext,
+      onClick: () => onFileClick(item),
+    };
+  } else if (isContentNodeAttachmentType(item)) {
+    const { title, contentType, sourceUrl, isInProjectContext } = item;
+    return {
+      title,
+      contentType,
+      fileId: null,
+      source: null,
+      category,
+      isInProjectContext,
+      onClick: sourceUrl
+        ? () => window.open(sourceUrl, "_blank", "noopener,noreferrer")
+        : undefined,
+    };
+  } else {
+    assertNever(item);
+  }
+}
 
 /**
  * Build a tree from flat GCS file entries by inferring directories from paths.
@@ -89,33 +186,4 @@ export function buildSandboxTree(
   }
 
   return root;
-}
-
-export function conversationAttachmentToRow(
-  item: ConversationAttachmentItem,
-  onFileClick: (item: ConversationAttachmentItem) => void
-): ConversationAttachmentRow {
-  if (isFileAttachmentType(item)) {
-    const { title, contentType, fileId, source } = item;
-    return {
-      title,
-      contentType,
-      fileId,
-      source,
-      onClick: () => onFileClick(item),
-    };
-  } else if (isContentNodeAttachmentType(item)) {
-    const { title, contentType, sourceUrl } = item;
-    return {
-      title,
-      contentType,
-      fileId: null,
-      source: null,
-      onClick: sourceUrl
-        ? () => window.open(sourceUrl, "_blank", "noopener,noreferrer")
-        : undefined,
-    };
-  } else {
-    assertNever(item);
-  }
 }


### PR DESCRIPTION
## Description

- Replace source-based grouping (Attached/Generated) with category-based grouping in the files side panel (behind sidepanel_files flag)
- Add 10 granular file categories with priority ordering: Frames, Slideshows, Documents, PDFs, Tables, Code, Images, Audio, Knowledge, Other
- Distinguish frames from slideshows (previously both mapped to "frame")
- Show project context files inline with a SpaceClosedIcon badge (previously filtered out)
- Remove unnecessary sandbox revalidation from ConversationViewer


<img width="676" height="460" alt="Screenshot 2026-03-16 at 13 18 21" src="https://github.com/user-attachments/assets/b1e7ca5c-87e1-4c64-90c2-38e92d7b7bca" />

Note: this is an iteration, next I'm going to add more details on the card components as designed by Alex. 

## Tests

Locally. 

## Risk

Gated, can be rolled back. 

## Deploy Plan

Deploy front. 