### PR TITLE
[front] Add creator avatars and dates to ConversationFilesPanel cards

### DIFF
--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -5,6 +5,7 @@ import type {
 import { CATEGORY_CONFIG } from "@app/components/assistant/conversation/files_panel/utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
+  Avatar,
   Card,
   CardGrid,
   Icon,
@@ -13,6 +14,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
+import moment from "moment";
 import { useMemo } from "react";
 
 interface FilesTabProps {
@@ -82,32 +84,65 @@ function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
             variant="primary"
             onClick={row.onClick}
           >
-            <div className="flex items-center gap-2">
-              <Icon visual={FileIcon} size="sm" className="shrink-0" />
-              <div className="min-w-0 flex-1 truncate text-sm font-medium">
-                {row.title}
+            <div className="flex w-full flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <Icon visual={FileIcon} size="sm" className="shrink-0" />
+                <div className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {row.title}
+                </div>
               </div>
-              {row.isInProjectContext && (
-                <Tooltip
-                  tooltipTriggerAsChild
-                  label="Saved to Project"
-                  trigger={
-                    <span className="inline-flex shrink-0">
-                      <Icon
-                        visual={SpaceClosedIcon}
-                        size="xs"
-                        className="text-muted-foreground dark:text-muted-foreground-night"
-                      />
-                    </span>
-                  }
-                />
-              )}
+              <div className="flex items-center justify-between">
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {row.date ? `${moment(row.date).fromNow()}.` : null}
+                </div>
+                <div className="flex items-center gap-1">
+                  {row.isInProjectContext && (
+                    <Tooltip
+                      tooltipTriggerAsChild
+                      label="Saved to Project"
+                      trigger={
+                        <span className="inline-flex">
+                          <Icon
+                            visual={SpaceClosedIcon}
+                            size="xs"
+                            className="text-muted-foreground dark:text-muted-foreground-night"
+                          />
+                        </span>
+                      }
+                    />
+                  )}
+                  <CreatorAvatar row={row} />
+                </div>
+              </div>
             </div>
           </Card>
         );
       })}
     </CardGrid>
   );
+}
+
+function CreatorAvatar({ row }: { row: ConversationAttachmentRow }) {
+  if (row.creator) {
+    return (
+      <Tooltip
+        tooltipTriggerAsChild
+        label={row.creator.name}
+        trigger={
+          <span className="inline-flex">
+            <Avatar
+              size="xs"
+              visual={row.creator.pictureUrl || undefined}
+              name={row.creator.name}
+              isRounded={row.creator.type === "user"}
+            />
+          </span>
+        }
+      />
+    );
+  }
+
+  return null;
 }
 
 function SectionLabel({ children }: { children: React.ReactNode }) {

--- a/front/components/assistant/conversation/files_panel/types.ts
+++ b/front/components/assistant/conversation/files_panel/types.ts
@@ -1,3 +1,4 @@
+import type { AttachmentCreator } from "@app/lib/api/assistant/conversation/attachments";
 import type { GetConversationAttachmentsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/attachments";
 
 export type ConversationAttachmentItem =
@@ -9,7 +10,6 @@ export type FilePanelCategory =
   | "document"
   | "pdf"
   | "table"
-  | "code"
   | "image"
   | "audio"
   | "knowledge"
@@ -22,6 +22,8 @@ export type ConversationAttachmentRow = {
   source: "agent" | "user" | null;
   category: FilePanelCategory;
   isInProjectContext: boolean;
+  creator: AttachmentCreator | null;
+  date: number | null;
   onClick?: () => void;
 };
 

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -29,7 +29,6 @@ export const CATEGORY_CONFIG: {
   { value: "document", label: "Documents" },
   { value: "pdf", label: "PDFs" },
   { value: "table", label: "Tables" },
-  { value: "code", label: "Code" },
   { value: "image", label: "Images" },
   { value: "audio", label: "Audio" },
   { value: "knowledge", label: "Knowledge" },
@@ -61,7 +60,6 @@ export function getFilePanelCategory(
     case "delimited":
       return "table";
     case "code":
-      return "code";
     case "viewer":
     case "markdown":
     case "text":
@@ -80,7 +78,8 @@ export function conversationAttachmentToRow(
   const category = getFilePanelCategory(item);
 
   if (isFileAttachmentType(item)) {
-    const { title, contentType, fileId, source, isInProjectContext } = item;
+    const { title, contentType, fileId, source, isInProjectContext, creator } =
+      item;
     return {
       title,
       contentType,
@@ -88,10 +87,12 @@ export function conversationAttachmentToRow(
       source,
       category,
       isInProjectContext,
+      creator,
+      date: item.updatedAt ?? item.createdAt ?? null,
       onClick: () => onFileClick(item),
     };
   } else if (isContentNodeAttachmentType(item)) {
-    const { title, contentType, sourceUrl, isInProjectContext } = item;
+    const { title, contentType, sourceUrl, isInProjectContext, creator } = item;
     return {
       title,
       contentType,
@@ -99,6 +100,8 @@ export function conversationAttachmentToRow(
       source: null,
       category,
       isInProjectContext,
+      creator,
+      date: null,
       onClick: sourceUrl
         ? () => window.open(sourceUrl, "_blank", "noopener,noreferrer")
         : undefined,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -26,6 +26,12 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
 
+export type AttachmentCreator = {
+  type: "agent" | "user";
+  name: string;
+  pictureUrl: string;
+};
+
 export type BaseConversationAttachmentType = {
   title: string;
   contentType: SupportedContentFragmentType;
@@ -36,6 +42,7 @@ export type BaseConversationAttachmentType = {
   isSearchable: boolean;
   isQueryable: boolean;
   isInProjectContext: boolean;
+  creator: AttachmentCreator | null;
 };
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
@@ -128,6 +135,14 @@ export function getAttachmentFromContentNodeContentFragment(
   const isSearchable =
     isSearchableContentType(cf.contentType) && !isUnmaterializedTable;
 
+  const creator: AttachmentCreator | null = cf.context.fullName
+    ? {
+        type: "user",
+        name: cf.context.fullName,
+        pictureUrl: cf.context.profilePictureUrl ?? "",
+      }
+    : null;
+
   const baseAttachment: BaseConversationAttachmentType = {
     title: cf.title,
     contentType: cf.contentType,
@@ -140,6 +155,7 @@ export function getAttachmentFromContentNodeContentFragment(
     isQueryable,
     isSearchable,
     isInProjectContext: false, // For now, content nodes can only be from the conversation, not the project. To be revisited if/when we allow connected data in the projects.
+    creator,
   };
 
   return {
@@ -174,6 +190,14 @@ export function getAttachmentFromFileContentFragment(
   const isQueryable = canDoJIT && isQueryableContentType(cf.contentType);
   const isIncludable = isConversationIncludableFileContentType(cf.contentType);
   const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
+  const creator: AttachmentCreator | null = cf.context.fullName
+    ? {
+        type: "user",
+        name: cf.context.fullName,
+        pictureUrl: cf.context.profilePictureUrl ?? "",
+      }
+    : null;
+
   const baseAttachment: BaseConversationAttachmentType = {
     title: cf.title,
     contentType: cf.contentType,
@@ -191,6 +215,7 @@ export function getAttachmentFromFileContentFragment(
     isQueryable,
     isSearchable,
     isInProjectContext: cf.isInProjectContext,
+    creator,
   };
 
   return {
@@ -210,6 +235,7 @@ export function getAttachmentFromFile({
   title,
   snippet,
   isInProjectContext,
+  creator = null,
 }: {
   fileId: string;
   source: "agent" | "user" | null;
@@ -219,6 +245,7 @@ export function getAttachmentFromFile({
   title: string;
   snippet: string | null;
   isInProjectContext: boolean;
+  creator?: AttachmentCreator | null;
 }): FileAttachmentType {
   const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
@@ -240,6 +267,7 @@ export function getAttachmentFromFile({
     isQueryable,
     isSearchable,
     isInProjectContext,
+    creator,
   };
 }
 

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -90,6 +90,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -346,6 +347,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -399,6 +401,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: false,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -448,6 +451,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: false,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -488,6 +492,7 @@ describe("getJITServers", () => {
           isSearchable: false,
           isQueryable: true,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -531,6 +536,7 @@ describe("getJITServers", () => {
           isSearchable: false,
           isQueryable: true,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -582,6 +588,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 
@@ -661,6 +668,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          creator: null,
         },
       ];
 

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -47,6 +47,11 @@ export async function listAttachments(
       }
     } else if (isAgentMessageType(m)) {
       const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);
+      const agentCreator = {
+        type: "agent" as const,
+        name: m.configuration.name,
+        pictureUrl: m.configuration.pictureUrl,
+      };
 
       for (const f of generatedFiles) {
         attachments.set(
@@ -60,6 +65,7 @@ export async function listAttachments(
             title: f.title,
             snippet: f.snippet,
             isInProjectContext: f.isInProjectContext ?? false,
+            creator: agentCreator,
           })
         );
       }


### PR DESCRIPTION
## Description

Enrich conversation file attachments with creator identity (agent avatar or user avatar) and display it on file cards in the side panel. Cards are now two-line: filename on top, relative date and creator avatar on the bottom row.

Backend: added a nullable `AttachmentCreator` object (`type`, `name`, `pictureUrl`) to the attachment types, populated from agent message configuration for generated files and from content fragment context for user uploads.

Frontend: two-line card layout with date on the bottom-left and creator avatar on the bottom-right. Project context files show a space icon badge. Also removed the "Code" category, merging it into "Documents".

-> We want to experiment with this design on prod to see if it's better on conversation with many files. 

On the left the dropdown that we want to replace, on the right the replacing side panel. 
<kbd>
<img width="1120" height="560" alt="Screenshot 2026-03-16 at 13 59 36" src="https://github.com/user-attachments/assets/ff4c9c7c-ddcc-4642-9311-94b6686238d9" />
</kbd>

## Tests

Locally. 

## Risk

This panel is gated for now. 
This PR can be rolled back. 

## Deploy Plan

Deploy front. 