### PR TITLE
[BYOK] Add provider credential revocation

### DIFF
--- a/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
+++ b/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
@@ -1,4 +1,4 @@
-import { useProviderCredentialActions } from "@app/lib/swr/provider_credentials";
+import { useSaveProviderCredential } from "@app/lib/swr/provider_credentials";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -70,18 +70,17 @@ export function KeyConfigurationSheet({
   apiKey: initialApiKey,
 }: KeyConfigurationSheetProps) {
   const [apiKey, setApiKey] = useState(initialApiKey ?? "");
-  const [isSaving, setIsSaving] = useState(false);
 
-  const { saveProviderCredential } = useProviderCredentialActions({ owner });
+  const { saveProviderCredential, isSaving } = useSaveProviderCredential({
+    owner,
+  });
 
   const handleSave = async () => {
-    setIsSaving(true);
     const result = await saveProviderCredential({
       providerId,
       apiKey,
       isNew: initialApiKey === undefined,
     });
-    setIsSaving(false);
 
     if (result) {
       setApiKey("");

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -1,4 +1,5 @@
 import { KeyConfigurationSheet } from "@app/components/pages/workspace/model_providers/KeyConfigurationSheet";
+import { RemoveKeyDialog } from "@app/components/pages/workspace/model_providers/RemoveKeyDialog";
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
@@ -11,24 +12,36 @@ interface ConfigureButtonProps {
   isLoading: boolean;
   apiKey: string | undefined;
   openConfigurationSheet: () => void;
+  openRemoveKeyDialog: () => void;
 }
 
 function ProviderConfigurationActions({
   isLoading,
   apiKey,
   openConfigurationSheet,
+  openRemoveKeyDialog,
 }: ConfigureButtonProps) {
-  const configureLabel = apiKey ? "Edit" : "Configure";
   if (isLoading) {
     return null;
   }
 
+  const configureLabel = apiKey ? "Edit" : "Configure";
+
   return (
-    <Button
-      label={configureLabel}
-      variant="outline"
-      onClick={openConfigurationSheet}
-    />
+    <div className="flex items-center gap-2">
+      <Button
+        label={configureLabel}
+        variant="outline"
+        onClick={openConfigurationSheet}
+      />
+      {apiKey && (
+        <Button
+          label="Remove"
+          variant="warning"
+          onClick={openRemoveKeyDialog}
+        />
+      )}
+    </div>
   );
 }
 
@@ -49,6 +62,7 @@ export function ProviderConfigurationContextItem({
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isRemoveKeyDialogOpen, setIsRemoveKeyDialogOpen] = useState(false);
 
   return (
     <>
@@ -61,6 +75,7 @@ export function ProviderConfigurationContextItem({
             isLoading={isLoading}
             apiKey={apiKey}
             openConfigurationSheet={() => setIsSheetOpen(true)}
+            openRemoveKeyDialog={() => setIsRemoveKeyDialogOpen(true)}
           />
         }
       >
@@ -83,6 +98,12 @@ export function ProviderConfigurationContextItem({
         onOpenChange={setIsSheetOpen}
         logo={LogoComponent}
         apiKey={apiKey}
+      />
+      <RemoveKeyDialog
+        owner={owner}
+        providerId={providerId}
+        open={isRemoveKeyDialogOpen}
+        onOpenChange={setIsRemoveKeyDialogOpen}
       />
     </>
   );

--- a/front/components/pages/workspace/model_providers/RemoveKeyDialog.tsx
+++ b/front/components/pages/workspace/model_providers/RemoveKeyDialog.tsx
@@ -1,0 +1,68 @@
+import { useDeleteProviderCredential } from "@app/lib/swr/provider_credentials";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+
+interface RemoveKeyDialogProps {
+  owner: LightWorkspaceType;
+  providerId: ByokModelProviderIdType;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function RemoveKeyDialog({
+  owner,
+  providerId,
+  open,
+  onOpenChange,
+}: RemoveKeyDialogProps) {
+  const { deleteProviderCredential, isDeleting } = useDeleteProviderCredential({
+    owner,
+  });
+
+  const handleRemove = async () => {
+    const deleted = await deleteProviderCredential({ providerId });
+    if (deleted) {
+      onOpenChange(false);
+    }
+  };
+
+  const description =
+    providerId === "openai"
+      ? "OpenAI powers your embedding model. Removing this key will not only disable all agents powered by OpenAI, but also search and data syncing across the entire workspace."
+      : "Agents relying on this provider will stop responding immediately.";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Remove this model provider API key?</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            disabled: isDeleting,
+          }}
+          rightButtonProps={{
+            label: "Remove key",
+            variant: "warning",
+            onClick: handleRemove,
+            disabled: isDeleting,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -63,6 +63,7 @@ vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
     OAuthAPI: vi.fn().mockImplementation(function () {
       return {
         getCredentials: mockGetCredentials,
+        deleteCredentials: vi.fn().mockResolvedValue(new Ok(undefined)),
       };
     }),
   };

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -372,6 +372,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   async delete(
     auth: Authenticator
   ): Promise<Result<number | undefined, Error>> {
+    assert(auth.isAdmin(), "Only admins can delete provider credentials.");
+    assert(
+      auth.getNonNullablePlan().isByok,
+      "BYOK must be enabled to delete provider credentials."
+    );
+
     try {
       const workspace = auth.getNonNullableWorkspace();
       const affectedCount = await this.model.destroy({
@@ -381,9 +387,16 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
         },
       });
 
-      await ProviderCredentialResource.invalidateProviderCredentialCache(
-        workspace.id
-      );
+      if (affectedCount !== null) {
+        const oauthClient = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        await oauthClient.deleteCredentials({
+          credentialsId: this.credentialId,
+        });
+
+        await ProviderCredentialResource.invalidateProviderCredentialCache(
+          workspace.id
+        );
+      }
 
       return new Ok(affectedCount);
     } catch (error) {

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -387,7 +387,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
         },
       });
 
-      if (affectedCount !== null) {
+      if (affectedCount !== 0) {
         const oauthClient = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         await oauthClient.deleteCredentials({
           credentialsId: this.credentialId,

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -6,18 +6,26 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type { GetProviderCredentialsResponseBody } from "@app/pages/api/w/[wId]/provider_credentials";
 import type {
-  GetProviderCredentialsResponseBody,
-  PostProviderCredentialBody,
-  PostProviderCredentialResponseBody,
-} from "@app/pages/api/w/[wId]/provider_credentials";
+  ProviderCredentialBody,
+  ProviderCredentialResponseBody,
+} from "@app/pages/api/w/[wId]/provider_credentials/[providerId]";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ProviderCredentialType } from "@app/types/provider_credential";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";
 import { useSWRConfig } from "swr";
+
+const baseProviderCredentialsApiUrl = (workspaceId: string) =>
+  `/api/w/${workspaceId}/provider_credentials`;
+
+const providerCredentialApiUrl = (
+  workspaceId: string,
+  providerId: ByokModelProviderIdType
+) => `${baseProviderCredentialsApiUrl(workspaceId)}/${providerId}`;
 
 export function useProviderCredentials({
   owner,
@@ -29,7 +37,7 @@ export function useProviderCredentials({
     fetcher;
 
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/provider_credentials`,
+    baseProviderCredentialsApiUrl(owner.sId),
     providerCredentialsFetcher
   );
 
@@ -42,13 +50,14 @@ export function useProviderCredentials({
   };
 }
 
-export function useProviderCredentialActions({
+export function useSaveProviderCredential({
   owner,
 }: {
   owner: LightWorkspaceType;
 }) {
   const sendNotification = useSendNotification();
   const { mutate } = useSWRConfig();
+  const [isSaving, setIsSaving] = useState(false);
 
   const saveProviderCredential = useCallback(
     async ({
@@ -60,52 +69,116 @@ export function useProviderCredentialActions({
       apiKey: string;
       isNew?: boolean;
     }): Promise<ProviderCredentialType | null> => {
-      let response: Response;
       try {
-        response = await clientFetch(
-          `/api/w/${owner.sId}/provider_credentials`,
-          {
+        setIsSaving(true);
+        let response: Response;
+        try {
+          const url = providerCredentialApiUrl(owner.sId, providerId);
+
+          response = await clientFetch(url, {
             method: isNew ? "POST" : "PATCH",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              providerId,
-              apiKey,
-            } satisfies PostProviderCredentialBody),
-          }
-        );
-      } catch (e) {
+            body: JSON.stringify({ apiKey } satisfies ProviderCredentialBody),
+          });
+        } catch (e) {
+          const message = normalizeError(e).message;
+          sendNotification({
+            type: "error",
+            title: "Failed to save API key",
+            description: message,
+          });
+          return null;
+        }
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to save API key",
+            description: error.message,
+          });
+          return null;
+        }
+
+        const data: ProviderCredentialResponseBody = await response.json();
+
         sendNotification({
-          type: "error",
-          title: "Failed to save API key",
-          description: normalizeError(e).message,
+          type: "success",
+          title: "API key saved",
+          description: "Your API key has been configured successfully.",
         });
-        return null;
+
+        await mutate(baseProviderCredentialsApiUrl(owner.sId));
+
+        return data.providerCredential;
+      } finally {
+        setIsSaving(false);
       }
-
-      if (!response.ok) {
-        const error = await getErrorFromResponse(response);
-        sendNotification({
-          type: "error",
-          title: "Failed to save API key",
-          description: error.message,
-        });
-        return null;
-      }
-
-      const data: PostProviderCredentialResponseBody = await response.json();
-
-      sendNotification({
-        type: "success",
-        title: "API key saved",
-        description: "Your API key has been configured successfully.",
-      });
-
-      await mutate(`/api/w/${owner.sId}/provider_credentials`);
-
-      return data.providerCredential;
     },
     [owner.sId, sendNotification, mutate]
   );
 
-  return { saveProviderCredential };
+  return { saveProviderCredential, isSaving };
+}
+
+export function useDeleteProviderCredential({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const deleteProviderCredential = useCallback(
+    async ({
+      providerId,
+    }: {
+      providerId: ByokModelProviderIdType;
+    }): Promise<boolean> => {
+      try {
+        setIsDeleting(true);
+        let response: Response;
+        try {
+          response = await clientFetch(
+            providerCredentialApiUrl(owner.sId, providerId),
+            { method: "DELETE" }
+          );
+        } catch (e) {
+          const message = normalizeError(e).message;
+          sendNotification({
+            type: "error",
+            title: "Failed to remove API key",
+            description: message,
+          });
+          return false;
+        }
+
+        if (!response.ok) {
+          const error = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to remove API key",
+            description: error.message,
+          });
+          return false;
+        }
+
+        sendNotification({
+          type: "success",
+          title: "API key removed",
+          description: "The API key has been removed successfully.",
+        });
+
+        await mutate(baseProviderCredentialsApiUrl(owner.sId));
+
+        return true;
+      } finally {
+        setIsDeleting(false);
+      }
+    },
+    [owner.sId, sendNotification, mutate]
+  );
+
+  return { deleteProviderCredential, isDeleting };
 }

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -69,26 +69,14 @@ export function useSaveProviderCredential({
       apiKey: string;
       isNew?: boolean;
     }): Promise<ProviderCredentialType | null> => {
+      setIsSaving(true);
       try {
-        setIsSaving(true);
-        let response: Response;
-        try {
-          const url = providerCredentialApiUrl(owner.sId, providerId);
-
-          response = await clientFetch(url, {
-            method: isNew ? "POST" : "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ apiKey } satisfies ProviderCredentialBody),
-          });
-        } catch (e) {
-          const message = normalizeError(e).message;
-          sendNotification({
-            type: "error",
-            title: "Failed to save API key",
-            description: message,
-          });
-          return null;
-        }
+        const url = providerCredentialApiUrl(owner.sId, providerId);
+        const response = await clientFetch(url, {
+          method: isNew ? "POST" : "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ apiKey } satisfies ProviderCredentialBody),
+        });
 
         if (!response.ok) {
           const error = await getErrorFromResponse(response);
@@ -111,6 +99,14 @@ export function useSaveProviderCredential({
         await mutate(baseProviderCredentialsApiUrl(owner.sId));
 
         return data.providerCredential;
+      } catch (e) {
+        const message = normalizeError(e).message;
+        sendNotification({
+          type: "error",
+          title: "Failed to save API key",
+          description: message,
+        });
+        return null;
       } finally {
         setIsSaving(false);
       }
@@ -136,23 +132,12 @@ export function useDeleteProviderCredential({
     }: {
       providerId: ByokModelProviderIdType;
     }): Promise<boolean> => {
+      setIsDeleting(true);
       try {
-        setIsDeleting(true);
-        let response: Response;
-        try {
-          response = await clientFetch(
-            providerCredentialApiUrl(owner.sId, providerId),
-            { method: "DELETE" }
-          );
-        } catch (e) {
-          const message = normalizeError(e).message;
-          sendNotification({
-            type: "error",
-            title: "Failed to remove API key",
-            description: message,
-          });
-          return false;
-        }
+        const response = await clientFetch(
+          providerCredentialApiUrl(owner.sId, providerId),
+          { method: "DELETE" }
+        );
 
         if (!response.ok) {
           const error = await getErrorFromResponse(response);
@@ -173,6 +158,14 @@ export function useDeleteProviderCredential({
         await mutate(baseProviderCredentialsApiUrl(owner.sId));
 
         return true;
+      } catch (e) {
+        const message = normalizeError(e).message;
+        sendNotification({
+          type: "error",
+          title: "Failed to remove API key",
+          description: message,
+        });
+        return false;
       } finally {
         setIsDeleting(false);
       }

--- a/front/pages/api/w/[wId]/provider_credentials/[providerId]/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/[providerId]/index.ts
@@ -1,0 +1,195 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { apiError } from "@app/logger/withlogging";
+import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ProviderCredentialType } from "@app/types/provider_credential";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const ProviderCredentialBodySchema = z.object({
+  apiKey: z.string(),
+});
+
+export type ProviderCredentialBody = z.infer<
+  typeof ProviderCredentialBodySchema
+>;
+
+const ProviderCredentialParamsSchema = z.object({
+  providerId: z.enum(BYOK_MODEL_PROVIDER_IDS),
+});
+
+export type ProviderCredentialResponseBody = {
+  providerCredential: ProviderCredentialType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ProviderCredentialResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can manage provider credentials.",
+      },
+    });
+  }
+
+  const plan = auth.getNonNullablePlan();
+  if (!plan.isByok) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "BYOK is not enabled on this workspace's plan.",
+      },
+    });
+  }
+
+  const paramsValidation = ProviderCredentialParamsSchema.safeParse(req.query);
+  if (!paramsValidation.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `The request params are invalid: ${paramsValidation.error.message}.`,
+      },
+    });
+  }
+
+  const { providerId } = paramsValidation.data;
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = ProviderCredentialBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${bodyValidation.error.message}.`,
+          },
+        });
+      }
+
+      const { apiKey } = bodyValidation.data;
+
+      const providerCredential = await ProviderCredentialResource.makeNew(
+        auth,
+        { providerId, apiKey }
+      );
+
+      if (!providerCredential) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The provided credentials are invalid or could not be verified.",
+          },
+        });
+      }
+
+      return res.status(201).json({
+        providerCredential: providerCredential.toJSON(),
+      });
+    }
+
+    case "PATCH": {
+      const bodyValidation = ProviderCredentialBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The request body is invalid: ${bodyValidation.error.message}.`,
+          },
+        });
+      }
+
+      const { apiKey } = bodyValidation.data;
+
+      const existing = await ProviderCredentialResource.fetchByProvider(
+        auth,
+        providerId
+      );
+
+      if (!existing) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "provider_not_found",
+            message: `No credential found for provider ${providerId}.`,
+          },
+        });
+      }
+
+      const providerCredential = await existing.updateApiKey(auth, { apiKey });
+
+      if (!providerCredential) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The provided credentials are invalid or could not be verified.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        providerCredential: providerCredential.toJSON(),
+      });
+    }
+
+    case "DELETE": {
+      const existing = await ProviderCredentialResource.fetchByProvider(
+        auth,
+        providerId
+      );
+
+      if (!existing) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "provider_not_found",
+            message: `No credential found for provider ${providerId}.`,
+          },
+        });
+      }
+
+      const deleteResult = await existing.delete(auth);
+
+      if (deleteResult.isErr() || !deleteResult.value) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to delete credential for provider ${providerId}.`,
+          },
+        });
+      }
+
+      res.status(204).end();
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, POST, PATCH or DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -3,35 +3,18 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { apiError } from "@app/logger/withlogging";
-import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ProviderCredentialType } from "@app/types/provider_credential";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
-
-const PostProviderCredentialBodySchema = z.object({
-  providerId: z.enum(BYOK_MODEL_PROVIDER_IDS),
-  apiKey: z.string(),
-});
-
-export type PostProviderCredentialBody = z.infer<
-  typeof PostProviderCredentialBodySchema
->;
 
 export type GetProviderCredentialsResponseBody = {
   providerCredentials: ProviderCredentialType[];
 };
 
-export type PostProviderCredentialResponseBody = {
-  providerCredential: ProviderCredentialType;
-};
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<
-      GetProviderCredentialsResponseBody | PostProviderCredentialResponseBody
-    >
+    WithAPIErrorResponse<GetProviderCredentialsResponseBody>
   >,
   auth: Authenticator
 ): Promise<void> {
@@ -67,99 +50,12 @@ async function handler(
       });
     }
 
-    case "POST": {
-      const bodyValidation = PostProviderCredentialBodySchema.safeParse(
-        req.body
-      );
-      if (!bodyValidation.success) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `The request body is invalid: ${bodyValidation.error.message}.`,
-          },
-        });
-      }
-
-      const { providerId, apiKey } = bodyValidation.data;
-
-      const providerCredential = await ProviderCredentialResource.makeNew(
-        auth,
-        { providerId, apiKey }
-      );
-
-      if (!providerCredential) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "The provided credentials are invalid or could not be verified.",
-          },
-        });
-      }
-
-      return res.status(201).json({
-        providerCredential: providerCredential.toJSON(),
-      });
-    }
-
-    case "PATCH": {
-      const bodyValidation = PostProviderCredentialBodySchema.safeParse(
-        req.body
-      );
-      if (!bodyValidation.success) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `The request body is invalid: ${bodyValidation.error.message}.`,
-          },
-        });
-      }
-
-      const { providerId, apiKey } = bodyValidation.data;
-
-      const existing = await ProviderCredentialResource.fetchByProvider(
-        auth,
-        providerId
-      );
-
-      if (!existing) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "provider_not_found",
-            message: `No credential found for provider ${providerId}.`,
-          },
-        });
-      }
-
-      const providerCredential = await existing.updateApiKey(auth, { apiKey });
-
-      if (!providerCredential) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "The provided credentials are invalid or could not be verified.",
-          },
-        });
-      }
-
-      return res.status(200).json({
-        providerCredential: providerCredential.toJSON(),
-      });
-    }
-
     default:
       return apiError(req, res, {
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, GET, POST or PATCH is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }


### PR DESCRIPTION
## Description

Adds the ability for workspace admins to revoke BYOK provider API keys.
Introduces a `/[providerId]` route for credential mutations (POST/PATCH/DELETE),
a confirmation dialog with provider-specific copy (with a stronger warning for OpenAI),
and OAuth secret cleanup on deletion.

<img width="968" height="691" alt="image" src="https://github.com/user-attachments/assets/912404c6-9523-4d1d-b9f0-5d40cf8098ce" />


## Tests

Tested manually: configured, edited, and removed credentials for OpenAI and Anthropic providers.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`