### PR TITLE
[front] - fix(SelectField): pass portal ref

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuTrigger,
   Input,
 } from "@dust-tt/sparkle";
-import { ChevronDownIcon } from "lucide-react";
 import type { Control, FieldValues, Path } from "react-hook-form";
 
 interface SelectFieldOption {
@@ -26,11 +25,13 @@ export function SelectField<T extends FieldValues>({
   name,
   title,
   options,
+  mountPortalContainer,
 }: {
   control: Control<T>;
   name: Path<T>;
   title?: string;
   options: SelectFieldOption[];
+  mountPortalContainer?: HTMLElement;
 }) {
   return (
     <PokeFormField
@@ -49,14 +50,11 @@ export function SelectField<T extends FieldValues>({
             <PokeFormControl>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    label={displayLabel}
-                    icon={ChevronDownIcon}
-                    isSelect
-                  />
+                  <Button variant="outline" label={displayLabel} isSelect />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
+                <DropdownMenuContent
+                  mountPortalContainer={mountPortalContainer}
+                >
                   {options.map((option) => (
                     <DropdownMenuItem
                       key={option.value}

--- a/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
@@ -24,7 +24,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 export default function FreePlanUpgradeDialog({
@@ -36,6 +36,15 @@ export default function FreePlanUpgradeDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const [portalContainer, setPortalContainer] = useState<
+    HTMLElement | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalContainer(document.body);
+    }
+  }, []);
 
   const { plans } = usePokePlans();
 
@@ -130,6 +139,7 @@ export default function FreePlanUpgradeDialog({
                       control={form.control}
                       name="planCode"
                       title="Free Plan"
+                      mountPortalContainer={portalContainer}
                       options={plans
                         .filter(
                           (plan) =>


### PR DESCRIPTION
## Description

Fixes dropdown rendering issue in `FreePlanUpgradeDialog` where the dropdown menu was hidden behind the modal dialog. The `SelectField` component now accepts an optional `mountPortalContainer` prop to specify where the dropdown portal should be mounted. In `FreePlanUpgradeDialog`, the portal container is set to `document.body` using a `useEffect` hook and passed to `SelectField`, ensuring the dropdown renders above the dialog instead of behind it

**References:**
- Fixes https://github.com/dust-tt/tasks/issues/7114

## Tests

- [x] Locally

## Risk

Low - poke-only fix for dialog dropdown rendering

## Deploy Plan

Deploy front
