### PR TITLE
[front] - feat(RA): notification (2/2)

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -112,8 +112,13 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
   { key: "negative", label: "Negative" },
 ] as const;
 
-export const USER_MESSAGE_ORIGIN_LABELS: Record<
+export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
+  "reinforced_agent_notification"
+>;
+
+export const USER_MESSAGE_ORIGIN_LABELS: Record<
+  AnalyticsVisibleOrigin,
   { label: string; color: string }
 > = {
   web: { label: "Conversation", color: buildColorClass("blue", 500) },

--- a/front/components/agent_builder/observability/types.ts
+++ b/front/components/agent_builder/observability/types.ts
@@ -1,4 +1,4 @@
-import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import type { AnalyticsVisibleOrigin } from "@app/components/agent_builder/observability/constants";
 
 const TOOL_CHART_MODES = ["version", "step"] as const;
 
@@ -40,7 +40,7 @@ export type ToolLatencyDatum = {
 };
 
 export type SourceChartDatum = {
-  origin: UserMessageOrigin;
+  origin: AnalyticsVisibleOrigin;
   count: number;
   percent: number;
   label: string;

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -1,3 +1,4 @@
+import type { AnalyticsVisibleOrigin } from "@app/components/agent_builder/observability/constants";
 import {
   buildColorClass,
   INDEXED_BASE_COLORS,
@@ -10,7 +11,6 @@ import type { ObservabilityMode } from "@app/components/agent_builder/observabil
 import type { SourceChartDatum } from "@app/components/agent_builder/observability/types";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import { formatShortDate } from "@app/lib/utils/timestamps";
-import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import moment from "moment-timezone";
 
 export type VersionMarker = { version: string; timestamp: number };
@@ -23,11 +23,11 @@ export type SourceBucket = { origin: string; count: number };
 
 export function isUserMessageOrigin(
   origin?: string | null
-): origin is UserMessageOrigin {
+): origin is AnalyticsVisibleOrigin {
   return !!origin && origin in USER_MESSAGE_ORIGIN_LABELS;
 }
 
-export function getSourceColor(source: UserMessageOrigin) {
+export function getSourceColor(source: AnalyticsVisibleOrigin) {
   return USER_MESSAGE_ORIGIN_LABELS[source].color;
 }
 
@@ -69,7 +69,7 @@ export function buildSourceChartData(
   // Aggregate by label so origins sharing the same display name are merged.
   const aggregatedByLabel = new Map<
     string,
-    { origin: UserMessageOrigin; count: number }
+    { origin: AnalyticsVisibleOrigin; count: number }
   >();
 
   for (const b of buckets) {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -32,6 +32,7 @@ import { useInboxNotifications } from "@app/hooks/useInboxNotifications";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useMoveConversationToProject } from "@app/hooks/useMoveConversationToProject";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useNotificationClickHandler } from "@app/hooks/useNotificationClickHandler";
 import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useSearchProjects } from "@app/hooks/useSearchProjects";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
@@ -431,10 +432,11 @@ export function AgentSidebarMenu({
 
   const { setSidebarOpen } = useContext(SidebarContext);
 
-  const {
-    notifications: inboxNotifications,
-    markAsRead: markNotificationAsRead,
-  } = useInboxNotifications();
+  const { notifications: inboxNotifications, markAsRead } =
+    useInboxNotifications();
+
+  const { handleNotificationClick, loadingNotificationId } =
+    useNotificationClickHandler({ owner, markAsRead });
 
   const {
     conversations,
@@ -753,7 +755,8 @@ export function AgentSidebarMenu({
         loadMore={loadMore}
         isLoadingMore={isLoadingMore}
         inboxNotifications={inboxNotifications}
-        onNotificationClick={markNotificationAsRead}
+        onNotificationClick={handleNotificationClick}
+        loadingNotificationId={loadingNotificationId}
       />
     );
   }, [
@@ -775,7 +778,8 @@ export function AgentSidebarMenu({
     loadMore,
     isLoadingMore,
     inboxNotifications,
-    markNotificationAsRead,
+    handleNotificationClick,
+    loadingNotificationId,
   ]);
 
   return (
@@ -1099,13 +1103,15 @@ const ConversationListContainer = ({
 interface InboxSectionProps
   extends Omit<InboxConversationListProps, "dateLabel"> {
   inboxNotifications: InboxNotification[];
-  onNotificationClick: (notificationId: string) => Promise<void>;
+  onNotificationClick: (notification: InboxNotification) => Promise<void>;
+  loadingNotificationId: string | null;
 }
 
 function InboxSection({
   inboxConversations,
   inboxNotifications,
   onNotificationClick,
+  loadingNotificationId,
   isMultiSelect,
   isMarkingAllAsRead,
   titleFilter,
@@ -1147,8 +1153,10 @@ function InboxSection({
           status="unread"
           icon={RobotIcon}
           label={notification.subject ?? "New notification"}
-          href={notification.primaryAction?.redirect?.url}
-          onClick={() => void onNotificationClick(notification.id)}
+          onClick={() => void onNotificationClick(notification)}
+          className={cn(
+            loadingNotificationId === notification.id && "opacity-50"
+          )}
         />
       ))}
       {inboxConversations.map((conversation) => (
@@ -1348,7 +1356,8 @@ interface NavigationListWithInboxProps {
   loadMore: () => void;
   isLoadingMore: boolean;
   inboxNotifications: InboxNotification[];
-  onNotificationClick: (notificationId: string) => Promise<void>;
+  onNotificationClick: (notification: InboxNotification) => Promise<void>;
+  loadingNotificationId: string | null;
 }
 
 function NavigationListWithInbox({
@@ -1371,6 +1380,7 @@ function NavigationListWithInbox({
   isLoadingMore,
   inboxNotifications,
   onNotificationClick,
+  loadingNotificationId,
 }: NavigationListWithInboxProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { readConversations, inboxConversations } = useMemo(() => {
@@ -1429,6 +1439,7 @@ function NavigationListWithInbox({
           inboxConversations={inboxConversations}
           inboxNotifications={inboxNotifications}
           onNotificationClick={onNotificationClick}
+          loadingNotificationId={loadingNotificationId}
           isMultiSelect={isMultiSelect}
           isMarkingAllAsRead={isMarkingAllAsRead}
           titleFilter={titleFilter}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -27,6 +27,8 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useHideTriggeredConversations } from "@app/hooks/useHideTriggeredConversations";
+import type { InboxNotification } from "@app/hooks/useInboxNotifications";
+import { useInboxNotifications } from "@app/hooks/useInboxNotifications";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useMoveConversationToProject } from "@app/hooks/useMoveConversationToProject";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -430,6 +432,11 @@ export function AgentSidebarMenu({
   const { setSidebarOpen } = useContext(SidebarContext);
 
   const {
+    notifications: inboxNotifications,
+    markAsRead: markNotificationAsRead,
+  } = useInboxNotifications();
+
+  const {
     conversations,
     isConversationsError,
     mutateConversations,
@@ -745,6 +752,8 @@ export function AgentSidebarMenu({
         hasMore={hasMore}
         loadMore={loadMore}
         isLoadingMore={isLoadingMore}
+        inboxNotifications={inboxNotifications}
+        onNotificationClick={markNotificationAsRead}
       />
     );
   }, [
@@ -765,6 +774,8 @@ export function AgentSidebarMenu({
     hasMore,
     loadMore,
     isLoadingMore,
+    inboxNotifications,
+    markNotificationAsRead,
   ]);
 
   return (
@@ -1085,28 +1096,33 @@ const ConversationListContainer = ({
   return <div className="sm:flex sm:flex-col sm:gap-0.5">{children}</div>;
 };
 
-const InboxConversationList = ({
+interface InboxSectionProps
+  extends Omit<InboxConversationListProps, "dateLabel"> {
+  inboxNotifications: InboxNotification[];
+  onNotificationClick: (notificationId: string) => Promise<void>;
+}
+
+function InboxSection({
   inboxConversations,
-  dateLabel,
+  inboxNotifications,
+  onNotificationClick,
   isMultiSelect,
   isMarkingAllAsRead,
   titleFilter,
   onMarkAllAsRead,
-  ...props
-}: InboxConversationListProps) => {
-  if (inboxConversations.length === 0) {
-    return null;
-  }
+  selectedConversations,
+  toggleConversationSelection,
+  activeConversationId,
+  owner,
+}: InboxSectionProps) {
+  const totalCount = inboxConversations.length + inboxNotifications.length;
 
   const shouldShowMarkAllAsReadButton =
-    inboxConversations.length > 0 &&
-    titleFilter.length === 0 &&
-    !isMultiSelect &&
-    onMarkAllAsRead;
+    totalCount > 0 && titleFilter.length === 0 && !isMultiSelect;
 
   return (
     <NavigationListCollapsibleSection
-      label={dateLabel}
+      label={`Inbox (${totalCount})`}
       className="border-b border-t border-border bg-background/50 px-2 pb-2 dark:border-border-night dark:bg-background-night/50"
       defaultOpen
       actionOnHover={false}
@@ -1125,17 +1141,30 @@ const InboxConversationList = ({
         ) : null
       }
     >
+      {inboxNotifications.map((notification) => (
+        <NavigationListItem
+          key={notification.id}
+          status="unread"
+          icon={RobotIcon}
+          label={notification.subject ?? "New notification"}
+          href={notification.primaryAction?.redirect?.url}
+          onClick={() => void onNotificationClick(notification.id)}
+        />
+      ))}
       {inboxConversations.map((conversation) => (
         <ConversationListItem
           key={conversation.sId}
           conversation={conversation}
           isMultiSelect={isMultiSelect}
-          {...props}
+          selectedConversations={selectedConversations}
+          toggleConversationSelection={toggleConversationSelection}
+          activeConversationId={activeConversationId}
+          owner={owner}
         />
       ))}
     </NavigationListCollapsibleSection>
   );
-};
+}
 
 const ConversationList = ({
   conversations,
@@ -1318,6 +1347,8 @@ interface NavigationListWithInboxProps {
   hasMore: boolean;
   loadMore: () => void;
   isLoadingMore: boolean;
+  inboxNotifications: InboxNotification[];
+  onNotificationClick: (notificationId: string) => Promise<void>;
 }
 
 function NavigationListWithInbox({
@@ -1338,6 +1369,8 @@ function NavigationListWithInbox({
   hasMore,
   loadMore,
   isLoadingMore,
+  inboxNotifications,
+  onNotificationClick,
 }: NavigationListWithInboxProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { readConversations, inboxConversations } = useMemo(() => {
@@ -1391,10 +1424,11 @@ function NavigationListWithInbox({
       ref={scrollContainerRef}
       className="dd-privacy-mask h-full w-full overflow-y-auto"
     >
-      {inboxConversations.length > 0 && (
-        <InboxConversationList
+      {(inboxConversations.length > 0 || inboxNotifications.length > 0) && (
+        <InboxSection
           inboxConversations={inboxConversations}
-          dateLabel={`Inbox (${inboxConversations.length})`}
+          inboxNotifications={inboxNotifications}
+          onNotificationClick={onNotificationClick}
           isMultiSelect={isMultiSelect}
           isMarkingAllAsRead={isMarkingAllAsRead}
           titleFilter={titleFilter}

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -122,6 +122,7 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
     (isUserMessage(message) &&
       (message.context.origin === "onboarding_conversation" ||
         message.context.origin === "project_kickoff" ||
+        message.context.origin === "reinforced_agent_notification" ||
         isSidekickBootstrapMessage(message))) ||
     isHandoverUserMessage(message)
   );

--- a/front/hooks/useInboxNotifications.ts
+++ b/front/hooks/useInboxNotifications.ts
@@ -13,6 +13,7 @@ export interface InboxNotification {
   };
   tags?: string[];
   createdAt: string;
+  data?: Record<string, unknown>;
 }
 
 const ADMIN_TAG = "admin";

--- a/front/hooks/useInboxNotifications.ts
+++ b/front/hooks/useInboxNotifications.ts
@@ -1,0 +1,81 @@
+import { useNovuClient } from "@app/hooks/useNovuClient";
+import type { Novu } from "@novu/js";
+import { useCallback, useEffect, useState } from "react";
+
+export interface InboxNotification {
+  id: string;
+  subject?: string;
+  body: string;
+  primaryAction?: {
+    redirect?: {
+      url: string;
+    };
+  };
+  tags?: string[];
+  createdAt: string;
+}
+
+const ADMIN_TAG = "admin";
+
+async function fetchNotifications(
+  novuClient: Novu
+): Promise<InboxNotification[]> {
+  const result = await novuClient.notifications.list({
+    tags: [ADMIN_TAG],
+    read: false,
+    limit: 20,
+  });
+
+  return result.data?.notifications ?? [];
+}
+
+export function useInboxNotifications() {
+  const { novuClient } = useNovuClient();
+  const [notifications, setNotifications] = useState<InboxNotification[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!novuClient) {
+      return;
+    }
+    const items = await fetchNotifications(novuClient);
+    setNotifications(items);
+  }, [novuClient]);
+
+  useEffect(() => {
+    if (!novuClient) {
+      return;
+    }
+
+    void refresh();
+
+    // Listen for real-time notification updates.
+    const unsubReceived = novuClient.on(
+      "notifications.notification_received",
+      () => {
+        void refresh();
+      }
+    );
+
+    const unsubListUpdated = novuClient.on("notifications.list.updated", () => {
+      void refresh();
+    });
+
+    return () => {
+      unsubReceived();
+      unsubListUpdated();
+    };
+  }, [novuClient, refresh]);
+
+  const markAsRead = useCallback(
+    async (notificationId: string) => {
+      if (!novuClient) {
+        return;
+      }
+      await novuClient.notifications.read({ notificationId });
+      setNotifications((prev) => prev.filter((n) => n.id !== notificationId));
+    },
+    [novuClient]
+  );
+
+  return { notifications, markAsRead };
+}

--- a/front/hooks/useNotificationClickHandler.ts
+++ b/front/hooks/useNotificationClickHandler.ts
@@ -1,5 +1,4 @@
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
-import type { FileBlob } from "@app/hooks/useFileUploaderService";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { InboxNotification } from "@app/hooks/useInboxNotifications";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -10,7 +9,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import { isString } from "@app/types/shared/utils/general";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { WorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 function formatSuggestionsAsText(
   suggestions: AgentSuggestionType[],
@@ -25,12 +24,6 @@ function formatSuggestionsAsText(
   }
 
   return lines.join("\n");
-}
-
-function isFileBlobWithFileId(
-  blob: FileBlob
-): blob is FileBlob & { fileId: string } {
-  return blob.fileId !== null;
 }
 
 interface UseNotificationClickHandlerParams {
@@ -57,10 +50,11 @@ export function useNotificationClickHandler({
   const [loadingNotificationId, setLoadingNotificationId] = useState<
     string | null
   >(null);
+  const loadingRef = useRef(false);
 
   const handleNotificationClick = useCallback(
     async (notification: InboxNotification) => {
-      if (loadingNotificationId) {
+      if (loadingRef.current) {
         return;
       }
 
@@ -68,6 +62,7 @@ export function useNotificationClickHandler({
       const agentName = notification.data?.agentName;
 
       if (isString(agentConfigurationId) && isString(agentName)) {
+        loadingRef.current = true;
         setLoadingNotificationId(notification.id);
 
         // Fetch pending suggestions for the agent.
@@ -90,13 +85,14 @@ export function useNotificationClickHandler({
 
         if (suggestions.length > 0) {
           const text = formatSuggestionsAsText(suggestions, agentName);
-          const fileName = `suggestions-${agentName}.txt`;
-          const file = new File([text], fileName, { type: "text/plain" });
+          const file = new File([text], `suggestions-${agentName}.txt`, {
+            type: "text/plain",
+          });
           const blobs = await fileUploaderService.handleFilesUpload([file]);
 
           if (blobs) {
             for (const blob of blobs) {
-              if (isFileBlobWithFileId(blob)) {
+              if (blob.fileId) {
                 uploaded.push({
                   fileId: blob.fileId,
                   title: `Improvement suggestions for @${agentName}`,
@@ -112,8 +108,15 @@ export function useNotificationClickHandler({
             input: `I have new improvement suggestions for my agent @${agentName}. Can you help me review and apply them?`,
             mentions: [{ configurationId: "dust" }],
             contentFragments: { uploaded, contentNodes: [] },
+            origin: "reinforced_agent_notification",
           },
           visibility: "unlisted",
+          metadata: {
+            reinforcedAgentNotification: {
+              agentName,
+              agentConfigurationId,
+            },
+          },
         });
 
         if (result.isOk()) {
@@ -127,7 +130,10 @@ export function useNotificationClickHandler({
           });
         }
 
-        fileUploaderService.resetUpload();
+        if (uploaded.length > 0) {
+          fileUploaderService.resetUpload();
+        }
+        loadingRef.current = false;
         setLoadingNotificationId(null);
       } else {
         // Fallback for notifications without agent data.
@@ -139,7 +145,6 @@ export function useNotificationClickHandler({
       }
     },
     [
-      loadingNotificationId,
       createConversationWithMessage,
       fileUploaderService,
       markAsRead,

--- a/front/hooks/useNotificationClickHandler.ts
+++ b/front/hooks/useNotificationClickHandler.ts
@@ -1,0 +1,157 @@
+import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
+import type { FileBlob } from "@app/hooks/useFileUploaderService";
+import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import type { InboxNotification } from "@app/hooks/useInboxNotifications";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { useAppRouter } from "@app/lib/platform";
+import { useUser } from "@app/lib/swr/user";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { GetSuggestionsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions";
+import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import type { WorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function formatSuggestionsAsText(
+  suggestions: AgentSuggestionType[],
+  agentName: string
+): string {
+  const lines = [`Pending improvement suggestions for @${agentName}:`, ""];
+
+  for (const suggestion of suggestions) {
+    lines.push(
+      `- [${suggestion.kind}] ${suggestion.analysis ?? "No analysis provided."}`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function isFileBlobWithFileId(
+  blob: FileBlob
+): blob is FileBlob & { fileId: string } {
+  return blob.fileId !== null;
+}
+
+interface UseNotificationClickHandlerParams {
+  owner: WorkspaceType;
+  markAsRead: (notificationId: string) => Promise<void>;
+}
+
+export function useNotificationClickHandler({
+  owner,
+  markAsRead,
+}: UseNotificationClickHandlerParams) {
+  const router = useAppRouter();
+  const { user } = useUser();
+  const sendNotification = useSendNotification();
+  const createConversationWithMessage = useCreateConversationWithMessage({
+    owner,
+    user,
+  });
+  const fileUploaderService = useFileUploaderService({
+    owner,
+    useCase: "conversation",
+  });
+
+  const [loadingNotificationId, setLoadingNotificationId] = useState<
+    string | null
+  >(null);
+
+  const handleNotificationClick = useCallback(
+    async (notification: InboxNotification) => {
+      if (loadingNotificationId) {
+        return;
+      }
+
+      const agentConfigurationId = notification.data?.agentConfigurationId;
+      const agentName = notification.data?.agentName;
+
+      if (isString(agentConfigurationId) && isString(agentName)) {
+        setLoadingNotificationId(notification.id);
+
+        // Fetch pending suggestions for the agent.
+        const suggestionsUrl = `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/suggestions?states=pending`;
+        const suggestionsResponse = await clientFetch(suggestionsUrl);
+        const suggestions: AgentSuggestionType[] = [];
+
+        if (suggestionsResponse.ok) {
+          const body =
+            (await suggestionsResponse.json()) as GetSuggestionsResponseBody;
+          suggestions.push(...body.suggestions);
+        }
+
+        // Upload suggestions as a text file content fragment.
+        const uploaded: {
+          fileId: string;
+          title: string;
+          contentType: "text/plain";
+        }[] = [];
+
+        if (suggestions.length > 0) {
+          const text = formatSuggestionsAsText(suggestions, agentName);
+          const fileName = `suggestions-${agentName}.txt`;
+          const file = new File([text], fileName, { type: "text/plain" });
+          const blobs = await fileUploaderService.handleFilesUpload([file]);
+
+          if (blobs) {
+            for (const blob of blobs) {
+              if (isFileBlobWithFileId(blob)) {
+                uploaded.push({
+                  fileId: blob.fileId,
+                  title: `Improvement suggestions for @${agentName}`,
+                  contentType: "text/plain",
+                });
+              }
+            }
+          }
+        }
+
+        const result = await createConversationWithMessage({
+          messageData: {
+            input: `I have new improvement suggestions for my agent @${agentName}. Can you help me review and apply them?`,
+            mentions: [{ configurationId: "dust" }],
+            contentFragments: { uploaded, contentNodes: [] },
+          },
+          visibility: "unlisted",
+        });
+
+        if (result.isOk()) {
+          void markAsRead(notification.id);
+          void router.push(getConversationRoute(owner.sId, result.value.sId));
+        } else {
+          sendNotification({
+            type: "error",
+            title: "Failed to create conversation",
+            description: result.error.message,
+          });
+        }
+
+        fileUploaderService.resetUpload();
+        setLoadingNotificationId(null);
+      } else {
+        // Fallback for notifications without agent data.
+        void markAsRead(notification.id);
+        const redirectUrl = notification.primaryAction?.redirect?.url;
+        if (redirectUrl) {
+          void router.push(redirectUrl);
+        }
+      }
+    },
+    [
+      loadingNotificationId,
+      createConversationWithMessage,
+      fileUploaderService,
+      markAsRead,
+      router,
+      owner.sId,
+      sendNotification,
+    ]
+  );
+
+  return { handleNotificationClick, loadingNotificationId };
+}

--- a/front/hooks/useNotificationClickHandler.ts
+++ b/front/hooks/useNotificationClickHandler.ts
@@ -7,14 +7,10 @@ import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useUser } from "@app/lib/swr/user";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { GetSuggestionsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions";
+import { isString } from "@app/types/shared/utils/general";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { WorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
-
-function isString(value: unknown): value is string {
-  return typeof value === "string";
-}
 
 function formatSuggestionsAsText(
   suggestions: AgentSuggestionType[],
@@ -80,8 +76,8 @@ export function useNotificationClickHandler({
         const suggestions: AgentSuggestionType[] = [];
 
         if (suggestionsResponse.ok) {
-          const body =
-            (await suggestionsResponse.json()) as GetSuggestionsResponseBody;
+          const body: { suggestions: AgentSuggestionType[] } =
+            await suggestionsResponse.json();
           suggestions.push(...body.suggestions);
         }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -513,6 +513,7 @@ export function isUserMessageContextValid(
     case "onboarding_conversation":
     case "agent_sidekick":
     case "project_kickoff":
+    case "reinforced_agent_notification":
     case "web":
       return false;
     default:

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -59,6 +59,10 @@ import {
 } from "@app/types/assistant/models/google_ai_studio";
 import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 
 interface DustLikeGlobalAgentArgs {
   settings: GlobalAgentSettingsModel | null;
@@ -312,28 +316,23 @@ function _getDustLikeGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     hasDeepDive,
-<<<<<<< HEAD
     prefetchedModels,
-=======
     globalAgentContext,
->>>>>>> 7d5e0814da ([assistant/conversation] - feature: recognize reinforced agent notifications as hidden messages)
   }: DustLikeGlobalAgentArgs,
-{
-  agentId,
+  {
+    agentId,
     name,
     preferredModelConfiguration,
     preferredReasoningEffort,
-}
-:
-{
-  agentId: GLOBAL_AGENTS_SID;
-  name: string;
-  preferredModelConfiguration?: ModelConfigurationType | null;
-  preferredReasoningEffort?: ReasoningEffort;
-}
-): AgentConfigurationType | null
-{
+  }: {
+    agentId: GLOBAL_AGENTS_SID;
+    name: string;
+    preferredModelConfiguration?: ModelConfigurationType | null;
+    preferredReasoningEffort?: ReasoningEffort;
+  }
+): AgentConfigurationType | null {
   const { agent_memory: agentMemoryMCPServerView } = mcpServerViews;
+  const owner = auth.getNonNullableWorkspace();
 
   const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
 - Find and analyze data across your company knowledge

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -33,9 +33,11 @@ import {
 import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
+  GlobalAgentContext,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
@@ -55,11 +57,8 @@ import {
   GEMINI_3_FLASH_MODEL_CONFIG,
   GEMINI_3_PRO_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
-import type {
-  ModelConfigurationType,
-  ReasoningEffort,
-} from "@app/types/assistant/models/types";
 
 interface DustLikeGlobalAgentArgs {
   settings: GlobalAgentSettingsModel | null;
@@ -67,6 +66,7 @@ interface DustLikeGlobalAgentArgs {
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   hasDeepDive: boolean;
   prefetchedModels: PrefetchedWhitelistedModels;
+  globalAgentContext?: GlobalAgentContext;
 }
 
 const INSTRUCTION_SECTIONS = {
@@ -292,6 +292,19 @@ function buildInstructions({
   return parts.join("\n\n");
 }
 
+function buildReinforcedAgentStaticResponse(
+  workspaceId: string,
+  agentName: string,
+  agentConfigurationId: string
+): string {
+  const builderUrl = getAgentBuilderRoute(workspaceId, agentConfigurationId);
+  return [
+    `Dust has analysed your workspace conversations with agent @${agentName} and found suggestions to improve it.`,
+    `You can view and apply these suggestions by going to the [agent builder](${builderUrl}).`,
+    "Let me know if you have further questions.",
+  ].join("\n");
+}
+
 function _getDustLikeGlobalAgent(
   auth: Authenticator,
   {
@@ -299,20 +312,27 @@ function _getDustLikeGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     hasDeepDive,
+<<<<<<< HEAD
     prefetchedModels,
+=======
+    globalAgentContext,
+>>>>>>> 7d5e0814da ([assistant/conversation] - feature: recognize reinforced agent notifications as hidden messages)
   }: DustLikeGlobalAgentArgs,
-  {
-    agentId,
+{
+  agentId,
     name,
     preferredModelConfiguration,
     preferredReasoningEffort,
-  }: {
-    agentId: GLOBAL_AGENTS_SID;
-    name: string;
-    preferredModelConfiguration?: ModelConfigurationType | null;
-    preferredReasoningEffort?: ReasoningEffort;
-  }
-): AgentConfigurationType | null {
+}
+:
+{
+  agentId: GLOBAL_AGENTS_SID;
+  name: string;
+  preferredModelConfiguration?: ModelConfigurationType | null;
+  preferredReasoningEffort?: ReasoningEffort;
+}
+): AgentConfigurationType | null
+{
   const { agent_memory: agentMemoryMCPServerView } = mcpServerViews;
 
   const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
@@ -321,9 +341,22 @@ function _getDustLikeGlobalAgent(
 - Create content like documents, presentations, images, and dashboards`;
   const pictureUrl = DUST_AVATAR_URL;
 
+  // Content fragments are posted before the user message and each gets its own
+  // rank, so the first user message may have rank > 0 (e.g. rank 1 when a file
+  // is attached). Use <= 1 to account for this.
+  const isFirstUserMessage =
+    globalAgentContext?.userMessageRank !== undefined &&
+    globalAgentContext.userMessageRank <= 1;
+  const isReinforcedAgentNotificationFirstTurn =
+    isFirstUserMessage && globalAgentContext?.reinforcedAgentNotification;
+
   let isPreferredModel = false;
 
   const modelConfiguration = (() => {
+    if (isReinforcedAgentNotificationFirstTurn) {
+      return NOOP_MODEL_CONFIG;
+    }
+
     if (!auth.isUpgraded()) {
       return prefetchedModels.small;
     }
@@ -341,20 +374,28 @@ function _getDustLikeGlobalAgent(
     return prefetchedModels.large;
   })();
 
-  let model: AgentModelConfigurationType;
-  if (modelConfiguration) {
-    model = {
-      providerId: modelConfiguration.providerId,
-      modelId: modelConfiguration.modelId,
-      temperature: 0.7,
-      reasoningEffort:
-        isPreferredModel && preferredReasoningEffort
-          ? preferredReasoningEffort
-          : modelConfiguration.defaultReasoningEffort,
-    };
-  } else {
-    model = dummyModelConfiguration;
-  }
+  const model: AgentModelConfigurationType = modelConfiguration
+    ? {
+        providerId: modelConfiguration.providerId,
+        modelId: modelConfiguration.modelId,
+        temperature: 0.7,
+        reasoningEffort:
+          isPreferredModel && preferredReasoningEffort
+            ? preferredReasoningEffort
+            : modelConfiguration.defaultReasoningEffort,
+        ...(isReinforcedAgentNotificationFirstTurn &&
+          globalAgentContext?.reinforcedAgentNotification && {
+            metaData: {
+              staticResponse: buildReinforcedAgentStaticResponse(
+                owner.sId,
+                globalAgentContext.reinforcedAgentNotification.agentName,
+                globalAgentContext.reinforcedAgentNotification
+                  .agentConfigurationId
+              ),
+            },
+          }),
+      }
+    : dummyModelConfiguration;
 
   const hasAgentMemory = agentMemoryMCPServerView !== null;
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -727,6 +727,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         prefetchedModels,
+        globalAgentContext,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_EDGE:

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -36,6 +36,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   agent_sidekick: "user",
   project_butler: "user",
   project_kickoff: "user",
+  reinforced_agent_notification: "user",
 };
 
 export const USER_USAGE_ORIGINS = Object.keys(

--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -40,7 +40,10 @@ export const agentSuggestionsReadyWorkflow = workflow(
             ),
           },
         },
-        data: {},
+        data: {
+          agentConfigurationId: payload.agentConfigurationId,
+          agentName: payload.agentName,
+        },
       };
     });
   },

--- a/front/lib/notifications/workflows/agent-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/agent-suggestions-ready.ts
@@ -40,9 +40,7 @@ export const agentSuggestionsReadyWorkflow = workflow(
             ),
           },
         },
-        data: {
-          autoDelete: true,
-        },
+        data: {},
       };
     });
   },

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -85,6 +85,7 @@ describe("conversation-unread workflow business logic", () => {
     triggered: false,
     triggered_programmatic: false,
     zendesk: false,
+    reinforced_agent_notification: false,
   };
   describe("shouldSendNotificationForAgentAnswer", () => {
     it.each(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -77,6 +77,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "onboarding_conversation":
     case "agent_sidekick":
     case "project_butler":
+    case "reinforced_agent_notification":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;
     case "api":

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -15,6 +15,7 @@ const UserMessageOriginSchema = t.union([
   t.literal("agent_sidekick"),
   t.literal("project_kickoff"),
   t.literal("extension"),
+  t.literal("reinforced_agent_notification"),
 ]);
 
 export const MessageBaseSchema = t.type({

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -130,6 +130,10 @@ export type AgentFetchVariant = "light" | "full" | "extra_light";
 export type GlobalAgentContext = {
   userMessageRank: number;
   sidekickIsNewAgentFromScratch?: boolean;
+  reinforcedAgentNotification?: {
+    agentName: string;
+    agentConfigurationId: string;
+  };
 };
 
 /**

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -28,6 +28,20 @@ import { Err, Ok } from "../shared/result";
 import { isGlobalAgentId } from "./assistant";
 import { ConversationError } from "./conversation";
 
+function isReinforcedAgentNotificationMetadata(
+  value: unknown
+): value is { agentName: string; agentConfigurationId: string } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  return (
+    "agentName" in value &&
+    typeof value.agentName === "string" &&
+    "agentConfigurationId" in value &&
+    typeof value.agentConfigurationId === "string"
+  );
+}
+
 /**
  * Error types for getAgentLoopData that indicate soft-deleted resources.
  * These are safe to ignore in callers since the resource was intentionally deleted.
@@ -297,11 +311,19 @@ export async function getAgentLoopDataWithAuth(
 
   const agentId = agentMessage.configuration.sId;
 
+  const reinforcedMeta = conversation.metadata?.reinforcedAgentNotification;
+  const reinforcedAgentNotification = isReinforcedAgentNotificationMetadata(
+    reinforcedMeta
+  )
+    ? reinforcedMeta
+    : undefined;
+
   const globalAgentContext: GlobalAgentContext = {
     userMessageRank: userMessage.rank,
     sidekickIsNewAgentFromScratch:
       conversation.metadata?.sidekickIsNewAgentFromScratch === true ||
       undefined,
+    reinforcedAgentNotification,
   };
 
   // As the agent configuration is never supposed to change during a loop, we can cache it for a long time.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -77,7 +77,8 @@ export type ClientMessageOrigin =
   | "web"
   | "project_kickoff"
   | "extension"
-  | "agent_sidekick";
+  | "agent_sidekick"
+  | "reinforced_agent_notification";
 
 export type UserMessageOrigin =
   // "api" is Custom API usage, while e.g. extension, gsheets and many other origins

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -341,6 +341,7 @@ const USER_MESSAGE_ORIGINS = [
   "agent_sidekick",
   "project_butler",
   "project_kickoff",
+  "reinforced_agent_notification",
 ] as const;
 
 const UserMessageOriginEnumSchema = z.enum(USER_MESSAGE_ORIGINS);


### PR DESCRIPTION
## Description

Implements inbox notifications UI for agent improvement suggestions (part 2/2, following #22931). Adds a new `useInboxNotifications` hook that fetches admin-tagged notifications from Novu and listens for real-time updates. 

The `SidebarMenu` now displays these notifications alongside conversations in the inbox section. When users click a notification for agent suggestions, the `useNotificationClickHandler` hook automatically fetches pending suggestions, uploads them as a text file, and creates a new conversation with `@dust` to review the improvements. 

The placeholder message is currently very simple - we can refine it as we use it.

**References:**
- Closes https://github.com/dust-tt/tasks/issues/7011

## Tests

Manually tested the notification flow: receiving notifications, clicking to create conversation with suggestions attached, and marking as read.

## Risk

Low - new feature behind admin-tagged notifications

## Deploy Plan

Deploy front
