### PR TITLE
[front] Extract ASSISTANT_EMAIL_SUBDOMAIN to constants to fix front-spa build

### DIFF
--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -1,5 +1,5 @@
 import { useEmailAgentsToggle } from "@app/hooks/useEmailAgentsToggle";
-import { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/email_trigger";
+import { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/constants";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ActionMailAiIcon,

--- a/front/lib/api/assistant/email/constants.ts
+++ b/front/lib/api/assistant/email/constants.ts
@@ -1,0 +1,5 @@
+import { isDevelopment } from "@app/types/shared/env";
+
+export const ASSISTANT_EMAIL_SUBDOMAIN = isDevelopment()
+  ? "dev.dust.help"
+  : "dust.team";

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -6,6 +6,7 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/constants";
 import config from "@app/lib/api/config";
 import { sendEmail, sendEmailToRecipients } from "@app/lib/api/email";
 import { generateValidationToken } from "@app/lib/api/email/validation_token";
@@ -27,7 +28,6 @@ import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { SupportedFileContentType } from "@app/types/files";
-import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString, isStringArray } from "@app/types/shared/utils/general";
@@ -186,9 +186,7 @@ export async function deleteEmailReplyContext(
   await redis.del(key);
 }
 
-export const ASSISTANT_EMAIL_SUBDOMAIN = isDevelopment()
-  ? "dev.dust.help"
-  : "dust.team";
+export { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/constants";
 
 export type EmailAttachment = {
   filepath: string; // Temp file path from formidable


### PR DESCRIPTION
## Description

The EmailAgentsToggle component (#22897) imports ASSISTANT_EMAIL_SUBDOMAIN from email_trigger.ts, a heavy server-side module that pulls in Redis, Sequelize, webpack and @swc/core into the Vite build. This causes the front-spa build to fail because Vite can't parse .node binary files.

Fix: extract ASSISTANT_EMAIL_SUBDOMAIN into a lightweight constants.ts file and update imports. Existing re-export from email_trigger.ts preserves backward compatibility for all other consumers.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
