### PR TITLE
[front] - refactor(AgentDetails): rename AgentDetails to AgentDetailsSheet

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -1,6 +1,6 @@
 import { AddToolsMenu } from "@app/components/actions/mcp/AddToolsMenu";
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
@@ -374,7 +374,7 @@ export const AdminActionsList = ({
 
   return (
     <>
-      <AgentDetails
+      <AgentDetailsSheet
         owner={owner}
         user={user}
         agentId={assistantSId}

--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -1,6 +1,6 @@
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { AgentDetailsDropdownMenu } from "@app/components/assistant/details/AgentDetailsButtonBar";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { rankAgentsByPopularity } from "@app/components/assistant/helpers/agents";
 import { ManageDropdownMenu } from "@app/components/assistant/ManageDropdownMenu";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
@@ -503,7 +503,7 @@ export function AgentBrowser({
         </div>
       )}
 
-      <AgentDetails
+      <AgentDetailsSheet
         owner={owner}
         user={user}
         agentId={displayedAssistantId}

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -9,7 +9,7 @@ import { ConversationTitle } from "@app/components/assistant/conversation/Conver
 import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { MemberDetails } from "@app/components/assistant/details/MemberDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
@@ -124,7 +124,7 @@ const ConversationLayoutContent = ({
 
   return (
     <BlockedActionsProvider owner={owner} conversation={conversation}>
-      <AgentDetails
+      <AgentDetailsSheet
         owner={owner}
         user={user}
         agentId={agentSId}

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -336,7 +336,7 @@ export function AgentDetailsDropdownMenu({
       ) : showTrigger ? (
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
-            <Button icon={MoreIcon} size="sm" variant="ghost" />
+            <Button icon={MoreIcon} size="sm" variant="outline" />
           </DropdownMenuTrigger>
           <DropdownMenuContent>{menuItems}</DropdownMenuContent>
         </DropdownMenu>

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -68,19 +68,19 @@ export const SCOPE_INFO: Record<
   },
 } as const;
 
-type AgentDetailsProps = {
+type AgentDetailsSheetProps = {
   owner: WorkspaceType;
   onClose: () => void;
   agentId: string | null;
   user: UserType;
 };
 
-export function AgentDetails({
+export function AgentDetailsSheet({
   agentId,
   onClose,
   owner,
   user,
-}: AgentDetailsProps) {
+}: AgentDetailsSheetProps) {
   const [selectedTab, setSelectedTab] = useState<
     "info" | "insights" | "editors" | "agent_memory" | "triggers"
   >("info");

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -1,5 +1,5 @@
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
-import { SCOPE_INFO } from "@app/components/assistant/details/AgentDetails";
+import { SCOPE_INFO } from "@app/components/assistant/details/AgentDetailsSheet";
 import { GlobalAgentAction } from "@app/components/assistant/manager/GlobalAgentAction";
 import { TableTagSelector } from "@app/components/assistant/manager/TableTagSelector";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -1,7 +1,7 @@
 import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
@@ -285,7 +285,7 @@ export function ManageAgentsPage() {
         <Custom404 />
       ) : (
         <>
-          <AgentDetails
+          <AgentDetailsSheet
             owner={owner}
             user={user}
             agentId={detailedAgentId}

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -1,5 +1,5 @@
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
 import { SkillsTable } from "@app/components/skills/SkillsTable";
@@ -227,7 +227,7 @@ export function ManageSkillsPage() {
         user={user}
         owner={owner}
       />
-      <AgentDetails
+      <AgentDetailsSheet
         owner={owner}
         user={user}
         agentId={agentId}

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -1,4 +1,4 @@
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ConnectorPermissionsModal } from "@app/components/data_source/ConnectorPermissionsModal";
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
@@ -601,7 +601,7 @@ export const SpaceResourcesList = ({
 
   return (
     <>
-      <AgentDetails
+      <AgentDetailsSheet
         owner={owner}
         user={user}
         agentId={assistantSId}

--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -1,4 +1,4 @@
-import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { AdminTriggersList } from "@app/components/triggers/AdminTriggersList";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
@@ -47,7 +47,7 @@ export const SystemSpaceTriggersList = ({
 
   return (
     <>
-      <AgentDetails
+      <AgentDetailsSheet
         owner={owner}
         user={user}
         agentId={agentSId}


### PR DESCRIPTION
## Description

Renames `AgentDetails` component to `AgentDetailsSheet` to better reflect its implementation and purpose as a sheet-based UI pattern. The component uses Sparkle's `Sheet` component under the hood, and this naming makes it consistent with similar components like `SkillDetailsSheet` and `MemberDetails`.

Also updates the dropdown trigger button variant from `ghost` to `outline` in `AgentDetailsButtonBar` for visual consistency.

## Tests

No behavior changes, this is a pure rename refactor.

## Risk

None. Pure refactor with no logic changes.

## Deploy Plan

Deploy front
