### PR TITLE
Fix unbounded LRU cache causing memory leak in agent-loop workers

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -20,5 +20,6 @@ export const isDeepDiveDisabledByAdmin = memoizer.sync({
     return `deep_dive_disabled_by_admin_${auth.getNonNullableWorkspace().id}`;
   },
 
+  max: 128,
   itemMaxAge: () => 3000,
 });

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -38,7 +38,7 @@ export const isDeepDiveDisabledByAdmin = (
       if (err) {
         reject(err);
       } else {
-        resolve(result!);
+        resolve(result ?? false);
       }
     });
   });

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -3,23 +3,42 @@ import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import memoizer from "lru-memoizer";
 
-export const isDeepDiveDisabledByAdmin = memoizer.sync({
-  load: async (auth: Authenticator): Promise<boolean> => {
-    // We cannot call getGlobalAgents here because it will cause a dependency cycle.
-    // Can be cached if too many calls are made.
-    const settings = await GlobalAgentSettingsModel.findOne({
+const DEEP_DIVE_DISABLED_TTL_MS = 3 * 1000; // 3 seconds
+
+// Use memoizer's callback-based API so the LRU cache stores the resolved value, not a Promise.
+// memoizer.sync with an async load caches the Promise itself, which retains Node async context and
+// causes memory growth.
+const _isDeepDiveDisabledByAdmin = memoizer<Authenticator, boolean>({
+  load: (auth, callback) => {
+    GlobalAgentSettingsModel.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
       },
-    });
-    return settings?.status === "disabled_by_admin";
+    })
+      .then((settings) =>
+        callback(null, settings?.status === "disabled_by_admin")
+      )
+      .catch((err: Error) => callback(err));
   },
 
-  hash: function (auth: Authenticator) {
-    return `deep_dive_disabled_by_admin_${auth.getNonNullableWorkspace().id}`;
-  },
+  hash: (auth: Authenticator) =>
+    `deep_dive_disabled_by_admin_${auth.getNonNullableWorkspace().id}`,
 
-  max: 128,
-  itemMaxAge: () => 3000,
+  max: 100,
+
+  ttl: DEEP_DIVE_DISABLED_TTL_MS,
 });
+
+export const isDeepDiveDisabledByAdmin = (
+  auth: Authenticator
+): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    _isDeepDiveDisabledByAdmin(auth, (err: Error | null, result?: boolean) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result!);
+      }
+    });
+  });

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -1,5 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { getFeatureFlags, invalidateFeatureFlagsCache } from "@app/lib/auth";
+import { invalidateFeatureFlagsCache } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -1,5 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { getFeatureFlags } from "@app/lib/auth";
+import { getFeatureFlags, invalidateFeatureFlagsCache } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
@@ -81,7 +81,7 @@ export const toggleFeatureFlagPlugin = createPlugin({
     // requests hitting it immediately reflect the updated flags. Other pods
     // will pick up the change once their 3s memoizer TTL expires.
     if (toAdd.length > 0 || toRemove.length > 0) {
-      getFeatureFlags.del(workspace);
+      invalidateFeatureFlagsCache(workspace);
     }
 
     const actions: string[] = [];

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1430,6 +1430,7 @@ export const getFeatureFlags = memoizer.sync({
     return `feature_flags_${workspace.id}`;
   },
 
+  max: 128,
   itemMaxAge: () => 3000,
 });
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1448,7 +1448,7 @@ export function getFeatureFlags(
       if (err) {
         reject(err);
       } else {
-        resolve(result!);
+        resolve(result ?? []);
       }
     });
   });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1414,25 +1414,51 @@ export async function prodAPICredentialsForOwner(
   };
 }
 
-export const getFeatureFlags = memoizer.sync({
-  load: async (
-    workspace: LightWorkspaceType
-  ): Promise<WhitelistableFeature[]> => {
+// Use memoizer's callback-based API so the LRU cache stores the resolved value, not a Promise.
+// memoizer.sync with an async load caches the Promise itself, which retains Node async context and
+// causes memory growth.
+const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
+  load: (workspace, callback) => {
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
-      return [...WHITELISTABLE_FEATURES];
-    } else {
-      const flags = await FeatureFlagResource.listForWorkspace(workspace);
-      return flags.map((flag) => flag.name);
+      callback(null, [...WHITELISTABLE_FEATURES]);
+      return;
     }
+
+    FeatureFlagResource.listForWorkspace(workspace)
+      .then((flags) =>
+        callback(
+          null,
+          flags.map((flag) => flag.name)
+        )
+      )
+      .catch((err: Error) => callback(err));
   },
 
-  hash: function (workspace: LightWorkspaceType) {
-    return `feature_flags_${workspace.id}`;
-  },
+  hash: (workspace: LightWorkspaceType) => `feature_flags_${workspace.id}`,
 
-  max: 128,
-  itemMaxAge: () => 3000,
+  max: 100,
+  ttl: 3000,
 });
+
+export function getFeatureFlags(
+  workspace: LightWorkspaceType
+): Promise<WhitelistableFeature[]> {
+  return new Promise((resolve, reject) => {
+    _getFeatureFlags(workspace, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result!);
+      }
+    });
+  });
+}
+
+export function invalidateFeatureFlagsCache(
+  workspace: LightWorkspaceType
+): void {
+  _getFeatureFlags.del(workspace);
+}
 
 export async function isRestrictedFromAgentCreation(
   owner: LightWorkspaceType

--- a/front/package.json
+++ b/front/package.json
@@ -161,7 +161,7 @@
     "jwks-rsa": "^3.1.0",
     "libphonenumber-js": "^1.12.33",
     "lodash": "^4.17.21",
-    "lru-memoizer": "^2.2.0",
+    "lru-memoizer": "^3.0.0",
     "lucide-react": "^0.363.0",
     "luxon": "^3.4.4",
     "marked": "^14.1.3",

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -21,7 +21,9 @@ vi.mock("@temporalio/activity", () => ({
 const PAST_THRESHOLD_MS = (PENDING_AGENTS_RETENTION_HOURS + 1) * 3600 * 1000;
 
 beforeEach(() => {
-  vi.useFakeTimers();
+  // Only fake Date — leave setImmediate/setTimeout real so lru-memoizer
+  // callbacks (used by getFeatureFlags) can fire.
+  vi.useFakeTimers({ toFake: ["Date"] });
 });
 
 afterEach(() => {

--- a/front/tests/utils/FeatureFlagFactory.ts
+++ b/front/tests/utils/FeatureFlagFactory.ts
@@ -1,4 +1,4 @@
-import { getFeatureFlags } from "@app/lib/auth";
+import { invalidateFeatureFlagsCache } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
@@ -11,6 +11,6 @@ export class FeatureFlagFactory {
     await FeatureFlagResource.enable(workspace, featureName);
 
     // Clear the memoizer cache so that the following calls see the updated feature flags.
-    getFeatureFlags.del(workspace);
+    invalidateFeatureFlagsCache(workspace);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -466,7 +466,7 @@
         "jwks-rsa": "^3.1.0",
         "libphonenumber-js": "^1.12.33",
         "lodash": "^4.17.21",
-        "lru-memoizer": "^2.2.0",
+        "lru-memoizer": "^3.0.0",
         "lucide-react": "^0.363.0",
         "luxon": "^3.4.4",
         "marked": "^14.1.3",
@@ -688,6 +688,25 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "front/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "front/node_modules/lru-memoizer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^11.0.1"
       }
     },
     "front/node_modules/openai": {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Agent-loop workers have been OOMing in production. Heap snapshot analysis revealed that `lru-memoizer` caches in `isDeepDiveDisabledByAdmin` and `getFeatureFlags` were growing unbounded, retaining ~25% of the heap (203 MB in a single snapshot).

## Root cause

Both memoizers used `memoizer.sync()` with an async load function. `memoizer.sync` caches the return value of load directly which for an async function is a `Promise` object, not the resolved value. Each Promise carries a `<symbol
kResourceStore>` (the Node.js async context from dd-trace and Temporal), retaining spans, activity contexts, and associated data.

Combined with missing max options, the cache grew unbounded. `itemMaxAge: 3000` (3s TTL) only triggers lazy eviction on access, so entries for workspaces that are never re-accessed stayed forever.

Heap snapshot retainer chain:
```
LRUCache (symbol cache) → 203 MB (25% of heap)
  -> result() (memoized function) → 203 MB
    -> isDeepDiveDisabledByAdmin in system / Context → 266 MB (33%)
      -> Timeout (300s timer, EventCoalescer cleanup interval)
        -> timerListMap in system / Context (root)
```

<img width="1067" height="80" alt="New_Tab" src="https://github.com/user-attachments/assets/fb4edfe4-9e70-4d71-9f27-e1400082a868" />

<img width="1071" height="89" alt="New_Tab" src="https://github.com/user-attachments/assets/62c96a18-2686-4b75-ba55-e16ec5f4abad" />

## Fix

- Switch from `memoizer.sync` to the callback-based memoizer API. The callback API stores the resolved value (a boolean / string array) in the cache, not thePromise. Eliminating the async context retention entirely.
- Add max: 100 to bound the cache and prevent unbounded growth from lazy TTL eviction.

## Reproduction

```
=== LRU Cache Implementation Test ===

--- OLD: memoizer.sync with async load ---
First call return type : object
Is a Promise?          : true
Same reference (cached): true
Resolved value         : true
Resolved type          : boolean

--- NEW: callback-based memoizer ---
First call resolved    : true
Resolved type          : boolean
Is a Promise?          : false
Second call resolved   : true
Same value (cached)    : true

--- Memory impact comparison ---
Entries cached          : 1000
Old (Promise) heap delta: 1624.8 KB
New (boolean) heap delta : -1216.9 KB

--- Assertions ---
PASS: old cache stores Promise objects
PASS: new cache stores resolved values (not Promises)

All checks passed.
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
