### PR TITLE
Fix extension refresh

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -38,7 +38,6 @@ import {
 } from "./interactWithPage";
 
 const log = console.error;
-const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
 
 function isGoogleChrome(): boolean {
   const brands =
@@ -1170,7 +1169,7 @@ const refreshToken = async (
           success: true,
           accessToken: data.accessToken,
           refreshToken: data.refreshToken || refreshToken,
-          expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
+          expirationDate: data.expirationDate,
           authentication_method: data.authenticationMethod,
         });
       });
@@ -1222,7 +1221,7 @@ const exchangeCodeForTokens = async (
       success: true,
       accessToken: data.accessToken,
       refreshToken: data.refreshToken,
-      expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY_IN_SECONDS,
+      expirationDate: data.expirationDate,
       authentication_method: data.authenticationMethod,
     };
   } catch (error) {

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -226,7 +226,7 @@ export const sendRefreshTokenMessage = (
         if (
           !response.accessToken ||
           !response.refreshToken ||
-          !response.expiresIn
+          !response.expirationDate
         ) {
           return reject(new Error("Invalid response received."));
         }

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -17,8 +17,6 @@ const POPUP_CONFIG = {
   CHECK_INTERVAL_MS: 100,
 } as const;
 
-const DEFAULT_TOKEN_EXPIRY = 5 * 60; // 5 minutes in seconds
-
 interface PopupResult<T = void> {
   data?: T;
   error?: Error;
@@ -164,7 +162,7 @@ export class FrontAuthService extends AuthService {
         success: true,
         accessToken: data.accessToken,
         refreshToken: data.refreshToken || "",
-        expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY,
+        expirationDate: data.expirationDate,
       });
 
       const claims = jwtDecode<Record<string, string>>(data.accessToken);
@@ -277,7 +275,7 @@ export class FrontAuthService extends AuthService {
         success: true,
         accessToken: data.accessToken,
         refreshToken: data.refreshToken || "",
-        expiresIn: data.expiresIn || DEFAULT_TOKEN_EXPIRY,
+        expirationDate: data.expirationDate,
       });
       return new Ok(storedTokens);
     } catch (error) {

--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -13,7 +13,7 @@ export type OAuthAuthorizeResponse = {
   success: true;
   accessToken: string;
   refreshToken: string;
-  expiresIn: number;
+  expirationDate: number;
   authentication_method?: string;
 };
 
@@ -51,7 +51,7 @@ export abstract class AuthService {
     const tokens: StoredTokens = {
       accessToken: rawTokens.accessToken,
       refreshToken: rawTokens.refreshToken,
-      expiresAt: Date.now() + rawTokens.expiresIn * 1000,
+      expiresAt: rawTokens.expirationDate,
     };
 
     for (const [key, value] of Object.entries(tokens)) {

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -29,14 +29,21 @@ export const useAuthHook = () => {
 
   // Set default fetch init for the extension (overrides RegionContext's credentials: "include").
   // Must be declared before any fetch effects so it's active when they run.
+  // The resolver calls getAccessToken() on every request so expired tokens are
+  // transparently refreshed before each fetch / EventSource connection.
   useEffect(() => {
     if (tokens?.accessToken) {
-      setDefaultInitResolver(() => ({
-        credentials: "omit",
-        headers: { Authorization: `Bearer ${tokens.accessToken}` },
-      }));
+      setDefaultInitResolver(async (): Promise<RequestInit> => {
+        const accessToken = await platform.auth.getAccessToken();
+        return {
+          credentials: "omit",
+          headers: accessToken
+            ? { Authorization: `Bearer ${accessToken}` }
+            : {},
+        };
+      });
     } else {
-      setDefaultInitResolver(() => ({
+      setDefaultInitResolver(async () => ({
         credentials: "omit",
       }));
     }
@@ -44,7 +51,7 @@ export const useAuthHook = () => {
     return () => {
       setDefaultInitResolver(null);
     };
-  }, [tokens?.accessToken]);
+  }, [tokens?.accessToken, platform.auth]);
 
   const isAuthenticated = useMemo(
     () => !!(tokens?.accessToken && tokens.expiresAt > Date.now()),
@@ -250,9 +257,10 @@ export const useAuthHook = () => {
       setTokens(newTokens);
       setRegionInfo(newRegionInfo, { keepInStorage: true });
       setAuthError(null);
+      scheduleRefresh(newTokens.expiresAt);
       // isLoading stays true — the user fetch effect will clear it.
     },
-    [forcedConnection]
+    [forcedConnection, scheduleRefresh]
   );
 
   const handleSelectOrganization = useCallback(

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -47,7 +47,7 @@ const stableEventSourceManager = {
    * @param uniqueId A unique identifier for this EventSource instance
    * @returns The newly created EventSource instance
    */
-  create(url: string, uniqueId: string) {
+  async create(url: string, uniqueId: string) {
     const urlWithCommitHash = new URL(url, document.baseURI);
     urlWithCommitHash.searchParams.append("commitHash", COMMIT_HASH);
 
@@ -57,7 +57,7 @@ const stableEventSourceManager = {
       urlWithCommitHash.search +
       urlWithCommitHash.hash;
 
-    const newSource = clientEventSource(pathWithQueryAndHash, {
+    const newSource = await clientEventSource(pathWithQueryAndHash, {
       heartbeatTimeout: HEARTBEAT_TIMEOUT_MS,
     });
     this.sources.set(uniqueId, newSource);
@@ -108,7 +108,7 @@ export function useEventSource(
   const sourceManager = stableEventSourceManager;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  const connect = useCallback(() => {
+  const connect = useCallback(async () => {
     const url = buildURL(lastEvent.current);
     if (!url) {
       // If the url is empty, it means streaming is done.
@@ -121,7 +121,7 @@ export function useEventSource(
     let source = sourceManager.get(uniqueId);
     // If the source is closed or doesn't exist, create a new one.
     if (!source || source.readyState === EventSourcePolyfill.CLOSED) {
-      source = sourceManager.create(url, uniqueId);
+      source = await sourceManager.create(url, uniqueId);
     }
 
     source.onopen = () => {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -17,13 +17,16 @@ export function getBaseUrl(): string {
 }
 
 // Pluggable default RequestInit resolver (e.g. credentials/headers per context).
-let defaultInitResolver: (() => RequestInit) | null = null;
+// The resolver may be async (e.g. to call getAccessToken() which refreshes expired tokens).
+let defaultInitResolver: (() => Promise<RequestInit>) | null = null;
 
-export function setDefaultInitResolver(fn: (() => RequestInit) | null): void {
+export function setDefaultInitResolver(
+  fn: (() => Promise<RequestInit>) | null
+): void {
   defaultInitResolver = fn;
 }
 
-export function getDefaultInit(): RequestInit | null {
+export function getDefaultInit(): Promise<RequestInit> | null {
   return defaultInitResolver?.() ?? null;
 }
 

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -193,7 +193,7 @@ export class BrowserMCPTransport implements Transport {
       params.set("lastEventId", this.lastEventId);
     }
 
-    this.eventSource = clientEventSource(
+    this.eventSource = await clientEventSource(
       `/api/sse/w/${this.workspaceId}/mcp/requests?${params.toString()}`,
       // The MCP SSE connection is idle most of the time (waiting for requests
       // from Dust). Disable the polyfill's heartbeat timeout so it doesn't

--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -5,10 +5,42 @@ import {
   type EventSourcePolyfillInit,
 } from "event-source-polyfill";
 
+/**
+ * Resolve the default RequestInit, merging it with `init` (caller takes precedence).
+ * The resolver may be async (e.g. refreshing an expired token), so we always await.
+ */
+async function resolveInit(
+  baseUrl: string,
+  init?: RequestInit
+): Promise<RequestInit | undefined> {
+  let defaults = await getDefaultInit();
+  if (!defaults && baseUrl) {
+    defaults = { credentials: "include" };
+  }
+
+  if (!defaults) {
+    return init;
+  }
+
+  const mergedHeaders =
+    defaults.headers || init?.headers
+      ? {
+          ...defaults.headers,
+          ...init?.headers,
+        }
+      : undefined;
+
+  return {
+    ...defaults,
+    ...init,
+    ...(mergedHeaders && { headers: mergedHeaders }),
+  };
+}
+
 // Client-side fetch helper. This is a simple alias for the global fetch, used to satisfy
 // the linter rule that discourages direct use of `fetch`. On the client, we cannot route
 // through a proxy, so this is just a pass-through.
-export function clientFetch(
+export async function clientFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
@@ -20,28 +52,7 @@ export function clientFetch(
     input = `${baseUrl}${input}`;
   }
 
-  // Merge default RequestInit from the resolver (caller's init takes precedence,
-  // headers are shallow-merged).
-  // When no resolver is set but a baseUrlResolver is active (SPA context),
-  // default to credentials: "include" for cross-origin cookie auth.
-  const defaults =
-    getDefaultInit() ?? (baseUrl ? { credentials: "include" } : null);
-
-  if (defaults) {
-    const mergedHeaders =
-      defaults.headers || init?.headers
-        ? {
-            ...defaults.headers,
-            ...init?.headers,
-          }
-        : undefined;
-
-    init = {
-      ...defaults,
-      ...init,
-      ...(mergedHeaders && { headers: mergedHeaders }),
-    };
-  }
+  init = await resolveInit(baseUrl, init);
 
   // eslint-disable-next-line no-restricted-globals
   return fetch(input, init);
@@ -50,21 +61,21 @@ export function clientFetch(
 // Client-side EventSource helper. Mirrors the URL-rewriting and header-merging
 // logic of `clientFetch` so that SSE connections pick up the same auth context
 // (Bearer tokens in the extension, cookies in the web app).
-export function clientEventSource(
+export async function clientEventSource(
   input: string,
   init?: EventSourcePolyfillInit
-): EventSourcePolyfill {
+): Promise<EventSourcePolyfill> {
   const baseUrl = getBaseUrl();
 
   if (baseUrl && input.startsWith("/")) {
     input = `${baseUrl}${input}`;
   }
 
-  // Merge default RequestInit headers from the resolver (caller's init takes
-  // precedence, headers are shallow-merged). Map `credentials` to
-  // `withCredentials` for the polyfill.
-  const defaults =
-    getDefaultInit() ?? (baseUrl ? { credentials: "include" } : null);
+  // Resolve defaults (may refresh token).
+  let defaults = await getDefaultInit();
+  if (!defaults && baseUrl) {
+    defaults = { credentials: "include" };
+  }
 
   if (defaults) {
     const defaultHeaders: Record<string, string> = {};

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -63,7 +63,7 @@ export function useUnifiedSearch({
   const eventSourceRef = useRef<EventSourcePolyfill | null>(null);
 
   const loadPage = useCallback(
-    (cursor?: string | null, appendResults = false) => {
+    async (cursor?: string | null, appendResults = false) => {
       if (disabled) {
         setIsSearchLoading(false);
         setIsLoadingNextPage(false);
@@ -102,7 +102,7 @@ export function useUnifiedSearch({
       }
 
       const url = `/api/w/${owner.sId}/search?${params.toString()}`;
-      const eventSource = clientEventSource(url);
+      const eventSource = await clientEventSource(url);
       eventSourceRef.current = eventSource;
 
       eventSource.onopen = () => {

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -73,6 +73,9 @@
  *                 expiresIn:
  *                   type: integer
  *                   description: Token expiry in seconds
+ *                 expirationDate:
+ *                   type: integer
+ *                   description: Token expiry date in milliseconds
  *       400:
  *         description: Invalid request
  * /api/workos/revoke-session:
@@ -270,7 +273,15 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
           refreshToken: refresh_token,
           clientId: config.getWorkOSClientId(),
         });
-      return res.status(200).json(result);
+
+      const jwtPayload = JSON.parse(
+        Buffer.from(result.accessToken.split(".")[1], "base64").toString()
+      );
+
+      return res.status(200).json({
+        ...result,
+        expirationDate: jwtPayload.exp * 1000,
+      });
     } catch (error) {
       if (error instanceof OauthException) {
         return res
@@ -306,7 +317,11 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
       ? jwtPayload.exp - Math.floor(Date.now() / 1000)
       : undefined;
 
-    return res.status(200).json({ ...authResult, expiresIn });
+    return res.status(200).json({
+      ...authResult,
+      expiresIn,
+      expirationDate: jwtPayload.exp * 1000,
+    });
   } catch (error) {
     if (error instanceof OauthException) {
       return res

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -8371,6 +8371,10 @@
                     "expiresIn": {
                       "type": "integer",
                       "description": "Token expiry in seconds"
+                    },
+                    "expirationDate": {
+                      "type": "integer",
+                      "description": "Token expiry date in milliseconds"
                     }
                   }
                 }


### PR DESCRIPTION
## Description

Fix extension token refresh: tokens were never refreshed because `getAccessToken()` was never called in the fetch path.

**Root cause:** The `setDefaultInitResolver` in `useAuth` captured a static `tokens.accessToken` from React state. Every `clientFetch` / `clientEventSource` call used this stale token. When the token expired, nothing triggered a refresh — `getAccessToken()` (which checks expiry and refreshes) was never in the request path.

**Changes:**

- **`front/lib/api/config.ts`** — `defaultInitResolver` is now async (`() => Promise<RequestInit>`), allowing the resolver to call `getAccessToken()` which transparently refreshes expired tokens.
- **`front/lib/egress/client.ts`** — `clientFetch` and `clientEventSource` are now async and await the resolver. Shared `resolveInit()` helper for the merge logic.
- **`front/hooks/useEventSource.ts`** — `stableEventSourceManager.create()` and `connect()` are now async to handle the async `clientEventSource`.
- **`front/lib/swr/search.ts`** — `loadPage` callback is now async to await `clientEventSource`.
- **`front/lib/client/BrowserMCPTransport.ts`** — await async `clientEventSource`.
- **`extension/ui/components/auth/useAuth.ts`** — The resolver now calls `platform.auth.getAccessToken()` on every request. Also added `scheduleRefresh(newTokens.expiresAt)` after login so the proactive refresh timer starts.
- **`extension/shared/services/auth.ts`** — Use `expirationDate` (absolute ms timestamp from server) instead of `expiresIn` (relative seconds) to compute `expiresAt`, avoiding clock drift from network latency.
- **`front/pages/api/workos/[action].ts`** — The `/api/workos/authenticate` endpoint now returns `expirationDate` (JWT `exp` claim in ms) alongside the existing `expiresIn`.

## Tests

Tested manually on the front platform (dust-hive):
- Fresh login → token refresh timer starts → tokens refresh before expiry
- Expired token → next `clientFetch` call transparently refreshes via `getAccessToken()`
- EventSource connections pick up refreshed tokens

## Risk

Low — the async resolver is a no-op when no resolver is set (Next.js web app path). The `expiresIn` field is kept for backward compatibility; `expirationDate` is additive.

## Deploy Plan

Standard deploy. The `expirationDate` field is additive to the API response, so no coordination needed.