### PR TITLE
Add share file capability to Google Drive tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -206,6 +206,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_comments": "never_ask",
     "list_drives": "never_ask",
     "search_files": "never_ask",
+    "share_file": "low",
     "update_document": "medium",
     "update_presentation": "medium",
     "update_spreadsheet": "medium",

--- a/front/lib/api/actions/servers/google_drive/helpers.ts
+++ b/front/lib/api/actions/servers/google_drive/helpers.ts
@@ -5,7 +5,6 @@ import {
   getGoogleSlidesClient,
 } from "@app/lib/providers/google_drive/utils";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import type { drive_v3 } from "googleapis";
 
 export async function getDriveClient(authInfo?: AuthInfo) {
   const accessToken = authInfo?.token;
@@ -37,41 +36,4 @@ export async function getSlidesClient(authInfo?: AuthInfo) {
     return null;
   }
   return getGoogleSlidesClient(accessToken);
-}
-
-interface SharingParams {
-  type: "user" | "group" | "domain";
-  role: "writer" | "commenter" | "reader";
-  emailAddress?: string;
-  domain?: string;
-  allowFileDiscovery?: boolean;
-  sendNotificationEmail?: boolean;
-  emailMessage?: string;
-}
-
-export async function setFilePermission(
-  drive: drive_v3.Drive,
-  fileId: string,
-  sharing: SharingParams
-): Promise<drive_v3.Schema$Permission> {
-  const res = await drive.permissions.create({
-    fileId,
-    supportsAllDrives: true,
-    sendNotificationEmail: sharing.sendNotificationEmail,
-    emailMessage: sharing.emailMessage,
-    requestBody: {
-      type: sharing.type,
-      role: sharing.role,
-      ...(["user", "group"].includes(sharing.type) && {
-        emailAddress: sharing.emailAddress,
-      }),
-      ...(sharing.type === "domain" && { domain: sharing.domain }),
-      ...(sharing.type === "domain" &&
-        sharing.allowFileDiscovery !== undefined && {
-          allowFileDiscovery: sharing.allowFileDiscovery,
-        }),
-    },
-  });
-
-  return res.data;
 }

--- a/front/lib/api/actions/servers/google_drive/helpers.ts
+++ b/front/lib/api/actions/servers/google_drive/helpers.ts
@@ -5,6 +5,7 @@ import {
   getGoogleSlidesClient,
 } from "@app/lib/providers/google_drive/utils";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { drive_v3 } from "googleapis";
 
 export async function getDriveClient(authInfo?: AuthInfo) {
   const accessToken = authInfo?.token;
@@ -36,4 +37,41 @@ export async function getSlidesClient(authInfo?: AuthInfo) {
     return null;
   }
   return getGoogleSlidesClient(accessToken);
+}
+
+interface SharingParams {
+  type: "user" | "group" | "domain";
+  role: "writer" | "commenter" | "reader";
+  emailAddress?: string;
+  domain?: string;
+  allowFileDiscovery?: boolean;
+  sendNotificationEmail?: boolean;
+  emailMessage?: string;
+}
+
+export async function setFilePermission(
+  drive: drive_v3.Drive,
+  fileId: string,
+  sharing: SharingParams
+): Promise<drive_v3.Schema$Permission> {
+  const res = await drive.permissions.create({
+    fileId,
+    supportsAllDrives: true,
+    sendNotificationEmail: sharing.sendNotificationEmail,
+    emailMessage: sharing.emailMessage,
+    requestBody: {
+      type: sharing.type,
+      role: sharing.role,
+      ...(["user", "group"].includes(sharing.type) && {
+        emailAddress: sharing.emailAddress,
+      }),
+      ...(sharing.type === "domain" && { domain: sharing.domain }),
+      ...(sharing.type === "domain" &&
+        sharing.allowFileDiscovery !== undefined && {
+          allowFileDiscovery: sharing.allowFileDiscovery,
+        }),
+    },
+  });
+
+  return res.data;
 }

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -490,6 +490,54 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       done: "Update Google presentation",
     },
   },
+  share_file: {
+    description:
+      "Share a Google Drive file with a specific person by email, or with everyone in a Google Workspace domain.",
+    schema: {
+      fileId: z.string().describe("The ID of the Google Drive file to share."),
+      type: z
+        .enum(["user", "group", "domain"])
+        .describe(
+          "'user' to share with a specific person, 'group' to share with a Google Group, 'domain' to share with an entire Google Workspace domain."
+        ),
+      role: z
+        .enum(["writer", "commenter", "reader"])
+        .describe("The access level to grant."),
+      emailAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the person or Google Group to share with. Required when type is 'user' or 'group'."
+        ),
+      domain: z
+        .string()
+        .optional()
+        .describe(
+          'The Google Workspace domain to share with (e.g. "dust.tt"). Required when type is "domain".'
+        ),
+      allowFileDiscovery: z
+        .boolean()
+        .optional()
+        .describe(
+          "Only applies when type is 'domain'. If true, the file appears in search results for domain members. If false (default), the file is only accessible via direct link."
+        ),
+      sendNotificationEmail: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to send a notification email. Only applies when type is 'user' or 'group'. Defaults to true."
+        ),
+      emailMessage: z
+        .string()
+        .optional()
+        .describe("A custom message to include in the notification email."),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Sharing Google Drive file",
+      done: "Share Google Drive file",
+    },
+  },
 });
 
 const ALL_TOOLS_METADATA = {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -330,7 +330,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
+          "Whether the user has edit access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canEdit field."
         ),
     },
     stake: "low",
@@ -350,7 +350,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
+          "Whether the user has edit access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canEdit field."
         ),
     },
     stake: "low",
@@ -374,7 +374,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
+          "Whether the user has edit access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canEdit field."
         ),
       requests: GoogleDocsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the document. Include multiple operations in a single call to minimize requests. " +
@@ -400,7 +400,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
+          "Whether the user has edit access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canEdit field."
         ),
       range: z
         .string()
@@ -446,7 +446,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
+          "Whether the user has edit access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canEdit field."
         ),
       requests: GoogleSheetsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the spreadsheet. Include multiple operations in a single call to minimize requests. " +
@@ -475,7 +475,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has edit access to this file, as returned by search_files or get_file_content in the capabilities.canEdit field. You MUST pass this value if available."
+          "Whether the user has edit access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canEdit field."
         ),
       requests: GoogleSlidesRequestsArraySchema.describe(
         "An array of batch update requests to apply to the presentation. Include multiple operations in a single call to minimize requests. " +
@@ -535,7 +535,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .boolean()
         .optional()
         .describe(
-          "Whether the user has sharing access to this file, as returned by search_files or get_file_content in the capabilities.canShare field. You MUST pass this value if available."
+          "Whether the user has sharing access to this file. Pass this value if it was returned by a previous search_files or get_file_content call in the capabilities.canShare field."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -531,6 +531,12 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe("A custom message to include in the notification email."),
+      canShare: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether the user has sharing access to this file, as returned by search_files or get_file_content in the capabilities.canShare field. You MUST pass this value if available."
+        ),
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -16,7 +16,6 @@ import {
   getDriveClient,
   getSheetsClient,
   getSlidesClient,
-  setFilePermission,
 } from "@app/lib/api/actions/servers/google_drive/helpers";
 import {
   GOOGLE_DRIVE_TOOLS_METADATA,
@@ -248,6 +247,75 @@ async function ensureWriteAccess(
   return null;
 }
 
+/**
+ * Pre-flight check to verify sharing access to a file.
+ *
+ * Uses the drive.readonly scope (present on the token) to read file capabilities —
+ * this works for any file the user can see, regardless of file picker authorization.
+ *
+ * Returns { canShare, fileName } if capabilities could be determined, or null if the
+ * file is inaccessible or the check fails — in both cases the caller should proceed
+ * and let the existing error flow handle it.
+ */
+async function checkShareAccess(
+  drive: NonNullable<Awaited<ReturnType<typeof getDriveClient>>>,
+  fileId: string
+): Promise<{ canShare: boolean; fileName: string } | null> {
+  try {
+    const res = await drive.files.get({
+      fileId,
+      supportsAllDrives: true,
+      fields: "capabilities(canShare),name",
+    });
+    const { capabilities, name } = res.data;
+    if (!capabilities) {
+      return null;
+    }
+    return {
+      canShare: capabilities.canShare ?? true,
+      fileName: name ?? fileId,
+    };
+  } catch {
+    // File inaccessible or unexpected error — proceed and let the existing error flow handle it.
+    return null;
+  }
+}
+
+/**
+ * Checks whether the caller can change sharing settings on a file before attempting
+ * to modify permissions.
+ * Returns an early Ok result with a no-share message when access is denied, or null to proceed.
+ */
+async function ensureShareAccess(
+  canShare: boolean | undefined,
+  fileId: string,
+  authInfo: ToolHandlerExtra["authInfo"]
+): Promise<ToolHandlerResult | null> {
+  if (canShare === false) {
+    return new Ok([
+      {
+        type: "text" as const,
+        text: "You don't have permission to change sharing settings on this file. Only the file owner can modify access. You could ask the file owner to grant you sharing privileges, or ask them to share the file directly.",
+      },
+    ]);
+  }
+  if (canShare === undefined) {
+    const drive = await getDriveClient(authInfo);
+    if (drive) {
+      const accessCheck = await checkShareAccess(drive, fileId);
+      if (accessCheck !== null && !accessCheck.canShare) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `You don't have permission to change sharing settings on "${accessCheck.fileName}". Only the file owner can modify access. You could ask the file owner to grant you sharing privileges, or ask them to share the file directly.`,
+          },
+        ]);
+      }
+    }
+  }
+  return null;
+}
+
 const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   list_drives: async ({ pageToken }, { authInfo }) => {
     const drive = await getDriveClient(authInfo);
@@ -297,7 +365,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         pageToken,
         pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
         fields:
-          "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared, capabilities(canEdit))",
+          "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared, capabilities(canEdit,canShare))",
         orderBy,
       };
 
@@ -344,7 +412,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       const fileMetadata = await drive.files.get({
         fileId,
         supportsAllDrives: true,
-        fields: "id, name, mimeType, size, capabilities(canEdit)",
+        fields: "id, name, mimeType, size, capabilities(canEdit,canShare)",
       });
       const file = fileMetadata.data;
 
@@ -430,6 +498,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
               fileName: file.name,
               mimeType: file.mimeType,
               canEdit: file.capabilities?.canEdit ?? null,
+              canShare: file.capabilities?.canShare ?? null,
               content: truncatedContent,
               returnedContentLength: truncatedContent.length,
               totalContentLength,
@@ -1012,30 +1081,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       allowFileDiscovery,
       sendNotificationEmail,
       emailMessage,
+      canShare,
     },
     { authInfo, agentLoopContext }
   ) => {
-    if (["user", "group"].includes(type) && !emailAddress) {
-      return new Err(
-        new MCPError(
-          "emailAddress is required when type is 'user' or 'group'.",
-          { tracked: false }
-        )
-      );
-    }
-    if (type === "domain" && !domain) {
-      return new Err(
-        new MCPError('domain is required when type is "domain".', {
-          tracked: false,
-        })
-      );
-    }
-    if (type !== "domain" && allowFileDiscovery !== undefined) {
-      return new Err(
-        new MCPError("allowFileDiscovery only applies when type is 'domain'.", {
-          tracked: false,
-        })
-      );
+    const shareError = await ensureShareAccess(canShare, fileId, authInfo);
+    if (shareError) {
+      return shareError;
     }
 
     const drive = await getDriveClient(authInfo);
@@ -1043,51 +1095,28 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    // Pre-check sharing capability before attempting to modify permissions.
-    let fileMeta: { name?: string; mimeType?: string } | undefined;
+    let res;
     try {
-      const fileMetadata = await drive.files.get({
+      res = await drive.permissions.create({
         fileId,
         supportsAllDrives: true,
-        fields: "capabilities(canShare),name,mimeType",
+        sendNotificationEmail,
+        emailMessage,
+        requestBody: {
+          type,
+          role,
+          ...(["user", "group"].includes(type) && { emailAddress }),
+          ...(type === "domain" && {
+            domain,
+            allowFileDiscovery: allowFileDiscovery ?? false,
+          }),
+        },
       });
-      fileMeta = {
-        name: fileMetadata.data.name ?? undefined,
-        mimeType: fileMetadata.data.mimeType ?? undefined,
-      };
-      if (fileMetadata.data.capabilities?.canShare === false) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "You don't have permission to change sharing settings on this file. Only the file owner can modify access. You could ask the file owner to grant you sharing privileges, or ask them to share the file directly.",
-          },
-        ]);
-      }
     } catch (err) {
       return handleFileAccessError(err, fileId, {
         authInfo,
         agentLoopContext,
       });
-    }
-
-    let permission;
-    try {
-      permission = await setFilePermission(drive, fileId, {
-        type,
-        role,
-        emailAddress,
-        domain,
-        allowFileDiscovery,
-        sendNotificationEmail,
-        emailMessage,
-      });
-    } catch (err) {
-      return handleFileAccessError(
-        err,
-        fileId,
-        { authInfo, agentLoopContext },
-        fileMeta
-      );
     }
 
     const sharedWith =
@@ -1101,7 +1130,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
             fileId,
             sharedWith,
             role,
-            permissionId: permission.id,
+            permissionId: res.data.id,
           },
           null,
           2

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -16,6 +16,7 @@ import {
   getDriveClient,
   getSheetsClient,
   getSlidesClient,
+  setFilePermission,
 } from "@app/lib/api/actions/servers/google_drive/helpers";
 import {
   GOOGLE_DRIVE_TOOLS_METADATA,
@@ -999,6 +1000,114 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         }
       );
     }
+  },
+
+  share_file: async (
+    {
+      fileId,
+      type,
+      role,
+      emailAddress,
+      domain,
+      allowFileDiscovery,
+      sendNotificationEmail,
+      emailMessage,
+    },
+    { authInfo, agentLoopContext }
+  ) => {
+    if (["user", "group"].includes(type) && !emailAddress) {
+      return new Err(
+        new MCPError(
+          "emailAddress is required when type is 'user' or 'group'.",
+          { tracked: false }
+        )
+      );
+    }
+    if (type === "domain" && !domain) {
+      return new Err(
+        new MCPError('domain is required when type is "domain".', {
+          tracked: false,
+        })
+      );
+    }
+    if (type !== "domain" && allowFileDiscovery !== undefined) {
+      return new Err(
+        new MCPError("allowFileDiscovery only applies when type is 'domain'.", {
+          tracked: false,
+        })
+      );
+    }
+
+    const drive = await getDriveClient(authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+
+    // Pre-check sharing capability before attempting to modify permissions.
+    let fileMeta: { name?: string; mimeType?: string } | undefined;
+    try {
+      const fileMetadata = await drive.files.get({
+        fileId,
+        supportsAllDrives: true,
+        fields: "capabilities(canShare),name,mimeType",
+      });
+      fileMeta = {
+        name: fileMetadata.data.name ?? undefined,
+        mimeType: fileMetadata.data.mimeType ?? undefined,
+      };
+      if (fileMetadata.data.capabilities?.canShare === false) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "You don't have permission to change sharing settings on this file. Only the file owner can modify access. You could ask the file owner to grant you sharing privileges, or ask them to share the file directly.",
+          },
+        ]);
+      }
+    } catch (err) {
+      return handleFileAccessError(err, fileId, {
+        authInfo,
+        agentLoopContext,
+      });
+    }
+
+    let permission;
+    try {
+      permission = await setFilePermission(drive, fileId, {
+        type,
+        role,
+        emailAddress,
+        domain,
+        allowFileDiscovery,
+        sendNotificationEmail,
+        emailMessage,
+      });
+    } catch (err) {
+      return handleFileAccessError(
+        err,
+        fileId,
+        { authInfo, agentLoopContext },
+        fileMeta
+      );
+    }
+
+    const sharedWith =
+      type === "domain" ? `everyone in ${domain}` : emailAddress;
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            fileId,
+            sharedWith,
+            role,
+            permissionId: permission.id,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
   },
 };
 


### PR DESCRIPTION
## Description
Add share file tool to Google drive tool suite, allowing a user to ask dust to share their file with a specific email address, google group, or with their whole domain.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
