### PR TITLE
[front] chore: Add purchase order for buy credit plugin

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -30,6 +30,10 @@ const BuyCreditPurchaseArgsSchema = z
         `Discount cannot exceed ${MAX_DISCOUNT_PERCENT}% (would result in selling below cost)`
       )
       .finite("Discount must be a valid number"),
+    purchaseOrderId: z
+      .string()
+      .max(140, "Purchase Order ID cannot exceed 140 characters")
+      .optional(),
     confirm: z.boolean(),
     confirmFreeCredit: z.boolean(),
     confirmProOverride: z.boolean(),
@@ -95,6 +99,13 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
         async: true,
         label: "Expiration Date",
         description: "When the credits expire.",
+      },
+      purchaseOrderId: {
+        type: "string",
+        variant: "text",
+        label: "Purchase Order ID (optional)",
+        description: "Customer's PO number to include on the Stripe invoice.",
+        dependsOn: { field: "isFreeCredit", value: false },
       },
       confirm: {
         type: "boolean",
@@ -230,6 +241,9 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
       discountPercent,
       startDate,
       expirationDate,
+      customerFacingInfo: validatedArgs.purchaseOrderId
+        ? { purchaseOrderId: validatedArgs.purchaseOrderId }
+        : undefined,
     });
 
     if (result.isErr()) {

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -1,5 +1,6 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import type { Authenticator } from "@app/lib/auth";
+import type { CustomerFacingInvoiceInfo } from "@app/lib/plans/stripe";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
   finalizeInvoice,
@@ -177,6 +178,7 @@ export async function createEnterpriseCreditPurchase({
   startDate,
   expirationDate,
   boughtByUserId,
+  customerFacingInfo,
 }: {
   auth: Authenticator;
   stripeSubscriptionId: string;
@@ -185,6 +187,7 @@ export async function createEnterpriseCreditPurchase({
   startDate?: Date;
   expirationDate?: Date;
   boughtByUserId?: number;
+  customerFacingInfo?: CustomerFacingInvoiceInfo;
 }): Promise<
   Result<{ credit: CreditResource; invoiceOrLineItemId: string }, Error>
 > {
@@ -222,6 +225,7 @@ export async function createEnterpriseCreditPurchase({
     stripeSubscriptionId,
     amountMicroUsd,
     couponId,
+    customerFacingInfo,
     collectionMethod: "send_invoice",
     daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
   });

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -713,17 +713,23 @@ type InvoiceLineItem = {
   couponId?: string;
 };
 
+export type CustomerFacingInvoiceInfo = {
+  purchaseOrderId?: string;
+};
+
 async function makeInvoice({
   stripeSubscription,
   metadata,
   lineItem,
   idempotencyKey,
+  customerFacingInfo,
   ...collectionParams
 }: {
   stripeSubscription: Stripe.Subscription;
   metadata: Record<string, string>;
   lineItem: InvoiceLineItem;
   idempotencyKey?: string;
+  customerFacingInfo?: CustomerFacingInvoiceInfo;
 } & InvoiceCollectionParams): Promise<
   Result<
     Stripe.Invoice,
@@ -742,6 +748,9 @@ async function makeInvoice({
     automatic_tax: {
       enabled: true,
     },
+    custom_fields: customerFacingInfo?.purchaseOrderId
+      ? [{ name: "Purchase Order", value: customerFacingInfo.purchaseOrderId }]
+      : undefined,
   };
 
   switch (collectionParams.collectionMethod) {
@@ -908,11 +917,13 @@ export async function makeCreditPurchaseOneOffInvoice({
   stripeSubscriptionId,
   amountMicroUsd,
   couponId,
+  customerFacingInfo,
   ...collectionParams
 }: {
   stripeSubscriptionId: string;
   amountMicroUsd: number;
   couponId?: string;
+  customerFacingInfo?: CustomerFacingInvoiceInfo;
 } & InvoiceCollectionParams): Promise<
   Result<Stripe.Invoice, { error_message: string }>
 > {
@@ -938,6 +949,7 @@ export async function makeCreditPurchaseOneOffInvoice({
       description: `Programmatic usage credit: $${amountDollars.toFixed(2)}`,
       couponId,
     },
+    customerFacingInfo,
     ...collectionParams,
   });
 }


### PR DESCRIPTION
## Description

Add an optional field in buy credits poke plugin to specify a purchase order ID that will appear in the stripe invoice.

<img width="1552" height="2048" alt="CleanShot 2026-03-16 at 16 14 28@2x" src="https://github.com/user-attachments/assets/0814daeb-5632-4392-a298-52962de0cb39" />

## Tests

- Tested locally

## Risk

Low

## Deploy Plan

- [ ] Deploy front