### PR TITLE
Limit the rejected suggestions that we include in the context

### DIFF
--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -69,24 +69,43 @@ async function loadAggregationContext(
     return null;
   }
 
-  const existingSuggestions =
-    await AgentSuggestionResource.listByAgentConfigurationId(
+  const REJECTED_SUGGESTIONS_MAX_COUNT = 20;
+  const REJECTED_SUGGESTIONS_MAX_AGE_MONTHS = 3;
+
+  const [pendingSuggestions, rejectedSuggestions] = await Promise.all([
+    AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
       {
         sources: ["reinforcement", "sidekick"],
-        states: ["pending", "rejected"],
+        states: ["pending"],
       }
-    );
+    ),
+    AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      {
+        sources: ["reinforcement", "sidekick"],
+        states: ["rejected"],
+        limit: REJECTED_SUGGESTIONS_MAX_COUNT,
+      }
+    ),
+  ]);
 
-  const existingReinforced = toReinforcedSuggestions(existingSuggestions);
+  const rejectedCutoff = new Date();
+  rejectedCutoff.setMonth(
+    rejectedCutoff.getMonth() - REJECTED_SUGGESTIONS_MAX_AGE_MONTHS
+  );
+  const recentRejectedSuggestions = rejectedSuggestions.filter(
+    (s) => s.createdAt >= rejectedCutoff
+  );
 
   const prompt = buildAggregationPrompt(
     agentConfig.name,
     toReinforcedSuggestions(syntheticSuggestions),
     {
-      pending: existingReinforced.filter((s) => s.state === "pending"),
-      rejected: existingReinforced.filter((s) => s.state === "rejected"),
+      pending: toReinforcedSuggestions(pendingSuggestions),
+      rejected: toReinforcedSuggestions(recentRejectedSuggestions),
     }
   );
 


### PR DESCRIPTION
## Description

- Limit rejected suggestions used during aggregation to at most 20 and no older than 3 months, to avoid bloating the LLM prompt with stale rejections
- Fetch pending and rejected suggestions separately (in parallel) to avoid unnecessary merge-then-split
- All pending suggestions are still kept without any limit

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, only affect Reinforced

## Deploy Plan

Front