### PR TITLE
Add Langfuse tracing for LLM batch mode

### DIFF
--- a/front/lib/api/instrumentation/processor.ts
+++ b/front/lib/api/instrumentation/processor.ts
@@ -25,10 +25,11 @@ export class FilteredLangfuseSpanProcessor extends LangfuseSpanProcessor {
       return true;
     }
 
-    // For Temporal client, we only want to capture agent loop workflow spans.
+    // For Temporal client, capture workflow start spans for traced workflows.
     if (
-      name === "StartWorkflow:agentLoopWorkflow" &&
-      scopeName === "@temporalio/interceptor-client"
+      scopeName === "@temporalio/interceptor-client" &&
+      (name === "StartWorkflow:agentLoopWorkflow" ||
+        name.startsWith("StartWorkflow:reinforcedAgent"))
     ) {
       return true;
     }

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -218,7 +218,9 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     return batch.processing_status === "ended" ? "ready" : "computing";
   }
 
-  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(
+    batchId: string
+  ): Promise<BatchResult> {
     const results = await this.client.messages.batches.results(batchId);
     const batchResult: BatchResult = new Map();
 

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -199,7 +199,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     }
   }
 
-  override async sendBatchProcessing(
+  protected override async internalSendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     const requests = Array.from(conversations.entries()).map(
@@ -218,7 +218,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     return batch.processing_status === "ended" ? "ready" : "computing";
   }
 
-  override async getBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
     const results = await this.client.messages.batches.results(batchId);
     const batchResult: BatchResult = new Map();
 

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -234,7 +234,9 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     }
   }
 
-  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(
+    batchId: string
+  ): Promise<BatchResult> {
     const { batchName, customIds } = GoogleLLM.decodeBatchId(batchId);
     const batch = await this.client.batches.get({ name: batchName });
     const inlinedResponses = batch.dest?.inlinedResponses ?? [];

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -164,7 +164,7 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
    * Note that Google does not use any custom IDs but preserve the order.
    * To keep the ids of the processed conversations we store them stringified in the batchId string.
    */
-  override async sendBatchProcessing(
+  protected override async internalSendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     const customIds = Array.from(conversations.keys());
@@ -234,7 +234,7 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     }
   }
 
-  override async getBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
     const { batchName, customIds } = GoogleLLM.decodeBatchId(batchId);
     const batch = await this.client.batches.get({ name: batchName });
     const inlinedResponses = batch.dest?.inlinedResponses ?? [];

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -127,7 +127,7 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     }
   }
 
-  override async sendBatchProcessing(
+  protected override async internalSendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     const requests = Array.from(conversations.entries()).map(
@@ -171,7 +171,7 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     }
   }
 
-  override async getBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
     const job = await this.client.batch.jobs.get({ jobId: batchId });
 
     if (!job.outputFile) {

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -171,7 +171,9 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     }
   }
 
-  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(
+    batchId: string
+  ): Promise<BatchResult> {
     const job = await this.client.batch.jobs.get({ jobId: batchId });
 
     if (!job.outputFile) {

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -138,7 +138,7 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
    * Sends a batch of conversations to be processed asynchronously.
    * OpenAi requires to upload a JSONL file with the conversations to run.
    */
-  override async sendBatchProcessing(
+  protected override async internalSendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     const lines = Array.from(conversations.entries()).map(
@@ -200,7 +200,7 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     }
   }
 
-  override async getBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
     const batch = await this.client.batches.retrieve(batchId);
 
     if (!batch.output_file_id) {

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -200,7 +200,9 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     }
   }
 
-  protected override async internalGetBatchResult(batchId: string): Promise<BatchResult> {
+  protected override async internalGetBatchResult(
+    batchId: string
+  ): Promise<BatchResult> {
     const batch = await this.client.batches.retrieve(batchId);
 
     if (!batch.output_file_id) {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -443,7 +443,9 @@ export abstract class LLM<TPayload = unknown> {
   /**
    * Override this method to implement provider-specific batch result retrieval.
    */
-  protected async internalGetBatchResult(_batchId: string): Promise<BatchResult> {
+  protected async internalGetBatchResult(
+    _batchId: string
+  ): Promise<BatchResult> {
     throw new Error(
       `Batch processing is not supported for ${this.metadata.clientId}/${this.metadata.modelId}`
     );
@@ -452,9 +454,7 @@ export abstract class LLM<TPayload = unknown> {
   /**
    * Traces batch results by creating one Langfuse generation per batch entry.
    */
-  private async traceBatchResults(
-    results: BatchResult
-  ): Promise<BatchResult> {
+  private async traceBatchResults(results: BatchResult): Promise<BatchResult> {
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
 
     for (const [customId, events] of results) {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -347,13 +347,75 @@ export abstract class LLM<TPayload = unknown> {
    * Submit a batch of conversations for asynchronous processing.
    * Returns a string that can be used to poll status and retrieve results.
    * Each entry in the map is keyed by a conversation identifier (custom_id).
+   * Inputs are automatically traced when a tracing context is set.
    */
   async sendBatchProcessing(
+    conversations: Map<string, LLMStreamParameters>
+  ): Promise<string> {
+    const batchId = await this.internalSendBatchProcessing(conversations);
+    if (this.context) {
+      this.traceBatchInputs(conversations);
+    }
+    return batchId;
+  }
+
+  /**
+   * Override this method to implement provider-specific batch submission.
+   */
+  protected async internalSendBatchProcessing(
     _conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
     throw new Error(
       `Batch processing is not supported for ${this.metadata.clientId}/${this.metadata.modelId}`
     );
+  }
+
+  /**
+   * Traces batch inputs by creating one Langfuse generation per conversation entry.
+   */
+  private traceBatchInputs(
+    conversations: Map<string, LLMStreamParameters>
+  ): void {
+    const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
+
+    for (const [customId, params] of conversations) {
+      const payload = this.buildStreamRequestPayload(params);
+
+      const generation = startObservation(
+        "llm-batch-input",
+        {
+          input: payload,
+          model: this.modelId,
+          modelParameters: {
+            reasoningEffort: this.reasoningEffort ?? "",
+            responseFormat: this.responseFormat ?? "",
+            temperature: this.temperature ?? "",
+          },
+          metadata: {
+            batchCustomId: customId,
+          },
+        },
+        { asType: "generation" }
+      );
+
+      generation.updateTrace({
+        metadata: {
+          batchCustomId: customId,
+          ...(this.authenticator.user()?.sId && {
+            actualUserId: this.authenticator.user()!.sId,
+          }),
+          authMethod: this.authenticator.authMethod() ?? "unknown",
+          ...pickBy(
+            this.context!,
+            (value, key) =>
+              value !== undefined && !["userId", "workspaceId"].includes(key)
+          ),
+        },
+        userId: workspaceId,
+      });
+
+      generation.end();
+    }
   }
 
   /**
@@ -368,11 +430,136 @@ export abstract class LLM<TPayload = unknown> {
   /**
    * Retrieve the results of a completed batch.
    * Only call this when getBatchStatus returns "ready".
+   * Results are automatically traced when a tracing context is set.
    */
-  async getBatchResult(_batchId: string): Promise<BatchResult> {
+  async getBatchResult(batchId: string): Promise<BatchResult> {
+    const results = await this.internalGetBatchResult(batchId);
+    if (!this.context) {
+      return results;
+    }
+    return this.traceBatchResults(results);
+  }
+
+  /**
+   * Override this method to implement provider-specific batch result retrieval.
+   */
+  protected async internalGetBatchResult(_batchId: string): Promise<BatchResult> {
     throw new Error(
       `Batch processing is not supported for ${this.metadata.clientId}/${this.metadata.modelId}`
     );
+  }
+
+  /**
+   * Traces batch results by creating one Langfuse generation per batch entry.
+   */
+  private async traceBatchResults(
+    results: BatchResult
+  ): Promise<BatchResult> {
+    const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
+
+    for (const [customId, events] of results) {
+      const traceId = createLLMTraceId(randomUUID());
+      const buffer = new LLMTraceBuffer(traceId, workspaceId, this.context!);
+
+      const generation = startObservation(
+        "llm-batch-completion",
+        {
+          input: { batchCustomId: customId },
+          model: this.modelId,
+          modelParameters: {
+            reasoningEffort: this.reasoningEffort ?? "",
+            responseFormat: this.responseFormat ?? "",
+            temperature: this.temperature ?? "",
+          },
+        },
+        { asType: "generation" }
+      );
+
+      generation.updateTrace({
+        metadata: {
+          dustTraceId: traceId,
+          batchCustomId: customId,
+          ...(this.authenticator.user()?.sId && {
+            actualUserId: this.authenticator.user()!.sId,
+          }),
+          ...(this.authenticator.key() && {
+            apiKeyId: this.authenticator.key()!.id,
+          }),
+          authMethod: this.authenticator.authMethod() ?? "unknown",
+          ...pickBy(
+            this.context!,
+            (value, key) =>
+              value !== undefined && !["userId", "workspaceId"].includes(key)
+          ),
+        },
+        userId: workspaceId,
+      });
+
+      const metricTags = [
+        `model_id:${this.modelId}`,
+        `client_id:${this.metadata.clientId}`,
+        `operation_type:${this.context!.operationType}`,
+      ];
+
+      let hasError = false;
+      for (const event of events) {
+        buffer.addEvent(event);
+
+        if (event.type === "error") {
+          hasError = true;
+          getStatsDClient().increment("llm_error.count", 1, metricTags);
+          generation.updateTrace({
+            tags: ["isError:true", `errorType:${event.content.type}`],
+          });
+        }
+      }
+
+      if (!hasError) {
+        getStatsDClient().increment("llm_success.count", 1, metricTags);
+      }
+      getStatsDClient().increment("llm_interaction.count", 1, metricTags);
+
+      const { tokenUsage, ...rest } = buffer.currentOutput;
+
+      generation.update({ output: { ...rest } });
+
+      if (this.getTraceOutput) {
+        const traceOutput = this.getTraceOutput(rest);
+        if (traceOutput) {
+          generation.updateTrace({ output: traceOutput });
+        }
+      } else {
+        generation.updateTrace({ output: { ...rest } });
+      }
+
+      if (tokenUsage) {
+        generation.update({
+          usageDetails: {
+            input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
+            output: tokenUsage.outputTokens,
+            total: tokenUsage.totalTokens,
+            cache_read_input_tokens: tokenUsage.cachedTokens ?? 0,
+            cache_creation_input_tokens: tokenUsage.cacheCreationTokens ?? 0,
+            reasoning_tokens: tokenUsage.reasoningTokens ?? 0,
+          },
+        });
+      }
+
+      if (buffer.error) {
+        generation.update({
+          level: "ERROR",
+          statusMessage: buffer.error.message,
+          metadata: {
+            errorType: buffer.error.type,
+            errorMessage: buffer.error.message,
+          },
+        });
+      }
+
+      generation.end();
+    }
+
+    return results;
   }
 
   /**

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -109,7 +109,8 @@ export function buildReinforcedLLMParams({
  * Get the LLM instance configured for reinforced agent analysis.
  */
 export async function getReinforcedLLM(
-  auth: Authenticator
+  auth: Authenticator,
+  operationType: ReinforcedOperationType
 ): Promise<LLM | null> {
   const owner = auth.workspace();
   if (!owner) {
@@ -122,7 +123,15 @@ export async function getReinforcedLLM(
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  return getLLM(auth, { modelId: model.modelId, credentials });
+  return getLLM(auth, {
+    modelId: "mistral-large-latest",
+    credentials,
+    context: {
+      operationType,
+      workspaceId: owner.sId,
+      userId: auth.user()?.sId,
+    },
+  });
 }
 
 /**
@@ -255,7 +264,7 @@ export async function runReinforcedAnalysis({
   operationType: ReinforcedOperationType;
   contextId: string;
 }): Promise<number> {
-  const llm = await getReinforcedLLM(auth);
+  const llm = await getReinforcedLLM(auth, operationType);
   if (!llm) {
     logger.error(
       { contextId },

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -111,7 +111,9 @@ export async function getTemporalClientForAgentNamespace() {
 }
 
 export async function getTemporalClientForFrontNamespace() {
-  return getTemporalClientForNamespace("front");
+  return getTemporalClientForNamespace("front", [
+    new OpenTelemetryWorkflowClientInterceptor(),
+  ]);
 }
 
 export async function getTemporalClientForConnectorsNamespace() {

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -18,6 +18,7 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
+import { updateActiveTrace } from "@langfuse/tracing";
 import { ApplicationFailure } from "@temporalio/common";
 
 const HOURS_LOOKBACK = 24;
@@ -83,6 +84,11 @@ export async function getRecentConversationsForAgentActivity({
   workspaceId: string;
   agentConfigurationId: string;
 }): Promise<string[]> {
+  updateActiveTrace({
+    name: "Reinforced Agent Workflow",
+    metadata: { agentConfigurationId },
+  });
+
   const auth = await getAuthForWorkspace(workspaceId);
 
   const updatedSince = new Date();
@@ -156,7 +162,10 @@ export async function startConversationAnalysisBatchActivity({
     return null;
   }
 
-  const llm = await getReinforcedLLM(auth);
+  const llm = await getReinforcedLLM(
+    auth,
+    "reinforced_agent_analyze_conversation"
+  );
   if (!llm) {
     return null;
   }
@@ -188,7 +197,10 @@ export async function checkBatchStatusActivity({
 }): Promise<BatchStatus> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  const llm = await getReinforcedLLM(auth);
+  const llm = await getReinforcedLLM(
+    auth,
+    "reinforced_agent_analyze_conversation"
+  );
   if (!llm) {
     throw ApplicationFailure.nonRetryable(
       "ReinforcedAgent: no LLM available for batch status check"
@@ -224,7 +236,10 @@ export async function processConversationAnalysisBatchResultActivity({
     return;
   }
 
-  const llm = await getReinforcedLLM(auth);
+  const llm = await getReinforcedLLM(
+    auth,
+    "reinforced_agent_analyze_conversation"
+  );
   if (!llm) {
     return;
   }
@@ -273,7 +288,10 @@ export async function startAggregationBatchActivity({
     return null;
   }
 
-  const llm = await getReinforcedLLM(auth);
+  const llm = await getReinforcedLLM(
+    auth,
+    "reinforced_agent_aggregate_suggestions"
+  );
   if (!llm) {
     return null;
   }
@@ -318,7 +336,10 @@ export async function processAggregationBatchResultActivity({
     return;
   }
 
-  const llm = await getReinforcedLLM(auth);
+  const llm = await getReinforcedLLM(
+    auth,
+    "reinforced_agent_aggregate_suggestions"
+  );
   if (!llm) {
     return;
   }

--- a/front/temporal/reinforced_agent/worker.ts
+++ b/front/temporal/reinforced_agent/worker.ts
@@ -1,4 +1,7 @@
-import { initializeOpenTelemetryInstrumentation } from "@app/lib/api/instrumentation/init";
+import {
+  initializeOpenTelemetryInstrumentation,
+  resource,
+} from "@app/lib/api/instrumentation/init";
 import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
@@ -7,8 +10,12 @@ import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/reinforced_agent/activities";
+import { isDevelopment } from "@app/types/shared/env";
+import { removeNulls } from "@app/types/shared/utils/general";
+import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { Context } from "@temporalio/activity";
 import {
+  makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,
 } from "@temporalio/interceptors-opentelemetry/lib/worker";
@@ -23,6 +30,8 @@ export async function runReinforcedAgentWorker() {
     serviceName: "dust-reinforced-agent",
   });
 
+  const spanExporter = new InMemorySpanExporter();
+
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "reinforced_agent",
@@ -35,6 +44,11 @@ export async function runReinforcedAgentWorker() {
     connection,
     namespace,
     interceptors: {
+      workflowModules: removeNulls([
+        !isDevelopment() || process.env.USE_TEMPORAL_BUNDLES === "true"
+          ? null
+          : require.resolve("./workflows"),
+      ]),
       activity: [
         (ctx: Context) => {
           return {
@@ -46,6 +60,10 @@ export async function runReinforcedAgentWorker() {
           outbound: new OpenTelemetryActivityOutboundInterceptor(ctx),
         }),
       ],
+    },
+    sinks: {
+      // @ts-expect-error InMemorySpanExporter type mismatch.
+      exporter: makeWorkflowExporter(spanExporter, resource),
     },
   });
 

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -1,5 +1,10 @@
 import type * as activities from "@app/temporal/reinforced_agent/activities";
 import {
+  OpenTelemetryInboundInterceptor,
+  OpenTelemetryInternalsInterceptor,
+  OpenTelemetryOutboundInterceptor,
+} from "@temporalio/interceptors-opentelemetry/lib/workflow";
+import {
   ApplicationFailure,
   ParentClosePolicy,
   proxyActivities,
@@ -7,8 +12,17 @@ import {
   sleep,
   startChild,
 } from "@temporalio/workflow";
+import type { WorkflowInterceptorsFactory } from "@temporalio/workflow";
 import { concurrentExecutor } from "../utils";
+
 import { runSignal } from "./signals";
+
+// Export an interceptors variable to add OpenTelemetry interceptors to the workflow.
+export const interceptors: WorkflowInterceptorsFactory = () => ({
+  inbound: [new OpenTelemetryInboundInterceptor()],
+  outbound: [new OpenTelemetryOutboundInterceptor()],
+  internals: [new OpenTelemetryInternalsInterceptor()],
+});
 
 const { getFlaggedWorkspacesActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -4,6 +4,7 @@ import {
   OpenTelemetryInternalsInterceptor,
   OpenTelemetryOutboundInterceptor,
 } from "@temporalio/interceptors-opentelemetry/lib/workflow";
+import type { WorkflowInterceptorsFactory } from "@temporalio/workflow";
 import {
   ApplicationFailure,
   ParentClosePolicy,
@@ -12,7 +13,6 @@ import {
   sleep,
   startChild,
 } from "@temporalio/workflow";
-import type { WorkflowInterceptorsFactory } from "@temporalio/workflow";
 import { concurrentExecutor } from "../utils";
 
 import { runSignal } from "./signals";


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/7065

Add langfuse tracing to the batch mode.
It's different from what we do in streaming cases as we don't have in the same call the input in the output.
We publish the input when we send the batch and the output when we receive the batch result.

## Tests

tested locally: 
<img width="2068" height="1688" alt="image" src="https://github.com/user-attachments/assets/5a7bba45-5575-4380-b9df-df449599cbe2" />

## Risk

low

## Deploy Plan

deploy front
