### PR TITLE
[BYOK] Automatically mark provider credentials as unhealthy on authentication errors

### DIFF
--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -5,7 +5,13 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, ContextItem, Icon } from "@dust-tt/sparkle";
+import {
+  Button,
+  ContentMessage,
+  ContextItem,
+  Icon,
+  InformationCircleIcon,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface ConfigureButtonProps {
@@ -51,6 +57,7 @@ interface ProviderConfigurationContextItemProps {
   description: string;
   isLoading: boolean;
   apiKey: string | undefined;
+  isHealthy: boolean | undefined;
 }
 export function ProviderConfigurationContextItem({
   owner,
@@ -58,6 +65,7 @@ export function ProviderConfigurationContextItem({
   description,
   isLoading,
   apiKey,
+  isHealthy,
 }: ProviderConfigurationContextItemProps) {
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
@@ -84,6 +92,19 @@ export function ProviderConfigurationContextItem({
             {description}
           </span>
         </ContextItem.Description>
+
+        {apiKey && isHealthy === false && (
+          <ContentMessage
+            variant="warning"
+            icon={InformationCircleIcon}
+            title="Invalid API key"
+            size="lg"
+            className="mt-4"
+          >
+            This key is no longer valid. Update it to restore affected agents.
+          </ContentMessage>
+        )}
+
         {apiKey && (
           <div className="font-mono text-lg mt-4 text-foreground dark:text-foreground-night truncate">
             {apiKey}

--- a/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
+++ b/front/components/pages/workspace/model_providers/ProviderConfigurationContextItem.tsx
@@ -3,6 +3,7 @@ import { RemoveKeyDialog } from "@app/components/pages/workspace/model_providers
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
+import type { ProviderCredentialType } from "@app/types/provider_credential";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -56,21 +57,22 @@ interface ProviderConfigurationContextItemProps {
   providerId: ByokModelProviderIdType;
   description: string;
   isLoading: boolean;
-  apiKey: string | undefined;
-  isHealthy: boolean | undefined;
+  providerCredential: ProviderCredentialType | undefined;
 }
 export function ProviderConfigurationContextItem({
   owner,
   providerId,
   description,
   isLoading,
-  apiKey,
-  isHealthy,
+  providerCredential,
 }: ProviderConfigurationContextItemProps) {
   const { isDark } = useTheme();
   const LogoComponent = getModelProviderLogo(providerId, isDark);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [isRemoveKeyDialogOpen, setIsRemoveKeyDialogOpen] = useState(false);
+
+  const apiKey = providerCredential?.credentials.api_key;
+  const isHealthy = providerCredential?.isHealthy;
 
   return (
     <>

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -33,8 +33,7 @@ export function ProvidersConfigurationList({
           providerId={providerId}
           description={description}
           isLoading={isProviderCredentialsLoading}
-          apiKey={credentialsByProvider[providerId]?.credentials.api_key}
-          isHealthy={credentialsByProvider[providerId]?.isHealthy}
+          providerCredential={credentialsByProvider[providerId]}
         />
       ))}
     </ContextItem.List>

--- a/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersConfigurationList.tsx
@@ -34,6 +34,7 @@ export function ProvidersConfigurationList({
           description={description}
           isLoading={isProviderCredentialsLoading}
           apiKey={credentialsByProvider[providerId]?.credentials.api_key}
+          isHealthy={credentialsByProvider[providerId]?.isHealthy}
         />
       ))}
     </ContextItem.List>

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -30,6 +30,7 @@ import OpenAI from "openai";
 import type { Attributes, ModelStatic } from "sequelize";
 
 const API_KEY_REVEAL_WINDOW_MINUTES = 2;
+const PROVIDER_CREDENTIALS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 type CachedProviderCredential = {
   id: ModelId;
@@ -143,7 +144,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   private static baseFetchCached = cacheWithRedis(
     ProviderCredentialResource._baseFetchUncached,
     ProviderCredentialResource.providerCredentialCacheKeyResolver,
-    { cacheNullValues: false }
+    { cacheNullValues: false, ttlMs: PROVIDER_CREDENTIALS_CACHE_TTL_MS }
   );
 
   private static invalidateProviderCredentialCache = invalidateCacheWithRedis(

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -370,6 +370,40 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     await this.invalidateProviderCredentialCache(workspace.id);
   }
 
+  static async markAsUnhealthy(
+    auth: Authenticator,
+    { providerId }: { providerId: ByokModelProviderIdType }
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+    assert(
+      auth.getNonNullablePlan().isByok,
+      "BYOK must be enabled to mark provider credentials as unhealthy."
+    );
+
+    const credential = await this.fetchByProvider(auth, providerId);
+    if (!credential) {
+      return;
+    }
+
+    const isAuthError = await hasCredentialAuthError({
+      provider: providerId,
+      credentials: credential.credentials,
+    });
+
+    if (!isAuthError) {
+      return;
+    }
+
+    const [affectedCount] = await ProviderCredentialModel.update(
+      { isHealthy: false },
+      { where: { workspaceId: workspace.id, providerId, isHealthy: true } }
+    );
+
+    if (affectedCount > 0) {
+      await this.invalidateProviderCredentialCache(workspace.id);
+    }
+  }
+
   async delete(
     auth: Authenticator
   ): Promise<Result<number | undefined, Error>> {
@@ -462,6 +496,42 @@ async function isCredentialHealthy({
       }
 
       return true;
+    }
+    default:
+      assertNever(provider);
+  }
+}
+
+// Returns true only if the credential fails with a 401 authentication error,
+// which confirms the key is invalid (not just a transient network/rate-limit issue).
+async function hasCredentialAuthError({
+  provider,
+  credentials,
+}: ModelProviderPostCredentialsBody): Promise<boolean> {
+  switch (provider) {
+    case "anthropic": {
+      const client = new Anthropic({ apiKey: credentials.api_key });
+      try {
+        await client.models.list();
+        return false;
+      } catch (error) {
+        return error instanceof Anthropic.AuthenticationError;
+      }
+    }
+    case "openai": {
+      const client = new OpenAI({
+        apiKey: credentials.api_key,
+        defaultHeaders: {
+          "Content-Type": "application/json; charset=utf-8",
+          Accept: "application/json; charset=utf-8",
+        },
+      });
+      try {
+        await client.models.list();
+        return false;
+      } catch (error) {
+        return error instanceof OpenAI.AuthenticationError;
+      }
     }
     default:
       assertNever(provider);

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -54,6 +54,7 @@ import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -70,6 +71,7 @@ import type { AgentActionsEvent } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { isTextContent } from "@app/types/assistant/generation";
+import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -606,6 +608,16 @@ export async function runModel(
         const errorDustRunId = llm?.getTraceId();
         const currentAttempt = Context.current().info.attempt;
         const isLastAttempt = currentAttempt >= RUN_MODEL_MAX_RETRIES;
+
+        if (
+          type === "authentication_error" &&
+          auth.getNonNullablePlan().isByok &&
+          isByokProviderId(model.providerId)
+        ) {
+          await ProviderCredentialResource.markAsUnhealthy(auth, {
+            providerId: model.providerId,
+          });
+        }
 
         if (!isRetryable || isLastAttempt) {
           // Non-retryable errors or last retry attempt: surface error to user.


### PR DESCRIPTION
## Description

When a BYOK model run fails with an `authentication_error`, we now verify the API key
against the provider and flip the credential to `isHealthy: false`. 
Also adds a 10-minute TTL to the provider credentials cache so the UI reflects the unhealthy state quickly
without needing an explicit invalidation.

<img width="887" height="438" alt="image" src="https://github.com/user-attachments/assets/c11dc81c-0e49-4ad7-88c1-9efb6c97a416" />

<img width="708" height="233" alt="image" src="https://github.com/user-attachments/assets/ce94b0a0-acf2-4b15-b152-5b6c3f2a3830" />


## Tests

Tested manually: set an invalid Anthropic/OpenAI key, triggered a run, and confirmed the
credential flips to unhealthy and the warning badge appears in the provider list.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`