### PR TITLE
[front] feat(byok): check provider credential health in isProviderWhitelisted

### DIFF
--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -75,6 +75,8 @@ export function transformAgentConfigurationToFormData(
   };
 }
 
+// TODO(BYOK): For BYOK workspaces, this should also check healthy provider credentials.
+// Needs a new endpoint + SWR hook to fetch BYOK-aware whitelisted providers.
 function isProviderWhitelistedSync(
   owner: WorkspaceType,
   providerId: ModelProviderIdType

--- a/front/components/pages/workspace/developers/ProvidersPage.tsx
+++ b/front/components/pages/workspace/developers/ProvidersPage.tsx
@@ -35,6 +35,8 @@ export function Providers({ owner }: ProvidersProps) {
   );
   const [isModelProvider, setIsModelProvider] = useState(true);
 
+  // TODO(BYOK): For BYOK workspaces, this should also filter by healthy provider credentials.
+  // Needs a new endpoint + SWR hook to fetch BYOK-aware whitelisted providers.
   const appWhiteListedProviders = owner.whiteListedProviders
     ? [...owner.whiteListedProviders, "azure_openai"]
     : APP_MODEL_PROVIDER_IDS;

--- a/front/hooks/useProvidersSelection.ts
+++ b/front/hooks/useProvidersSelection.ts
@@ -19,6 +19,8 @@ export function useProvidersSelection(
     useState<ProvidersSelection>(ALL_PROVIDERS_SELECTED);
   const sendNotifications = useSendNotification();
 
+  // TODO(BYOK): For BYOK workspaces, this should also filter by healthy provider credentials.
+  // Needs a new endpoint + SWR hook to fetch BYOK-aware whitelisted providers.
   const enabledProviders: Readonly<ModelProviderIdType[]> =
     workspace?.whiteListedProviders ?? MODEL_PROVIDER_IDS;
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -10,12 +10,35 @@ import {
   FREE_UPGRADED_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/resources/provider_credential_resource");
+
+function mockCredentials(
+  credentials: Array<{
+    providerId: ModelProviderIdType;
+    isHealthy: boolean;
+  }>
+) {
+  vi.mocked(ProviderCredentialResource.listByWorkspace).mockResolvedValue(
+    credentials.map(
+      (c) =>
+        ({
+          providerId: c.providerId,
+          isHealthy: c.isHealthy,
+        }) as unknown as ProviderCredentialResource
+    )
+  );
+}
 
 function createMockModel(
   overrides: Partial<ModelConfigurationType>
@@ -93,6 +116,41 @@ describe("getWhitelistedProviders", () => {
 
     const providers = await getWhitelistedProviders(auth);
     expect(providers).toEqual(new Set(["anthropic", "noop"]));
+  });
+
+  it("BYOK: only includes providers with healthy keys plus noop", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    mockCredentials([
+      { providerId: "openai", isHealthy: true },
+      { providerId: "anthropic", isHealthy: false },
+    ]);
+
+    const providers = await getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["openai", "noop"]));
+  });
+
+  it("BYOK + restricted whitelist: healthy key for non-whitelisted provider is ignored", async () => {
+    const workspace = await WorkspaceFactory.byok({
+      whiteListedProviders: ["anthropic"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    mockCredentials([
+      { providerId: "openai", isHealthy: true },
+      { providerId: "anthropic", isHealthy: true },
+    ]);
+
+    const providers = await getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["anthropic", "noop"]));
+  });
+
+  it("BYOK + no keys: only noop is whitelisted", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    mockCredentials([]);
+
+    const providers = await getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["noop"]));
   });
 });
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -4,6 +4,7 @@ import {
   isEntreprisePlanPrefix,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -48,6 +49,7 @@ export async function getWhitelistedProviders(
   auth: Authenticator
 ): Promise<Set<ModelProviderIdType>> {
   const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
   const whiteListedProviders = new Set<ModelProviderIdType>(
     owner.whiteListedProviders ?? MODEL_PROVIDER_IDS
   );
@@ -55,7 +57,20 @@ export async function getWhitelistedProviders(
   // noop never sees user data, always whitelisted.
   whiteListedProviders.add("noop");
 
-  return whiteListedProviders;
+  if (!plan.isByok) {
+    return whiteListedProviders;
+  }
+
+  // For BYOK: also require a healthy configured key.
+  const credentials = await ProviderCredentialResource.listByWorkspace(auth);
+  const healthyProviders = new Set<ModelProviderIdType>(
+    credentials.filter((c) => c.isHealthy).map((c) => c.providerId)
+  );
+
+  // noop never needs credentials.
+  healthyProviders.add("noop");
+
+  return whiteListedProviders.intersection(healthyProviders);
 }
 
 export async function isProviderWhitelisted(

--- a/front/tests/utils/ProviderCredentialFactory.ts
+++ b/front/tests/utils/ProviderCredentialFactory.ts
@@ -5,13 +5,14 @@ import type { LightWorkspaceType } from "@app/types/user";
 export class ProviderCredentialFactory {
   static async basic(
     workspace: LightWorkspaceType,
-    providerId: ByokModelProviderIdType = "openai"
+    providerId: ByokModelProviderIdType = "openai",
+    { isHealthy = true }: { isHealthy?: boolean } = {}
   ) {
     return ProviderCredentialModel.create({
       workspaceId: workspace.id,
       providerId,
       credentialId: `cred-${providerId}`,
-      isHealthy: true,
+      isHealthy,
       placeholder: "sk-...abc",
     });
   }


### PR DESCRIPTION
## Summary
- `getWhitelistedProviders` now checks BYOK credential health: for BYOK workspaces, a provider is only whitelisted if it has a healthy configured key (via `ProviderCredentialResource.listByWorkspace`, Redis-cached)
- Add BYOK-specific tests for `getWhitelistedProviders` (healthy/unhealthy/missing key, restricted whitelist intersection)
- Add `TODO(BYOK)` comments on 3 client-side files that bypass the server-side check (follow-up PR for endpoint + SWR hook)
- Add `isHealthy` param to `ProviderCredentialFactory.basic()`

Stacked on #23026.
Linked to: https://github.com/dust-tt/tasks/issues/6965

## Test plan
- [x] Type-check passes (`npx tsgo --noEmit`)
- [x] Biome lint/format passes
- [ ] BYOK tests: healthy key → whitelisted, unhealthy → not, missing → not, noop always whitelisted
- [ ] Non-BYOK workspaces: no behavior change (credential check skipped)