### PR TITLE
[front] Move Clay tracker from _document to _app

### DIFF
--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -138,7 +138,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
           {getLayout(<Component {...pageProps} />, pageProps)}
         </SparkleContext.Provider>
       </PostHogTracker>
-      {DUST_CLIENT_FACING_URL === "https://dust.tt" && (
+      {DUST_CLIENT_FACING_URL !== "https://app.dust.tt" && (
         <Script
           src="https://static.claydar.com/init.v1.js?id=clmYho8v0U"
           strategy="afterInteractive"

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -8,10 +8,12 @@ import "@app/styles/components.css";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
+import Script from "next/script";
 
 // Important: avoid destructuring process.env on the client.
 // Next.js replaces direct property access (process.env.NEXT_PUBLIC_*) at build time,
 // but destructuring `process.env` does not get inlined.
+const DUST_CLIENT_FACING_URL = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
 const NODE_ENV = process.env.NODE_ENV;
 const DATADOG_CLIENT_TOKEN = process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN;
 const DATADOG_SERVICE = process.env.NEXT_PUBLIC_DATADOG_SERVICE;
@@ -136,6 +138,12 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
           {getLayout(<Component {...pageProps} />, pageProps)}
         </SparkleContext.Provider>
       </PostHogTracker>
+      {DUST_CLIENT_FACING_URL === "https://dust.tt" && (
+        <Script
+          src="https://static.claydar.com/init.v1.js?id=clmYho8v0U"
+          strategy="afterInteractive"
+        />
+      )}
     </FetcherProvider>
   );
 }

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -139,10 +139,6 @@ class MyDocument extends Document {
               })();
             `}
           </Script>
-          <Script
-            src="https://static.claydar.com/init.v1.js?id=clmYho8v0U"
-            strategy="afterInteractive"
-          />
         </body>
       </Html>
     );


### PR DESCRIPTION
## Description

Extends Clay tracking script to load on both US and EU marketing sites. PR #23009 fixed the technical issue (moved script from `_document.tsx` to `_app.tsx` with correct `afterInteractive` strategy) but only loaded on US production (`dust.tt`). This PR changes the gate from `NEXT_PUBLIC_DUST_CLIENT_FACING_URL === "https://dust.tt"` to `!== "https://app.dust.tt"`, enabling tracking on both `dust.tt` and `eu.dust.tt` while still excluding the app.

## Tests

Manually verified script loads on both marketing sites but not on app.

## Risk

Low. Only changes the environment check logic for loading the tracking script.

## Deploy front.