### PR TITLE
Enforce dedicated tool if exists

### DIFF
--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -138,6 +138,7 @@ Important rules:
 - Use get_elements when you need to see what elements are available.
 - Use click_element for controls like buttons or links.
 - Use type_text for entering text into inputs. Or removing text with the replace option.
+- Do NOT use this tool on pages from services like Notion, Gmail, Google Docs, or Google Calendar without first checking for a dedicated MCP tool via toolsets__list. If one exists, use it instead.
 
 type_text automatically focuses the element before typing.
 delete_text automatically focuses the element before deleting the text.


### PR DESCRIPTION
## Description

If the page is a service that has a dedicated server-side MCP tool available (e.g. Notion, Gmail, Google Docs, Google Calendar, etc.), prefer using that tool instead of interacting with the page directly.

## Tests

Asked an agent to modify a Notion page. It used the Notion tool and not the page interaction tool

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
