### PR TITLE
Only shows the Reinforced agents suggestions if the flag is activated

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1454,6 +1454,14 @@ export function getFeatureFlags(
   });
 }
 
+export async function hasFeatureFlag(
+  auth: Authenticator,
+  flag: WhitelistableFeature
+): Promise<boolean> {
+  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  return flags.includes(flag);
+}
+
 export function invalidateFeatureFlagsCache(
   workspace: LightWorkspaceType
 ): void {

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -35,6 +35,7 @@ describe("AgentSuggestionResource", () => {
             type: "replace",
           },
           analysis: "Making the agent more helpful",
+          source: "reinforcement",
         }
       );
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -2,11 +2,15 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import type {
+  AgentSuggestionSource,
+  AgentSuggestionType,
+} from "@app/types/suggestions/agent_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -115,12 +119,20 @@ async function handler(
         });
       }
 
+      const sources: AgentSuggestionSource[] = (await hasFeatureFlag(
+        auth,
+        "reinforced_agents"
+      ))
+        ? ["sidekick", "reinforcement"]
+        : ["sidekick"];
+
       const suggestions =
         await AgentSuggestionResource.listByAgentConfigurationId(
           auth,
           agentConfigurationId,
           {
             states,
+            sources,
             kind,
             limit: parsedLimit,
           }

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -35,7 +35,7 @@ export class AgentSuggestionFactory {
         analysis:
           overrides.analysis ?? "Improved instructions for better coding help",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "reinforcement",
+        source: overrides.source ?? "sidekick",
       }
     );
   }
@@ -61,7 +61,7 @@ export class AgentSuggestionFactory {
         },
         analysis: overrides.analysis ?? "Added useful integration",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "reinforcement",
+        source: overrides.source ?? "sidekick",
       }
     );
   }
@@ -140,7 +140,7 @@ export class AgentSuggestionFactory {
         },
         analysis: overrides.analysis ?? "Suggested a more capable model",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "reinforcement",
+        source: overrides.source ?? "sidekick",
       }
     );
   }


### PR DESCRIPTION
## Description

I want to be able to run test on some agents without showing the suggestions in the sidekick UI?

## Tests

no

## Risk

low

## Deploy Plan

deploy front
