### PR TITLE
Title: Improve files panel with image thumbnails and search

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -107,7 +107,11 @@ export function ConversationFilesPanel({
   const hasSandbox = sandboxStatus !== null;
 
   const filesContent = (
-    <FilesTab isLoading={isConversationAttachmentsLoading} rows={fileRows} />
+    <FilesTab
+      isLoading={isConversationAttachmentsLoading}
+      owner={owner}
+      rows={fileRows}
+    />
   );
 
   if (!hasSandbox) {

--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -3,13 +3,17 @@ import type {
   FilePanelCategory,
 } from "@app/components/assistant/conversation/files_panel/types";
 import { CATEGORY_CONFIG } from "@app/components/assistant/conversation/files_panel/utils";
+import { useDebounce } from "@app/hooks/useDebounce";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import { getFileProcessedUrl } from "@app/lib/swr/files";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Card,
   CardGrid,
   Icon,
   ScrollArea,
+  SearchInput,
   SpaceClosedIcon,
   Spinner,
   Tooltip,
@@ -19,13 +23,28 @@ import { useMemo } from "react";
 
 interface FilesTabProps {
   isLoading: boolean;
+  owner: LightWorkspaceType;
   rows: ConversationAttachmentRow[];
 }
 
-export function FilesTab({ isLoading, rows }: FilesTabProps) {
+export function FilesTab({ isLoading, owner, rows }: FilesTabProps) {
+  const {
+    inputValue: search,
+    debouncedValue: debouncedSearch,
+    setValue: setSearch,
+  } = useDebounce("", { delay: 200 });
+
+  const filteredRows = useMemo(() => {
+    const query = debouncedSearch.trim().toLowerCase();
+    if (!query) {
+      return rows;
+    }
+    return rows.filter((row) => row.title.toLowerCase().includes(query));
+  }, [rows, debouncedSearch]);
+
   const groupedByCategory = useMemo(() => {
     const groups = new Map<FilePanelCategory, ConversationAttachmentRow[]>();
-    for (const row of rows) {
+    for (const row of filteredRows) {
       const existing = groups.get(row.category);
       if (existing) {
         existing.push(row);
@@ -34,7 +53,7 @@ export function FilesTab({ isLoading, rows }: FilesTabProps) {
       }
     }
     return groups;
-  }, [rows]);
+  }, [filteredRows]);
 
   if (isLoading) {
     return (
@@ -53,29 +72,82 @@ export function FilesTab({ isLoading, rows }: FilesTabProps) {
   }
 
   return (
-    <ScrollArea className="flex-1 p-4">
-      <div className="flex flex-col gap-4">
-        {CATEGORY_CONFIG.map(({ value, label }) => {
-          const categoryRows = groupedByCategory.get(value);
-          if (!categoryRows || categoryRows.length === 0) {
-            return null;
-          }
-          return (
-            <div key={value}>
-              <SectionLabel>{label}</SectionLabel>
-              <FileCards rows={categoryRows} />
-            </div>
-          );
-        })}
-      </div>
-    </ScrollArea>
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {rows.length >= 5 && (
+        <div className="shrink-0 px-4 pt-4">
+          <SearchInput
+            name="file-search"
+            placeholder="Search files..."
+            value={search}
+            onChange={setSearch}
+          />
+        </div>
+      )}
+      <ScrollArea className="flex-1 p-4">
+        <div className="flex flex-col gap-8">
+          {CATEGORY_CONFIG.map(({ value, label }) => {
+            const categoryRows = groupedByCategory.get(value);
+            if (!categoryRows || categoryRows.length === 0) {
+              return null;
+            }
+            return (
+              <div key={value}>
+                <SectionLabel>{label}</SectionLabel>
+                <FileCards rows={categoryRows} owner={owner} />
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
   );
 }
 
-function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
+function FileCards({
+  rows,
+  owner,
+}: {
+  rows: ConversationAttachmentRow[];
+  owner: LightWorkspaceType;
+}) {
   return (
     <CardGrid>
       {rows.map((row) => {
+        if (row.category === "image" && row.fileId) {
+          return (
+            <Card
+              key={row.fileId}
+              size="sm"
+              variant="primary"
+              onClick={row.onClick}
+              className="relative h-[106px] overflow-hidden"
+            >
+              <img
+                src={getFileProcessedUrl(owner, row.fileId)}
+                alt={row.title}
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+              <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-2 pt-6">
+                <Tooltip
+                  tooltipTriggerAsChild
+                  label={row.title}
+                  trigger={
+                    <div className="truncate text-sm font-medium text-white">
+                      {row.title}
+                    </div>
+                  }
+                />
+                <div className="flex items-center justify-between">
+                  <div className="text-xs text-white/70">
+                    {row.date ? `${moment(row.date).fromNow()}` : null}
+                  </div>
+                  <CreatorAvatar row={row} />
+                </div>
+              </div>
+            </Card>
+          );
+        }
+
         const FileIcon = getFileTypeIcon(row.contentType, row.title);
         return (
           <Card
@@ -84,16 +156,22 @@ function FileCards({ rows }: { rows: ConversationAttachmentRow[] }) {
             variant="primary"
             onClick={row.onClick}
           >
-            <div className="flex w-full flex-col gap-1">
+            <div className="flex w-full flex-col gap-3">
               <div className="flex items-center gap-2">
                 <Icon visual={FileIcon} size="sm" className="shrink-0" />
-                <div className="min-w-0 flex-1 truncate text-sm font-medium">
-                  {row.title}
-                </div>
+                <Tooltip
+                  tooltipTriggerAsChild
+                  label={row.title}
+                  trigger={
+                    <div className="min-w-0 flex-1 truncate text-sm font-medium">
+                      {row.title}
+                    </div>
+                  }
+                />
               </div>
               <div className="flex items-center justify-between">
                 <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  {row.date ? `${moment(row.date).fromNow()}.` : null}
+                  {row.date ? `${moment(row.date).fromNow()}` : null}
                 </div>
                 <div className="flex items-center gap-1">
                   {row.isInProjectContext && (

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -26,10 +26,10 @@ export const CATEGORY_CONFIG: {
 }[] = [
   { value: "frame", label: "Frames" },
   { value: "slideshow", label: "Slideshows" },
+  { value: "image", label: "Images" },
   { value: "document", label: "Documents" },
   { value: "pdf", label: "PDFs" },
   { value: "table", label: "Tables" },
-  { value: "image", label: "Images" },
   { value: "audio", label: "Audio" },
   { value: "knowledge", label: "Knowledge" },
   { value: "other", label: "Other" },


### PR DESCRIPTION
## Description

Enhance the conversation files panel with visual and usability improvements.
Image attachments now render as thumbnail cards with the actual image as background, using a gradient overlay for readable text on any image. The category ordering was updated to show images before documents.

File titles show a tooltip on hover when truncated. A search bar appears when there are 5 or more files, filtering across all categories by title.

<kbd>
<img width="1433" height="1093" alt="Screenshot 2026-03-16 at 17 51 13" src="https://github.com/user-attachments/assets/077fa9d6-f9b5-4f20-b0ac-1ea1573605f2" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 
Gated for now. 

## Deploy Plan

Deploy front. 
