### PR TITLE
Skip storing LLM input in trace buffer when Langfuse is enabled

### DIFF
--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -115,7 +115,7 @@ export function LLMTracePage() {
         <div className="flex flex-wrap gap-2">
           <Chip
             color="blue"
-            label={`Model: ${trace.input.modelId}`}
+            label={`Model: ${trace.input?.modelId ?? trace.metadata.modelId}`}
             size="sm"
           />
           <Chip
@@ -175,12 +175,14 @@ export function LLMTracePage() {
           </div>
         )}
 
-        <Tabs defaultValue="input">
+        <Tabs defaultValue={trace.input ? "input" : "output"}>
           <TabsList>
-            <TabsTrigger
-              value="input"
-              label={`Input (${trace.input.conversation.messages.length} messages)`}
-            />
+            {trace.input && (
+              <TabsTrigger
+                value="input"
+                label={`Input (${trace.input.conversation.messages.length} messages)`}
+              />
+            )}
             <TabsTrigger
               value="output"
               label={`Output (${toolCallCount ? `${toolCallCount} tool call${pluralize(toolCallCount)}` : "Generation"})`}
@@ -188,9 +190,11 @@ export function LLMTracePage() {
             <TabsTrigger value="raw" label="Raw JSON" />
           </TabsList>
 
-          <TabsContent value="input">
-            <InputTab input={trace.input} />
-          </TabsContent>
+          {trace.input && (
+            <TabsContent value="input">
+              <InputTab input={trace.input} />
+            </TabsContent>
+          )}
 
           <TabsContent value="output">
             <OutputTab output={trace.output} />

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -16,6 +16,7 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import config from "@app/lib/api/config";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -123,7 +124,12 @@ export abstract class LLM<TPayload = unknown> {
     const { conversation, prompt, specifications } = streamParameters;
 
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
-    const buffer = new LLMTraceBuffer(this.traceId, workspaceId, this.context);
+    const buffer = new LLMTraceBuffer(
+      this.traceId,
+      workspaceId,
+      this.context,
+      this.modelId
+    );
 
     this.generation = startObservation(
       "llm-completion",
@@ -167,15 +173,20 @@ export abstract class LLM<TPayload = unknown> {
 
     const startTime = Date.now();
 
-    buffer.setInput({
-      conversation,
-      modelId: this.modelId,
-      prompt,
-      reasoningEffort: this.reasoningEffort,
-      responseFormat: this.responseFormat,
-      specifications,
-      temperature: this.temperature,
-    });
+    // Only store the full input in the GCS trace buffer when Langfuse is not available.
+    // When Langfuse is enabled, input is already captured via the generation span,
+    // avoiding a redundant copy of the conversation in memory.
+    if (!config.isLangfuseEnabled()) {
+      buffer.setInput({
+        conversation,
+        modelId: this.modelId,
+        prompt,
+        reasoningEffort: this.reasoningEffort,
+        responseFormat: this.responseFormat,
+        specifications,
+        temperature: this.temperature,
+      });
+    }
 
     // Track LLM interaction metric
     const metricTags = [
@@ -247,6 +258,7 @@ export abstract class LLM<TPayload = unknown> {
         }
 
         const durationMs = Date.now() - startTime;
+
         buffer
           .writeToGCS({ durationMs, startTime, timeToFirstEventMs })
           .catch(() => {});

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,
@@ -16,7 +17,6 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import config from "@app/lib/api/config";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";

--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -71,7 +71,8 @@ export class LLMTraceBuffer {
   constructor(
     private readonly traceId: LLMTraceId,
     private readonly workspaceId: string,
-    private readonly context: LLMTraceContext
+    private readonly context: LLMTraceContext,
+    private readonly modelId: ModelIdType | "unknown" = "unknown"
   ) {}
 
   /**
@@ -190,7 +191,7 @@ export class LLMTraceBuffer {
     }
 
     const tags = [
-      `model_id:${this.input?.modelId ?? "unknown"}`,
+      `model_id:${this.input?.modelId ?? this.modelId}`,
       `agent_configuration_id:${agentConfigurationId}`,
     ];
 
@@ -283,17 +284,13 @@ export class LLMTraceBuffer {
     startTimestamp: string;
     timeToFirstEventMs?: number;
   }): LLMTrace {
-    if (!this.input) {
-      throw new Error("Input must be set before creating trace");
-    }
-
     const trace: LLMTrace = {
       context: this.context,
-      input: this.input,
+      ...(this.input ? { input: this.input } : {}),
       metadata: {
         durationMs,
         endTimestamp,
-        modelId: this.input.modelId,
+        modelId: this.input?.modelId ?? this.modelId,
         startTimestamp,
         timeToFirstEventMs,
       },

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -106,7 +106,7 @@ interface LLMTraceMetadata {
   capturedBytes?: number;
   durationMs: number;
   endTimestamp?: string;
-  modelId: ModelIdType;
+  modelId: ModelIdType | "unknown";
   startTimestamp: string;
   timeToFirstEventMs?: number;
   /** Reason for truncation if applicable */
@@ -120,7 +120,7 @@ export interface LLMTrace {
   /** Unique identifier for this trace (format: llm_${uuid}) */
   context: LLMTraceContext;
   error?: LLMTraceError;
-  input: LLMTraceInput;
+  input?: LLMTraceInput;
   metadata: LLMTraceMetadata;
   output?: LLMTraceOutput;
   traceId: string;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When Langfuse is enabled (mainly in production), we skip storing the full conversation/prompt in the GCS trace buffer as Langfuse already captures it via the generation span. This eliminates a redundant in-memory copy of every LLM request payload (200 KB - 4.5 MB each) per concurrent stream
 
Heap snapshots from agent-loop worker pods showed +60 MB of string growth in 5 minutes, primarily from duplicated LLM request payloads retained both in the Langfuse generation span and in the `LLMTraceBuffer.input` (for GCS). This change removes the duplication in production.

We can revisit later, FWIW they both have the same retention policy.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
