### PR TITLE
[front] Fix Ctrl+Enter send message shortcut on Windows/Linux

### DIFF
--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -379,7 +379,9 @@ const useCustomEditor = ({
               !event.ctrlKey &&
               !event.metaKey &&
               !event.altKey) ||
-            (isCmdEnterForSubmission && event.key === "Enter" && event.metaKey);
+            (isCmdEnterForSubmission &&
+              event.key === "Enter" &&
+              (event.metaKey || event.ctrlKey));
 
           if (isSubmissionKey) {
             const mentionPluginState = mentionPluginKey.getState(view.state);

--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -3,6 +3,7 @@ import { NotificationPreferences } from "@app/components/me/NotificationPreferen
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { usePatchUser, useUser } from "@app/lib/swr/user";
 import type { WorkspaceType } from "@app/types/user";
@@ -27,7 +28,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useController, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -48,6 +49,19 @@ type AccountSettingsType = z.infer<typeof AccountSettingsSchema>;
 export function AccountSettings({ owner }: AccountSettingsProps) {
   const { user, isUserLoading } = useUser();
   const { theme: currentTheme, setTheme } = useTheme();
+  const isMac = useIsMac();
+  const modEnterLabel = useMemo(
+    () => (isMac ? "Cmd + Enter (⌘ + ↵)" : "Ctrl + Enter"),
+    [isMac]
+  );
+  const modEnterMenuLabel = useMemo(
+    () => (isMac ? "Cmd + Enter" : "Ctrl + Enter"),
+    [isMac]
+  );
+  const modEnterShortcut = useMemo(
+    () => (isMac ? "⌘ + ↵" : "Ctrl + ↵"),
+    [isMac]
+  );
 
   const { patchUser } = usePatchUser();
   const isProvisioned = user?.origin === "provisioned";
@@ -326,7 +340,7 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
                     label={
                       submitKeyField.value === "enter"
                         ? "Enter (↵)"
-                        : "Cmd + Enter (⌘ + ↵)"
+                        : modEnterLabel
                     }
                     isSelect
                     className="w-fit"
@@ -344,8 +358,10 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
                   <DropdownMenuItem
                     onClick={() => submitKeyField.onChange("cmd+enter")}
                   >
-                    Cmd + Enter
-                    <DropdownMenuShortcut>⌘ + ↵</DropdownMenuShortcut>
+                    {modEnterMenuLabel}
+                    <DropdownMenuShortcut>
+                      {modEnterShortcut}
+                    </DropdownMenuShortcut>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenuPortal>

--- a/front/hooks/useKeyboardShortcutLabel.ts
+++ b/front/hooks/useKeyboardShortcutLabel.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 /**
  * Detects if the user is on a Mac platform
  */
-function useIsMac(): boolean {
+export function useIsMac(): boolean {
   return useMemo(() => {
     if (typeof window === "undefined") {
       return false;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7081

The "Send with Cmd+Enter" user preference only checked `event.metaKey` (Command key on Mac), but never `event.ctrlKey` (Ctrl key on Windows/Linux). This made the shortcut non-functional on PC.

Changes:
- **`useCustomEditor.tsx`**: Check `(event.metaKey || event.ctrlKey)` instead of just `event.metaKey`
- **`AccountSettings.tsx`**: Show "Ctrl + Enter" on Windows/Linux instead of always showing "Cmd + Enter (⌘ + ↵)"
- **`useKeyboardShortcutLabel.ts`**: Export existing `useIsMac` hook for reuse

## Risks

Blast radius: message submission shortcut behavior + settings UI labels
Risk: low

## Deploy Plan
- pmrr (not urgent)
- deploy front