### PR TITLE
feat: remove cron for notification delay

### DIFF
--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -19,28 +19,22 @@ export type NotificationPreferencesDelay =
 
 type NotificationDelayAmountConfig = {
   amount: number;
-  unit: "minutes" | "hours" | "days";
+  unit: "minutes" | "hours" | "days" | "weeks";
 };
-
-type NotificationDelayCronConfig = { cron: string };
-
-type NotificationDelayConfig =
-  | NotificationDelayAmountConfig
-  | NotificationDelayCronConfig;
 
 /**
  * Maps delay option keys to their time configurations.
  */
 export const NOTIFICATION_PREFERENCES_DELAYS: Record<
   NotificationPreferencesDelay,
-  NotificationDelayConfig
+  NotificationDelayAmountConfig
 > = {
   "5_minutes": { amount: 5, unit: "minutes" },
   "15_minutes": { amount: 15, unit: "minutes" },
   "30_minutes": { amount: 30, unit: "minutes" },
   "1_hour": { amount: 1, unit: "hours" },
-  daily: { cron: "0 6 * * *" }, // Every day at 6am
-  weekly: { cron: "0 6 * * 1" }, // Every Monday at 6am
+  daily: { amount: 1, unit: "days" },
+  weekly: { amount: 1, unit: "weeks" },
 };
 
 export const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay =


### PR DESCRIPTION





## Description
Fixes https://github.com/dust-tt/tasks/issues/7117

This PR removes cron-based scheduling for notification delays and replaces it with duration-based delays.

This is useful to avoid request spikes on Monday morning at 6am.

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment. Monitor notification delivery patterns after deployment.
