### PR TITLE
Give the reinforced context the list of tools/skills

### DIFF
--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -149,6 +149,18 @@ export async function buildUserContext(
   return `<user_context>\n${formatted}\n</user_context>`;
 }
 
+export async function buildToolsAndSkillsContext(
+  auth: Authenticator
+): Promise<string> {
+  const [skills, tools] = await Promise.all([
+    listAvailableSkills(auth),
+    listAvailableTools(auth),
+  ]);
+  return [formatAvailableSkills(skills), formatAvailableTools(tools)].join(
+    "\n\n"
+  );
+}
+
 export async function buildWorkspaceContext(
   auth: Authenticator
 ): Promise<string> {

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -1,4 +1,5 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
@@ -72,25 +73,27 @@ async function loadAggregationContext(
   const REJECTED_SUGGESTIONS_MAX_COUNT = 20;
   const REJECTED_SUGGESTIONS_MAX_AGE_MONTHS = 3;
 
-  const [pendingSuggestions, rejectedSuggestions] = await Promise.all([
-    AgentSuggestionResource.listByAgentConfigurationId(
-      auth,
-      agentConfigurationId,
-      {
-        sources: ["reinforcement", "sidekick"],
-        states: ["pending"],
-      }
-    ),
-    AgentSuggestionResource.listByAgentConfigurationId(
-      auth,
-      agentConfigurationId,
-      {
-        sources: ["reinforcement", "sidekick"],
-        states: ["rejected"],
-        limit: REJECTED_SUGGESTIONS_MAX_COUNT,
-      }
-    ),
-  ]);
+  const [pendingSuggestions, rejectedSuggestions, toolsAndSkillsContext] =
+    await Promise.all([
+      AgentSuggestionResource.listByAgentConfigurationId(
+        auth,
+        agentConfigurationId,
+        {
+          sources: ["reinforcement", "sidekick"],
+          states: ["pending"],
+        }
+      ),
+      AgentSuggestionResource.listByAgentConfigurationId(
+        auth,
+        agentConfigurationId,
+        {
+          sources: ["reinforcement", "sidekick"],
+          states: ["rejected"],
+          limit: REJECTED_SUGGESTIONS_MAX_COUNT,
+        }
+      ),
+      buildToolsAndSkillsContext(auth),
+    ]);
 
   const rejectedCutoff = new Date();
   rejectedCutoff.setMonth(
@@ -106,7 +109,8 @@ async function loadAggregationContext(
     {
       pending: toReinforcedSuggestions(pendingSuggestions),
       rejected: toReinforcedSuggestions(recentRejectedSuggestions),
-    }
+    },
+    toolsAndSkillsContext
   );
 
   return { agentConfig, syntheticSuggestions, prompt };
@@ -144,7 +148,8 @@ export function buildAggregationPrompt(
   existingSuggestions: {
     pending: ReinforcedSuggestionType[];
     rejected: ReinforcedSuggestionType[];
-  }
+  },
+  toolsAndSkillsContext: string
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = `You are an AI agent improvement analyst. You have been given multiple suggestions from individual conversation analyses for the same agent. Your job is to deduplicate, merge, and prioritize them into a concise set of high-quality, actionable suggestions.
 
@@ -165,6 +170,8 @@ You have three tools available:
 You MUST call at least one tool. If no suggestions survive aggregation, call suggest_prompt_edits with an empty suggestions array.`;
 
   let userMessage = `## Agent: ${agentName}
+
+${toolsAndSkillsContext}
 
 ## Synthetic suggestions from conversation analyses
 

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -1,5 +1,6 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -11,7 +12,8 @@ import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
 export function buildAnalysisPrompt(
   agentConfig: AgentConfigurationType,
-  conversationText: string
+  conversationText: string,
+  toolsAndSkillsContext: string
 ): { systemPrompt: string; userMessage: string } {
   const descriptionSection = agentConfig.description
     ? `Description: ${agentConfig.description}`
@@ -25,7 +27,7 @@ export function buildAnalysisPrompt(
 ## Your task
 Analyze the conversation and identify areas where the agent's instructions could be improved. Pay special attention to any user feedback (thumbs up/down and comments) as direct signals of satisfaction or dissatisfaction. Focus on:
 - Cases where the agent misunderstood the user's intent
-- Missing knowledge or capabilities the agent should have
+- Missing tools and skills the agent should have. Prioritize those over instruction changes when you detect a clear need for a tool or skill.
 - Tone or style improvements based on user reactions and feedback
 - Specific instructions that could prevent repeated mistakes
 
@@ -42,6 +44,8 @@ You MUST call at least one tool. If no improvements are needed, call suggest_pro
 Name: ${agentConfig.name}
 ${descriptionSection}
 ${instructionsSection}
+
+${toolsAndSkillsContext}
 
 ## Conversation to analyze
 
@@ -74,6 +78,8 @@ export async function buildConversationAnalysisBatchMap(
     return null;
   }
 
+  const toolsAndSkillsContext = await buildToolsAndSkillsContext(auth);
+
   const batchMap = new Map<string, LLMStreamParameters>();
 
   for (const conversationId of conversationIds) {
@@ -89,7 +95,11 @@ export async function buildConversationAnalysisBatchMap(
       continue;
     }
 
-    const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
+    const prompt = buildAnalysisPrompt(
+      agentConfig,
+      conversationRes.value.text,
+      toolsAndSkillsContext
+    );
     batchMap.set(conversationId, buildReinforcedLLMParams(prompt));
   }
 
@@ -127,10 +137,13 @@ export async function analyzeConversationForReinforcement(
     return;
   }
 
-  const conversationRes = await getShrinkWrappedConversation(auth, {
-    conversationId,
-    includeFeedback: true,
-  });
+  const [conversationRes, toolsAndSkillsContext] = await Promise.all([
+    getShrinkWrappedConversation(auth, {
+      conversationId,
+      includeFeedback: true,
+    }),
+    buildToolsAndSkillsContext(auth),
+  ]);
   if (conversationRes.isErr()) {
     logger.warn(
       { conversationId, error: conversationRes.error },
@@ -139,7 +152,11 @@ export async function analyzeConversationForReinforcement(
     return;
   }
 
-  const prompt = buildAnalysisPrompt(agentConfig, conversationRes.value.text);
+  const prompt = buildAnalysisPrompt(
+    agentConfig,
+    conversationRes.value.text,
+    toolsAndSkillsContext
+  );
 
   const createdCount = await runReinforcedAnalysis({
     auth,


### PR DESCRIPTION
## Description

- The reinforced agent supports suggesting tools/skills to add or remove from agents, but it had no visibility into what tools and skills are actually available in the workspace
- Added buildToolsAndSkillsContext() in sidekick_context.ts, reusing the existing formatAvailableSkills/formatAvailableTools helpers (same as buildWorkspaceContext but without models)
- Injected this context into both the conversation analysis and aggregation prompts so the LLM can make informed tool/skill suggestions

## Tests

Manual. I did managed to get it to suggest a tool add!

## Risk

Low, under flag

## Deploy Plan

Front