### PR TITLE
[front] enh: update webtools `format` description

### DIFF
--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -111,7 +111,11 @@ export function isWebsearchInputType(
 }
 
 export const WebbrowseInputSchema = z.object({
-  urls: z.string().array().describe("List of urls to browse"),
+  urls: z
+    .string()
+    .array()
+    .max(MAX_BROWSE_URLS)
+    .describe(`List of urls to browse (max: ${MAX_BROWSE_URLS})`),
   format: z
     .enum(["markdown", "html"])
     .optional()

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -2,6 +2,8 @@ import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_acti
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 
+export const MAX_BROWSE_URLS = 16;
+
 export const SearchInputSchema = z.object({
   query: z
     .string()

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -121,7 +121,10 @@ export const WebbrowseInputSchema = z.object({
   format: z
     .enum(["markdown", "html"])
     .optional()
-    .describe("Format to return content: 'markdown' (default) or 'html'."),
+    .describe(
+      "Format to return content: 'markdown' (default) or 'html'. " +
+        "Markdown is the default choice and should be used unless there's a specific reason for using HTML."
+    ),
   screenshotMode: z
     .enum(["none", "viewport", "fullPage"])
     .optional()

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -1,5 +1,9 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  WebbrowseInputSchema,
+  WebsearchInputSchema,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -13,15 +13,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
   websearch: {
     description:
       "A tool that performs a Google web search based on a string query.",
-    schema: {
-      query: z
-        .string()
-        .describe(
-          "The query used to perform the Google search. If requested by the " +
-            "user, use the Google syntax `site:` to restrict the search " +
-            "to a particular website or domain."
-        ),
-    },
+    schema: WebsearchInputSchema.shape,
     stake: "never_ask",
     enableAlerting: true,
     displayLabels: {
@@ -31,27 +23,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
   },
   webbrowser: {
     description: `A tool to browse websites, you can provide a list of up to ${MAX_BROWSE_URLS} urls to browse all at once.`,
-    schema: {
-      urls: z
-        .string()
-        .array()
-        .max(MAX_BROWSE_URLS)
-        .describe(`List of urls to browse (max: ${MAX_BROWSE_URLS})`),
-      format: z
-        .enum(["markdown", "html"])
-        .optional()
-        .describe("Format to return content: 'markdown' (default) or 'html'."),
-      screenshotMode: z
-        .enum(["none", "viewport", "fullPage"])
-        .optional()
-        .describe(
-          "Screenshot mode: 'none' (default), 'viewport', or 'fullPage'."
-        ),
-      links: z
-        .boolean()
-        .optional()
-        .describe("If true, also retrieve outgoing links from the page."),
-    },
+    schema: WebbrowseInputSchema.shape,
     stake: "never_ask",
     enableAlerting: true,
     displayLabels: {

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -1,6 +1,7 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  MAX_BROWSE_URLS,
   WebbrowseInputSchema,
   WebsearchInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
@@ -8,7 +9,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const MAX_BROWSE_URLS = 16;
 export const WEB_SEARCH_BROWSE_SERVER_NAME = "web_search_&_browse" as const;
 export const WEB_SEARCH_BROWSE_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";


### PR DESCRIPTION
## Description

- This PR refactors the webtools metadata to use the shared zod schema.
- Also updates the description of the `format` field to nudge towards keeping markdown by default.
- We've had examples where the model arbitrarily chooses html a portion of the time and overfloods its context rapidly.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.