### PR TITLE
fix(poke): enterprise plan upgrade dropdown

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -30,7 +30,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
@@ -46,6 +46,7 @@ export default function EnterpriseUpgradeDialog({
   subscription,
   programmaticUsageConfig,
 }: EnterpriseUpgradeDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -139,7 +140,10 @@ export default function EnterpriseUpgradeDialog({
       <DialogTrigger asChild>
         <Button variant="outline" label="🏢 Upgrade to Enterprise" />
       </DialogTrigger>
-      <DialogContent className="bg-primary-50 dark:bg-primary-50-night sm:max-w-[600px]">
+      <DialogContent
+        ref={dialogRef}
+        className="bg-primary-50 dark:bg-primary-50-night sm:max-w-[600px]"
+      >
         <DialogHeader>
           <DialogTitle>Upgrade {owner.name} to Enterprise.</DialogTitle>
           <DialogDescription>
@@ -166,6 +170,9 @@ export default function EnterpriseUpgradeDialog({
                       control={form.control}
                       name="planCode"
                       title="Enterprise Plan"
+                      mountPortalContainer={
+                        dialogRef.current ?? undefined
+                      }
                       options={plans
                         .filter((plan) => isEntreprisePlanPrefix(plan.code))
                         .map((plan) => ({


### PR DESCRIPTION
## Description

Fixes the remaining UI issue from dust-tt/tasks#7123: the enterprise plan dropdown in Poke was rendering behind the dialog, so the plan could not be selected.

The fix has two parts:
- mount the enterprise plan dropdown to `document.body`, like the existing free-plan workaround
- fix `sparkle` `useSheetContainer()` so an explicit `mountPortalContainer` passed after mount is actually respected

Regression attribution:
- the likely trigger is the February 26, 2026 `sparkle` refactor (`c4bcb72ecb`) that moved portal resolution into `useSheetContainer()`
- the March 16, 2026 front fix (`2b1ac9dbea`) only covered the free-plan dialog, leaving the enterprise dialog as the last remaining broken path

## Tests

- manual check in Poke subscriptions: open the Upgrade / Downgrade sheet, open the enterprise upgrade dialog, and verify the dropdown opens above the dialog and remains clickable
- `cd sparkle && npm run build`

## Risk

Low. The user-facing change in `front` is scoped to the enterprise upgrade dialog. The shared `sparkle` change only makes explicit portal containers reliable when they are assigned after mount.

## Deploy Plan

Normal front deploy. No migration or backfill required.