### PR TITLE
Add client side MCP deregister API

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -27,7 +27,10 @@ import {
   MCPServerPersonalAuthenticationRequiredError,
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import {
+  getServerTypeAndIdFromSId,
+  isMcpTimeoutError,
+} from "@app/lib/actions/mcp_helper";
 import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerNameAndWorkspaceId,
@@ -97,7 +100,6 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   CallToolResultSchema,
-  McpError,
   ProgressNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Context, heartbeat } from "@temporalio/activity";
@@ -603,8 +605,7 @@ export async function* tryCallMCPTool(
       "Exception calling MCP tool in tryCallMCPTool()"
     );
 
-    const isMCPTimeoutError =
-      error instanceof McpError && error.code === -32001;
+    const isMCPTimeoutError = isMcpTimeoutError(error);
 
     if (isMCPTimeoutError) {
       // If the tool should not be retried on interrupt, the error is returned

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -31,6 +31,21 @@ import {
   asDisplayName,
   asDisplayToolName,
 } from "@app/types/shared/utils/string_utils";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * JSON-RPC error code for request timeout (MCP RequestTimeout).
+ * @see https://github.com/modelcontextprotocol/typescript-sdk/pull/103
+ */
+const MCP_REQUEST_TIMEOUT_ERROR_CODE = -32001;
+
+/**
+ * Type guard for MCP request timeout errors.
+ * Use when handling errors from MCP client operations (connect, listTools, callTool).
+ */
+export function isMcpTimeoutError(e: unknown): e is McpError {
+  return e instanceof McpError && e.code === MCP_REQUEST_TIMEOUT_ERROR_CODE;
+}
 
 export const getServerTypeAndIdFromSId = (
   mcpServerId: string

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -57,7 +57,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { McpError, type Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
@@ -663,13 +663,20 @@ export async function connectToMCPServer(
           timeout: CLIENT_SIDE_CONNECT_TIMEOUT_MS,
         });
       } catch (e: unknown) {
-        logger.error(
+        const isTimeout = e instanceof McpError && e.code === -32001;
+
+        logger[isTimeout ? "warn" : "error"](
           {
             connectionType,
             workspaceId: auth.getNonNullableWorkspace().sId,
+            mcpServerId: params.mcpServerId,
+            isTimeout,
+            errorCode: e instanceof McpError ? e.code : undefined,
             error: e,
           },
-          "Error establishing connection to client side MCP server"
+          isTimeout
+            ? "Client-side MCP server timed out (browser likely disconnected)"
+            : "Error establishing connection to client-side MCP server"
         );
 
         return new Err(

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -13,7 +13,10 @@ import {
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import {
+  getServerTypeAndIdFromSId,
+  isMcpTimeoutError,
+} from "@app/lib/actions/mcp_helper";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
 import {
   getInternalMCPServerInfo,
@@ -663,7 +666,7 @@ export async function connectToMCPServer(
           timeout: CLIENT_SIDE_CONNECT_TIMEOUT_MS,
         });
       } catch (e: unknown) {
-        const isTimeout = e instanceof McpError && e.code === -32001;
+        const isTimeout = isMcpTimeoutError(e);
 
         logger[isTimeout ? "warn" : "error"](
           {

--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -252,12 +252,13 @@ export async function deregisterMCPServer(
   auth: Authenticator,
   { serverId }: { serverId: string }
 ): Promise<boolean> {
-  if (!serverId) {
-    return false;
-  }
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const userModelId = auth.getNonNullableUser().id.toString();
-  const key = getMCPServerRegistryKey({ workspaceId, userId: userModelId, serverId });
+  const key = getMCPServerRegistryKey({
+    workspaceId,
+    userId: userModelId,
+    serverId,
+  });
 
   const deleted = await runOnRedis(
     { origin: "mcp_client_side_request" },

--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -245,6 +245,28 @@ export async function updateMCPServerHeartbeat(
 }
 
 /**
+ * Remove a client-side MCP server registration from Redis immediately.
+ * Returns true if the key was present and deleted, false if it was already gone.
+ */
+export async function deregisterMCPServer(
+  auth: Authenticator,
+  { serverId }: { serverId: string }
+): Promise<boolean> {
+  if (!serverId) {
+    return false;
+  }
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const userModelId = auth.getNonNullableUser().id.toString();
+  const key = getMCPServerRegistryKey({ workspaceId, userId: userModelId, serverId });
+
+  const deleted = await runOnRedis(
+    { origin: "mcp_client_side_request" },
+    async (redis) => redis.del(key)
+  );
+  return deleted === 1;
+}
+
+/**
  * Validate that a server ID belongs to the current user in the given workspace.
  * Uses a single EXPIRE to atomically check existence and refresh the TTL.
  */

--- a/front/pages/api/w/[wId]/mcp/deregister.test.ts
+++ b/front/pages/api/w/[wId]/mcp/deregister.test.ts
@@ -1,0 +1,98 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { RequestMethod } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDeregisterMCPServer } = vi.hoisted(() => ({
+  mockDeregisterMCPServer: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/actions/mcp/client_side_registry", () => ({
+  deregisterMCPServer: mockDeregisterMCPServer,
+}));
+
+import handler from "./deregister";
+
+async function setupTest(
+  role: "builder" | "user" | "admin" = "admin",
+  method: RequestMethod = "POST"
+) {
+  const { req, res, workspace } = await createPrivateApiMockRequest({
+    role,
+    method,
+  });
+
+  req.query.wId = workspace.sId;
+
+  return { req, res, workspace };
+}
+
+describe("POST /api/w/[wId]/mcp/deregister", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeregisterMCPServer.mockResolvedValue(undefined);
+  });
+
+  it("should deregister a server successfully", async () => {
+    const { req, res } = await setupTest("admin", "POST");
+
+    const serverId = "test-server-id-123";
+    req.body = { serverId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+    expect(mockDeregisterMCPServer).toHaveBeenCalledWith(expect.anything(), {
+      serverId,
+    });
+  });
+
+  it("should return 400 when serverId is missing", async () => {
+    const { req, res } = await setupTest("admin", "POST");
+
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: expect.stringContaining("Invalid request body"),
+      },
+    });
+    expect(mockDeregisterMCPServer).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when serverId is not a string", async () => {
+    const { req, res } = await setupTest("admin", "POST");
+
+    req.body = { serverId: 123 };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain("Invalid request body");
+    expect(mockDeregisterMCPServer).not.toHaveBeenCalled();
+  });
+
+  it("should return 405 for non-POST methods", async () => {
+    for (const method of ["GET", "PUT", "DELETE", "PATCH"] as const) {
+      const { req, res } = await setupTest("admin", method);
+
+      req.body = { serverId: "test-server-id" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message: "Method not allowed.",
+        },
+      });
+      expect(mockDeregisterMCPServer).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/mcp/deregister.ts
+++ b/front/pages/api/w/[wId]/mcp/deregister.ts
@@ -1,0 +1,58 @@
+/** @ignoreswagger */
+import { deregisterMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const PostMCPDeregisterRequestBodyCodec = t.type({
+  serverId: t.string,
+});
+
+export type PostMCPDeregisterRequestBody = t.TypeOf<
+  typeof PostMCPDeregisterRequestBodyCodec
+>;
+
+type DeregisterMCPResponseType = {
+  success: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<DeregisterMCPResponseType>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Method not allowed.",
+      },
+    });
+  }
+
+  const bodyValidation = PostMCPDeregisterRequestBodyCodec.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const { serverId } = bodyValidation.right;
+
+  await deregisterMCPServer(auth, { serverId });
+
+  res.status(200).json({ success: true });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/7121
* Adding logging 
* Plan is to deregister MCP server on close, so the registration is cleaned up the moment the browser disconnects. In createClientSideMCPServerConfigurations, filter out servers whose metadata returns null so the agent loop never attempts to connect to a dead server. Only doing API to start to avoid deployment race conditions

## Tests

* API not used yet

## Risk

* Low

## Deploy Plan

* Deploy front