### PR TITLE
Add guards in front code, removed unnecessary stubs

### DIFF
--- a/front-spa/email.html
+++ b/front-spa/email.html
@@ -6,26 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Dust - Email Validation</title>
-    <script>
-      // Shim for Node.js Buffer API used by some dependencies
-      globalThis.Buffer = globalThis.Buffer || {
-        isBuffer: function () {
-          return false;
-        },
-        from: function (x) {
-          return new Uint8Array(
-            typeof x === "string"
-              ? Array.from(x).map(function (c) {
-                  return c.charCodeAt(0);
-                })
-              : x
-          );
-        },
-        alloc: function (n) {
-          return new Uint8Array(n);
-        },
-      };
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/front-spa/index.html
+++ b/front-spa/index.html
@@ -8,26 +8,6 @@
     <title>Dust</title>
     <link rel="preload" href="/static/fonts/Geist-Regular.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/static/fonts/Geist-SemiBold.woff2" as="font" type="font/woff2" crossorigin />
-    <script>
-      // Shim for Node.js Buffer API used by some dependencies
-      globalThis.Buffer = globalThis.Buffer || {
-        isBuffer: function () {
-          return false;
-        },
-        from: function (x) {
-          return new Uint8Array(
-            typeof x === "string"
-              ? Array.from(x).map(function (c) {
-                  return c.charCodeAt(0);
-                })
-              : x
-          );
-        },
-        alloc: function (n) {
-          return new Uint8Array(n);
-        },
-      };
-    </script>
     <!-- Datadog RUM (Real User Monitoring) -->
     <script>
       (function (h, o, u, n, d) {

--- a/front-spa/oauth.html
+++ b/front-spa/oauth.html
@@ -6,26 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Dust - OAuth</title>
-    <script>
-      // Shim for Node.js Buffer API used by some dependencies
-      globalThis.Buffer = globalThis.Buffer || {
-        isBuffer: function () {
-          return false;
-        },
-        from: function (x) {
-          return new Uint8Array(
-            typeof x === "string"
-              ? Array.from(x).map(function (c) {
-                  return c.charCodeAt(0);
-                })
-              : x
-          );
-        },
-        alloc: function (n) {
-          return new Uint8Array(n);
-        },
-      };
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/front-spa/poke.html
+++ b/front-spa/poke.html
@@ -5,26 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dust - Poke</title>
-    <script>
-      // Shim for Node.js Buffer API used by some dependencies
-      globalThis.Buffer = globalThis.Buffer || {
-        isBuffer: function () {
-          return false;
-        },
-        from: function (x) {
-          return new Uint8Array(
-            typeof x === "string"
-              ? Array.from(x).map(function (c) {
-                  return c.charCodeAt(0);
-                })
-              : x
-          );
-        },
-        alloc: function (n) {
-          return new Uint8Array(n);
-        },
-      };
-    </script>
   </head>
   <body>
     <script>

--- a/front-spa/share.html
+++ b/front-spa/share.html
@@ -17,26 +17,6 @@
       content="noindex, nofollow, noarchive, nosnippet, noimageindex"
     />
     <title>Dust - Shared Content</title>
-    <script>
-      // Shim for Node.js Buffer API used by some dependencies
-      globalThis.Buffer = globalThis.Buffer || {
-        isBuffer: function () {
-          return false;
-        },
-        from: function (x) {
-          return new Uint8Array(
-            typeof x === "string"
-              ? Array.from(x).map(function (c) {
-                  return c.charCodeAt(0);
-                })
-              : x
-          );
-        },
-        alloc: function (n) {
-          return new Uint8Array(n);
-        },
-      };
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -43,60 +43,113 @@ const apps = {
 };
 
 // Virtual module plugin to stub out server-side only modules
-function stubModulesPlugin(): Plugin {
-  const stubs: Record<string, string> = {
-    // Stream: minimal stub for Node.js stream module
-    stream:
-      "export class Readable { pipe() { return this; } on() { return this; } once() { return this; } destroy() {} } export class Writable { write() { return true; } end() {} on() { return this; } once() { return this; } } export class Transform extends Readable {} export class Duplex extends Readable { write() { return true; } end() {} } export default { Readable, Writable, Transform, Duplex };",
-    // Buffer: minimal stub for Node.js Buffer
-    buffer:
-      "export const Buffer = { isBuffer: () => false, from: (x) => new Uint8Array(typeof x === 'string' ? [...x].map(c => c.charCodeAt(0)) : x), alloc: (n) => new Uint8Array(n) }; export default { Buffer };",
-    // Assert: minimal stub for Node.js assert module
-    assert:
-      "function assert(value, message) { if (!value) throw new Error(message || 'Assertion failed'); } assert.ok = assert; assert.strictEqual = (a, b, msg) => { if (a !== b) throw new Error(msg || `Expected ${a} to strictly equal ${b}`); }; assert.deepStrictEqual = assert.strictEqual; export default assert; export { assert };",
-    // Crypto: minimal stub for Node.js crypto module (server-only functions)
-    crypto:
-      "export const createHmac = () => { throw new Error('createHmac is not available in browser'); }; export const timingSafeEqual = () => { throw new Error('timingSafeEqual is not available in browser'); }; export default { createHmac, timingSafeEqual };",
-    // Child process: minimal stub for Node.js child_process module
-    child_process:
-      "export const execSync = () => { throw new Error('execSync is not available in browser'); }; export const exec = () => { throw new Error('exec is not available in browser'); }; export const spawn = () => { throw new Error('spawn is not available in browser'); }; export default { execSync, exec, spawn };",
-  };
+// Detects server-only imports leaking into the SPA bundle.
+// Fails the build if a Node.js builtin or server-only module is imported.
+function detectServerImportsPlugin(): Plugin {
+  const NODE_BUILTINS = new Set([
+    "assert",
+    "buffer",
+    "child_process",
+    "crypto",
+    "dns",
+    "fs",
+    "http",
+    "http2",
+    "https",
+    "net",
+    "os",
+    "path",
+    "stream",
+    "tls",
+    "worker_threads",
+    "zlib",
+  ]);
 
-  // Stubs for resolved file paths (after @dust-tt/front alias is applied)
-  const filePathStubs: Record<string, string> = {
-    // Logger
-    "logger/logger":
-      "const noop = () => {}; const logger = { info: noop, warn: noop, error: noop, debug: noop, trace: noop, fatal: noop, child: () => logger }; export default logger;",
-    // Text extraction
-    "types/shared/text_extraction/index":
-      "export const pagePrefixesPerMimeType = {}; export const isTextExtractionSupportedContentType = () => false; export class TextExtraction { constructor() {} fromStream() { throw new Error('Not available in browser'); } }",
-    // Structured data
-    "types/shared/utils/structured_data":
-      "export class InvalidStructuredDataHeaderError extends Error {} export const getSanitizedHeaders = () => { throw new Error('Not available in browser'); }; export const guessDelimiter = async () => undefined; export const parseAndStringifyCsv = async () => { throw new Error('Not available in browser'); };",
-  };
+  const SERVER_ONLY_PATTERNS = [
+    /\/front\/temporal\//,
+    /\/front\/lib\/resources\//,
+  ];
+
+  // Known exceptions that are tolerated.
+  // Each entry should have a comment explaining why it's allowed.
+  const ALLOWED = new Set([
+    // string_ids.ts is a utility imported by 139+ files. Needs a broader refactor to split.
+    "front/lib/resources/string_ids.ts",
+    // run.ts uses fs/path for Dust app execution. Only imported transitively, never called in SPA.
+    "fs",
+    "path",
+    // Buffer is used by sdks/js (client.esm.js) for file download. Shimmed via globalThis.Buffer in HTML.
+    "buffer",
+  ]);
+
+  const violations = new Map<string, Set<string>>();
+
+  function addViolation(mod: string, importer: string | undefined) {
+    const importers = violations.get(mod) ?? new Set();
+    if (importer) {
+      importers.add(importer.replace(/.*\/front\//, "front/"));
+    }
+    violations.set(mod, importers);
+  }
+
+  // Runtime global shim for Node.js Buffer API used by sdks/js at runtime.
+  const bufferShim = `<script>
+      globalThis.Buffer = globalThis.Buffer || {
+        isBuffer: function () { return false; },
+        from: function (x) {
+          return new Uint8Array(
+            typeof x === "string"
+              ? Array.from(x).map(function (c) { return c.charCodeAt(0); })
+              : x
+          );
+        },
+        alloc: function (n) { return new Uint8Array(n); },
+      };
+    </script>`;
 
   return {
-    name: "stub-server-modules",
+    name: "detect-server-imports",
     enforce: "pre",
-    resolveId(id) {
-      if (id in stubs) {
-        return `\0virtual:${id}`;
+    transformIndexHtml(html) {
+      return html.replace("<head>", `<head>\n    ${bufferShim}`);
+    },
+    resolveId(id, importer) {
+      if (NODE_BUILTINS.has(id) || NODE_BUILTINS.has(id.replace("node:", ""))) {
+        addViolation(id, importer);
       }
       return null;
     },
-    load(id) {
-      // Handle virtual modules
-      if (id.startsWith("\0virtual:")) {
-        const moduleId = id.slice("\0virtual:".length);
-        return stubs[moduleId];
-      }
-      // Handle resolved file paths
-      for (const [pathSuffix, stub] of Object.entries(filePathStubs)) {
-        if (id.endsWith(pathSuffix + ".ts") || id.endsWith(pathSuffix)) {
-          return stub;
+    transform(_code, id) {
+      for (const pattern of SERVER_ONLY_PATTERNS) {
+        if (pattern.test(id)) {
+          addViolation(id.replace(/.*\/front\//, "front/"), undefined);
         }
       }
       return null;
+    },
+    buildEnd() {
+      const newViolations = new Map<string, Set<string>>();
+      for (const [mod, importers] of violations) {
+        if (!ALLOWED.has(mod)) {
+          newViolations.set(mod, importers);
+        }
+      }
+      if (newViolations.size > 0) {
+        const lines = [
+          `${newViolations.size} server-only module(s) detected in SPA build:`,
+        ];
+        for (const [mod, importers] of newViolations) {
+          const importerList = [...importers].join(", ");
+          lines.push(
+            `  ${mod}${importerList ? ` (imported by: ${importerList})` : ""}`
+          );
+        }
+        lines.push(
+          "Server-only code has leaked into the SPA. Split the offending file to separate server and client concerns.",
+          "If this is intentional, add the module to the ALLOWED set in detectServerImportsPlugin()."
+        );
+        this.error(lines.join("\n"));
+      }
     },
   };
 }
@@ -211,7 +264,7 @@ export default defineConfig(({ mode }) => {
     root: path.resolve(__dirname, "."),
     publicDir: path.resolve(__dirname, "../front/public"),
     plugins: [
-      stubModulesPlugin(),
+      detectServerImportsPlugin(),
       serveHtmlPlugin(appDefinition),
       organizeMultiEntryOutputPlugin(appDefinition),
       reactScanPlugin(enableReactScan),
@@ -246,6 +299,14 @@ export default defineConfig(({ mode }) => {
         {
           find: "@app/lib/platform",
           replacement: path.resolve(__dirname, "src/lib/platform.tsx"),
+        },
+        // Logger: redirect server-side pino logger to browser-safe Datadog logger
+        {
+          find: "@app/logger/logger",
+          replacement: path.resolve(
+            __dirname,
+            "../front/logger/datadogLogger.ts"
+          ),
         },
         // @app alias for front internal imports
         {

--- a/front/components/groups/GroupsList.tsx
+++ b/front/components/groups/GroupsList.tsx
@@ -1,3 +1,4 @@
+import assert from "@app/lib/utils/assert";
 import type { GroupType } from "@app/types/groups";
 import {
   Button,
@@ -7,7 +8,6 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
-import assert from "assert";
 import { useMemo } from "react";
 
 type GroupRowData = {

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -1,4 +1,5 @@
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
+import assert from "@app/lib/utils/assert";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { MembershipOriginType } from "@app/types/memberships";
 import type {
@@ -14,7 +15,6 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
-import assert from "assert";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -14,6 +14,7 @@ import type {
   MCPServerViewType,
 } from "@app/lib/api/mcp";
 import type { AdditionalConfigurationValueType } from "@app/lib/models/agent/actions/mcp";
+import assert from "@app/lib/utils/assert";
 import {
   areSchemasEqual,
   ensurePathExists,
@@ -29,7 +30,6 @@ import { isString, removeNulls } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
 import type { InternalToolInputMimeType } from "@dust-tt/client";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import assert from "assert";
 import type {
   JSONSchema7 as JSONSchema,
   JSONSchema7Type as JSONSchemaType,

--- a/front/lib/llms/agent_message_content_parser.ts
+++ b/front/lib/llms/agent_message_content_parser.ts
@@ -1,4 +1,5 @@
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import assert from "@app/lib/utils/assert";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import {
   CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION,
@@ -16,7 +17,6 @@ import {
 } from "@app/types/assistant/models/togetherai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import assert from "assert";
 import escapeRegExp from "lodash/escapeRegExp";
 
 type AgentMessageTokenClassification = GenerationTokensEvent["classification"];

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -17,7 +17,7 @@ import {
 } from "@app/lib/triggers/rate_limits";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
-import { verifySignature } from "@app/lib/webhookSource";
+import { verifySignature } from "@app/lib/webhookSource_server";
 import logger from "@app/logger/logger";
 
 import { launchAgentTriggerWorkflow } from "@app/temporal/triggers/common/client";

--- a/front/lib/utils/assert.ts
+++ b/front/lib/utils/assert.ts
@@ -1,0 +1,11 @@
+/**
+ * Browser-safe assert function. Throws an Error if the condition is falsy.
+ */
+export default function assert(
+  condition: unknown,
+  message?: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message || "Assertion failed");
+  }
+}

--- a/front/lib/webhookSource.ts
+++ b/front/lib/webhookSource.ts
@@ -8,10 +8,8 @@ import {
 } from "@app/components/resources/resources_icon_names";
 import type {
   WebhookSourceForAdminType,
-  WebhookSourceSignatureAlgorithm,
   WebhookSourceWithViewsType,
 } from "@app/types/triggers/webhooks";
-import { createHmac, timingSafeEqual } from "crypto";
 
 export const DEFAULT_WEBHOOK_ICON: InternalAllowedIconType =
   "ActionGlobeAltIcon" as const;
@@ -46,49 +44,6 @@ export const filterWebhookSource = (
     );
   }
 };
-
-export const verifySignature = ({
-  signedContent,
-  secret,
-  signature,
-  algorithm,
-}: {
-  signedContent: string;
-  secret: string;
-  signature: string;
-  algorithm: WebhookSourceSignatureAlgorithm;
-}): boolean => {
-  if (!secret || !signature) {
-    return false;
-  }
-
-  // Try "{algorithm}={hex}" format first (GitHub-style).
-  const prefixedHex = `${algorithm}=${createHmac(algorithm, secret)
-    .update(signedContent, "utf8")
-    .digest("hex")}`;
-  if (safeCompare(signature, prefixedHex)) {
-    return true;
-  }
-
-  // Try raw base64 format (HelpScout, etc.).
-  const rawBase64 = createHmac(algorithm, secret)
-    .update(signedContent, "utf8")
-    .digest("base64");
-  if (safeCompare(signature, rawBase64)) {
-    return true;
-  }
-
-  return false;
-};
-
-function safeCompare(a: string, b: string): boolean {
-  try {
-    return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-  } catch {
-    // Length mismatch.
-    return false;
-  }
-}
 
 export const buildWebhookUrl = ({
   apiBaseUrl,

--- a/front/lib/webhookSource_server.ts
+++ b/front/lib/webhookSource_server.ts
@@ -1,0 +1,45 @@
+import type { WebhookSourceSignatureAlgorithm } from "@app/types/triggers/webhooks";
+import { createHmac, timingSafeEqual } from "crypto";
+
+export const verifySignature = ({
+  signedContent,
+  secret,
+  signature,
+  algorithm,
+}: {
+  signedContent: string;
+  secret: string;
+  signature: string;
+  algorithm: WebhookSourceSignatureAlgorithm;
+}): boolean => {
+  if (!secret || !signature) {
+    return false;
+  }
+
+  // Try "{algorithm}={hex}" format first (GitHub-style).
+  const prefixedHex = `${algorithm}=${createHmac(algorithm, secret)
+    .update(signedContent, "utf8")
+    .digest("hex")}`;
+  if (safeCompare(signature, prefixedHex)) {
+    return true;
+  }
+
+  // Try raw base64 format (HelpScout, etc.).
+  const rawBase64 = createHmac(algorithm, secret)
+    .update(signedContent, "utf8")
+    .digest("base64");
+  if (safeCompare(signature, rawBase64)) {
+    return true;
+  }
+
+  return false;
+};
+
+function safeCompare(a: string, b: string): boolean {
+  try {
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    // Length mismatch.
+    return false;
+  }
+}

--- a/front/logger/datadogLogger.ts
+++ b/front/logger/datadogLogger.ts
@@ -1,4 +1,3 @@
-import localLogger from "@app/logger/logger";
 import { datadogLogs } from "@datadog/browser-logs";
 
 // Keep the exported Logger type for compatibility with existing imports.
@@ -56,18 +55,16 @@ function makeLogger(baseBindings?: LogContext) {
 
     try {
       if (IS_DEV) {
-        // In dev, use the local pino logger so logs appear locally and pretty-printed.
+        // In dev, log to the browser console.
+        const consoleLevel =
+          level === "trace" || level === "debug" ? "debug" : level;
         const hasCtx = Object.keys(mergedContext).length > 0;
-        // Pino signature: logger[level](obj?, msg?)
         if (hasCtx && message !== undefined) {
-          // Prefer structured + message
-          localLogger[level](mergedContext, message);
+          console[consoleLevel](message, mergedContext);
         } else if (hasCtx) {
-          localLogger[level](mergedContext);
+          console[consoleLevel](mergedContext);
         } else if (message !== undefined) {
-          localLogger[level](message);
-        } else {
-          localLogger[level]("");
+          console[consoleLevel](message);
         }
         return;
       }

--- a/front/tests/lib/webhookSource.test.ts
+++ b/front/tests/lib/webhookSource.test.ts
@@ -1,4 +1,4 @@
-import { verifySignature } from "@app/lib/webhookSource";
+import { verifySignature } from "@app/lib/webhookSource_server";
 import { createHmac } from "crypto";
 import { describe, expect, test } from "vitest";
 


### PR DESCRIPTION
## Description

Follow-up to #23047. Removes unnecessary Node.js polyfill stubs from the Vite SPA build by splitting server-only code out of shared files, and adds a build-time guard to prevent server-only imports from leaking into the SPA bundle.

### Stubs removed

- **`assert`** — replaced `import assert from "assert"` (Node.js builtin) with a browser-safe `lib/utils/assert.ts` in 4 files used by the SPA (`MembersList.tsx`, `GroupsList.tsx`, `input_configuration.ts`, `agent_message_content_parser.ts`)
- **`crypto`** — split `lib/webhookSource.ts`: moved `verifySignature` (uses `crypto.createHmac`/`timingSafeEqual`) to `lib/webhookSource_server.ts`, kept browser-safe utils (`normalizeWebhookIcon`, `filterWebhookSource`, `buildWebhookUrl`) in the original file

### Logger

- Removed pino (Node.js) dependency from `logger/datadogLogger.ts` — dev mode now uses `console.*` instead of the pino logger, production uses Datadog browser logs as before. This makes the datadogLogger fully browser-native.
- Updated the Vite logger stub to redirect `logger/logger` imports to `datadogLogger` instead of a noop, so SPA logging actually works (goes to Datadog in prod, console in dev).

### HTML cleanup

- Centralized the `globalThis.Buffer` shim (duplicated across all 5 HTML entrypoints) into `stubModulesPlugin`'s `transformIndexHtml` hook in `vite.config.ts`

### Build-time guard

- Added `detectServerImportsPlugin` to `vite.config.ts` — warns at build time if `lib/resources/` or `temporal/` modules leak into the SPA bundle

## Tests

- Both `vite build` targets (app + poke) pass
- `npx tsgo --noEmit` passes
- `npm run build:workers` passes

## Risk

Low. Code splits are import-path-only changes. The logger change affects dev-mode SPA logging (pino → console), which is a minor cosmetic difference. Production logging (Datadog) is unchanged.

## Deploy Plan

Standard deploy. No migration or config changes needed.