### PR TITLE
feat: extension mainpage tags and hide convert to agent

### DIFF
--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -642,25 +642,23 @@ export function AgentBrowser({
 
       {viewTab === "all" ? (
         <>
-          {!isMobileOrExtension && (
-            <div className="mb-2 flex flex-wrap items-center gap-2">
-              {noTagsDefined ? null : (
-                <>
-                  {uniqueTags.map((tag) => (
-                    <Button
-                      size="xs"
-                      variant={selectedTag === tag.sId ? "primary" : "outline"}
-                      key={tag.sId}
-                      label={tag.name}
-                      onClick={() => {
-                        setSelectedTag(tag.sId);
-                      }}
-                    />
-                  ))}
-                </>
-              )}
-            </div>
-          )}
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            {noTagsDefined ? null : (
+              <>
+                {uniqueTags.map((tag) => (
+                  <Button
+                    size="xs"
+                    variant={selectedTag === tag.sId ? "primary" : "outline"}
+                    key={tag.sId}
+                    label={tag.name}
+                    onClick={() => {
+                      setSelectedTag(tag.sId);
+                    }}
+                  />
+                ))}
+              </>
+            )}
+          </div>
 
           <div className="flex flex-col gap-4">
             {uniqueTags

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -13,6 +13,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -148,13 +149,18 @@ export function ConversationMenu({
   const { hasFeature, featureFlags } = useFeatureFlags();
   const confirm = useContext(ConfirmContext);
 
+  const clientType = useClientType();
+
   const router = useAppRouter();
 
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
     !isBuilder(owner);
   const canTurnIntoAgent =
-    !!conversation && !!user && !isRestrictedFromAgentCreation;
+    !!conversation &&
+    !!user &&
+    !isRestrictedFromAgentCreation &&
+    clientType !== "extension";
   const sendNotification = useSendNotification();
 
   const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7118

This PR improves the extension UI by showing tag filters on the main page and hiding the convert-to-agent feature.

- Display tag filter buttons in the extension
- Disable the "convert to agent" menu option when using the extension
<img width="318" height="428" alt="Capture d’écran 2026-03-17 à 09 40 55" src="https://github.com/user-attachments/assets/3b226640-b0d2-44f7-8e5b-f4d2d6a047e2" />

## Tests

Manually

## Risks

Low risk - UI-only changes.

## Deploy Plan

Standard deployment.
