### PR TITLE
refactor: getFeatureFlags to auth

### DIFF
--- a/front/lib/actions/mcp_internal_actions/enabled.ts
+++ b/front/lib/actions/mcp_internal_actions/enabled.ts
@@ -12,7 +12,7 @@ export const isEnabledForWorkspace = async (
 
   // If the server has a restriction, check if the restrictions are met.
   if (mcpServer.isRestricted) {
-    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    const featureFlags = await getFeatureFlags(auth);
     const plan = auth.getNonNullablePlan();
     const isDeepDiveDisabled = await isDeepDiveDisabledByAdmin(auth);
 

--- a/front/lib/api/actions/servers/salesforce/tools/index.ts
+++ b/front/lib/api/actions/servers/salesforce/tools/index.ts
@@ -202,8 +202,7 @@ export function createSalesforceTools(auth: Authenticator): ToolDefinition[] {
     },
 
     update_object: async ({ objectName, records, allOrNone }, extra) => {
-      const owner = auth.getNonNullableWorkspace();
-      const featureFlags = await getFeatureFlags(owner);
+      const featureFlags = await getFeatureFlags(auth);
 
       if (!featureFlags.includes("salesforce_tool_write")) {
         return new Err(

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1591,7 +1591,7 @@ async function canPublishAgent(auth: Authenticator): Promise<{
   canPublish: boolean;
   message: string | null;
 }> {
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const featureFlags = await getFeatureFlags(auth);
   const level = getPublishingRestrictionLevel(featureFlags);
   if (!level || canPublishForAuth(auth, level)) {
     return { canPublish: true, message: null };

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -566,7 +566,7 @@ export async function postUserMessage(
     });
   }
 
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   const isPartOfProject = isProjectConversation(conversation);
 
   if (isPartOfProject) {
@@ -1225,7 +1225,7 @@ export async function editUserMessage(
     agentMessages
   );
 
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   if (
     featureFlags.includes("conversation_butler") &&
     isProjectConversation(conversation)
@@ -1309,8 +1309,6 @@ export async function retryAgentMessage(
     message: AgentMessageType;
   }
 ): Promise<Result<AgentMessageType, APIErrorWithStatusCode>> {
-  const owner = auth.getNonNullableWorkspace();
-
   // Find the parent user message to get the original context for rate limiting.
   // This ensures retries are counted with the same origin (web vs programmatic) as the original.
   const parentUserMessage = conversation.content
@@ -1507,7 +1505,7 @@ export async function retryAgentMessage(
     startStep: 0,
   });
 
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   if (
     featureFlags.includes("conversation_butler") &&
     isProjectConversation(conversation)
@@ -1667,7 +1665,7 @@ export async function postNewContentFragment(
     message: messageRow,
   });
 
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   if (
     featureFlags.includes("conversation_butler") &&
     isProjectConversation(conversation)

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -65,8 +65,9 @@ async function isEmailAgentsEnabled(
     );
     return false;
   }
-  const workspace = authResult.value.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(workspace);
+  const auth = authResult.value;
+  const workspace = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("email_agents")) {
     logger.info(
       { workspaceId: authType.workspaceId },

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -13,7 +13,7 @@ import { generateValidationToken } from "@app/lib/api/email/validation_token";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -347,7 +347,7 @@ export async function userAndWorkspaceFromEmail({
       type: "user_not_found",
       message:
         `Failed to match a valid Dust user for email: ${email}. ` +
-        `Please sign up for Dust at https://dust.tt to interact with assitsants over email.`,
+        `Please sign up for Dust at https://dust.tt to interact with assistants over email.`,
     });
   }
   const workspaceModels = await WorkspaceModel.findAll({
@@ -378,7 +378,11 @@ export async function userAndWorkspaceFromEmail({
   const eligibleWorkspaceModels: typeof workspaceModels = [];
   for (const w of workspaceModels) {
     const lightWorkspace = renderLightWorkspaceType({ workspace: w });
-    const flags = await getFeatureFlags(lightWorkspace);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      lightWorkspace.sId
+    );
+    const flags = await getFeatureFlags(auth);
     if (
       flags.includes("email_agents") &&
       lightWorkspace.metadata?.allowEmailAgents === true

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1062,7 +1062,7 @@ export async function getGlobalAgents(
       // We only want to fetch sidekick global agents if explicitly requested.
       .filter((sId) => sId !== GLOBAL_AGENTS_SID.SIDEKICK);
 
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
 
   if (!flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(

--- a/front/lib/api/assistant/jit/project_conversation.ts
+++ b/front/lib/api/assistant/jit/project_conversation.ts
@@ -15,8 +15,7 @@ export async function getProjectConversationServer(
   auth: Authenticator,
   conversation: ConversationWithoutContentType
 ): Promise<ServerSideMCPServerConfigurationType | null> {
-  const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
 
   if (
     !featureFlags.includes("projects") ||

--- a/front/lib/api/assistant/jit/project_manager.ts
+++ b/front/lib/api/assistant/jit/project_manager.ts
@@ -15,8 +15,7 @@ export async function getProjectManagerServer(
   auth: Authenticator,
   conversation: ConversationWithoutContentType
 ): Promise<ServerSideMCPServerConfigurationType | null> {
-  const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
 
   if (
     !featureFlags.includes("projects") ||

--- a/front/lib/api/assistant/jit/projects.ts
+++ b/front/lib/api/assistant/jit/projects.ts
@@ -19,7 +19,7 @@ export async function getProjectSearchServer(
   conversation: ConversationWithoutContentType
 ): Promise<ServerSideMCPServerConfigurationType | null> {
   const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
 
   if (
     !featureFlags.includes("projects") ||

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -39,8 +39,7 @@ export interface AvailableSkill {
 export async function getAvailableModelsForWorkspace(
   auth: Authenticator
 ): Promise<ModelConfigurationType[]> {
-  const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
 
   const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
   return filterCustomAvailableAndWhitelistedModels(

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -166,7 +166,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     }
 
     // Check if the feature flag is enabled
-    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    const featureFlags = await getFeatureFlags(auth);
     if (!featureFlags.includes("self_created_slack_app_connector_rollout")) {
       return undefined;
     }
@@ -201,9 +201,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       } = extraConfig;
       return restConfig;
     } else if (useCase === "platform_actions") {
-      const feature_flags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
+      const feature_flags = await getFeatureFlags(auth);
       const config = { ...extraConfig };
       if (feature_flags.includes("slack_bot_mcp")) {
         config.slack_bot_mcp_feature_flag = "true";

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1441,8 +1441,10 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
 });
 
 export function getFeatureFlags(
-  workspace: LightWorkspaceType
+  auth: Authenticator
 ): Promise<WhitelistableFeature[]> {
+  const workspace = auth.getNonNullableWorkspace();
+
   return new Promise((resolve, reject) => {
     _getFeatureFlags(workspace, (err, result) => {
       if (err) {
@@ -1458,25 +1460,18 @@ export async function hasFeatureFlag(
   auth: Authenticator,
   flag: WhitelistableFeature
 ): Promise<boolean> {
-  const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const flags = await getFeatureFlags(auth);
   return flags.includes(flag);
 }
 
 export function invalidateFeatureFlagsCache(
-  workspace: LightWorkspaceType
+  authOrWorkspace: Authenticator | LightWorkspaceType
 ): void {
+  const workspace =
+    authOrWorkspace instanceof Authenticator
+      ? authOrWorkspace.getNonNullableWorkspace()
+      : authOrWorkspace;
   _getFeatureFlags.del(workspace);
-}
-
-export async function isRestrictedFromAgentCreation(
-  owner: LightWorkspaceType
-): Promise<boolean> {
-  const featureFlags = await getFeatureFlags(owner);
-
-  return (
-    featureFlags.includes("disallow_agent_creation_to_users") &&
-    !isBuilder(owner)
-  );
 }
 
 export function getApiKeyNameFromHeaders(headers: {

--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -115,7 +115,7 @@ const isSlackNotificationsFeatureEnabled = async (
     subscriberId,
     workspaceId
   );
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const featureFlags = await getFeatureFlags(auth);
 
   return featureFlags.includes("conversations_slack_notifications");
 };

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -19,7 +19,7 @@ export const discoverSkillsSkill = {
   icon: "PuzzleIcon",
   isAutoEnabled: true,
   isRestricted: async (auth: Authenticator) => {
-    const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    const flags = await getFeatureFlags(auth);
 
     return !flags.includes("discover_skills");
   },

--- a/front/lib/resources/skill/global/sandbox.ts
+++ b/front/lib/resources/skill/global/sandbox.ts
@@ -24,7 +24,7 @@ export const sandboxSkill = {
   version: 1,
   icon: "CommandLineIcon",
   isRestricted: async (auth: Authenticator) => {
-    const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    const flags = await getFeatureFlags(auth);
 
     return !flags.includes("sandbox_tools");
   },

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -271,8 +271,7 @@ async function handler(
         workspace.sId
       );
 
-      const featureFlagWorkspace = auth.getNonNullableWorkspace();
-      const featureFlags = await getFeatureFlags(featureFlagWorkspace);
+      const featureFlags = await getFeatureFlags(auth);
       if (!featureFlags.includes("email_agents")) {
         await replyToError(email, {
           type: "invalid_email_error",

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -87,8 +87,7 @@ async function handler(
         });
       }
 
-      const workspace = auth.getNonNullableWorkspace();
-      const flags = await getFeatureFlags(workspace);
+      const flags = await getFeatureFlags(auth);
       if (!flags.includes("agent_management_tool")) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/v1/w/[wId]/feature_flags.ts
+++ b/front/pages/api/v1/w/[wId]/feature_flags.ts
@@ -18,7 +18,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
   if (!auth.isSystemKey()) {
     return apiError(req, res, {
       status_code: 404,
@@ -31,7 +30,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const feature_flags = await getFeatureFlags(owner);
+      const feature_flags = await getFeatureFlags(auth);
       return res.status(200).json({ feature_flags });
 
     default:

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -282,7 +282,7 @@ async function handler(
       }
 
       // Fetch the feature flags for the owner of the run.
-      const keyWorkspaceFlags = await getFeatureFlags(owner);
+      const keyWorkspaceFlags = await getFeatureFlags(auth);
 
       let credentials: CredentialsType | null = null;
       if (useDustCredentials) {
@@ -315,7 +315,7 @@ async function handler(
       }
 
       // Fetch the feature flags of the app's workspace.
-      const flags = await getFeatureFlags(owner);
+      const flags = await getFeatureFlags(auth);
       const storeBlocksResults = !flags.includes("disable_run_logs");
 
       logger.info(

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -23,9 +23,7 @@ async function handler(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("sandbox_tools")) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -36,7 +36,7 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
   if (!flags.includes("usage_data_api")) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -118,7 +118,7 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
   if (!flags.includes("usage_data_api")) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -49,8 +49,7 @@ async function handler(
     bodyValidationResult._tag === "Right" &&
     bodyValidationResult.right.auto_respond_without_mention
   ) {
-    const owner = auth.getNonNullableWorkspace();
-    const featureFlags = await getFeatureFlags(owner);
+    const featureFlags = await getFeatureFlags(auth);
     if (!featureFlags.includes("slack_enhanced_default_agent")) {
       return apiError(req, res, {
         status_code: 403,

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -85,7 +85,7 @@ async function handler(
     ? await isWorkspaceEligibleForTrial(auth)
     : false;
 
-  const featureFlags = await getFeatureFlags(workspace);
+  const featureFlags = await getFeatureFlags(auth);
 
   return res.status(200).json({
     user: user.toJSON(),

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_status.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_status.ts
@@ -77,7 +77,7 @@ async function handler(
     });
   }
 
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
   if (!flags.includes("advanced_notion_management")) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
@@ -38,7 +38,7 @@ async function handler(
   // endpoint protected by feature flag
   if (
     !dataSource ||
-    !(await getFeatureFlags(owner)).includes("advanced_notion_management")
+    !(await getFeatureFlags(auth)).includes("advanced_notion_management")
   ) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/feature-flags.ts
+++ b/front/pages/api/w/[wId]/feature-flags.ts
@@ -44,11 +44,9 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
   switch (req.method) {
     case "GET":
-      const feature_flags = await getFeatureFlags(owner);
+      const feature_flags = await getFeatureFlags(auth);
       return res.status(200).json({ feature_flags });
 
     default:

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -229,9 +229,7 @@ async function handler(
   let space: SpaceResource | null = null;
   if (file.useCaseMetadata?.spaceId) {
     if (file.useCase === "project_context") {
-      const featureFlags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
+      const featureFlags = await getFeatureFlags(auth);
       if (!featureFlags.includes("projects")) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.ts
@@ -43,7 +43,7 @@ async function handler(
 
   // Check feature flag for project_context files
   if (file.useCase === "project_context") {
-    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    const featureFlags = await getFeatureFlags(auth);
     if (!featureFlags.includes("projects")) {
       return apiError(req, res, {
         status_code: 500,

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -37,7 +37,7 @@ async function handler(
     });
   }
 
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("projects")) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -78,8 +78,7 @@ async function handler(
         }
       }
 
-      const owner = auth.getNonNullableWorkspace();
-      const flags = await getFeatureFlags(owner);
+      const flags = await getFeatureFlags(auth);
       if (!flags.includes("labs_mcp_actions_dashboard")) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -41,7 +41,7 @@ async function handler(
 ): Promise<void> {
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
 
   if (!flags.includes("labs_transcripts")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/labs/transcripts/connector.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/connector.ts
@@ -33,8 +33,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
 
   if (!flags.includes("labs_transcripts")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/labs/transcripts/default.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/default.ts
@@ -23,8 +23,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
 
   if (!flags.includes("labs_transcripts")) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -92,7 +92,7 @@ async function handler(
 ): Promise<void> {
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
-  const flags = await getFeatureFlags(owner);
+  const flags = await getFeatureFlags(auth);
   const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
   if (!flags.includes("labs_transcripts")) {

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -28,9 +28,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const featureFlags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
+      const featureFlags = await getFeatureFlags(auth);
 
       const isFeatureEnabled = featureFlags.includes(
         "conversations_slack_notifications"

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -104,7 +104,7 @@ async function handler(
       return;
 
     case "POST":
-      const featureFlags = await getFeatureFlags(owner);
+      const featureFlags = await getFeatureFlags(auth);
       // Allow Dust Super User to force role for testing
       const allowForSuperUserTesting =
         showDebugTools(featureFlags) &&

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -27,7 +27,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const featureFlags = await getFeatureFlags(owner);
+      const featureFlags = await getFeatureFlags(auth);
       // Include both standard models and custom models (from GCS at build time)
       const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
       const models = await filterCustomAvailableAndWhitelistedModels(

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -260,9 +260,7 @@ async function handler(
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
       if (fileAttachments) {
-        const featureFlags = await getFeatureFlags(
-          auth.getNonNullableWorkspace()
-        );
+        const featureFlags = await getFeatureFlags(auth);
         if (
           !featureFlags.includes("sandbox_tools") &&
           fileAttachments.length > 0

--- a/front/pages/api/w/[wId]/skills/detect.ts
+++ b/front/pages/api/w/[wId]/skills/detect.ts
@@ -40,7 +40,7 @@ async function handler(
         });
       }
 
-      const featureFlags = await getFeatureFlags(owner);
+      const featureFlags = await getFeatureFlags(auth);
       if (!featureFlags.includes("sandbox_tools")) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/skills/import.ts
+++ b/front/pages/api/w/[wId]/skills/import.ts
@@ -42,7 +42,7 @@ async function handler(
         });
       }
 
-      const featureFlags = await getFeatureFlags(owner);
+      const featureFlags = await getFeatureFlags(auth);
       if (!featureFlags.includes("sandbox_tools")) {
         return apiError(req, res, {
           status_code: 403,

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -285,9 +285,7 @@ async function handler(
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
       if (fileAttachments) {
-        const featureFlags = await getFeatureFlags(
-          auth.getNonNullableWorkspace()
-        );
+        const featureFlags = await getFeatureFlags(auth);
         if (
           !featureFlags.includes("sandbox_tools") &&
           fileAttachments.length > 0

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -124,11 +124,11 @@ async function handler(
       );
       const inputDataset = inputConfigEntry ? inputConfigEntry.dataset : null;
 
-      const flags = await getFeatureFlags(owner);
+      const flags = await getFeatureFlags(auth);
       const storeBlocksResults = !flags.includes("disable_run_logs");
 
       // Fetch the feature flags of the app's workspace.
-      const keyWorkspaceFlags = await getFeatureFlags(owner);
+      const keyWorkspaceFlags = await getFeatureFlags(auth);
 
       const dustRun = await coreAPI.createRun(
         owner,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -243,7 +243,7 @@ const handleDataSourceWithProvider = async ({
     });
   }
 
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
 
   // Checking that the provider is allowed for the workspace plan
   const isDataSourceAllowedInPlan = isConnectorProviderAllowedForPlan(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests.ts
@@ -23,8 +23,7 @@ async function handler(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("project_butler")) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
@@ -25,8 +25,7 @@ export async function handler(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
+  const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("project_butler")) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -92,7 +92,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
   }
 
   const auth = authResult.value;
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const featureFlags = await getFeatureFlags(auth);
 
   let shouldSignalButler = false;
   if (featureFlags.includes("conversation_butler")) {

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -194,7 +194,7 @@ async function _runModelAndCreateActionsActivity({
   }
 
   // Tool test run: bypass LLM and directly execute tool commands.
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const featureFlags = await getFeatureFlags(auth);
   if (featureFlags.includes("run_tools_from_prompt")) {
     const result = await handlePromptCommand(auth, runAgentData, step, runIds);
     if (result !== "not_a_command") {

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -44,7 +44,7 @@ export async function getFlaggedWorkspacesActivity(): Promise<string[]> {
 
   for (const workspace of allWorkspaces) {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    const featureFlags = await getFeatureFlags(auth);
     if (featureFlags.includes("reinforced_agents")) {
       flaggedIds.push(workspace.sId);
     }


### PR DESCRIPTION
## Description

Change `getFeatureFlags(workspace)` to `getFeatureFlags(auth)`

It's more consistent with the code base, and it'll allow to have `getFeatureFlags` handle groups (as we have them in the auth).

It's a noop, apart from one place, see comments

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
