### PR TITLE
feat: add groupIds to feature flags

### DIFF
--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -1,6 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -9,6 +10,7 @@ export class FeatureFlagModel extends WorkspaceAwareModel<FeatureFlagModel> {
   declare updatedAt: CreationOptional<Date>;
 
   declare name: WhitelistableFeature;
+  declare groupIds: ModelId[] | null;
 }
 
 FeatureFlagModel.init(
@@ -26,6 +28,13 @@ FeatureFlagModel.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+      allowNull: true,
+      defaultValue: null,
+      comment:
+        "Per-group feature flag targeting. NULL means workspace-wide (current behavior), an array of group IDs means the flag is only enabled for users who belong to at least one of those groups.",
     },
   },
   {

--- a/front/migrations/db/migration_567.sql
+++ b/front/migrations/db/migration_567.sql
@@ -1,0 +1,6 @@
+-- Migration created on Mar 16, 2026
+-- Add groupIds column to feature_flags table for per-group feature flag targeting.
+-- NULL means workspace-wide (current behavior), an array of group IDs means the flag
+-- is only enabled for users who belong to at least one of those groups.
+ALTER TABLE "feature_flags"
+    ADD COLUMN "groupIds" INTEGER[] DEFAULT NULL;


### PR DESCRIPTION
## Description

We want to support features for a given workspace and groups, we store it in an array in the feature flag table, see => https://dust4ai.slack.com/archives/C050SM8NSPK/p1773672024341949

* Add a nullable groups array column to the existing feature_flags table <= this PR
* Change getFeatureFlags(workspace) to getFeatureFlags(auth) so it has access to the user's group memberships (already loaded on the Authenticator at construction time). Flags are returned if groups is null (workspace-wide) or the user belongs to at least one listed group. No extra SQL query needed.
* Frontend stays unchanged — it still receives WhitelistableFeature[] from the auth-context endpoint.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
