### PR TITLE
feat: add groupId to feature flags

### DIFF
--- a/front/lib/auth.test.ts
+++ b/front/lib/auth.test.ts
@@ -1,0 +1,88 @@
+import { getFeatureFlags } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("getFeatureFlags", () => {
+  describe("workspace-wide flags (groupIds = null)", () => {
+    it("returns the flag for any user in the workspace", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+
+      await FeatureFlagFactory.basic(authenticator, "labs_transcripts");
+
+      const flags = await getFeatureFlags(authenticator);
+      expect(flags).toContain("labs_transcripts");
+    });
+
+    it("returns an empty array when no flags are enabled", async () => {
+      const { authenticator } = await createResourceTest({ role: "user" });
+
+      const flags = await getFeatureFlags(authenticator);
+      expect(flags).toEqual([]);
+    });
+  });
+
+  describe("group-scoped flags (groupIds set)", () => {
+    it("returns the flag when user belongs to a targeted group", async () => {
+      const { authenticator, globalGroup } = await createResourceTest({
+        role: "user",
+      });
+
+      await FeatureFlagFactory.basic(authenticator, "labs_transcripts", {
+        groupIds: [globalGroup.id],
+      });
+
+      const flags = await getFeatureFlags(authenticator);
+      expect(flags).toContain("labs_transcripts");
+    });
+
+    it("does not return the flag when user is not in any targeted group", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+
+      // Create a separate group that the user is NOT a member of.
+      const isolatedGroup = await GroupResource.makeNew({
+        name: "isolated-group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      await FeatureFlagFactory.basic(authenticator, "labs_transcripts", {
+        groupIds: [isolatedGroup.id],
+      });
+
+      const flags = await getFeatureFlags(authenticator);
+      expect(flags).not.toContain("labs_transcripts");
+    });
+
+    it("returns both workspace-wide and matching group-scoped flags", async () => {
+      const { workspace, authenticator, globalGroup } =
+        await createResourceTest({ role: "user" });
+
+      // Workspace-wide flag.
+      await FeatureFlagFactory.basic(authenticator, "labs_transcripts");
+
+      // Group-scoped flag targeting the global group (user is a member).
+      await FeatureFlagFactory.basic(authenticator, "gong_tool", {
+        groupIds: [globalGroup.id],
+      });
+
+      // Group-scoped flag targeting a group the user is NOT in.
+      const otherGroup = await GroupResource.makeNew({
+        name: "other-group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await FeatureFlagFactory.basic(authenticator, "discord_bot", {
+        groupIds: [otherGroup.id],
+      });
+
+      const flags = await getFeatureFlags(authenticator);
+      expect(flags).toContain("labs_transcripts");
+      expect(flags).toContain("gong_tool");
+      expect(flags).not.toContain("discord_bot");
+    });
+  });
+});

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1543,10 +1543,18 @@ function getGlobalFeatureFlags(): Promise<GlobalFeatureFlagResource[]> {
   });
 }
 
-const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
+type FeatureFlagEntry = {
+  name: WhitelistableFeature;
+  groupIds: ModelId[] | null;
+};
+
+const _getFeatureFlags = memoizer<LightWorkspaceType, FeatureFlagEntry[]>({
   load: (workspace, callback) => {
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
-      callback(null, [...WHITELISTABLE_FEATURES]);
+      callback(
+        null,
+        WHITELISTABLE_FEATURES.map((name) => ({ name, groupIds: null }))
+      );
       return;
     }
 
@@ -1559,8 +1567,10 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
           workspaceFlags.map((flag) => flag.name)
         );
 
-        // Start with workspace-level flags (always take precedence).
-        const effectiveFlags = [...workspaceFlagNames];
+        // Start with workspace-level flags (always take precedence), preserving groupIds.
+        const effectiveFlags: FeatureFlagEntry[] = workspaceFlags.map(
+          (flag) => ({ name: flag.name, groupIds: flag.groupIds })
+        );
 
         // Add global flags that aren't already set at workspace level.
         for (const globalFlag of globalFlags) {
@@ -1571,7 +1581,7 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
               globalFlag.rolloutPercentage
             )
           ) {
-            effectiveFlags.push(globalFlag.name);
+            effectiveFlags.push({ name: globalFlag.name, groupIds: null });
           }
         }
 
@@ -1586,11 +1596,9 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
   ttl: 3000,
 });
 
-export function getFeatureFlags(
-  auth: Authenticator
-): Promise<WhitelistableFeature[]> {
-  const workspace = auth.getNonNullableWorkspace();
-
+function getWorkspaceFeatureFlags(
+  workspace: LightWorkspaceType
+): Promise<FeatureFlagEntry[]> {
   return new Promise((resolve, reject) => {
     _getFeatureFlags(workspace, (err, result) => {
       if (err) {
@@ -1600,6 +1608,22 @@ export function getFeatureFlags(
       }
     });
   });
+}
+
+export async function getFeatureFlags(
+  auth: Authenticator
+): Promise<WhitelistableFeature[]> {
+  const workspace = auth.getNonNullableWorkspace();
+  const flags = await getWorkspaceFeatureFlags(workspace);
+  const userGroupIds = new Set(auth.groupModelIds());
+
+  return flags
+    .filter(
+      (flag) =>
+        flag.groupIds === null ||
+        flag.groupIds.some((gId) => userGroupIds.has(gId))
+    )
+    .map((flag) => flag.name);
 }
 
 export async function hasFeatureFlag(

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -1,6 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -9,6 +10,7 @@ export class FeatureFlagModel extends WorkspaceAwareModel<FeatureFlagModel> {
   declare updatedAt: CreationOptional<Date>;
 
   declare name: WhitelistableFeature;
+  declare groupIds: ModelId[] | null;
 }
 
 FeatureFlagModel.init(
@@ -26,6 +28,13 @@ FeatureFlagModel.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    groupIds: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+      allowNull: true,
+      defaultValue: null,
+      comment:
+        "Per-group feature flag targeting. NULL means workspace-wide (current behavior), an array of group IDs means the flag is only enabled for users who belong to at least one of those groups.",
     },
   },
   {

--- a/front/lib/resources/feature_flag_resource.ts
+++ b/front/lib/resources/feature_flag_resource.ts
@@ -7,6 +7,7 @@ import {
   isWhitelistableFeature,
   type WhitelistableFeature,
 } from "@app/types/shared/feature_flags";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
@@ -56,11 +57,13 @@ export class FeatureFlagResource extends BaseResource<FeatureFlagModel> {
 
   static async enable(
     workspace: WorkspaceResource | WorkspaceType | LightWorkspaceType,
-    name: WhitelistableFeature
+    name: WhitelistableFeature,
+    { groupIds }: { groupIds?: ModelId[] } = {}
   ): Promise<void> {
     await FeatureFlagModel.create({
       workspaceId: workspace.id,
       name,
+      groupIds: groupIds ?? null,
     });
   }
 

--- a/front/migrations/db/migration_567.sql
+++ b/front/migrations/db/migration_567.sql
@@ -1,0 +1,6 @@
+-- Migration created on Mar 16, 2026
+-- Add groupIds column to feature_flags table for per-group feature flag targeting.
+-- NULL means workspace-wide (current behavior), an array of group IDs means the flag
+-- is only enabled for users who belong to at least one of those groups.
+ALTER TABLE "feature_flags"
+    ADD COLUMN "groupIds" INTEGER[] DEFAULT NULL;

--- a/front/tests/utils/FeatureFlagFactory.ts
+++ b/front/tests/utils/FeatureFlagFactory.ts
@@ -2,11 +2,18 @@ import { type Authenticator, invalidateFeatureFlagsCache } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
+import type { ModelId } from "@app/types/shared/model_id";
+
 export class FeatureFlagFactory {
-  static async basic(auth: Authenticator, featureName: WhitelistableFeature) {
+  static async basic(
+    auth: Authenticator,
+    featureName: WhitelistableFeature,
+    { groupIds }: { groupIds?: ModelId[] } = {}
+  ) {
     await FeatureFlagResource.enable(
       auth.getNonNullableWorkspace(),
-      featureName
+      featureName,
+      { groupIds }
     );
 
     // Clear the memoizer cache so that the following calls see the updated feature flags.


### PR DESCRIPTION
## Description

Now that we have groups in the feature flag table, we can surface them and use them

* Add a nullable groups array column to the existing feature_flags table <= this PR
* Change getFeatureFlags(workspace) to getFeatureFlags(auth) so it has access to the user's group memberships (already loaded on the Authenticator at construction time). Flags are returned if groups is null (workspace-wide) or the user belongs to at least one listed group. No extra SQL query needed <= this PR
* Frontend stays unchanged — it still receives WhitelistableFeature[] from the auth-context endpoint.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
