### PR TITLE
[front] feat: add Sandbox skill

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1042,7 +1042,7 @@ export const INTERNAL_MCP_SERVERS = {
   },
   sandbox: {
     id: 1024,
-    availability: "auto",
+    availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: true,
     isRestricted: ({ featureFlags }) => {

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -63,15 +63,7 @@ export const SANDBOX_SERVER = {
     authorization: null,
     icon: "CommandLineIcon",
     documentationUrl: null,
-    // Predates the introduction of the rule, would require extensive work to
-    // improve, already widely adopted.
-
-    instructions:
-      // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
-      "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
-      "Use `bash` to run commands and scripts. " +
-      "The sandbox persists for the conversation duration. " +
-      "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
+    instructions: null,
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -6,6 +6,7 @@ import { discoverToolsSkill } from "@app/lib/resources/skill/global/discover_too
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/global/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/global/mention_users";
+import { sandboxSkill } from "@app/lib/resources/skill/global/sandbox";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -87,6 +88,7 @@ const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   framesSkill,
   goDeepSkill,
   mentionUsersSkill,
+  sandboxSkill,
 ] as const);
 
 // Build lookup map for direct access by sId.

--- a/front/lib/resources/skill/global/sandbox.ts
+++ b/front/lib/resources/skill/global/sandbox.ts
@@ -25,4 +25,5 @@ export const sandboxSkill = {
 
     return !flags.includes("sandbox_tools");
   },
+  isAutoEnabled: true,
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/sandbox.ts
+++ b/front/lib/resources/skill/global/sandbox.ts
@@ -1,0 +1,21 @@
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
+
+const SANDBOX_INSTRUCTIONS =
+  "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
+  "Use `bash` to run commands and scripts. " +
+  "The sandbox persists for the conversation duration. " +
+  "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.";
+
+export const sandboxSkill = {
+  sId: "sandbox",
+  name: "Sandbox",
+  userFacingDescription:
+    "Run code, scripts, and shell commands in an isolated Linux environment.",
+  agentFacingDescription:
+    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthly tool outputs, run code, " +
+    "process data, install packages, manipulate files, or perform any task requiring shell access.",
+  instructions: SANDBOX_INSTRUCTIONS,
+  mcpServers: [{ name: "sandbox" }],
+  version: 1,
+  icon: "CommandLineIcon",
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/sandbox.ts
+++ b/front/lib/resources/skill/global/sandbox.ts
@@ -1,3 +1,5 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 
 const SANDBOX_INSTRUCTIONS =
@@ -18,4 +20,9 @@ export const sandboxSkill = {
   mcpServers: [{ name: "sandbox" }],
   version: 1,
   icon: "CommandLineIcon",
+  isRestricted: async (auth: Authenticator) => {
+    const flags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
+    return !flags.includes("sandbox_tools");
+  },
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/sandbox.ts
+++ b/front/lib/resources/skill/global/sandbox.ts
@@ -14,7 +14,7 @@ export const sandboxSkill = {
   userFacingDescription:
     "Run code, scripts, and shell commands in an isolated Linux environment.",
   agentFacingDescription:
-    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthly tool outputs, run code, " +
+    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
     "process data, install packages, manipulate files, or perform any task requiring shell access.",
   instructions: SANDBOX_INSTRUCTIONS,
   mcpServers: [{ name: "sandbox" }],


### PR DESCRIPTION
## Description

- Context in [thread](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1773738906528579).
- This PR adds a global skill Sandbox that will bundle tools and instructions relative to the usage of the sandbox.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
