### PR TITLE
[BYOK] Add unhealthy credentials warning

### DIFF
--- a/front-spa/src/app/layouts/ConversationRouterLayout.tsx
+++ b/front-spa/src/app/layouts/ConversationRouterLayout.tsx
@@ -8,8 +8,15 @@ import { Outlet } from "react-router-dom";
  */
 export function ConversationRouterLayout() {
   const owner = useWorkspace();
-  const { subscription, user, isAdmin, isBuilder, featureFlags, vizUrl } =
-    useAuth();
+  const {
+    subscription,
+    user,
+    isAdmin,
+    isBuilder,
+    featureFlags,
+    vizUrl,
+    providersHealth,
+  } = useAuth();
 
   const pageProps = {
     workspace: owner,
@@ -19,6 +26,7 @@ export function ConversationRouterLayout() {
     isBuilder,
     featureFlags,
     vizUrl,
+    providersHealth,
   };
 
   return (

--- a/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
+++ b/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
@@ -45,6 +45,7 @@ export function PokeWorkspacePage({ children }: PokeLayoutProps) {
     ...authContext,
     featureFlags: [],
     vizUrl: "",
+    providersHealth: null,
   };
 
   return (

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -6,11 +6,13 @@ import { HelpDropdown } from "@app/components/navigation/HelpDropdown";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { UserMenu } from "@app/components/UserMenu";
 import type { AppStatus } from "@app/lib/api/status";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { SubscriptionType } from "@app/types/plan";
+import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
@@ -80,20 +82,14 @@ export const NavigationSidebar = React.forwardRef<
 
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
-      <div
-        className={cn(
-          "flex flex-col gap-2",
-          appStatus?.dustStatus ||
-            appStatus?.providersStatus ||
-            subscription.paymentFailingSince
-            ? ""
-            : "pt-3"
-        )}
-      >
-        {appStatus && <AppStatusBanner appStatus={appStatus} />}
-        {subscription.paymentFailingSince && isAdmin(owner) && (
-          <SubscriptionPastDueBanner />
-        )}
+      <div className={cn("flex flex-col gap-3")}>
+        <div className={cn("flex flex-col gap-2")}>
+          <UnhealthyCredentialsBanner owner={owner} />
+          {appStatus && <AppStatusBanner appStatus={appStatus} />}
+          {subscription.paymentFailingSince && isAdmin(owner) && (
+            <SubscriptionPastDueBanner />
+          )}
+        </div>
         {navs.length > 1 && (
           <Tabs value={currentTab?.id ?? "conversations"}>
             <div className="border-b border-separator px-2 dark:border-separator-night">
@@ -229,6 +225,49 @@ function StatusBanner({
       <div className="font-normal">{description}</div>
       {footer && <div>{footer}</div>}
     </div>
+  );
+}
+
+function UnhealthyCredentialsBanner({ owner }: { owner: WorkspaceType }) {
+  const { providersHealth } = useAuth();
+
+  if (!providersHealth) {
+    return null;
+  }
+
+  const hasConfiguredProviders = Object.keys(providersHealth).length > 0;
+  const isWorkspaceHealthy = Object.values(providersHealth).every(Boolean);
+
+  if (hasConfiguredProviders && isWorkspaceHealthy) {
+    return null;
+  }
+
+  const description = !hasConfiguredProviders
+    ? "No provider credentials configured. Please set up at least one model provider."
+    : "The following model providers have invalid credentials: " +
+      Object.entries(providersHealth)
+        .filter(([_, isHealthy]) => !isHealthy)
+        .map(
+          ([providerId]) =>
+            PRETTIFIED_PROVIDER_NAMES[providerId as ByokModelProviderIdType]
+        )
+        .join(", ") +
+      ".";
+  const footer = isAdmin(owner) ? (
+    <LinkWrapper href={`/w/${owner.sId}/model-providers`} className="underline">
+      Model providers
+    </LinkWrapper>
+  ) : (
+    <>Contact your workspace admin.</>
+  );
+
+  return (
+    <StatusBanner
+      title="Your workspace is not operational"
+      description={description}
+      variant="warning"
+      footer={footer}
+    />
   );
 }
 

--- a/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
+++ b/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
@@ -69,7 +69,7 @@ export function KeyConfigurationSheet({
   logo,
   apiKey: initialApiKey,
 }: KeyConfigurationSheetProps) {
-  const [apiKey, setApiKey] = useState(initialApiKey ?? "");
+  const [apiKey, setApiKey] = useState("");
 
   const { saveProviderCredential, isSaving } = useSaveProviderCredential({
     owner,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -26,9 +26,9 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
+import type { ProvidersHealth } from "@app/types/provider_credential";
 import type {
   PermissionType,
   ResourcePermission,
@@ -64,8 +64,6 @@ const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 const DustApiKeyNameHeader = "x-dust-api-key-name";
 
 const SANDBOX_TOKEN_AUTH_METHOD = "sandbox_token" as const;
-
-type ProvidersHealth = Partial<Record<ByokModelProviderIdType, boolean>>;
 
 export type AuthMethodType =
   | "system_api_key"

--- a/front/lib/auth/AuthContext.tsx
+++ b/front/lib/auth/AuthContext.tsx
@@ -1,4 +1,5 @@
 import type { SubscriptionType } from "@app/types/plan";
+import type { ProvidersHealth } from "@app/types/provider_credential";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { createContext, useCallback, useContext } from "react";
@@ -13,6 +14,7 @@ export interface AuthContextValue {
   isBuilder: boolean;
   featureFlags: WhitelistableFeature[];
   vizUrl: string;
+  providersHealth: ProvidersHealth | null;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -6,6 +6,7 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { workspaceAuthContextUrl } from "@app/lib/swr/workspaces";
 import type { GetProviderCredentialsResponseBody } from "@app/pages/api/w/[wId]/provider_credentials";
 import type {
   ProviderCredentialBody,
@@ -97,6 +98,7 @@ export function useSaveProviderCredential({
         });
 
         await mutate(baseProviderCredentialsApiUrl(owner.sId));
+        await mutate(workspaceAuthContextUrl(owner.sId));
 
         return data.providerCredential;
       } catch (e) {
@@ -156,7 +158,7 @@ export function useDeleteProviderCredential({
         });
 
         await mutate(baseProviderCredentialsApiUrl(owner.sId));
-
+        await mutate(workspaceAuthContextUrl(owner.sId));
         return true;
       } catch (e) {
         const message = normalizeError(e).message;

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -626,6 +626,9 @@ export function useWorkspaceSeatsCount({
   };
 }
 
+export const workspaceAuthContextUrl = (workspaceId: string) =>
+  `/api/w/${workspaceId}/auth-context`;
+
 interface UseAuthContextResult<T> {
   authContext: T | undefined;
   isAuthenticated: boolean;
@@ -655,7 +658,7 @@ export function useAuthContext(
   const regionContext = useRegionContext();
 
   const url = workspaceId
-    ? `/api/w/${workspaceId}/auth-context`
+    ? workspaceAuthContextUrl(workspaceId)
     : `/api/auth-context`;
 
   const authContextFetcher: Fetcher<

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -8,6 +8,7 @@ import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { SubscriptionType } from "@app/types/plan";
+import type { ProvidersHealth } from "@app/types/provider_credential";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -22,6 +23,7 @@ export type GetWorkspaceAuthContextResponseType = {
   featureFlags: WhitelistableFeature[];
   isEligibleForTrial?: boolean;
   vizUrl: string;
+  providersHealth: ProvidersHealth | null;
 };
 
 async function handler(
@@ -96,6 +98,7 @@ async function handler(
     featureFlags,
     ...(isEligibleForTrial !== undefined && { isEligibleForTrial }),
     vizUrl: config.getVizPublicUrl(),
+    providersHealth: auth.providersHealth(),
   });
 }
 

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -2,6 +2,8 @@ import type { ByokModelProviderIdType } from "@app/types/assistant/models/types"
 import type { ModelId } from "@app/types/shared/model_id";
 import { z } from "zod";
 
+export type ProvidersHealth = Partial<Record<ByokModelProviderIdType, boolean>>;
+
 export type LLMCredentialsType = {
   OPENAI_API_KEY?: string;
   OPENAI_EMBEDDING_API_KEY?: string;


### PR DESCRIPTION
## Description

Surfaces an inline warning banner in the navigation sidebar when any BYOK provider credential is unhealthy. Also fixes a minor UX bug where the API key input wasn't cleared when reopening the configuration sheet.

<img width="418" height="310" alt="image" src="https://github.com/user-attachments/assets/d85e04f7-211e-493d-97be-9814db9708b9" />


## Tests

Tested manually — verified the warning banner appears/disappears as credentials are toggled healthy/unhealthy.

## Risk

Low — additive changes only (new endpoint, new UI banner, no schema changes).

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`