### PR TITLE
[front] Fix folder click after search navigating back to category page

### DIFF
--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -228,12 +228,6 @@ function BackendSearch({
     minLength: MIN_SEARCH_QUERY_SIZE,
   });
 
-  const handleClearSearch = React.useCallback(() => {
-    searchParam.setParam(undefined);
-    setSearchValue("");
-    setNodeOrUrlCandidate(null);
-  }, [searchParam, setSearchValue]);
-
   const handleSearchChange = (value: string) => {
     searchParam.setParam(value);
     setSearchValue(value);
@@ -463,7 +457,6 @@ function BackendSearch({
               isLoading={isSearchLoading}
               onOpenDocument={handleOpenDocument}
               setEffectiveContentNode={setEffectiveContentNode}
-              onClearSearch={handleClearSearch}
               sorting={sorting}
               setSorting={handleSortingChange}
               scrollableDataTableRef={scrollableDataTableRef}
@@ -557,7 +550,6 @@ interface SearchResultsTableProps {
   isLoading: boolean;
   onOpenDocument?: (node: DataSourceViewContentNode) => void;
   setEffectiveContentNode: (node: DataSourceViewContentNode) => void;
-  onClearSearch: () => void;
   scrollableDataTableRef: React.Ref<HTMLDivElement>;
 }
 
@@ -575,7 +567,6 @@ function SearchResultsTable({
   isLoading,
   onOpenDocument,
   setEffectiveContentNode,
-  onClearSearch,
   scrollableDataTableRef,
 }: SearchResultsTableProps) {
   const router = useAppRouter();
@@ -677,7 +668,6 @@ function SearchResultsTable({
                   ? baseUrl
                   : `${baseUrl}?parentId=${parentId}`;
               void router.push(url);
-              onClearSearch();
             }
           },
         }),
@@ -698,7 +688,6 @@ function SearchResultsTable({
       };
     });
   }, [
-    onClearSearch,
     addToSpace,
     canReadInSpace,
     canWriteInSpace,

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -233,6 +233,15 @@ function BackendSearch({
     setSearchValue(value);
   };
 
+  // Clear local search state after navigating into a folder. Intentionally does
+  // not call searchParam.setParam(undefined): that shallow-pushes to the current
+  // pathname, racing with the folder navigation push and overriding it when
+  // invoked from the category page (see tasks#7098).
+  const handleClearSearchState = React.useCallback(() => {
+    setSearchValue("");
+    setNodeOrUrlCandidate(null);
+  }, [setSearchValue]);
+
   // Check if the search term is a URL
   React.useEffect(() => {
     if (debouncedSearch.length >= MIN_SEARCH_QUERY_SIZE) {
@@ -457,6 +466,7 @@ function BackendSearch({
               isLoading={isSearchLoading}
               onOpenDocument={handleOpenDocument}
               setEffectiveContentNode={setEffectiveContentNode}
+              onClearSearchState={handleClearSearchState}
               sorting={sorting}
               setSorting={handleSortingChange}
               scrollableDataTableRef={scrollableDataTableRef}
@@ -550,6 +560,7 @@ interface SearchResultsTableProps {
   isLoading: boolean;
   onOpenDocument?: (node: DataSourceViewContentNode) => void;
   setEffectiveContentNode: (node: DataSourceViewContentNode) => void;
+  onClearSearchState: () => void;
   scrollableDataTableRef: React.Ref<HTMLDivElement>;
 }
 
@@ -567,6 +578,7 @@ function SearchResultsTable({
   isLoading,
   onOpenDocument,
   setEffectiveContentNode,
+  onClearSearchState,
   scrollableDataTableRef,
 }: SearchResultsTableProps) {
   const router = useAppRouter();
@@ -668,6 +680,7 @@ function SearchResultsTable({
                   ? baseUrl
                   : `${baseUrl}?parentId=${parentId}`;
               void router.push(url);
+              onClearSearchState();
             }
           },
         }),
@@ -688,6 +701,7 @@ function SearchResultsTable({
       };
     });
   }, [
+    onClearSearchState,
     addToSpace,
     canReadInSpace,
     canWriteInSpace,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7098

When clicking a folder in search results on the **category page**, `onClearSearch()` triggered a shallow `router.push` (to remove `?q=` from `router.pathname`) that raced with the actual folder navigation. Since `router.pathname` on the category page doesn't include the `data_source_views` segment, the shallow push won and redirected back to the category page.

The root cause was only the `searchParam.setParam(undefined)` call inside `onClearSearch`. The state-clearing portion (`setSearchValue` + `setNodeOrUrlCandidate`) was intentional (added in #12175 to clear the search input when navigating into a sub-folder from the DSV page — e.g. inside a Google Drive connector). This fix restores that state-only clear while dropping the URL manipulation that caused the race.

This works correctly for both cases:
- **Category page → folder** (cross-page navigation): component unmounts; state clear is a no-op, URL never had `?q=` race issue.
- **DSV page → sub-folder** (same-page navigation, e.g. Google Drive): `setSearchValue()` hides the search panel; `?q=` disappears naturally from the URL since the destination doesn't include it.

## Risks

Blast radius: folder navigation from search results in spaces (category page and DSV page)
Risk: none

## Deploy Plan

- deploy front