### PR TITLE
[MCP Views] Migrate dependencies before deleting regular views

### DIFF
--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -11,6 +11,212 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
+const getConversationDependencyKey = ({
+  conversationId,
+  agentConfigurationId,
+}: Pick<
+  ConversationMCPServerViewModel,
+  "conversationId" | "agentConfigurationId"
+>) => `${conversationId}:${agentConfigurationId ?? "null"}`;
+
+const getSkillDependencyKey = ({
+  skillConfigurationId,
+}: Pick<SkillMCPServerConfigurationModel, "skillConfigurationId">) =>
+  `${skillConfigurationId}`;
+
+export const reassignMCPServerViewDependencies = async (
+  auth: Authenticator,
+  {
+    fromMCPServerViewIds,
+    toMCPServerViewId,
+    transaction,
+  }: {
+    fromMCPServerViewIds: ModelId[];
+    toMCPServerViewId: ModelId;
+    transaction?: Transaction;
+  }
+) => {
+  if (fromMCPServerViewIds.length === 0) {
+    return;
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const referencedMCPServerViewIds = [
+    toMCPServerViewId,
+    ...fromMCPServerViewIds,
+  ];
+  const fromMCPServerViewIdSet = new Set(fromMCPServerViewIds);
+
+  await AgentMCPServerConfigurationModel.update(
+    { mcpServerViewId: toMCPServerViewId },
+    {
+      where: {
+        workspaceId,
+        mcpServerViewId: { [Op.in]: fromMCPServerViewIds },
+      },
+      transaction,
+    }
+  );
+
+  const conversationDependencies = await ConversationMCPServerViewModel.findAll(
+    {
+      where: {
+        workspaceId,
+        mcpServerViewId: { [Op.in]: referencedMCPServerViewIds },
+      },
+      order: [
+        ["updatedAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      transaction,
+    }
+  );
+
+  const conversationDependencyMap = new Map<
+    string,
+    ConversationMCPServerViewModel[]
+  >();
+  for (const dependency of conversationDependencies) {
+    const key = getConversationDependencyKey(dependency);
+    const existingDependencies = conversationDependencyMap.get(key) ?? [];
+    existingDependencies.push(dependency);
+    conversationDependencyMap.set(key, existingDependencies);
+  }
+
+  const conversationDependencyIdsToDelete: ModelId[] = [];
+  const conversationDependencyIdsToUpdate: ModelId[] = [];
+  for (const dependencies of conversationDependencyMap.values()) {
+    const targetDependencies = dependencies.filter(
+      (dependency) => dependency.mcpServerViewId === toMCPServerViewId
+    );
+
+    if (targetDependencies.length > 0) {
+      const [keptTargetDependency, ...duplicatedTargetDependencies] =
+        targetDependencies;
+      conversationDependencyIdsToDelete.push(
+        ...duplicatedTargetDependencies.map((dependency) => dependency.id),
+        ...dependencies
+          .filter(
+            (dependency) =>
+              dependency.id !== keptTargetDependency.id &&
+              fromMCPServerViewIdSet.has(dependency.mcpServerViewId)
+          )
+          .map((dependency) => dependency.id)
+      );
+      continue;
+    }
+
+    const [dependencyToUpdate, ...dependenciesToDelete] = dependencies;
+    if (fromMCPServerViewIdSet.has(dependencyToUpdate.mcpServerViewId)) {
+      conversationDependencyIdsToUpdate.push(dependencyToUpdate.id);
+    }
+    conversationDependencyIdsToDelete.push(
+      ...dependenciesToDelete.map((dependency) => dependency.id)
+    );
+  }
+
+  if (conversationDependencyIdsToUpdate.length > 0) {
+    await ConversationMCPServerViewModel.update(
+      { mcpServerViewId: toMCPServerViewId },
+      {
+        where: {
+          workspaceId,
+          id: { [Op.in]: conversationDependencyIdsToUpdate },
+        },
+        transaction,
+      }
+    );
+  }
+
+  if (conversationDependencyIdsToDelete.length > 0) {
+    await ConversationMCPServerViewModel.destroy({
+      where: {
+        workspaceId,
+        id: { [Op.in]: conversationDependencyIdsToDelete },
+      },
+      transaction,
+    });
+  }
+
+  const skillDependencies = await SkillMCPServerConfigurationModel.findAll({
+    where: {
+      workspaceId,
+      mcpServerViewId: { [Op.in]: referencedMCPServerViewIds },
+    },
+    order: [
+      ["updatedAt", "DESC"],
+      ["id", "DESC"],
+    ],
+    transaction,
+  });
+
+  const skillDependencyMap = new Map<
+    string,
+    SkillMCPServerConfigurationModel[]
+  >();
+  for (const dependency of skillDependencies) {
+    const key = getSkillDependencyKey(dependency);
+    const existingDependencies = skillDependencyMap.get(key) ?? [];
+    existingDependencies.push(dependency);
+    skillDependencyMap.set(key, existingDependencies);
+  }
+
+  const skillDependencyIdsToDelete: ModelId[] = [];
+  const skillDependencyIdsToUpdate: ModelId[] = [];
+  for (const dependencies of skillDependencyMap.values()) {
+    const targetDependencies = dependencies.filter(
+      (dependency) => dependency.mcpServerViewId === toMCPServerViewId
+    );
+
+    if (targetDependencies.length > 0) {
+      const [keptTargetDependency, ...duplicatedTargetDependencies] =
+        targetDependencies;
+      skillDependencyIdsToDelete.push(
+        ...duplicatedTargetDependencies.map((dependency) => dependency.id),
+        ...dependencies
+          .filter(
+            (dependency) =>
+              dependency.id !== keptTargetDependency.id &&
+              fromMCPServerViewIdSet.has(dependency.mcpServerViewId)
+          )
+          .map((dependency) => dependency.id)
+      );
+      continue;
+    }
+
+    const [dependencyToUpdate, ...dependenciesToDelete] = dependencies;
+    if (fromMCPServerViewIdSet.has(dependencyToUpdate.mcpServerViewId)) {
+      skillDependencyIdsToUpdate.push(dependencyToUpdate.id);
+    }
+    skillDependencyIdsToDelete.push(
+      ...dependenciesToDelete.map((dependency) => dependency.id)
+    );
+  }
+
+  if (skillDependencyIdsToUpdate.length > 0) {
+    await SkillMCPServerConfigurationModel.update(
+      { mcpServerViewId: toMCPServerViewId },
+      {
+        where: {
+          workspaceId,
+          id: { [Op.in]: skillDependencyIdsToUpdate },
+        },
+        transaction,
+      }
+    );
+  }
+
+  if (skillDependencyIdsToDelete.length > 0) {
+    await SkillMCPServerConfigurationModel.destroy({
+      where: {
+        workspaceId,
+        id: { [Op.in]: skillDependencyIdsToDelete },
+      },
+      transaction,
+    });
+  }
+};
+
 export const destroyMCPServerViewDependencies = async (
   auth: Authenticator,
   {

--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -6,7 +6,10 @@ import {
   AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
-import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import {
+  SkillMCPServerConfigurationModel,
+  SkillVersionModel,
+} from "@app/lib/models/skill";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -23,6 +26,30 @@ const getSkillDependencyKey = ({
   skillConfigurationId,
 }: Pick<SkillMCPServerConfigurationModel, "skillConfigurationId">) =>
   `${skillConfigurationId}`;
+
+const remapMCPServerViewIds = (
+  mcpServerViewIds: ModelId[],
+  fromMCPServerViewIdSet: Set<ModelId>,
+  toMCPServerViewId: ModelId
+) => {
+  const remappedMCPServerViewIds: ModelId[] = [];
+  const seenMCPServerViewIds = new Set<ModelId>();
+
+  for (const mcpServerViewId of mcpServerViewIds) {
+    const nextMCPServerViewId = fromMCPServerViewIdSet.has(mcpServerViewId)
+      ? toMCPServerViewId
+      : mcpServerViewId;
+
+    if (seenMCPServerViewIds.has(nextMCPServerViewId)) {
+      continue;
+    }
+
+    remappedMCPServerViewIds.push(nextMCPServerViewId);
+    seenMCPServerViewIds.add(nextMCPServerViewId);
+  }
+
+  return remappedMCPServerViewIds;
+};
 
 export const reassignMCPServerViewDependencies = async (
   auth: Authenticator,
@@ -212,6 +239,32 @@ export const reassignMCPServerViewDependencies = async (
       },
       transaction,
     });
+  }
+
+  const skillVersions = await SkillVersionModel.findAll({
+    where: {
+      workspaceId,
+    },
+    transaction,
+  });
+
+  for (const skillVersion of skillVersions) {
+    if (
+      !skillVersion.mcpServerViewIds.some((mcpServerViewId) =>
+        fromMCPServerViewIdSet.has(mcpServerViewId)
+      )
+    ) {
+      continue;
+    }
+
+    const remappedMCPServerViewIds = remapMCPServerViewIds(
+      skillVersion.mcpServerViewIds,
+      fromMCPServerViewIdSet,
+      toMCPServerViewId
+    );
+
+    skillVersion.mcpServerViewIds = remappedMCPServerViewIds;
+    await skillVersion.save({ transaction });
   }
 };
 

--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -79,8 +79,7 @@ export const reassignMCPServerViewDependencies = async (
   for (const dependency of conversationDependencies) {
     const key = getConversationDependencyKey(dependency);
     const existingDependencies = conversationDependencyMap.get(key) ?? [];
-    existingDependencies.push(dependency);
-    conversationDependencyMap.set(key, existingDependencies);
+    conversationDependencyMap.set(key, [...existingDependencies, dependency]);
   }
 
   const conversationDependencyIdsToDelete: ModelId[] = [];
@@ -157,8 +156,7 @@ export const reassignMCPServerViewDependencies = async (
   for (const dependency of skillDependencies) {
     const key = getSkillDependencyKey(dependency);
     const existingDependencies = skillDependencyMap.get(key) ?? [];
-    existingDependencies.push(dependency);
-    skillDependencyMap.set(key, existingDependencies);
+    skillDependencyMap.set(key, [...existingDependencies, dependency]);
   }
 
   const skillDependencyIdsToDelete: ModelId[] = [];

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -1,15 +1,16 @@
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
-import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
-import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
-import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { AgentMCPServerConfigurationResource } from "@app/lib/resources/agent_mcp_server_configuration_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { ConversationMCPServerViewFactory } from "@app/tests/utils/ConversationMCPServerViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -571,13 +572,10 @@ describe("MCPServerViewResource", () => {
         agentConfigurationId: agent.sId,
         messagesCreatedAt: [new Date()],
       });
-      await ConversationMCPServerViewModel.create({
-        workspaceId: workspace.id,
-        conversationId: conversation.id,
+      await ConversationMCPServerViewFactory.create(userAuth, {
+        conversation,
         mcpServerViewId: regularView.id,
-        userId: user.id,
-        enabled: true,
-        source: "manual",
+        source: "agent_enabled",
         agentConfigurationId: agent.sId,
       });
 
@@ -590,34 +588,24 @@ describe("MCPServerViewResource", () => {
         space: globalSpace,
       });
 
-      const migratedAgentConfiguration =
-        await AgentMCPServerConfigurationModel.findOne({
-          where: {
-            workspaceId: workspace.id,
-            id: agentMCPServerConfiguration.id,
-          },
-        });
-      expect(migratedAgentConfiguration).not.toBeNull();
-      expect(migratedAgentConfiguration?.mcpServerViewId).toBe(globalView.id);
+      const [migratedAgentConfiguration] =
+        await AgentMCPServerConfigurationResource.fetchByModelIds(userAuth, [
+          agentMCPServerConfiguration.id,
+        ]);
+      expect(migratedAgentConfiguration).toBeDefined();
+      expect(migratedAgentConfiguration.mcpServerViewId).toBe(globalView.id);
 
       const conversationDependencies =
-        await ConversationMCPServerViewModel.findAll({
-          where: {
-            workspaceId: workspace.id,
-            conversationId: conversation.id,
-          },
+        await ConversationResource.fetchMCPServerViews(userAuth, conversation, {
+          agentConfigurationId: agent.sId,
         });
       expect(conversationDependencies).toHaveLength(1);
       expect(conversationDependencies[0].mcpServerViewId).toBe(globalView.id);
 
-      const skillDependencies = await SkillMCPServerConfigurationModel.findAll({
-        where: {
-          workspaceId: workspace.id,
-          skillConfigurationId: skill.id,
-        },
-      });
-      expect(skillDependencies).toHaveLength(1);
-      expect(skillDependencies[0].mcpServerViewId).toBe(globalView.id);
+      const reloadedSkill = await SkillResource.fetchById(userAuth, skill.sId);
+      expect(reloadedSkill).not.toBeNull();
+      expect(reloadedSkill?.mcpServerViews).toHaveLength(1);
+      expect(reloadedSkill?.mcpServerViews[0].id).toBe(globalView.id);
 
       const deletedRegularView =
         await MCPServerViewResource.getByMCPServerAndSpace(
@@ -678,26 +666,18 @@ describe("MCPServerViewResource", () => {
         agentConfigurationId: agent.sId,
         messagesCreatedAt: [new Date()],
       });
-      await ConversationMCPServerViewModel.bulkCreate([
-        {
-          workspaceId: workspace.id,
-          conversationId: conversation.id,
-          mcpServerViewId: firstRegularView.id,
-          userId: user.id,
-          enabled: true,
-          source: "manual",
-          agentConfigurationId: agent.sId,
-        },
-        {
-          workspaceId: workspace.id,
-          conversationId: conversation.id,
-          mcpServerViewId: secondRegularView.id,
-          userId: user.id,
-          enabled: true,
-          source: "manual",
-          agentConfigurationId: agent.sId,
-        },
-      ]);
+      await ConversationMCPServerViewFactory.create(userAuth, {
+        conversation,
+        mcpServerViewId: firstRegularView.id,
+        source: "agent_enabled",
+        agentConfigurationId: agent.sId,
+      });
+      await ConversationMCPServerViewFactory.create(userAuth, {
+        conversation,
+        mcpServerViewId: secondRegularView.id,
+        source: "agent_enabled",
+        agentConfigurationId: agent.sId,
+      });
 
       const skill = await SkillFactory.create(userAuth, {
         mcpServerViews: [firstRegularView, secondRegularView],
@@ -709,23 +689,16 @@ describe("MCPServerViewResource", () => {
       });
 
       const conversationDependencies =
-        await ConversationMCPServerViewModel.findAll({
-          where: {
-            workspaceId: workspace.id,
-            conversationId: conversation.id,
-          },
+        await ConversationResource.fetchMCPServerViews(userAuth, conversation, {
+          agentConfigurationId: agent.sId,
         });
       expect(conversationDependencies).toHaveLength(1);
       expect(conversationDependencies[0].mcpServerViewId).toBe(globalView.id);
 
-      const skillDependencies = await SkillMCPServerConfigurationModel.findAll({
-        where: {
-          workspaceId: workspace.id,
-          skillConfigurationId: skill.id,
-        },
-      });
-      expect(skillDependencies).toHaveLength(1);
-      expect(skillDependencies[0].mcpServerViewId).toBe(globalView.id);
+      const reloadedSkill = await SkillResource.fetchById(userAuth, skill.sId);
+      expect(reloadedSkill).not.toBeNull();
+      expect(reloadedSkill?.mcpServerViews).toHaveLength(1);
+      expect(reloadedSkill?.mcpServerViews[0].id).toBe(globalView.id);
 
       const deletedFirstRegularView =
         await MCPServerViewResource.getByMCPServerAndSpace(

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -1,15 +1,22 @@
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
+import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -515,6 +522,226 @@ describe("MCPServerViewResource", () => {
 
       const json = view!.toJSON();
       expect(json.toolsMetadata).toEqual([]);
+    });
+  });
+
+  describe("create", () => {
+    it("should migrate agent, conversation, and skill dependencies when creating a global view", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          adminAuth,
+          remoteServer.sId
+        );
+      if (!systemView) {
+        throw new Error("Missing system MCP server view");
+      }
+
+      const regularView = await MCPServerViewFactory.create(
+        workspace,
+        remoteServer.sId,
+        regularSpace
+      );
+      const agent = await AgentConfigurationFactory.createTestAgent(userAuth);
+
+      const agentMCPServerConfiguration =
+        await AgentMCPServerConfigurationFactory.create(
+          userAuth,
+          regularSpace,
+          {
+            agent,
+            mcpServerView: regularView,
+          }
+        );
+      const conversation = await ConversationFactory.create(userAuth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date()],
+      });
+      await ConversationMCPServerViewModel.create({
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        mcpServerViewId: regularView.id,
+        userId: user.id,
+        enabled: true,
+        source: "manual",
+        agentConfigurationId: agent.sId,
+      });
+
+      const skill = await SkillFactory.create(userAuth, {
+        mcpServerViews: [regularView],
+      });
+
+      const globalView = await MCPServerViewResource.create(adminAuth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      const migratedAgentConfiguration =
+        await AgentMCPServerConfigurationModel.findOne({
+          where: {
+            workspaceId: workspace.id,
+            id: agentMCPServerConfiguration.id,
+          },
+        });
+      expect(migratedAgentConfiguration).not.toBeNull();
+      expect(migratedAgentConfiguration?.mcpServerViewId).toBe(globalView.id);
+
+      const conversationDependencies =
+        await ConversationMCPServerViewModel.findAll({
+          where: {
+            workspaceId: workspace.id,
+            conversationId: conversation.id,
+          },
+        });
+      expect(conversationDependencies).toHaveLength(1);
+      expect(conversationDependencies[0].mcpServerViewId).toBe(globalView.id);
+
+      const skillDependencies = await SkillMCPServerConfigurationModel.findAll({
+        where: {
+          workspaceId: workspace.id,
+          skillConfigurationId: skill.id,
+        },
+      });
+      expect(skillDependencies).toHaveLength(1);
+      expect(skillDependencies[0].mcpServerViewId).toBe(globalView.id);
+
+      const deletedRegularView =
+        await MCPServerViewResource.getByMCPServerAndSpace(
+          adminAuth,
+          remoteServer.sId,
+          regularSpace
+        );
+      expect(deletedRegularView).toBeNull();
+    });
+
+    it("should deduplicate conversation and skill dependencies when collapsing multiple regular views into a global view", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const { globalSpace } = await SpaceFactory.defaults(adminAuth);
+      const firstRegularSpace = await SpaceFactory.regular(workspace);
+      const secondRegularSpace = await SpaceFactory.regular(workspace);
+
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          adminAuth,
+          remoteServer.sId
+        );
+      if (!systemView) {
+        throw new Error("Missing system MCP server view");
+      }
+
+      const firstRegularView = await MCPServerViewFactory.create(
+        workspace,
+        remoteServer.sId,
+        firstRegularSpace
+      );
+      const secondRegularView = await MCPServerViewFactory.create(
+        workspace,
+        remoteServer.sId,
+        secondRegularSpace
+      );
+      const agent = await AgentConfigurationFactory.createTestAgent(userAuth);
+
+      await AgentMCPServerConfigurationFactory.create(
+        userAuth,
+        firstRegularSpace,
+        {
+          agent,
+          mcpServerView: firstRegularView,
+        }
+      );
+      const conversation = await ConversationFactory.create(userAuth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date()],
+      });
+      await ConversationMCPServerViewModel.bulkCreate([
+        {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+          mcpServerViewId: firstRegularView.id,
+          userId: user.id,
+          enabled: true,
+          source: "manual",
+          agentConfigurationId: agent.sId,
+        },
+        {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+          mcpServerViewId: secondRegularView.id,
+          userId: user.id,
+          enabled: true,
+          source: "manual",
+          agentConfigurationId: agent.sId,
+        },
+      ]);
+
+      const skill = await SkillFactory.create(userAuth, {
+        mcpServerViews: [firstRegularView, secondRegularView],
+      });
+
+      const globalView = await MCPServerViewResource.create(adminAuth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      const conversationDependencies =
+        await ConversationMCPServerViewModel.findAll({
+          where: {
+            workspaceId: workspace.id,
+            conversationId: conversation.id,
+          },
+        });
+      expect(conversationDependencies).toHaveLength(1);
+      expect(conversationDependencies[0].mcpServerViewId).toBe(globalView.id);
+
+      const skillDependencies = await SkillMCPServerConfigurationModel.findAll({
+        where: {
+          workspaceId: workspace.id,
+          skillConfigurationId: skill.id,
+        },
+      });
+      expect(skillDependencies).toHaveLength(1);
+      expect(skillDependencies[0].mcpServerViewId).toBe(globalView.id);
+
+      const deletedFirstRegularView =
+        await MCPServerViewResource.getByMCPServerAndSpace(
+          adminAuth,
+          remoteServer.sId,
+          firstRegularSpace
+        );
+      expect(deletedFirstRegularView).toBeNull();
+
+      const deletedSecondRegularView =
+        await MCPServerViewResource.getByMCPServerAndSpace(
+          adminAuth,
+          remoteServer.sId,
+          secondRegularSpace
+        );
+      expect(deletedSecondRegularView).toBeNull();
     });
   });
 });

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -18,6 +18,7 @@ import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillVersionFactory } from "@app/tests/utils/SkillVersionFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -582,6 +583,9 @@ describe("MCPServerViewResource", () => {
       const skill = await SkillFactory.create(userAuth, {
         mcpServerViews: [regularView],
       });
+      await SkillVersionFactory.create(skill, {
+        mcpServerViews: [regularView],
+      });
 
       const globalView = await MCPServerViewResource.create(adminAuth, {
         systemView,
@@ -606,6 +610,10 @@ describe("MCPServerViewResource", () => {
       expect(reloadedSkill).not.toBeNull();
       expect(reloadedSkill?.mcpServerViews).toHaveLength(1);
       expect(reloadedSkill?.mcpServerViews[0].id).toBe(globalView.id);
+      const skillVersions = await reloadedSkill?.listVersions(userAuth);
+      expect(skillVersions).toHaveLength(1);
+      expect(skillVersions?.[0].mcpServerViews).toHaveLength(1);
+      expect(skillVersions?.[0].mcpServerViews[0].id).toBe(globalView.id);
 
       const deletedRegularView =
         await MCPServerViewResource.getByMCPServerAndSpace(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -16,7 +16,10 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/mcp_server_view_helper";
+import {
+  destroyMCPServerViewDependencies,
+  reassignMCPServerViewDependencies,
+} from "@app/lib/models/agent/actions/mcp_server_view_helper";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
@@ -30,6 +33,7 @@ import type {
   ResourceFindOptions,
 } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { tracer } from "@app/logger/tracer";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -194,33 +198,47 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
     const mcpServerId = systemView.mcpServerId;
     const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
+    const regularMCPServerViews =
+      space.kind === "global"
+        ? (await this.listByMCPServer(auth, mcpServerId)).filter(
+            (mcpServerView) => mcpServerView.space.kind === "regular"
+          )
+        : [];
 
-    if (space.kind === "global") {
-      const mcpServerViews = await this.listByMCPServer(auth, mcpServerId);
-      for (const mcpServerView of mcpServerViews) {
-        if (mcpServerView.space.kind === "regular") {
-          await mcpServerView.delete(auth, { hardDelete: true });
+    return withTransaction(async (transaction) => {
+      const view = await this.makeNew(
+        auth,
+        {
+          serverType,
+          internalMCPServerId: serverType === "internal" ? mcpServerId : null,
+          remoteMCPServerId: serverType === "remote" ? id : null,
+          // Always copy the oAuthUseCase, name and description from the system view to the custom view.
+          // This way, it's always available on the MCP server view without having to fetch the system view.
+          oAuthUseCase: systemView.oAuthUseCase,
+          name: systemView.name,
+          description: systemView.description,
+        },
+        space,
+        auth.user() ?? undefined,
+        transaction
+      );
+
+      if (regularMCPServerViews.length > 0) {
+        await reassignMCPServerViewDependencies(auth, {
+          fromMCPServerViewIds: regularMCPServerViews.map(
+            (mcpServerView) => mcpServerView.id
+          ),
+          toMCPServerViewId: view.id,
+          transaction,
+        });
+
+        for (const regularMCPServerView of regularMCPServerViews) {
+          await regularMCPServerView.hardDelete(auth, transaction);
         }
       }
-    }
 
-    const view = await this.makeNew(
-      auth,
-      {
-        serverType,
-        internalMCPServerId: serverType === "internal" ? mcpServerId : null,
-        remoteMCPServerId: serverType === "remote" ? id : null,
-        // Always copy the oAuthUseCase, name and description from the system view to the custom view.
-        // This way, it's always available on the MCP server view without having to fetch the system view.
-        oAuthUseCase: systemView.oAuthUseCase,
-        name: systemView.name,
-        description: systemView.description,
-      },
-      space,
-      auth.user() ?? undefined
-    );
-
-    return view;
+      return view;
+    });
   }
 
   // Fetching.

--- a/front/tests/utils/ConversationMCPServerViewFactory.ts
+++ b/front/tests/utils/ConversationMCPServerViewFactory.ts
@@ -1,0 +1,36 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import assert from "assert";
+
+export class ConversationMCPServerViewFactory {
+  static async create(
+    auth: Authenticator,
+    {
+      conversation,
+      mcpServerViewId,
+      enabled = true,
+      source,
+      agentConfigurationId = null,
+    }: {
+      conversation: ConversationWithoutContentType;
+      mcpServerViewId: number;
+      enabled?: boolean;
+      source: "agent_enabled" | "conversation";
+      agentConfigurationId?: string | null;
+    }
+  ) {
+    const user = auth.user();
+    assert(user, "User is required");
+
+    return ConversationMCPServerViewModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversation.id,
+      mcpServerViewId,
+      userId: user.id,
+      enabled,
+      source,
+      agentConfigurationId,
+    });
+  }
+}

--- a/front/tests/utils/SkillVersionFactory.ts
+++ b/front/tests/utils/SkillVersionFactory.ts
@@ -1,0 +1,40 @@
+import { SkillVersionModel } from "@app/lib/models/skill";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+
+export class SkillVersionFactory {
+  static async create(
+    skill: SkillResource,
+    {
+      mcpServerViews,
+      version = 1,
+    }: {
+      mcpServerViews: MCPServerViewResource[];
+      version?: number;
+    }
+  ) {
+    const skillVersion = SkillVersionModel.build();
+
+    skillVersion.workspaceId = skill.workspaceId;
+    skillVersion.skillConfigurationId = skill.id;
+    skillVersion.version = version;
+    skillVersion.status = skill.status;
+    skillVersion.name = skill.name;
+    skillVersion.agentFacingDescription = skill.agentFacingDescription;
+    skillVersion.userFacingDescription = skill.userFacingDescription;
+    skillVersion.instructions = skill.instructions;
+    skillVersion.requestedSpaceIds = skill.requestedSpaceIds;
+    skillVersion.editedBy = skill.editedBy;
+    skillVersion.mcpServerViewIds = mcpServerViews.map(
+      (mcpServerView) => mcpServerView.id
+    );
+    skillVersion.fileAttachmentIds = [];
+    skillVersion.source = skill.source;
+    skillVersion.sourceMetadata = skill.sourceMetadata;
+    skillVersion.createdAt = skill.createdAt;
+    skillVersion.updatedAt = skill.updatedAt;
+    skillVersion.isDefault = skill.isDefault;
+
+    return skillVersion.save();
+  }
+}


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7049

When a regular MCP view is made global, we now create the global view first, reassign agent/conversation/skill dependencies to it, and only then hard-delete the old regular views.

This keeps existing tool attachments intact during the `/spaces/[spaceId]/mcp_views` POST flow instead of silently detaching them.

## Risks
Blast radius: global MCP view creation and the dependent agent/skill/conversation references for the same MCP server
Risk: standard

## Deploy Plan
- deploy front
- no migrations or backfills required because the change only reorders and remaps existing writes

## Tests
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run --config vite.config.mjs ./lib/resources/mcp_server_view_resource.test.ts`
