### PR TITLE
fix: correct serverId for extension tool approval arguments

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -232,6 +232,8 @@ function makeClientSideMCPToolConfigurations(
   config: ClientSideMCPServerConfigurationType,
   tools: ClientSideMCPToolTypeWithStakeLevel[]
 ): ClientSideMCPToolConfigurationType[] {
+  const toolServerId = getBaseServerId(config.clientSideMcpServerId);
+
   return tools.map((tool) => ({
     sId: generateRandomModelSId(),
     type: "mcp_configuration",
@@ -249,10 +251,10 @@ function makeClientSideMCPToolConfigurations(
     permission: tool.stakeLevel,
     // Use the base serverId (without suffix) to ensure tools are shared across all instances
     // of the same server name, allowing for consistent tool behavior.
-    toolServerId: getBaseServerId(config.clientSideMcpServerId),
+    toolServerId,
     icon: config.icon,
     argumentsRequiringApproval: getClientSideToolArgumentsRequiringApproval(
-      config.clientSideMcpServerId,
+      toolServerId,
       tool.name
     ),
   }));


### PR DESCRIPTION
## Description

This PR fixes the `serverId` parameter passed to the `getClientSideToolArgumentsRequiringApproval` function to use the base server ID to retrieve arguments requiring approval correctly.

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment.
