### PR TITLE
[Poke] Raise PAYG and free credits programmatic limits

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -21,8 +21,8 @@ import assert from "assert";
 import type Stripe from "stripe";
 import { z } from "zod";
 
-export const MAX_FREE_CREDITS_DOLLARS = 1_000;
-export const MAX_PAYG_CAP_DOLLARS = 10_000;
+export const MAX_FREE_CREDITS_DOLLARS = 2_000;
+export const MAX_PAYG_CAP_DOLLARS = 20_000;
 export const MAX_DAILY_CAP_DOLLARS = 10_000;
 const MIN_DAILY_CAP_DOLLARS = 100;
 


### PR DESCRIPTION
## Description
Context: https://dust4ai.slack.com/archives/C09QQ87AAER/p1773684700688989

Raise the maximum allowed values for programmatic usage limits in the poke plugin:
- PAYG spending cap: $10,000 → $20,000
- Free credits: $1,000 → $2,000

## Risks

Blast radius: Poke plugin for managing programmatic usage configuration on enterprise workspaces
Risk: none

## Deploy Plan
- pmrr
- deploy front