### PR TITLE
Store the conversation id for synthetic suggestions

### DIFF
--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -112,6 +112,26 @@ export function makeColumnsForSuggestions(
       ),
     },
     {
+      accessorKey: "conversationId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Conversation" />
+      ),
+      cell: ({ row }) => {
+        const conversationId = row.original.conversationId;
+        if (!conversationId) {
+          return "-";
+        }
+        return (
+          <a
+            href={`/${owner.sId}/conversation/${conversationId}`}
+            className="text-action-500 hover:underline"
+          >
+            {conversationId}
+          </a>
+        );
+      },
+    },
+    {
       accessorKey: "analysis",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Analysis" />

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -35,6 +35,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -58,7 +59,6 @@ import { isContentFragmentType } from "@app/types/content_fragment";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { CoreAPI } from "@app/types/core/core_api";
 import { isJobType } from "@app/types/job_type";
-import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -197,13 +197,13 @@ export async function createInstructionSuggestions({
   agentConfigurationId,
   suggestions,
   source,
-  conversationModelId,
+  conversation,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: InstructionSuggestionInput[];
   source: AgentSuggestionSource;
-  conversationModelId?: ModelId;
+  conversation?: ConversationResource;
 }): Promise<
   Result<{ sId: string; kind: string; targetBlockId: string }[], string>
 > {
@@ -262,7 +262,7 @@ export async function createInstructionSuggestions({
         analysis: analysis ?? null,
         state: "pending",
         source,
-        conversationId: conversationModelId ?? null,
+        conversationId: conversation?.id ?? null,
       }
     );
 
@@ -295,13 +295,13 @@ export async function createToolsSuggestions({
   agentConfigurationId,
   suggestions,
   source,
-  conversationModelId,
+  conversation,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: ToolsSuggestionInput[];
   source: AgentSuggestionSource;
-  conversationModelId?: ModelId;
+  conversation?: ConversationResource;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same tool.
   const suggestionToolIds = suggestions.map((s) => s.toolId);
@@ -391,7 +391,7 @@ export async function createToolsSuggestions({
         analysis: analysis ?? null,
         state: "pending",
         source,
-        conversationId: conversationModelId ?? null,
+        conversationId: conversation?.id ?? null,
       }
     );
 
@@ -414,13 +414,13 @@ export async function createSkillsSuggestions({
   agentConfigurationId,
   suggestions,
   source,
-  conversationModelId,
+  conversation,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: SkillsSuggestionInput[];
   source: AgentSuggestionSource;
-  conversationModelId?: ModelId;
+  conversation?: ConversationResource;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same skill.
   const suggestionSkillIds = suggestions.map((s) => s.skillId);
@@ -497,7 +497,7 @@ export async function createSkillsSuggestions({
         analysis: analysis ?? null,
         state: "pending",
         source,
-        conversationId: conversationModelId ?? null,
+        conversationId: conversation?.id ?? null,
       }
     );
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -58,6 +58,7 @@ import { isContentFragmentType } from "@app/types/content_fragment";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { CoreAPI } from "@app/types/core/core_api";
 import { isJobType } from "@app/types/job_type";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -196,11 +197,13 @@ export async function createInstructionSuggestions({
   agentConfigurationId,
   suggestions,
   source,
+  conversationModelId,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: InstructionSuggestionInput[];
   source: AgentSuggestionSource;
+  conversationModelId?: ModelId;
 }): Promise<
   Result<{ sId: string; kind: string; targetBlockId: string }[], string>
 > {
@@ -259,6 +262,7 @@ export async function createInstructionSuggestions({
         analysis: analysis ?? null,
         state: "pending",
         source,
+        conversationId: conversationModelId ?? null,
       }
     );
 
@@ -291,11 +295,13 @@ export async function createToolsSuggestions({
   agentConfigurationId,
   suggestions,
   source,
+  conversationModelId,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: ToolsSuggestionInput[];
   source: AgentSuggestionSource;
+  conversationModelId?: ModelId;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same tool.
   const suggestionToolIds = suggestions.map((s) => s.toolId);
@@ -385,6 +391,7 @@ export async function createToolsSuggestions({
         analysis: analysis ?? null,
         state: "pending",
         source,
+        conversationId: conversationModelId ?? null,
       }
     );
 
@@ -407,11 +414,13 @@ export async function createSkillsSuggestions({
   agentConfigurationId,
   suggestions,
   source,
+  conversationModelId,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: SkillsSuggestionInput[];
   source: AgentSuggestionSource;
+  conversationModelId?: ModelId;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same skill.
   const suggestionSkillIds = suggestions.map((s) => s.skillId);
@@ -488,6 +497,7 @@ export async function createSkillsSuggestions({
         analysis: analysis ?? null,
         state: "pending",
         source,
+        conversationId: conversationModelId ?? null,
       }
     );
 

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -295,16 +295,12 @@ export async function destroyConversation(
     },
   });
 
-  // Nullify conversationId on agent suggestions (nullable FK, RESTRICT).
-  await AgentSuggestionModel.update(
-    { conversationId: null },
-    {
-      where: {
-        workspaceId: owner.id,
-        conversationId: conversation.id,
-      },
-    }
-  );
+  await AgentSuggestionModel.destroy({
+    where: {
+      workspaceId: owner.id,
+      conversationId: conversation.id,
+    },
+  });
 
   await ConversationSkillModel.destroy({
     where: {

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,5 +1,6 @@
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
@@ -293,6 +294,17 @@ export async function destroyConversation(
       conversationId: conversation.id,
     },
   });
+
+  // Nullify conversationId on agent suggestions (nullable FK, RESTRICT).
+  await AgentSuggestionModel.update(
+    { conversationId: null },
+    {
+      where: {
+        workspaceId: owner.id,
+        conversationId: conversation.id,
+      },
+    }
+  );
 
   await ConversationSkillModel.destroy({
     where: {

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -98,7 +98,7 @@ AgentSuggestionModel.init(
         concurrently: true,
       },
       {
-        fields: ["conversationId"],
+        fields: ["workspaceId", "conversationId"],
         concurrently: true,
       },
     ],

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -26,6 +26,7 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
 
   declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
+  declare conversation: NonAttribute<ConversationModel | null>;
 }
 
 AgentSuggestionModel.init(

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -1,4 +1,5 @@
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -22,6 +23,7 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
 
   declare state: AgentSuggestionState;
   declare source: AgentSuggestionSource;
+  declare conversationId: ForeignKey<ConversationModel["id"]> | null;
 
   declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
 }
@@ -71,6 +73,12 @@ AgentSuggestionModel.init(
       allowNull: false,
       comment: "Origin of the suggestion such as reinforcement or sidekick",
     },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      comment:
+        "FK to the conversation that triggered this suggestion (only set for synthetic suggestions)",
+    },
   },
   {
     modelName: "agent_suggestion",
@@ -89,6 +97,10 @@ AgentSuggestionModel.init(
         fields: ["agentConfigurationId"],
         concurrently: true,
       },
+      {
+        fields: ["conversationId"],
+        concurrently: true,
+      },
     ],
   }
 );
@@ -102,4 +114,11 @@ AgentSuggestionModel.belongsTo(AgentConfigurationModel, {
 AgentConfigurationModel.hasMany(AgentSuggestionModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   as: "suggestions",
+});
+
+// Association with ConversationModel (nullable — only set for synthetic suggestions).
+AgentSuggestionModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: true },
+  onDelete: "RESTRICT",
+  as: "conversation",
 });

--- a/front/lib/reinforced_agent/aggregate_suggestions.test.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.test.ts
@@ -18,6 +18,7 @@ function makeInstructionSuggestion(
     analysis: "Should be more polite",
     state: "pending",
     source: "synthetic",
+    conversationId: null,
     kind: "instructions",
     suggestion: {
       content: "<p>Always be polite.</p>",
@@ -40,6 +41,7 @@ function makeToolSuggestion(
     analysis: "Needs search capability",
     state: "pending",
     source: "synthetic",
+    conversationId: null,
     kind: "tools",
     suggestion: {
       action: "add",
@@ -61,6 +63,7 @@ function makeSkillSuggestion(
     analysis: "Needs coding skill",
     state: "pending",
     source: "synthetic",
+    conversationId: null,
     kind: "skills",
     suggestion: {
       action: "add",

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -7,6 +7,7 @@ import {
   buildReinforcedLLMParams,
   runReinforcedAnalysis,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
@@ -137,16 +138,21 @@ export async function analyzeConversationForReinforcement(
     return;
   }
 
-  const [conversationRes, toolsAndSkillsContext] = await Promise.all([
-    getShrinkWrappedConversation(auth, {
-      conversationId,
-      includeFeedback: true,
-    }),
-    buildToolsAndSkillsContext(auth),
-  ]);
-  if (conversationRes.isErr()) {
+  const [conversationRes, conversationResource, toolsAndSkillsContext] =
+    await Promise.all([
+      getShrinkWrappedConversation(auth, {
+        conversationId,
+        includeFeedback: true,
+      }),
+      ConversationResource.fetchById(auth, conversationId),
+      buildToolsAndSkillsContext(auth),
+    ]);
+  if (conversationRes.isErr() || !conversationResource) {
     logger.warn(
-      { conversationId, error: conversationRes.error },
+      {
+        conversationId,
+        error: conversationRes.isErr() && conversationRes.error,
+      },
       "ReinforcedAgent: conversation not found"
     );
     return;
@@ -165,6 +171,7 @@ export async function analyzeConversationForReinforcement(
     source: "synthetic",
     operationType: "reinforced_agent_analyze_conversation",
     contextId: conversationId,
+    conversationModelId: conversationResource.id,
   });
 
   if (createdCount > 0) {

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -171,7 +171,7 @@ export async function analyzeConversationForReinforcement(
     source: "synthetic",
     operationType: "reinforced_agent_analyze_conversation",
     contextId: conversationId,
-    conversationModelId: conversationResource.id,
+    conversation: conversationResource,
   });
 
   if (createdCount > 0) {

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -12,9 +12,9 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { AgentSuggestionSource } from "@app/types/suggestions/agent_suggestion";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -120,7 +120,7 @@ export async function processReinforcedEvents({
   source,
   operationType,
   contextId,
-  conversationModelId,
+  conversation,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
@@ -128,7 +128,7 @@ export async function processReinforcedEvents({
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
-  conversationModelId?: ModelId;
+  conversation?: ConversationResource;
 }): Promise<number> {
   const errorEvents = events.filter((e) => e.type === "error");
   if (errorEvents.length > 0) {
@@ -168,7 +168,7 @@ export async function processReinforcedEvents({
       source,
       operationType,
       contextId,
-      conversationModelId,
+      conversation,
     });
   }
 
@@ -186,7 +186,7 @@ async function createSuggestionsFromToolCall({
   source,
   operationType,
   contextId,
-  conversationModelId,
+  conversation,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
@@ -195,7 +195,7 @@ async function createSuggestionsFromToolCall({
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
-  conversationModelId?: ModelId;
+  conversation?: ConversationResource;
 }): Promise<number> {
   switch (toolName) {
     case "suggest_prompt_edits": {
@@ -218,7 +218,7 @@ async function createSuggestionsFromToolCall({
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
-        conversationModelId,
+        conversation,
       });
       if (result.isErr()) {
         logger.warn(
@@ -249,7 +249,7 @@ async function createSuggestionsFromToolCall({
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
-        conversationModelId,
+        conversation,
       });
       if (result.isErr()) {
         logger.warn(
@@ -280,7 +280,7 @@ async function createSuggestionsFromToolCall({
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
-        conversationModelId,
+        conversation,
       });
       if (result.isErr()) {
         logger.warn(
@@ -313,7 +313,7 @@ export async function runReinforcedAnalysis({
   source,
   operationType,
   contextId,
-  conversationModelId,
+  conversation,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
@@ -321,7 +321,7 @@ export async function runReinforcedAnalysis({
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
-  conversationModelId?: ModelId;
+  conversation?: ConversationResource;
 }): Promise<number> {
   const llm = await getReinforcedLLM(auth, operationType);
   if (!llm) {
@@ -344,6 +344,6 @@ export async function runReinforcedAnalysis({
     source,
     operationType,
     contextId,
-    conversationModelId,
+    conversation,
   });
 }

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -14,6 +14,7 @@ import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { AgentSuggestionSource } from "@app/types/suggestions/agent_suggestion";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -119,6 +120,7 @@ export async function processReinforcedEvents({
   source,
   operationType,
   contextId,
+  conversationModelId,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
@@ -126,6 +128,7 @@ export async function processReinforcedEvents({
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
+  conversationModelId?: ModelId;
 }): Promise<number> {
   const errorEvents = events.filter((e) => e.type === "error");
   if (errorEvents.length > 0) {
@@ -165,6 +168,7 @@ export async function processReinforcedEvents({
       source,
       operationType,
       contextId,
+      conversationModelId,
     });
   }
 
@@ -182,6 +186,7 @@ async function createSuggestionsFromToolCall({
   source,
   operationType,
   contextId,
+  conversationModelId,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
@@ -190,6 +195,7 @@ async function createSuggestionsFromToolCall({
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
+  conversationModelId?: ModelId;
 }): Promise<number> {
   switch (toolName) {
     case "suggest_prompt_edits": {
@@ -212,6 +218,7 @@ async function createSuggestionsFromToolCall({
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
+        conversationModelId,
       });
       if (result.isErr()) {
         logger.warn(
@@ -242,6 +249,7 @@ async function createSuggestionsFromToolCall({
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
+        conversationModelId,
       });
       if (result.isErr()) {
         logger.warn(
@@ -272,6 +280,7 @@ async function createSuggestionsFromToolCall({
         agentConfigurationId: agentConfig.sId,
         suggestions: parsed.data.suggestions,
         source,
+        conversationModelId,
       });
       if (result.isErr()) {
         logger.warn(
@@ -304,6 +313,7 @@ export async function runReinforcedAnalysis({
   source,
   operationType,
   contextId,
+  conversationModelId,
 }: {
   auth: Authenticator;
   agentConfig: LightAgentConfigurationType;
@@ -311,6 +321,7 @@ export async function runReinforcedAnalysis({
   source: AgentSuggestionSource;
   operationType: ReinforcedOperationType;
   contextId: string;
+  conversationModelId?: ModelId;
 }): Promise<number> {
   const llm = await getReinforcedLLM(auth, operationType);
   if (!llm) {
@@ -333,5 +344,6 @@ export async function runReinforcedAnalysis({
     source,
     operationType,
     contextId,
+    conversationModelId,
   });
 }

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -2,6 +2,7 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -46,15 +47,18 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
 
   readonly editorsGroupId: ModelId | null;
   readonly agentConfigurationSId: string;
+  readonly conversationSId: string | null;
   constructor(
     model: ModelStatic<AgentSuggestionModel>,
     blob: Attributes<AgentSuggestionModel>,
     editorsGroupId: ModelId | null,
-    agentConfigurationSId: string
+    agentConfigurationSId: string,
+    conversationId: string | null
   ) {
     super(AgentSuggestionModel, blob);
     this.editorsGroupId = editorsGroupId;
     this.agentConfigurationSId = agentConfigurationSId;
+    this.conversationSId = conversationId;
   }
 
   /**
@@ -147,7 +151,8 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       AgentSuggestionModel,
       suggestion.get(),
       editorsGroupId ?? null,
-      agentConfiguration.sId
+      agentConfiguration.sId,
+      null
     );
   }
 
@@ -168,6 +173,12 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
           model: AgentConfigurationModel,
           as: "agentConfiguration",
           required: true,
+        },
+        {
+          model: ConversationModel,
+          as: "conversation",
+          required: false,
+          attributes: ["sId"],
         },
       ],
       ...otherOptions,
@@ -201,7 +212,8 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
           AgentSuggestionModel,
           suggestion.get(),
           editorsGroupId,
-          agentConfig.sId
+          agentConfig.sId,
+          suggestion.conversation?.sId ?? null
         );
       })
     );
@@ -399,6 +411,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       analysis: this.analysis,
       state: this.state,
       source: this.source,
+      conversationId: this.conversationSId,
       ...suggestionData,
     };
   }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5120,6 +5120,7 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
 const KNOWN_CONVERSATION_RELATED_MODELS = [
   "agent_message_skills",
   "agent_message_feedback",
+  "agent_suggestion",
   "conversation_branch",
   "conversation_mcp_server_view",
   "conversation_participant",

--- a/front/migrations/db/migration_542.sql
+++ b/front/migrations/db/migration_542.sql
@@ -1,3 +1,3 @@
--- Migration created on Mar 17, 2026
+-- Migration created on Mar 18, 2026
 ALTER TABLE "public"."agent_suggestions" ADD COLUMN "conversationId" BIGINT REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE; COMMENT ON COLUMN "agent_suggestions"."conversationId" IS 'FK to the conversation that triggered this suggestion (only set for synthetic suggestions)';
-CREATE INDEX CONCURRENTLY "agent_suggestions_conversation_id" ON "agent_suggestions" ("workspaceId", "conversationId");
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_id_conversation_id" ON "agent_suggestions" ("workspaceId", "conversationId");

--- a/front/migrations/db/migration_542.sql
+++ b/front/migrations/db/migration_542.sql
@@ -1,3 +1,3 @@
 -- Migration created on Mar 17, 2026
 ALTER TABLE "public"."agent_suggestions" ADD COLUMN "conversationId" BIGINT REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE; COMMENT ON COLUMN "agent_suggestions"."conversationId" IS 'FK to the conversation that triggered this suggestion (only set for synthetic suggestions)';
-CREATE INDEX CONCURRENTLY "agent_suggestions_conversation_id" ON "agent_suggestions" ("conversationId");
+CREATE INDEX CONCURRENTLY "agent_suggestions_conversation_id" ON "agent_suggestions" ("workspaceId", "conversationId");

--- a/front/migrations/db/migration_542.sql
+++ b/front/migrations/db/migration_542.sql
@@ -1,0 +1,3 @@
+-- Migration created on Mar 17, 2026
+ALTER TABLE "public"."agent_suggestions" ADD COLUMN "conversationId" BIGINT REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE; COMMENT ON COLUMN "agent_suggestions"."conversationId" IS 'FK to the conversation that triggered this suggestion (only set for synthetic suggestions)';
+CREATE INDEX CONCURRENTLY "agent_suggestions_conversation_id" ON "agent_suggestions" ("conversationId");

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -248,15 +248,13 @@ export async function processConversationAnalysisBatchResultActivity({
 
   const results = await llm.getBatchResult(batchId);
 
-  // Resolve conversation sIds to model IDs for FK storage.
-  const conversationIds = [...results.keys()];
+  // Resolve conversation sIds to resources for FK storage.
+  const conversationSIds = [...results.keys()];
   const conversations = await ConversationResource.fetchByIds(
     auth,
-    conversationIds
+    conversationSIds
   );
-  const conversationModelIdById = new Map(
-    conversations.map((c) => [c.sId, c.id])
-  );
+  const conversationById = new Map(conversations.map((c) => [c.sId, c]));
 
   let totalCreated = 0;
   for (const [conversationId, events] of results) {
@@ -267,7 +265,7 @@ export async function processConversationAnalysisBatchResultActivity({
       source: "synthetic",
       operationType: "reinforced_agent_analyze_conversation",
       contextId: conversationId,
-      conversationModelId: conversationModelIdById.get(conversationId),
+      conversation: conversationById.get(conversationId),
     });
     totalCreated += createdCount;
   }

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -248,6 +248,16 @@ export async function processConversationAnalysisBatchResultActivity({
 
   const results = await llm.getBatchResult(batchId);
 
+  // Resolve conversation sIds to model IDs for FK storage.
+  const conversationIds = [...results.keys()];
+  const conversations = await ConversationResource.fetchByIds(
+    auth,
+    conversationIds
+  );
+  const conversationModelIdById = new Map(
+    conversations.map((c) => [c.sId, c.id])
+  );
+
   let totalCreated = 0;
   for (const [conversationId, events] of results) {
     const createdCount = await processReinforcedEvents({
@@ -257,6 +267,7 @@ export async function processConversationAnalysisBatchResultActivity({
       source: "synthetic",
       operationType: "reinforced_agent_analyze_conversation",
       contextId: conversationId,
+      conversationModelId: conversationModelIdById.get(conversationId),
     });
     totalCreated += createdCount;
   }

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -249,10 +249,10 @@ export async function processConversationAnalysisBatchResultActivity({
   const results = await llm.getBatchResult(batchId);
 
   // Resolve conversation sIds to resources for FK storage.
-  const conversationSIds = [...results.keys()];
+  const conversationIds = [...results.keys()];
   const conversations = await ConversationResource.fetchByIds(
     auth,
-    conversationSIds
+    conversationIds
   );
   const conversationById = new Map(conversations.map((c) => [c.sId, c]));
 

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -162,6 +162,7 @@ const BaseAgentSuggestionSchema = z.object({
   analysis: z.string().nullable(),
   state: z.enum(AGENT_SUGGESTION_STATES),
   source: z.enum(AGENT_SUGGESTION_SOURCES),
+  conversationId: z.string().nullable(),
 });
 
 export const AgentSuggestionSchema = BaseAgentSuggestionSchema.and(


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/7112

- Add a new conversationId FK in the suggestions table. It's only set for synthetic suggestions
- Right now, we're setting it but not yet using it

## Tests

Manual

## Risk

Low

## Deploy Plan

First run migration script tne deploy.