### PR TITLE
[Connectors] fix(github): handle WorkflowExecutionAlreadyStartedError in code sync workflows

### DIFF
--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -435,23 +435,34 @@ export async function githubRepoSyncWorkflow({
     }
   }
 
-  await executeChild(githubCodeSyncStatelessWorkflow, {
-    workflowId: getCodeSyncStatelessWorkflowId(connectorId, repoId),
-    searchAttributes: {
-      connectorId: [connectorId],
-    },
-    args: [
-      {
-        connectorId,
-        dataSourceConfig,
-        forceResync: forceCodeResync,
-        repoId,
-        repoLogin,
-        repoName,
+  try {
+    await executeChild(githubCodeSyncStatelessWorkflow, {
+      workflowId: getCodeSyncStatelessWorkflowId(connectorId, repoId),
+      searchAttributes: {
+        connectorId: [connectorId],
       },
-    ],
-    memo: workflowInfo().memo,
-  });
+      args: [
+        {
+          connectorId,
+          dataSourceConfig,
+          forceResync: forceCodeResync,
+          repoId,
+          repoLogin,
+          repoName,
+        },
+      ],
+      memo: workflowInfo().memo,
+    });
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.name === "WorkflowExecutionAlreadyStartedError"
+    ) {
+      // Workflow already running for this repo, it will be synced by that execution.
+      return;
+    }
+    throw err;
+  }
 }
 
 export async function githubCodeSyncWorkflow(
@@ -478,22 +489,33 @@ export async function githubCodeSyncWorkflow(
       continue;
     }
 
-    await executeChild(githubCodeSyncStatelessWorkflow, {
-      workflowId: getCodeSyncStatelessWorkflowId(connectorId, repoId),
-      searchAttributes: {
-        connectorId: [connectorId],
-      },
-      args: [
-        {
-          connectorId,
-          dataSourceConfig,
-          repoId,
-          repoLogin,
-          repoName,
+    try {
+      await executeChild(githubCodeSyncStatelessWorkflow, {
+        workflowId: getCodeSyncStatelessWorkflowId(connectorId, repoId),
+        searchAttributes: {
+          connectorId: [connectorId],
         },
-      ],
-      memo: workflowInfo().memo,
-    });
+        args: [
+          {
+            connectorId,
+            dataSourceConfig,
+            repoId,
+            repoLogin,
+            repoName,
+          },
+        ],
+        memo: workflowInfo().memo,
+      });
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.name === "WorkflowExecutionAlreadyStartedError"
+      ) {
+        // Workflow already running for this repo, it will be synced by that execution.
+        return;
+      }
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Similar to: https://github.com/dust-tt/dust/pull/22619

`githubCodeSyncStatelessWorkflow` child workflow calls were not catching `WorkflowExecutionAlreadyStartedError`, causing the parent workflow to fail when a code sync was already running for the same repo.

Example failure: https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/workflow-github-274877911849-full-sync/019ce236-1c69-75f8-9de9-d8d6cc63341d/timeline