### PR TITLE
[sdk+connectors] fix: add agent_context_pruned event to SDK types and Slack handler

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -645,8 +645,9 @@ async function streamAgentAnswerToSlack(
         return new Ok(undefined);
       }
 
+      case "agent_context_pruned":
       case "agent_message_done":
-        // No-op, we handle completion in "agent_message_success"
+        // No-op.
         break;
 
       default:

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -10,6 +10,7 @@ import type {
   AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentConfigurationViewType,
+  AgentContextPrunedEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
   AgentMessageDoneEvent,
@@ -159,6 +160,7 @@ const DEFAULT_RECONNECT_DELAY = 5000;
 type AgentEvent =
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
+  | AgentContextPrunedEvent
   | AgentErrorEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1480,6 +1480,16 @@ export type AgentGenerationCancelledEvent = z.infer<
   typeof AgentGenerationCancelledEventSchema
 >;
 
+const AgentContextPrunedEventSchema = z.object({
+  type: z.literal("agent_context_pruned"),
+  created: z.number(),
+  configurationId: z.string(),
+  messageId: z.string(),
+});
+export type AgentContextPrunedEvent = z.infer<
+  typeof AgentContextPrunedEventSchema
+>;
+
 const UserMessageErrorEventSchema = z.object({
   type: z.literal("user_message_error"),
   created: z.number(),
@@ -1537,6 +1547,7 @@ const AgentMessageEventTypeSchema = z.object({
     AgentErrorEventSchema,
     AgentActionSpecificEventSchema,
     AgentActionSuccessEventSchema,
+    AgentContextPrunedEventSchema,
     AgentGenerationCancelledEventSchema,
     GenerationTokensEventSchema,
   ]),


### PR DESCRIPTION
## Summary

- The server emits `agent_context_pruned` events during agent message streaming, but the SDK's `AgentEvent` type union didn't include it
- This caused `assertNever` to throw at runtime in the Slack connector's `streamAgentAnswerToSlack` when the event hit the default switch case
- Add `AgentContextPrunedEvent` to SDK types (`types.ts` + `AgentEvent` union in `index.ts`)
- Handle the event as a no-op in the Slack connector's stream handler

## Context

https://dust4ai.slack.com/archives/C05F84CFP0E/p1773747372156799

