### PR TITLE
[front] feat: add sandbox skill to dust global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -479,7 +479,13 @@ function _getDustLikeGlobalAgent(
     ...dustAgent,
     status: "active",
     actions,
-    skills: ["discover_skills", "frames", "go-deep", "mention_users"],
+    skills: [
+      "discover_skills",
+      "frames",
+      "go-deep",
+      "mention_users",
+      "sandbox",
+    ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }


### PR DESCRIPTION
## Description

- This PR adsd the sandbox skill to dust like global agents.

## Tests

- Tested locally.

## Risk

- Low. will change the behavior for workspaces where the feature flag is enabled.

## Deploy Plan

- Deploy front.
