### PR TITLE
Prevent name conflict on agent restore

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1253,7 +1253,9 @@ export async function archiveAgentConfiguration(
 export async function restoreAgentConfiguration(
   auth: Authenticator,
   agentConfigurationId: string
-): Promise<Result<{ restored: boolean }, Error>> {
+): Promise<
+  Result<{ restored: boolean }, DustError<"name_conflict" | "internal_error">>
+> {
   const owner = auth.getNonNullableWorkspace();
 
   const latestConfig = await AgentConfigurationModel.findOne({
@@ -1265,10 +1267,32 @@ export async function restoreAgentConfiguration(
     limit: 1,
   });
   if (!latestConfig) {
-    return new Err(new Error("Could not find agent configuration"));
+    return new Err(
+      new DustError("internal_error", "Could not find agent configuration")
+    );
   }
   if (latestConfig.status !== "archived") {
-    return new Err(new Error("Agent configuration is not archived"));
+    return new Err(
+      new DustError("internal_error", "Agent configuration is not archived")
+    );
+  }
+
+  // Check for an active agent with the same name to avoid a unique constraint violation on
+  // (workspaceId, name) during the update.
+  const existingActive = await AgentConfigurationModel.findOne({
+    where: {
+      workspaceId: owner.id,
+      name: latestConfig.name,
+      status: "active",
+    },
+  });
+  if (existingActive) {
+    return new Err(
+      new DustError(
+        "name_conflict",
+        `Cannot restore: an active agent named "${latestConfig.name}" already exists.`
+      )
+    );
   }
 
   const updated = await AgentConfigurationModel.update(

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -8,6 +8,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type RestoreAgentConfigurationResponseBody = {
@@ -68,7 +69,30 @@ async function handler(
         agentConfiguration.sId
       );
 
-      if (!restoredResult.isOk() || !restoredResult.value.restored) {
+      if (restoredResult.isErr()) {
+        switch (restoredResult.error.code) {
+          case "name_conflict":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: restoredResult.error.message,
+              },
+            });
+          case "internal_error":
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Could not restore the agent configuration.",
+              },
+            });
+          default:
+            assertNever(restoredResult.error.code);
+        }
+      }
+
+      if (!restoredResult.value.restored) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -7,6 +7,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type RestoreAgentConfigurationResponseBody = {
@@ -44,7 +45,30 @@ async function handler(
         agentConfiguration.sId
       );
 
-      if (!restoredResult.isOk() || !restoredResult.value.restored) {
+      if (restoredResult.isErr()) {
+        switch (restoredResult.error.code) {
+          case "name_conflict":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: restoredResult.error.message,
+              },
+            });
+          case "internal_error":
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Could not restore the agent configuration.",
+              },
+            });
+          default:
+            assertNever(restoredResult.error.code);
+        }
+      }
+
+      if (!restoredResult.value.restored) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {


### PR DESCRIPTION
## Description

Better error than SequelizeError when restoring an agent that clashes on name with a current agent.

<img width="328" height="108" alt="Screenshot 2026-03-17 at 14 07 02" src="https://github.com/user-attachments/assets/e109948b-49da-490a-b74f-8135eab1098c" />

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`