### PR TITLE
Allow USAGE grant on INTEGRATION for Snowflake connector

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -628,6 +628,7 @@ async function _checkRoleGrants(
       [
         "FILE_FORMAT",
         "FUNCTION",
+        "INTEGRATION",
         "PROCEDURE",
         "STAGE",
         "SEQUENCE",


### PR DESCRIPTION
## Description

Allow the `USAGE` privilege on `INTEGRATION` objects in the Snowflake connector's read-only connection check. Snowflake integrations (e.g. for external access) can have USAGE grants assigned to roles — this is a read-only privilege that was previously rejected, causing connection validation to fail.

## Tests

Manually verified the grant validation logic. The change adds `INTEGRATION` to the existing group of object types (FILE_FORMAT, FUNCTION, PROCEDURE, etc.) that accept USAGE and READ privileges.

## Risk

Low — this is a purely additive change that allows a previously-rejected read-only grant. No existing behavior changes.

## Deploy Plan

Standard deploy, no special steps needed.