### PR TITLE
[front] fix: handle errors from discoverAuthorizationServerMetadata

### DIFF
--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -36,7 +36,10 @@ import {
   registerClient,
   selectResourceURL,
 } from "@modelcontextprotocol/sdk/client/auth.js";
-import type { OAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type {
+  AuthorizationServerMetadata,
+  OAuthProtectedResourceMetadata,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import assert from "assert";
 import type {
@@ -429,10 +432,21 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       resourceMetadata ?? undefined
     );
 
-    const metadata = await discoverAuthorizationServerMetadata(authServerUrl, {
-      fetchFn,
-    });
-    if (!metadata) {
+    let metadata: AuthorizationServerMetadata | undefined;
+    try {
+      metadata = await discoverAuthorizationServerMetadata(authServerUrl, {
+        fetchFn,
+      });
+      if (!metadata) {
+        return new Err(
+          new DustError("internal_error", "Failed to discover OAuth metadata")
+        );
+      }
+    } catch (e) {
+      logger.info(
+        { error: e, serverUrl },
+        "Failed to discover authorization server metadata"
+      );
       return new Err(
         new DustError("internal_error", "Failed to discover OAuth metadata")
       );


### PR DESCRIPTION
## Summary

- Wrap `discoverAuthorizationServerMetadata` in a try/catch in `RemoteMCPServerResource.discoverOAuthMetadata` to prevent unhandled exceptions when remote servers return invalid responses (non-JSON or missing OAuth fields)
- Matches the existing error handling pattern used for `discoverOAuthProtectedResourceMetadata` just above

## Context

https://dust4ai.slack.com/archives/C05F84CFP0E/p1773748502077489

