### PR TITLE
Poke: Add a time option for triggering the reinforced agent

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -67,7 +67,7 @@ export function PluginForm({
               key,
               arg.async && asyncArgs?.[key] !== undefined
                 ? (asyncArgs[key] as number)
-                : 0,
+                : (arg.default ?? 0),
             ];
           case "boolean":
             return [

--- a/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
+++ b/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
@@ -16,6 +16,13 @@ export const runReinforcedAgentPlugin = createPlugin({
         description:
           "Process conversations via batch LLM API (slower but cheaper). Uncheck to use streaming (faster but more expensive).",
       },
+      daysOfConversations: {
+        type: "number",
+        variant: "text",
+        label: "Days of conversations to analyze",
+        description: "Number of past days of conversations to analyze.",
+        default: 1,
+      },
     },
   },
   execute: async (auth, resource, args) => {
@@ -29,6 +36,7 @@ export const runReinforcedAgentPlugin = createPlugin({
       workspaceId: workspace.sId,
       agentConfigurationId: resource.sId,
       useBatchMode: args.useBatchMode,
+      daysOfConversations: args.daysOfConversations,
     });
 
     if (result.isErr()) {

--- a/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
+++ b/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
@@ -16,7 +16,7 @@ export const runReinforcedAgentPlugin = createPlugin({
         description:
           "Process conversations via batch LLM API (slower but cheaper). Uncheck to use streaming (faster but more expensive).",
       },
-      daysOfConversations: {
+      conversationLookbackDays: {
         type: "number",
         variant: "text",
         label: "Days of conversations to analyze",
@@ -36,7 +36,7 @@ export const runReinforcedAgentPlugin = createPlugin({
       workspaceId: workspace.sId,
       agentConfigurationId: resource.sId,
       useBatchMode: args.useBatchMode,
-      daysOfConversations: args.daysOfConversations,
+      conversationLookbackDays: args.conversationLookbackDays,
     });
 
     if (result.isErr()) {

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -78,11 +78,11 @@ export async function getAgentConfigurationsActivity({
 export async function getRecentConversationsForAgentActivity({
   workspaceId,
   agentConfigurationId,
-  daysOfConversations = 1,
+  conversationLookbackDays = 1,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
-  daysOfConversations?: number;
+  conversationLookbackDays?: number;
 }): Promise<string[]> {
   updateActiveTrace({
     name: "Reinforced Agent Workflow",
@@ -92,7 +92,9 @@ export async function getRecentConversationsForAgentActivity({
   const auth = await getAuthForWorkspace(workspaceId);
 
   const updatedSince = new Date();
-  updatedSince.setHours(updatedSince.getHours() - daysOfConversations * 24);
+  updatedSince.setHours(
+    updatedSince.getHours() - conversationLookbackDays * 24
+  );
 
   return ConversationResource.listRecentConversationsForAgent(auth, {
     agentConfigurationId,

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -21,8 +21,6 @@ import logger from "@app/logger/logger";
 import { updateActiveTrace } from "@langfuse/tracing";
 import { ApplicationFailure } from "@temporalio/common";
 
-const HOURS_LOOKBACK = 24;
-
 async function getAuthForWorkspace(
   workspaceId: string
 ): Promise<Authenticator> {
@@ -80,9 +78,11 @@ export async function getAgentConfigurationsActivity({
 export async function getRecentConversationsForAgentActivity({
   workspaceId,
   agentConfigurationId,
+  daysOfConversations = 1,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
+  daysOfConversations?: number;
 }): Promise<string[]> {
   updateActiveTrace({
     name: "Reinforced Agent Workflow",
@@ -92,7 +92,7 @@ export async function getRecentConversationsForAgentActivity({
   const auth = await getAuthForWorkspace(workspaceId);
 
   const updatedSince = new Date();
-  updatedSince.setHours(updatedSince.getHours() - HOURS_LOOKBACK);
+  updatedSince.setHours(updatedSince.getHours() - daysOfConversations * 24);
 
   return ConversationResource.listRecentConversationsForAgent(auth, {
     agentConfigurationId,

--- a/front/temporal/reinforced_agent/admin/cli.ts
+++ b/front/temporal/reinforced_agent/admin/cli.ts
@@ -66,13 +66,13 @@ const main = async () => {
         usage();
         process.exit(1);
       }
-      const daysOfConversations =
+      const conversationLookbackDays =
         argv["days"] !== undefined ? Number(argv["days"]) : 1;
       await startReinforcedAgentForAgentWorkflow({
         workspaceId,
         agentConfigurationId: agentId,
         useBatchMode: argv["batch"],
-        daysOfConversations,
+        conversationLookbackDays,
       });
       return;
     }

--- a/front/temporal/reinforced_agent/admin/cli.ts
+++ b/front/temporal/reinforced_agent/admin/cli.ts
@@ -12,11 +12,11 @@ import parseArgs from "minimist";
 
 function usage() {
   console.error(`Usage:
-  start                                                              Start the cron workflow
-  stop                                                               Stop the cron workflow
-  run-now                                                            Trigger the top-level workflow immediately
-  run-workspace --workspace-id <sId> [--batch]                       Run for a specific workspace (--batch defaults to false)
-  run-agent --workspace-id <sId> --agent-id <sId> [--batch]         Run for a specific agent (--batch defaults to false)`);
+  start                                                                          Start the cron workflow
+  stop                                                                           Stop the cron workflow
+  run-now                                                                        Trigger the top-level workflow immediately
+  run-workspace --workspace-id <sId> [--batch]                                  Run for a specific workspace (--batch defaults to false)
+  run-agent --workspace-id <sId> --agent-id <sId> [--batch] [--days <n>]       Run for a specific agent (--batch defaults to false, --days defaults to 1)`);
 }
 
 const main = async () => {
@@ -66,10 +66,13 @@ const main = async () => {
         usage();
         process.exit(1);
       }
+      const daysOfConversations =
+        argv["days"] !== undefined ? Number(argv["days"]) : 1;
       await startReinforcedAgentForAgentWorkflow({
         workspaceId,
         agentConfigurationId: agentId,
         useBatchMode: argv["batch"],
+        daysOfConversations,
       });
       return;
     }

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -90,18 +90,25 @@ export async function startReinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
   useBatchMode,
-  daysOfConversations = 1,
+  conversationLookbackDays = 1,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
-  daysOfConversations?: number;
+  conversationLookbackDays?: number;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = `reinforced-agent-${workspaceId}-${agentConfigurationId}-manual-${Date.now()}`;
 
   await client.workflow.start(reinforcedAgentForAgentWorkflow, {
-    args: [{ workspaceId, agentConfigurationId, useBatchMode, daysOfConversations }],
+    args: [
+      {
+        workspaceId,
+        agentConfigurationId,
+        useBatchMode,
+        conversationLookbackDays,
+      },
+    ],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -90,16 +90,18 @@ export async function startReinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
   useBatchMode,
+  daysOfConversations = 1,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
+  daysOfConversations?: number;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = `reinforced-agent-${workspaceId}-${agentConfigurationId}-manual-${Date.now()}`;
 
   await client.workflow.start(reinforcedAgentForAgentWorkflow, {
-    args: [{ workspaceId, agentConfigurationId, useBatchMode }],
+    args: [{ workspaceId, agentConfigurationId, useBatchMode, daysOfConversations }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -175,17 +175,17 @@ export async function reinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
   useBatchMode,
-  daysOfConversations = 1,
+  conversationLookbackDays = 1,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
-  daysOfConversations?: number;
+  conversationLookbackDays?: number;
 }): Promise<void> {
   const conversationIds = await getRecentConversationsForAgentActivity({
     workspaceId,
     agentConfigurationId,
-    daysOfConversations,
+    conversationLookbackDays,
   });
 
   if (useBatchMode) {

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -175,14 +175,17 @@ export async function reinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
   useBatchMode,
+  daysOfConversations = 1,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
+  daysOfConversations?: number;
 }): Promise<void> {
   const conversationIds = await getRecentConversationsForAgentActivity({
     workspaceId,
     agentConfigurationId,
+    daysOfConversations,
   });
 
   if (useBatchMode) {

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -58,6 +58,7 @@ interface NumberArgDefinition extends BaseArgDefinition {
   type: "number";
   values?: never;
   variant?: "text" | "spinner";
+  default?: number;
 }
 
 interface TextArgDefinition extends BaseArgDefinition {


### PR DESCRIPTION
## Description

So we can run analysis over more than one day of data from Poke or CLI

<img width="1272" height="710" alt="image" src="https://github.com/user-attachments/assets/38b70692-d32b-4cac-b7bd-3a0077b29bc4" />

## Tests

tested locally

## Risk

low, it's poke

## Deploy Plan

deploy front
