### PR TITLE
[Poke] Fix enterprise upgrade dropdown portal

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -30,7 +30,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
@@ -49,6 +49,15 @@ export default function EnterpriseUpgradeDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const [portalContainer, setPortalContainer] = useState<
+    HTMLElement | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalContainer(document.body);
+    }
+  }, []);
 
   const { plans } = usePokePlans();
   const router = useAppRouter();
@@ -166,6 +175,7 @@ export default function EnterpriseUpgradeDialog({
                       control={form.control}
                       name="planCode"
                       title="Enterprise Plan"
+                      mountPortalContainer={portalContainer}
                       options={plans
                         .filter((plan) => isEntreprisePlanPrefix(plan.code))
                         .map((plan) => ({

--- a/sparkle/src/hooks/useSheetContainer.ts
+++ b/sparkle/src/hooks/useSheetContainer.ts
@@ -8,6 +8,11 @@ export function useSheetContainer(
   );
 
   useEffect(() => {
+    if (mountPortalContainer) {
+      setContainer(mountPortalContainer);
+      return;
+    }
+
     if (!container) {
       const dialogElements = document.querySelectorAll(
         ".s-sheet[role=dialog][data-state=open]"
@@ -17,7 +22,7 @@ export function useSheetContainer(
         setContainer(lastDialog);
       }
     }
-  }, [container]);
+  }, [container, mountPortalContainer]);
 
   return container;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7123.
Follows https://github.com/dust-tt/dust/pull/23044.

This applies the explicit `document.body` portal target to the enterprise plan dropdown and fixes `sparkle` `useSheetContainer()` so explicit portal containers set after mount are actually respected.

## Risks

Blast radius: Poke subscription upgrade dialogs and other `sparkle` dropdown/popover call sites that rely on explicit portal containers.
Risk: low

## Deploy Plan
- pmrr
- deploy front