### PR TITLE
feat: extension dismiss suggestions

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -24,6 +24,19 @@ interface ConversationContainerProps {
   serverId?: string;
 }
 
+const SUGGESTIONS = {
+  formHelper: {
+    id: "form_helper",
+    title: "Dust can help you fill out forms",
+    description: "Ask an agent to get started",
+  },
+  multiTab: {
+    id: "multi_tab",
+    title: "Dust can work across all your open tabs",
+    description: "Ask an agent to get started",
+  },
+} as const;
+
 export const ConversationContainer = ({
   workspace,
   user,
@@ -62,6 +75,7 @@ export const ConversationContainer = ({
 
   const [suggestion, setSuggestion] = useState<
     | {
+        id: string;
         title: string;
         description: string;
       }
@@ -91,21 +105,37 @@ export const ConversationContainer = ({
     };
   }, [platform.messaging, fileUploaderService.uploadContentTab]);
 
+  const handleDismissSuggestion = async (id: string) => {
+    const dismissed = await platform.storage.get<string[]>(
+      "dismissedSuggestions"
+    );
+    const updated = [...(dismissed ?? []), id];
+    await platform.storage.set("dismissedSuggestions", updated);
+    setSuggestion(undefined);
+  };
+
   useEffect(() => {
+    const isSuggestionDismissed = async (id: string): Promise<boolean> => {
+      const dismissed = await platform.storage.get<string[]>(
+        "dismissedSuggestions"
+      );
+      return (dismissed ?? []).includes(id);
+    };
+
     void sendGetSessionInfoMessage()
-      .then((response) => {
-        if (response.currentTabHasForm) {
-          setSuggestion({
-            title: "Dust can help you fill out forms",
-            description: "Ask an agent to get started",
-          });
+      .then(async (response) => {
+        if (
+          response.currentTabHasForm &&
+          !(await isSuggestionDismissed(SUGGESTIONS.formHelper.id))
+        ) {
+          setSuggestion(SUGGESTIONS.formHelper);
           return;
         }
-        if (response.tabsCount > 2) {
-          setSuggestion({
-            title: "Dust can work across all your open tabs",
-            description: "Ask an agent to get started",
-          });
+        if (
+          response.tabsCount > 2 &&
+          !(await isSuggestionDismissed(SUGGESTIONS.multiTab.id))
+        ) {
+          setSuggestion(SUGGESTIONS.multiTab);
         }
       })
       .catch(() => {
@@ -126,6 +156,7 @@ export const ConversationContainer = ({
           conversationId={conversationId}
           clientSideMCPServerIds={clientSideMCPServerIds}
           suggestion={suggestion}
+          onDismissSuggestion={handleDismissSuggestion}
         />
       </div>
       {conversation && currentPanel && (

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -26,7 +26,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import { Card, LightbulbIcon, Page } from "@dust-tt/sparkle";
+import { Button, Card, LightbulbIcon, Page, XMarkIcon } from "@dust-tt/sparkle";
 import { useCallback, useContext, useEffect, useState } from "react";
 
 interface ConversationContainerProps {
@@ -36,9 +36,11 @@ interface ConversationContainerProps {
   conversationId?: string | null;
   clientSideMCPServerIds?: string[];
   suggestion?: {
+    id: string;
     title: string;
     description: string;
   };
+  onDismissSuggestion?: (suggestionId: string) => void;
 }
 
 export function ConversationContainerVirtuoso({
@@ -48,6 +50,7 @@ export function ConversationContainerVirtuoso({
   conversationId: conversationIdProp,
   clientSideMCPServerIds,
   suggestion,
+  onDismissSuggestion,
 }: ConversationContainerProps) {
   const conversationIdFromRouter = useActiveConversationId();
   const activeConversationId =
@@ -198,11 +201,25 @@ export function ConversationContainerVirtuoso({
 
           {suggestion && (
             <div className="w-full max-w-3xl mt-1">
-              <Card variant="highlight" size="md" containerClassName="w-full">
+              <Card
+                variant="highlight"
+                size="md"
+                containerClassName="w-full group"
+              >
                 <div className="flex w-full flex-col gap-2 text-sm">
                   <div className="flex w-full items-center gap-2 font-semibold text-highlight-600 dark:text-highlight-400">
-                    <LightbulbIcon className="text-highlight-600 h-5 w-5" />
+                    <LightbulbIcon className="text-highlight-600 dark:text-highlight-400 h-5 w-5" />
                     <div className="w-full">{suggestion.title}</div>
+                    <div className="opacity-0 transition-opacity group-hover:opacity-100">
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        icon={XMarkIcon}
+                        tooltip="Dismiss"
+                        onClick={() => onDismissSuggestion?.(suggestion.id)}
+                        className="text-highlight-600 dark:text-highlight-400"
+                      />
+                    </div>
                   </div>
                   <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                     {suggestion.description}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7140

This PR adds the ability to dismiss suggestions in the extension conversation UI.

- Adds persistent storage for dismissed suggestion IDs
- Introduces unique IDs for each suggestion type (form helper, multi-tab)
- Shows a dismiss button on hover that hides the suggestion permanently
<img width="329" height="428" alt="Capture d’écran 2026-03-17 à 15 38 23" src="https://github.com/user-attachments/assets/cf13b824-059b-4eb4-a9e5-bbc48030ae14" />

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.
