### PR TITLE
[BYOK] Add providers health to Authenticator and filter whitelisted providers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -99,7 +99,7 @@ export async function summarizeWithLLM({
 async function getFastModelConfigForSummarization(
   auth: Authenticator
 ): Promise<ModelConfigurationType | null> {
-  const providers = await getWhitelistedProviders(auth);
+  const providers = getWhitelistedProviders(auth);
 
   if (providers.has("anthropic")) {
     return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;

--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -93,7 +93,7 @@ export async function getSuggestedAgentsForContent(
   }
 
   // TODO(daphne): See if we can put Flash 2 as the default model.
-  const providers = await getWhitelistedProviders(auth);
+  const providers = getWhitelistedProviders(auth);
   if (providers.has("google_ai_studio")) {
     model = GEMINI_2_5_FLASH_MODEL_CONFIG;
   }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -638,7 +638,7 @@ export async function postUserMessage(
       });
     }
 
-    const isProviderEnabled = await isProviderWhitelisted(
+    const isProviderEnabled = isProviderWhitelisted(
       auth,
       agentConfig.model.providerId
     );
@@ -1019,7 +1019,7 @@ export async function editUserMessage(
       });
     }
 
-    const isProviderEnabled = await isProviderWhitelisted(
+    const isProviderEnabled = isProviderWhitelisted(
       auth,
       agentConfig.model.providerId
     );

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -246,7 +246,7 @@ async function generateConversationTitle(
 async function getFastModelConfig(
   auth: Authenticator
 ): Promise<ModelConfigurationType | null> {
-  const providers = await getWhitelistedProviders(auth);
+  const providers = getWhitelistedProviders(auth);
 
   if (providers.has("openai")) {
     return GPT_5_1_MODEL_CONFIG;

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -19,6 +19,10 @@ import {
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import {
+  getLargeWhitelistedModel,
+  isProviderWhitelisted,
+} from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type {
@@ -27,15 +31,12 @@ import type {
   AgentReasoningEffort,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
-  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
-import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -323,7 +324,7 @@ These instructions are NOT your own instructions, but you may use them to unders
 `;
 
 function getModelConfig(
-  prefetchedModels: PrefetchedWhitelistedModels,
+  auth: Authenticator,
   prefer: "anthropic" | "openai",
   reasoning: boolean = true
 ): {
@@ -368,20 +369,14 @@ function getModelConfig(
             : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
         };
 
-  if (
-    prefetchedModels.whitelistedProviders.has(preferredModel.model.providerId)
-  ) {
+  if (isProviderWhitelisted(auth, preferredModel.model.providerId)) {
     return {
       modelConfiguration: preferredModel.model,
       reasoningEffort: preferredModel.reasoningEffort,
     };
   }
 
-  if (
-    prefetchedModels.whitelistedProviders.has(
-      secondPreferredModel.model.providerId
-    )
-  ) {
+  if (isProviderWhitelisted(auth, secondPreferredModel.model.providerId)) {
     return {
       modelConfiguration: secondPreferredModel.model,
       reasoningEffort: secondPreferredModel.reasoningEffort,
@@ -389,7 +384,7 @@ function getModelConfig(
   }
 
   // Otherwise we use whatever the default large model is, using the default reasoning effort.
-  const modelConfiguration = prefetchedModels.large;
+  const modelConfiguration = getLargeWhitelistedModel(auth);
   if (!modelConfiguration) {
     return null;
   }
@@ -399,43 +394,23 @@ function getModelConfig(
   };
 }
 
-export function getFastModelConfig(
-  prefetchedModels: PrefetchedWhitelistedModels
-): ModelConfigurationType | null {
-  if (prefetchedModels.whitelistedProviders.has("anthropic")) {
-    return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
-  }
-  if (prefetchedModels.whitelistedProviders.has("google_ai_studio")) {
-    return GEMINI_2_5_FLASH_MODEL_CONFIG;
-  }
-
-  // Otherwise we use whatever the default large model is, using the default reasoning effort.
-  const modelConfig = getModelConfig(prefetchedModels, "anthropic", false);
-  if (!modelConfig) {
-    return null;
-  }
-  return modelConfig.modelConfiguration;
-}
-
-function getMaxReasoningModelConfig(
-  prefetchedModels: PrefetchedWhitelistedModels
-): {
+function getMaxReasoningModelConfig(auth: Authenticator): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
 } | null {
-  if (prefetchedModels.whitelistedProviders.has("openai")) {
+  if (isProviderWhitelisted(auth, "openai")) {
     return {
       modelConfiguration: GPT_5_4_MODEL_CONFIG,
       reasoningEffort: "high",
     };
   }
-  if (prefetchedModels.whitelistedProviders.has("anthropic")) {
+  if (isProviderWhitelisted(auth, "anthropic")) {
     return {
       modelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
       reasoningEffort: "high",
     };
   }
-  return getModelConfig(prefetchedModels, "anthropic");
+  return getModelConfig(auth, "anthropic");
 }
 
 export function _getDeepDiveGlobalAgent(
@@ -444,21 +419,18 @@ export function _getDeepDiveGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
-  const modelConfig = getModelConfig(prefetchedModels, "anthropic");
+  const modelConfig = getModelConfig(auth, "anthropic");
 
   const enterpriseModelConfig =
-    shouldUseOpus(auth) &&
-    prefetchedModels.whitelistedProviders.has("anthropic")
+    shouldUseOpus(auth) && isProviderWhitelisted(auth, "anthropic")
       ? {
           modelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
           reasoningEffort: modelConfig?.reasoningEffort ?? ("medium" as const),
@@ -605,12 +577,10 @@ export function _getDustTaskGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ): AgentConfigurationType | null {
   const name = "dust-task";
@@ -644,7 +614,7 @@ export function _getDustTaskGlobalAgent(
     canEdit: false,
   };
 
-  const modelConfig = getModelConfig(prefetchedModels, "anthropic", false);
+  const modelConfig = getModelConfig(auth, "anthropic", false);
 
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
@@ -721,10 +691,8 @@ export function _getPlanningAgent(
   auth: Authenticator,
   {
     settings,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ): AgentConfigurationType | null {
   const name = "dust-planning";
@@ -758,7 +726,7 @@ export function _getPlanningAgent(
     canEdit: false,
   };
 
-  const modelConfig = getMaxReasoningModelConfig(prefetchedModels);
+  const modelConfig = getMaxReasoningModelConfig(auth);
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
       ...planningAgent,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -24,6 +24,11 @@ import {
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+  isProviderWhitelisted,
+} from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {
@@ -40,7 +45,6 @@ import type {
   GlobalAgentContext,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
@@ -69,7 +73,6 @@ interface DustLikeGlobalAgentArgs {
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   hasDeepDive: boolean;
-  prefetchedModels: PrefetchedWhitelistedModels;
   globalAgentContext?: GlobalAgentContext;
 }
 
@@ -316,7 +319,6 @@ function _getDustLikeGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     hasDeepDive,
-    prefetchedModels,
     globalAgentContext,
   }: DustLikeGlobalAgentArgs,
   {
@@ -357,20 +359,18 @@ function _getDustLikeGlobalAgent(
     }
 
     if (!auth.isUpgraded()) {
-      return prefetchedModels.small;
+      return getSmallWhitelistedModel(auth);
     }
 
     if (
       preferredModelConfiguration &&
-      prefetchedModels.whitelistedProviders.has(
-        preferredModelConfiguration.providerId
-      )
+      isProviderWhitelisted(auth, preferredModelConfiguration.providerId)
     ) {
       isPreferredModel = true;
       return preferredModelConfiguration;
     }
 
-    return prefetchedModels.large;
+    return getLargeWhitelistedModel(auth);
   })();
 
   const model: AgentModelConfigurationType = modelConfiguration

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -6,13 +6,17 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+  isProviderWhitelisted,
+} from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   GlobalAgentContext,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
@@ -461,13 +465,11 @@ export function _getSidekickGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     globalAgentContext,
-    prefetchedModels,
   }: {
     sidekickContext: SidekickContext | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     globalAgentContext?: GlobalAgentContext;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ): AgentConfigurationType {
   const companyDataAction = getCompanyDataAction(
@@ -495,10 +497,10 @@ export function _getSidekickGlobalAgent(
   const modelConfiguration = isNewAgentFromScratchFirstTurn
     ? NOOP_MODEL_CONFIG
     : isFirstTurn
-      ? prefetchedModels.whitelistedProviders.has("anthropic")
+      ? isProviderWhitelisted(auth, "anthropic")
         ? CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG
-        : prefetchedModels.small
-      : prefetchedModels.large;
+        : getSmallWhitelistedModel(auth)
+      : getLargeWhitelistedModel(auth);
   const model = modelConfiguration
     ? {
         providerId: modelConfiguration.providerId,

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -7,23 +7,24 @@ import {
   _getDefaultWebActionsForGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 export function _getHelperGlobalAgent({
   auth,
   mcpServerViews,
-  prefetchedModels,
 }: {
   auth: Authenticator;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-  prefetchedModels: PrefetchedWhitelistedModels;
 }): AgentConfigurationType {
   let prompt = `<primary_goal>
 You are a customer success AI agent called @help designed by Dust and embedded in the platform. Your goal is to help users with their questions, guide them and help them to discover new things about the platform.
@@ -61,8 +62,8 @@ The user you're interacting with is granted with the role ${role}. Their name is
   }
 
   const modelConfiguration = auth.isUpgraded()
-    ? prefetchedModels.large
-    : prefetchedModels.small;
+    ? getLargeWhitelistedModel(auth)
+    : getSmallWhitelistedModel(auth);
 
   const model: AgentModelConfigurationType = modelConfiguration
     ? {

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -6,6 +6,10 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -13,7 +17,6 @@ import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
 } from "@app/types/assistant/agent";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConnectorProvider } from "@app/types/data_source";
 
@@ -29,7 +32,6 @@ function _getManagedDataSourceAgent(
     pictureUrl,
     preFetchedDataSources,
     searchMCPServerView,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     connectorProvider: ConnectorProvider;
@@ -40,12 +42,11 @@ function _getManagedDataSourceAgent(
     pictureUrl: string;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ): AgentConfigurationType | null {
   const modelConfiguration = auth.isUpgraded()
-    ? prefetchedModels.large
-    : prefetchedModels.small;
+    ? getLargeWhitelistedModel(auth)
+    : getSmallWhitelistedModel(auth);
 
   const model: AgentModelConfigurationType = modelConfiguration
     ? {
@@ -154,12 +155,10 @@ export function _getGoogleDriveGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ): AgentConfigurationType | null {
   const agentId = GLOBAL_AGENTS_SID.GOOGLE_DRIVE;
@@ -177,7 +176,6 @@ export function _getGoogleDriveGlobalAgent(
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
-    prefetchedModels,
   });
 }
 
@@ -187,12 +185,10 @@ export function _getSlackGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.SLACK;
@@ -210,7 +206,6 @@ export function _getSlackGlobalAgent(
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
-    prefetchedModels,
   });
 }
 
@@ -220,12 +215,10 @@ export function _getGithubGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.GITHUB;
@@ -243,7 +236,6 @@ export function _getGithubGlobalAgent(
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
-    prefetchedModels,
   });
 }
 
@@ -253,12 +245,10 @@ export function _getNotionGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.NOTION;
@@ -276,7 +266,6 @@ export function _getNotionGlobalAgent(
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
-    prefetchedModels,
   });
 }
 
@@ -286,12 +275,10 @@ export function _getIntercomGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    prefetchedModels,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-    prefetchedModels: PrefetchedWhitelistedModels;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.INTERCOM;
@@ -309,6 +296,5 @@ export function _getIntercomGlobalAgent(
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
     searchMCPServerView: mcpServerViews.search,
-    prefetchedModels,
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -83,7 +83,7 @@ import {
   getDataSourcesAndWorkspaceIdForGlobalAgents,
   getMCPServerViewsForGlobalAgents,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { prefetchWhitelistedModels } from "@app/lib/assistant";
+import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
@@ -93,7 +93,6 @@ import type {
   GlobalAgentContext,
   GlobalAgentStatus,
 } from "@app/types/assistant/agent";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import {
   GLOBAL_AGENTS_SID,
   isGlobalAgentId,
@@ -505,7 +504,6 @@ function getGlobalAgent({
   sidekickContext,
   hasDeepDive,
   globalAgentContext,
-  prefetchedModels,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -515,7 +513,6 @@ function getGlobalAgent({
   sidekickContext: SidekickContext | null;
   hasDeepDive: boolean;
   globalAgentContext?: GlobalAgentContext;
-  prefetchedModels: PrefetchedWhitelistedModels;
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -527,7 +524,6 @@ function getGlobalAgent({
       agentConfiguration = _getHelperGlobalAgent({
         auth,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT35_TURBO:
@@ -685,7 +681,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.GOOGLE_DRIVE:
@@ -693,7 +688,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.NOTION:
@@ -701,7 +695,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.GITHUB:
@@ -709,7 +702,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.INTERCOM:
@@ -717,7 +709,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST:
@@ -726,7 +717,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
         globalAgentContext,
       });
       break;
@@ -736,7 +726,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT:
@@ -745,7 +734,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM:
@@ -754,7 +742,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_ANT_HIGH:
@@ -763,7 +750,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_KIMI:
@@ -772,7 +758,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM:
@@ -781,7 +766,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_KIMI_HIGH:
@@ -790,7 +774,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GLM:
@@ -799,7 +782,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM:
@@ -808,7 +790,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GLM_HIGH:
@@ -817,7 +798,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MINIMAX:
@@ -826,7 +806,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM:
@@ -835,7 +814,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH:
@@ -844,7 +822,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_QUICK:
@@ -853,7 +830,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI:
@@ -862,7 +838,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_MEDIUM:
@@ -871,7 +846,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_OAI_HIGH:
@@ -880,7 +854,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG:
@@ -889,7 +862,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM:
@@ -898,7 +870,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM:
@@ -907,7 +878,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_NEXT:
@@ -916,7 +886,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM:
@@ -925,7 +894,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_NEXT_HIGH:
@@ -934,7 +902,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasDeepDive,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
@@ -942,7 +909,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
@@ -950,7 +916,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY:
@@ -959,7 +924,6 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.DUST_PLANNING:
       agentConfiguration = _getPlanningAgent(auth, {
         settings,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.SIDEKICK:
@@ -968,7 +932,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         globalAgentContext,
-        prefetchedModels,
       });
       break;
     case GLOBAL_AGENTS_SID.NOOP:
@@ -1037,21 +1000,16 @@ export async function getGlobalAgents(
 
   const isDeepDiveDisabled = await isDeepDiveDisabledByAdmin(auth);
 
-  const [
-    preFetchedDataSources,
-    globalAgentSettings,
-    mcpServerViews,
-    prefetchedModels,
-  ] = await Promise.all([
-    variant === "full"
-      ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
-      : null,
-    GlobalAgentSettingsModel.findAll({
-      where: { workspaceId: owner.id },
-    }),
-    getMCPServerViewsForGlobalAgents(auth, variant),
-    prefetchWhitelistedModels(auth),
-  ]);
+  const [preFetchedDataSources, globalAgentSettings, mcpServerViews] =
+    await Promise.all([
+      variant === "full"
+        ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
+        : null,
+      GlobalAgentSettingsModel.findAll({
+        where: { workspaceId: owner.id },
+      }),
+      getMCPServerViewsForGlobalAgents(auth, variant),
+    ]);
 
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of
@@ -1141,7 +1099,6 @@ export async function getGlobalAgents(
       sidekickContext,
       hasDeepDive: !isDeepDiveDisabled,
       globalAgentContext: options?.globalAgentContext,
-      prefetchedModels,
     })
   );
 
@@ -1151,9 +1108,7 @@ export async function getGlobalAgents(
     if (
       agentFetcherResult &&
       agentFetcherResult.scope === "global" &&
-      prefetchedModels.whitelistedProviders.has(
-        agentFetcherResult.model.providerId
-      )
+      isProviderWhitelisted(auth, agentFetcherResult.model.providerId)
     ) {
       globalAgents.push(agentFetcherResult);
     }

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -29,15 +29,13 @@ function mockCredentials(
     isHealthy: boolean;
   }>
 ) {
-  vi.mocked(ProviderCredentialResource.listByWorkspace).mockResolvedValue(
-    credentials.map(
-      (c) =>
-        ({
-          providerId: c.providerId,
-          isHealthy: c.isHealthy,
-        }) as unknown as ProviderCredentialResource
-    )
-  );
+  const health = Object.fromEntries(
+    credentials.map((c) => [c.providerId, c.isHealthy])
+  ) as Partial<Record<ModelProviderIdType, boolean>>;
+
+  vi.mocked(
+    ProviderCredentialResource.fetchProvidersHealthByWorkspaceId
+  ).mockResolvedValue(health);
 }
 
 function createMockModel(
@@ -104,7 +102,7 @@ describe("getWhitelistedProviders", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = await getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(auth);
     expect(providers).toEqual(new Set(MODEL_PROVIDER_IDS));
   });
 
@@ -114,44 +112,42 @@ describe("getWhitelistedProviders", () => {
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = await getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(auth);
     expect(providers).toEqual(new Set(["anthropic", "noop"]));
   });
 
-  // TODO (BYOK): unskip
-  it.skip("BYOK: only includes providers with healthy keys plus noop", async () => {
+  it("BYOK: only includes providers with configured keys plus noop", async () => {
     const workspace = await WorkspaceFactory.byok();
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     mockCredentials([
       { providerId: "openai", isHealthy: true },
       { providerId: "anthropic", isHealthy: false },
     ]);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = await getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["openai", "noop"]));
+    const providers = getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["openai", "anthropic", "noop"]));
   });
 
   it("BYOK + restricted whitelist: healthy key for non-whitelisted provider is ignored", async () => {
     const workspace = await WorkspaceFactory.byok({
       whiteListedProviders: ["anthropic"],
     });
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     mockCredentials([
       { providerId: "openai", isHealthy: true },
       { providerId: "anthropic", isHealthy: true },
     ]);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = await getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(auth);
     expect(providers).toEqual(new Set(["anthropic", "noop"]));
   });
 
-  // TODO (BYOK): unskip
-  it.skip("BYOK + no keys: only noop is whitelisted", async () => {
+  it("BYOK + no keys: only noop is whitelisted", async () => {
     const workspace = await WorkspaceFactory.byok();
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     mockCredentials([]);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const providers = await getWhitelistedProviders(auth);
+    const providers = getWhitelistedProviders(auth);
     expect(providers).toEqual(new Set(["noop"]));
   });
 });

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -4,7 +4,6 @@ import {
   isEntreprisePlanPrefix,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
-import type { PrefetchedWhitelistedModels } from "@app/types/assistant/assistant";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
@@ -44,10 +43,11 @@ export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   );
 }
 
-export async function getWhitelistedProviders(
+export function getWhitelistedProviders(
   auth: Authenticator
-): Promise<Set<ModelProviderIdType>> {
+): Set<ModelProviderIdType> {
   const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
   const whiteListedProviders = new Set<ModelProviderIdType>(
     owner.whiteListedProviders ?? MODEL_PROVIDER_IDS
   );
@@ -55,33 +55,34 @@ export async function getWhitelistedProviders(
   // noop never sees user data, always whitelisted.
   whiteListedProviders.add("noop");
 
-  return whiteListedProviders;
+  if (!plan.isByok) {
+    return whiteListedProviders;
+  }
+
+  const providersHealth = auth.providersHealth();
+
+  const configuredProviders = new Set(
+    Object.keys(providersHealth ?? {}) as ModelProviderIdType[]
+  );
+
+  // noop never needs credentials.
+  configuredProviders.add("noop");
+
+  return whiteListedProviders.intersection(configuredProviders);
 }
 
-export async function isProviderWhitelisted(
+export function isProviderWhitelisted(
   auth: Authenticator,
   providerId: ModelProviderIdType
-): Promise<boolean> {
-  const whitelistedProviders = await getWhitelistedProviders(auth);
+): boolean {
+  const whitelistedProviders = getWhitelistedProviders(auth);
   return whitelistedProviders.has(providerId);
 }
 
-export async function prefetchWhitelistedModels(
+export function getFastestWhitelistedModel(
   auth: Authenticator
-): Promise<PrefetchedWhitelistedModels> {
-  const whitelistedProviders = await getWhitelistedProviders(auth);
-
-  return {
-    small: _getSmallWhitelistedModel(whitelistedProviders),
-    large: _getLargeWhitelistedModel(whitelistedProviders),
-    whitelistedProviders,
-  };
-}
-
-export async function getFastestWhitelistedModel(
-  auth: Authenticator
-): Promise<ModelConfigurationType | null> {
-  const whitelistedProviders = await getWhitelistedProviders(auth);
+): ModelConfigurationType | null {
+  const whitelistedProviders = getWhitelistedProviders(auth);
   if (whitelistedProviders.has("mistral")) {
     return MISTRAL_SMALL_MODEL_CONFIG;
   }
@@ -91,17 +92,17 @@ export async function getFastestWhitelistedModel(
   return _getSmallWhitelistedModel(whitelistedProviders);
 }
 
-export async function getSmallWhitelistedModel(
+export function getSmallWhitelistedModel(
   auth: Authenticator
-): Promise<ModelConfigurationType | null> {
-  const whitelistedProviders = await getWhitelistedProviders(auth);
+): ModelConfigurationType | null {
+  const whitelistedProviders = getWhitelistedProviders(auth);
   return _getSmallWhitelistedModel(whitelistedProviders);
 }
 
-export async function getLargeWhitelistedModel(
+export function getLargeWhitelistedModel(
   auth: Authenticator
-): Promise<ModelConfigurationType | null> {
-  const whitelistedProviders = await getWhitelistedProviders(auth);
+): ModelConfigurationType | null {
+  const whitelistedProviders = getWhitelistedProviders(auth);
   return _getLargeWhitelistedModel(whitelistedProviders);
 }
 
@@ -198,13 +199,13 @@ export function isModelCustomAvailable(
   return true;
 }
 
-export async function filterCustomAvailableAndWhitelistedModels(
+export function filterCustomAvailableAndWhitelistedModels(
   models: ModelConfigurationType[],
   featureFlags: WhitelistableFeature[],
   auth: Authenticator
-): Promise<ModelConfigurationType[]> {
+): ModelConfigurationType[] {
   const plan = auth.plan();
-  const whitelistedProviders = await getWhitelistedProviders(auth);
+  const whitelistedProviders = getWhitelistedProviders(auth);
 
   return models.filter(
     (m) =>

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -17,6 +17,7 @@ import {
   SECRET_KEY_PREFIX,
 } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -25,6 +26,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
+import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type {
@@ -62,6 +64,8 @@ const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 const DustApiKeyNameHeader = "x-dust-api-key-name";
 
 const SANDBOX_TOKEN_AUTH_METHOD = "sandbox_token" as const;
+
+type ProvidersHealth = Partial<Record<ByokModelProviderIdType, boolean>>;
 
 export type AuthMethodType =
   | "system_api_key"
@@ -104,6 +108,7 @@ export class Authenticator {
   _groupModelIds: ModelId[];
   _workspace: WorkspaceResource | null;
   _authMethod: AuthMethodType;
+  _providersHealth: ProvidersHealth | null;
 
   // Should only be called from the static methods below.
   constructor({
@@ -114,6 +119,7 @@ export class Authenticator {
     authMethod,
     subscription,
     key,
+    providersHealth,
   }: {
     workspace?: WorkspaceResource | null;
     user?: UserResource | null;
@@ -122,6 +128,7 @@ export class Authenticator {
     authMethod: AuthMethodType;
     subscription?: SubscriptionResource | null;
     key?: KeyAuthType;
+    providersHealth?: ProvidersHealth | null;
   }) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
@@ -133,6 +140,7 @@ export class Authenticator {
     this._subscription = subscription || null;
     this._authMethod = authMethod;
     this._key = key;
+    this._providersHealth = providersHealth ?? null;
     if (user) {
       tracer.setUser({
         id: user?.sId,
@@ -257,6 +265,11 @@ export class Authenticator {
         subscription = authData.subscription;
       }
 
+      const providersHealth = await this.fetchByokProvidersHealth(
+        workspace,
+        subscription
+      );
+
       return new Authenticator({
         authMethod:
           session?.authenticationMethod === "bearer" ? "oauth" : "session",
@@ -265,6 +278,7 @@ export class Authenticator {
         role,
         groupModelIds,
         subscription,
+        providersHealth,
       });
     });
   }
@@ -274,6 +288,18 @@ export class Authenticator {
    */
   static isMember(role: RoleType): boolean {
     return role !== "none";
+  }
+
+  private static async fetchByokProvidersHealth(
+    workspace: WorkspaceResource | null | undefined,
+    subscription: SubscriptionResource | null
+  ): Promise<ProvidersHealth | null> {
+    if (!workspace || !subscription?.getPlan().isByok) {
+      return null;
+    }
+    return ProviderCredentialResource.fetchProvidersHealthByWorkspaceId(
+      workspace.id
+    );
   }
 
   async refresh({ transaction }: { transaction?: Transaction } = {}) {
@@ -360,6 +386,11 @@ export class Authenticator {
       subscription = authData.subscription;
     }
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      subscription
+    );
+
     return new Authenticator({
       authMethod: "internal",
       workspace,
@@ -367,6 +398,7 @@ export class Authenticator {
       role,
       groupModelIds,
       subscription,
+      providersHealth,
     });
   }
 
@@ -399,6 +431,11 @@ export class Authenticator {
       workspace,
     });
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      authData.subscription
+    );
+
     return new Ok(
       new Authenticator({
         authMethod: "oauth",
@@ -407,6 +444,7 @@ export class Authenticator {
         user,
         role: authData.role,
         subscription: authData.subscription,
+        providersHealth,
       })
     );
   }
@@ -473,6 +511,11 @@ export class Authenticator {
       workspace.id
     );
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      authData.subscription
+    );
+
     return new Ok(
       new Authenticator({
         authMethod: SANDBOX_TOKEN_AUTH_METHOD,
@@ -481,6 +524,7 @@ export class Authenticator {
         role: authData.role,
         groupModelIds,
         subscription: authData.subscription,
+        providersHealth,
       })
     );
   }
@@ -611,6 +655,11 @@ export class Authenticator {
     }
     const allGroups = requestedGroupIds ? requestedGroups : keyGroups;
 
+    const workspaceProvidersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      workspaceSubscription
+    );
+
     return {
       workspaceAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
@@ -620,6 +669,7 @@ export class Authenticator {
         role,
         subscription: workspaceSubscription,
         workspace,
+        providersHealth: workspaceProvidersHealth,
       }),
       keyAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
@@ -699,12 +749,18 @@ export class Authenticator {
       SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
     ]);
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      subscription
+    );
+
     return new Authenticator({
       authMethod: "internal",
       workspace,
       role: "builder",
       groupModelIds: globalGroup ? [globalGroup.id] : [],
       subscription,
+      providersHealth,
     });
   }
 
@@ -736,12 +792,18 @@ export class Authenticator {
       SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
     ]);
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      subscription
+    );
+
     return new Authenticator({
       authMethod: "internal",
       workspace,
       role: "admin",
       groupModelIds: groups.map((g) => g.id),
       subscription,
+      providersHealth,
     });
   }
 
@@ -834,6 +896,10 @@ export class Authenticator {
       subscription: this._subscription,
       workspace: this._workspace,
     });
+  }
+
+  providersHealth(): ProvidersHealth | null {
+    return this._providersHealth;
   }
 
   role(): RoleType {
@@ -1153,6 +1219,11 @@ export class Authenticator {
       authType.groupIds.map((sId) => getResourceIdFromSId(sId))
     );
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      subscription
+    );
+
     return new Ok(
       new Authenticator({
         authMethod: authType.authMethod,
@@ -1162,6 +1233,7 @@ export class Authenticator {
         groupModelIds: groupIds,
         subscription,
         key: authType.key,
+        providersHealth,
       })
     );
   }

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -80,6 +80,7 @@ function getCacheKey(workspaceId: number): string {
 
 describe("ProviderCredentialResource", () => {
   beforeEach(() => {
+    mockGetCredentials.mockClear();
     mockGetCredentials.mockResolvedValue(
       new Ok({ credential: { content: { api_key: "sk-test" } } })
     );
@@ -113,6 +114,9 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
       const workspace = authenticator.getNonNullableWorkspace();
+      // Authenticator init populates the cache (empty) via fetchByokProvidersHealth; clear it so
+      // credentials created below are visible on first listByWorkspace call.
+      inMemoryCache.clear();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
       await ProviderCredentialFactory.basic(workspace, "anthropic");
@@ -135,6 +139,7 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
       const workspace = authenticator.getNonNullableWorkspace();
+      inMemoryCache.clear();
       await ProviderCredentialFactory.basic(workspace, "openai");
 
       const result =
@@ -161,6 +166,7 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
       const workspace = authenticator.getNonNullableWorkspace();
+      inMemoryCache.clear();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
 
@@ -203,6 +209,7 @@ describe("ProviderCredentialResource", () => {
       });
       const workspace = authenticator.getNonNullableWorkspace();
       const cacheKey = getCacheKey(workspace.id);
+      inMemoryCache.clear();
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
 
@@ -217,6 +224,7 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
       const workspace = authenticator.getNonNullableWorkspace();
+      inMemoryCache.clear();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
 
@@ -239,6 +247,7 @@ describe("ProviderCredentialResource", () => {
       });
       const workspace = authenticator.getNonNullableWorkspace();
       const cacheKey = getCacheKey(workspace.id);
+      inMemoryCache.clear();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
 
@@ -276,6 +285,7 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
       const workspace = authenticator.getNonNullableWorkspace();
+      inMemoryCache.clear();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
 

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -360,6 +360,18 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     return this.baseFetch(auth);
   }
 
+  /**
+   * Fetches health records for all providers in a workspace by workspace model ID.
+   * Bypasses auth check for use during Authenticator initialization.
+   */
+  static async fetchProvidersHealthByWorkspaceId(
+    workspaceId: ModelId
+  ): Promise<Partial<Record<ByokModelProviderIdType, boolean>>> {
+    const cached = await this.baseFetchCached(workspaceId);
+
+    return Object.fromEntries(cached.map((c) => [c.providerId, c.isHealthy]));
+  }
+
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 

--- a/front/tests/sidekick-evals/lib/config.ts
+++ b/front/tests/sidekick-evals/lib/config.ts
@@ -7,7 +7,6 @@ import {
   MCP_SERVERS_FOR_GLOBAL_AGENTS,
   type MCPServerViewsForGlobalAgentsMap,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { prefetchWhitelistedModels } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import type { SidekickConfig } from "@app/tests/sidekick-evals/lib/types";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -98,12 +97,10 @@ export async function getSidekickConfig(): Promise<{
       `Unknown SIDEKICK_AGENT: "${SIDEKICK_AGENT}". Must be "default".`
     );
   }
-  const prefetchedModels = await prefetchWhitelistedModels(auth);
   const sidekickConfig = _getSidekickGlobalAgent(auth, {
     sidekickContext: mockSidekickContext,
     preFetchedDataSources: null,
     mcpServerViews: MOCK_MCP_SERVER_VIEWS,
-    prefetchedModels,
   });
 
   const tools: AgentActionSpecification[] = [GET_AGENT_CONFIG_SPEC];


### PR DESCRIPTION
## Description

For BYOK workspaces, `getWhitelistedProviders` now intersects the workspace whitelist with the set of providers that have credentials configured. Provider health is fetched eagerly during `Authenticator` construction (via a new auth-bypass method on `ProviderCredentialResource`) and exposed via `auth.providersHealth()`, which also allowed all provider-whitelist helpers to become synchronous, removing the `prefetchedModels` prop that was threaded through every global agent configuration function.

## Tests

Unit tests updated and passing (`lib/assistant.test.ts`): mocks target the new `fetchProvidersHealthByWorkspaceId` method and are set up before `Authenticator` construction to match the eager fetch.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`