### PR TITLE
Script to change recent Haiku agents to Sonnet

### DIFF
--- a/front/migrations/20260317_fixup_agent_model.ts
+++ b/front/migrations/20260317_fixup_agent_model.ts
@@ -23,7 +23,12 @@ makeScript({}, async ({ execute }, logger) => {
     dangerouslyBypassWorkspaceIsolationSecurity: true,
   });
 
-  console.log(
+  logger.info(
+    {
+      count: activeAgents.length,
+      modelId: OLD_MODEL_ID,
+      cutoff: CUTOFF_DATE.toISOString(),
+    },
     `Found ${activeAgents.length} active agents using model ${OLD_MODEL_ID}. Checking for creation date after ${CUTOFF_DATE.toISOString()}...`
   );
 

--- a/front/migrations/20260317_fixup_agent_model.ts
+++ b/front/migrations/20260317_fixup_agent_model.ts
@@ -1,0 +1,76 @@
+import { Op } from "sequelize";
+
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeScript } from "@app/scripts/helpers";
+
+const CUTOFF_DATE = new Date("2026-03-16T14:20:00Z");
+const OLD_MODEL_ID = "claude-haiku-4-5-20251001";
+const NEW_MODEL_ID = "claude-sonnet-4-6";
+
+const AgentConfigurationModelWithBypass: ModelStaticWorkspaceAware<AgentConfigurationModel> =
+  AgentConfigurationModel;
+
+makeScript({}, async ({ execute }, logger) => {
+  // Find all active agent configurations using the old model.
+  const activeAgents = await AgentConfigurationModelWithBypass.findAll({
+    where: {
+      modelId: OLD_MODEL_ID,
+      status: "active",
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  console.log(
+    `Found ${activeAgents.length} active agents using model ${OLD_MODEL_ID}. Checking for creation date after ${CUTOFF_DATE.toISOString()}...`
+  );
+
+  // For each active agent, check that version 0 was created after the cutoff.
+  // This filters out agents that existed before and were just updated.
+  const agentsToUpdate: AgentConfigurationModel[] = [];
+
+  for (const agent of activeAgents) {
+    const firstVersion = await AgentConfigurationModelWithBypass.findOne({
+      where: {
+        sId: agent.sId,
+        version: 0,
+        createdAt: { [Op.gt]: CUTOFF_DATE },
+      },
+      // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    if (firstVersion) {
+      agentsToUpdate.push(agent);
+    }
+  }
+
+  logger.info(
+    { count: agentsToUpdate.length },
+    `Found ${agentsToUpdate.length} agents to update from ${OLD_MODEL_ID} to ${NEW_MODEL_ID}.`
+  );
+
+  if (agentsToUpdate.length === 0) {
+    return;
+  }
+
+  for (const agent of agentsToUpdate) {
+    logger.info(
+      {
+        sId: agent.sId,
+        version: agent.version,
+        workspaceId: agent.workspaceId,
+      },
+      `Updating agent ${agent.sId} (version ${agent.version}).`
+    );
+
+    if (execute) {
+      await agent.update({ modelId: NEW_MODEL_ID });
+    }
+  }
+
+  logger.info("Migration complete.");
+});


### PR DESCRIPTION
## Description

- Add migration script to fix agent model for agents created after March 16 2:30pm that were incorrectly set to claude-haiku-4-5-20251001
- Updates matching agents to claude-sonnet-4-6, only targeting agents that were truly first created after the cutoff (not pre-existing agents that were simply updated)

## Tests

Tried locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
