### PR TITLE
[front] chore: update skill builder advanced settings tooltip + dialog description

### DIFF
--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -43,7 +43,7 @@ export function SkillBuilderIsDefaultSection() {
           Allow agents to discover this skill
         </span>
         <Tooltip
-          label="Agents with the Discover Skills tool will be able to find and enable this skill on their own."
+          label="This skill will be set as default. Agents with Discover Skills will be able to find and enable it on their own"
           trigger={
             <InformationCircleIcon className="text-muted-foreground dark:text-muted-foreground-night h-4 w-4" />
           }
@@ -61,8 +61,9 @@ export function SkillBuilderIsDefaultSection() {
           <DialogHeader hideButton>
             <DialogTitle>Allow agents to discover this skill?</DialogTitle>
             <DialogDescription className="pt-4">
-              Agents with <span className="font-semibold">Discover Skills</span>{" "}
-              will be able to find and enable this skill on their own.
+              This skill will be set as default. Agents with&nbsp;
+              <span className="font-semibold">Discover Skills</span>&nbsp; will
+              be able to find and enable this skill on their own.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -63,7 +63,7 @@ export function SkillBuilderIsDefaultSection() {
             <DialogDescription className="pt-4">
               This skill will be set as default. Agents with&nbsp;
               <span className="font-semibold">Discover Skills</span>&nbsp; will
-              be able to find and enable this skill on their own.
+              be able to find and enable it on their own.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter


### PR DESCRIPTION
## Description

- This PR update the dialog description for setting a skill as being discoverable to follow the design in https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=4328-97040&t=jptsMtXPivZc5zHO-0

<img width="970" height="404" alt="Screenshot 2026-03-17 at 6 09 54 PM" src="https://github.com/user-attachments/assets/ce874eba-8f35-4ba6-b378-942583f4384f" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
