### PR TITLE
Upload multiple tabs, update stakes

### DIFF
--- a/extension/platforms/chrome/page.ts
+++ b/extension/platforms/chrome/page.ts
@@ -224,7 +224,7 @@ declare global {
         if (callback) {
           callback(
             screenshots.map((screenshot) =>
-              screenshot.canvas.toDataURL("image/jpeg", 0.8)
+              screenshot.canvas.toDataURL("image/jpeg", 0.6)
             )
           );
         }

--- a/extension/platforms/chrome/tools/attachPageTextTool.ts
+++ b/extension/platforms/chrome/tools/attachPageTextTool.ts
@@ -3,43 +3,59 @@ import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/to
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@extension/shared/lib/utils";
 import type { CaptureService } from "@extension/shared/services/capture";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * Registers the attach_page_text tool with the MCP server.
  * Extracts the text content of a browser tab.
  */
-export async function attachPageTextTool({
-  tabId,
+export async function attachTabsTextTool({
+  tabIds,
   captureService,
 }: {
-  tabId: number;
+  tabIds: number[];
   captureService: CaptureService | null;
 }): Promise<ToolHandlerResult> {
   if (!captureService) {
     return new Err(new MCPError("Capture service not available."));
   }
 
-  try {
-    const result = await captureService.handleOperation(
-      "capture-page-content",
-      { includeContent: true, includeCapture: false, tabId }
-    );
+  const results: CallToolResult["content"] = [];
+  const errors: Error[] = [];
 
-    if (result.isErr()) {
-      return new Err(new MCPError(`Error: ${result.error.message}`));
+  if (tabIds.length === 0) {
+    return new Err(new MCPError("No tabs specified."));
+  }
+
+  for (const tabId of tabIds) {
+    try {
+      const result = await captureService.handleOperation(
+        "capture-page-content",
+        { includeContent: true, includeCapture: false, tabId }
+      );
+
+      if (result.isErr()) {
+        return new Err(new MCPError(`Error: ${result.error.message}`));
+      }
+
+      const { title, url, content } = result.value;
+      const parts = [`Title: ${title}`, `URL: ${url}`];
+      if (content) {
+        parts.push(`Content:\n${content}`);
+      }
+
+      results.push({ type: "text", text: parts.join("\n") });
+    } catch (error) {
+      errors.push(normalizeError(error));
     }
+  }
 
-    const { title, url, content } = result.value;
-    const parts = [`Title: ${title}`, `URL: ${url}`];
-    if (content) {
-      parts.push(`Content:\n${content}`);
-    }
-
-    return new Ok([{ type: "text", text: parts.join("\n") }]);
-  } catch (error) {
+  if (results.length === 0) {
     return new Err(
-      new MCPError(normalizeError(error).message) ??
+      new MCPError(errors.map((error) => error.message).join("\n")) ??
         "An unknown error occurred while capturing page content."
     );
   }
+
+  return new Ok(results);
 }

--- a/extension/platforms/chrome/tools/index.ts
+++ b/extension/platforms/chrome/tools/index.ts
@@ -3,7 +3,7 @@ import {
   buildClientTools,
   type ClientToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { attachPageTextTool } from "@extension/platforms/chrome/tools/attachPageTextTool";
+import { attachTabsTextTool } from "@extension/platforms/chrome/tools/attachPageTextTool";
 import {
   closeBrowserTabTool,
   moveBrowserTabTool,
@@ -28,8 +28,8 @@ export function registerAllTools(
   workspaceId: string
 ): void {
   const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
-    attach_page_text: (params) =>
-      attachPageTextTool({ ...params, captureService }),
+    attach_tabs_text: (params) =>
+      attachTabsTextTool({ ...params, captureService }),
     take_screenshot_or_attach_file: (params) =>
       takeScreenshotOrAttachFileTool({
         ...params,

--- a/extension/platforms/chrome/tools/takeScreenshotOrAttachFileTool.ts
+++ b/extension/platforms/chrome/tools/takeScreenshotOrAttachFileTool.ts
@@ -6,6 +6,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { normalizeError } from "@extension/shared/lib/utils";
 import type { CaptureService } from "@extension/shared/services/capture";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // Max characters of extracted text to include inline in the tool result.
 // The full content is also indexed in the conversation JIT data source.
@@ -104,11 +105,11 @@ async function uploadPdf(
  * Captures a screenshot or attaches the file content of a browser tab.
  */
 export async function takeScreenshotOrAttachFileTool({
-  tabId,
+  tabIds,
   captureService,
   workspaceId,
 }: {
-  tabId: number;
+  tabIds: number[];
   captureService: CaptureService | null;
   workspaceId: string;
 }): Promise<ToolHandlerResult> {
@@ -116,70 +117,91 @@ export async function takeScreenshotOrAttachFileTool({
     return new Err(new MCPError("Capture service not available."));
   }
 
-  try {
-    const result = await captureService.handleOperation(
-      "capture-page-content",
-      { includeContent: false, includeCapture: true, tabId }
-    );
+  const results: CallToolResult["content"] = [];
+  const errors: Error[] = [];
 
-    if (result.isErr()) {
-      return new Err(new MCPError(`Error: ${result.error.message}`));
-    }
+  if (tabIds.length === 0) {
+    return new Err(new MCPError("No tabs specified."));
+  }
 
-    const { captures, fileData } = result.value;
+  for (const tabId of tabIds) {
+    try {
+      const result = await captureService.handleOperation(
+        "capture-page-content",
+        { includeContent: false, includeCapture: true, tabId }
+      );
 
-    if (fileData) {
-      const { base64, mimeType, url } = fileData;
+      if (result.isErr()) {
+        errors.push(new MCPError(`Error: ${result.error.message}`));
+        continue;
+      }
 
-      if (mimeType === "application/pdf") {
-        const data = await uploadPdf(workspaceId, base64, mimeType, url);
-        if (data) {
-          // The MCP SDK strips non-standard fields from resource objects during
-          // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
-          // so they survive the MCP protocol round-trip. The server will move
-          // them back to the root level in mcp_actions.ts (tryCallMCPTool).
-          const resource = {
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-            uri: `/api/w/${workspaceId}/files/${data.fileId}`,
-            text: data.extractedText ?? `PDF from ${url}`,
-            _meta: {
-              fileId: data.fileId,
-              title: data.fileName,
-              contentType: mimeType,
-              snippet: data.extractedText
-                ? data.extractedText.slice(0, 500)
-                : null,
-            },
-          };
-          return new Ok([{ type: "resource" as const, resource }]);
+      const { captures, fileData } = result.value;
+
+      if (fileData) {
+        const { base64, mimeType, url } = fileData;
+
+        if (mimeType === "application/pdf") {
+          const data = await uploadPdf(workspaceId, base64, mimeType, url);
+          if (data) {
+            // The MCP SDK strips non-standard fields from resource objects during
+            // parsing. We store Dust-specific fields (fileId, title, etc.) in _meta
+            // so they survive the MCP protocol round-trip. The server will move
+            // them back to the root level in mcp_actions.ts (tryCallMCPTool).
+            const resource = {
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+              uri: `/api/w/${workspaceId}/files/${data.fileId}`,
+              text: data.extractedText ?? `PDF from ${url}`,
+              _meta: {
+                fileId: data.fileId,
+                title: data.fileName,
+                contentType: mimeType,
+                snippet: data.extractedText
+                  ? data.extractedText.slice(0, 500)
+                  : null,
+              },
+            };
+            results.push({ type: "resource" as const, resource });
+            continue;
+          }
+          errors.push(
+            new MCPError(
+              "Failed to process the PDF. It may be too large or inaccessible."
+            )
+          );
+          continue;
         }
-        return new Err(
-          new MCPError(
-            "Failed to process the PDF. It may be too large or inaccessible."
-          )
-        );
+
+        // For images, return the raw image so the model can analyze it visually.
+        if (mimeType.startsWith("image/")) {
+          results.push({ type: "image" as const, data: base64, mimeType });
+          continue;
+        }
       }
 
-      // For images, return the raw image so the model can analyze it visually.
-      if (mimeType.startsWith("image/")) {
-        return new Ok([{ type: "image" as const, data: base64, mimeType }]);
+      if (!captures || captures.length === 0) {
+        errors.push(new MCPError("No screenshot captured."));
+        continue;
       }
-    }
 
-    if (!captures || captures.length === 0) {
-      return new Err(new MCPError("No screenshot captured."));
+      results.push(
+        ...captures.map((dataUrl) => {
+          const [header, data] = dataUrl.split(",");
+          const mimeType = header.replace("data:", "").replace(";base64", "");
+          return { type: "image" as const, data, mimeType };
+        })
+      );
+    } catch (error) {
+      errors.push(normalizeError(error));
     }
+  }
 
-    return new Ok(
-      captures.map((dataUrl) => {
-        const [header, data] = dataUrl.split(",");
-        const mimeType = header.replace("data:", "").replace(";base64", "");
-        return { type: "image" as const, data, mimeType };
-      })
-    );
-  } catch (error) {
+  if (results.length === 0) {
     return new Err(
-      new MCPError(`Failed to capture page: ${normalizeError(error).message}`)
+      new MCPError(errors.map((error) => error.message).join("\n")) ??
+        "An unknown error occurred while capturing page content."
     );
   }
+
+  return new Ok(results);
 }

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -96,7 +96,7 @@ export function MCPToolValidationRequired({
     const args = blockedAction.argumentsRequiringApproval ?? [];
     const argValues = args
       .filter((arg) => blockedAction.inputs[arg] != null)
-      .map((arg) => `${blockedAction.inputs[arg]}`);
+      .map((arg) => JSON.stringify(blockedAction.inputs[arg]));
 
     return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
       argValues.length > 0

--- a/front/lib/actions/mcp_client_side/metadata.ts
+++ b/front/lib/actions/mcp_client_side/metadata.ts
@@ -2,17 +2,19 @@ import { createClientToolsRecord } from "@app/lib/actions/mcp_internal_actions/t
 import { z } from "zod";
 
 export const CHROME_TOOLS_METADATA = createClientToolsRecord({
-  attach_page_text: {
+  attach_tabs_text: {
     description:
       "Extracts the title, URL, and text content of a browser tab. " +
       "Use this to read and understand what the user is viewing. " +
       "For non-text pages (PDFs, images, etc.), use take_screenshot_or_attach_file instead — it will attach the file directly to the conversation." +
       "Use list_browser_tabs to discover tab IDs.",
     schema: {
-      tabId: z.number().describe("The tab ID to read."),
+      tabsToFetch: z
+        .string()
+        .describe("The list of tabs title, readable for the user."),
+      tabIds: z.number().array().describe("The tab IDs to read."),
     },
-    argumentsRequiringApproval: ["tabId"],
-    stake: "medium",
+    stake: "high",
     displayLabels: {
       running: "Getting page content...",
       done: "Page content retrieved",
@@ -26,10 +28,12 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       "For HTML pages, takes a screenshot for visual inspection (Drive canvas, dashboards, etc.)." +
       "Use list_browser_tabs to discover tab IDs.",
     schema: {
-      tabId: z.number().describe("The tab ID to capture."),
+      tabsToFetch: z
+        .string()
+        .describe("The list of tabs title, readable for the user."),
+      tabIds: z.number().array().describe("The tab IDs to capture."),
     },
-    argumentsRequiringApproval: ["tabId"],
-    stake: "medium",
+    stake: "high",
     displayLabels: {
       running: "Attaching tab content...",
       done: "Tab content attached",

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -159,12 +159,13 @@ export async function processToolResults(
     conversationId: conversation.sId,
   };
 
+  const timestamp = Date.now();
   const cleanContent: {
     content: CallToolResult["content"][number];
     file: FileResource | null;
   }[] = await concurrentExecutor(
     toolCallResultContent,
-    async (block) => {
+    async (block, idx) => {
       switch (block.type) {
         case "text": {
           // If the text is too large we create a file and return a resource block that references the file.
@@ -172,7 +173,7 @@ export async function processToolResults(
             computeTextByteSize(block.text) > MAX_TEXT_CONTENT_SIZE_BYTES &&
             toolConfiguration.mcpServerName !== "conversation_files"
           ) {
-            const fileName = `${toolConfiguration.mcpServerName}_${Date.now()}.txt`;
+            const fileName = `${toolConfiguration.mcpServerName}_${timestamp}_${idx}.txt`;
             const snippet =
               block.text.substring(0, MAXED_OUTPUT_FILE_SNIPPET_LENGTH) +
               "... (truncated)";
@@ -206,7 +207,7 @@ export async function processToolResults(
         case "image": {
           const fileName = isResourceWithName(block)
             ? block.name
-            : `generated-image-${Date.now()}${extensionsForContentType(block.mimeType as any)[0]}`;
+            : `generated-image-${timestamp}_${idx}${extensionsForContentType(block.mimeType as any)[0]}`;
 
           return handleBase64Upload(auth, {
             base64Data: block.data,

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -296,6 +296,15 @@ export class BrowserMCPTransport implements Transport {
    * Send a message to the server.
    * This method is required by the Transport interface.
    */
+  private async postResult(body: string): Promise<Response> {
+    return clientFetch(`/api/w/${this.workspaceId}/mcp/results`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body,
+    });
+  }
+
   async send(message: JSONRPCMessage): Promise<void> {
     if (!this.serverId) {
       console.error("[BrowserMCPTransport] Server ID is not set");
@@ -303,33 +312,57 @@ export class BrowserMCPTransport implements Transport {
     }
 
     try {
-      // Send tool results back to Dust via HTTP POST.
-      const response = await clientFetch(
-        `/api/w/${this.workspaceId}/mcp/results`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          credentials: "include",
-          body: JSON.stringify({
-            serverId: this.serverId,
-            result: message,
-          }),
-        }
-      );
+      const body = JSON.stringify({
+        serverId: this.serverId,
+        result: message,
+      });
+
+      const response = await this.postResult(body);
 
       if (!response.ok) {
         let errorData: unknown;
         try {
-          errorData = await response.json();
+          const text = await response.text();
+          try {
+            errorData = JSON.parse(text);
+          } catch {
+            errorData = text;
+          }
         } catch {
-          errorData = await response.text();
+          errorData = `HTTP ${response.status}`;
         }
         console.error(
           "[BrowserMCPTransport] Failed to send MCP result:",
           errorData
         );
+
+        // If the payload was too large and this was a response (has an id),
+        // re-send as an error response so the server doesn't hang.
+        if (response.status === 413 && "id" in message && message.id) {
+          console.warn(
+            "[BrowserMCPTransport] Payload too large, sending error response instead"
+          );
+          const errorBody = JSON.stringify({
+            serverId: this.serverId,
+            result: {
+              jsonrpc: "2.0",
+              id: message.id,
+              error: {
+                code: -32000,
+                message:
+                  "Tool result too large to send. Try capturing fewer screenshots or smaller content.",
+              },
+            },
+          });
+          const errorResponse = await this.postResult(errorBody);
+          if (!errorResponse.ok) {
+            console.error(
+              "[BrowserMCPTransport] Failed to send error response"
+            );
+          }
+          return;
+        }
+
         this.onerror?.(
           new Error(`Failed to send MCP result: ${response.status}`)
         );

--- a/front/pages/api/w/[wId]/mcp/results.ts
+++ b/front/pages/api/w/[wId]/mcp/results.ts
@@ -10,6 +10,14 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "16mb",
+    },
+  },
+};
+
 const PostMCPResultsRequestBodyCodec = t.type({
   result: t.unknown,
   serverId: t.string,


### PR DESCRIPTION
## Description

Update `attach_page_text` and `take_screenshot_or_attach_file` extension tools to support multiple tabs in a single call:

- Rename `attach_page_text` → `attach_tabs_text`, accept `tabIds: number[]` instead of `tabId: number`
- Update `take_screenshot_or_attach_file` to also accept `tabIds: number[]`
- Add a `tabsToFetch` string param for user-readable display of which tabs are being accessed
- Raise stake from `medium` to `high` (multi-tab access is more sensitive)
- Remove per-arg approval (`argumentsRequiringApproval`) since the high stake already triggers approval
- Fix approval label rendering: use `JSON.stringify` for arg values so arrays display correctly
- Both tools now loop over tabs, collect results, and return aggregated content/errors

## Tests

Manual testing with the Chrome extension.

## Risk

Low — the tools are additive (superset of previous behavior). Agents that previously passed a single `tabId` will need to pass `tabIds` array instead, but metadata update ensures they get the new schema.

## Deploy Plan

Standard deploy, no migration needed.