### PR TITLE
[MCP Views] Notify admins about affected agents on global share

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -509,10 +509,12 @@ describe("tryCallMCPTool", () => {
 
     const mcpServerView =
       existingView ??
-      (await MCPServerViewResource.create(auth, {
-        systemView,
-        space: systemSpace,
-      }));
+      (
+        await MCPServerViewResource.create(auth, {
+          systemView,
+          space: systemSpace,
+        })
+      ).view;
 
     // Create agent configuration and conversation
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -11,6 +11,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import sgMail from "@sendgrid/mail";
+import { escape } from "html-escaper";
 
 let sgMailClient: typeof sgMail | null = null;
 
@@ -212,6 +213,34 @@ export async function sendCreditUsageAlertEmail({
         <li>Learn more about <a href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e">programmatic usage at Dust</a></li>
       </ul>
       <p>Please reply to this email if you have any questions.</p>`,
+  });
+}
+
+export async function sendMCPGlobalSharingReconfigurationEmail({
+  email,
+  workspaceName,
+  toolName,
+  agentNames,
+}: {
+  email: string;
+  workspaceName: string;
+  toolName: string;
+  agentNames: string[];
+}): Promise<Result<void, Error>> {
+  const agentsList = agentNames
+    .map((agentName) => `<li>${escape(agentName)}</li>`)
+    .join("");
+
+  return sendEmailWithTemplate({
+    to: email,
+    from: config.getSupportEmailAddress(),
+    subject: `[Dust] Agents to reconfigure after sharing ${toolName}`,
+    body: `
+      <p>You're receiving this as Admin of the Dust workspace <strong>${escape(workspaceName)}</strong>.</p>
+      <p>The tool <strong>${escape(toolName)}</strong> was just made available to all workspace members.</p>
+      <p>This removes older space-specific versions of the same tool. The following agents may need to be reconfigured:</p>
+      <ul>${agentsList}</ul>
+      <p>Please review these agents and re-add the tool if needed.</p>`,
   });
 }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -189,6 +189,17 @@ export async function getMembers(
   };
 }
 
+export async function getActiveAdminEmails(
+  auth: Authenticator
+): Promise<string[]> {
+  const { members } = await getMembers(auth, {
+    roles: ["admin"],
+    activeOnly: true,
+  });
+
+  return Array.from(new Set(members.map((member) => member.email)));
+}
+
 export async function searchMembers(
   auth: Authenticator,
   options: {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -354,20 +354,26 @@ describe("fetchMCPServerViews", () => {
         remoteMCPServer1.sId
       );
     assert(systemView1, "MCP server view not found");
-    const mcpServerView1 = await MCPServerViewResource.create(authenticator, {
-      systemView: systemView1,
-      space: globalSpace,
-    });
+    const { view: mcpServerView1 } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView: systemView1,
+        space: globalSpace,
+      }
+    );
     const systemView2 =
       await MCPServerViewResource.getMCPServerViewForSystemSpace(
         authenticator,
         remoteMCPServer2.sId
       );
     assert(systemView2, "MCP server view not found");
-    const mcpServerView2 = await MCPServerViewResource.create(authenticator, {
-      systemView: systemView2,
-      space: globalSpace,
-    });
+    const { view: mcpServerView2 } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView: systemView2,
+        space: globalSpace,
+      }
+    );
     assert(mcpServerView1, "MCP server view not found");
     assert(mcpServerView2, "MCP server view not found");
 
@@ -417,10 +423,13 @@ describe("fetchMCPServerViews", () => {
         remoteMCPServer.sId
       );
     assert(systemView, "MCP server view not found");
-    const mcpServerView = await MCPServerViewResource.create(authenticator, {
-      systemView,
-      space: globalSpace,
-    });
+    const { view: mcpServerView } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView,
+        space: globalSpace,
+      }
+    );
 
     // Create one enabled and one disabled relationship
     await ConversationResource.upsertMCPServerViews(authenticator, {
@@ -438,10 +447,13 @@ describe("fetchMCPServerViews", () => {
         remoteMCPServer2.sId
       );
     assert(systemView2, "MCP server view not found");
-    const mcpServerView2 = await MCPServerViewResource.create(authenticator, {
-      systemView: systemView2,
-      space: globalSpace,
-    });
+    const { view: mcpServerView2 } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView: systemView2,
+        space: globalSpace,
+      }
+    );
 
     await ConversationResource.upsertMCPServerViews(authenticator, {
       conversation: conversation,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -236,7 +236,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       return [];
     }
 
-    const workspaceId = auth.getNonNullableWorkspace().id;
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
     const query = `
       SELECT DISTINCT ranked_agents.name
       FROM (
@@ -246,7 +246,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
                  ORDER BY ac.version DESC
                ) AS rn
         FROM agent_configurations ac
-        WHERE ac."workspaceId" = :workspaceId
+        WHERE ac."workspaceId" = :workspaceModelId
       ) ranked_agents
       INNER JOIN agent_mcp_server_configurations amsc
         ON amsc."agentConfigurationId" = ranked_agents.id
@@ -263,7 +263,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     const rows =
       (await AgentConfigurationModel.sequelize?.query<AgentNameRow>(query, {
         replacements: {
-          workspaceId,
+          workspaceModelId,
           mcpServerViewIds: regularViewIds,
         },
         type: SequelizeQueryTypes.SELECT,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -15,6 +15,7 @@ import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions/ena
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/mcp_server_view_helper";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
@@ -47,7 +48,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
-import { Op, QueryTypes as SequelizeQueryTypes } from "sequelize";
+import { Op } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -224,52 +225,121 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return view;
   }
 
-  static async listLatestActiveAgentNamesToReconfigureOnGlobalShare(
+  static async createWithAffectedAgentNames(
+    auth: Authenticator,
+    {
+      systemView,
+      space,
+    }: {
+      systemView: MCPServerViewResource;
+      space: SpaceResource;
+    }
+  ): Promise<{
+    serverView: MCPServerViewResource;
+    affectedAgentNames: string[];
+  }> {
+    const affectedAgentNames =
+      space.kind === "global"
+        ? await this.listLatestActiveAgentNamesToReconfigureOnGlobalShare(
+            auth,
+            systemView.mcpServerId
+          )
+        : [];
+
+    const serverView = await this.create(auth, {
+      systemView,
+      space,
+    });
+
+    return { serverView, affectedAgentNames };
+  }
+
+  private static async listLatestActiveAgentNamesToReconfigureOnGlobalShare(
     auth: Authenticator,
     mcpServerId: string
   ): Promise<string[]> {
-    const regularViewIds = (await this.listByMCPServer(auth, mcpServerId))
+    const regularMCPServerViewModelIds = (
+      await this.listByMCPServer(auth, mcpServerId)
+    )
       .filter((view) => view.space.kind === "regular")
       .map((view) => view.id);
 
-    if (regularViewIds.length === 0) {
+    if (regularMCPServerViewModelIds.length === 0) {
       return [];
     }
 
     const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const query = `
-      SELECT DISTINCT ranked_agents.name
-      FROM (
-        SELECT ac.*,
-               ROW_NUMBER() OVER (
-                 PARTITION BY ac."sId"
-                 ORDER BY ac.version DESC
-               ) AS rn
-        FROM agent_configurations ac
-        WHERE ac."workspaceId" = :workspaceModelId
-      ) ranked_agents
-      INNER JOIN agent_mcp_server_configurations amsc
-        ON amsc."agentConfigurationId" = ranked_agents.id
-      WHERE ranked_agents.rn = 1
-        AND ranked_agents.status = 'active'
-        AND amsc."mcpServerViewId" IN (:mcpServerViewIds)
-      ORDER BY ranked_agents.name ASC
-    `;
-
-    type AgentNameRow = {
-      name: string;
-    };
-
-    const rows =
-      (await AgentConfigurationModel.sequelize?.query<AgentNameRow>(query, {
-        replacements: {
-          workspaceModelId,
-          mcpServerViewIds: regularViewIds,
+    const impactedMCPServerConfigurations =
+      await AgentMCPServerConfigurationModel.findAll({
+        where: {
+          workspaceId: workspaceModelId,
+          mcpServerViewId: {
+            [Op.in]: regularMCPServerViewModelIds,
+          },
         },
-        type: SequelizeQueryTypes.SELECT,
-      })) ?? [];
+        attributes: ["agentConfigurationId"],
+      });
 
-    return uniq(rows.map((row) => row.name));
+    const impactedAgentConfigurationModelIds = new Set(
+      impactedMCPServerConfigurations.map(
+        (configuration) => configuration.agentConfigurationId
+      )
+    );
+
+    if (impactedAgentConfigurationModelIds.size === 0) {
+      return [];
+    }
+
+    const impactedAgentConfigurations = await AgentConfigurationModel.findAll({
+      where: {
+        workspaceId: workspaceModelId,
+        id: {
+          [Op.in]: Array.from(impactedAgentConfigurationModelIds),
+        },
+      },
+      attributes: ["sId"],
+    });
+
+    const impactedAgentSIds = uniq(
+      impactedAgentConfigurations.map((configuration) => configuration.sId)
+    );
+
+    if (impactedAgentSIds.length === 0) {
+      return [];
+    }
+
+    const agentConfigurations = await AgentConfigurationModel.findAll({
+      where: {
+        workspaceId: workspaceModelId,
+        sId: {
+          [Op.in]: impactedAgentSIds,
+        },
+      },
+      attributes: ["id", "sId", "name", "status", "version"],
+      order: [["version", "DESC"]],
+    });
+
+    const latestAgentConfigurations = new Map<
+      string,
+      AgentConfigurationModel
+    >();
+    for (const agentConfiguration of agentConfigurations) {
+      if (!latestAgentConfigurations.has(agentConfiguration.sId)) {
+        latestAgentConfigurations.set(
+          agentConfiguration.sId,
+          agentConfiguration
+        );
+      }
+    }
+
+    return Array.from(latestAgentConfigurations.values())
+      .filter(
+        (agentConfiguration) =>
+          agentConfiguration.status === "active" &&
+          impactedAgentConfigurationModelIds.has(agentConfiguration.id)
+      )
+      .map((agentConfiguration) => agentConfiguration.name)
+      .sort((left, right) => left.localeCompare(right));
   }
 
   // Fetching.

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -55,11 +55,15 @@ import { Op } from "sequelize";
 export interface MCPServerViewResource
   extends ReadonlyAttributesType<MCPServerViewModel> {}
 
+export type MCPServerViewCreationResult = {
+  view: MCPServerViewResource;
+  affectedAgents?: Attributes<AgentConfigurationModel>[];
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel> {
   static model: ModelStatic<MCPServerViewModel> = MCPServerViewModel;
   readonly editedByUser?: Attributes<UserModel>;
-  affectedAgents?: Attributes<AgentConfigurationModel>[];
   private internalToolsMetadata?: Attributes<RemoteMCPServerToolMetadataModel>[];
   private remoteToolsMetadata?: Attributes<RemoteMCPServerToolMetadataModel>[];
   private remoteMCPServer?: RemoteMCPServerResource;
@@ -188,7 +192,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       systemView: MCPServerViewResource;
       space: SpaceResource;
     }
-  ): Promise<MCPServerViewResource> {
+  ): Promise<MCPServerViewCreationResult> {
     if (systemView.space.kind !== "system") {
       throw new Error(
         "You must pass the system view to create a new MCP server view"
@@ -197,42 +201,39 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
     const mcpServerId = systemView.mcpServerId;
     const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
-    const affectedAgents =
-      space.kind === "global"
-        ? await this.listLatestActiveAgentsToReconfigureOnGlobalShare(
-            auth,
-            mcpServerId
-          )
-        : undefined;
+    const blob = {
+      serverType,
+      internalMCPServerId: serverType === "internal" ? mcpServerId : null,
+      remoteMCPServerId: serverType === "remote" ? id : null,
+      // Always copy the oAuthUseCase, name and description from the system view to the custom view.
+      // This way, it's always available on the MCP server view without having to fetch the system view.
+      oAuthUseCase: systemView.oAuthUseCase,
+      name: systemView.name,
+      description: systemView.description,
+    };
 
     if (space.kind === "global") {
+      const affectedAgents =
+        await this.listLatestActiveAgentsToReconfigureOnGlobalShare(
+          auth,
+          mcpServerId
+        );
       const mcpServerViews = await this.listByMCPServer(auth, mcpServerId);
       for (const mcpServerView of mcpServerViews) {
         if (mcpServerView.space.kind === "regular") {
           await mcpServerView.delete(auth, { hardDelete: true });
         }
       }
+
+      return {
+        view: await this.makeNew(auth, blob, space, auth.user() ?? undefined),
+        affectedAgents,
+      };
     }
 
-    const view = await this.makeNew(
-      auth,
-      {
-        serverType,
-        internalMCPServerId: serverType === "internal" ? mcpServerId : null,
-        remoteMCPServerId: serverType === "remote" ? id : null,
-        // Always copy the oAuthUseCase, name and description from the system view to the custom view.
-        // This way, it's always available on the MCP server view without having to fetch the system view.
-        oAuthUseCase: systemView.oAuthUseCase,
-        name: systemView.name,
-        description: systemView.description,
-      },
-      space,
-      auth.user() ?? undefined
-    );
-
-    view.affectedAgents = affectedAgents;
-
-    return view;
+    return {
+      view: await this.makeNew(auth, blob, space, auth.user() ?? undefined),
+    };
   }
 
   private static async listLatestActiveAgentsToReconfigureOnGlobalShare(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -59,6 +59,7 @@ export interface MCPServerViewResource
 export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel> {
   static model: ModelStatic<MCPServerViewModel> = MCPServerViewModel;
   readonly editedByUser?: Attributes<UserModel>;
+  affectedAgents?: Attributes<AgentConfigurationModel>[];
   private internalToolsMetadata?: Attributes<RemoteMCPServerToolMetadataModel>[];
   private remoteToolsMetadata?: Attributes<RemoteMCPServerToolMetadataModel>[];
   private remoteMCPServer?: RemoteMCPServerResource;
@@ -196,6 +197,13 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
     const mcpServerId = systemView.mcpServerId;
     const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
+    const affectedAgents =
+      space.kind === "global"
+        ? await this.listLatestActiveAgentsToReconfigureOnGlobalShare(
+            auth,
+            mcpServerId
+          )
+        : undefined;
 
     if (space.kind === "global") {
       const mcpServerViews = await this.listByMCPServer(auth, mcpServerId);
@@ -222,42 +230,15 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       auth.user() ?? undefined
     );
 
+    view.affectedAgents = affectedAgents;
+
     return view;
   }
 
-  static async createWithAffectedAgentNames(
-    auth: Authenticator,
-    {
-      systemView,
-      space,
-    }: {
-      systemView: MCPServerViewResource;
-      space: SpaceResource;
-    }
-  ): Promise<{
-    serverView: MCPServerViewResource;
-    affectedAgentNames: string[];
-  }> {
-    const affectedAgentNames =
-      space.kind === "global"
-        ? await this.listLatestActiveAgentNamesToReconfigureOnGlobalShare(
-            auth,
-            systemView.mcpServerId
-          )
-        : [];
-
-    const serverView = await this.create(auth, {
-      systemView,
-      space,
-    });
-
-    return { serverView, affectedAgentNames };
-  }
-
-  private static async listLatestActiveAgentNamesToReconfigureOnGlobalShare(
+  private static async listLatestActiveAgentsToReconfigureOnGlobalShare(
     auth: Authenticator,
     mcpServerId: string
-  ): Promise<string[]> {
+  ): Promise<Attributes<AgentConfigurationModel>[]> {
     const regularMCPServerViewModelIds = (
       await this.listByMCPServer(auth, mcpServerId)
     )
@@ -338,8 +319,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           agentConfiguration.status === "active" &&
           impactedAgentConfigurationModelIds.has(agentConfiguration.id)
       )
-      .map((agentConfiguration) => agentConfiguration.name)
-      .sort((left, right) => left.localeCompare(right));
+      .map((agentConfiguration) => agentConfiguration.get())
+      .sort((left, right) => left.name.localeCompare(right.name));
   }
 
   // Fetching.

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -18,6 +18,7 @@ import { DustError } from "@app/lib/error";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/mcp_server_view_helper";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
@@ -46,7 +47,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
-import { Op } from "sequelize";
+import { Op, QueryTypes as SequelizeQueryTypes } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -221,6 +222,54 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     );
 
     return view;
+  }
+
+  static async listLatestActiveAgentNamesToReconfigureOnGlobalShare(
+    auth: Authenticator,
+    mcpServerId: string
+  ): Promise<string[]> {
+    const regularViewIds = (await this.listByMCPServer(auth, mcpServerId))
+      .filter((view) => view.space.kind === "regular")
+      .map((view) => view.id);
+
+    if (regularViewIds.length === 0) {
+      return [];
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const query = `
+      SELECT DISTINCT ranked_agents.name
+      FROM (
+        SELECT ac.*,
+               ROW_NUMBER() OVER (
+                 PARTITION BY ac."sId"
+                 ORDER BY ac.version DESC
+               ) AS rn
+        FROM agent_configurations ac
+        WHERE ac."workspaceId" = :workspaceId
+      ) ranked_agents
+      INNER JOIN agent_mcp_server_configurations amsc
+        ON amsc."agentConfigurationId" = ranked_agents.id
+      WHERE ranked_agents.rn = 1
+        AND ranked_agents.status = 'active'
+        AND amsc."mcpServerViewId" IN (:mcpServerViewIds)
+      ORDER BY ranked_agents.name ASC
+    `;
+
+    type AgentNameRow = {
+      name: string;
+    };
+
+    const rows =
+      (await AgentConfigurationModel.sequelize?.query<AgentNameRow>(query, {
+        replacements: {
+          workspaceId,
+          mcpServerViewIds: regularViewIds,
+        },
+        type: SequelizeQueryTypes.SELECT,
+      })) ?? [];
+
+    return uniq(rows.map((row) => row.name));
   }
 
   // Fetching.

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -55,9 +55,14 @@ import { Op } from "sequelize";
 export interface MCPServerViewResource
   extends ReadonlyAttributesType<MCPServerViewModel> {}
 
+type AffectedAgent = Pick<
+  Attributes<AgentConfigurationModel>,
+  "id" | "sId" | "name"
+>;
+
 export type MCPServerViewCreationResult = {
   view: MCPServerViewResource;
-  affectedAgents?: Attributes<AgentConfigurationModel>[];
+  affectedAgents?: AffectedAgent[];
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -213,39 +218,50 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     };
 
     if (space.kind === "global") {
+      const mcpServerViews = await this.listByMCPServer(auth, mcpServerId);
+      const regularMCPServerViewModelIds = mcpServerViews
+        .filter((view) => view.space.kind === "regular")
+        .map((view) => view.id);
       const affectedAgents =
         await this.listLatestActiveAgentsToReconfigureOnGlobalShare(
           auth,
-          mcpServerId
+          regularMCPServerViewModelIds
         );
-      const mcpServerViews = await this.listByMCPServer(auth, mcpServerId);
       for (const mcpServerView of mcpServerViews) {
         if (mcpServerView.space.kind === "regular") {
           await mcpServerView.delete(auth, { hardDelete: true });
         }
       }
 
+      const view = await this.makeNew(
+        auth,
+        blob,
+        space,
+        auth.user() ?? undefined
+      );
+
       return {
-        view: await this.makeNew(auth, blob, space, auth.user() ?? undefined),
+        view,
         affectedAgents,
       };
     }
 
+    const view = await this.makeNew(
+      auth,
+      blob,
+      space,
+      auth.user() ?? undefined
+    );
+
     return {
-      view: await this.makeNew(auth, blob, space, auth.user() ?? undefined),
+      view,
     };
   }
 
   private static async listLatestActiveAgentsToReconfigureOnGlobalShare(
     auth: Authenticator,
-    mcpServerId: string
-  ): Promise<Attributes<AgentConfigurationModel>[]> {
-    const regularMCPServerViewModelIds = (
-      await this.listByMCPServer(auth, mcpServerId)
-    )
-      .filter((view) => view.space.kind === "regular")
-      .map((view) => view.id);
-
+    regularMCPServerViewModelIds: ModelId[]
+  ): Promise<AffectedAgent[]> {
     if (regularMCPServerViewModelIds.length === 0) {
       return [];
     }
@@ -272,11 +288,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       attributes: ["id", "sId"],
     });
 
-    const impactedAgentConfigurationModelIds = new Set(
+    const impactedAgentIds = new Set(
       impactedAgentConfigurations.map((configuration) => configuration.id)
     );
 
-    if (impactedAgentConfigurationModelIds.size === 0) {
+    if (impactedAgentIds.size === 0) {
       return [];
     }
 
@@ -318,10 +334,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return Array.from(latestAgentConfigurations.values())
       .filter(
         (agentConfiguration) =>
-          agentConfiguration.status === "active" &&
-          impactedAgentConfigurationModelIds.has(agentConfiguration.id)
+          impactedAgentIds.has(agentConfiguration.id) &&
+          agentConfiguration.status === "active"
       )
-      .map((agentConfiguration) => agentConfiguration.get())
+      .map((agentConfiguration) => ({
+        id: agentConfiguration.id,
+        sId: agentConfiguration.sId,
+        name: agentConfiguration.name,
+      }))
       .sort((left, right) => left.name.localeCompare(right.name));
   }
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -251,36 +251,34 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     }
 
     const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const impactedMCPServerConfigurations =
-      await AgentMCPServerConfigurationModel.findAll({
-        where: {
-          workspaceId: workspaceModelId,
-          mcpServerViewId: {
-            [Op.in]: regularMCPServerViewModelIds,
+    const impactedAgentConfigurations = await AgentConfigurationModel.findAll({
+      where: {
+        workspaceId: workspaceModelId,
+      },
+      include: [
+        {
+          model: AgentMCPServerConfigurationModel,
+          as: "mcpServerConfigurations",
+          required: true,
+          where: {
+            workspaceId: workspaceModelId,
+            mcpServerViewId: {
+              [Op.in]: regularMCPServerViewModelIds,
+            },
           },
+          attributes: [],
         },
-        attributes: ["agentConfigurationId"],
-      });
+      ],
+      attributes: ["id", "sId"],
+    });
 
     const impactedAgentConfigurationModelIds = new Set(
-      impactedMCPServerConfigurations.map(
-        (configuration) => configuration.agentConfigurationId
-      )
+      impactedAgentConfigurations.map((configuration) => configuration.id)
     );
 
     if (impactedAgentConfigurationModelIds.size === 0) {
       return [];
     }
-
-    const impactedAgentConfigurations = await AgentConfigurationModel.findAll({
-      where: {
-        workspaceId: workspaceModelId,
-        id: {
-          [Op.in]: Array.from(impactedAgentConfigurationModelIds),
-        },
-      },
-      attributes: ["sId"],
-    });
 
     const impactedAgentSIds = uniq(
       impactedAgentConfigurations.map((configuration) => configuration.sId)
@@ -298,7 +296,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         },
       },
       attributes: ["id", "sId", "name", "status", "version"],
-      order: [["version", "DESC"]],
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
     });
 
     const latestAgentConfigurations = new Map<

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -98,10 +98,13 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/tools", () => {
         remoteMCPServer.sId
       );
     assert(systemView, "MCP server view not found");
-    const mcpServerView = await MCPServerViewResource.create(adminAuth, {
-      systemView,
-      space: globalSpace,
-    });
+    const { view: mcpServerView } = await MCPServerViewResource.create(
+      adminAuth,
+      {
+        systemView,
+        space: globalSpace,
+      }
+    );
 
     req.body = {
       action: "add",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -367,10 +367,13 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - additionalRequested
       );
     expect(systemMcpServerView).not.toBeNull();
 
-    const mcpServerView = await MCPServerViewResource.create(authenticator, {
-      systemView: systemMcpServerView!,
-      space: openSpace,
-    });
+    const { view: mcpServerView } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView: systemMcpServerView!,
+        space: openSpace,
+      }
+    );
 
     req.body = {
       assistant: {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -92,7 +92,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
         remoteMCPServer1.sId
       );
     assert(systemView1, "MCP server view not found");
-    const mcpServerView1 = await MCPServerViewResource.create(auth, {
+    const { view: mcpServerView1 } = await MCPServerViewResource.create(auth, {
       systemView: systemView1,
       space: globalSpace,
     });
@@ -102,7 +102,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
         remoteMCPServer2.sId
       );
     assert(systemView2, "MCP server view not found");
-    const mcpServerView2 = await MCPServerViewResource.create(auth, {
+    const { view: mcpServerView2 } = await MCPServerViewResource.create(auth, {
       systemView: systemView2,
       space: globalSpace,
     });
@@ -166,7 +166,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
           remoteMCPServer.sId
         );
       assert(systemView, "MCP server view not found");
-      const mcpServerView = await MCPServerViewResource.create(auth, {
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
         systemView,
         space: globalSpace,
       });
@@ -202,7 +202,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
           remoteMCPServer.sId
         );
       assert(systemView, "MCP server view not found");
-      const mcpServerView = await MCPServerViewResource.create(auth, {
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
         systemView,
         space: globalSpace,
       });
@@ -247,7 +247,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
           remoteMCPServer.sId
         );
       assert(systemView, "MCP server view not found");
-      const mcpServerView = await MCPServerViewResource.create(auth, {
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
         systemView,
         space: globalSpace,
       });
@@ -301,7 +301,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
           remoteMCPServer.sId
         );
       assert(systemView, "MCP server view not found");
-      const mcpServerView = await MCPServerViewResource.create(auth, {
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
         systemView,
         space: globalSpace,
       });
@@ -348,7 +348,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
           remoteMCPServer.sId
         );
       assert(systemView, "MCP server view not found");
-      const mcpServerView = await MCPServerViewResource.create(auth, {
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
         systemView,
         space: globalSpace,
       });
@@ -453,7 +453,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/tools", () => {
           remoteMCPServer.sId
         );
       assert(systemView, "MCP server view not found");
-      const mcpServerView = await MCPServerViewResource.create(
+      const { view: mcpServerView } = await MCPServerViewResource.create(
         await Authenticator.internalAdminForWorkspace(workspace.sId),
         {
           systemView,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -1,11 +1,32 @@
+import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { describe, expect, it } from "vitest";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
+
+vi.mock(import("@app/lib/api/email"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    sendMCPGlobalSharingReconfigurationEmail: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(sendMCPGlobalSharingReconfigurationEmail).mockReset();
+  vi.mocked(sendMCPGlobalSharingReconfigurationEmail).mockResolvedValue(
+    new Ok(undefined)
+  );
+});
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
   it("returns MCP servers views", async () => {
@@ -100,6 +121,159 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
     // Add the second server (same name) to a different space — should succeed.
     req.query.spaceId = regularSpace.sId;
     req.body = { mcpServerId: server2.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().success).toBe(true);
+  });
+
+  it("emails workspace admins with affected latest active agent names when sharing globally", async () => {
+    const {
+      req,
+      res,
+      workspace,
+      user,
+      authenticator,
+      globalSpace,
+      globalGroup,
+    } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "POST",
+    });
+
+    await SpaceFactory.defaults(authenticator);
+
+    const regularSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(regularSpace, globalGroup);
+
+    const extraAdmin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, extraAdmin, { role: "admin" });
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Notion",
+    });
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        authenticator,
+        server.sId
+      );
+
+    expect(systemView).not.toBeNull();
+
+    const regularView = await MCPServerViewResource.create(authenticator, {
+      systemView: systemView!,
+      space: regularSpace,
+    });
+
+    const impactedAgent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Needs Reconfiguration",
+      }
+    );
+    await AgentMCPServerConfigurationFactory.create(
+      authenticator,
+      regularSpace,
+      {
+        agent: impactedAgent,
+        mcpServerView: regularView,
+      }
+    );
+
+    const staleAgent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Stale Agent",
+      }
+    );
+    await AgentMCPServerConfigurationFactory.create(
+      authenticator,
+      regularSpace,
+      {
+        agent: staleAgent,
+        mcpServerView: regularView,
+      }
+    );
+    await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      staleAgent.sId,
+      {
+        name: "Stale Agent",
+      }
+    );
+
+    req.query.spaceId = globalSpace.sId;
+    req.body = { mcpServerId: server.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const emailCalls = vi
+      .mocked(sendMCPGlobalSharingReconfigurationEmail)
+      .mock.calls.map(([args]) => args);
+
+    expect(emailCalls).toHaveLength(2);
+    expect(emailCalls.map((call) => call.email).sort()).toEqual(
+      [user.email, extraAdmin.email].sort()
+    );
+    emailCalls.forEach((call) => {
+      expect(call.workspaceName).toBe(workspace.name);
+      expect(call.toolName).toBe("Notion");
+      expect(call.agentNames).toEqual(["Needs Reconfiguration"]);
+    });
+  });
+
+  it("does not fail the sharing request when the notification email fails", async () => {
+    vi.mocked(sendMCPGlobalSharingReconfigurationEmail).mockResolvedValue(
+      new Err(new Error("email failed"))
+    );
+
+    const { req, res, workspace, authenticator, globalSpace, globalGroup } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "POST",
+      });
+
+    await SpaceFactory.defaults(authenticator);
+
+    const regularSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(regularSpace, globalGroup);
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Notion",
+    });
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        authenticator,
+        server.sId
+      );
+
+    expect(systemView).not.toBeNull();
+
+    const regularView = await MCPServerViewResource.create(authenticator, {
+      systemView: systemView!,
+      space: regularSpace,
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Needs Reconfiguration",
+      }
+    );
+    await AgentMCPServerConfigurationFactory.create(
+      authenticator,
+      regularSpace,
+      {
+        agent,
+        mcpServerView: regularView,
+      }
+    );
+
+    req.query.spaceId = globalSpace.sId;
+    req.body = { mcpServerId: server.sId };
 
     await handler(req, res);
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -161,10 +161,13 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
 
     expect(systemView).not.toBeNull();
 
-    const regularView = await MCPServerViewResource.create(authenticator, {
-      systemView: systemView!,
-      space: regularSpace,
-    });
+    const { view: regularView } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView: systemView!,
+        space: regularSpace,
+      }
+    );
 
     const impactedAgent = await AgentConfigurationFactory.createTestAgent(
       authenticator,
@@ -252,10 +255,13 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
 
     expect(systemView).not.toBeNull();
 
-    const regularView = await MCPServerViewResource.create(authenticator, {
-      systemView: systemView!,
-      space: regularSpace,
-    });
+    const { view: regularView } = await MCPServerViewResource.create(
+      authenticator,
+      {
+        systemView: systemView!,
+        space: regularSpace,
+      }
+    );
 
     const agent = await AgentConfigurationFactory.createTestAgent(
       authenticator,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -1,4 +1,3 @@
-import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
@@ -8,24 +7,39 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { Err, Ok } from "@app/types/shared/result";
+import sgMail from "@sendgrid/mail";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
-vi.mock(import("@app/lib/api/email"), async (importOriginal) => {
+vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
     ...mod,
-    sendMCPGlobalSharingReconfigurationEmail: vi.fn(),
+    default: {
+      ...mod.default,
+      getSendgridApiKey: vi.fn().mockReturnValue("SG.test"),
+      getGenericEmailTemplate: vi.fn().mockReturnValue("d-test"),
+      getSupportEmailAddress: vi.fn().mockReturnValue({
+        name: "Dust team",
+        email: "support@dust.tt",
+      }),
+    },
   };
 });
 
+vi.spyOn(sgMail, "setApiKey").mockImplementation(() => {});
+vi.spyOn(sgMail, "send").mockResolvedValue([
+  { statusCode: 202, headers: {}, body: {} },
+  {},
+] as never);
+
 beforeEach(() => {
-  vi.mocked(sendMCPGlobalSharingReconfigurationEmail).mockReset();
-  vi.mocked(sendMCPGlobalSharingReconfigurationEmail).mockResolvedValue(
-    new Ok(undefined)
-  );
+  vi.clearAllMocks();
+  vi.mocked(sgMail.send).mockResolvedValue([
+    { statusCode: 202, headers: {}, body: {} },
+    {},
+  ] as never);
 });
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
@@ -213,25 +227,32 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
 
     expect(res._getStatusCode()).toBe(200);
 
-    const emailCalls = vi
-      .mocked(sendMCPGlobalSharingReconfigurationEmail)
-      .mock.calls.map(([args]) => args);
+    const sentMessages = vi.mocked(sgMail.send).mock.calls.map(([message]) => {
+      return message;
+    });
 
-    expect(emailCalls).toHaveLength(2);
-    expect(emailCalls.map((call) => call.email).sort()).toEqual(
+    expect(sentMessages).toHaveLength(2);
+    expect(sentMessages.flatMap((message) => message.to).sort()).toEqual(
       [user.email, extraAdmin.email].sort()
     );
-    emailCalls.forEach((call) => {
-      expect(call.workspaceName).toBe(workspace.name);
-      expect(call.toolName).toBe("Notion");
-      expect(call.agentNames).toEqual(["Needs Reconfiguration"]);
+    sentMessages.forEach((message) => {
+      expect(message.from).toEqual({
+        name: "Dust team",
+        email: "support@dust.tt",
+      });
+      expect(message.templateId).toBe("d-test");
+      expect(message.dynamic_template_data.subject).toBe(
+        "[Dust] Agents to reconfigure after sharing Notion"
+      );
+      expect(message.dynamic_template_data.body).toContain(workspace.name);
+      expect(message.dynamic_template_data.body).toContain(
+        "Needs Reconfiguration"
+      );
     });
   });
 
   it("does not fail the sharing request when the notification email fails", async () => {
-    vi.mocked(sendMCPGlobalSharingReconfigurationEmail).mockResolvedValue(
-      new Err(new Error("email failed"))
-    );
+    vi.mocked(sgMail.send).mockRejectedValue(new Error("email failed"));
 
     const { req, res, workspace, authenticator, globalSpace, globalGroup } =
       await createPrivateApiMockRequest({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -12,6 +12,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
+type TemplateEmailMessage = {
+  to: string;
+  from: {
+    name: string;
+    email: string;
+  };
+  templateId: string;
+  dynamic_template_data: {
+    subject: string;
+    body: string;
+  };
+};
+
 vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
@@ -227,9 +240,12 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
 
     expect(res._getStatusCode()).toBe(200);
 
-    const sentMessages = vi.mocked(sgMail.send).mock.calls.map(([message]) => {
-      return message;
-    });
+    const sentMessages = vi
+      .mocked(sgMail.send)
+      .mock.calls.flatMap(([message]) =>
+        Array.isArray(message) ? message : [message]
+      )
+      .map((message) => message as TemplateEmailMessage);
 
     expect(sentMessages).toHaveLength(2);
     expect(sentMessages.flatMap((message) => message.to).sort()).toEqual(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -241,12 +241,13 @@ async function handler(
         });
       }
 
-      const serverView = await MCPServerViewResource.create(auth, {
-        systemView,
-        space,
-      });
+      const { view: serverView, affectedAgents } =
+        await MCPServerViewResource.create(auth, {
+          systemView,
+          space,
+        });
       const affectedAgentNames =
-        serverView.affectedAgents?.map((agent) => agent.name) ?? [];
+        affectedAgents?.map((agent) => agent.name) ?? [];
 
       if (space.kind === "global" && affectedAgentNames.length > 0) {
         const toolName = getMcpServerViewDisplayName(systemView.toJSON());

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -9,7 +9,7 @@ import {
   withWorkspaceConnectionRequirement,
 } from "@app/lib/api/mcp_oauth_prerequisites";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
-import { getMembers } from "@app/lib/api/workspace";
+import { getActiveAdminEmails } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -63,13 +63,7 @@ async function notifyWorkspaceAdminsAboutAffectedAgents(
   }
 
   const workspace = auth.getNonNullableWorkspace();
-  const { members } = await getMembers(auth, {
-    roles: ["admin"],
-    activeOnly: true,
-  });
-  const adminEmails = Array.from(
-    new Set(members.map((member) => member.email))
-  );
+  const adminEmails = await getActiveAdminEmails(auth);
 
   const results = await concurrentExecutor(
     adminEmails,
@@ -247,18 +241,11 @@ async function handler(
         });
       }
 
-      const affectedAgentNames =
-        space.kind === "global"
-          ? await MCPServerViewResource.listLatestActiveAgentNamesToReconfigureOnGlobalShare(
-              auth,
-              mcpServerId
-            )
-          : [];
-
-      const serverView = await MCPServerViewResource.create(auth, {
-        systemView,
-        space,
-      });
+      const { serverView, affectedAgentNames } =
+        await MCPServerViewResource.createWithAffectedAgentNames(auth, {
+          systemView,
+          space,
+        });
 
       if (space.kind === "global" && affectedAgentNames.length > 0) {
         const toolName = getMcpServerViewDisplayName(systemView.toJSON());

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -13,6 +13,7 @@ import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -70,15 +71,16 @@ async function notifyWorkspaceAdminsAboutAffectedAgents(
     new Set(members.map((member) => member.email))
   );
 
-  const results = await Promise.all(
-    adminEmails.map((email) =>
+  const results = await concurrentExecutor(
+    adminEmails,
+    async (email) =>
       sendMCPGlobalSharingReconfigurationEmail({
         email,
         workspaceName: workspace.name,
         toolName,
         agentNames,
-      })
-    )
+      }),
+    { concurrency: 8 }
   );
 
   const failedEmails = results.flatMap((result, index) =>

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -1,5 +1,7 @@
 /** @ignoreswagger */
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   listWorkspaceConnectedMCPServerIds,
@@ -7,9 +9,11 @@ import {
   withWorkspaceConnectionRequirement,
 } from "@app/lib/api/mcp_oauth_prerequisites";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { SpaceKind } from "@app/types/space";
@@ -42,6 +46,57 @@ const PostQueryParamsSchema = t.type({
 });
 
 export type PostMCPServersQueryParams = t.TypeOf<typeof PostQueryParamsSchema>;
+
+async function notifyWorkspaceAdminsAboutAffectedAgents(
+  auth: Authenticator,
+  {
+    toolName,
+    agentNames,
+  }: {
+    toolName: string;
+    agentNames: string[];
+  }
+): Promise<void> {
+  if (agentNames.length === 0) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const { members } = await getMembers(auth, {
+    roles: ["admin"],
+    activeOnly: true,
+  });
+  const adminEmails = Array.from(
+    new Set(members.map((member) => member.email))
+  );
+
+  const results = await Promise.all(
+    adminEmails.map((email) =>
+      sendMCPGlobalSharingReconfigurationEmail({
+        email,
+        workspaceName: workspace.name,
+        toolName,
+        agentNames,
+      })
+    )
+  );
+
+  const failedEmails = results.flatMap((result, index) =>
+    result.isErr() ? [adminEmails[index]] : []
+  );
+
+  if (failedEmails.length > 0) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        toolName,
+        agentNames,
+        failedEmails,
+      },
+      "Failed to send MCP global sharing reconfiguration emails"
+    );
+  }
+}
 
 async function handler(
   req: NextApiRequest,
@@ -190,10 +245,39 @@ async function handler(
         });
       }
 
+      const affectedAgentNames =
+        space.kind === "global"
+          ? await MCPServerViewResource.listLatestActiveAgentNamesToReconfigureOnGlobalShare(
+              auth,
+              mcpServerId
+            )
+          : [];
+
       const serverView = await MCPServerViewResource.create(auth, {
         systemView,
         space,
       });
+
+      if (space.kind === "global" && affectedAgentNames.length > 0) {
+        const toolName = getMcpServerViewDisplayName(systemView.toJSON());
+
+        try {
+          await notifyWorkspaceAdminsAboutAffectedAgents(auth, {
+            toolName,
+            agentNames: affectedAgentNames,
+          });
+        } catch (error) {
+          logger.error(
+            {
+              error,
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              toolName,
+              agentNames: affectedAgentNames,
+            },
+            "Failed to notify workspace admins about MCP global sharing impact"
+          );
+        }
+      }
 
       return res.status(200).json({
         success: true,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -17,6 +17,9 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceKind } from "@app/types/space";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -57,31 +60,35 @@ async function notifyWorkspaceAdminsAboutAffectedAgents(
     toolName: string;
     agentNames: string[];
   }
-): Promise<void> {
+): Promise<Result<void, Error>> {
   if (agentNames.length === 0) {
-    return;
+    return new Ok(undefined);
   }
 
   const workspace = auth.getNonNullableWorkspace();
-  const adminEmails = await getActiveAdminEmails(auth);
+  try {
+    const adminEmails = await getActiveAdminEmails(auth);
 
-  const results = await concurrentExecutor(
-    adminEmails,
-    async (email) =>
-      sendMCPGlobalSharingReconfigurationEmail({
-        email,
-        workspaceName: workspace.name,
-        toolName,
-        agentNames,
-      }),
-    { concurrency: 8 }
-  );
+    const results = await concurrentExecutor(
+      adminEmails,
+      async (email) =>
+        sendMCPGlobalSharingReconfigurationEmail({
+          email,
+          workspaceName: workspace.name,
+          toolName,
+          agentNames,
+        }),
+      { concurrency: 8 }
+    );
 
-  const failedEmails = results.flatMap((result, index) =>
-    result.isErr() ? [adminEmails[index]] : []
-  );
+    const failedEmails = results.flatMap((result, index) =>
+      result.isErr() ? [adminEmails[index]] : []
+    );
 
-  if (failedEmails.length > 0) {
+    if (failedEmails.length === 0) {
+      return new Ok(undefined);
+    }
+
     logger.error(
       {
         workspaceId: workspace.sId,
@@ -91,6 +98,24 @@ async function notifyWorkspaceAdminsAboutAffectedAgents(
       },
       "Failed to send MCP global sharing reconfiguration emails"
     );
+
+    return new Err(
+      new Error("Failed to send MCP global sharing reconfiguration emails")
+    );
+  } catch (error) {
+    const normalizedError = normalizeError(error);
+
+    logger.error(
+      {
+        error: normalizedError,
+        workspaceId: workspace.sId,
+        toolName,
+        agentNames,
+      },
+      "Failed to notify workspace admins about MCP global sharing impact"
+    );
+
+    return new Err(normalizedError);
   }
 }
 
@@ -252,22 +277,10 @@ async function handler(
       if (space.kind === "global" && affectedAgentNames.length > 0) {
         const toolName = getMcpServerViewDisplayName(systemView.toJSON());
 
-        try {
-          await notifyWorkspaceAdminsAboutAffectedAgents(auth, {
-            toolName,
-            agentNames: affectedAgentNames,
-          });
-        } catch (error) {
-          logger.error(
-            {
-              error,
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              toolName,
-              agentNames: affectedAgentNames,
-            },
-            "Failed to notify workspace admins about MCP global sharing impact"
-          );
-        }
+        await notifyWorkspaceAdminsAboutAffectedAgents(auth, {
+          toolName,
+          agentNames: affectedAgentNames,
+        });
       }
 
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -241,11 +241,12 @@ async function handler(
         });
       }
 
-      const { serverView, affectedAgentNames } =
-        await MCPServerViewResource.createWithAffectedAgentNames(auth, {
-          systemView,
-          space,
-        });
+      const serverView = await MCPServerViewResource.create(auth, {
+        systemView,
+        space,
+      });
+      const affectedAgentNames =
+        serverView.affectedAgents?.map((agent) => agent.name) ?? [];
 
       if (space.kind === "global" && affectedAgentNames.length > 0) {
         const toolName = getMcpServerViewDisplayName(systemView.toJSON());

--- a/front/tests/utils/MCPServerViewFactory.ts
+++ b/front/tests/utils/MCPServerViewFactory.ts
@@ -22,9 +22,11 @@ export class MCPServerViewFactory {
       );
     }
 
-    return MCPServerViewResource.create(auth, {
+    const { view } = await MCPServerViewResource.create(auth, {
       systemView,
       space,
     });
+
+    return view;
   }
 }


### PR DESCRIPTION
## Description
FIxes https://github.com/dust-tt/tasks/issues/7049

- detect the latest active agents that still use regular-space views for an MCP server before that server is made global
- after the share succeeds, send a best-effort email to workspace admins with the affected agent names so they know what to reconfigure
- refactors `MCPServerViewResource.create`

## Risks
Blast radius: MCP sharing changes in the space settings flow and the related admin email notifications.
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run --config vite.config.mjs ./pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts`
