### PR TITLE
Fix copy to clipboard on Arc

### DIFF
--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -202,6 +202,7 @@ function createSidebar(): void {
   // Mark the URL so PortProvider knows it is embedded in a content-script
   // sidebar (Arc, etc.) rather than running as a native side panel.
   iframeElement.src = chrome.runtime.getURL("main.html") + "?embedded=1";
+  iframeElement.allow = "clipboard-write";
   iframeElement.style.cssText = `
     flex: 1;
     width: 100%;


### PR DESCRIPTION
## Description

In Chromium-based browsers (except Chrome), the browser extension is displayed in an iframe.
This PR allows the iframe to copy to clipboard.

## Tests

On Arc and Edge:
- Send a code block in a message
- Click on the "Copy" button in the user message

## Risk

None

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
