### PR TITLE
Pass --norc to bash to prevent loading .bashrc

### DIFF
--- a/front/lib/api/sandbox/image/profile/tests/_test_utils.ts
+++ b/front/lib/api/sandbox/image/profile/tests/_test_utils.ts
@@ -16,7 +16,7 @@ export function runBashFunction(
   const profilePath = path.join(PROFILE_LOCAL_DIR, "common.sh");
   const result = spawnSync(
     "bash",
-    ["-c", `source "${profilePath}" && ${funcCall}`],
+    ["--norc", "-c", `source "${profilePath}" && ${funcCall}`],
     {
       cwd,
       encoding: "utf-8",


### PR DESCRIPTION
## Description

From https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html:

> When Bash runs as an interactive shell that is not a login shell, it reads and executes commands from ~/.bashrc, if that file exists. The --norc option inhibits this behavior.

That fixes the unwanted `Executing .bashrc` that was showing up before the expected output.

## Tests

Pass on my box now

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
