### PR TITLE
[front] Improve feedback UI

### DIFF
--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -10,6 +10,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  HandThumbDownIcon,
+  HandThumbUpIcon,
   Label,
   MagicIcon,
   Spinner,
@@ -45,7 +47,7 @@ interface FeedbackSelectorProps extends FeedbackSelectorBaseProps {
   isGlobalAgent: boolean;
 }
 
-const OTHER_ANSWER = "Other (add details below)";
+const OTHER_ANSWER = "Other";
 
 const FEEDBACK_PREDEFINED_ANSWERS = [
   "Factually incorrect",
@@ -56,42 +58,30 @@ const FEEDBACK_PREDEFINED_ANSWERS = [
   OTHER_ANSWER,
 ] as const;
 
-const feedbackBaseSchema = z.object({
-  selectedAnswer: z.string().default(""),
-  feedbackContent: z.string().default(""),
-  isConversationShared: z.boolean().default(true),
-});
-
-function makeFeedbackSchema(
-  thumbDirection: ThumbReaction,
-  showPredefinedAnswers: boolean
-) {
-  if (thumbDirection === "up") {
-    return feedbackBaseSchema;
-  }
-
-  // Valid when: a non-"Other" predefined answer is selected, or free text is provided.
-  // Note: we are not using superRefine here because thumbDirection is not a form value.
-  return feedbackBaseSchema.refine(
+const feedbackSchema = z
+  .object({
+    thumbDirection: z.enum(["up", "down"]).nullable().default(null),
+    selectedAnswer: z.string().default(""),
+    feedbackContent: z.string().default(""),
+    isConversationShared: z.boolean().default(true),
+  })
+  .refine(
     (data) => {
+      if (data.thumbDirection !== "down") {
+        return true;
+      }
       const hasAnswer =
-        showPredefinedAnswers &&
-        data.selectedAnswer.length > 0 &&
-        data.selectedAnswer !== OTHER_ANSWER;
+        data.selectedAnswer.length > 0 && data.selectedAnswer !== OTHER_ANSWER;
       const hasContent = data.feedbackContent.trim().length > 0;
-
       return hasAnswer || hasContent;
     },
     {
-      message: showPredefinedAnswers
-        ? "Please select a reason or describe the issue."
-        : "Please describe the issue.",
+      message: "Please select a reason or describe the issue.",
       path: ["feedbackContent"],
     }
   );
-}
 
-type FeedbackFormValues = z.infer<ReturnType<typeof makeFeedbackSchema>>;
+type FeedbackFormValues = z.infer<typeof feedbackSchema>;
 
 export function FeedbackSelector({
   feedback,
@@ -106,22 +96,26 @@ export function FeedbackSelector({
   // Predefined answers are not so relevant in the context of sidekick.
   const showPredefinedAnswers = !isSidekick;
 
-  // "Improve this agent" would be confusing in the context of sidekick so we show "Improve @sidekick" instead
-  const improveLabel = isSidekick
-    ? `Improve @${agentName}`
+  const improveLabel = isGlobalAgent
+    ? "Provide feedback"
     : "Improve this agent";
 
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
-  const [thumbDirection, setThumbDirection] =
-    React.useState<ThumbReaction>("up");
 
   const form = useForm<FeedbackFormValues>({
-    resolver: zodResolver(
-      makeFeedbackSchema(thumbDirection, showPredefinedAnswers)
-    ),
-    defaultValues: feedbackBaseSchema.parse({}),
+    resolver: zodResolver(feedbackSchema),
+    defaultValues: {
+      thumbDirection: null,
+      selectedAnswer: "",
+      feedbackContent: "",
+      isConversationShared: true,
+    },
   });
 
+  const thumbDirectionField = useController({
+    control: form.control,
+    name: "thumbDirection",
+  });
   const selectedAnswerField = useController({
     control: form.control,
     name: "selectedAnswer",
@@ -135,9 +129,24 @@ export function FeedbackSelector({
     name: "isConversationShared",
   });
 
-  const openDialog = (direction: ThumbReaction) => {
-    setThumbDirection(direction);
-    setIsDialogOpen(true);
+  const thumbDirection = thumbDirectionField.field.value;
+
+  const handleButtonClick = async () => {
+    if (feedback) {
+      await onSubmitThumb({
+        thumb: feedback.thumb,
+        shouldRemoveExistingFeedback: true,
+        feedbackContent: null,
+        isConversationShared: false,
+      });
+    } else {
+      setIsDialogOpen(true);
+    }
+  };
+
+  const handleThumbSelect = (direction: ThumbReaction) => {
+    thumbDirectionField.field.onChange(direction);
+    form.clearErrors();
   };
 
   const closeDialog = () => {
@@ -146,6 +155,10 @@ export function FeedbackSelector({
   };
 
   const handleSubmit = form.handleSubmit(async (data) => {
+    if (!data.thumbDirection) {
+      return;
+    }
+
     const predefinedAnswer = data.selectedAnswer.trim();
     const details = data.feedbackContent.trim();
 
@@ -153,7 +166,7 @@ export function FeedbackSelector({
       [predefinedAnswer, details].filter(Boolean).join("\n\n") || null;
 
     await onSubmitThumb({
-      thumb: thumbDirection,
+      thumb: data.thumbDirection,
       shouldRemoveExistingFeedback: false,
       feedbackContent,
       isConversationShared: data.isConversationShared,
@@ -161,28 +174,13 @@ export function FeedbackSelector({
     closeDialog();
   });
 
-  const handleThumbClick = async (direction: ThumbReaction) => {
-    const shouldRemoveExistingFeedback = feedback?.thumb === direction;
-    if (shouldRemoveExistingFeedback) {
-      await onSubmitThumb({
-        thumb: direction,
-        shouldRemoveExistingFeedback,
-        feedbackContent: null,
-        isConversationShared: false,
-      });
-      return;
-    }
-
-    openDialog(direction);
-  };
-
   return (
     <div className="flex items-center">
       <Button
         variant={feedback ? "primary" : "outline"}
         size="xs"
         disabled={isSubmittingThumb}
-        onClick={() => handleThumbClick("down")}
+        onClick={handleButtonClick}
         icon={MagicIcon}
         label={improveLabel}
         className={feedback ? "" : "text-muted-foreground"}
@@ -198,7 +196,7 @@ export function FeedbackSelector({
       >
         <DialogContent size="lg">
           <DialogHeader>
-            <DialogTitle>Give feedback on @{agentName}</DialogTitle>
+            <DialogTitle>Provide feedback on @{agentName}</DialogTitle>
           </DialogHeader>
 
           <DialogContainer className="py-3">
@@ -209,81 +207,132 @@ export function FeedbackSelector({
             ) : (
               <div className="flex flex-col gap-4 pt-2">
                 <div>
-                  <Label htmlFor="feedback-content" className="mb-2 block">
-                    {thumbDirection === "down"
-                      ? "What was the issue?"
-                      : "Glad you liked it! Tell us more?"}
-                  </Label>
-
-                  {thumbDirection === "down" && showPredefinedAnswers && (
-                    <div className="mb-3 flex flex-wrap gap-2">
-                      {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => (
-                        <Button
-                          key={answer}
-                          label={answer}
-                          size="xs"
-                          variant={
-                            selectedAnswerField.field.value === answer
-                              ? "primary"
-                              : "outline"
-                          }
-                          onClick={() => {
-                            selectedAnswerField.field.onChange(
-                              selectedAnswerField.field.value === answer
-                                ? ""
-                                : answer
-                            );
-                          }}
-                        />
-                      ))}
-                    </div>
-                  )}
-
-                  <TextArea
-                    id="feedback-content"
-                    placeholder={
-                      thumbDirection === "down"
-                        ? "Describe what went wrong"
-                        : "Share details"
-                    }
-                    resize="vertical"
-                    rows={3}
-                    value={feedbackContentField.field.value}
-                    onChange={(e) =>
-                      feedbackContentField.field.onChange(e.target.value)
-                    }
-                    error={
-                      feedbackContentField.fieldState.error?.message ?? null
-                    }
-                    showErrorLabel={!!feedbackContentField.fieldState.error}
-                  />
-                </div>
-
-                <div className="flex items-start gap-2">
-                  <Checkbox
-                    id="share-conversation"
-                    checked={isConversationSharedField.field.value}
-                    onCheckedChange={(value) => {
-                      isConversationSharedField.field.onChange(!!value);
-                    }}
-                    size="xs"
-                    className="mt-1"
-                  />
-                  <div className="flex flex-col">
-                    <Label htmlFor="share-conversation">
-                      Share conversation with the agent’s editors
-                    </Label>
-                    <span className="text-xs text-muted-foreground">
-                      Helps editors improve the agent
-                    </span>
+                  <Label className="mb-3 block">Was this answer helpful?</Label>
+                  <div className="flex gap-2">
+                    <Button
+                      label="Yes, helpful"
+                      icon={HandThumbUpIcon}
+                      size="sm"
+                      variant={thumbDirection === "up" ? "primary" : "outline"}
+                      onClick={() => handleThumbSelect("up")}
+                    />
+                    <Button
+                      label="Needs work"
+                      icon={HandThumbDownIcon}
+                      size="sm"
+                      variant={
+                        thumbDirection === "down" ? "primary" : "outline"
+                      }
+                      onClick={() => handleThumbSelect("down")}
+                    />
                   </div>
                 </div>
 
-                <FeedbackSelectorPopoverContent
-                  owner={owner}
-                  agentConfigurationId={agentConfigurationId}
-                  isGlobalAgent={isGlobalAgent}
-                />
+                <div
+                  className="grid transition-[grid-template-rows] duration-200 ease-out"
+                  style={{
+                    gridTemplateRows: thumbDirection ? "1fr" : "0fr",
+                  }}
+                >
+                  <div className="overflow-hidden">
+                    <div className="flex flex-col gap-4 pt-2">
+                      <div>
+                        <Label
+                          htmlFor="feedback-content"
+                          className="mb-2 block"
+                        >
+                          {thumbDirection === "down"
+                            ? "What was the issue?"
+                            : "Glad you liked it! Tell us more?"}
+                        </Label>
+
+                        {showPredefinedAnswers && (
+                          <div
+                            className="grid transition-[grid-template-rows] duration-200 ease-out"
+                            style={{
+                              gridTemplateRows:
+                                thumbDirection === "down" ? "1fr" : "0fr",
+                            }}
+                          >
+                            <div className="overflow-hidden">
+                              <div className="mb-3 flex flex-wrap gap-2">
+                                {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => (
+                                  <Button
+                                    key={answer}
+                                    label={answer}
+                                    size="xs"
+                                    variant={
+                                      selectedAnswerField.field.value ===
+                                      answer
+                                        ? "primary"
+                                        : "outline"
+                                    }
+                                    onClick={() => {
+                                      selectedAnswerField.field.onChange(
+                                        selectedAnswerField.field.value ===
+                                          answer
+                                          ? ""
+                                          : answer
+                                      );
+                                    }}
+                                  />
+                                ))}
+                              </div>
+                            </div>
+                          </div>
+                        )}
+
+                        <TextArea
+                          id="feedback-content"
+                          placeholder={
+                            thumbDirection === "down"
+                              ? "Describe what went wrong"
+                              : "Share details"
+                          }
+                          resize="vertical"
+                          rows={3}
+                          value={feedbackContentField.field.value}
+                          onChange={(e) =>
+                            feedbackContentField.field.onChange(e.target.value)
+                          }
+                          error={
+                            feedbackContentField.fieldState.error?.message ??
+                            null
+                          }
+                          showErrorLabel={
+                            !!feedbackContentField.fieldState.error
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-start gap-2">
+                        <Checkbox
+                          id="share-conversation"
+                          checked={isConversationSharedField.field.value}
+                          onCheckedChange={(value) => {
+                            isConversationSharedField.field.onChange(!!value);
+                          }}
+                          size="xs"
+                          className="mt-1"
+                        />
+                        <div className="flex flex-col">
+                          <Label htmlFor="share-conversation">
+                            Share conversation with the agent’s editors
+                          </Label>
+                          <span className="text-xs text-muted-foreground">
+                            Helps editors improve the agent
+                          </span>
+                        </div>
+                      </div>
+
+                      <FeedbackSelectorPopoverContent
+                        owner={owner}
+                        agentConfigurationId={agentConfigurationId}
+                        isGlobalAgent={isGlobalAgent}
+                      />
+                    </div>
+                  </div>
+                </div>
               </div>
             )}
           </DialogContainer>
@@ -293,7 +342,7 @@ export function FeedbackSelector({
               label: "Submit",
               variant: "primary",
               onClick: handleSubmit,
-              disabled: isSubmittingThumb,
+              disabled: !thumbDirection || isSubmittingThumb,
             }}
           />
         </DialogContent>

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -102,9 +102,11 @@ export function FeedbackSelector({
   // Predefined answers are not so relevant in the context of sidekick.
   const showPredefinedAnswers = !isSidekick;
 
-  const improveLabel = isGlobalAgent
-    ? "Provide feedback"
-    : "Improve this agent";
+  const buttonLabel = feedback
+    ? "Clear feedback"
+    : isGlobalAgent
+      ? "Provide feedback"
+      : "Improve this agent";
 
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
@@ -188,7 +190,7 @@ export function FeedbackSelector({
         disabled={isSubmittingThumb}
         onClick={handleButtonClick}
         icon={MagicIcon}
-        label={improveLabel}
+        label={buttonLabel}
         className={feedback ? "" : "text-muted-foreground"}
       />
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -58,30 +58,36 @@ const FEEDBACK_PREDEFINED_ANSWERS = [
   OTHER_ANSWER,
 ] as const;
 
-const feedbackSchema = z
-  .object({
-    thumbDirection: z.enum(["up", "down"]).nullable().default(null),
-    selectedAnswer: z.string().default(""),
-    feedbackContent: z.string().default(""),
-    isConversationShared: z.boolean().default(true),
-  })
-  .refine(
-    (data) => {
-      if (data.thumbDirection !== "down") {
-        return true;
-      }
-      const hasAnswer =
-        data.selectedAnswer.length > 0 && data.selectedAnswer !== OTHER_ANSWER;
-      const hasContent = data.feedbackContent.trim().length > 0;
-      return hasAnswer || hasContent;
-    },
-    {
-      message: "Please select a reason or describe the issue.",
-      path: ["feedbackContent"],
-    }
-  );
+const feedbackBaseSchema = z.object({
+  thumbDirection: z.enum(["up", "down"]).nullable().default(null),
+  selectedAnswer: z.string().default(""),
+  feedbackContent: z.string().default(""),
+  isConversationShared: z.boolean().default(true),
+});
 
-type FeedbackFormValues = z.infer<typeof feedbackSchema>;
+function makeFeedbackSchema(showPredefinedAnswers: boolean) {
+  return feedbackBaseSchema.superRefine((data, ctx) => {
+    if (data.thumbDirection !== "down") {
+      return;
+    }
+    const hasAnswer =
+      showPredefinedAnswers &&
+      data.selectedAnswer.length > 0 &&
+      data.selectedAnswer !== OTHER_ANSWER;
+    const hasContent = data.feedbackContent.trim().length > 0;
+    if (!hasAnswer && !hasContent) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: showPredefinedAnswers
+          ? "Please select a reason or describe the issue."
+          : "Please describe the issue.",
+        path: ["feedbackContent"],
+      });
+    }
+  });
+}
+
+type FeedbackFormValues = z.infer<ReturnType<typeof makeFeedbackSchema>>;
 
 export function FeedbackSelector({
   feedback,
@@ -103,7 +109,7 @@ export function FeedbackSelector({
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
   const form = useForm<FeedbackFormValues>({
-    resolver: zodResolver(feedbackSchema),
+    resolver: zodResolver(makeFeedbackSchema(showPredefinedAnswers)),
     defaultValues: {
       thumbDirection: null,
       selectedAnswer: "",

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -3,7 +3,6 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
-  ButtonGroup,
   Checkbox,
   Dialog,
   DialogContainer,
@@ -11,7 +10,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  HandThumbUpIcon,
   Label,
   MagicIcon,
   Spinner,
@@ -180,25 +178,15 @@ export function FeedbackSelector({
 
   return (
     <div className="flex items-center">
-      <ButtonGroup>
-        <Button
-          variant={feedback?.thumb === "up" ? "primary" : "outline"}
-          size="xs"
-          disabled={isSubmittingThumb}
-          onClick={() => handleThumbClick("up")}
-          icon={HandThumbUpIcon}
-          className={feedback?.thumb === "up" ? "" : "text-muted-foreground"}
-        />
-        <Button
-          variant={feedback?.thumb === "down" ? "primary" : "outline"}
-          size="xs"
-          disabled={isSubmittingThumb}
-          onClick={() => handleThumbClick("down")}
-          icon={MagicIcon}
-          label={improveLabel}
-          className={feedback?.thumb === "down" ? "" : "text-muted-foreground"}
-        />
-      </ButtonGroup>
+      <Button
+        variant={feedback ? "primary" : "outline"}
+        size="xs"
+        disabled={isSubmittingThumb}
+        onClick={() => handleThumbClick("down")}
+        icon={MagicIcon}
+        label={improveLabel}
+        className={feedback ? "" : "text-muted-foreground"}
+      />
 
       <Dialog
         open={isDialogOpen}

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -207,7 +207,7 @@ export function FeedbackSelector({
             ) : (
               <div className="flex flex-col gap-4 pt-2">
                 <div>
-                  <Label className="mb-3 block">Was this answer helpful?</Label>
+                  <p className="mb-3 text-sm font-semibold text-foreground">Was this answer helpful?</p>
                   <div className="flex gap-2">
                     <Button
                       label="Yes, helpful"

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -213,7 +213,9 @@ export function FeedbackSelector({
             ) : (
               <div className="flex flex-col gap-4 pt-2">
                 <div>
-                  <p className="mb-3 text-sm font-semibold text-foreground">Was this answer helpful?</p>
+                  <p className="mb-3 text-sm font-semibold text-foreground dark:text-foreground-night">
+                    Was this answer helpful?
+                  </p>
                   <div className="flex gap-2">
                     <Button
                       label="Yes, helpful"
@@ -268,8 +270,7 @@ export function FeedbackSelector({
                                     label={answer}
                                     size="xs"
                                     variant={
-                                      selectedAnswerField.field.value ===
-                                      answer
+                                      selectedAnswerField.field.value === answer
                                         ? "primary"
                                         : "outline"
                                     }

--- a/front/hooks/useMessageFeedback.ts
+++ b/front/hooks/useMessageFeedback.ts
@@ -55,7 +55,7 @@ export function useMessageFeedback({
         if (!shouldRemoveExistingFeedback) {
           sendNotification({
             title: "Feedback sent",
-            description: "Your feedback helps improve this agent.",
+            description: "The agent will improve with your feedback.",
             type: "success",
           });
         }

--- a/front/hooks/useMessageFeedback.ts
+++ b/front/hooks/useMessageFeedback.ts
@@ -55,7 +55,7 @@ export function useMessageFeedback({
         if (!shouldRemoveExistingFeedback) {
           sendNotification({
             title: "Feedback sent",
-            description: "The agent will improve with your feedback.",
+            description: "Your feedback helps improve this agent.",
             type: "success",
           });
         }


### PR DESCRIPTION
## Description
This PR is to improve feedback buttons & modal UI. We now show only one "Improve this agent" (or "Provide feedback" for default agents) and show thumb up/down inside the modal like this:
 

https://github.com/user-attachments/assets/6db8237f-3ffa-4cb9-9f65-430a16282e9f


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
