### PR TITLE
[front] hide feedback button for onboarding conversation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -156,6 +156,7 @@ interface AgentMessageProps {
   owner: WorkspaceType;
   user: UserType;
   triggeringUser: UserType | null;
+  isOnboardingConversation: boolean;
   handleSubmit: (
     input: string,
     mentions: RichMention[],
@@ -173,6 +174,7 @@ export function AgentMessage({
   owner,
   user,
   triggeringUser,
+  isOnboardingConversation,
   handleSubmit,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
@@ -577,6 +579,7 @@ export function AgentMessage({
 
   const shouldShowFeedback =
     !isDeleted &&
+    !isOnboardingConversation &&
     agentMessage.status !== "created" &&
     agentMessage.status !== "failed" &&
     agentMessage.configuration.status !== "draft" &&

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -853,7 +853,7 @@ export function AgentMessage({
     }
 
     return (
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-5">
         {messageContent}
         {footerButtons}
       </div>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -845,6 +845,9 @@ export const ConversationViewer = ({
     ? (spaceInfo?.isMember ?? false) // Default false while loading (restrictive)
     : undefined;
 
+  // After reversal in the hook, messages[0] is the oldest page. This only
+  // returns the actual first conversation message when all pages are loaded
+  // (works for onboarding conversations which are short / single-page).
   const firstMessage = messages.at(-1)?.messages.at(0);
   const isOnboardingConversation =
     !!firstMessage &&

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -43,7 +43,10 @@ import type {
   ConversationWithoutContentType,
   LightMessageType,
 } from "@app/types/assistant/conversation";
-import { isUserMessageTypeWithContentFragments } from "@app/types/assistant/conversation";
+import {
+  isUserMessageType,
+  isUserMessageTypeWithContentFragments,
+} from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import {
   isRichAgentMention,
@@ -842,12 +845,19 @@ export const ConversationViewer = ({
     ? (spaceInfo?.isMember ?? false) // Default false while loading (restrictive)
     : undefined;
 
+  const firstMessage = messages.at(-1)?.messages.at(0);
+  const isOnboardingConversation =
+    !!firstMessage &&
+    isUserMessageType(firstMessage) &&
+    firstMessage.context.origin === "onboarding_conversation";
+
   const context: VirtuosoMessageListContext = useMemo(() => {
     return {
       user,
       owner,
       handleSubmit,
       conversation,
+      isOnboardingConversation,
       draftKey: `conversation-${conversationId}`,
       agentBuilderContext,
       feedbacksByMessageId,
@@ -866,6 +876,7 @@ export const ConversationViewer = ({
     owner,
     handleSubmit,
     conversation,
+    isOnboardingConversation,
     conversationId,
     agentBuilderContext,
     feedbacksByMessageId,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -168,6 +168,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}
               handleSubmit={context.handleSubmit}
+              isOnboardingConversation={context.isOnboardingConversation}
               additionalMarkdownComponents={
                 context.additionalMarkdownComponents
               }

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -65,6 +65,7 @@ export type VirtuosoMessage =
 export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;
   user: UserType;
+  isOnboardingConversation: boolean;
   handleSubmit: (
     input: string,
     mentions: RichMention[],


### PR DESCRIPTION
## Description
This PR is a quick fix to hide feedback button for onboarding conversations per [this thread](https://dust4ai.slack.com/archives/C0A6TBTU7JS/p1773761242152229).


e.g. 

onboarding conversation: https://pr-23118-merge--app.preview.dust.tt/w/0ec9852c2f/conversation/9ppNnzNNbG 
normal conversation: https://pr-23118-merge--app.preview.dust.tt/w/0ec9852c2f/conversation/2uKUvFWhYw
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
