### PR TITLE
Add apply_patch sandbox tool for OpenAI models

### DIFF
--- a/.github/workflows/release-sandbox-tool.yml
+++ b/.github/workflows/release-sandbox-tool.yml
@@ -1,0 +1,74 @@
+name: Release sandbox tool
+
+on:
+  workflow_dispatch:
+    inputs:
+      codex_tag:
+        description: "openai/codex release tag to build from (e.g. rust-v0.115.0)"
+        required: true
+        default: "rust-v0.115.0"
+      apply_patch_version:
+        description: "apply_patch release version (e.g. 0.1.0)"
+        required: true
+        default: "0.1.0"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: release_sandbox_tool
+  cancel-in-progress: false
+
+jobs:
+  apply-patch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codex repo at pinned tag
+        uses: actions/checkout@v4
+        with:
+          repository: openai/codex
+          ref: ${{ inputs.codex_tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build with cross
+        working-directory: codex-rs
+        run: cross build --release --target x86_64-unknown-linux-musl -p codex-apply-patch
+
+      - name: Prepare release artifacts
+        run: |
+          mkdir -p artifacts
+          cp codex-rs/target/x86_64-unknown-linux-musl/release/apply_patch artifacts/apply_patch-linux-x86_64
+          cd artifacts
+          sha256sum apply_patch-linux-x86_64 > checksums-sha256.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        with:
+          tag_name: apply-patch-v${{ inputs.apply_patch_version }}
+          name: apply_patch v${{ inputs.apply_patch_version }}
+          body: |
+            Built from [openai/codex](https://github.com/openai/codex) at tag `${{ inputs.codex_tag }}` (Apache-2.0).
+
+            ### Download
+
+            | Platform | Architecture | Binary |
+            |----------|--------------|--------|
+            | Linux    | x86_64       | `apply_patch-linux-x86_64` |
+
+            ### Verify checksum
+
+            ```bash
+            sha256sum -c checksums-sha256.txt
+            ```
+          files: |
+            artifacts/apply_patch-linux-x86_64
+            artifacts/checksums-sha256.txt
+          fail_on_unmatched_files: true

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -11,6 +11,9 @@ import fs from "fs";
 import path from "path";
 
 const DSBX_CLI_VERSION = "0.1.1";
+// Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
+// Released via the "Release sandbox tool" GitHub Actions workflow.
+const APPLY_PATCH_VERSION = "0.1.0";
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 
 interface PythonLibrary {
@@ -154,6 +157,26 @@ SHELLEOF`)
         "grep dsbx-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/dsbx\"}' | sha256sum -c - && " +
         "chmod +x /tmp/dsbx && " +
         "sudo mv /tmp/dsbx /opt/bin/dsbx",
+    }
+  )
+  .registerTool(
+    {
+      name: "apply_patch",
+      description:
+        "Apply V4A diffs to files. Supports add, update, and delete operations",
+      usage:
+        "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
+      returns: "Summary of applied changes (A/M/D per file)",
+      runtime: "system",
+      profile: "openai",
+    },
+    {
+      installCmd:
+        `curl -fsSL https://github.com/dust-tt/dust/releases/download/apply-patch-v${APPLY_PATCH_VERSION}/apply_patch-linux-x86_64 -o /tmp/apply_patch && ` +
+        `curl -fsSL https://github.com/dust-tt/dust/releases/download/apply-patch-v${APPLY_PATCH_VERSION}/checksums-sha256.txt -o /tmp/checksums-sha256.txt && ` +
+        "grep apply_patch-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/apply_patch\"}' | sha256sum -c - && " +
+        "chmod +x /tmp/apply_patch && " +
+        "sudo mv /tmp/apply_patch /opt/bin/apply_patch",
     }
   )
   .runCmd(`sudo mkdir -p ${PROFILE_DIR}`)


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds the OpenAI `apply_patch` binary to the sandbox image, available only when running with OpenAI models (via the profile: "openai" flag). `apply_patch` is a standalone Rust binary from the [openai/codex](https://github.com/openai/codex) repo (Apache-2.0) that applies V4A-style diffs to files. OpenAI models are trained to emit this format natively, so having the binary available in the sandbox lets them edit files efficiently.

This PR includes a GitHub Actions workflow to build the binary from a pinned upstream tag and publish it to our GitHub Releases, following the same pattern we use for dsbx. The sandbox image registration in registry.ts then downloads it with checksum verification.

The workflow needs to be run once to create the apply-patch-v0.1.0 release before the image can be rebuilt.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
