### PR TITLE
[sparkle] - feat(Dropdown): arrows navigation with searchbar

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -296,6 +296,22 @@ function getDropdownSearchInput(
   );
 }
 
+function resolveDropdownSearchInput(
+  searchInputRef: React.RefObject<HTMLInputElement | null> | undefined,
+  container: ParentNode
+): HTMLInputElement | null {
+  return searchInputRef?.current ?? getDropdownSearchInput(container);
+}
+
+function isDropdownTextEntryElement(
+  element: Element | null
+): element is HTMLInputElement | HTMLTextAreaElement {
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  );
+}
+
 function setDropdownSearchInputValue(
   input: HTMLInputElement,
   nextValue: string
@@ -350,8 +366,7 @@ const DropdownMenuContent = React.forwardRef<
         return;
       }
 
-      const input =
-        searchInputRef?.current ?? getDropdownSearchInput(e.currentTarget);
+      const input = resolveDropdownSearchInput(searchInputRef, e.currentTarget);
       const firstItem = getFirstDropdownMenuItem(e.currentTarget);
 
       if (!input || !firstItem || document.activeElement !== firstItem) {
@@ -369,15 +384,11 @@ const DropdownMenuContent = React.forwardRef<
         return;
       }
 
-      const isInput =
-        document.activeElement instanceof HTMLInputElement ||
-        document.activeElement instanceof HTMLTextAreaElement;
-      if (isInput) {
+      if (isDropdownTextEntryElement(document.activeElement)) {
         return;
       }
 
-      const input =
-        searchInputRef?.current ?? getDropdownSearchInput(e.currentTarget);
+      const input = resolveDropdownSearchInput(searchInputRef, e.currentTarget);
       if (!input) {
         return;
       }

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -21,7 +21,7 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import * as React from "react";
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -263,6 +263,11 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName;
 
+const nativeInputValueSetter =
+  typeof window !== "undefined"
+    ? Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+    : undefined;
+
 interface DropdownMenuContentProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
   mountPortal?: boolean;
@@ -285,12 +290,79 @@ const DropdownMenuContent = React.forwardRef<
       dropdownHeaders,
       preventAutoFocusOnClose = true,
       onCloseAutoFocus,
+      onKeyDown,
       children,
       ...props
     },
     ref
   ) => {
-    const handleCloseAutoFocus = React.useCallback(
+    const contentRef = useRef<HTMLDivElement | null>(null);
+
+    const mergedRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        contentRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref]
+    );
+
+    const handleKeyDownCapture = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key !== "ArrowUp") {
+          return;
+        }
+
+        const input = contentRef.current?.querySelector("input");
+        if (!input) {
+          return;
+        }
+
+        const items = contentRef.current?.querySelectorAll('[role="menuitem"]');
+        if (items && items.length > 0 && document.activeElement === items[0]) {
+          e.preventDefault();
+          e.stopPropagation();
+          input.focus();
+        }
+      },
+      []
+    );
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+
+      const isInput =
+        document.activeElement instanceof HTMLInputElement ||
+        document.activeElement instanceof HTMLTextAreaElement;
+      if (isInput) {
+        return;
+      }
+
+      const input = contentRef.current?.querySelector("input");
+      if (!input || !nativeInputValueSetter) {
+        return;
+      }
+
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        input.focus();
+        nativeInputValueSetter.call(input, input.value + e.key);
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      } else if (e.key === "Backspace" && input.value.length > 0) {
+        e.preventDefault();
+        input.focus();
+        nativeInputValueSetter.call(input, input.value.slice(0, -1));
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+    };
+
+    const handleCloseAutoFocus = useCallback(
       (event: Event) => {
         if (preventAutoFocusOnClose) {
           event.preventDefault();
@@ -302,8 +374,10 @@ const DropdownMenuContent = React.forwardRef<
 
     const content = (
       <DropdownMenuPrimitive.Content
-        ref={ref}
+        ref={mergedRef}
         sideOffset={sideOffset}
+        onKeyDownCapture={handleKeyDownCapture}
+        onKeyDown={handleKeyDown}
         className={cn(
           menuStyleClasses.container,
           "s-flex s-flex-col s-p-0 s-shadow-md",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -21,7 +21,7 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import * as React from "react";
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -268,6 +268,47 @@ const nativeInputValueSetter =
     ? Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
     : undefined;
 
+const SEARCHABLE_MENU_ITEM_SELECTOR =
+  '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]';
+const OPEN_SEARCHABLE_MENU_ITEM_SELECTOR = [
+  '[data-radix-menu-content][data-state=open] [role="menuitem"]',
+  '[data-radix-menu-content][data-state=open] [role="menuitemcheckbox"]',
+  '[data-radix-menu-content][data-state=open] [role="menuitemradio"]',
+].join(", ");
+
+function getFirstDropdownMenuItem(container: ParentNode): HTMLElement | null {
+  return container.querySelector<HTMLElement>(SEARCHABLE_MENU_ITEM_SELECTOR);
+}
+
+function getFirstOpenDropdownMenuItem(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    OPEN_SEARCHABLE_MENU_ITEM_SELECTOR
+  );
+}
+
+function getDropdownSearchInput(
+  container: ParentNode
+): HTMLInputElement | null {
+  return (
+    container.querySelector<HTMLInputElement>(
+      '[data-dropdown-searchbar] input[type="text"]'
+    ) ?? container.querySelector<HTMLInputElement>('input[type="text"]')
+  );
+}
+
+function setDropdownSearchInputValue(
+  input: HTMLInputElement,
+  nextValue: string
+): void {
+  if (!nativeInputValueSetter) {
+    return;
+  }
+
+  // Use the native setter so React sees the value change before the input event.
+  nativeInputValueSetter.call(input, nextValue);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
 interface DropdownMenuContentProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
   mountPortal?: boolean;
@@ -275,6 +316,7 @@ interface DropdownMenuContentProps
   dropdownHeaders?: React.ReactNode;
   preventAutoFocusOnClose?: boolean;
   onOpenAutoFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
+  searchInputRef?: React.RefObject<HTMLInputElement | null>;
 }
 
 const DropdownMenuContent = React.forwardRef<
@@ -290,42 +332,35 @@ const DropdownMenuContent = React.forwardRef<
       dropdownHeaders,
       preventAutoFocusOnClose = true,
       onCloseAutoFocus,
+      onKeyDownCapture,
       onKeyDown,
+      searchInputRef,
       children,
       ...props
     },
     ref
   ) => {
-    const contentRef = useRef<HTMLDivElement | null>(null);
-
-    const mergedRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        contentRef.current = node;
-        if (typeof ref === "function") {
-          ref(node);
-        } else if (ref) {
-          ref.current = node;
-        }
-      },
-      [ref]
-    );
-
     const handleKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDownCapture?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+
       if (e.key !== "ArrowUp") {
         return;
       }
 
-      const input = contentRef.current?.querySelector("input");
-      if (!input) {
+      const input =
+        searchInputRef?.current ?? getDropdownSearchInput(e.currentTarget);
+      const firstItem = getFirstDropdownMenuItem(e.currentTarget);
+
+      if (!input || !firstItem || document.activeElement !== firstItem) {
         return;
       }
 
-      const items = contentRef.current?.querySelectorAll('[role="menuitem"]');
-      if (items && items.length > 0 && document.activeElement === items[0]) {
-        e.preventDefault();
-        e.stopPropagation();
-        input.focus();
-      }
+      e.preventDefault();
+      e.stopPropagation();
+      input.focus();
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -341,25 +376,24 @@ const DropdownMenuContent = React.forwardRef<
         return;
       }
 
-      const input = contentRef.current?.querySelector("input");
-      if (!input || !nativeInputValueSetter) {
+      const input =
+        searchInputRef?.current ?? getDropdownSearchInput(e.currentTarget);
+      if (!input) {
         return;
       }
 
       if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
         input.focus();
-        nativeInputValueSetter.call(input, input.value + e.key);
-        input.dispatchEvent(new Event("input", { bubbles: true }));
+        setDropdownSearchInputValue(input, input.value + e.key);
       } else if (e.key === "Backspace" && input.value.length > 0) {
         e.preventDefault();
         input.focus();
-        nativeInputValueSetter.call(input, input.value.slice(0, -1));
-        input.dispatchEvent(new Event("input", { bubbles: true }));
+        setDropdownSearchInputValue(input, input.value.slice(0, -1));
       }
     };
 
-    const handleCloseAutoFocus = useCallback(
+    const handleCloseAutoFocus = React.useCallback(
       (event: Event) => {
         if (preventAutoFocusOnClose) {
           event.preventDefault();
@@ -371,7 +405,7 @@ const DropdownMenuContent = React.forwardRef<
 
     const content = (
       <DropdownMenuPrimitive.Content
-        ref={mergedRef}
+        ref={ref}
         sideOffset={sideOffset}
         onKeyDownCapture={handleKeyDownCapture}
         onKeyDown={handleKeyDown}
@@ -739,18 +773,14 @@ const DropdownMenuSearchbar = React.forwardRef<
       if (!e.defaultPrevented) {
         if (e.key === "Enter") {
           e.preventDefault();
-          const firstItem = document.querySelector(
-            '[data-radix-menu-content][data-state=open] [role="menuitem"]'
-          );
+          const firstItem = getFirstOpenDropdownMenuItem();
           if (firstItem instanceof HTMLElement) {
             firstItem.click();
           }
         }
         if (e.key === "Tab" || e.key === "ArrowDown") {
           e.preventDefault();
-          const firstItem = document.querySelector(
-            '[data-radix-menu-content][data-state=open] [role="menuitem"]'
-          );
+          const firstItem = getFirstOpenDropdownMenuItem();
           if (firstItem instanceof HTMLElement) {
             firstItem.focus();
           }
@@ -759,7 +789,10 @@ const DropdownMenuSearchbar = React.forwardRef<
     };
 
     return (
-      <div className={cn("s-flex s-gap-1.5 s-p-1.5", className)}>
+      <div
+        className={cn("s-flex s-gap-1.5 s-p-1.5", className)}
+        data-dropdown-searchbar
+      >
         <SearchInput
           className="s-w-full"
           ref={internalRef}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -393,7 +393,8 @@ const DropdownMenuContent = React.forwardRef<
         return;
       }
 
-      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      // Treat single-character keys as search input
+      if (e.key.length === 1) {
         e.preventDefault();
         input.focus();
         setDropdownSearchInputValue(input, input.value + e.key);

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -310,26 +310,23 @@ const DropdownMenuContent = React.forwardRef<
       [ref]
     );
 
-    const handleKeyDownCapture = useCallback(
-      (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (e.key !== "ArrowUp") {
-          return;
-        }
+    const handleKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "ArrowUp") {
+        return;
+      }
 
-        const input = contentRef.current?.querySelector("input");
-        if (!input) {
-          return;
-        }
+      const input = contentRef.current?.querySelector("input");
+      if (!input) {
+        return;
+      }
 
-        const items = contentRef.current?.querySelectorAll('[role="menuitem"]');
-        if (items && items.length > 0 && document.activeElement === items[0]) {
-          e.preventDefault();
-          e.stopPropagation();
-          input.focus();
-        }
-      },
-      []
-    );
+      const items = contentRef.current?.querySelectorAll('[role="menuitem"]');
+      if (items && items.length > 0 && document.activeElement === items[0]) {
+        e.preventDefault();
+        e.stopPropagation();
+        input.focus();
+      }
+    };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
       onKeyDown?.(e);

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -12,6 +12,10 @@ const OPEN_MENU_ITEM_SELECTOR = [
   '[data-radix-menu-content][data-state=open] [role="menuitemradio"]',
 ].join(", ");
 
+function getFirstOpenMenuItem(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(OPEN_MENU_ITEM_SELECTOR);
+}
+
 type SearchDropdownMenuProps = {
   searchInputValue: string;
   setSearchInputValue: (value: string) => void;
@@ -63,9 +67,7 @@ export function SearchDropdownMenu({
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
-              const firstItem = document.querySelector<HTMLElement>(
-                OPEN_MENU_ITEM_SELECTOR
-              );
+              const firstItem = getFirstOpenMenuItem();
               if (firstItem instanceof HTMLElement) {
                 firstItem.click();
               }
@@ -73,9 +75,7 @@ export function SearchDropdownMenu({
             }
             if (e.key === "Tab" || e.key === "ArrowDown") {
               e.preventDefault();
-              const firstItem = document.querySelector<HTMLElement>(
-                OPEN_MENU_ITEM_SELECTOR
-              );
+              const firstItem = getFirstOpenMenuItem();
               if (firstItem instanceof HTMLElement) {
                 firstItem.focus();
               }

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -6,6 +6,12 @@ import {
 import { SearchInput } from "@sparkle/components/SearchInput";
 import React, { useRef, useState } from "react";
 
+const OPEN_MENU_ITEM_SELECTOR = [
+  '[data-radix-menu-content][data-state=open] [role="menuitem"]',
+  '[data-radix-menu-content][data-state=open] [role="menuitemcheckbox"]',
+  '[data-radix-menu-content][data-state=open] [role="menuitemradio"]',
+].join(", ");
+
 type SearchDropdownMenuProps = {
   searchInputValue: string;
   setSearchInputValue: (value: string) => void;
@@ -57,8 +63,8 @@ export function SearchDropdownMenu({
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
-              const firstItem = document.querySelector(
-                '[data-radix-menu-content][data-state=open] [role="menuitem"]'
+              const firstItem = document.querySelector<HTMLElement>(
+                OPEN_MENU_ITEM_SELECTOR
               );
               if (firstItem instanceof HTMLElement) {
                 firstItem.click();
@@ -67,8 +73,8 @@ export function SearchDropdownMenu({
             }
             if (e.key === "Tab" || e.key === "ArrowDown") {
               e.preventDefault();
-              const firstItem = document.querySelector(
-                '[data-radix-menu-content][data-state=open] [role="menuitem"]'
+              const firstItem = document.querySelector<HTMLElement>(
+                OPEN_MENU_ITEM_SELECTOR
               );
               if (firstItem instanceof HTMLElement) {
                 firstItem.focus();
@@ -81,6 +87,7 @@ export function SearchDropdownMenu({
         side="bottom"
         align="start"
         className="s-w-[--radix-popper-anchor-width]"
+        searchInputRef={searchInputRef}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
         }}


### PR DESCRIPTION
## Description

This PR enhances keyboard navigation for `Dropdown` components with searchbars. When navigating menu items with arrow keys, users can now press `ArrowUp` from the first item to return focus to the search input. Additionally, when focus is on a menu item, typing any character or pressing `Backspace` will automatically redirect focus to the search input and update its value accordingly.

## Tests

- [x] Locally on storybook

## Risk

Low. Changes are isolated to the `Dropdown` component's keyboard event handling

## Deploy Plan

N/A
