### PR TITLE
[front] chore: weaken Ashby zod schemas

### DIFF
--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -1,8 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AshbyClient } from "@app/lib/api/actions/servers/ashby/client";
-// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
-import { renderReferralForm } from "@app/lib/api/actions/servers/ashby/rendering";
+import {
+  JOB_FIELD_PATH,
+  renderReferralForm,
+} from "@app/lib/api/actions/servers/ashby/rendering";
 import type {
   AshbyCandidate,
   AshbyFieldSubmission,
@@ -13,8 +15,6 @@ import type {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
-
-export const JOB_FIELD_PATH = "_systemfield.job";
 
 interface CandidateSearchParams {
   email?: string;

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -187,7 +187,7 @@ function renderSingleNote(note: AshbyCandidateNote): string {
 
   lines.push(`**Created at:** ${new Date(note.createdAt).toISOString()}`);
   lines.push("");
-  lines.push(note.content);
+  lines.push(note.content ?? "Empty note");
 
   return lines.join("\n");
 }

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -1,5 +1,3 @@
-// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
-import { JOB_FIELD_PATH } from "@app/lib/api/actions/servers/ashby/helpers";
 import type {
   AshbyCandidate,
   AshbyCandidateInfo,
@@ -14,6 +12,8 @@ import type {
 } from "@app/lib/api/actions/servers/ashby/types";
 import { toCsv } from "@app/lib/api/csv";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export const JOB_FIELD_PATH = "_systemfield.job";
 
 function renderCandidate(candidate: AshbyCandidate): string {
   const lines = [`ID: ${candidate.id}`, `Name: ${candidate.name}`];

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -50,7 +50,7 @@ export const AshbyReportSynchronousResponseSchema = z.object({
         requestId: z.string(),
         status: z.literal("complete"),
         reportData: z.object({
-          data: z.array(z.array(z.union([z.string(), z.number()]))),
+          data: z.array(z.array(z.union([z.string(), z.number(), z.null()]))),
           columnNames: z.array(z.string()),
           metadata: z
             .object({
@@ -201,7 +201,7 @@ export type AshbyCandidateListNotesRequest = z.infer<
 export const AshbyCandidateNoteSchema = z
   .object({
     id: z.string(),
-    content: z.string(),
+    content: z.string().nullable().optional(),
     createdAt: z.string(),
     author: z
       .object({
@@ -703,7 +703,7 @@ export const AshbyCandidateInfoSchema = z
       )
       .optional(),
     applicationIds: z.array(z.string()).optional(),
-    createdAt: z.string(),
+    createdAt: z.string().optional().nullable(),
   })
   .passthrough();
 

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -103,7 +103,7 @@ export type AshbyApplicationFeedbackListRequest = z.infer<
 export const AshbyFeedbackSubmissionSchema = z
   .object({
     id: z.string(),
-    submittedAt: z.string().optional().nullable(),
+    submittedAt: z.string().nullish(),
     submittedByUser: z
       .object({
         id: z.string(),
@@ -113,8 +113,8 @@ export const AshbyFeedbackSubmissionSchema = z
       })
       .optional()
       .nullable(),
-    interviewId: z.string().optional().nullable(),
-    interviewEventId: z.string().optional().nullable(),
+    interviewId: z.string().nullish(),
+    interviewEventId: z.string().nullish(),
     formDefinition: z
       .object({
         sections: z
@@ -201,7 +201,7 @@ export type AshbyCandidateListNotesRequest = z.infer<
 export const AshbyCandidateNoteSchema = z
   .object({
     id: z.string(),
-    content: z.string().nullable().optional(),
+    content: z.string().nullish(),
     createdAt: z.string(),
     author: z
       .object({
@@ -475,14 +475,14 @@ export const AshbyJobPostingSchema = z
         secondaryLocationIds: z.array(z.string()),
       })
       .optional(),
-    workplaceType: z.string().optional().nullable(),
+    workplaceType: z.string().nullish(),
     employmentType: z.string(),
     isListed: z.boolean(),
     publishedDate: z.string(),
-    applicationDeadline: z.string().optional().nullable(),
-    externalLink: z.string().optional().nullable(),
+    applicationDeadline: z.string().nullish(),
+    externalLink: z.string().nullish(),
     applyLink: z.string(),
-    compensationTierSummary: z.string().optional().nullable(),
+    compensationTierSummary: z.string().nullish(),
     shouldDisplayCompensationOnJobBoard: z.boolean(),
     updatedAt: z.string(),
   })
@@ -533,9 +533,9 @@ export const AshbyJobPostingInfoSchema = z
     descriptionHtml: z.string().optional(),
     descriptionParts: z
       .object({
-        descriptionOpening: AshbyDescriptionPartSchema.optional().nullable(),
-        descriptionBody: AshbyDescriptionPartSchema.optional().nullable(),
-        descriptionClosing: AshbyDescriptionPartSchema.optional().nullable(),
+        descriptionOpening: AshbyDescriptionPartSchema.nullish(),
+        descriptionBody: AshbyDescriptionPartSchema.nullish(),
+        descriptionClosing: AshbyDescriptionPartSchema.nullish(),
       })
       .optional(),
   })
@@ -684,9 +684,9 @@ export const AshbyCandidateInfoSchema = z
       .optional(),
     location: z
       .object({
-        city: z.string().optional().nullable(),
-        region: z.string().optional().nullable(),
-        country: z.string().optional().nullable(),
+        city: z.string().nullish(),
+        region: z.string().nullish(),
+        country: z.string().nullish(),
       })
       .passthrough()
       .optional()
@@ -703,7 +703,7 @@ export const AshbyCandidateInfoSchema = z
       )
       .optional(),
     applicationIds: z.array(z.string()).optional(),
-    createdAt: z.string().optional().nullable(),
+    createdAt: z.string().nullish(),
   })
   .passthrough();
 
@@ -734,7 +734,7 @@ export type AshbyOfferFormFieldValue = z.infer<
 export const AshbyOfferVersionSchema = z
   .object({
     id: z.string().optional(),
-    startDate: z.string().optional().nullable(),
+    startDate: z.string().nullish(),
     formFieldValues: z.array(AshbyOfferFormFieldValueSchema).optional(),
   })
   .passthrough();
@@ -746,8 +746,8 @@ export const AshbyOfferSchema = z
     id: z.string(),
     applicationId: z.string().optional(),
     status: z.string().optional(),
-    decidedAt: z.string().optional().nullable(),
-    latestVersion: AshbyOfferVersionSchema.optional().nullable(),
+    decidedAt: z.string().nullish(),
+    latestVersion: AshbyOfferVersionSchema.nullish(),
   })
   .passthrough();
 
@@ -783,9 +783,9 @@ export const AshbyJobInfoSchema = z
     id: z.string(),
     title: z.string(),
     status: z.string(),
-    departmentName: z.string().optional().nullable(),
-    teamName: z.string().optional().nullable(),
-    locationName: z.string().optional().nullable(),
+    departmentName: z.string().nullish(),
+    teamName: z.string().nullish(),
+    locationName: z.string().nullish(),
     customFields: z
       .array(
         z


### PR DESCRIPTION
## Description

- This PR closes a few gaps there are between the zod schemas we use for validating the responses of the Ashby API and what is specified in the documentation https://app.dust.tt/w/0ec9852c2f/conversation/FblNdoxPpZ
- Also fixes a circular dependency.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
