### PR TITLE
feat: upgrade things in elevenlabs

### DIFF
--- a/front/lib/api/actions/servers/elevenlabs/utils.ts
+++ b/front/lib/api/actions/servers/elevenlabs/utils.ts
@@ -1,11 +1,14 @@
-import type {
-  VoiceGender,
-  VoiceLanguage,
-  VoiceUseCase,
+import {
+  VOICE_LANGUAGES,
+  type VoiceGender,
+  type VoiceLanguage,
+  type VoiceUseCase,
 } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
+import logger from "@app/logger/logger";
 import { dustManagedServiceCredentials } from "@app/types/api/credentials";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import type { Voice } from "@elevenlabs/elevenlabs-js/api/types";
 import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
 
 interface VoiceDefinition {
@@ -14,122 +17,199 @@ interface VoiceDefinition {
   gender: VoiceGender;
   languages: VoiceLanguage[];
   useCase: VoiceUseCase;
+  score: number;
 }
 
-// Curated list of voices mapped from the provided JSON, restricted to our current
-// VoiceLanguage union. We favor high-quality and broadly applicable options.
-const VOICES: VoiceDefinition[] = [
-  {
-    voiceId: "JBFqnCBsd6RMkjVDRZzb",
-    name: "George",
-    gender: "male",
-    languages: ["english_british", "french", "japanese", "hindi"],
-    useCase: "narrative_story",
-  },
-  {
-    voiceId: "CwhRBWXzGAHq8TQ4Fs17",
-    name: "Roger",
-    gender: "male",
-    languages: ["english_american", "french", "german", "dutch"],
-    useCase: "conversational",
-  },
-  {
-    voiceId: "2EiwWnXFnvU5JabPnv8n",
-    name: "Clyde",
-    gender: "male",
-    languages: ["english_american"],
-    useCase: "characters_animation",
-  },
-  {
-    voiceId: "FGY2WhTYpPnrIDTdsKH5",
-    name: "Laura",
-    gender: "female",
-    languages: ["english_american", "french", "chinese", "german"],
-    useCase: "social_media",
-  },
-  {
-    voiceId: "EXAVITQu4vr4xnSDxMaL",
-    name: "Sarah",
-    gender: "female",
-    languages: ["english_american", "french", "chinese", "hindi"],
-    useCase: "entertainment_tv",
-  },
-  {
-    voiceId: "Xb7hH8MSUJpSbSDYk0k2",
-    name: "Alice",
-    gender: "female",
-    languages: ["english_british", "italian", "french", "japanese", "hindi"],
-    useCase: "advertisement",
-  },
-  {
-    voiceId: "XrExE9yKIg1WjnnlVkGX",
-    name: "Matilda",
-    gender: "female",
-    languages: ["english_american", "italian", "french", "german"],
-    useCase: "informative_educational",
-  },
-  {
-    voiceId: "pFZP5JQG7iQjIQuC4Bku",
-    name: "Lily",
-    gender: "female",
-    languages: ["english_american", "italian", "german", "chinese", "dutch"],
-    useCase: "narrative_story",
-  },
-  {
-    voiceId: "cgSgspJ2msm6clMCkdW9",
-    name: "Jessica",
-    gender: "female",
-    languages: [
-      "english_american",
-      "french",
-      "japanese",
-      "chinese",
-      "german",
-      "hindi",
-    ],
-    useCase: "conversational",
-  },
-  {
-    voiceId: "TX3LPaxmHKxFdv7VOQHJ",
-    name: "Liam",
-    gender: "male",
-    languages: ["english_american", "german", "hindi"],
-    useCase: "social_media",
-  },
-  {
-    voiceId: "bIHbv24MWmeRgasZH58o",
-    name: "Will",
-    gender: "male",
-    languages: ["english_american", "french", "german", "chinese"],
-    useCase: "conversational",
-  },
-  {
-    voiceId: "nPczCjzI2devNBz1zQrb",
-    name: "Brian",
-    gender: "male",
-    languages: ["english_american", "chinese", "german", "dutch", "hindi"],
-    useCase: "social_media",
-  },
-];
+// Maps our VoiceLanguage identifiers to ElevenLabs locale prefixes used in
+// verifiedLanguages[].locale (e.g. "en-US", "fr-FR").
+const LANGUAGE_TO_LOCALE_PREFIX: Record<VoiceLanguage, string[]> = {
+  english_american: ["en-US", "en"],
+  english_british: ["en-GB", "en-UK"],
+  french: ["fr"],
+  german: ["de"],
+  dutch: ["nl"],
+  italian: ["it"],
+  japanese: ["ja"],
+  hindi: ["hi"],
+  chinese: ["zh"],
+  spanish: ["es"],
+  portuguese: ["pt"],
+  korean: ["ko"],
+  arabic: ["ar"],
+  turkish: ["tr"],
+  polish: ["pl"],
+  swedish: ["sv"],
+  russian: ["ru"],
+  indonesian: ["id"],
+  filipino: ["fil", "tl"],
+  thai: ["th"],
+  vietnamese: ["vi"],
+};
 
+function matchesLanguage(
+  locale: string | undefined,
+  language: string | undefined,
+  voiceLanguage: VoiceLanguage
+): boolean {
+  const prefixes = LANGUAGE_TO_LOCALE_PREFIX[voiceLanguage];
+  if (locale) {
+    return prefixes.some(
+      (p) => locale === p || locale.startsWith(`${p}-`) || locale.startsWith(p)
+    );
+  }
+  if (language) {
+    const lc = language.toLowerCase();
+    return prefixes.some(
+      (p) => lc === p.toLowerCase() || lc.startsWith(p.toLowerCase())
+    );
+  }
+  return false;
+}
+
+function extractLanguages(voice: Voice): VoiceLanguage[] {
+  const languages = voice.verifiedLanguages;
+  if (!languages || languages.length === 0) {
+    return [];
+  }
+  const matched = new Set<VoiceLanguage>();
+  for (const vl of languages) {
+    for (const lang of VOICE_LANGUAGES) {
+      if (matchesLanguage(vl.locale, vl.language, lang)) {
+        matched.add(lang);
+      }
+    }
+  }
+  return [...matched];
+}
+
+function normalizeGender(labels: Record<string, string>): VoiceGender {
+  const raw = (labels["gender"] ?? labels["Gender"] ?? "").toLowerCase();
+  if (raw.includes("male") && !raw.includes("female")) {
+    return "male";
+  }
+  return "female";
+}
+
+function inferUseCase(labels: Record<string, string>): VoiceUseCase {
+  const raw = (
+    labels["use case"] ??
+    labels["use_case"] ??
+    labels["Use Case"] ??
+    ""
+  ).toLowerCase();
+  if (raw.match(/narrat|story|audiobook|documentary/)) {
+    return "narrative_story";
+  }
+  if (raw.match(/charact|anime|animation|cartoon|acting/)) {
+    return "characters_animation";
+  }
+  if (raw.match(/social|tiktok|instagram|influencer|shorts/)) {
+    return "social_media";
+  }
+  if (raw.match(/tv|broadcast|film|cinema|entertainment/)) {
+    return "entertainment_tv";
+  }
+  if (raw.match(/ad |ads|advert|commercial|promo/)) {
+    return "advertisement";
+  }
+  if (raw.match(/educat|tutorial|lesson|course|informative|explainer/)) {
+    return "informative_educational";
+  }
+  return "conversational";
+}
+
+function scoreVoice(voice: Voice): number {
+  const category = (voice.category ?? "").toLowerCase();
+  const labels = voice.labels ?? {};
+  const featured = (labels["featured"] ?? "").toLowerCase();
+  let score = 0;
+  if (
+    category.includes("high_quality") ||
+    category.includes("professional") ||
+    category.includes("premade")
+  ) {
+    score += 5;
+  }
+  if (featured === "true" || featured === "yes") {
+    score += 3;
+  }
+  if (voice.previewUrl) {
+    score += 2;
+  }
+  return score;
+}
+
+function toVoiceDefinition(voice: Voice): VoiceDefinition | undefined {
+  const labels = voice.labels ?? {};
+  const languages = extractLanguages(voice);
+  if (languages.length === 0) {
+    return undefined;
+  }
+  return {
+    voiceId: voice.voiceId,
+    name: voice.name ?? "",
+    gender: normalizeGender(labels),
+    languages,
+    useCase: inferUseCase(labels),
+    score: scoreVoice(voice),
+  };
+}
+
+// In-memory cache for fetched voices. Refreshes every 6 hours.
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+let cachedVoices: VoiceDefinition[] | null = null;
+let cacheTimestampMs = 0;
+
+async function fetchVoices(): Promise<VoiceDefinition[]> {
+  const now = Date.now();
+  if (cachedVoices && now - cacheTimestampMs < CACHE_TTL_MS) {
+    return cachedVoices;
+  }
+
+  try {
+    const client = getElevenLabsClient();
+    const resp = await client.voices.getAll();
+    const definitions = resp.voices
+      .map(toVoiceDefinition)
+      .filter((v): v is VoiceDefinition => v !== undefined);
+
+    // Sort by score descending for deterministic best-first selection.
+    definitions.sort(
+      (a, b) => b.score - a.score || a.name.localeCompare(b.name)
+    );
+
+    cachedVoices = definitions;
+    cacheTimestampMs = now;
+
+    logger.info(
+      { voiceCount: definitions.length },
+      "Refreshed ElevenLabs voice cache."
+    );
+
+    return definitions;
+  } catch (err) {
+    logger.error({ err }, "Failed to fetch ElevenLabs voices, using cache.");
+    // Return stale cache if available, otherwise empty.
+    return cachedVoices ?? [];
+  }
+}
+
+// Hardcoded fallbacks used when the API is unreachable and cache is empty.
 const DEFAULT_GENDER_FALLBACK = {
   male: "JBFqnCBsd6RMkjVDRZzb", // George
   female: "cgSgspJ2msm6clMCkdW9", // Jessica
 } as const;
 
-function pickBestCandidate(
-  candidates: VoiceDefinition[]
-): VoiceDefinition | undefined {
+function pickBest(candidates: VoiceDefinition[]): string | undefined {
   if (candidates.length === 0) {
     return undefined;
   }
-  // Prefer high_quality, then featured, then stable alphabetical by name for determinism.
-  return candidates.slice().sort((a, b) => {
-    return a.name.localeCompare(b.name);
-  })[0];
+  // Already sorted by score desc, so first match is best.
+  return candidates[0].voiceId;
 }
 
-export function resolveDefaultVoiceId({
+export async function resolveDefaultVoiceId({
   language,
   gender,
   useCase,
@@ -137,45 +217,43 @@ export function resolveDefaultVoiceId({
   language: VoiceLanguage;
   gender: VoiceGender;
   useCase: VoiceUseCase;
-}): string {
+}): Promise<string> {
+  const voices = await fetchVoices();
+
   // 1) language + useCase + gender
-  let candidates = VOICES.filter(
-    (v) =>
-      v.languages.includes(language) &&
-      v.useCase === useCase &&
-      v.gender === gender
+  let voiceId = pickBest(
+    voices.filter(
+      (v) =>
+        v.languages.includes(language) &&
+        v.useCase === useCase &&
+        v.gender === gender
+    )
   );
-  let chosen = pickBestCandidate(candidates);
-  if (chosen) {
-    return chosen.voiceId;
+  if (voiceId) {
+    return voiceId;
   }
 
-  // 2) language + useCase
-  candidates = VOICES.filter(
-    (v) => v.languages.includes(language) && v.useCase === useCase
+  // 2) language + gender (relax use case)
+  voiceId = pickBest(
+    voices.filter((v) => v.languages.includes(language) && v.gender === gender)
   );
-  chosen = pickBestCandidate(candidates);
-  if (chosen) {
-    return chosen.voiceId;
+  if (voiceId) {
+    return voiceId;
   }
 
-  // 3) language + gender
-  candidates = VOICES.filter(
-    (v) => v.languages.includes(language) && v.gender === gender
-  );
-  chosen = pickBestCandidate(candidates);
-  if (chosen) {
-    return chosen.voiceId;
+  // 3) language only
+  voiceId = pickBest(voices.filter((v) => v.languages.includes(language)));
+  if (voiceId) {
+    return voiceId;
   }
 
-  // 4) language only
-  candidates = VOICES.filter((v) => v.languages.includes(language));
-  chosen = pickBestCandidate(candidates);
-  if (chosen) {
-    return chosen.voiceId;
+  // 4) gender only
+  voiceId = pickBest(voices.filter((v) => v.gender === gender));
+  if (voiceId) {
+    return voiceId;
   }
 
-  // 5) Final safety fallback to previous behavior.
+  // 5) Final safety fallback.
   return DEFAULT_GENDER_FALLBACK[gender];
 }
 

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -18,6 +18,18 @@ export const VOICE_LANGUAGES = [
   "japanese",
   "hindi",
   "chinese",
+  "spanish",
+  "portuguese",
+  "korean",
+  "arabic",
+  "turkish",
+  "polish",
+  "swedish",
+  "russian",
+  "indonesian",
+  "filipino",
+  "thai",
+  "vietnamese",
 ] as const;
 
 export type VoiceLanguage = (typeof VOICE_LANGUAGES)[number];
@@ -43,7 +55,7 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
       text: z
         .string()
         .min(1)
-        .max(10_000)
+        .max(5_000)
         .describe("The text to convert to speech."),
       gender: z
         .enum(VOICE_GENDERS)

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -21,7 +21,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
     try {
       const client = getElevenLabsClient();
 
-      const voiceId = resolveDefaultVoiceId({
+      const voiceId = await resolveDefaultVoiceId({
         language,
         useCase: use_case,
         gender,
@@ -30,7 +30,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
       const stream = await client.textToSpeech.convert(voiceId, {
         text,
         enableLogging: false,
-        modelId: "eleven_multilingual_v2",
+        modelId: "eleven_v3",
         outputFormat: "mp3_44100_128",
       });
 
@@ -66,13 +66,16 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
     try {
       const client = getElevenLabsClient();
 
-      const inputs = dialogues.map((d) => {
+      // resolveDefaultVoiceId is called once (cached after first call), so
+      // sequential resolution here avoids redundant API fetches on cold start.
+      const inputs: { text: string; voiceId: string }[] = [];
+      for (const d of dialogues) {
         const { gender, language, use_case: useCase } = d.speaker;
-        return {
+        inputs.push({
           text: d.text,
-          voiceId: resolveDefaultVoiceId({ gender, language, useCase }),
-        };
-      });
+          voiceId: await resolveDefaultVoiceId({ gender, language, useCase }),
+        });
+      }
 
       const stream = await client.textToDialogue.stream({
         inputs,

--- a/front/lib/utils/transcribe_service.ts
+++ b/front/lib/utils/transcribe_service.ts
@@ -26,7 +26,7 @@ async function getElevenLabs() {
   });
 }
 
-const _ELEVENLABS_TRANSCRIBE_MODEL = "scribe_v1";
+const _ELEVENLABS_TRANSCRIBE_MODEL = "scribe_v2";
 
 type FormidableFileLike = Pick<
   formidable.File,

--- a/front/package.json
+++ b/front/package.json
@@ -44,7 +44,7 @@
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.7.7",
     "@elastic/elasticsearch": "^8.15.0",
-    "@elevenlabs/elevenlabs-js": "^2.17.0",
+    "@elevenlabs/elevenlabs-js": "^2.39.0",
     "@emoji-mart/data": "^1.2.1",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,7 +349,7 @@
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.7.7",
         "@elastic/elasticsearch": "^8.15.0",
-        "@elevenlabs/elevenlabs-js": "^2.17.0",
+        "@elevenlabs/elevenlabs-js": "^2.39.0",
         "@emoji-mart/data": "^1.2.1",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -5801,9 +5801,9 @@
       }
     },
     "node_modules/@elevenlabs/elevenlabs-js": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.37.0.tgz",
-      "integrity": "sha512-GngmGe97krIhOzo3ZW6CYr1oiBmka/sVPLxMK5tZ8VioCZveY1P411yIY5x8qsK12hdwhmeq73S6dtJtc3UumA==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.39.0.tgz",
+      "integrity": "sha512-Yfh2wa5Y7wwoEHi2Na1YWrkc3z21oeHMo8qhGc5kcbQoWfgQfIxWuGfXHZSmUXOJz0mNL5bAfp3hHaJEX68DIA==",
       "license": "MIT",
       "dependencies": {
         "command-exists": "^1.2.9",


### PR DESCRIPTION
## Description

Improve elevenlabs integration:

1. STT: change model from scribe_v1 to scribe_v2
	- Gains: 90+ languages, word-level timestamps, speaker diarization, entity detection, keyterm prompting

2. TTS: change model from multilingual_v2 to eleven_v3
    - Gains: audio tags support, 74 languages, more expressive prosody

3. Expanded supported languages from 9 to 21

4. Replace hardcoded 12-voice list with a dynamic approach
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
