### PR TITLE
Use tab for auth flow

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -1026,11 +1026,11 @@ const authenticate = async (
   ) => void
 ) => {
   // First we call /authorize endpoint to get the authorization code (PKCE flow).
-  const redirectUrl = chrome.identity.getRedirectURL();
+  const expectedRedirectUrl = chrome.identity.getRedirectURL();
   const { codeVerifier, codeChallenge } = await generatePKCE();
 
   const options: Record<string, string> = {
-    redirect_uri: redirectUrl,
+    redirect_uri: expectedRedirectUrl,
     code_challenge_method: "S256",
     code_challenge: codeChallenge,
     ...(organizationId ? { organizationId } : {}),
@@ -1040,56 +1040,70 @@ const authenticate = async (
 
   const authUrl = `${DUST_US_URL}/api/workos/login?${queryString}`;
 
-  chrome.identity.launchWebAuthFlow(
-    { url: authUrl, interactive: true },
-    async (redirectUrl) => {
-      if (chrome.runtime.lastError) {
-        log(`WebAuthFlow error: ${chrome.runtime.lastError.message}`);
-        sendResponse({
-          success: false,
-          error: `WebAuthFlow error: ${chrome.runtime.lastError.message}`,
-        });
-        return;
-      }
-      if (!redirectUrl || redirectUrl.includes("error")) {
-        log(`Error in redirect URL: ${redirectUrl}`);
-        sendResponse({
-          success: false,
-          error: `Error in redirect URL: ${redirectUrl}`,
-        });
-        return;
-      }
+  // Open auth flow in a regular tab instead of chrome.identity.launchWebAuthFlow
+  // to avoid "Authorization page could not be loaded" errors when Google's OAuth
+  // pages are slow and users double-click.
+  const tab = await chrome.tabs.create({ url: authUrl });
+  const tabId = tab.id;
+  if (!tabId) {
+    sendResponse({ success: false, error: "Failed to open auth tab." });
+    return;
+  }
 
-      const url = new URL(redirectUrl);
-      const queryParams = new URLSearchParams(url.search);
-      const authorizationCode = queryParams.get("code");
+  const cleanup = () => {
+    chrome.tabs.onUpdated.removeListener(onUpdated);
+    chrome.tabs.onRemoved.removeListener(onRemoved);
+  };
 
-      const error = queryParams.get("error");
-
-      if (error) {
-        log(`Authentication error: ${error}`);
-        sendResponse({
-          success: false,
-          error: `Authentication error: ${error}`,
-        });
-        return;
-      }
-
-      if (authorizationCode) {
-        const data = await exchangeCodeForTokens(
-          authorizationCode,
-          codeVerifier
-        );
-        sendResponse(data);
-      } else {
-        log(`Missing authorization code: ${redirectUrl}`);
-        sendResponse({
-          success: false,
-          error: `Missing authorization code`,
-        });
-      }
+  const onUpdated = async (
+    updatedTabId: number,
+    _changeInfo: chrome.tabs.TabChangeInfo,
+    updatedTab: chrome.tabs.Tab
+  ) => {
+    if (updatedTabId !== tabId || !updatedTab.url) {
+      return;
     }
-  );
+
+    if (!updatedTab.url.startsWith(expectedRedirectUrl)) {
+      return;
+    }
+
+    cleanup();
+    void chrome.tabs.remove(tabId);
+
+    const url = new URL(updatedTab.url);
+    const queryParams = new URLSearchParams(url.search);
+
+    if (url.href.includes("error")) {
+      const error = queryParams.get("error") || "Unknown error";
+      log(`Authentication error: ${error}`);
+      sendResponse({ success: false, error: `Authentication error: ${error}` });
+      return;
+    }
+
+    const authorizationCode = queryParams.get("code");
+    if (authorizationCode) {
+      const data = await exchangeCodeForTokens(authorizationCode, codeVerifier);
+      sendResponse(data);
+    } else {
+      log(`Missing authorization code: ${updatedTab.url}`);
+      sendResponse({ success: false, error: "Missing authorization code" });
+    }
+  };
+
+  const onRemoved = (removedTabId: number) => {
+    if (removedTabId !== tabId) {
+      return;
+    }
+    cleanup();
+    sendResponse({
+      success: false,
+      error: "Authentication cancelled: tab was closed.",
+    });
+  };
+
+  chrome.tabs.onUpdated.addListener(onUpdated);
+  chrome.tabs.onRemoved.addListener(onRemoved);
 };
 
 /**


### PR DESCRIPTION
## Description

Replace `chrome.identity.launchWebAuthFlow` with a regular `chrome.tabs.create` approach for the Chrome extension authentication flow.

**Problem:** Many users are experiencing login failures when Google's OAuth pages are slow (ongoing Google-side issue for ~1 week). When users double-click on the Google account chooser (due to lack of feedback), Chrome's managed auth popup immediately closes with `"Authorization page could not be loaded"`, failing the entire auth flow.

**Root cause:** `chrome.identity.launchWebAuthFlow` uses a tightly controlled popup — any navigation interruption (e.g., a second click triggering a new navigation while the first is in-flight) causes Chrome to abort the flow entirely.

**Fix:** Open the auth URL in a regular browser tab instead, and listen for the redirect via `chrome.tabs.onUpdated`. A regular tab is resilient to double-clicks and slow page loads — the user can interact freely, and we only act when the final OAuth redirect arrives. The tab is auto-closed once the auth code is captured. This is the same approach used by the Claude extension.

## Tests

Manual testing:
- Verified login flow opens in a new tab and completes successfully
- Verified double-clicking on Google account chooser no longer breaks auth
- Verified closing the tab manually reports "Authentication cancelled"

## Risk

**Low.** The change is isolated to the Chrome extension auth flow. The redirect URL (`chrome.identity.getRedirectURL()`) and the rest of the PKCE/token exchange flow remain unchanged. The only visible difference is that auth opens in a full tab instead of a popup. No manifest changes required — existing `tabs` permission and `<all_urls>` host permissions are sufficient.

## Deploy Plan

Standard extension deployment. No backend changes needed.