### PR TITLE
[sparkle] - fix(CollapseButton): fix animation

### DIFF
--- a/sparkle/src/components/CollapseButton.tsx
+++ b/sparkle/src/components/CollapseButton.tsx
@@ -1,6 +1,6 @@
 import collapseBar from "@sparkle/lottie/collapseBar";
 import Lottie, { type LottieRefCurrentProps } from "lottie-react";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 
 // Custom color definitions
 const customColors = {
@@ -86,6 +86,11 @@ const CollapseButton: React.FC<CollapseButtonProps> = ({
   variant = "light",
 }) => {
   const lottieRef = useRef<LottieRefCurrentProps | null>(null);
+  const animationData = useMemo(
+    () =>
+      replaceColors(JSON.parse(JSON.stringify(collapseBar)), colors[variant]),
+    [variant]
+  );
 
   // Function to handle hover event
   const handleMouseEnter = () => {
@@ -148,10 +153,7 @@ const CollapseButton: React.FC<CollapseButtonProps> = ({
     >
       <Lottie
         lottieRef={lottieRef}
-        animationData={replaceColors(
-          JSON.parse(JSON.stringify(collapseBar)),
-          colors[variant]
-        )}
+        animationData={animationData}
         loop={false}
         autoplay={false}
       />


### PR DESCRIPTION
## Description

This PR fixes the `CollapseButton` animation. The `CollapseButton` component was passing a new object to Lottie's `animationData` prop on every render.

Explanation:
> lottie-react sees a new animationData reference and destroys and recreates the animation instance. This resets it to the initial frame. The `useEffect` that advances the animation to the IDLE frame only runs when direction changes -> after any other re-render, the animation is stuck at frame 0 and the hover handlers (which play segments starting from IDLE) produce no visible effect.

## Tests

- [x] Locally

## Risk

Low

## Deploy Plan

Deploy front
