### PR TITLE
Show real server icon and name in toolset enable action

### DIFF
--- a/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
@@ -1,17 +1,44 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { getIcon } from "@app/components/resources/resources_icons";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
+import { useSpaces } from "@app/lib/swr/spaces";
 import { BoltIcon } from "@dust-tt/sparkle";
 
 export function MCPToolsetsEnableActionDetails({
+  owner,
+  toolParams,
   displayContext,
 }: ToolExecutionDetailsProps) {
+  const toolsetId =
+    typeof toolParams.toolsetId === "string" ? toolParams.toolsetId : null;
+
+  const { spaces } = useSpaces({
+    kinds: ["global"],
+    workspaceId: owner.sId,
+  });
+  const { serverViews: mcpServerViews } = useMCPServerViews({
+    owner,
+    space: spaces[0] ?? undefined,
+    availability: "all",
+  });
+
+  const mcpServerView = toolsetId
+    ? mcpServerViews.find((v) => v.sId === toolsetId)
+    : null;
+
+  const toolName = mcpServerView
+    ? getMcpServerViewDisplayName(mcpServerView)
+    : null;
+  const visual = mcpServerView ? getIcon(mcpServerView.server.icon) : BoltIcon;
+  const actionName = toolName ? `Enable ${toolName} tool` : "Enable tool";
+
   return (
     <ActionDetailsWrapper
       displayContext={displayContext}
-      actionName={
-        displayContext === "conversation" ? "Enabled tool" : "Enable tool"
-      }
-      visual={BoltIcon}
+      actionName={actionName}
+      visual={visual}
     />
   );
 }

--- a/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
@@ -4,6 +4,7 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { isString } from "@app/types/shared/utils/general";
 import { BoltIcon } from "@dust-tt/sparkle";
 
 export function MCPToolsetsEnableActionDetails({
@@ -11,8 +12,8 @@ export function MCPToolsetsEnableActionDetails({
   toolParams,
   displayContext,
 }: ToolExecutionDetailsProps) {
-  const toolsetId =
-    typeof toolParams.toolsetId === "string" ? toolParams.toolsetId : null;
+  const { toolsetId } = toolParams;
+  const resolvedToolsetId = isString(toolsetId) ? toolsetId : null;
 
   const { spaces } = useSpaces({
     kinds: ["global"],
@@ -24,8 +25,8 @@ export function MCPToolsetsEnableActionDetails({
     availability: "all",
   });
 
-  const mcpServerView = toolsetId
-    ? mcpServerViews.find((v) => v.sId === toolsetId)
+  const mcpServerView = resolvedToolsetId
+    ? mcpServerViews.find((v) => v.sId === resolvedToolsetId)
     : null;
 
   const toolName = mcpServerView

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -13,8 +13,8 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing toolsets",
-      done: "List toolsets",
+      running: "Listing tools",
+      done: "List tools",
     },
   },
   enable: {
@@ -24,8 +24,8 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Enabling toolset",
-      done: "Enable toolset",
+      running: "Enabling tool",
+      done: "Enabled tool",
     },
   },
 });


### PR DESCRIPTION
## Description

The toolset enable action previously showed a generic bolt icon and "Enable tool" label regardless of which tool was being enabled. This resolves the actual MCP server view from the toolsetId parameter to display the server's real icon and name (e.g. "Enable Slack tool" with the Slack icon). Also renames "toolset" to "tool" in all display labels for consistency with user-facing terminology.


### Before
<kbd>
<img width="828" height="514" alt="Screenshot 2026-03-18 at 11 19 12" src="https://github.com/user-attachments/assets/a1b53f05-5f8c-497d-92f9-12913f2e6a88" />
</kbd>

### After
<kbd>
<img width="842" height="522" alt="Screenshot 2026-03-18 at 11 17 30" src="https://github.com/user-attachments/assets/aa830743-da84-4ea6-adac-53109ecb58b4" />
</kbd>

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
