### PR TITLE
[front] fix double dot in generated image names

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -206,7 +206,7 @@ export async function processToolResults(
         case "image": {
           const fileName = isResourceWithName(block)
             ? block.name
-            : `generated-image-${Date.now()}.${extensionsForContentType(block.mimeType as any)[0]}`;
+            : `generated-image-${Date.now()}${extensionsForContentType(block.mimeType as any)[0]}`;
 
           return handleBase64Upload(auth, {
             base64Data: block.data,


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/7162
- The extensions in each value of `FILE_FORMATS` already contain a dot.
- When generating a name for images we add a 2nd one, thus generating names like `generated-image-1773828838758..jpg`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
