### PR TITLE
[DX] Remove biome format-on-save from shared VSCode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
   ],
   "js/ts.preferences.importModuleSpecifier": "non-relative",
   "github-actions.workflows.pinned.workflows": [],
-  "editor.formatOnSave": true,
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer",
     "editor.formatOnSave": true,
@@ -22,10 +21,6 @@
   "rust-analyzer.inlayHints.typeHints.enable": false,
   "rust-analyzer.lens.implementations.enable": false,
   "git.ignoreLimitWarning": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.biome": "explicit",
-    "source.organizeImports.biome": "explicit"
-  },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "rust-analyzer.linkedProjects": [
     "./core/Cargo.toml"
   ],
-  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "js/ts.preferences.importModuleSpecifier": "non-relative",
   "github-actions.workflows.pinned.workflows": [],
   "editor.formatOnSave": true,
   "[rust]": {


### PR DESCRIPTION
## Description

Removes `editor.formatOnSave` and `editor.codeActionsOnSave` (biome fix + organizeImports) from the shared `.vscode/settings.json`. Workspace settings take precedence over user settings in VSCode, so these overrode each contributor's own preferences with no way to opt out. Format-on-save is a personal workflow choice — moving it out of the shared config lets each developer decide in their own user settings.

Also fixes a deprecation warning: `typescript.preferences.importModuleSpecifier` → `js/ts.preferences.importModuleSpecifier`.

## Tests

Config-only change, tested manually by verifying VSCode no longer enforces format-on-save globally.

## Risk

No risk — VSCode config only, no code changes.

## Deploy Plan

- Standard deploy, no migration needed