### PR TITLE
[front] Upgrade htmlparser2 to v9 to align with connectors

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -146,7 +146,7 @@
     "googleapis": "^118.0.0",
     "hot-shots": "^10.0.0",
     "html-escaper": "^3.0.3",
-    "htmlparser2": "^8.0.2",
+    "htmlparser2": "^9.1.0",
     "image-size": "^2.0.2",
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,7 +451,7 @@
         "googleapis": "^118.0.0",
         "hot-shots": "^10.0.0",
         "html-escaper": "^3.0.3",
-        "htmlparser2": "^8.0.2",
+        "htmlparser2": "^9.1.0",
         "image-size": "^2.0.2",
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
@@ -642,25 +642,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "front/node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
       }
     },
     "front/node_modules/lru-cache": {


### PR DESCRIPTION
Stacked on #23131.

## Description

Upgrade `htmlparser2` from `^8.0.2` to `^9.1.0` in `front` to align with `connectors` and eliminate a duplicate/non-hoisted dependency in npm workspaces.

No breaking changes for our usage — `front` only uses the `Parser` class with standard event callbacks (`onopentag`, `ontext`, `onclosetag`, `onerror`), which are unchanged in v9. The v9 breaking changes are internal (entity decoding spec alignment, internal stack reversal).

## Tests

No code changes — only dependency version bump. Verified `htmlparser2` is now hoisted to root `node_modules`.

## Risk

Low. The `Parser` event-based API is stable between v8 and v9.

## Deploy Plan

Standard deploy, no special steps needed.