### PR TITLE
[BYOK] Fix missing providersHealth field in extension auth context

### DIFF
--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -158,6 +158,7 @@ export function ExtensionAuthProvider({
       isBuilder: isBuilder(workspace),
       featureFlags,
       vizUrl: process.env.VIZ_PUBLIC_URL ?? "",
+      providersHealth: null,
     };
   }, [user, workspace, featureFlags]);
 


### PR DESCRIPTION
## Description

Adds the missing `providersHealth: null` field to the extension's `AuthContext` value to fix a type error introduced when `providersHealth` was added to the shared `AuthContext` type.

## Tests

Verified the extension builds without type errors.

## Risk

Low — one-line null initialisation with no behavioural change.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`