### PR TITLE
[Data Retention] Purge restricted-space conversations

### DIFF
--- a/front/temporal/data_retention/activities.test.ts
+++ b/front/temporal/data_retention/activities.test.ts
@@ -1,0 +1,124 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import {
+  purgeAgentConversationsBatchActivity,
+  purgeConversationsBatchActivity,
+} from "@app/temporal/data_retention/activities";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { assert, describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", () => ({
+  heartbeat: vi.fn(),
+}));
+
+const RETENTION_DAYS = 30;
+const OLD_CONVERSATION_DAYS = RETENTION_DAYS + 1;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const dateFromDaysAgo = (days: number) =>
+  new Date(Date.now() - days * DAY_IN_MS);
+
+async function createOldRestrictedConversation() {
+  const { authenticator, user, workspace } = await createResourceTest({
+    role: "admin",
+  });
+
+  const agent = await AgentConfigurationFactory.createTestAgent(authenticator);
+  const restrictedSpace = await SpaceFactory.regular(workspace);
+
+  const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const addMemberRes = await restrictedSpace.addMembers(internalAdminAuth, {
+    userIds: [user.sId],
+  });
+  assert(addMemberRes.isOk(), "Failed to add admin user to restricted space.");
+
+  const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const conversation = await ConversationFactory.create(adminAuth, {
+    agentConfigurationId: agent.sId,
+    conversationCreatedAt: dateFromDaysAgo(OLD_CONVERSATION_DAYS),
+    messagesCreatedAt: [dateFromDaysAgo(OLD_CONVERSATION_DAYS)],
+    requestedSpaceIds: [restrictedSpace.id],
+    spaceId: restrictedSpace.id,
+  });
+
+  return {
+    agent,
+    conversation,
+    workspace,
+  };
+}
+
+describe("data retention activities", () => {
+  it("purges workspace-level retained conversations in restricted regular spaces", async () => {
+    const { conversation, workspace } = await createOldRestrictedConversation();
+
+    await WorkspaceModel.update(
+      {
+        conversationsRetentionDays: RETENTION_DAYS,
+      },
+      {
+        where: {
+          id: workspace.id,
+        },
+      }
+    );
+
+    const result = await purgeConversationsBatchActivity({
+      workspaceIds: [workspace.id],
+    });
+
+    expect(result).toEqual([
+      {
+        workspaceId: workspace.sId,
+        workspaceModelId: workspace.id,
+        nbConversationsDeleted: 1,
+      },
+    ]);
+
+    const deletedConversation = await ConversationModel.findOne({
+      where: {
+        sId: conversation.sId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    expect(deletedConversation).toBeNull();
+  });
+
+  it("purges agent-level retained conversations in restricted regular spaces", async () => {
+    const { agent, conversation, workspace } =
+      await createOldRestrictedConversation();
+
+    const result = await purgeAgentConversationsBatchActivity({
+      agentConfigurationId: agent.sId,
+      retentionDays: RETENTION_DAYS,
+      workspaceId: workspace.id,
+    });
+
+    expect(result).toEqual({
+      agentConfigurationId: agent.sId,
+      workspaceId: workspace.sId,
+      workspaceModelId: workspace.id,
+      retentionDays: RETENTION_DAYS,
+      nbConversationsDeleted: 1,
+    });
+
+    const deletedConversation = await ConversationModel.findOne({
+      where: {
+        sId: conversation.sId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    expect(deletedConversation).toBeNull();
+  });
+});

--- a/front/temporal/data_retention/activities.test.ts
+++ b/front/temporal/data_retention/activities.test.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   purgeAgentConversationsBatchActivity,
   purgeConversationsBatchActivity,
@@ -52,24 +52,41 @@ async function createOldRestrictedConversation() {
 
   return {
     agent,
+    adminAuth,
     conversation,
     workspace,
   };
 }
 
+async function expectConversationDeleted(
+  auth: Authenticator,
+  conversationId: string
+) {
+  const deletedConversation = await ConversationResource.fetchById(
+    auth,
+    conversationId,
+    {
+      dangerouslySkipPermissionFiltering: true,
+      includeDeleted: true,
+    }
+  );
+
+  expect(deletedConversation).toBeNull();
+}
+
 describe("data retention activities", () => {
   it("purges workspace-level retained conversations in restricted regular spaces", async () => {
-    const { conversation, workspace } = await createOldRestrictedConversation();
+    const { adminAuth, conversation, workspace } =
+      await createOldRestrictedConversation();
 
-    await WorkspaceModel.update(
-      {
-        conversationsRetentionDays: RETENTION_DAYS,
-      },
-      {
-        where: {
-          id: workspace.id,
-        },
-      }
+    const updateRetentionRes =
+      await WorkspaceResource.updateConversationsRetention(
+        workspace.id,
+        RETENTION_DAYS
+      );
+    assert(
+      updateRetentionRes.isOk(),
+      "Failed to set workspace conversation retention."
     );
 
     const result = await purgeConversationsBatchActivity({
@@ -84,18 +101,11 @@ describe("data retention activities", () => {
       },
     ]);
 
-    const deletedConversation = await ConversationModel.findOne({
-      where: {
-        sId: conversation.sId,
-        workspaceId: workspace.id,
-      },
-    });
-
-    expect(deletedConversation).toBeNull();
+    await expectConversationDeleted(adminAuth, conversation.sId);
   });
 
   it("purges agent-level retained conversations in restricted regular spaces", async () => {
-    const { agent, conversation, workspace } =
+    const { adminAuth, agent, conversation, workspace } =
       await createOldRestrictedConversation();
 
     const result = await purgeAgentConversationsBatchActivity({
@@ -112,13 +122,6 @@ describe("data retention activities", () => {
       nbConversationsDeleted: 1,
     });
 
-    const deletedConversation = await ConversationModel.findOne({
-      where: {
-        sId: conversation.sId,
-        workspaceId: workspace.id,
-      },
-    });
-
-    expect(deletedConversation).toBeNull();
+    await expectConversationDeleted(adminAuth, conversation.sId);
   });
 });

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -63,6 +63,7 @@ export async function purgeConversationsBatchActivity({
       cutoffDate,
       {
         batchSize: WORKSPACE_CONVERSATIONS_BATCH_SIZE,
+        // Retention is internal maintenance, so selection must ignore end-user space visibility.
         dangerouslySkipPermissionFiltering: true,
         includeDeleted: true,
       }
@@ -175,6 +176,7 @@ export async function purgeAgentConversationsBatchActivity({
         cutoffDate,
       },
       {
+        // Retention is internal maintenance, so selection must ignore end-user space visibility.
         dangerouslySkipPermissionFiltering: true,
         includeDeleted: true,
       }

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -63,6 +63,7 @@ export async function purgeConversationsBatchActivity({
       cutoffDate,
       {
         batchSize: WORKSPACE_CONVERSATIONS_BATCH_SIZE,
+        dangerouslySkipPermissionFiltering: true,
         includeDeleted: true,
       }
     );
@@ -174,6 +175,7 @@ export async function purgeAgentConversationsBatchActivity({
         cutoffDate,
       },
       {
+        dangerouslySkipPermissionFiltering: true,
         includeDeleted: true,
       }
     );


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7064

Makes internal conversation retention selection bypass conversation permission filtering so purge workflows still pick up old conversations in restricted regular spaces. Adds a focused regression test for both workspace-level and agent-level retention paths.

## Risks
Blast radius: front temporal conversation retention for workspace and agent purge workflows
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run ./temporal/data_retention/activities.test.ts`
