### PR TITLE
[LLM] Add omitted thinking eval variants for Dust global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -74,7 +74,6 @@ interface DustLikeGlobalAgentArgs {
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   hasDeepDive: boolean;
   globalAgentContext?: GlobalAgentContext;
-  omittedThinking?: boolean;
 }
 
 const INSTRUCTION_SECTIONS = {
@@ -321,20 +320,21 @@ function _getDustLikeGlobalAgent(
     mcpServerViews,
     hasDeepDive,
     globalAgentContext,
-    omittedThinking,
   }: DustLikeGlobalAgentArgs,
   {
     agentId,
     name,
     preferredModelConfiguration,
     preferredReasoningEffort,
+    omittedThinking,
   }: {
     agentId: GLOBAL_AGENTS_SID;
     name: string;
     preferredModelConfiguration?: ModelConfigurationType | null;
     preferredReasoningEffort?: ReasoningEffort;
+    omittedThinking?: boolean;
   }
-): AgentConfigurationType | null {
+): (AgentConfigurationType & { omittedThinking?: boolean }) | null {
   const { agent_memory: agentMemoryMCPServerView } = mcpServerViews;
   const owner = auth.getNonNullableWorkspace();
 
@@ -572,6 +572,7 @@ export function _getDustHighOmittedGlobalAgent(
     name: "dust-high-omitted",
     preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "high",
+    omittedThinking: true,
   });
 }
 
@@ -584,6 +585,7 @@ export function _getDustOmittedGlobalAgent(
     name: "dust-omitted",
     preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "medium",
+    omittedThinking: true,
   });
 }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -74,6 +74,7 @@ interface DustLikeGlobalAgentArgs {
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   hasDeepDive: boolean;
   globalAgentContext?: GlobalAgentContext;
+  omittedThinking?: boolean;
 }
 
 const INSTRUCTION_SECTIONS = {
@@ -320,6 +321,7 @@ function _getDustLikeGlobalAgent(
     mcpServerViews,
     hasDeepDive,
     globalAgentContext,
+    omittedThinking,
   }: DustLikeGlobalAgentArgs,
   {
     agentId,
@@ -527,6 +529,7 @@ function _getDustLikeGlobalAgent(
       "sandbox",
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    omittedThinking: omittedThinking ?? false,
   };
 }
 
@@ -543,6 +546,42 @@ export function _getDustGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
+    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "medium",
+  });
+}
+
+export function _getDustHighGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_HIGH,
+    name: "dust-high",
+    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "high",
+  });
+}
+
+export function _getDustHighOmittedGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED,
+    name: "dust-high-omitted",
+    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "high",
+  });
+}
+
+export function _getDustOmittedGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_OMITTED,
+    name: "dust-omitted",
     preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "medium",
   });

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -637,6 +637,32 @@ export function _getDustAntHighGlobalAgent(
   });
 }
 
+export function _getDustAntMediumOmittedGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED,
+    name: "dust-ant-medium-omitted",
+    preferredModelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "medium",
+    omittedThinking: true,
+  });
+}
+
+export function _getDustAntHighOmittedGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
+    name: "dust-ant-high-omitted",
+    preferredModelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "high",
+    omittedThinking: true,
+  });
+}
+
 export function _getDustKimiGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -355,6 +355,22 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "Same as dust-ant but with high reasoning effort.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED,
+        name: "dust-ant-medium-omitted",
+        description:
+          "Same as dust-ant-medium but with omitted reasoning summaries.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
+        name: "dust-ant-high-omitted",
+        description:
+          "Same as dust-ant-high but with omitted reasoning summaries.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_KIMI:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_KIMI,

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -432,6 +432,30 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "An agent with context on your company data.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_HIGH:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_HIGH,
+        name: "dust-high",
+        description:
+          "An agent with context on your company data, with high reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_OMITTED:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_OMITTED,
+        name: "dust-omitted",
+        description:
+          "An agent with context on your company data, with omitted reasoning summaries.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED,
+        name: "dust-high-omitted",
+        description:
+          "An agent with context on your company data, with high reasoning effort and omitted reasoning summaries.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       return {
         sId: GLOBAL_AGENTS_SID.DEEP_DIVE,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -18,7 +18,9 @@ import {
 import {
   _getDustAntGlobalAgent,
   _getDustAntHighGlobalAgent,
+  _getDustAntHighOmittedGlobalAgent,
   _getDustAntMediumGlobalAgent,
+  _getDustAntMediumOmittedGlobalAgent,
   _getDustEdgeGlobalAgent,
   _getDustGlmGlobalAgent,
   _getDustGlmHighGlobalAgent,
@@ -201,6 +203,18 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -800,6 +814,22 @@ function getGlobalAgent({
         hasDeepDive,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED:
+      agentConfiguration = _getDustAntMediumOmittedGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED:
+      agentConfiguration = _getDustAntHighOmittedGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DUST_KIMI:
       agentConfiguration = _getDustKimiGlobalAgent(auth, {
         settings,
@@ -1090,9 +1120,14 @@ export async function getGlobalAgents(
     );
   }
   const DUST_INTERNAL_AGENTS = [
+    GLOBAL_AGENTS_SID.DUST_HIGH,
+    GLOBAL_AGENTS_SID.DUST_OMITTED,
+    GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED,
     GLOBAL_AGENTS_SID.DUST_ANT,
     GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM,
     GLOBAL_AGENTS_SID.DUST_ANT_HIGH,
+    GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED,
+    GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
     GLOBAL_AGENTS_SID.DUST_EDGE,
     GLOBAL_AGENTS_SID.DUST_KIMI,
     GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -26,6 +26,8 @@ import {
   _getDustGlobalAgent,
   _getDustGoogGlobalAgent,
   _getDustGoogMediumGlobalAgent,
+  _getDustHighGlobalAgent,
+  _getDustHighOmittedGlobalAgent,
   _getDustKimiGlobalAgent,
   _getDustKimiHighGlobalAgent,
   _getDustKimiMediumGlobalAgent,
@@ -38,6 +40,7 @@ import {
   _getDustOaiGlobalAgent,
   _getDustOaiHighGlobalAgent,
   _getDustOaiMediumGlobalAgent,
+  _getDustOmittedGlobalAgent,
   _getDustQuickGlobalAgent,
   _getDustQuickMediumGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
@@ -114,6 +117,24 @@ const GLOBAL_AGENT_FLAGS: Record<
   }
 > = {
   [GLOBAL_AGENTS_SID.DUST]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_OMITTED]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -718,6 +739,35 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         globalAgentContext,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.DUST_HIGH:
+      agentConfiguration = _getDustHighGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        globalAgentContext,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.DUST_OMITTED:
+      agentConfiguration = _getDustOmittedGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        globalAgentContext,
+        omittedThinking: true,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED:
+      agentConfiguration = _getDustHighOmittedGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        globalAgentContext,
+        omittedThinking: true,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_EDGE:

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -757,7 +757,6 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         globalAgentContext,
-        omittedThinking: true,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_HIGH_OMITTED:
@@ -767,7 +766,6 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         globalAgentContext,
-        omittedThinking: true,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_EDGE:

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -93,6 +93,7 @@ function buildSystemBlocks(
 
 export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   private client: Anthropic;
+  private omittedThinking: boolean;
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters & { modelId: AnthropicWhitelistedModelId }
@@ -101,6 +102,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     super(auth, ANTHROPIC_PROVIDER_ID, params);
     const { ANTHROPIC_API_KEY } = llmParameters.credentials;
     assert(ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY credential is required");
+    this.omittedThinking = params.omittedThinking ?? false;
 
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
@@ -113,9 +115,13 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     prompt,
     specifications,
     forceToolCall,
+    omittedThinking = this.omittedThinking,
   }: LLMStreamParameters): MessageCreateParamsNonStreaming {
     const messages = conversation.messages.map((msg, index, array) =>
-      toMessage(msg, { isLast: index === array.length - 1 })
+      toMessage(msg, {
+        isLast: index === array.length - 1,
+        omittedThinking: this.omittedThinking,
+      })
     );
 
     // Build thinking config, use custom type if specified.
@@ -123,7 +129,8 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       this.modelConfig.customThinkingType === "auto"
         ? toAutoThinkingConfig(
             this.reasoningEffort,
-            this.modelConfig.useNativeLightReasoning
+            this.modelConfig.useNativeLightReasoning,
+            this.omittedThinking
           )
         : toThinkingConfig(
             this.reasoningEffort,

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -35,6 +35,7 @@ import type {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
+import compact from "lodash/compact";
 
 function userContentToParam(
   content: Content
@@ -60,8 +61,14 @@ function assistantContentToParam(
   content:
     | AgentTextContentType
     | AgentReasoningContentType
-    | AgentFunctionCallContentType
-): TextBlockParam | ImageBlockParam | ThinkingBlockParam | ToolUseBlockParam {
+    | AgentFunctionCallContentType,
+  omittedThinking: boolean
+):
+  | TextBlockParam
+  | ImageBlockParam
+  | ThinkingBlockParam
+  | ToolUseBlockParam
+  | undefined {
   switch (content.type) {
     case "text_content":
       return {
@@ -69,6 +76,9 @@ function assistantContentToParam(
         text: content.value,
       };
     case "reasoning":
+      if (omittedThinking) {
+        return;
+      }
       assert(content.value.reasoning, "Reasoning content is missing reasoning");
       const signature = extractEncryptedContentFromMetadata(
         content.value.metadata
@@ -128,9 +138,14 @@ function userMessage(
 function assistantMessage(
   message:
     | AssistantFunctionCallMessageTypeModel
-    | AssistantContentMessageTypeModel
+    | AssistantContentMessageTypeModel,
+  omittedThinking: boolean
 ): MessageParam {
-  const contents = message.contents.map(assistantContentToParam);
+  const contents = compact(
+    message.contents.map((content) =>
+      assistantContentToParam(content, omittedThinking)
+    )
+  );
 
   return {
     role: "assistant",
@@ -140,7 +155,10 @@ function assistantMessage(
 
 export function toMessage(
   message: ModelMessageTypeMultiActionsWithoutContentFragment,
-  { isLast }: { isLast: boolean } = { isLast: false }
+  { isLast, omittedThinking }: { isLast: boolean; omittedThinking: boolean } = {
+    isLast: false,
+    omittedThinking: false,
+  }
 ): MessageParam {
   switch (message.role) {
     case "user":
@@ -148,7 +166,7 @@ export function toMessage(
     case "function":
       return functionMessage(message);
     case "assistant":
-      return assistantMessage(message);
+      return assistantMessage(message, omittedThinking);
     default:
       assertNever(message);
   }

--- a/front/lib/api/llm/clients/anthropic/utils/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.test.ts
@@ -69,7 +69,7 @@ describe("toThinkingConfig", () => {
 describe("toAutoThinkingConfig", () => {
   it("returns adaptive thinking when reasoning effort is null", () => {
     expect(toAutoThinkingConfig(null)).toEqual({
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
     });
   });
 
@@ -87,7 +87,7 @@ describe("toAutoThinkingConfig", () => {
 
   it('returns adaptive thinking with output_config for "medium"', () => {
     expect(toAutoThinkingConfig("medium")).toEqual({
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
       output_config: {
         effort: ANTHROPIC_THINKING_EFFORT_MAPPING.medium,
       },
@@ -96,7 +96,7 @@ describe("toAutoThinkingConfig", () => {
 
   it('returns adaptive thinking with output_config for "high"', () => {
     expect(toAutoThinkingConfig("high")).toEqual({
-      thinking: { type: "adaptive" },
+      thinking: { type: "adaptive", display: "summarized" },
       output_config: {
         effort: ANTHROPIC_THINKING_EFFORT_MAPPING.high,
       },

--- a/front/lib/api/llm/clients/anthropic/utils/index.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.ts
@@ -37,7 +37,8 @@ export const ANTHROPIC_THINKING_EFFORT_MAPPING: Record<
 
 export function toAutoThinkingConfig(
   reasoningEffort: ReasoningEffort | null,
-  useNativeLightReasoning?: boolean
+  useNativeLightReasoning?: boolean,
+  omittedThinking: boolean = false
 ): {
   thinking: ThinkingConfigParam;
   output_config?: BetaOutputConfig;
@@ -49,7 +50,12 @@ export function toAutoThinkingConfig(
 
   switch (reasoningEffort) {
     case null:
-      return { thinking: { type: "adaptive" } };
+      return {
+        thinking: {
+          type: "adaptive",
+          display: omittedThinking ? "omitted" : "summarized",
+        },
+      };
     case "none":
       return { thinking: { type: "disabled" } };
     case "light":
@@ -58,6 +64,7 @@ export function toAutoThinkingConfig(
       return {
         thinking: {
           type: "adaptive",
+          display: omittedThinking ? "omitted" : "summarized",
         },
         output_config: {
           effort: ANTHROPIC_THINKING_EFFORT_MAPPING[reasoningEffort],

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -31,7 +31,10 @@ describe("toMessage", () => {
         throw new Error("No user message found in test fixtures");
       }
 
-      const result = toMessage(userMessage, { isLast: false });
+      const result = toMessage(userMessage, {
+        isLast: false,
+        omittedThinking: false,
+      });
 
       // Verify no cache_control is present
       if (Array.isArray(result.content)) {
@@ -49,7 +52,10 @@ describe("toMessage", () => {
         throw new Error("No user message found in test fixtures");
       }
 
-      const result = toMessage(userMessage, { isLast: true });
+      const result = toMessage(userMessage, {
+        isLast: true,
+        omittedThinking: false,
+      });
 
       // Verify cache_control is added to the last content block
       if (Array.isArray(result.content) && result.content.length > 0) {
@@ -69,7 +75,10 @@ describe("toMessage", () => {
         throw new Error("No assistant message found in test fixtures");
       }
 
-      const result = toMessage(assistantMessage, { isLast: true });
+      const result = toMessage(assistantMessage, {
+        isLast: true,
+        omittedThinking: false,
+      });
 
       // Assistant messages should not have cache_control even if isLast is true
       if (Array.isArray(result.content)) {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -30,6 +30,7 @@ export async function getLLM(
     metaData,
     bypassFeatureFlag = false,
     context,
+    omittedThinking,
   }: LLMParameters
 ): Promise<LLM | null> {
   const modelConfig = getModelConfigByModelId(modelId);
@@ -89,6 +90,7 @@ export async function getLLM(
       responseFormat,
       bypassFeatureFlag,
       context,
+      omittedThinking,
     });
   }
 

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -105,6 +105,7 @@ export type LLMParameters = {
   responseFormat?: string | null;
   metaData?: Record<string, unknown>;
   temperature?: number | null;
+  omittedThinking?: boolean;
 } & LLMTraceCustomization;
 
 export type LLMParameterOverwrites = Partial<
@@ -128,4 +129,5 @@ export interface LLMStreamParameters {
    * tools defined in the `specifications` array.
    */
   forceToolCall?: ForceToolCall;
+  omittedThinking?: boolean;
 }

--- a/front/package.json
+++ b/front/package.json
@@ -37,7 +37,7 @@
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
+    "@anthropic-ai/sdk": "^0.79.0",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -505,6 +505,7 @@ export async function runModel(
     responseFormat: agentConfiguration.model.responseFormat,
     metaData: agentConfiguration.model.metaData,
     context: traceContext,
+    omittedThinking: agentConfiguration.omittedThinking,
     // Custom trace input: show only the last user message instead of full conversation.
     getTraceInput: (conv) => {
       const lastUserMessage = conv.messages.findLast(

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -192,6 +192,8 @@ export type LightAgentConfigurationType = {
 
   canRead: boolean;
   canEdit: boolean;
+  // TODO (Pierre): Remove after omitted thinking evals
+  omittedThinking?: boolean;
 };
 
 export type AgentConfigurationType = LightAgentConfigurationType & {

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -60,6 +60,8 @@ export enum GLOBAL_AGENTS_SID {
   DUST_ANT = "dust-ant",
   DUST_ANT_MEDIUM = "dust-ant-medium",
   DUST_ANT_HIGH = "dust-ant-high",
+  DUST_ANT_MEDIUM_OMITTED = "dust-ant-medium-omitted",
+  DUST_ANT_HIGH_OMITTED = "dust-ant-high-omitted",
   DUST_KIMI = "dust-kimi",
   DUST_KIMI_MEDIUM = "dust-kimi-medium",
   DUST_KIMI_HIGH = "dust-kimi-high",

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -44,6 +44,9 @@ export function isSupportingResponseFormat(modelId: ModelIdType) {
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
+  DUST_OMITTED = "dust-omitted",
+  DUST_HIGH = "dust-high",
+  DUST_HIGH_OMITTED = "dust-high-omitted",
   DUST_EDGE = "dust-edge",
   DUST_QUICK = "dust-quick",
   DUST_QUICK_MEDIUM = "dust-quick-medium",

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,7 +342,7 @@
       "name": "@dust-tt/front",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
+        "@anthropic-ai/sdk": "^0.79.0",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
-      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.79.0.tgz",
+      "integrity": "sha512-ietmtM6glcnnrWq26H+BZm8J07iay9Cob6hRzDTr/A9QWF1m2T//TQhFO4MTKcZht2/7LS8bG9wUYEhcizKRnA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"


### PR DESCRIPTION
## Description

> ⚠️ **INTENDED TO BE REVERTED AFTER EVAL RUN** — Dust users should see reasoning summaries; this is a temporary eval-only change.

Adds three temporary global agent variants (`dust-high`, `dust-omitted`, `dust-high-omitted`) with an `omittedThinking` flag to compare Claude responses with thinking blocks stripped vs. summarized.

## Tests

Unit tests updated; manually tested end-to-end.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`