### PR TITLE
[front] - fix(icons): update icons for creating new conversations

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -59,8 +59,7 @@ import {
   BoltOffIcon,
   BracesIcon,
   Button,
-  ChatBubbleBottomCenterTextIcon,
-  ChatBubbleLeftRightIcon,
+  ChatBubbleBottomCenterPlusIcon,
   Checkbox,
   CheckDoubleIcon,
   cn,
@@ -321,7 +320,7 @@ function SearchResults({
             <>
               <Button
                 size="xmini"
-                icon={ChatBubbleLeftRightIcon}
+                icon={ChatBubbleBottomCenterPlusIcon}
                 variant="ghost"
                 tooltip="New Conversation"
                 href={getConversationRoute(owner.sId)}
@@ -847,7 +846,7 @@ export function AgentSidebarMenu({
                   <Button
                     label="New"
                     href={getConversationRoute(owner.sId)}
-                    icon={ChatBubbleBottomCenterTextIcon}
+                    icon={ChatBubbleBottomCenterPlusIcon}
                     className="shrink-0"
                     tooltip="Create a new conversation"
                     onClick={handleNewClick}
@@ -1459,7 +1458,7 @@ function NavigationListWithInbox({
             <>
               <Button
                 size="xmini"
-                icon={ChatBubbleLeftRightIcon}
+                icon={ChatBubbleBottomCenterPlusIcon}
                 variant="ghost"
                 aria-label="New Conversation"
                 tooltip="New Conversation"

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -17,7 +17,7 @@ import { isAdmin, isBuilder } from "@app/types/user";
 import {
   BracesIcon,
   Button,
-  ChatBubbleBottomCenterTextIcon,
+  ChatBubbleBottomCenterPlusIcon,
   ClipboardIcon,
   DocumentIcon,
   DropdownMenu,
@@ -108,7 +108,7 @@ export function AgentDetailsButtonBar({
 
       {canShowAgentConversationActions(agentConfiguration.sId) && (
         <Button
-          icon={ChatBubbleBottomCenterTextIcon}
+          icon={ChatBubbleBottomCenterPlusIcon}
           size="sm"
           variant="outline"
           tooltip="New conversation"

--- a/front/components/mentions/MentionDropdown.test.tsx
+++ b/front/components/mentions/MentionDropdown.test.tsx
@@ -32,14 +32,14 @@ vi.mock("@dust-tt/sparkle", () => {
       <button onClick={onClick}>{label}</button>
     </div>
   );
-  const ChatBubbleBottomCenterTextIcon = () => null;
+  const ChatBubbleBottomCenterPlusIcon = () => null;
   const EyeIcon = () => null;
   return {
     DropdownMenu,
     DropdownMenuTrigger,
     DropdownMenuContent,
     DropdownMenuItem,
-    ChatBubbleBottomCenterTextIcon,
+    ChatBubbleBottomCenterPlusIcon,
     EyeIcon,
   };
 });

--- a/front/components/mentions/MentionDropdown.tsx
+++ b/front/components/mentions/MentionDropdown.tsx
@@ -17,7 +17,7 @@ import {
 } from "@app/types/assistant/mentions";
 import type { WorkspaceType } from "@app/types/user";
 import {
-  ChatBubbleBottomCenterTextIcon,
+  ChatBubbleBottomCenterPlusIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -70,7 +70,7 @@ export const MentionDropdown = React.forwardRef<
         <DropdownMenuContent side="bottom" align="start">
           <DropdownMenuItem
             onClick={handleAgentStartConversation}
-            icon={ChatBubbleBottomCenterTextIcon}
+            icon={ChatBubbleBottomCenterPlusIcon}
             label={`New conversation with @${mention.label}`}
           />
           <DropdownMenuItem


### PR DESCRIPTION
## Description

This PR ensures that all buttons leading to a new conversation use the same `ChatBubbleBottomCenterPlusIcon` icon.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front