### PR TITLE
Allow to disable notif when running reinforced agent from poke plugin

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -74,7 +74,7 @@ export function PluginForm({
               key,
               arg.async && asyncArgs?.[key] !== undefined
                 ? (asyncArgs[key] as boolean)
-                : false,
+                : (arg.default ?? false),
             ];
           case "enum":
             return [

--- a/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
+++ b/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
@@ -23,6 +23,13 @@ export const runReinforcedAgentPlugin = createPlugin({
         description: "Number of past days of conversations to analyze.",
         default: 1,
       },
+      disableNotifications: {
+        type: "boolean",
+        label: "Disable notifications",
+        description:
+          "Disable sending notifications to agent editors when new suggestions are created.",
+        default: true,
+      },
     },
   },
   execute: async (auth, resource, args) => {
@@ -37,6 +44,7 @@ export const runReinforcedAgentPlugin = createPlugin({
       agentConfigurationId: resource.sId,
       useBatchMode: args.useBatchMode,
       conversationLookbackDays: args.conversationLookbackDays,
+      disableNotifications: args.disableNotifications,
     });
 
     if (result.isErr()) {

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -218,7 +218,8 @@ export async function buildAggregationBatchMap(
  */
 export async function aggregateSyntheticSuggestions(
   auth: Authenticator,
-  agentConfigurationId: string
+  agentConfigurationId: string,
+  { disableNotifications }: { disableNotifications: boolean }
 ): Promise<void> {
   const ctx = await loadAggregationContext(auth, agentConfigurationId);
   if (!ctx) {
@@ -236,7 +237,7 @@ export async function aggregateSyntheticSuggestions(
     contextId: "n/a",
   });
 
-  if (createdCount > 0) {
+  if (createdCount > 0 && !disableNotifications) {
     notifyAgentSuggestionsReady(auth, {
       agentConfiguration: agentConfig,
       suggestionCount: createdCount,

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -219,7 +219,7 @@ export async function buildAggregationBatchMap(
 export async function aggregateSyntheticSuggestions(
   auth: Authenticator,
   agentConfigurationId: string,
-  { disableNotifications }: { disableNotifications: boolean }
+  disableNotifications: boolean
 ): Promise<void> {
   const ctx = await loadAggregationContext(auth, agentConfigurationId);
   if (!ctx) {

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -137,9 +137,11 @@ export async function aggregateSuggestionsActivity({
 }): Promise<void> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  await aggregateSyntheticSuggestions(auth, agentConfigurationId, {
-    disableNotifications,
-  });
+  await aggregateSyntheticSuggestions(
+    auth,
+    agentConfigurationId,
+    disableNotifications
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -2,6 +2,7 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import {
   aggregateSyntheticSuggestions,
   buildAggregationBatchMap,
@@ -128,13 +129,17 @@ export async function analyzeConversationActivity({
 export async function aggregateSuggestionsActivity({
   workspaceId,
   agentConfigurationId,
+  disableNotifications,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
+  disableNotifications: boolean;
 }): Promise<void> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  await aggregateSyntheticSuggestions(auth, agentConfigurationId);
+  await aggregateSyntheticSuggestions(auth, agentConfigurationId, {
+    disableNotifications,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -328,10 +333,12 @@ export async function processAggregationBatchResultActivity({
   workspaceId,
   agentConfigurationId,
   batchId,
+  disableNotifications,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   batchId: string;
+  disableNotifications: boolean;
 }): Promise<void> {
   const auth = await getAuthForWorkspace(workspaceId);
 
@@ -367,6 +374,13 @@ export async function processAggregationBatchResultActivity({
       source: "reinforcement",
       operationType: "reinforced_agent_aggregate_suggestions",
       contextId: "n/a",
+    });
+  }
+
+  if (createdCount > 0 && !disableNotifications) {
+    notifyAgentSuggestionsReady(auth, {
+      agentConfiguration: agentConfig,
+      suggestionCount: createdCount,
     });
   }
 

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -91,11 +91,13 @@ export async function startReinforcedAgentForAgentWorkflow({
   agentConfigurationId,
   useBatchMode,
   conversationLookbackDays = 1,
+  disableNotifications,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
   conversationLookbackDays?: number;
+  disableNotifications?: boolean;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = `reinforced-agent-${workspaceId}-${agentConfigurationId}-manual-${Date.now()}`;
@@ -107,6 +109,7 @@ export async function startReinforcedAgentForAgentWorkflow({
         agentConfigurationId,
         useBatchMode,
         conversationLookbackDays,
+        disableNotifications,
       },
     ],
     taskQueue: QUEUE_NAME,

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -176,11 +176,13 @@ export async function reinforcedAgentForAgentWorkflow({
   agentConfigurationId,
   useBatchMode,
   conversationLookbackDays = 1,
+  disableNotifications = false,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
   conversationLookbackDays?: number;
+  disableNotifications?: boolean;
 }): Promise<void> {
   const conversationIds = await getRecentConversationsForAgentActivity({
     workspaceId,
@@ -221,6 +223,7 @@ export async function reinforcedAgentForAgentWorkflow({
         workspaceId,
         agentConfigurationId,
         batchId: aggregationBatchId,
+        disableNotifications,
       });
     }
   } else {
@@ -240,6 +243,7 @@ export async function reinforcedAgentForAgentWorkflow({
     await aggregateSuggestionsActivity({
       workspaceId,
       agentConfigurationId,
+      disableNotifications,
     });
   }
 }

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -70,6 +70,7 @@ interface BooleanArgDefinition extends BaseArgDefinition {
   type: "boolean";
   values?: never;
   variant?: "checkbox" | "toggle";
+  default?: boolean;
   async?: false;
 }
 
@@ -77,6 +78,7 @@ interface AsyncBooleanArgDefinition extends BaseArgDefinition {
   type: "boolean";
   values?: never;
   variant?: "checkbox" | "toggle";
+  default?: boolean;
   async: true;
 }
 


### PR DESCRIPTION
## Description

closing https://github.com/dust-tt/tasks/issues/7122

We want to be able to run analsysis for tests without notifying the owners of the agent

<img width="1006" height="722" alt="image" src="https://github.com/user-attachments/assets/0a8e5a41-57ac-4003-9cd7-2afec6ea3aa0" />


## Tests

Tested locally

## Risk

low

## Deploy Plan

deploy front
