### PR TITLE
[front] feat(skill): add tab in skill import dialog to import from a zip

### DIFF
--- a/front/components/skills/import/ImportFromFilesTab.tsx
+++ b/front/components/skills/import/ImportFromFilesTab.tsx
@@ -79,6 +79,9 @@ export function ImportFromFilesTab({
       );
       if (rejected.length > 0) {
         setFileTypeError("Only .zip files are accepted.");
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
         return;
       }
       setFileTypeError(null);

--- a/front/components/skills/import/ImportFromFilesTab.tsx
+++ b/front/components/skills/import/ImportFromFilesTab.tsx
@@ -38,8 +38,13 @@ export function ImportFromFilesTab({
   const { setValue } = useFormContext<FilesImportFormValues>();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const { detectedSkills, isDetecting, detectError, triggerDetect } =
-    useDetectSkillsFromFiles({ owner });
+  const {
+    detectedSkills,
+    isUploading,
+    isDetecting,
+    detectError,
+    triggerDetect,
+  } = useDetectSkillsFromFiles({ owner });
 
   // Re-sync selected skills when detection completes or when this tab becomes active.
   useEffect(() => {
@@ -55,8 +60,8 @@ export function ImportFromFilesTab({
   }, [isActive, detectedSkills, setValue]);
 
   useEffect(() => {
-    onDetectingChange(isDetecting);
-  }, [isDetecting, onDetectingChange]);
+    onDetectingChange(isUploading || isDetecting);
+  }, [isUploading, isDetecting, onDetectingChange]);
 
   useEffect(() => {
     onDetectedCountChange(detectedSkills.length);
@@ -98,8 +103,8 @@ export function ImportFromFilesTab({
           handleFilesSelected(Array.from(e.target.files ?? []));
         }}
         fileInputRef={fileInputRef}
-        disabled={isImporting}
-        isLoading={isDetecting}
+        disabled={isImporting || isDetecting}
+        isLoading={isUploading}
       />
       <DetectedSkillsList
         detectedSkills={detectedSkills}
@@ -137,7 +142,7 @@ function SkillFileDropzone({
       )}
       onDragOver={(e) => {
         e.preventDefault();
-        if (!isLoading) {
+        if (!disabled && !isLoading) {
           setIsDragOver(true);
         }
       }}
@@ -145,7 +150,7 @@ function SkillFileDropzone({
       onDrop={(e) => {
         e.preventDefault();
         setIsDragOver(false);
-        if (!isLoading) {
+        if (!disabled && !isLoading) {
           onDrop(e);
         }
       }}
@@ -159,7 +164,7 @@ function SkillFileDropzone({
         <>
           <Spinner size="md" />
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Detecting skills...
+            Uploading files...
           </p>
         </>
       ) : (

--- a/front/components/skills/import/ImportFromFilesTab.tsx
+++ b/front/components/skills/import/ImportFromFilesTab.tsx
@@ -38,13 +38,8 @@ export function ImportFromFilesTab({
   const { setValue } = useFormContext<FilesImportFormValues>();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const {
-    detectedSkills,
-    isUploading,
-    isDetecting,
-    detectError,
-    triggerDetect,
-  } = useDetectSkillsFromFiles({ owner });
+  const { detectedSkills, isUploading, detectError, triggerDetect } =
+    useDetectSkillsFromFiles({ owner });
 
   // Re-sync selected skills when detection completes or when this tab becomes active.
   useEffect(() => {
@@ -60,8 +55,8 @@ export function ImportFromFilesTab({
   }, [isActive, detectedSkills, setValue]);
 
   useEffect(() => {
-    onDetectingChange(isUploading || isDetecting);
-  }, [isUploading, isDetecting, onDetectingChange]);
+    onDetectingChange(isUploading);
+  }, [isUploading, onDetectingChange]);
 
   useEffect(() => {
     onDetectedCountChange(detectedSkills.length);
@@ -106,12 +101,13 @@ export function ImportFromFilesTab({
           handleFilesSelected(Array.from(e.target.files ?? []));
         }}
         fileInputRef={fileInputRef}
-        disabled={isImporting || isDetecting}
+        disabled={isImporting}
         isLoading={isUploading}
       />
       <DetectedSkillsList
         detectedSkills={detectedSkills}
-        isDetecting={isDetecting}
+        // The detection happens jointly with the upload and we can't really dissociate the two.
+        isDetecting={false}
         detectError={fileTypeError ?? detectError}
       />
       <FileRequirements />

--- a/front/components/skills/import/ImportFromFilesTab.tsx
+++ b/front/components/skills/import/ImportFromFilesTab.tsx
@@ -1,0 +1,218 @@
+import { DetectedSkillsList } from "@app/components/skills/import/DetectedSkillsList";
+import type { FilesImportFormValues } from "@app/components/skills/import/formSchema";
+import { isImportableSkillStatus } from "@app/lib/skill_detection";
+import { useDetectSkillsFromFiles } from "@app/lib/swr/skill_configurations";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContentMessage,
+  cn,
+  DropzoneOverlay,
+  Hoverable,
+  InformationCircleIcon,
+  PlusIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+const ACCEPTED_EXTENSIONS = [".zip"];
+
+interface ImportFromFilesTabProps {
+  owner: LightWorkspaceType;
+  isActive: boolean;
+  onDetectingChange: (isDetecting: boolean) => void;
+  onDetectedCountChange: (count: number) => void;
+  onFilesChange: (files: File[]) => void;
+  isImporting: boolean;
+}
+
+export function ImportFromFilesTab({
+  owner,
+  isActive,
+  onDetectingChange,
+  onDetectedCountChange,
+  onFilesChange,
+  isImporting,
+}: ImportFromFilesTabProps) {
+  const { setValue } = useFormContext<FilesImportFormValues>();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { detectedSkills, isDetecting, detectError, triggerDetect } =
+    useDetectSkillsFromFiles({ owner });
+
+  // Re-sync selected skills when detection completes or when this tab becomes active.
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    setValue(
+      "selectedSkillNames",
+      detectedSkills
+        .filter((skill) => isImportableSkillStatus(skill.status))
+        .map((skill) => skill.name)
+    );
+  }, [isActive, detectedSkills, setValue]);
+
+  useEffect(() => {
+    onDetectingChange(isDetecting);
+  }, [isDetecting, onDetectingChange]);
+
+  useEffect(() => {
+    onDetectedCountChange(detectedSkills.length);
+  }, [detectedSkills.length, onDetectedCountChange]);
+
+  const [fileTypeError, setFileTypeError] = useState<string | null>(null);
+
+  const handleFilesSelected = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+      const rejected = files.filter(
+        (f) => !ACCEPTED_EXTENSIONS.some((ext) => f.name.endsWith(ext))
+      );
+      if (rejected.length > 0) {
+        setFileTypeError("Only .zip files are accepted.");
+        return;
+      }
+      setFileTypeError(null);
+      onFilesChange(files);
+      void triggerDetect(files);
+    },
+    [triggerDetect, onFilesChange]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      handleFilesSelected(Array.from(e.dataTransfer.files));
+    },
+    [handleFilesSelected]
+  );
+
+  return (
+    <div className="flex flex-col gap-3 pt-4">
+      <SkillFileDropzone
+        onDrop={handleDrop}
+        onFileInputChange={(e) => {
+          handleFilesSelected(Array.from(e.target.files ?? []));
+        }}
+        fileInputRef={fileInputRef}
+        disabled={isImporting}
+        isLoading={isDetecting}
+      />
+      <DetectedSkillsList
+        detectedSkills={detectedSkills}
+        isDetecting={isDetecting}
+        detectError={fileTypeError ?? detectError}
+      />
+      <FileRequirements />
+    </div>
+  );
+}
+
+interface SkillFileDropzoneProps {
+  onDrop: (e: React.DragEvent) => void;
+  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  disabled: boolean;
+  isLoading: boolean;
+}
+
+function SkillFileDropzone({
+  onDrop,
+  onFileInputChange,
+  fileInputRef,
+  disabled,
+  isLoading,
+}: SkillFileDropzoneProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col items-center gap-3 overflow-hidden rounded-xl",
+        "border-2 border-dashed border-border bg-muted-background px-4 py-6",
+        "transition-colors dark:border-border-night dark:bg-muted-background-night"
+      )}
+      onDragOver={(e) => {
+        e.preventDefault();
+        if (!isLoading) {
+          setIsDragOver(true);
+        }
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setIsDragOver(false);
+        if (!isLoading) {
+          onDrop(e);
+        }
+      }}
+    >
+      <DropzoneOverlay
+        isDragActive={isDragOver}
+        title="Drop files here"
+        description="Upload .zip files"
+      />
+      {isLoading ? (
+        <>
+          <Spinner size="md" />
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Detecting skills...
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Drag and drop or click to upload
+          </p>
+          <input
+            className="hidden"
+            type="file"
+            accept={ACCEPTED_EXTENSIONS.join(",")}
+            ref={fileInputRef}
+            multiple
+            onChange={onFileInputChange}
+          />
+          <Button
+            label="Upload files"
+            icon={PlusIcon}
+            variant="primary"
+            size="sm"
+            disabled={disabled}
+            onClick={() => fileInputRef.current?.click()}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function FileRequirements() {
+  return (
+    <ContentMessage
+      title="File requirements"
+      icon={InformationCircleIcon}
+      variant="outline"
+      size="lg"
+    >
+      <ul className="list-disc pl-4 text-sm">
+        <li>The imported .zip must include a SKILL.md file</li>
+        <li>
+          This file must contain the skill name and description formatted in
+          YAML
+        </li>
+      </ul>
+      Read more about importing skills&nbsp;
+      <Hoverable
+        variant="highlight"
+        href="https://agentskills.io/specification"
+        target="_blank"
+      >
+        here
+      </Hoverable>
+      .
+    </ContentMessage>
+  );
+}

--- a/front/components/skills/import/ImportFromRepositoryTab.tsx
+++ b/front/components/skills/import/ImportFromRepositoryTab.tsx
@@ -1,5 +1,5 @@
 import { DetectedSkillsList } from "@app/components/skills/import/DetectedSkillsList";
-import type { ImportFormValues } from "@app/components/skills/import/formSchema";
+import type { RepositoryImportFormValues } from "@app/components/skills/import/formSchema";
 import {
   isImportableSkillStatus,
   parseGitHubRepoUrl,
@@ -12,6 +12,7 @@ import { useController, useFormContext } from "react-hook-form";
 
 interface ImportFromRepositoryTabProps {
   owner: LightWorkspaceType;
+  isActive: boolean;
   onDetectingChange: (isDetecting: boolean) => void;
   onDetectedCountChange: (count: number) => void;
   isImporting: boolean;
@@ -19,27 +20,30 @@ interface ImportFromRepositoryTabProps {
 
 export function ImportFromRepositoryTab({
   owner,
+  isActive,
   onDetectingChange,
   onDetectedCountChange,
   isImporting,
 }: ImportFromRepositoryTabProps) {
-  const { control, setValue } = useFormContext<ImportFormValues>();
+  const { control, setValue } = useFormContext<RepositoryImportFormValues>();
   const { field: repoUrlField } = useController({ name: "repoUrl", control });
 
   const { detectedSkills, isDetecting, detectError, triggerDetect } =
     useDetectSkillsFromRepo({ owner });
 
-  // Pre-select all importable skills when detection completes. detectedSkills come
-  // from an async SWR hook (useDetectSkillsFromRepo), so the values don't exist at
-  // form initialization time and can't be provided as defaultValues.
+  // Re-sync selected skills when detection completes or when this tab becomes active.
+  // detectedSkills come from an async hook, so values don't exist at form init time.
   useEffect(() => {
+    if (!isActive) {
+      return;
+    }
     setValue(
       "selectedSkillNames",
       detectedSkills
         .filter((skill) => isImportableSkillStatus(skill.status))
         .map((skill) => skill.name)
     );
-  }, [detectedSkills, setValue]);
+  }, [isActive, detectedSkills, setValue]);
 
   // Sync detecting state to the parent. Expects a stable callback (e.g. setState).
   useEffect(() => {

--- a/front/components/skills/import/ImportSkillsDialog.tsx
+++ b/front/components/skills/import/ImportSkillsDialog.tsx
@@ -6,8 +6,12 @@ import {
   importFormSchema,
   isImportType,
 } from "@app/components/skills/import/formSchema";
+import { ImportFromFilesTab } from "@app/components/skills/import/ImportFromFilesTab";
 import { ImportFromRepositoryTab } from "@app/components/skills/import/ImportFromRepositoryTab";
-import { useImportSkills } from "@app/lib/swr/skill_configurations";
+import {
+  useImportSkills,
+  useImportSkillsFromFiles,
+} from "@app/lib/swr/skill_configurations";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -24,7 +28,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { FormProvider, useController, useForm } from "react-hook-form";
 
 interface ImportSkillsDialogProps {
@@ -34,6 +38,7 @@ interface ImportSkillsDialogProps {
 
 const TAB_DESCRIPTION: Record<ImportType, string> = {
   repository: "Enter a GitHub repository URL to detect skills.",
+  files: "Upload a .zip file with your skills.",
 };
 
 export function ImportSkillsDialog({
@@ -65,19 +70,50 @@ export function ImportSkillsDialog({
     name: "selectedSkillNames",
   });
 
-  const { importSkills, isImporting } = useImportSkills({ owner });
+  const uploadedFilesRef = useRef<File[]>([]);
+  const handleFilesChange = useCallback((files: File[]) => {
+    uploadedFilesRef.current = files;
+  }, []);
+
+  const { importSkills, isImporting: isImportingFromRepo } = useImportSkills({
+    owner,
+  });
+  const { importSkillsFromFiles, isImporting: isImportingFromFiles } =
+    useImportSkillsFromFiles({ owner });
+
+  const isImporting = isImportingFromRepo || isImportingFromFiles;
 
   const onSubmit = useCallback(
     async (data: ImportFormValues) => {
       if (data.selectedSkillNames.length === 0) {
         return;
       }
-      const result = await importSkills(data.repoUrl, data.selectedSkillNames);
-      if (result.successCount > 0) {
+
+      let successCount = 0;
+      switch (data.importType) {
+        case "repository": {
+          const result = await importSkills(
+            data.repoUrl,
+            data.selectedSkillNames
+          );
+          successCount = result.successCount;
+          break;
+        }
+        case "files": {
+          const result = await importSkillsFromFiles(
+            uploadedFilesRef.current,
+            data.selectedSkillNames
+          );
+          successCount = result.successCount;
+          break;
+        }
+      }
+
+      if (successCount > 0) {
         onClose();
       }
     },
-    [importSkills, onClose]
+    [importSkills, importSkillsFromFiles, onClose]
   );
 
   const selectedCount = selectedSkillNamesField.value.length;
@@ -108,19 +144,29 @@ export function ImportSkillsDialog({
               onValueChange={(value) => {
                 if (isImportType(value)) {
                   importTypeField.onChange(value);
-                  selectedSkillNamesField.onChange([]);
-                  setDetectedCount(0);
                 }
               }}
             >
               <TabsList>
                 <TabsTrigger value="repository" label="Repository" />
+                <TabsTrigger value="files" label="Files" />
               </TabsList>
               <TabsContent value="repository">
                 <ImportFromRepositoryTab
                   owner={owner}
+                  isActive={importTypeField.value === "repository"}
                   onDetectingChange={setIsDetecting}
                   onDetectedCountChange={setDetectedCount}
+                  isImporting={isImporting}
+                />
+              </TabsContent>
+              <TabsContent value="files">
+                <ImportFromFilesTab
+                  owner={owner}
+                  isActive={importTypeField.value === "files"}
+                  onDetectingChange={setIsDetecting}
+                  onDetectedCountChange={setDetectedCount}
+                  onFilesChange={handleFilesChange}
                   isImporting={isImporting}
                 />
               </TabsContent>

--- a/front/components/skills/import/ImportSkillsDialog.tsx
+++ b/front/components/skills/import/ImportSkillsDialog.tsx
@@ -8,10 +8,7 @@ import {
 } from "@app/components/skills/import/formSchema";
 import { ImportFromFilesTab } from "@app/components/skills/import/ImportFromFilesTab";
 import { ImportFromRepositoryTab } from "@app/components/skills/import/ImportFromRepositoryTab";
-import {
-  useImportSkills,
-  useImportSkillsFromFiles,
-} from "@app/lib/swr/skill_configurations";
+import { useImportSkills } from "@app/lib/swr/skill_configurations";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -75,13 +72,7 @@ export function ImportSkillsDialog({
     uploadedFilesRef.current = files;
   }, []);
 
-  const { importSkills, isImporting: isImportingFromRepo } = useImportSkills({
-    owner,
-  });
-  const { importSkillsFromFiles, isImporting: isImportingFromFiles } =
-    useImportSkillsFromFiles({ owner });
-
-  const isImporting = isImportingFromRepo || isImportingFromFiles;
+  const { importSkills, isImporting } = useImportSkills({ owner });
 
   const onSubmit = useCallback(
     async (data: ImportFormValues) => {
@@ -89,31 +80,12 @@ export function ImportSkillsDialog({
         return;
       }
 
-      let successCount = 0;
-      switch (data.importType) {
-        case "repository": {
-          const result = await importSkills(
-            data.repoUrl,
-            data.selectedSkillNames
-          );
-          successCount = result.successCount;
-          break;
-        }
-        case "files": {
-          const result = await importSkillsFromFiles(
-            uploadedFilesRef.current,
-            data.selectedSkillNames
-          );
-          successCount = result.successCount;
-          break;
-        }
-      }
-
-      if (successCount > 0) {
+      const result = await importSkills(data, uploadedFilesRef.current);
+      if (result.successCount > 0) {
         onClose();
       }
     },
-    [importSkills, importSkillsFromFiles, onClose]
+    [importSkills, onClose]
   );
 
   const selectedCount = selectedSkillNamesField.value.length;

--- a/front/components/skills/import/formSchema.ts
+++ b/front/components/skills/import/formSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const IMPORT_TYPES = ["repository"] as const;
+export const IMPORT_TYPES = ["repository", "files"] as const;
 
 export type ImportType = (typeof IMPORT_TYPES)[number];
 
@@ -8,12 +8,28 @@ export function isImportType(value: string): value is ImportType {
   return IMPORT_TYPES.includes(value as ImportType);
 }
 
-export const importFormSchema = z.object({
-  importType: z.enum(IMPORT_TYPES),
+const selectedSkillNames = z
+  .array(z.string())
+  .min(1, "Select at least one skill to import");
+
+const repositoryImportSchema = z.object({
+  importType: z.literal("repository"),
   repoUrl: z.string().min(1, "A repository URL is required"),
-  selectedSkillNames: z
-    .array(z.string())
-    .min(1, "Select at least one skill to import"),
+  selectedSkillNames,
 });
 
+const filesImportSchema = z.object({
+  importType: z.literal("files"),
+  selectedSkillNames,
+});
+
+export const importFormSchema = z.discriminatedUnion("importType", [
+  repositoryImportSchema,
+  filesImportSchema,
+]);
+
 export type ImportFormValues = z.infer<typeof importFormSchema>;
+
+export type RepositoryImportFormValues = z.infer<typeof repositoryImportSchema>;
+
+export type FilesImportFormValues = z.infer<typeof filesImportSchema>;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -426,6 +426,45 @@ export function useDetectSkillsFromRepo({
   return { detectedSkills, isDetecting, detectError, triggerDetect };
 }
 
+function notifyImportResult(
+  data: ImportSkillsResponseBody,
+  sendNotification: ReturnType<typeof useSendNotification>
+): {
+  successCount: number;
+  errors: string[];
+} {
+  const importedCount = data.imported.length;
+  const updatedCount = data.updated.length;
+  const successCount = importedCount + updatedCount;
+  const errors = data.errored.map((e) => e.message);
+
+  if (successCount > 0) {
+    const parts: string[] = [];
+    if (importedCount > 0) {
+      parts.push(`${importedCount} skill${pluralize(importedCount)} imported`);
+    }
+    if (updatedCount > 0) {
+      parts.push(`${updatedCount} skill${pluralize(updatedCount)} updated`);
+    }
+    if (errors.length > 0) {
+      parts.push(`${errors.length} skill${pluralize(errors.length)} failed`);
+    }
+    sendNotification({
+      type: "success",
+      title: "Import successful",
+      description: parts.join(", ") + ".",
+    });
+  } else {
+    sendNotification({
+      type: "error",
+      title: "Import failed",
+      description: errors[0] ?? "Failed to import skills.",
+    });
+  }
+
+  return { successCount, errors };
+}
+
 export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
   const [isImporting, setIsImporting] = useState(false);
@@ -460,42 +499,7 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
 
         void mutateActiveSkills();
 
-        const importedCount = data.imported.length;
-        const updatedCount = data.updated.length;
-        const successCount = importedCount + updatedCount;
-        const errors = data.errored.map((e) => e.message);
-
-        if (successCount > 0) {
-          const parts: string[] = [];
-          if (importedCount > 0) {
-            parts.push(
-              `${importedCount} skill${pluralize(importedCount)} imported`
-            );
-          }
-          if (updatedCount > 0) {
-            parts.push(
-              `${updatedCount} skill${pluralize(updatedCount)} updated`
-            );
-          }
-          if (errors.length > 0) {
-            parts.push(
-              `${errors.length} skill${pluralize(errors.length)} failed`
-            );
-          }
-          sendNotification({
-            type: "success",
-            title: "Import successful",
-            description: parts.join(", ") + ".",
-          });
-        } else {
-          sendNotification({
-            type: "error",
-            title: "Import failed",
-            description: errors[0] ?? "Failed to import skills.",
-          });
-        }
-
-        return { successCount, errors };
+        return notifyImportResult(data, sendNotification);
       } finally {
         setIsImporting(false);
       }
@@ -504,4 +508,112 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
   );
 
   return { importSkills, isImporting };
+}
+
+export function useDetectSkillsFromFiles({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const [detectedSkills, setDetectedSkills] = useState<DetectedSkillSummary[]>(
+    []
+  );
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [detectError, setDetectError] = useState<string | null>(null);
+
+  const triggerDetect = useCallback(
+    async (files: File[]) => {
+      setIsDetecting(true);
+      setDetectError(null);
+      setDetectedSkills([]);
+
+      const formData = new FormData();
+      for (const file of files) {
+        formData.append("files", file);
+      }
+
+      try {
+        const res = await clientFetch(
+          `/api/w/${owner.sId}/skills/detect/upload`,
+          { method: "POST", body: formData }
+        );
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          setDetectError(errorData.message);
+          return;
+        }
+
+        const data: DetectSkillsResponseBody = await res.json();
+        setDetectedSkills(data.skills);
+      } catch (err) {
+        setDetectError(
+          isAPIErrorResponse(err)
+            ? err.error.message
+            : "Failed to detect skills from the uploaded files."
+        );
+      } finally {
+        setIsDetecting(false);
+      }
+    },
+    [owner.sId]
+  );
+
+  return { detectedSkills, isDetecting, detectError, triggerDetect };
+}
+
+export function useImportSkillsFromFiles({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isImporting, setIsImporting] = useState(false);
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+      disabled: true,
+    });
+
+  const importSkillsFromFiles = useCallback(
+    async (files: File[], names: string[]) => {
+      setIsImporting(true);
+      try {
+        const formData = new FormData();
+        for (const file of files) {
+          formData.append("files", file);
+        }
+        for (const name of names) {
+          formData.append("names", name);
+        }
+
+        const res = await clientFetch(
+          `/api/w/${owner.sId}/skills/import/upload`,
+          { method: "POST", body: formData }
+        );
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Import failed",
+            description: errorData.message,
+          });
+          return { successCount: 0, errors: [errorData.message] };
+        }
+
+        const data: ImportSkillsResponseBody = await res.json();
+
+        void mutateActiveSkills();
+
+        return notifyImportResult(data, sendNotification);
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [owner.sId, mutateActiveSkills, sendNotification]
+  );
+
+  return { importSkillsFromFiles, isImporting };
 }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -543,7 +543,6 @@ export function useDetectSkillsFromFiles({
     []
   );
   const [isUploading, setIsUploading] = useState(false);
-  const [isDetecting, setIsDetecting] = useState(false);
   const [detectError, setDetectError] = useState<string | null>(null);
 
   const triggerDetect = useCallback(
@@ -563,10 +562,6 @@ export function useDetectSkillsFromFiles({
           { method: "POST", body: formData }
         );
 
-        // Upload complete, server has responded.
-        setIsUploading(false);
-        setIsDetecting(true);
-
         if (!res.ok) {
           const errorData = await getErrorFromResponse(res);
           setDetectError(errorData.message);
@@ -583,7 +578,6 @@ export function useDetectSkillsFromFiles({
         );
       } finally {
         setIsUploading(false);
-        setIsDetecting(false);
       }
     },
     [owner.sId]
@@ -592,7 +586,6 @@ export function useDetectSkillsFromFiles({
   return {
     detectedSkills,
     isUploading,
-    isDetecting,
     detectError,
     triggerDetect,
   };

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -542,12 +542,13 @@ export function useDetectSkillsFromFiles({
   const [detectedSkills, setDetectedSkills] = useState<DetectedSkillSummary[]>(
     []
   );
+  const [isUploading, setIsUploading] = useState(false);
   const [isDetecting, setIsDetecting] = useState(false);
   const [detectError, setDetectError] = useState<string | null>(null);
 
   const triggerDetect = useCallback(
     async (files: File[]) => {
-      setIsDetecting(true);
+      setIsUploading(true);
       setDetectError(null);
       setDetectedSkills([]);
 
@@ -561,6 +562,10 @@ export function useDetectSkillsFromFiles({
           `/api/w/${owner.sId}/skills/detect/upload`,
           { method: "POST", body: formData }
         );
+
+        // Upload complete, server has responded.
+        setIsUploading(false);
+        setIsDetecting(true);
 
         if (!res.ok) {
           const errorData = await getErrorFromResponse(res);
@@ -577,12 +582,18 @@ export function useDetectSkillsFromFiles({
             : "Failed to detect skills from the uploaded files."
         );
       } finally {
+        setIsUploading(false);
         setIsDetecting(false);
       }
     },
     [owner.sId]
   );
 
-  return { detectedSkills, isDetecting, detectError, triggerDetect };
+  return {
+    detectedSkills,
+    isUploading,
+    isDetecting,
+    detectError,
+    triggerDetect,
+  };
 }
-

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -1,3 +1,4 @@
+import type { ImportFormValues } from "@app/components/skills/import/formSchema";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
@@ -476,14 +477,37 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
     });
 
   const importSkills = useCallback(
-    async (repoUrl: string, names: string[]) => {
+    async (formData: ImportFormValues, files: File[]) => {
       setIsImporting(true);
       try {
-        const res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ repoUrl, names }),
-        });
+        let res: Response;
+        switch (formData.importType) {
+          case "repository": {
+            res = await clientFetch(`/api/w/${owner.sId}/skills/import`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                repoUrl: formData.repoUrl,
+                names: formData.selectedSkillNames,
+              }),
+            });
+            break;
+          }
+          case "files": {
+            const body = new FormData();
+            for (const file of files) {
+              body.append("files", file);
+            }
+            for (const name of formData.selectedSkillNames) {
+              body.append("names", name);
+            }
+            res = await clientFetch(
+              `/api/w/${owner.sId}/skills/import/upload`,
+              { method: "POST", body }
+            );
+            break;
+          }
+        }
 
         if (!res.ok) {
           const errorData = await getErrorFromResponse(res);
@@ -562,58 +586,3 @@ export function useDetectSkillsFromFiles({
   return { detectedSkills, isDetecting, detectError, triggerDetect };
 }
 
-export function useImportSkillsFromFiles({
-  owner,
-}: {
-  owner: LightWorkspaceType;
-}) {
-  const sendNotification = useSendNotification();
-  const [isImporting, setIsImporting] = useState(false);
-  const { mutateSkillsWithRelations: mutateActiveSkills } =
-    useSkillsWithRelations({
-      owner,
-      status: "active",
-      disabled: true,
-    });
-
-  const importSkillsFromFiles = useCallback(
-    async (files: File[], names: string[]) => {
-      setIsImporting(true);
-      try {
-        const formData = new FormData();
-        for (const file of files) {
-          formData.append("files", file);
-        }
-        for (const name of names) {
-          formData.append("names", name);
-        }
-
-        const res = await clientFetch(
-          `/api/w/${owner.sId}/skills/import/upload`,
-          { method: "POST", body: formData }
-        );
-
-        if (!res.ok) {
-          const errorData = await getErrorFromResponse(res);
-          sendNotification({
-            type: "error",
-            title: "Import failed",
-            description: errorData.message,
-          });
-          return { successCount: 0, errors: [errorData.message] };
-        }
-
-        const data: ImportSkillsResponseBody = await res.json();
-
-        void mutateActiveSkills();
-
-        return notifyImportResult(data, sendNotification);
-      } finally {
-        setIsImporting(false);
-      }
-    },
-    [owner.sId, mutateActiveSkills, sendNotification]
-  );
-
-  return { importSkillsFromFiles, isImporting };
-}


### PR DESCRIPTION
## Description

- This PR adds a tab in the skill import dialog (currently only has 1 tab Repository) to import skills from an uploaded zip file.
- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=3684-181814&t=PTUystn2WfSpY67v-0).

<img width="970" height="636" alt="Screenshot 2026-03-18 at 2 25 27 PM" src="https://github.com/user-attachments/assets/987c0e5a-b896-4f71-95ab-0106e46ca1f3" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
