### PR TITLE
Fix SSE memory retention: free consumed history in async generators

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -26,7 +26,7 @@ export async function* getMCPEventsForServer(
   const channelId = getMCPServerChannelId(auth, { mcpServerId });
 
   const callbackReader = createCallbackReader<EventPayload | "close">();
-  const { history, unsubscribe } = await getRedisHybridManager().subscribe(
+  let { history, unsubscribe } = await getRedisHybridManager().subscribe(
     channelId,
     callbackReader.callback,
     "mcp_events",
@@ -36,15 +36,19 @@ export async function* getMCPEventsForServer(
   // Unsubscribe if the signal is aborted.
   signal.addEventListener("abort", unsubscribe, { once: true });
 
-  // Yield the history based on the lastEventId.
-  for (const event of history) {
-    yield {
-      eventId: event.id,
-      data: JSON.parse(event.message.payload),
-    };
-  }
-
   try {
+    // Yield the history based on the lastEventId.
+    for (const event of history) {
+      yield {
+        eventId: event.id,
+        data: JSON.parse(event.message.payload),
+      };
+    }
+
+    // Free history entries: V8 retains all locals across `await` in async generators,
+    // pinning large event payloads for the entire SSE connection lifetime.
+    history = [];
+
     // Do not loop forever, we will timeout after some time to avoid blocking the load balancer.
     while (true) {
       if (signal.aborted) {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -35,7 +35,7 @@ export async function* getConversationEvents({
   const pubsubChannel = getConversationChannelId(conversationId);
 
   const callbackReader = createCallbackReader<EventPayload | "close">();
-  const { history, unsubscribe } = await getRedisHybridManager().subscribe(
+  let { history, unsubscribe } = await getRedisHybridManager().subscribe(
     pubsubChannel,
     callbackReader.callback,
     "conversation_events",
@@ -45,14 +45,17 @@ export async function* getConversationEvents({
   // Unsubscribe if the signal is aborted
   signal.addEventListener("abort", unsubscribe, { once: true });
 
-  for (const event of history) {
-    yield {
-      eventId: event.id,
-      data: JSON.parse(event.message.payload),
-    };
-  }
-
   try {
+    for (const event of history) {
+      yield {
+        eventId: event.id,
+        data: JSON.parse(event.message.payload),
+      };
+    }
+    // Free history entries: V8 retains all locals across `await` in async generators,
+    // pinning large event payloads for the entire SSE connection lifetime.
+    history = [];
+
     // As most clients always listen to conversation events, we have a longer timeout to limit the overhead of initiating a new subscription.
     // See https://dust4ai.slack.com/archives/C050SM8NSPK/p1757577149634519
     const TIMEOUT = 180000; // 3 minutes
@@ -159,7 +162,7 @@ export async function* getMessagesEvents(
   const TIMEOUT = 60000; // 1 minute
 
   const callbackReader = createCallbackReader<EventPayload | "close">();
-  const { history, unsubscribe } = await getRedisHybridManager().subscribe(
+  let { history, unsubscribe } = await getRedisHybridManager().subscribe(
     pubsubChannel,
     callbackReader.callback,
     "message_events",
@@ -176,6 +179,9 @@ export async function* getMessagesEvents(
         data: JSON.parse(event.message.payload),
       };
     }
+    // Free history entries: V8 retains all locals across `await` in async generators,
+    // pinning large event payloads for the entire SSE connection lifetime.
+    history = [];
 
     // Do not loop forever, we will timeout after some time to avoid blocking the load balancer
     while (Date.now() - start < TIMEOUT) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1773843180815279).

Async generators in V8 retain all local variables in their suspended state (`parameters_and_registers`) across await points. In `getMessagesEvents` and `getConversationEvents`, the history array fetched during subscription setup contains serialized event payloads that can be hundreds of KB each (e.g. `agent_message_success` with full action outputs). 
After the initial `for...of` loop yields all history events, the array remains referenced for the entire SSE connection lifetime, pinning those payloads in memory until the client disconnects.

Heap profiling on `front-sse` pods with ~984 active connections showed a single retained `agent_message_success` payload at 497 KB, held inside the generator's register file. Extrapolated across connections, this accounts for a significant portion of the 191 MB retained by the `RedisHybridManager` subscribers map.

This change clears the history array after consumption so V8 can collect the payloads while the generator remains suspended waiting for live events.

<img width="1187" height="81" alt="image" src="https://github.com/user-attachments/assets/cd3f5f87-d0e1-4b43-b6e1-551a931acfba" />

<img width="1190" height="1051" alt="image" src="https://github.com/user-attachments/assets/cdaf5968-e2d3-43d0-a775-6c71d43b1453" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
