### PR TITLE
[front] fix: add google tag manager script element idempotently

### DIFF
--- a/front/hooks/useGTMScript.ts
+++ b/front/hooks/useGTMScript.ts
@@ -7,7 +7,7 @@ import { useEffect } from "react";
 export function useGTMScript() {
   useEffect(() => {
     const gtmId = process.env.NEXT_PUBLIC_GTM_TRACKING_ID;
-    if (!gtmId) {
+    if (!gtmId || document.getElementById("google-tag-manager")) {
       return;
     }
 

--- a/front/hooks/useGTMScript.ts
+++ b/front/hooks/useGTMScript.ts
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
 
+const ELEMENT_ID = "google-tag-manager";
+
 /**
  * Injects the Google Tag Manager script into the page.
  * Uses process.env.NEXT_PUBLIC_GTM_TRACKING_ID (compile-time substituted).
@@ -7,12 +9,12 @@ import { useEffect } from "react";
 export function useGTMScript() {
   useEffect(() => {
     const gtmId = process.env.NEXT_PUBLIC_GTM_TRACKING_ID;
-    if (!gtmId || document.getElementById("google-tag-manager")) {
+    if (!gtmId || document.getElementById(ELEMENT_ID)) {
       return;
     }
 
     const script = document.createElement("script");
-    script.id = "google-tag-manager";
+    script.id = ELEMENT_ID;
     script.async = true;
     script.textContent = `
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7165.
- This PR aims at preventing an issue where we add several `google-tag-manager` script elements by not adding it if it already exists.
- The component is mounted once so no difference expected, but still a harmless addition.
- `Script` from next used to do this deduplication.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
