### PR TITLE
Allow fathom personal action

### DIFF
--- a/front/lib/api/oauth/providers/fathom.ts
+++ b/front/lib/api/oauth/providers/fathom.ts
@@ -38,7 +38,12 @@ export class FathomOAuthProvider implements BaseOAuthStrategyProvider {
     return getStringFromQuery(query, "state");
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType) {
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      return (
+        Object.keys(extraConfig).length === 1 && "mcp_server_id" in extraConfig
+      );
+    }
     return Object.keys(extraConfig).length === 0;
   }
 }


### PR DESCRIPTION
## Description

* isExtraConfigValid must allow for the mcp_server_id when using personal action

## Tests

* Created personal connection locally

## Risk

* Low (fixing issue)

## Deploy Plan

* Deploy front