### PR TITLE
Add ability to read full slack canvas content

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1194,8 +1194,6 @@ type EnrichedCanvasInfo = {
   title: string;
   name: string;
   permalink?: string;
-  created?: number;
-  timestamp?: number;
   user?: string;
   label?: string;
 };
@@ -1206,7 +1204,6 @@ function formatCanvasAsMarkdown(c: EnrichedCanvasInfo): string {
     `  - ID: ${c.id}`,
     `  - Title: ${c.title || "(none)"}`,
     `  - Name: ${c.name || "(none)"}`,
-    `  - Created: ${c.created ?? c.timestamp ?? ""}`,
     `  - Creator: ${c.user ?? ""}`,
     `  - Permalink: ${c.permalink ?? ""}`,
     c.label ? `  - Tab label: ${c.label}` : null,
@@ -1241,7 +1238,7 @@ export async function executeGetChannelCanvases({
     async (c) => {
       const info = await slackClient.files.info({ file: c.canvas_id });
       if (!info.ok || !info.file) {
-        throw new Error(info.error ?? "files.info failed");
+        throw new MCPError(info.error ?? "files.info failed");
       }
       const f = info.file;
       return {
@@ -1249,8 +1246,6 @@ export async function executeGetChannelCanvases({
         title: f.title ?? "",
         name: f.name ?? "",
         permalink: f.permalink,
-        created: f.created,
-        timestamp: f.timestamp,
         user: f.user,
         label: c.label,
       } satisfies EnrichedCanvasInfo;
@@ -1280,7 +1275,7 @@ export async function executeReadCanvas({
 
   const info = await slackClient.files.info({ file: canvas_id });
   if (!info.ok || !info.file) {
-    throw new Error(info.error ?? "unknown error");
+    return new Err(new MCPError(info.error ?? "unknown error"));
   }
   const { url_private, url_private_download } = info.file;
   const url = url_private ?? url_private_download ?? "";

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -2,8 +2,10 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { untrustedFetch } from "@app/lib/egress/server";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { removeDiacritics } from "@app/lib/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
@@ -1187,6 +1189,31 @@ async function getChannelCanvases({
   return canvases;
 }
 
+type EnrichedCanvasInfo = {
+  id: string;
+  title: string;
+  name: string;
+  permalink?: string;
+  created?: number;
+  timestamp?: number;
+  user?: string;
+  label?: string;
+};
+
+function formatCanvasAsMarkdown(c: EnrichedCanvasInfo): string {
+  const lines = [
+    `- **${c.title || c.name || c.id}**`,
+    `  - ID: ${c.id}`,
+    `  - Title: ${c.title || "(none)"}`,
+    `  - Name: ${c.name || "(none)"}`,
+    `  - Created: ${c.created ?? c.timestamp ?? ""}`,
+    `  - Creator: ${c.user ?? ""}`,
+    `  - Permalink: ${c.permalink ?? ""}`,
+    c.label ? `  - Tab label: ${c.label}` : null,
+  ].filter(Boolean);
+  return lines.join("\n");
+}
+
 export async function executeGetChannelCanvases({
   channel_id,
   accessToken,
@@ -1206,82 +1233,72 @@ export async function executeGetChannelCanvases({
       },
     ]);
   }
-  const lines = canvases.map(
-    (c) => `- ${c.canvas_id} (${c.type}${c.label ? `, "${c.label}"` : ""})`
+
+  const slackClient = await getSlackClient(accessToken);
+
+  const enrichedCanvases = await concurrentExecutor(
+    canvases,
+    async (c) => {
+      const info = await slackClient.files.info({ file: c.canvas_id });
+      if (!info.ok || !info.file) {
+        throw new Error(info.error ?? "files.info failed");
+      }
+      const f = info.file;
+      return {
+        id: c.canvas_id,
+        title: f.title ?? "",
+        name: f.name ?? "",
+        permalink: f.permalink,
+        created: f.created,
+        timestamp: f.timestamp,
+        user: f.user,
+        label: c.label,
+      } satisfies EnrichedCanvasInfo;
+    },
+    { concurrency: 5 }
   );
+
+  const markdown = enrichedCanvases.map(formatCanvasAsMarkdown).join("\n\n");
   return new Ok([
     {
       type: "text" as const,
-      text: `Channel ${channel_id} — ${canvases.length} canvas/canvases:\n\n${lines.join("\n")}\n\nUse these canvas_id values with read_canvas or write_canvas.`,
+      text:
+        `Channel ${channel_id} — ${enrichedCanvases.length} canvas/canvases:\n\n${markdown}\n\n` +
+        "Use these canvas IDs with read_canvas or write_canvas.",
     },
   ]);
 }
 
 export async function executeReadCanvas({
   canvas_id,
-  section_types,
-  contains_text,
   accessToken,
 }: {
   canvas_id: string;
-  section_types?: Array<"h1" | "h2" | "h3" | "any_header">;
-  contains_text?: string;
   accessToken: string;
 }): Promise<Ok<Array<{ type: "text"; text: string }>> | Err<MCPError>> {
   const slackClient = await getSlackClient(accessToken);
 
-  const criteria: Record<string, unknown> = {
-    section_types:
-      section_types && section_types.length > 0
-        ? section_types
-        : ["any_header"],
-  };
-  if (contains_text) {
-    criteria.contains_text = contains_text;
+  const info = await slackClient.files.info({ file: canvas_id });
+  if (!info.ok || !info.file) {
+    throw new Error(info.error ?? "unknown error");
+  }
+  const { url_private, url_private_download } = info.file;
+  const url = url_private ?? url_private_download ?? "";
+  if (!url) {
+    return new Err(new MCPError("File has no downloadable URL"));
   }
 
-  const resp = await slackClient.apiCall("canvases.sections.lookup", {
-    canvas_id,
-    criteria,
+  const response = await untrustedFetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
   });
-  if (!resp.ok) {
+  if (!response.ok) {
     return new Err(
-      new MCPError(
-        `Failed to look up canvas sections: ${resp.error ?? "unknown error"}`
-      )
+      new MCPError(`Failed to download (HTTP ${response.status})`)
     );
   }
 
-  const rawSections = resp.sections;
-  const sections = Array.isArray(rawSections)
-    ? rawSections.filter(
-        (s): s is { id: string } =>
-          s !== null &&
-          typeof s === "object" &&
-          "id" in s &&
-          typeof s.id === "string"
-      )
-    : [];
-
-  if (sections.length === 0) {
-    return new Ok([
-      {
-        type: "text" as const,
-        text: `No sections found in canvas "${canvas_id}" matching the given criteria.`,
-      },
-    ]);
-  }
-
-  const formatted = sections.map((s, i) => `${i + 1}. ${s.id}`).join("\n");
-
-  return new Ok([
-    {
-      type: "text" as const,
-      text:
-        `Canvas "${canvas_id}" — ${sections.length} section(s) found:\n\n${formatted}\n\n` +
-        "Use these section IDs with write_canvas to target specific sections.",
-    },
-  ]);
+  const content = await response.text();
+  return new Ok([{ type: "text" as const, text: content }]);
 }
 
 export async function executeWriteCanvas({

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -302,27 +302,19 @@ Set search_all=true only if the user explicitly requests to search all public wo
   },
   read_canvas: {
     description:
-      "Find sections within a Slack canvas. " +
-      "Returns section IDs that can be used with write_canvas to insert, replace, or delete specific sections.",
+      "Read the full text/markdown content of a Slack canvas by its file ID. " +
+      "Use get_channel_canvases first to discover available canvas IDs.",
     schema: {
-      canvas_id: z.string().describe("The canvas file ID (e.g. 'F01234ABCD')."),
-      section_types: z
-        .array(z.enum(["h1", "h2", "h3", "any_header"]))
-        .optional()
-        .describe(
-          "Filter by section type. Defaults to ['any_header'] to return all headings"
-        ),
-      contains_text: z
+      canvas_id: z
         .string()
-        .optional()
         .describe(
-          "Narrow results to sections containing this text. Can be combined with section_types."
+          "The Slack file ID of the canvas (e.g. 'F01234ABCD'). Use get_channel_canvases to find canvas IDs."
         ),
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading Slack canvas sections",
-      done: "Read Slack canvas sections",
+      running: "Reading Slack canvas",
+      done: "Read Slack canvas",
     },
   },
   write_canvas: {
@@ -332,11 +324,11 @@ Set search_all=true only if the user explicitly requests to search all public wo
       "  - Optionally provide title, content (initial markdown), and channel_id to pin it to a channel tab.\n" +
       "**Editing an existing canvas** (provide canvas_id + operation):\n" +
       "  - insert_at_end / insert_at_start: add content at the end or beginning (requires content).\n" +
-      "  - insert_after / insert_before: insert content relative to a section (requires content + section_id from read_canvas).\n" +
+      "  - insert_after / insert_before: insert content relative to a section (requires content + section_id).\n" +
       "  - replace: replace entire canvas or a specific section (requires content; section_id optional).\n" +
       "  - delete: remove a specific section (requires section_id).\n" +
       "  - rename: rename the canvas (requires title).\n\n" +
-      "Content must be Markdown. Use read_canvas to get section IDs before doing relative edits.",
+      "Content must be Markdown.",
     schema: {
       canvas_id: z
         .string()

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -857,22 +857,14 @@ export function createSlackPersonalTools(
       }
     },
 
-    read_canvas: async (
-      { canvas_id, section_types, contains_text },
-      { authInfo }
-    ) => {
+    read_canvas: async ({ canvas_id }, { authInfo }) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
       }
 
       try {
-        return await executeReadCanvas({
-          canvas_id,
-          section_types,
-          contains_text,
-          accessToken,
-        });
+        return await executeReadCanvas({ canvas_id, accessToken });
       } catch (error) {
         const authError = handleSlackAuthError(error);
         if (authError) {

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -55,6 +55,7 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
             "im:history",
             "mpim:history",
             "channels:read",
+            "files:read",
             "files:write",
             "groups:read",
             "im:read",


### PR DESCRIPTION
## Description

* Adding ability to list slack canvases and read full content as opposed to only reading section metadata
* This will require addition of slack scope `files:read` (which I believe we already have in the app, but would appreciate validation)
* note there is no API to actually read the canvas content, you need to make HTTP call (with untrusted fetch)

## Tests

<img width="576" height="570" alt="Screenshot 2026-03-18 at 10 32 20 AM" src="https://github.com/user-attachments/assets/dc491803-fa43-4ff0-8375-13aaef4de51e" />
<img width="573" height="604" alt="Screenshot 2026-03-18 at 10 32 33 AM" src="https://github.com/user-attachments/assets/0b88aae0-cf9b-4846-a8c3-d28c796f0de7" />


## Risk

* Scope additional may require users to re-oauth

## Deploy Plan

* Deploy front