### PR TITLE
[Slack] Log skipped file reasons in thread uploads

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1278,15 +1278,45 @@ async function makeContentFragments(
     }
   }
 
-  const supportedFiles = removeNulls(
+  const slackFiles = removeNulls(
     allMessages.filter((m) => m.files).flatMap((m) => m.files)
-  ).filter(
-    (f) =>
-      isSupportedFileContentType(f.mimetype ?? "") &&
-      !!f.size &&
-      !!f.url_private_download &&
-      f.size <= MAX_FILE_SIZE_TO_UPLOAD
   );
+
+  const supportedFiles = slackFiles.flatMap((file) => {
+    const skipReason = !isSupportedFileContentType(file.mimetype ?? "")
+      ? "unsupported_mimetype"
+      : !file.size
+        ? "missing_size"
+        : !file.url_private_download
+          ? "missing_private_download_url"
+          : file.size > MAX_FILE_SIZE_TO_UPLOAD
+            ? "over_size_limit"
+            : null;
+
+    if (!skipReason) {
+      return [file];
+    }
+
+    logger.warn(
+      {
+        channelId,
+        connectorId: connector.id,
+        conversationId,
+        fileId: file.id,
+        fileName: file.name ?? null,
+        fileTitle: file.title ?? null,
+        fileMimetype: file.mimetype ?? null,
+        fileSize: file.size ?? null,
+        hasPrivateDownloadUrl: !!file.url_private_download,
+        maxFileSize: MAX_FILE_SIZE_TO_UPLOAD,
+        skipReason,
+        threadTs,
+      },
+      "Skipping slack file attachment"
+    );
+
+    return [];
+  });
 
   if (supportedFiles.length > 0) {
     logger.info({ conversationId }, "Found supported files, uploading them.");

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1308,7 +1308,7 @@ async function makeContentFragments(
         fileMimetype: file.mimetype ?? null,
         fileSize: file.size ?? null,
         hasPrivateDownloadUrl: !!file.url_private_download,
-        maxFileSize: MAX_FILE_SIZE_TO_UPLOAD,
+        maxFileSizeBytes: MAX_FILE_SIZE_TO_UPLOAD,
         skipReason,
         threadTs,
       },


### PR DESCRIPTION
## Description
Part of https://github.com/dust-tt/tasks/issues/7094

Adds structured warning logs for Slack thread attachments that are dropped before upload so we can distinguish missing download URLs, missing sizes, unsupported MIME types, and the 10 MB connector cap.

## Risks
Blast radius: Slack thread attachment ingestion logging only
Risk: low

## Deploy Plan
- pmrr
- deploy connectors