### PR TITLE
Custom page interaction tool validation popup

### DIFF
--- a/extension/platforms/chrome/tools/metadata.ts
+++ b/extension/platforms/chrome/tools/metadata.ts
@@ -149,17 +149,20 @@ Avoid unnecessary actions.`,
         .describe(
           "ID of the element to interact with. Required for click_element, type_text and delete_text. Must match an element returned by get_elements."
         ),
-
       text: z
         .string()
         .nullish()
         .describe("Text to insert when using type_text."),
-
       textActionVariant: z
         .enum(["replace", "append"])
         .nullish()
         .describe(
           "How text should be applied when using type_text: replace existing content or append to it."
+        ),
+      humanReadableDescription: z
+        .string()
+        .describe(
+          "A human-readable description of the interaction being performed. Describe the tab, the element, and the action clearly, e.g. 'Click the Submit button on the Login tab' or 'Type \"hello\" into the search input on the Google tab'."
         ),
     }).shape,
     argumentsRequiringApproval: ["tabId"],

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -17,6 +17,28 @@ import {
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
+type ToolOverride = {
+  title?: (agentName: string, inputs: Record<string, unknown>) => string;
+  alwaysAllowLabel?: (
+    agentName: string,
+    inputs: Record<string, unknown>
+  ) => string;
+};
+
+/** Overrides title and alwaysAllowLabel for specific MCP tools */
+const MCP_TOOL_OVERRIDES: Partial<
+  Record<string, Partial<Record<string, ToolOverride>>>
+> = {
+  "dust-chrome-extension": {
+    interact_with_page: {
+      title: (agentName, inputs) =>
+        `Allow ${asDisplayName(agentName)} to ${inputs.humanReadableDescription}?`,
+      alwaysAllowLabel: (agentName, inputs) =>
+        "Allow all the interactions with this tab",
+    },
+  },
+};
+
 interface MCPToolValidationRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
@@ -76,8 +98,19 @@ export function MCPToolValidationRequired({
     setNeverAskAgain(false);
   };
 
+  const toolOverride =
+    MCP_TOOL_OVERRIDES[blockedAction.metadata.mcpServerName]?.[
+      blockedAction.metadata.toolName
+    ];
+
   const title = useMemo(() => {
     if (isTriggeredByCurrentUser) {
+      if (toolOverride?.title) {
+        return toolOverride.title(
+          blockedAction.metadata.agentName,
+          blockedAction.inputs
+        );
+      }
       return `Allow ${asDisplayName(blockedAction.metadata.mcpServerName)} to ${asDisplayName(blockedAction.metadata.toolName)}?`;
     } else {
       return `Permission needed for ${asDisplayName(blockedAction.metadata.mcpServerName)}.`;
@@ -85,12 +118,22 @@ export function MCPToolValidationRequired({
   }, [
     blockedAction.metadata.mcpServerName,
     blockedAction.metadata.toolName,
+    blockedAction.metadata.agentName,
+    blockedAction.inputs,
     isTriggeredByCurrentUser,
+    toolOverride,
   ]);
 
   const alwaysAllowLabel = useMemo(() => {
     if (blockedAction.stake !== "medium") {
       return "Always allow";
+    }
+
+    if (toolOverride?.alwaysAllowLabel) {
+      return toolOverride.alwaysAllowLabel(
+        blockedAction.metadata.agentName,
+        blockedAction.inputs
+      );
     }
 
     const args = blockedAction.argumentsRequiringApproval ?? [];
@@ -109,6 +152,7 @@ export function MCPToolValidationRequired({
     blockedAction.inputs,
     blockedAction.metadata.agentName,
     blockedAction.metadata.toolName,
+    toolOverride,
   ]);
 
   return (

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -103,57 +103,42 @@ export function MCPToolValidationRequired({
       blockedAction.metadata.toolName
     ];
 
-  const title = useMemo(() => {
-    if (isTriggeredByCurrentUser) {
-      if (toolOverride?.title) {
-        return toolOverride.title(
-          blockedAction.metadata.agentName,
-          blockedAction.inputs
-        );
-      }
-      return `Allow ${asDisplayName(blockedAction.metadata.mcpServerName)} to ${asDisplayName(blockedAction.metadata.toolName)}?`;
-    } else {
+  function getTitle() {
+    if (!isTriggeredByCurrentUser) {
       return `Permission needed for ${asDisplayName(blockedAction.metadata.mcpServerName)}.`;
     }
-  }, [
-    blockedAction.metadata.mcpServerName,
-    blockedAction.metadata.toolName,
-    blockedAction.metadata.agentName,
-    blockedAction.inputs,
-    isTriggeredByCurrentUser,
-    toolOverride,
-  ]);
+    if (toolOverride?.title) {
+      return toolOverride.title(
+        blockedAction.metadata.agentName,
+        blockedAction.inputs
+      );
+    }
+    return `Allow ${asDisplayName(blockedAction.metadata.mcpServerName)} to ${asDisplayName(blockedAction.metadata.toolName)}?`;
+  }
 
-  const alwaysAllowLabel = useMemo(() => {
+  function getAlwaysAllowLabel() {
     if (blockedAction.stake !== "medium") {
       return "Always allow";
     }
-
     if (toolOverride?.alwaysAllowLabel) {
       return toolOverride.alwaysAllowLabel(
         blockedAction.metadata.agentName,
         blockedAction.inputs
       );
     }
-
     const args = blockedAction.argumentsRequiringApproval ?? [];
     const argValues = args
       .filter((arg) => blockedAction.inputs[arg] != null)
       .map((arg) => JSON.stringify(blockedAction.inputs[arg]));
-
     return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
       argValues.length > 0
         ? ` for the following parameters: ${argValues.join(", ")}`
         : ""
     }`;
-  }, [
-    blockedAction.stake,
-    blockedAction.argumentsRequiringApproval,
-    blockedAction.inputs,
-    blockedAction.metadata.agentName,
-    blockedAction.metadata.toolName,
-    toolOverride,
-  ]);
+  }
+
+  const title = getTitle();
+  const alwaysAllowLabel = getAlwaysAllowLabel();
 
   return (
     <ContentMessage


### PR DESCRIPTION
## Description

Adds custom validation popup messages for the Chrome extension's `interact_with_page` tool to improve UX. Instead of showing generic technical messages like `Allow @assistant to Interact with page?`, the popup now displays human-readable descriptions such as "Allow @assistant to Click the Submit button on the Login tab?".

This is achieved by:
- Adding a `humanReadableDescription` parameter to the tool schema that describes the tab, element, and action clearly
- Introducing a `MCP_TOOL_OVERRIDES` configuration in `MCPToolValidationRequired.tsx` that customizes the `title` and `alwaysAllowLabel` for specific MCP tools
- The override reads the `humanReadableDescription` from inputs to display contextual messages

<img width="601" height="199" alt="image" src="https://github.com/user-attachments/assets/f5081729-424f-4a89-add0-bf0efb9fecde" />


## Tests

Manually tested the interact_with_page tool in the Chrome extension, verifying that the validation popup displays the human-readable description instead of generic tool names.

## Risk

Low. Changes are isolated to the validation popup UI component and the tool schema. The override pattern is additive and only applies to the chrome extension's interact_with_page tool.
