### PR TITLE
[front] fix: mark data warehouse schema retrieval errors as untracked

### DIFF
--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -178,7 +178,8 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     if (schemaResult.isErr()) {
       return new Err(
         new MCPError(
-          `Error retrieving database schema: ${schemaResult.error.message}`
+          `Error retrieving database schema: ${schemaResult.error.message}`,
+          { tracked: false }
         )
       );
     }


### PR DESCRIPTION
## Summary

- Set `tracked: false` on the schema retrieval error in the `data_warehouses` tool (`describe_tables` handler), matching the existing pattern in `query_tables_v2` and other customer-side errors in the same file
- Prevents Snowflake/BigQuery "Error retrieving database schema: Failed to retrieve table schemas" from triggering our alerting, since these are customer-side data configuration issues

## Context

- https://dust4ai.slack.com/archives/C05F84CFP0E/p1773840320403689

## Test plan

- [ ] Verify existing data warehouse tests still pass
- [ ] Confirm schema retrieval errors no longer appear in tracked alerts