### PR TITLE
[front] chore: add dialog on batch agent unpublish

### DIFF
--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -87,7 +87,6 @@ export const AgentEditBar = ({
           onClose();
           setIsUnpublishDialogOpen(false);
         }}
-        mutateAgentConfigurations={mutateAgentConfigurations}
       />
 
       <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2 dark:bg-muted-background-night">

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -1,7 +1,4 @@
-import {
-  useBatchUpdateAgentScope,
-  useBatchUpdateAgentTags,
-} from "@app/lib/swr/assistants";
+import { useBatchUpdateAgentTags } from "@app/lib/swr/assistants";
 import { compareForFuzzySort, subFilter, tagsSorter } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TagType } from "@app/types/tag";
@@ -25,6 +22,7 @@ import {
 import { useState } from "react";
 
 import { DeleteAssistantsDialog } from "./DeleteAssistantsDialog";
+import { UnpublishAssistantsDialog } from "./UnpublishAssistantsDialog";
 
 type AgentEditBarProps = {
   onClose: () => void;
@@ -42,14 +40,11 @@ export const AgentEditBar = ({
   mutateAgentConfigurations,
 }: AgentEditBarProps) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isUnpublishDialogOpen, setIsUnpublishDialogOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const batchUpdateAgentTags = useBatchUpdateAgentTags({
-    owner,
-  });
-
-  const batchUpdateAgentScope = useBatchUpdateAgentScope({
     owner,
   });
 
@@ -81,6 +76,18 @@ export const AgentEditBar = ({
           onClose();
           setIsDeleteDialogOpen(false);
         }}
+      />
+
+      <UnpublishAssistantsDialog
+        owner={owner}
+        agentConfigurations={selectedAgents}
+        isOpen={isUnpublishDialogOpen}
+        onClose={() => setIsUnpublishDialogOpen(false)}
+        onSave={() => {
+          onClose();
+          setIsUnpublishDialogOpen(false);
+        }}
+        mutateAgentConfigurations={mutateAgentConfigurations}
       />
 
       <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2 dark:bg-muted-background-night">
@@ -168,15 +175,8 @@ export const AgentEditBar = ({
           icon={EyeSlashIcon}
           label="Unpublish"
           disabled={selectedAgents.length === 0 || isLoading}
-          onClick={async () => {
-            setIsLoading(true);
-            await batchUpdateAgentScope(
-              selectedAgents.map((a) => a.sId),
-              { scope: "hidden" }
-            );
-            void mutateAgentConfigurations();
-            setIsLoading(false);
-            onClose();
+          onClick={() => {
+            setIsUnpublishDialogOpen(true);
           }}
         />
 

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -76,7 +76,6 @@ export const AgentEditBar = ({
         }}
       />
 
-
       <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2 dark:bg-muted-background-night">
         <Button
           size="xs"

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuTagItem,
   DropdownMenuTagList,
   DropdownMenuTrigger,
-  EyeSlashIcon,
   Spinner,
   TagIcon,
   TrashIcon,
@@ -40,7 +39,6 @@ export const AgentEditBar = ({
   mutateAgentConfigurations,
 }: AgentEditBarProps) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [isUnpublishDialogOpen, setIsUnpublishDialogOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -78,16 +76,6 @@ export const AgentEditBar = ({
         }}
       />
 
-      <UnpublishAssistantsDialog
-        owner={owner}
-        agentConfigurations={selectedAgents}
-        isOpen={isUnpublishDialogOpen}
-        onClose={() => setIsUnpublishDialogOpen(false)}
-        onSave={() => {
-          onClose();
-          setIsUnpublishDialogOpen(false);
-        }}
-      />
 
       <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2 dark:bg-muted-background-night">
         <Button
@@ -168,15 +156,11 @@ export const AgentEditBar = ({
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <Button
-          size="xs"
-          variant="outline"
-          icon={EyeSlashIcon}
-          label="Unpublish"
+        <UnpublishAssistantsDialog
+          owner={owner}
+          agentConfigurations={selectedAgents}
           disabled={selectedAgents.length === 0 || isLoading}
-          onClick={() => {
-            setIsUnpublishDialogOpen(true);
-          }}
+          onSave={onClose}
         />
 
         <Button

--- a/front/components/assistant/UnpublishAssistantsDialog.tsx
+++ b/front/components/assistant/UnpublishAssistantsDialog.tsx
@@ -6,6 +6,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -13,22 +14,22 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
+  EyeSlashIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface UnpublishAssistantsDialogProps {
   agentConfigurations: LightAgentConfigurationType[];
-  isOpen: boolean;
+  disabled: boolean;
   owner: LightWorkspaceType;
-  onClose: () => void;
   onSave: () => void;
 }
 
 export function UnpublishAssistantsDialog({
   agentConfigurations,
-  isOpen,
+  disabled,
   owner,
-  onClose,
   onSave,
 }: UnpublishAssistantsDialogProps) {
   const [isUnpublishing, setIsUnpublishing] = useState(false);
@@ -48,14 +49,16 @@ export function UnpublishAssistantsDialog({
   );
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          size="xs"
+          variant="outline"
+          icon={EyeSlashIcon}
+          label="Unpublish"
+          disabled={disabled}
+        />
+      </DialogTrigger>
       <DialogContent size="md" isAlertDialog>
         <DialogHeader hideButton>
           <DialogTitle>
@@ -66,7 +69,7 @@ export function UnpublishAssistantsDialog({
             <div>
               <span className="font-bold">
                 {total > 0 &&
-                  `These agents have been used ${total} time${pluralize(total)} in the last 30 days.&nbsp;`}
+                  `These agents have been used ${total} time${pluralize(total)} in the last 30 days. `}
               </span>
               Unpublished agents will no longer be accessible to everyone in the
               workspace. Members will need to manually add them to use them.

--- a/front/components/assistant/UnpublishAssistantsDialog.tsx
+++ b/front/components/assistant/UnpublishAssistantsDialog.tsx
@@ -1,0 +1,97 @@
+import { useBatchUpdateAgentScope } from "@app/lib/swr/assistants";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface UnpublishAssistantsDialogProps {
+  agentConfigurations: LightAgentConfigurationType[];
+  isOpen: boolean;
+  owner: LightWorkspaceType;
+  onClose: () => void;
+  onSave: () => void;
+  mutateAgentConfigurations: () => Promise<unknown>;
+}
+
+export function UnpublishAssistantsDialog({
+  agentConfigurations,
+  isOpen,
+  owner,
+  onClose,
+  onSave,
+  mutateAgentConfigurations,
+}: UnpublishAssistantsDialogProps) {
+  const [isUnpublishing, setIsUnpublishing] = useState(false);
+
+  const batchUpdateAgentScope = useBatchUpdateAgentScope({ owner });
+
+  const total = agentConfigurations.reduce(
+    (acc, a) => acc + (a.usage?.messageCount ?? 0),
+    0
+  );
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>
+            Unpublishing {agentConfigurations.length} agent
+            {pluralize(agentConfigurations.length)}
+          </DialogTitle>
+          <DialogDescription>
+            <div>
+              <span className="font-bold">
+                {total > 0 &&
+                  `These agents have been used ${total} time${pluralize(total)} in the last 30 days.&nbsp;`}
+              </span>
+              Unpublished agents will no longer be accessible to everyone in the
+              workspace. Members will need to manually add them to use them.
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="font-bold">Are you sure you want to proceed?</div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            disabled: isUnpublishing,
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Unpublish",
+            variant: "warning",
+            disabled: isUnpublishing,
+            onClick: async (e: React.MouseEvent) => {
+              e.preventDefault();
+              setIsUnpublishing(true);
+              await batchUpdateAgentScope(
+                agentConfigurations.map((a) => a.sId),
+                { scope: "hidden" }
+              );
+              void mutateAgentConfigurations();
+              setIsUnpublishing(false);
+              onSave();
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/assistant/UnpublishAssistantsDialog.tsx
+++ b/front/components/assistant/UnpublishAssistantsDialog.tsx
@@ -1,4 +1,7 @@
-import { useBatchUpdateAgentScope } from "@app/lib/swr/assistants";
+import {
+  useAgentConfigurations,
+  useBatchUpdateAgentScope,
+} from "@app/lib/swr/assistants";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -19,7 +22,6 @@ interface UnpublishAssistantsDialogProps {
   owner: LightWorkspaceType;
   onClose: () => void;
   onSave: () => void;
-  mutateAgentConfigurations: () => Promise<unknown>;
 }
 
 export function UnpublishAssistantsDialog({
@@ -28,9 +30,15 @@ export function UnpublishAssistantsDialog({
   owner,
   onClose,
   onSave,
-  mutateAgentConfigurations,
 }: UnpublishAssistantsDialogProps) {
   const [isUnpublishing, setIsUnpublishing] = useState(false);
+
+  const { mutateRegardlessOfQueryParams: mutateAgentConfigurations } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: null,
+      disabled: true,
+    });
 
   const batchUpdateAgentScope = useBatchUpdateAgentScope({ owner });
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7158.
- This PR adds a dialog to warn the user before batch unpublishing agents from the Manage Agents page.
- Previous behavior was to batch unpublish directly.

<img width="970" height="636" alt="Screenshot 2026-03-18 at 4 05 16 PM" src="https://github.com/user-attachments/assets/fd357519-9e77-4739-aedf-5c39eb714196" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
