### PR TITLE
[front] - refactor: remove feature toggle for YAML agent operations

### DIFF
--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -85,14 +85,12 @@ export const CreateDropdown = ({
             }
           )}
         />
-        {hasFeature("agent_to_yaml") && (
-          <DropdownMenuItem
-            label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
-            icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpenIcon}
-            disabled={isUploadingYAML}
-            onClick={triggerYAMLUpload}
-          />
-        )}
+        <DropdownMenuItem
+          label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
+          icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpenIcon}
+          disabled={isUploadingYAML}
+          onClick={triggerYAMLUpload}
+        />
         {isBuilder(owner) && (
           <>
             <DropdownMenuLabel label="Skills" />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -895,26 +895,24 @@ export function AgentSidebarMenu({
                                       "create_from_template"
                                     )}
                                   />
-                                  {hasFeature("agent_to_yaml") && (
-                                    <DropdownMenuItem
-                                      icon={
-                                        isUploadingYAML ? (
-                                          <Spinner size="xs" />
-                                        ) : (
-                                          BracesIcon
-                                        )
-                                      }
-                                      label={
-                                        isUploadingYAML
-                                          ? "Uploading..."
-                                          : "From YAML"
-                                      }
-                                      disabled={isUploadingYAML}
-                                      onClick={triggerYAMLUpload}
-                                      data-gtm-label="yamlUploadButton"
-                                      data-gtm-location="sidebarMenu"
-                                    />
-                                  )}
+                                  <DropdownMenuItem
+                                    icon={
+                                      isUploadingYAML ? (
+                                        <Spinner size="xs" />
+                                      ) : (
+                                        BracesIcon
+                                      )
+                                    }
+                                    label={
+                                      isUploadingYAML
+                                        ? "Uploading..."
+                                        : "From YAML"
+                                    }
+                                    disabled={isUploadingYAML}
+                                    onClick={triggerYAMLUpload}
+                                    data-gtm-label="yamlUploadButton"
+                                    data-gtm-location="sidebarMenu"
+                                  />
                                 </DropdownMenuSubContent>
                               </DropdownMenuPortal>
                             </DropdownMenuSub>

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -26,10 +26,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",
   },
-  agent_to_yaml: {
-    description: "Export and Import agents to/from YAML format",
-    stage: "dust_only",
-  },
   claude_4_opus_feature: {
     description: "Access to Claude 4 Opus model in the agent builder",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -673,7 +673,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_copilot_builders"
   | "agent_builder_shrink_wrap"
   | "agent_management_tool"
-  | "agent_to_yaml"
   | "analytics_csv_export"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"


### PR DESCRIPTION
## Description

This PR removes the `agent_to_yaml` feature flag, making YAML agent import and export functionality available to all users by default. The feature was previously gated under the `dust_only` stage and is now considered stable enough for general availability. This change removes the conditional checks in `CreateDropdown` and `SidebarMenu` components that were hiding the "From YAML" upload option behind the feature flag.

## Tests

It's been tested for a while

## Risk

Low. The YAML functionality has been stable and this only removes the feature flag gating

## Deploy Plan

Deploy front