### PR TITLE
Add agent prompt, tools and skills in the reinforced agent prompts

### DIFF
--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -62,7 +62,7 @@ export function formatAvailableSkills(skills: AvailableSkill[]): string {
         `- **${s.name}** (ID: ${s.sId}): ${(s.agentFacingDescription ?? "No description").replace(/\n/g, " ")}`
     )
     .join("\n");
-  return `## AVAILABLE SKILLS\n${skills.length} skills available.\n\n${skillLines}`;
+  return `## AVAILABLE SKILLS IN WORKSPACE\n${skills.length} skills available.\n\n${skillLines}`;
 }
 
 export function formatAvailableTools(tools: AvailableTool[]): string {
@@ -72,7 +72,7 @@ export function formatAvailableTools(tools: AvailableTool[]): string {
         `- **${t.name}** (ID: ${t.sId}): ${t.description.replace(/\n/g, " ")}`
     )
     .join("\n");
-  return `## AVAILABLE TOOLS\n${tools.length} tools available.\n\n${toolLines}`;
+  return `## AVAILABLE TOOLS IN WORKSPACE\n${tools.length} tools available.\n\n${toolLines}`;
 }
 
 async function fetchSidekickUserMetadata(

--- a/front/lib/reinforced_agent/aggregate_suggestions.test.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.test.ts
@@ -1,6 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { buildAggregationPrompt } from "@app/lib/reinforced_agent/aggregate_suggestions";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentInstructionsSuggestionType,
@@ -18,14 +17,14 @@ function makeAgentConfig(
     version: 1,
     versionCreatedAt: null,
     versionAuthorId: null,
+    instructions: null,
     model: {
-      modelId: "gpt-4o-mini" as const,
-      providerId: "openai" as const,
+      modelId: "gpt-4o-mini",
+      providerId: "openai",
       temperature: 0.7,
-      reasoningEffort: null,
     },
     status: "active",
-    scope: "workspace",
+    scope: "visible",
     userFavorite: false,
     name: "TestAgent",
     description: "A test agent",
@@ -38,10 +37,33 @@ function makeAgentConfig(
     canRead: true,
     canEdit: true,
     instructionsHtml: null,
-    instructions: null,
     actions: [],
     ...overrides,
-  } as AgentConfigurationType;
+  };
+}
+
+function makeAction(
+  overrides: Partial<ServerSideMCPServerConfigurationType> = {}
+): ServerSideMCPServerConfigurationType {
+  return {
+    id: 1,
+    sId: "tool-1",
+    type: "mcp_server_configuration",
+    name: "test_tool",
+    description: null,
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: "view-1",
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId: null,
+    ...overrides,
+  };
 }
 
 function makeInstructionSuggestion(
@@ -279,13 +301,7 @@ describe("buildAggregationPrompt", () => {
   });
 
   it("includes agent configured tools in user message", () => {
-    const action = {
-      id: 1,
-      sId: "tool-ws",
-      type: "mcp_server_configuration",
-      name: "web_search",
-      description: "Search the web",
-    } as ServerSideMCPServerConfigurationType;
+    const action = makeAction({ name: "web_search", sId: "tool-ws" });
     const { userMessage } = buildAggregationPrompt(
       makeAgentConfig({ actions: [action] }),
       [makeInstructionSuggestion()],
@@ -299,11 +315,7 @@ describe("buildAggregationPrompt", () => {
   });
 
   it("includes agent configured skills in user message", () => {
-    const skill = {
-      name: "code_review",
-      sId: "skill-cr",
-      agentFacingDescription: "Review code for quality",
-    } as SkillResource;
+    const skill = { name: "code_review", sId: "skill-cr" };
     const { userMessage } = buildAggregationPrompt(
       makeAgentConfig(),
       [makeInstructionSuggestion()],

--- a/front/lib/reinforced_agent/aggregate_suggestions.test.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.test.ts
@@ -1,10 +1,48 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { buildAggregationPrompt } from "@app/lib/reinforced_agent/aggregate_suggestions";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentInstructionsSuggestionType,
   AgentSkillsSuggestionType,
   AgentToolsSuggestionType,
 } from "@app/types/suggestions/agent_suggestion";
 import { describe, expect, it } from "vitest";
+
+function makeAgentConfig(
+  overrides: Partial<AgentConfigurationType> = {}
+): AgentConfigurationType {
+  return {
+    id: 1,
+    sId: "agent-1",
+    version: 1,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    model: {
+      modelId: "gpt-4o-mini" as const,
+      providerId: "openai" as const,
+      temperature: 0.7,
+      reasoningEffort: null,
+    },
+    status: "active",
+    scope: "workspace",
+    userFavorite: false,
+    name: "TestAgent",
+    description: "A test agent",
+    pictureUrl: "https://example.com/pic.png",
+    maxStepsPerRun: 3,
+    tags: [],
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    canRead: true,
+    canEdit: true,
+    instructionsHtml: null,
+    instructions: null,
+    actions: [],
+    ...overrides,
+  } as AgentConfigurationType;
+}
 
 function makeInstructionSuggestion(
   overrides: Partial<AgentInstructionsSuggestionType> = {}
@@ -76,13 +114,14 @@ function makeSkillSuggestion(
 describe("buildAggregationPrompt", () => {
   it("includes the agent name in the user message", () => {
     const { userMessage } = buildAggregationPrompt(
-      "SalesBot",
+      makeAgentConfig({ name: "SalesBot" }),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
-    expect(userMessage).toContain("## Agent: SalesBot");
+    expect(userMessage).toContain("Name: SalesBot");
   });
 
   it("formats instruction suggestions with targetBlockId and content", () => {
@@ -94,10 +133,11 @@ describe("buildAggregationPrompt", () => {
       },
     });
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [suggestion],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("kind: instructions");
@@ -107,10 +147,11 @@ describe("buildAggregationPrompt", () => {
 
   it("formats tool suggestions with action and toolId", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeToolSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("kind: tools");
@@ -120,10 +161,11 @@ describe("buildAggregationPrompt", () => {
 
   it("formats skill suggestions with action and skillId", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeSkillSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("kind: skills");
@@ -134,10 +176,11 @@ describe("buildAggregationPrompt", () => {
   it("shows N/A when analysis is null", () => {
     const suggestion = makeInstructionSuggestion({ analysis: null });
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [suggestion],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("analysis: N/A");
@@ -145,10 +188,11 @@ describe("buildAggregationPrompt", () => {
 
   it("numbers multiple suggestions sequentially", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion(), makeToolSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("### Suggestion 1");
@@ -157,10 +201,11 @@ describe("buildAggregationPrompt", () => {
 
   it("includes pending suggestions section when non-empty", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion()],
       { pending: [makeToolSuggestion()], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain(
@@ -170,10 +215,11 @@ describe("buildAggregationPrompt", () => {
 
   it("omits pending suggestions section when empty", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).not.toContain("Existing pending suggestions");
@@ -181,10 +227,11 @@ describe("buildAggregationPrompt", () => {
 
   it("includes rejected suggestions section when non-empty", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [makeToolSuggestion()] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain(
@@ -194,10 +241,11 @@ describe("buildAggregationPrompt", () => {
 
   it("omits rejected suggestions section when empty", () => {
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).not.toContain("Previously rejected suggestions");
@@ -206,10 +254,11 @@ describe("buildAggregationPrompt", () => {
   it("includes tools and skills context", () => {
     const toolsContext = "## Available tools\n- web_search\n- code_review";
     const { userMessage } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] },
-      toolsContext
+      toolsContext,
+      []
     );
 
     expect(userMessage).toContain(toolsContext);
@@ -217,14 +266,53 @@ describe("buildAggregationPrompt", () => {
 
   it("system prompt mentions the three tools", () => {
     const { systemPrompt } = buildAggregationPrompt(
-      "TestAgent",
+      makeAgentConfig(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] },
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(systemPrompt).toContain("suggest_prompt_edits");
     expect(systemPrompt).toContain("suggest_tools");
     expect(systemPrompt).toContain("suggest_skills");
+  });
+
+  it("includes agent configured tools in user message", () => {
+    const action = {
+      id: 1,
+      sId: "tool-ws",
+      type: "mcp_server_configuration",
+      name: "web_search",
+      description: "Search the web",
+    } as ServerSideMCPServerConfigurationType;
+    const { userMessage } = buildAggregationPrompt(
+      makeAgentConfig({ actions: [action] }),
+      [makeInstructionSuggestion()],
+      { pending: [], rejected: [] },
+      "No tools.",
+      []
+    );
+
+    expect(userMessage).toContain("## Agent's configured tools");
+    expect(userMessage).toContain("web_search (ID: tool-ws)");
+  });
+
+  it("includes agent configured skills in user message", () => {
+    const skill = {
+      name: "code_review",
+      sId: "skill-cr",
+      agentFacingDescription: "Review code for quality",
+    } as SkillResource;
+    const { userMessage } = buildAggregationPrompt(
+      makeAgentConfig(),
+      [makeInstructionSuggestion()],
+      { pending: [], rejected: [] },
+      "No tools.",
+      [skill]
+    );
+
+    expect(userMessage).toContain("## Agent's configured skills");
+    expect(userMessage).toContain("code_review (ID: skill-cr)");
   });
 });

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -3,13 +3,15 @@ import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
+import { formatAgentContext } from "@app/lib/reinforced_agent/format_agent_context";
 import {
   buildReinforcedLLMParams,
   runReinforcedAnalysis,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentInstructionsSuggestionType,
   AgentSkillsSuggestionType,
@@ -28,7 +30,7 @@ const REINFORCED_SUGGESTION_KINDS = new Set([
 ]);
 
 interface AggregationContext {
-  agentConfig: LightAgentConfigurationType;
+  agentConfig: AgentConfigurationType;
   syntheticSuggestions: AgentSuggestionResource[];
   prompt: { systemPrompt: string; userMessage: string };
 }
@@ -60,7 +62,7 @@ async function loadAggregationContext(
 
   const [agentConfig] = await getAgentConfigurations(auth, {
     agentIds: [agentConfigurationId],
-    variant: "light",
+    variant: "full",
   });
   if (!agentConfig) {
     logger.warn(
@@ -73,27 +75,32 @@ async function loadAggregationContext(
   const REJECTED_SUGGESTIONS_MAX_COUNT = 20;
   const REJECTED_SUGGESTIONS_MAX_AGE_MONTHS = 3;
 
-  const [pendingSuggestions, rejectedSuggestions, toolsAndSkillsContext] =
-    await Promise.all([
-      AgentSuggestionResource.listByAgentConfigurationId(
-        auth,
-        agentConfigurationId,
-        {
-          sources: ["reinforcement", "sidekick"],
-          states: ["pending"],
-        }
-      ),
-      AgentSuggestionResource.listByAgentConfigurationId(
-        auth,
-        agentConfigurationId,
-        {
-          sources: ["reinforcement", "sidekick"],
-          states: ["rejected"],
-          limit: REJECTED_SUGGESTIONS_MAX_COUNT,
-        }
-      ),
-      buildToolsAndSkillsContext(auth),
-    ]);
+  const [
+    pendingSuggestions,
+    rejectedSuggestions,
+    toolsAndSkillsContext,
+    agentSkills,
+  ] = await Promise.all([
+    AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      {
+        sources: ["reinforcement", "sidekick"],
+        states: ["pending"],
+      }
+    ),
+    AgentSuggestionResource.listByAgentConfigurationId(
+      auth,
+      agentConfigurationId,
+      {
+        sources: ["reinforcement", "sidekick"],
+        states: ["rejected"],
+        limit: REJECTED_SUGGESTIONS_MAX_COUNT,
+      }
+    ),
+    buildToolsAndSkillsContext(auth),
+    SkillResource.listByAgentConfiguration(auth, agentConfig),
+  ]);
 
   const rejectedCutoff = new Date();
   rejectedCutoff.setMonth(
@@ -104,13 +111,14 @@ async function loadAggregationContext(
   );
 
   const prompt = buildAggregationPrompt(
-    agentConfig.name,
+    agentConfig,
     toReinforcedSuggestions(syntheticSuggestions),
     {
       pending: toReinforcedSuggestions(pendingSuggestions),
       rejected: toReinforcedSuggestions(recentRejectedSuggestions),
     },
-    toolsAndSkillsContext
+    toolsAndSkillsContext,
+    agentSkills
   );
 
   return { agentConfig, syntheticSuggestions, prompt };
@@ -143,13 +151,14 @@ function formatSuggestions(suggestions: ReinforcedSuggestionType[]): string {
 }
 
 export function buildAggregationPrompt(
-  agentName: string,
+  agentConfig: AgentConfigurationType,
   syntheticSuggestions: ReinforcedSuggestionType[],
   existingSuggestions: {
     pending: ReinforcedSuggestionType[];
     rejected: ReinforcedSuggestionType[];
   },
-  toolsAndSkillsContext: string
+  toolsAndSkillsContext: string,
+  agentSkills: SkillResource[]
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = `You are an AI agent improvement analyst. You have been given multiple suggestions from individual conversation analyses for the same agent. Your job is to deduplicate, merge, and prioritize them into a concise set of high-quality, actionable suggestions.
 
@@ -169,7 +178,7 @@ You have three tools available:
 
 You MUST call at least one tool. If no suggestions survive aggregation, call suggest_prompt_edits with an empty suggestions array.`;
 
-  let userMessage = `## Agent: ${agentName}
+  let userMessage = `${formatAgentContext(agentConfig, agentSkills)}
 
 ${toolsAndSkillsContext}
 

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -3,7 +3,10 @@ import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
-import { formatAgentContext } from "@app/lib/reinforced_agent/format_agent_context";
+import {
+  type AgentContextSkill,
+  formatAgentContext,
+} from "@app/lib/reinforced_agent/format_agent_context";
 import {
   buildReinforcedLLMParams,
   runReinforcedAnalysis,
@@ -158,7 +161,7 @@ export function buildAggregationPrompt(
     rejected: ReinforcedSuggestionType[];
   },
   toolsAndSkillsContext: string,
-  agentSkills: SkillResource[]
+  agentSkills: AgentContextSkill[]
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = `You are an AI agent improvement analyst. You have been given multiple suggestions from individual conversation analyses for the same agent. Your job is to deduplicate, merge, and prioritize them into a concise set of high-quality, actionable suggestions.
 

--- a/front/lib/reinforced_agent/analyze_conversation.test.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.test.ts
@@ -1,4 +1,6 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { buildAnalysisPrompt } from "@app/lib/reinforced_agent/analyze_conversation";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { describe, expect, it } from "vitest";
 
@@ -42,7 +44,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       agent,
       "User: hello",
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("Name: SalesBot");
@@ -53,7 +56,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       agent,
       "User: hello",
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("Description: Handles sales queries");
@@ -64,7 +68,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       agent,
       "User: hello",
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).not.toContain("Description:");
@@ -77,7 +82,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       agent,
       "User: hello",
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("### Current instructions");
@@ -89,7 +95,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       agent,
       "User: hello",
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).not.toContain("### Current instructions");
@@ -100,7 +107,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig(),
       conversationText,
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(userMessage).toContain("<conversation>");
@@ -113,7 +121,8 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig(),
       "User: hello",
-      toolsContext
+      toolsContext,
+      []
     );
 
     expect(userMessage).toContain(toolsContext);
@@ -123,11 +132,48 @@ describe("buildAnalysisPrompt", () => {
     const { systemPrompt } = buildAnalysisPrompt(
       makeAgentConfig(),
       "User: hello",
-      "No tools."
+      "No tools.",
+      []
     );
 
     expect(systemPrompt).toContain("suggest_prompt_edits");
     expect(systemPrompt).toContain("suggest_tools");
     expect(systemPrompt).toContain("suggest_skills");
+  });
+
+  it("includes agent configured tools in user message", () => {
+    const action = {
+      id: 1,
+      sId: "tool-ws",
+      type: "mcp_server_configuration",
+      name: "web_search",
+      description: "Search the web",
+    } as ServerSideMCPServerConfigurationType;
+    const { userMessage } = buildAnalysisPrompt(
+      makeAgentConfig({ actions: [action] }),
+      "User: hello",
+      "No tools.",
+      []
+    );
+
+    expect(userMessage).toContain("## Agent's configured tools");
+    expect(userMessage).toContain("web_search (ID: tool-ws)");
+  });
+
+  it("includes agent configured skills in user message", () => {
+    const skill = {
+      name: "code_review",
+      sId: "skill-cr",
+      agentFacingDescription: "Review code for quality",
+    } as SkillResource;
+    const { userMessage } = buildAnalysisPrompt(
+      makeAgentConfig(),
+      "User: hello",
+      "No tools.",
+      [skill]
+    );
+
+    expect(userMessage).toContain("## Agent's configured skills");
+    expect(userMessage).toContain("code_review (ID: skill-cr)");
   });
 });

--- a/front/lib/reinforced_agent/analyze_conversation.test.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.test.ts
@@ -1,6 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { buildAnalysisPrompt } from "@app/lib/reinforced_agent/analyze_conversation";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { describe, expect, it } from "vitest";
 
@@ -13,14 +12,14 @@ function makeAgentConfig(
     version: 1,
     versionCreatedAt: null,
     versionAuthorId: null,
+    instructions: null,
     model: {
-      modelId: "gpt-4o-mini" as const,
-      providerId: "openai" as const,
+      modelId: "gpt-4o-mini",
+      providerId: "openai",
       temperature: 0.7,
-      reasoningEffort: null,
     },
     status: "active",
-    scope: "workspace",
+    scope: "visible",
     userFavorite: false,
     name: "TestAgent",
     description: "A test agent",
@@ -35,7 +34,31 @@ function makeAgentConfig(
     instructionsHtml: null,
     actions: [],
     ...overrides,
-  } as AgentConfigurationType;
+  };
+}
+
+function makeAction(
+  overrides: Partial<ServerSideMCPServerConfigurationType> = {}
+): ServerSideMCPServerConfigurationType {
+  return {
+    id: 1,
+    sId: "tool-1",
+    type: "mcp_server_configuration",
+    name: "test_tool",
+    description: null,
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: "view-1",
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId: null,
+    ...overrides,
+  };
 }
 
 describe("buildAnalysisPrompt", () => {
@@ -142,13 +165,7 @@ describe("buildAnalysisPrompt", () => {
   });
 
   it("includes agent configured tools in user message", () => {
-    const action = {
-      id: 1,
-      sId: "tool-ws",
-      type: "mcp_server_configuration",
-      name: "web_search",
-      description: "Search the web",
-    } as ServerSideMCPServerConfigurationType;
+    const action = makeAction({ name: "web_search", sId: "tool-ws" });
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig({ actions: [action] }),
       "User: hello",
@@ -161,11 +178,7 @@ describe("buildAnalysisPrompt", () => {
   });
 
   it("includes agent configured skills in user message", () => {
-    const skill = {
-      name: "code_review",
-      sId: "skill-cr",
-      agentFacingDescription: "Review code for quality",
-    } as SkillResource;
+    const skill = { name: "code_review", sId: "skill-cr" };
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig(),
       "User: hello",

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -3,26 +3,22 @@ import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversatio
 import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { formatAgentContext } from "@app/lib/reinforced_agent/format_agent_context";
 import {
   buildReinforcedLLMParams,
   runReinforcedAnalysis,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
 export function buildAnalysisPrompt(
   agentConfig: AgentConfigurationType,
   conversationText: string,
-  toolsAndSkillsContext: string
+  toolsAndSkillsContext: string,
+  agentSkills: SkillResource[]
 ): { systemPrompt: string; userMessage: string } {
-  const descriptionSection = agentConfig.description
-    ? `Description: ${agentConfig.description}`
-    : "";
-  const instructionsSection = agentConfig.instructionsHtml
-    ? `\n### Current instructions\n${agentConfig.instructionsHtml}`
-    : "";
-
   const systemPrompt = `You are an AI agent improvement analyst. Your job is to analyze a conversation handled by an AI agent and suggest concrete improvements to the agent's configuration.
 
 ## Your task
@@ -41,10 +37,7 @@ You have three tools available:
 
 You MUST call at least one tool. If no improvements are needed, call suggest_prompt_edits with an empty suggestions array.`;
 
-  const userMessage = `## Agent being analyzed
-Name: ${agentConfig.name}
-${descriptionSection}
-${instructionsSection}
+  const userMessage = `${formatAgentContext(agentConfig, agentSkills)}
 
 ${toolsAndSkillsContext}
 
@@ -79,7 +72,10 @@ export async function buildConversationAnalysisBatchMap(
     return null;
   }
 
-  const toolsAndSkillsContext = await buildToolsAndSkillsContext(auth);
+  const [toolsAndSkillsContext, agentSkills] = await Promise.all([
+    buildToolsAndSkillsContext(auth),
+    SkillResource.listByAgentConfiguration(auth, agentConfig),
+  ]);
 
   const batchMap = new Map<string, LLMStreamParameters>();
 
@@ -99,7 +95,8 @@ export async function buildConversationAnalysisBatchMap(
     const prompt = buildAnalysisPrompt(
       agentConfig,
       conversationRes.value.text,
-      toolsAndSkillsContext
+      toolsAndSkillsContext,
+      agentSkills
     );
     batchMap.set(conversationId, buildReinforcedLLMParams(prompt));
   }
@@ -138,15 +135,20 @@ export async function analyzeConversationForReinforcement(
     return;
   }
 
-  const [conversationRes, conversationResource, toolsAndSkillsContext] =
-    await Promise.all([
-      getShrinkWrappedConversation(auth, {
-        conversationId,
-        includeFeedback: true,
-      }),
-      ConversationResource.fetchById(auth, conversationId),
-      buildToolsAndSkillsContext(auth),
-    ]);
+  const [
+    conversationRes,
+    conversationResource,
+    toolsAndSkillsContext,
+    agentSkills,
+  ] = await Promise.all([
+    getShrinkWrappedConversation(auth, {
+      conversationId,
+      includeFeedback: true,
+    }),
+    ConversationResource.fetchById(auth, conversationId),
+    buildToolsAndSkillsContext(auth),
+    SkillResource.listByAgentConfiguration(auth, agentConfig),
+  ]);
   if (conversationRes.isErr() || !conversationResource) {
     logger.warn(
       {
@@ -161,7 +163,8 @@ export async function analyzeConversationForReinforcement(
   const prompt = buildAnalysisPrompt(
     agentConfig,
     conversationRes.value.text,
-    toolsAndSkillsContext
+    toolsAndSkillsContext,
+    agentSkills
   );
 
   const createdCount = await runReinforcedAnalysis({

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -3,7 +3,10 @@ import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversatio
 import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import { formatAgentContext } from "@app/lib/reinforced_agent/format_agent_context";
+import {
+  type AgentContextSkill,
+  formatAgentContext,
+} from "@app/lib/reinforced_agent/format_agent_context";
 import {
   buildReinforcedLLMParams,
   runReinforcedAnalysis,
@@ -17,7 +20,7 @@ export function buildAnalysisPrompt(
   agentConfig: AgentConfigurationType,
   conversationText: string,
   toolsAndSkillsContext: string,
-  agentSkills: SkillResource[]
+  agentSkills: AgentContextSkill[]
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = `You are an AI agent improvement analyst. Your job is to analyze a conversation handled by an AI agent and suggest concrete improvements to the agent's configuration.
 

--- a/front/lib/reinforced_agent/format_agent_context.ts
+++ b/front/lib/reinforced_agent/format_agent_context.ts
@@ -1,9 +1,18 @@
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+export interface AgentContextConfig {
+  name: string;
+  description: string;
+  instructionsHtml: string | null;
+  actions: { name: string; sId: string }[];
+}
+
+export interface AgentContextSkill {
+  name: string;
+  sId: string;
+}
 
 export function formatAgentContext(
-  agentConfig: AgentConfigurationType,
-  agentSkills: SkillResource[]
+  agentConfig: AgentContextConfig,
+  agentSkills: AgentContextSkill[]
 ): string {
   const sections: string[] = [];
 

--- a/front/lib/reinforced_agent/format_agent_context.ts
+++ b/front/lib/reinforced_agent/format_agent_context.ts
@@ -1,0 +1,42 @@
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+
+export function formatAgentContext(
+  agentConfig: AgentConfigurationType,
+  agentSkills: SkillResource[]
+): string {
+  const sections: string[] = [];
+
+  const descriptionSection = agentConfig.description
+    ? `Description: ${agentConfig.description}`
+    : "";
+  const instructionsSection = agentConfig.instructionsHtml
+    ? `\n### Current instructions\n${agentConfig.instructionsHtml}`
+    : "";
+
+  sections.push(
+    `## Agent being analyzed\nName: ${agentConfig.name}\n${descriptionSection}${instructionsSection}`
+  );
+
+  // Only list names and IDs here — descriptions are already included in the
+  // workspace-level tools/skills context (buildToolsAndSkillsContext).
+  if (agentConfig.actions.length > 0) {
+    const toolLines = agentConfig.actions
+      .map((a) => `- ${a.name} (ID: ${a.sId})`)
+      .join("\n");
+    sections.push(
+      `## Agent's configured tools\n${agentConfig.actions.length} tools configured.\n\n${toolLines}`
+    );
+  }
+
+  if (agentSkills.length > 0) {
+    const skillLines = agentSkills
+      .map((s) => `- ${s.name} (ID: ${s.sId})`)
+      .join("\n");
+    sections.push(
+      `## Agent's configured skills\n${agentSkills.length} skills configured.\n\n${skillLines}`
+    );
+  }
+
+  return sections.join("\n\n");
+}


### PR DESCRIPTION
## Description

The prompts need to contain the agent prompt and tools/skills in order to do valid suggestions.
They also need to see what are the available tool/skills

<img width="1364" height="1146" alt="image" src="https://github.com/user-attachments/assets/dbe07e9c-ed94-483f-bb89-5c2541cf21bc" />

## Tests

add unit tests

## Risk

low, still behind Feature flag

## Deploy Plan

deploy front 
