### PR TITLE
[Slack] Retry thread fetch for pending file metadata

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -27,12 +27,19 @@ import {
 } from "@connectors/connectors/slack/lib/slack_client";
 import { getRepliesFromThread } from "@connectors/connectors/slack/lib/thread";
 import {
+  countPendingSlackFileMetadata,
+  getSlackFilesFromMessages,
+  hasPendingSlackFileMetadata,
+  selectBotThreadMessages,
+} from "@connectors/connectors/slack/lib/thread_file_upload";
+import {
   isBotAllowed,
   notifyIfSlackUserIsNotAllowed,
 } from "@connectors/connectors/slack/lib/workspace_limits";
 import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import { makeConversationUrl } from "@connectors/lib/bot/conversation_utils";
 import type { MentionMatch } from "@connectors/lib/bot/mentions";
 import { processMentions } from "@connectors/lib/bot/mentions";
@@ -64,13 +71,7 @@ import type {
   SupportedFileContentType,
   UserMessageType,
 } from "@dust-tt/client";
-import {
-  DustAPI,
-  Err,
-  isSupportedFileContentType,
-  Ok,
-  removeNulls,
-} from "@dust-tt/client";
+import { DustAPI, Err, isSupportedFileContentType, Ok } from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import removeMarkdown from "remove-markdown";
@@ -81,6 +82,8 @@ const SLACK_ERROR_TEXT =
   "An unexpected error occurred while answering your message, please retry.";
 
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
+const SLACK_FILE_READINESS_RETRY_COUNT = 2;
+const SLACK_FILE_READINESS_RETRY_DELAY_MS = 2_000;
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
 
@@ -1252,7 +1255,7 @@ async function makeContentFragments(
     },
   });
 
-  const replies = await getRepliesFromThread({
+  let replies = await getRepliesFromThread({
     connectorId: connector.id,
     slackClient,
     channelId,
@@ -1260,27 +1263,49 @@ async function makeContentFragments(
     useCase: "bot",
   });
 
-  let shouldTake = false;
-  for (const reply of replies) {
-    if (reply.ts === startingAtTs) {
-      // Signal that we must take all the messages starting from this one.
-      shouldTake = true;
-    }
+  allMessages = selectBotThreadMessages({
+    replies,
+    startingAtTs,
+    allowedSlackBotId,
+  });
 
-    const isFromAllowedBot =
-      allowedSlackBotId && reply.bot_id === allowedSlackBotId;
-    // Message is not from a user or an allowed bot, so we skip it.
-    if (!reply.user && !isFromAllowedBot) {
-      continue;
-    }
-    if (shouldTake) {
-      allMessages.push(reply);
-    }
+  let slackFiles = getSlackFilesFromMessages(allMessages);
+  for (
+    let retryCount = 1;
+    retryCount <= SLACK_FILE_READINESS_RETRY_COUNT &&
+    hasPendingSlackFileMetadata(slackFiles);
+    retryCount += 1
+  ) {
+    logger.info(
+      {
+        channelId,
+        connectorId: connector.id,
+        conversationId,
+        retryCount,
+        retryDelayMs: SLACK_FILE_READINESS_RETRY_DELAY_MS,
+        threadTs,
+        ...countPendingSlackFileMetadata(slackFiles),
+      },
+      "Retrying slack thread fetch while waiting for file metadata"
+    );
+
+    await setTimeoutAsync(SLACK_FILE_READINESS_RETRY_DELAY_MS);
+
+    replies = await getRepliesFromThread({
+      connectorId: connector.id,
+      slackClient,
+      channelId,
+      threadTs,
+      useCase: "bot",
+    });
+
+    allMessages = selectBotThreadMessages({
+      replies,
+      startingAtTs,
+      allowedSlackBotId,
+    });
+    slackFiles = getSlackFilesFromMessages(allMessages);
   }
-
-  const slackFiles = removeNulls(
-    allMessages.filter((m) => m.files).flatMap((m) => m.files)
-  );
 
   const supportedFiles = slackFiles.flatMap((file) => {
     const skipReason = !isSupportedFileContentType(file.mimetype ?? "")

--- a/connectors/src/connectors/slack/lib/thread_file_upload.test.ts
+++ b/connectors/src/connectors/slack/lib/thread_file_upload.test.ts
@@ -1,0 +1,106 @@
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
+import { describe, expect, it } from "vitest";
+
+import {
+  countPendingSlackFileMetadata,
+  getSlackFilesFromMessages,
+  hasPendingSlackFileMetadata,
+  type SlackThreadFile,
+  selectBotThreadMessages,
+} from "./thread_file_upload";
+
+describe("selectBotThreadMessages", () => {
+  it("keeps thread messages from the starting ts and allows the configured bot", () => {
+    const replies = [
+      { ts: "1", user: "U1", text: "before" },
+      { ts: "2", bot_id: "B2", text: "ignored bot" },
+      { ts: "3", user: "U3", text: "start" },
+      { ts: "4", bot_id: "B-allowed", text: "allowed bot" },
+      { ts: "5", user: "U5", text: "after" },
+    ] as MessageElement[];
+
+    expect(
+      selectBotThreadMessages({
+        replies,
+        startingAtTs: "3",
+        allowedSlackBotId: "B-allowed",
+      }).map((reply) => reply.ts)
+    ).toEqual(["3", "4", "5"]);
+  });
+});
+
+describe("getSlackFilesFromMessages", () => {
+  it("returns files from all messages and removes null entries", () => {
+    const messages = [
+      {
+        ts: "1",
+        user: "U1",
+        files: [{ id: "F1" }, null, { id: "F2" }],
+      },
+      {
+        ts: "2",
+        user: "U2",
+      },
+    ] as MessageElement[];
+
+    expect(getSlackFilesFromMessages(messages).map((file) => file.id)).toEqual([
+      "F1",
+      "F2",
+    ]);
+  });
+});
+
+describe("hasPendingSlackFileMetadata", () => {
+  it("returns true when slack file metadata is not fully ready", () => {
+    expect(
+      hasPendingSlackFileMetadata([
+        {
+          id: "F1",
+          mimetype: "application/pdf",
+          size: 42,
+          url_private_download: "https://example.com",
+        },
+        {
+          id: "F2",
+          mimetype: "application/pdf",
+          size: 42,
+        },
+      ] as SlackThreadFile[])
+    ).toBe(true);
+  });
+
+  it("returns false when all slack file metadata is ready", () => {
+    expect(
+      hasPendingSlackFileMetadata([
+        {
+          id: "F1",
+          mimetype: "application/pdf",
+          size: 42,
+          url_private_download: "https://example.com",
+        },
+      ] as SlackThreadFile[])
+    ).toBe(false);
+  });
+});
+
+describe("countPendingSlackFileMetadata", () => {
+  it("counts each missing field independently", () => {
+    expect(
+      countPendingSlackFileMetadata([
+        {
+          id: "F1",
+          mimetype: "application/pdf",
+          size: 42,
+        },
+        {
+          id: "F2",
+          url_private_download: "https://example.com",
+        },
+      ] as SlackThreadFile[])
+    ).toEqual({
+      missingMimetypeCount: 1,
+      missingPrivateDownloadUrlCount: 1,
+      missingSizeCount: 1,
+    });
+  });
+});

--- a/connectors/src/connectors/slack/lib/thread_file_upload.ts
+++ b/connectors/src/connectors/slack/lib/thread_file_upload.ts
@@ -1,0 +1,68 @@
+import { removeNulls } from "@dust-tt/client";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
+
+export type SlackThreadFile = NonNullable<MessageElement["files"]>[number];
+
+export function selectBotThreadMessages({
+  replies,
+  startingAtTs,
+  allowedSlackBotId,
+}: {
+  replies: MessageElement[];
+  startingAtTs: string | null;
+  allowedSlackBotId: string | undefined;
+}) {
+  let shouldTake = false;
+  const messages: MessageElement[] = [];
+
+  for (const reply of replies) {
+    if (reply.ts === startingAtTs) {
+      shouldTake = true;
+    }
+
+    const isFromAllowedBot =
+      allowedSlackBotId && reply.bot_id === allowedSlackBotId;
+    if (!reply.user && !isFromAllowedBot) {
+      continue;
+    }
+    if (shouldTake) {
+      messages.push(reply);
+    }
+  }
+
+  return messages;
+}
+
+export function getSlackFilesFromMessages(messages: MessageElement[]) {
+  return removeNulls(messages.flatMap((message) => message.files ?? []));
+}
+
+export function hasPendingSlackFileMetadata(files: SlackThreadFile[]) {
+  return files.some(
+    (file) => !file.mimetype || !file.size || !file.url_private_download
+  );
+}
+
+export function countPendingSlackFileMetadata(files: SlackThreadFile[]) {
+  let missingMimetypeCount = 0;
+  let missingSizeCount = 0;
+  let missingPrivateDownloadUrlCount = 0;
+
+  for (const file of files) {
+    if (!file.mimetype) {
+      missingMimetypeCount += 1;
+    }
+    if (!file.size) {
+      missingSizeCount += 1;
+    }
+    if (!file.url_private_download) {
+      missingPrivateDownloadUrlCount += 1;
+    }
+  }
+
+  return {
+    missingMimetypeCount,
+    missingSizeCount,
+    missingPrivateDownloadUrlCount,
+  };
+}


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7094
Follows https://github.com/dust-tt/dust/pull/23169
Retries `conversations.replies` up to 2 times with a 2s delay when Slack thread files are still missing mimetype, size, or download URL before falling back to the normal skip logic.

## Risks
Blast radius: Slack thread attachment ingestion when Slack file metadata is delayed
Risk: low

## Deploy Plan
- deploy connectors