### PR TITLE
[front] fix: add type guard in isSupportedModel to prevent TypeError on undefined model

### DIFF
--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -22,11 +22,20 @@ export function isSupportedModel(
   model: unknown,
   checkProvider: boolean = true
 ): model is SupportedModel {
-  const maybeSupportedModel = model as SupportedModel;
+  if (
+    typeof model !== "object" ||
+    model === null ||
+    !("modelId" in model) ||
+    typeof model.modelId !== "string"
+  ) {
+    return false;
+  }
+
   return SUPPORTED_MODEL_CONFIGS.some(
     (m) =>
-      m.modelId === maybeSupportedModel.modelId &&
-      (!checkProvider || m.providerId === maybeSupportedModel.providerId)
+      m.modelId === model.modelId &&
+      (!checkProvider ||
+        ("providerId" in model && m.providerId === model.providerId))
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace unsafe `as SupportedModel` cast with a proper type guard in `isSupportedModel`
- The function receives `unknown` (used as an io-ts codec validator) but was casting directly without null/type checks, causing `TypeError: Cannot read properties of undefined (reading 'modelId')` when called with `undefined` or non-object values

## Context

- https://dust4ai.slack.com/archives/C05F84CFP0E/p1773846313882259

