### PR TITLE
[Data Retention] Reject usage exports outside retention window

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -13,6 +13,7 @@ import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
 import datadogLogger from "@app/logger/datadogLogger";
+import { isAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { BarChartIcon, Page } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -50,6 +51,11 @@ export function AnalyticsPage() {
       );
 
       if (!response.ok) {
+        const responseBody = await response.json().catch(() => null);
+        if (isAPIErrorResponse(responseBody)) {
+          throw new Error(responseBody.error.message);
+        }
+
         throw new Error(`Error: ${response.status}`);
       }
 
@@ -100,7 +106,7 @@ export function AnalyticsPage() {
         },
         "[Analytics] Failed to download activity data"
       );
-      alert("Failed to download activity data.");
+      window.alert(normalizedError.message);
     } finally {
       setDownloadingMonth(null);
     }

--- a/front/lib/workspace_usage_retention.test.ts
+++ b/front/lib/workspace_usage_retention.test.ts
@@ -1,0 +1,54 @@
+import {
+  getWorkspaceUsageRetentionErrorMessage,
+  getWorkspaceUsageRetentionStartDate,
+} from "@app/lib/workspace_usage_retention";
+import { describe, expect, it } from "vitest";
+
+describe("workspace_usage_retention", () => {
+  describe("getWorkspaceUsageRetentionStartDate", () => {
+    it("should compute the first supported day from the retention period", () => {
+      const retentionStartDate = getWorkspaceUsageRetentionStartDate({
+        now: new Date(2026, 2, 18, 12, 0, 0),
+        retentionDays: 60,
+      });
+
+      expect(retentionStartDate).toEqual(new Date(2026, 0, 17, 0, 0, 0, 0));
+    });
+  });
+
+  describe("getWorkspaceUsageRetentionErrorMessage", () => {
+    it("should return null when the workspace has no conversation retention", () => {
+      const errorMessage = getWorkspaceUsageRetentionErrorMessage({
+        startDate: new Date(2026, 0, 1, 0, 0, 0),
+        retentionDays: null,
+        now: new Date(2026, 2, 18, 12, 0, 0),
+      });
+
+      expect(errorMessage).toBeNull();
+    });
+
+    it("should return null when the requested period is within retention", () => {
+      const errorMessage = getWorkspaceUsageRetentionErrorMessage({
+        startDate: new Date(2026, 0, 17, 0, 0, 0),
+        retentionDays: 60,
+        now: new Date(2026, 2, 18, 12, 0, 0),
+      });
+
+      expect(errorMessage).toBeNull();
+    });
+
+    it("should return an explicit error when the requested period is older than retention", () => {
+      const errorMessage = getWorkspaceUsageRetentionErrorMessage({
+        startDate: new Date(2026, 0, 1, 0, 0, 0),
+        retentionDays: 60,
+        now: new Date(2026, 2, 18, 12, 0, 0),
+      });
+
+      expect(errorMessage).toBe(
+        "This workspace has a 60-day conversation retention policy. " +
+          "Detailed activity reports and the related usage API rely on live " +
+          "conversation data and would be incomplete for periods starting before 2026-01-17."
+      );
+    });
+  });
+});

--- a/front/lib/workspace_usage_retention.test.ts
+++ b/front/lib/workspace_usage_retention.test.ts
@@ -12,7 +12,7 @@ describe("workspace_usage_retention", () => {
         retentionDays: 60,
       });
 
-      expect(retentionStartDate).toEqual(new Date(2026, 0, 17, 0, 0, 0, 0));
+      expect(retentionStartDate).toEqual(new Date(2026, 0, 18, 0, 0, 0, 0));
     });
   });
 
@@ -29,7 +29,7 @@ describe("workspace_usage_retention", () => {
 
     it("should return null when the requested period is within retention", () => {
       const errorMessage = getWorkspaceUsageRetentionErrorMessage({
-        startDate: new Date(2026, 0, 17, 0, 0, 0),
+        startDate: new Date(2026, 0, 18, 0, 0, 0),
         retentionDays: 60,
         now: new Date(2026, 2, 18, 12, 0, 0),
       });
@@ -47,7 +47,7 @@ describe("workspace_usage_retention", () => {
       expect(errorMessage).toBe(
         "This workspace has a 60-day conversation retention policy. " +
           "Detailed activity reports and the related usage API rely on live " +
-          "conversation data and would be incomplete for periods starting before 2026-01-17."
+          "conversation data and would be incomplete for periods starting before 2026-01-18."
       );
     });
   });

--- a/front/lib/workspace_usage_retention.ts
+++ b/front/lib/workspace_usage_retention.ts
@@ -1,4 +1,5 @@
 const ZEROED_TIME_COMPONENT = 0;
+const ONE_DAY_IN_DAYS = 1;
 
 function formatDate(date: Date): string {
   const year = date.getFullYear();
@@ -15,14 +16,19 @@ export function getWorkspaceUsageRetentionStartDate({
   now?: Date;
   retentionDays: number;
 }): Date {
-  const retentionStartDate = new Date(now);
-  retentionStartDate.setDate(retentionStartDate.getDate() - retentionDays);
+  const retentionCutoffDate = new Date(now);
+  retentionCutoffDate.setDate(retentionCutoffDate.getDate() - retentionDays);
+
+  const retentionStartDate = new Date(retentionCutoffDate);
   retentionStartDate.setHours(
     ZEROED_TIME_COMPONENT,
     ZEROED_TIME_COMPONENT,
     ZEROED_TIME_COMPONENT,
     ZEROED_TIME_COMPONENT
   );
+  if (retentionCutoffDate > retentionStartDate) {
+    retentionStartDate.setDate(retentionStartDate.getDate() + ONE_DAY_IN_DAYS);
+  }
 
   return retentionStartDate;
 }

--- a/front/lib/workspace_usage_retention.ts
+++ b/front/lib/workspace_usage_retention.ts
@@ -1,0 +1,57 @@
+const ZEROED_TIME_COMPONENT = 0;
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+export function getWorkspaceUsageRetentionStartDate({
+  now = new Date(),
+  retentionDays,
+}: {
+  now?: Date;
+  retentionDays: number;
+}): Date {
+  const retentionStartDate = new Date(now);
+  retentionStartDate.setDate(retentionStartDate.getDate() - retentionDays);
+  retentionStartDate.setHours(
+    ZEROED_TIME_COMPONENT,
+    ZEROED_TIME_COMPONENT,
+    ZEROED_TIME_COMPONENT,
+    ZEROED_TIME_COMPONENT
+  );
+
+  return retentionStartDate;
+}
+
+export function getWorkspaceUsageRetentionErrorMessage({
+  startDate,
+  retentionDays,
+  now = new Date(),
+}: {
+  startDate: Date;
+  retentionDays: number | null;
+  now?: Date;
+}): string | null {
+  if (retentionDays === null) {
+    return null;
+  }
+
+  const retentionStartDate = getWorkspaceUsageRetentionStartDate({
+    now,
+    retentionDays,
+  });
+
+  if (startDate >= retentionStartDate) {
+    return null;
+  }
+
+  return (
+    `This workspace has a ${retentionDays}-day conversation retention policy. ` +
+    "Detailed activity reports and the related usage API rely on live " +
+    `conversation data and would be incomplete for periods starting before ${formatDate(retentionStartDate)}.`
+  );
+}

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -1,7 +1,9 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { getConversationsDataRetention } from "@app/lib/data_retention";
 import { unsafeGetUsageData } from "@app/lib/workspace_usage";
+import { getWorkspaceUsageRetentionErrorMessage } from "@app/lib/workspace_usage_retention";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { GetWorkspaceUsageResponseType } from "@dust-tt/client";
@@ -62,12 +64,25 @@ async function handler(
       }
 
       const query = queryValidation.right;
+      const startDate = new Date(query.start_date);
+      const endDate = query.end_date ? new Date(query.end_date) : new Date();
+      const conversationsRetentionDays =
+        await getConversationsDataRetention(auth);
+      const retentionErrorMessage = getWorkspaceUsageRetentionErrorMessage({
+        startDate,
+        retentionDays: conversationsRetentionDays,
+      });
+      if (retentionErrorMessage) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: retentionErrorMessage,
+          },
+        });
+      }
 
-      const csvData = await unsafeGetUsageData(
-        new Date(query.start_date),
-        query.end_date ? new Date(query.end_date) : new Date(),
-        owner
-      );
+      const csvData = await unsafeGetUsageData(startDate, endDate, owner);
       res.setHeader("Content-Type", "text/csv");
       res.status(200).send(csvData);
       return;

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -1,6 +1,7 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { getConversationsDataRetention } from "@app/lib/data_retention";
 import {
   getAssistantsUsageData,
   getBuildersUsageData,
@@ -8,6 +9,7 @@ import {
   getMessageUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
+import { getWorkspaceUsageRetentionErrorMessage } from "@app/lib/workspace_usage_retention";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -158,6 +160,21 @@ async function handler(
       }
 
       const { endDate, startDate } = resolveDates(query);
+      const conversationsRetentionDays =
+        await getConversationsDataRetention(auth);
+      const retentionErrorMessage = getWorkspaceUsageRetentionErrorMessage({
+        startDate,
+        retentionDays: conversationsRetentionDays,
+      });
+      if (retentionErrorMessage) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: retentionErrorMessage,
+          },
+        });
+      }
       const data = await fetchUsageData({
         table: query.table,
         start: startDate,

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getConversationsDataRetention } from "@app/lib/data_retention";
 import {
   getAssistantsUsageData,
   getBuildersUsageData,
@@ -8,6 +9,7 @@ import {
   getMessageUsageData,
   getUserUsageData,
 } from "@app/lib/workspace_usage";
+import { getWorkspaceUsageRetentionErrorMessage } from "@app/lib/workspace_usage_retention";
 import { apiError } from "@app/logger/withlogging";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
@@ -99,6 +101,21 @@ async function handler(
 
       const query = queryValidation.right;
       const { endDate, startDate } = resolveDates(query);
+      const conversationsRetentionDays =
+        await getConversationsDataRetention(auth);
+      const retentionErrorMessage = getWorkspaceUsageRetentionErrorMessage({
+        startDate,
+        retentionDays: conversationsRetentionDays,
+      });
+      if (retentionErrorMessage) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: retentionErrorMessage,
+          },
+        });
+      }
       const includeInactiveParam = req.query.includeInactive;
       const includeInactive = Array.isArray(includeInactiveParam)
         ? includeInactiveParam[0] === "true"

--- a/front/temporal/data_retention/activities.test.ts
+++ b/front/temporal/data_retention/activities.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { CONVERSATIONS_RETENTION_MIN_DAYS } from "@app/lib/conversations_retention";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
@@ -15,7 +16,7 @@ vi.mock("@temporalio/activity", () => ({
   heartbeat: vi.fn(),
 }));
 
-const RETENTION_DAYS = 30;
+const RETENTION_DAYS = CONVERSATIONS_RETENTION_MIN_DAYS;
 const OLD_CONVERSATION_DAYS = RETENTION_DAYS + 1;
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7063
Follows https://github.com/dust-tt/dust/pull/23166
Context: [slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1773843215032129)

Reject legacy detailed activity report requests when the requested period starts before the first fully supported day in the workspace conversation-retention window.
The workspace Analytics page now surfaces the API error instead of a generic download failure.

This surface will be deleted later on when the new Analytics take over.

## Risks
Blast radius: legacy detailed activity reports and workspace usage API exports
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test npm --workspace @dust-tt/front test -- workspace_usage_retention.test.ts`
- [x] `NODE_ENV=test npm --workspace @dust-tt/front test -- activities.test.ts`
