### PR TITLE
[front] fix(cron-rule): remove redundant JSON.parse on already-parsed req.body

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -34,7 +34,7 @@ async function handler(
   switch (req.method) {
     case "POST": {
       const bodyValidation = PostTextAsCronRuleRequestBodySchema.safeParse(
-        JSON.parse(req.body)
+        req.body
       );
 
       if (!bodyValidation.success) {


### PR DESCRIPTION
## Summary

- Fix `SyntaxError: "[object Object]" is not valid JSON` in `text_as_cron_rule` endpoint
- Next.js auto-parses JSON request bodies, so `req.body` is already an object — calling `JSON.parse` on it stringifies it to `"[object Object]"` which fails
- Removed the redundant `JSON.parse` call and pass `req.body` directly to zod's `safeParse`

## References

- Slack thread: https://dust4ai.slack.com/archives/C05F84CFP0E/p1773847034349499

