### PR TITLE
[front] refactor: move trigger to dialog component in agent batch deletion

### DIFF
--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -15,7 +15,6 @@ import {
   DropdownMenuTrigger,
   Spinner,
   TagIcon,
-  TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -38,7 +37,6 @@ export const AgentEditBar = ({
   tags,
   mutateAgentConfigurations,
 }: AgentEditBarProps) => {
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [tagSearch, setTagSearch] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -65,17 +63,6 @@ export const AgentEditBar = ({
 
   return (
     <>
-      <DeleteAssistantsDialog
-        owner={owner}
-        agentConfigurations={selectedAgents}
-        isOpen={isDeleteDialogOpen}
-        onClose={() => setIsDeleteDialogOpen(false)}
-        onSave={() => {
-          onClose();
-          setIsDeleteDialogOpen(false);
-        }}
-      />
-
       <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2 dark:bg-muted-background-night">
         <Button
           size="xs"
@@ -154,23 +141,18 @@ export const AgentEditBar = ({
             </DropdownMenuTagList>
           </DropdownMenuContent>
         </DropdownMenu>
-
         <UnpublishAssistantsDialog
           owner={owner}
           agentConfigurations={selectedAgents}
           disabled={selectedAgents.length === 0 || isLoading}
           onSave={onClose}
         />
-
-        <Button
-          size="xs"
-          variant="warning"
-          icon={TrashIcon}
-          label="Archive selection"
+        a{" "}
+        <DeleteAssistantsDialog
+          owner={owner}
+          agentConfigurations={selectedAgents}
           disabled={selectedAgents.length === 0 || isLoading}
-          onClick={() => {
-            setIsDeleteDialogOpen(true);
-          }}
+          onSave={onClose}
         />
       </div>
     </>

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -147,7 +147,6 @@ export const AgentEditBar = ({
           disabled={selectedAgents.length === 0 || isLoading}
           onSave={onClose}
         />
-        a{" "}
         <DeleteAssistantsDialog
           owner={owner}
           agentConfigurations={selectedAgents}

--- a/front/components/assistant/DeleteAssistantsDialog.tsx
+++ b/front/components/assistant/DeleteAssistantsDialog.tsx
@@ -3,6 +3,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -10,23 +11,22 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface DeleteAssistantsDialogProps {
   agentConfigurations: LightAgentConfigurationType[];
-  isOpen: boolean;
-  isPrivateAssistant?: boolean;
+  disabled: boolean;
   owner: LightWorkspaceType;
-  onClose: () => void;
   onSave: () => void;
 }
 
 export function DeleteAssistantsDialog({
   agentConfigurations,
-  isOpen,
+  disabled,
   owner,
-  onClose,
   onSave,
 }: DeleteAssistantsDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false);
@@ -41,14 +41,16 @@ export function DeleteAssistantsDialog({
   );
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          size="xs"
+          variant="warning"
+          icon={TrashIcon}
+          label="Archive selection"
+          disabled={disabled}
+        />
+      </DialogTrigger>
       <DialogContent size="md" isAlertDialog>
         <DialogHeader hideButton>
           <DialogTitle>


### PR DESCRIPTION
## Description

- This PR does a similar refactoring as suggested in https://github.com/dust-tt/dust/pull/23180#discussion_r2954148089 but for a different component.
- In the Manage Agents page there's a button to batch delete agents. This button opens a dialog, but the two components are separated and there is a common state that ties the two. This PR instead has the dialog trigger be the button.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
