### PR TITLE
[front] fix import from `client` to `types` in worker code

### DIFF
--- a/front/lib/api/actions/servers/poke/tools/index.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.ts
@@ -9,7 +9,7 @@ import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { isDustWorkspace } from "@app/types/shared/env";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@dust-tt/client/src/error_utils";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof POKE_TOOLS_METADATA> = {
   [GET_WORKSPACE_METADATA_TOOL_NAME]: async ({ workspace_id }, { auth }) => {


### PR DESCRIPTION
## Description

- Context in [incident thread](https://dust4ai.slack.com/archives/C0AMC2RRAHL/p1773850372240409).
- This PR fixes an import from the client that crashes the workers.
- The MCP tools code is used by the workers, therefore we can't import from `dust-tt/client/src` there.

## Tests

- Checking locally.

## Risk

- Medium, will have to be doubled checked

## Deploy Plan

- Deploy front.
