### PR TITLE
[Email Agents] Fix reply-to-all: parse To/Cc recipients from raw headers

### DIFF
--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -30,6 +30,44 @@ export const config = {
   },
 };
 
+function extractEmailAddressesFromHeader(headerValue: string | null): string[] {
+  if (!headerValue) {
+    return [];
+  }
+  const addresses: string[] = [];
+  const seen = new Set<string>();
+
+  const addEmail = (raw: string) => {
+    const email = raw.trim().toLowerCase();
+    if (!seen.has(email)) {
+      seen.add(email);
+      addresses.push(email);
+    }
+  };
+
+  // First pass: extract addresses inside angle brackets (e.g., "Name <email@domain.com>").
+  // This correctly handles display names with special characters (apostrophes, quotes, etc.)
+  // and ensures case-insensitive matching by lowercasing here.
+  const anglePattern = /<([^>]+)>/g;
+  let match;
+  while ((match = anglePattern.exec(headerValue)) !== null) {
+    const content = match[1].trim();
+    // Basic validation: must contain exactly one "@" and no spaces.
+    if (content.includes("@") && !content.includes(" ")) {
+      addEmail(content);
+    }
+  }
+
+  // Second pass: extract bare email addresses from parts without angle brackets.
+  const remaining = headerValue.replace(/<[^>]*>/g, " ");
+  const barePattern = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+  while ((match = barePattern.exec(remaining)) !== null) {
+    addEmail(match[0]);
+  }
+
+  return addresses;
+}
+
 function parseHeaderValue(
   rawHeaders: string,
   headerName: string
@@ -128,10 +166,20 @@ const parseSendgridWebhookContent = async (
         isString(rawHeaders) ? rawHeaders : null
       ),
       envelope: {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        to: envelope.to || [],
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        cc: envelope.cc || [],
+        // Use raw headers to get all To/Cc recipients: Sendgrid's envelope.to only
+        // contains addresses matching the inbound-parse domain, omitting human recipients.
+        // envelope.cc is not populated by Sendgrid at all.
+        // Fall back to envelope.to if headers are absent so agent routing still works.
+        to: (() => {
+          const fromHeaders = extractEmailAddressesFromHeader(
+            isString(rawHeaders) ? parseHeaderValue(rawHeaders, "To") : null
+          );
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          return fromHeaders.length > 0 ? fromHeaders : envelope.to || [];
+        })(),
+        cc: extractEmailAddressesFromHeader(
+          isString(rawHeaders) ? parseHeaderValue(rawHeaders, "Cc") : null
+        ),
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         bcc: envelope.bcc || [],
         from,


### PR DESCRIPTION
## Description

Fixes a bug where the agent email reply only went to the original sender, ignoring other recipients in To or Cc.

**Root cause:** Sendgrid's `envelope` JSON only includes:
- `from`: sender address
- `to`: **only** addresses matching the configured inbound-parse domain (`dust.team`), omitting human recipients
- `cc`: **not present** — Sendgrid does not populate this field

So `buildSuccessReplyRecipients` was building replies with just `[sender]` in `to` and an empty `cc`, completely ignoring other people in the loop.

**Fix:** Parse the full `To:` and `Cc:` raw email headers (already captured by Sendgrid in the `headers` field) instead of relying on the `envelope` object. Two-pass extraction (angle brackets first, then bare emails) handles display names with special characters. All addresses are lowercased to ensure correct case-insensitive matching against the agent domain.

Falls back to `envelope.to` if raw headers are absent, so agent routing still works in that edge case.

`buildSuccessReplyRecipients` itself (which correctly filters agent addresses and deduplicates) is unchanged.

## Risks

Blast radius: inbound email agent replies (To/Cc recipient list)
Risk: low

## Deploy Plan
- pmrr
- deploy front