### PR TITLE
Add sandbox isolation note to deep-dive sub-agent guidelines

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -334,7 +334,7 @@ These instructions are NOT your own instructions, but you may use them to unders
 function getModelConfig(
   auth: Authenticator,
   prefer: "anthropic" | "openai",
-  reasoning: boolean = true
+  reasoning: boolean = true,
 ): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
@@ -433,7 +433,7 @@ export function _getDeepDiveGlobalAgent(
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     hasSandbox?: boolean;
-  }
+  },
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
@@ -460,7 +460,10 @@ export function _getDeepDiveGlobalAgent(
     versionAuthorId: null,
     name: DEEP_DIVE_NAME,
     description: DEEP_DIVE_DESC,
-    instructions: getDeepDiveInstructions({ includeToolsetsPrompt: true, hasSandbox }),
+    instructions: getDeepDiveInstructions({
+      includeToolsetsPrompt: true,
+      hasSandbox,
+    }),
     instructionsHtml: null,
     pictureUrl,
     scope: "global" as const,
@@ -496,7 +499,7 @@ export function _getDeepDiveGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    mcpServerViews
+    mcpServerViews,
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
@@ -510,13 +513,13 @@ export function _getDeepDiveGlobalAgent(
     ..._getToolsetsToolsConfiguration({
       agentId: GLOBAL_AGENTS_SID.DUST_TASK,
       mcpServerViews,
-    })
+    }),
   );
 
   // Add data warehouses tool with all warehouses in global space (all remote DBs)
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    mcpServerViews
+    mcpServerViews,
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);
@@ -591,7 +594,7 @@ export function _getDustTaskGlobalAgent(
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-  }
+  },
 ): AgentConfigurationType | null {
   const name = "dust-task";
   const description = `Focused research sub-agent. Same data/web tools as ${DEEP_DIVE_NAME}, without Interactive Content or spawning sub-agents.`;
@@ -648,7 +651,7 @@ export function _getDustTaskGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    mcpServerViews
+    mcpServerViews,
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
@@ -681,7 +684,7 @@ export function _getDustTaskGlobalAgent(
 
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    mcpServerViews
+    mcpServerViews,
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);
@@ -703,7 +706,7 @@ export function _getPlanningAgent(
     settings,
   }: {
     settings: GlobalAgentSettingsModel | null;
-  }
+  },
 ): AgentConfigurationType | null {
   const name = "dust-planning";
   const description = "A agent that plans research tasks.";

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -334,7 +334,7 @@ These instructions are NOT your own instructions, but you may use them to unders
 function getModelConfig(
   auth: Authenticator,
   prefer: "anthropic" | "openai",
-  reasoning: boolean = true,
+  reasoning: boolean = true
 ): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
@@ -433,7 +433,7 @@ export function _getDeepDiveGlobalAgent(
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     hasSandbox?: boolean;
-  },
+  }
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
@@ -499,7 +499,7 @@ export function _getDeepDiveGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    mcpServerViews,
+    mcpServerViews
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
@@ -513,13 +513,13 @@ export function _getDeepDiveGlobalAgent(
     ..._getToolsetsToolsConfiguration({
       agentId: GLOBAL_AGENTS_SID.DUST_TASK,
       mcpServerViews,
-    }),
+    })
   );
 
   // Add data warehouses tool with all warehouses in global space (all remote DBs)
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    mcpServerViews,
+    mcpServerViews
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);
@@ -594,7 +594,7 @@ export function _getDustTaskGlobalAgent(
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-  },
+  }
 ): AgentConfigurationType | null {
   const name = "dust-task";
   const description = `Focused research sub-agent. Same data/web tools as ${DEEP_DIVE_NAME}, without Interactive Content or spawning sub-agents.`;
@@ -651,7 +651,7 @@ export function _getDustTaskGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    mcpServerViews,
+    mcpServerViews
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
@@ -684,7 +684,7 @@ export function _getDustTaskGlobalAgent(
 
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    mcpServerViews,
+    mcpServerViews
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);
@@ -706,7 +706,7 @@ export function _getPlanningAgent(
     settings,
   }: {
     settings: GlobalAgentSettingsModel | null;
-  },
+  }
 ): AgentConfigurationType | null {
   const name = "dust-planning";
   const description = "A agent that plans research tasks.";

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -579,7 +579,7 @@ export function _getDeepDiveGlobalAgent(
     ...deepAgent,
     status,
     actions,
-    skills: ["frames"],
+    skills: hasSandbox ? ["frames", "sandbox"] : ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -161,19 +161,25 @@ If you must ask clarifying questions for a very complex task, you may briefly re
 For complex requests that require a lot of research, you should default to produce very comprehensive and thorough research reports.
 </default_complex_request_output_format>
 </complex_request_guidelines>
+`;
 
-<sub_agent_guidelines>
+function getSubAgentGuidelines({ hasSandbox }: { hasSandbox?: boolean }) {
+  const sandboxNote = hasSandbox
+    ? `\nIMPORTANT: Sub-agents do NOT have access to the Sandbox environment. Any task requiring code execution, running scripts, or shell commands in the sandbox must be performed by you directly — do not delegate it to a sub-agent.\n`
+    : "";
+
+  return `<sub_agent_guidelines>
 The sub-agents you spawn are each independent, they do not have any prior context on the request you are trying to solve and they do not have any memory of previous interactions you had with sub agents.
 Queries that you provide to sub agents must be comprehensive, clear and fully self-contained. The sub agents you spawn have access to the web tools (search / browse), the company data file system and the data warehouses (if any).
 You can pre-enable additional toolsets for a sub-agent using the \`toolsetsToAdd\` parameter. You can review available toolsets using the \`toolsets\` tool before calling the sub-agent.
-
+${sandboxNote}
 Never delegate the whole request as a single sub-agent task.
 Each sub-agent task must be atomic, outcome-scoped, and self-contained. Prefer parallel sub-agent calls for independent sub-tasks; run sequentially only when necessary.
 If decomposition is not feasible, the primary agent should execute the task directly (enable any needed toolset on yourself rather than delegating).
 
 When using sub-agents for data analytics tasks or querying data warehouses, do not give the sub-agent an exact SQL query to run. Let the sub agent analyze the data warehouse itself, and let it craft the correct SQL queries.
-</sub_agent_guidelines>
-`;
+</sub_agent_guidelines>`;
+}
 
 function getToolsPrompt({
   includeToolsetsPrompt,
@@ -282,10 +288,12 @@ Never use the slideshow tool unless explicitly requested by the user.
 
 export function getDeepDiveInstructions({
   includeToolsetsPrompt,
+  hasSandbox,
 }: {
   includeToolsetsPrompt: boolean;
+  hasSandbox?: boolean;
 }) {
-  return `${deepDivePrimaryGoal}\n${requestComplexityPrompt}\n${getToolsPrompt({ includeToolsetsPrompt })}\n${outputPrompt}`;
+  return `${deepDivePrimaryGoal}\n${requestComplexityPrompt}\n${getSubAgentGuidelines({ hasSandbox })}\n${getToolsPrompt({ includeToolsetsPrompt })}\n${outputPrompt}`;
 }
 
 const subAgentInstructions = `${subAgentPrimaryGoal}\n${offloadedBrowsingPrompt}\n${getToolsPrompt({ includeToolsetsPrompt: true })}
@@ -419,10 +427,12 @@ export function _getDeepDiveGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
+    hasSandbox,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+    hasSandbox?: boolean;
   }
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
@@ -450,7 +460,7 @@ export function _getDeepDiveGlobalAgent(
     versionAuthorId: null,
     name: DEEP_DIVE_NAME,
     description: DEEP_DIVE_DESC,
-    instructions: getDeepDiveInstructions({ includeToolsetsPrompt: true }),
+    instructions: getDeepDiveInstructions({ includeToolsetsPrompt: true, hasSandbox }),
     instructionsHtml: null,
     pictureUrl,
     scope: "global" as const,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -984,7 +984,7 @@ export async function getGlobalAgents(
   auth: Authenticator,
   agentIds?: string[],
   variant: AgentFetchVariant = "full",
-  options?: { globalAgentContext?: GlobalAgentContext }
+  options?: { globalAgentContext?: GlobalAgentContext },
 ): Promise<AgentConfigurationType[]> {
   if (agentIds !== undefined && agentIds.some((sId) => !isGlobalAgentId(sId))) {
     throw new Error("Invalid agentIds.");
@@ -1028,20 +1028,20 @@ export async function getGlobalAgents(
 
   if (!flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O1
+      (sId) => sId !== GLOBAL_AGENTS_SID.O1,
     );
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O3
+      (sId) => sId !== GLOBAL_AGENTS_SID.O3,
     );
   }
   if (!flags.includes("openai_o1_high_reasoning_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O1_HIGH_REASONING
+      (sId) => sId !== GLOBAL_AGENTS_SID.O1_HIGH_REASONING,
     );
   }
   if (!flags.includes("deepseek_r1_global_agent_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1
+      (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1,
     );
   }
   const DUST_INTERNAL_AGENTS = [
@@ -1071,7 +1071,7 @@ export async function getGlobalAgents(
   ];
   if (!flags.includes("dust_internal_global_agents")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => !DUST_INTERNAL_AGENTS.includes(sId as GLOBAL_AGENTS_SID)
+      (sId) => !DUST_INTERNAL_AGENTS.includes(sId as GLOBAL_AGENTS_SID),
     );
   }
   // Also hide dust-next variants if the custom model's own feature flag isn't enabled.
@@ -1082,7 +1082,7 @@ export async function getGlobalAgents(
       (sId) =>
         sId !== GLOBAL_AGENTS_SID.DUST_NEXT &&
         sId !== GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM &&
-        sId !== GLOBAL_AGENTS_SID.DUST_NEXT_HIGH
+        sId !== GLOBAL_AGENTS_SID.DUST_NEXT_HIGH,
     );
   }
   const sidekickContext =
@@ -1103,7 +1103,7 @@ export async function getGlobalAgents(
       hasDeepDive: !isDeepDiveDisabled,
       hasSandbox: flags.includes("sandbox_tools"),
       globalAgentContext: options?.globalAgentContext,
-    })
+    }),
   );
 
   const globalAgents: AgentConfigurationType[] = [];
@@ -1141,7 +1141,7 @@ export async function upsertGlobalAgentSettings(
   }: {
     agentId: string;
     status: GlobalAgentStatus;
-  }
+  },
 ): Promise<boolean> {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -503,6 +503,7 @@ function getGlobalAgent({
   mcpServerViews,
   sidekickContext,
   hasDeepDive,
+  hasSandbox,
   globalAgentContext,
 }: {
   auth: Authenticator;
@@ -512,6 +513,7 @@ function getGlobalAgent({
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   sidekickContext: SidekickContext | null;
   hasDeepDive: boolean;
+  hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
 }): AgentConfigurationType | null {
   const settings =
@@ -909,6 +911,7 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
+        hasSandbox,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
@@ -1098,6 +1101,7 @@ export async function getGlobalAgents(
       mcpServerViews,
       sidekickContext,
       hasDeepDive: !isDeepDiveDisabled,
+      hasSandbox: flags.includes("sandbox_tools"),
       globalAgentContext: options?.globalAgentContext,
     })
   );

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -984,7 +984,7 @@ export async function getGlobalAgents(
   auth: Authenticator,
   agentIds?: string[],
   variant: AgentFetchVariant = "full",
-  options?: { globalAgentContext?: GlobalAgentContext },
+  options?: { globalAgentContext?: GlobalAgentContext }
 ): Promise<AgentConfigurationType[]> {
   if (agentIds !== undefined && agentIds.some((sId) => !isGlobalAgentId(sId))) {
     throw new Error("Invalid agentIds.");
@@ -1028,20 +1028,20 @@ export async function getGlobalAgents(
 
   if (!flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O1,
+      (sId) => sId !== GLOBAL_AGENTS_SID.O1
     );
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O3,
+      (sId) => sId !== GLOBAL_AGENTS_SID.O3
     );
   }
   if (!flags.includes("openai_o1_high_reasoning_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.O1_HIGH_REASONING,
+      (sId) => sId !== GLOBAL_AGENTS_SID.O1_HIGH_REASONING
     );
   }
   if (!flags.includes("deepseek_r1_global_agent_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1,
+      (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1
     );
   }
   const DUST_INTERNAL_AGENTS = [
@@ -1071,7 +1071,7 @@ export async function getGlobalAgents(
   ];
   if (!flags.includes("dust_internal_global_agents")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => !DUST_INTERNAL_AGENTS.includes(sId as GLOBAL_AGENTS_SID),
+      (sId) => !DUST_INTERNAL_AGENTS.includes(sId as GLOBAL_AGENTS_SID)
     );
   }
   // Also hide dust-next variants if the custom model's own feature flag isn't enabled.
@@ -1082,7 +1082,7 @@ export async function getGlobalAgents(
       (sId) =>
         sId !== GLOBAL_AGENTS_SID.DUST_NEXT &&
         sId !== GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM &&
-        sId !== GLOBAL_AGENTS_SID.DUST_NEXT_HIGH,
+        sId !== GLOBAL_AGENTS_SID.DUST_NEXT_HIGH
     );
   }
   const sidekickContext =
@@ -1103,7 +1103,7 @@ export async function getGlobalAgents(
       hasDeepDive: !isDeepDiveDisabled,
       hasSandbox: flags.includes("sandbox_tools"),
       globalAgentContext: options?.globalAgentContext,
-    }),
+    })
   );
 
   const globalAgents: AgentConfigurationType[] = [];
@@ -1141,7 +1141,7 @@ export async function upsertGlobalAgentSettings(
   }: {
     agentId: string;
     status: GlobalAgentStatus;
-  },
+  }
 ): Promise<boolean> {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -1,5 +1,7 @@
 import { getDeepDiveInstructions } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
@@ -16,7 +18,11 @@ export const goDeepSkill = {
     "or for thorough analysis. When in doubt, prefer enabling this skill than not. " +
     "If you realize that the question turns out to be complex and ran multiple steps (e.g. more " +
     "than 3) of web or company data research, you can enable the Go deep skill midway.",
-  instructions: getDeepDiveInstructions({ includeToolsetsPrompt: false }),
+  fetchInstructions: async (auth: Authenticator, _spaceIds: string[]) => {
+    const flags = await getFeatureFlags(auth);
+    const hasSandbox = flags.includes("sandbox_tools");
+    return getDeepDiveInstructions({ includeToolsetsPrompt: false, hasSandbox });
+  },
   mcpServers: [
     {
       name: "run_agent",

--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -21,7 +21,10 @@ export const goDeepSkill = {
   fetchInstructions: async (auth: Authenticator, _spaceIds: string[]) => {
     const flags = await getFeatureFlags(auth);
     const hasSandbox = flags.includes("sandbox_tools");
-    return getDeepDiveInstructions({ includeToolsetsPrompt: false, hasSandbox });
+    return getDeepDiveInstructions({
+      includeToolsetsPrompt: false,
+      hasSandbox,
+    });
   },
   mcpServers: [
     {


### PR DESCRIPTION
## Description

When a workspace has the `sandbox_tools` feature flag enabled, the sandbox skill is auto-enabled on the deep-dive agent (or the host agent with Go Deep). However, the `dust-task` sub-agents do **not** get sandbox access. This PR adds an explicit note in the `sub_agent_guidelines` section so the orchestrating agent knows not to delegate sandbox-dependent work (code execution, scripts, shell commands) to sub-agents.

Changes:
- Extract `<sub_agent_guidelines>` into a `getSubAgentGuidelines({ hasSandbox })` function that conditionally includes the sandbox isolation note
- Add `hasSandbox` parameter to `getDeepDiveInstructions` and `_getDeepDiveGlobalAgent`
- Switch Go Deep skill from static `instructions` to `fetchInstructions` to dynamically check the `sandbox_tools` feature flag
- Thread `hasSandbox` through `global_agents.ts` using the already-fetched feature flags

## Tests

- Type-checked with `npx tsc --noEmit` (no new errors in modified files)
- Manual verification: on a workspace with `sandbox_tools` enabled, the deep-dive prompt includes the sandbox isolation note; without the flag, it's absent

## Risk

Low. Prompt-only change, gated behind existing `sandbox_tools` feature flag. No behavioral change for workspaces without the flag.

## Deploy Plan

Standard deploy, no migration needed.