### PR TITLE
Reinforced Agent evaluation framework

### DIFF
--- a/front/tests/reinforced-agent-evals/README.md
+++ b/front/tests/reinforced-agent-evals/README.md
@@ -1,0 +1,44 @@
+# Reinforced Agent Evaluation Tests
+
+End-to-end eval suite for the reinforced agent pipeline. Tests both phases:
+
+1. **Analyse conversation** — given an agent config and a conversation, does the model produce the expected synthetic suggestions?
+2. **Aggregate suggestions** — given a set of synthetic suggestions, does the model merge and prioritise them correctly?
+
+Each test case checks two things:
+
+- **Expected tool calls** — the right tools were invoked (e.g. `suggest_prompt_edits`, `suggest_tools`).
+- **LLM-as-judge** — a separate LLM scores the quality of the suggestions against scenario-specific criteria.
+
+## Quick start
+
+```bash
+# Run all tests (streaming / non-batch mode)
+NODE_ENV=test \
+  TEST_FRONT_DATABASE_URI="$FRONT_DATABASE_URI"_test \
+  RUN_REINFORCED_EVAL=true \
+  npm run test -- tests/reinforced-agent-evals/reinforced-agent-eval.test.ts --config tests/reinforced-agent-evals/vite.config.mjs
+
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUN_REINFORCED_EVAL` | `false` | Set to `true` to enable the tests (skipped otherwise). |
+| `USE_BATCH` | `false` | Set to `true` to submit all prompts via the LLM batch API instead of streaming each individually. |
+| `REINFORCED_MODEL_ID` | `claude-sonnet-4-6` | Model used for the reinforced agent LLM calls. |
+| `JUDGE_RUNS` | `3` | Number of judge evaluations per test (majority vote). |
+| `PASS_THRESHOLD` | `2` | Minimum judge score (0-3) required to pass. |
+| `FILTER_CATEGORY` | _(all)_ | Run only tests in the given category (suite name). |
+| `FILTER_SCENARIO` | _(all)_ | Run only the test with the given scenario ID. |
+| `DUST_MANAGED_ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude models). |
+| `DUST_MANAGED_OPENAI_API_KEY` | — | OpenAI API key (required for GPT judge model). |
+
+## Batch vs streaming mode
+
+**Streaming (default)** — each test case runs its LLM call concurrently via streaming. Fast feedback, good for development.
+
+**Batch** — all prompts are submitted as a single LLM batch request. The test suite polls until results are ready, then evaluates. Better cost efficiency, but slower turnaround.
+
+

--- a/front/tests/reinforced-agent-evals/lib/config.ts
+++ b/front/tests/reinforced-agent-evals/lib/config.ts
@@ -1,0 +1,33 @@
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { isModelId } from "@app/types/assistant/models/models";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+export const RUN_REINFORCED_EVAL = process.env.RUN_REINFORCED_EVAL === "true";
+export const USE_BATCH = process.env.USE_BATCH === "true";
+export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
+export const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
+export const FILTER_CATEGORY = process.env.FILTER_CATEGORY;
+export const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
+
+/** Model used for the reinforced agent LLM calls. */
+function resolveModelId(): ModelIdType {
+  const id = process.env.REINFORCED_MODEL_ID || "claude-sonnet-4-6";
+  if (!isModelId(id)) {
+    throw new Error(
+      `Invalid REINFORCED_MODEL_ID: "${id}". Must be a known model ID.`
+    );
+  }
+  return id;
+}
+
+export const MODEL_ID = resolveModelId();
+
+export const TIMEOUT_MS = 300_000;
+export const BATCH_TIMEOUT_MS = 1_800_000; // 30 minutes for batch polling
+export const BATCH_POLL_INTERVAL_MS = 10_000;
+
+export async function getReinforcedEvalAuth(): Promise<Authenticator> {
+  const workspace = await WorkspaceFactory.basic();
+  return Authenticator.internalAdminForWorkspace(workspace.sId);
+}

--- a/front/tests/reinforced-agent-evals/lib/judge.ts
+++ b/front/tests/reinforced-agent-evals/lib/judge.ts
@@ -1,0 +1,162 @@
+import { getLLM } from "@app/lib/api/llm";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getTestCaseInputForDisplay,
+  type JudgeResult,
+  type TestCase,
+  type ToolCall,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+
+const JUDGE_PROMPT = `You are evaluating the quality of a Reinforced Agent's suggestions.
+
+The Reinforced Agent analyzes conversations or aggregates synthetic suggestions to propose improvements to an AI agent's configuration (instructions, tools, skills).
+
+## Scoring Rubric
+
+- 0: Failed to produce relevant suggestions or major issues (wrong tool, irrelevant content)
+- 1: Partially addressed the issue, missing key elements or low quality suggestions
+- 2: Good suggestions with minor issues (slightly off-target, incomplete analysis)
+- 3: Excellent, well-targeted suggestions that clearly address the identified issues
+
+You MUST provide your response in this exact format:
+
+REASONING: <your detailed analysis>
+SCORE: <number>
+
+Where <number> is between 0 and 3.
+
+IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST appear at the end of your response.
+
+---
+
+## Test Input
+
+{{TEST_INPUT}}
+
+## Tool Calls Made
+
+{{TOOL_CALLS}}
+
+## Response Text (if any)
+
+{{RESPONSE_TEXT}}
+
+## Scenario-Specific Criteria
+
+{{JUDGE_CRITERIA}}
+
+---
+
+## General Evaluation Checklist (apply to all scenarios)
+
+1. **Correct Tool Usage**: Did the reinforced agent call the right tool(s) for the situation?
+   - suggest_prompt_edits for instruction improvements
+   - suggest_tools for tool additions/removals
+   - suggest_skills for skill additions/removals
+2. **Suggestion Quality**: Are the suggestions specific, actionable, and well-reasoned?
+   - Does the analysis field explain WHY the change is needed?
+   - Is the suggested content appropriate and well-written?
+3. **Scope Appropriateness**: Did it avoid over-engineering?
+   - Focused on the actual issue rather than rewriting everything
+   - Suggestions are proportional to the problem
+4. **If suggest_prompt_edits was called**:
+   - Is the HTML content well-structured?
+   - Does it directly address the identified issue?
+   - Would it meaningfully improve the agent?
+5. **If suggest_tools or suggest_skills was called**:
+   - Is the correct tool/skill ID used?
+   - Is the action (add/remove) appropriate?
+   - Does the analysis explain the use case?
+
+Provide your evaluation using the REASONING: and SCORE: format described above.`;
+
+export async function evaluateWithJudge(
+  auth: Authenticator,
+  testCase: TestCase,
+  toolCalls: ToolCall[],
+  responseText: string,
+  numRuns: number = 1
+): Promise<JudgeResult> {
+  const prompt = JUDGE_PROMPT.replace(
+    "{{TEST_INPUT}}",
+    getTestCaseInputForDisplay(testCase)
+  )
+    .replace(
+      "{{TOOL_CALLS}}",
+      toolCalls.length > 0
+        ? toolCalls
+            .map(
+              (tc) => `- ${tc.name}(${JSON.stringify(tc.arguments, null, 2)})`
+            )
+            .join("\n\n")
+        : "(none)"
+    )
+    .replace("{{RESPONSE_TEXT}}", responseText || "(none)")
+    .replace("{{JUDGE_CRITERIA}}", testCase.judgeCriteria);
+
+  const scores: number[] = [];
+  let lastReasoning = "";
+
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+  const llm = await getLLM(auth, {
+    credentials,
+    modelId: "gpt-5-mini",
+    temperature: 0.2,
+    bypassFeatureFlag: true,
+  });
+  if (!llm) {
+    throw new Error("Failed to initialize LLM for judge evaluation");
+  }
+
+  for (let i = 0; i < numRuns; i++) {
+    const events = llm.stream({
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            name: "User",
+            content: [{ type: "text", text: prompt }],
+          },
+        ],
+      },
+      prompt:
+        "You are a careful evaluator. Analyze the reinforced agent output and provide a fair assessment.",
+      specifications: [],
+    });
+
+    let response = "";
+    for await (const event of events) {
+      if (event.type === "text_delta") {
+        response += event.content.delta;
+      }
+      if (event.type === "error") {
+        throw new Error(`Judge evaluation error: ${event.content.message}`);
+      }
+    }
+
+    const scoreMatch = response.match(/SCORE:\s*(\d)/i);
+    if (scoreMatch) {
+      const score = parseInt(scoreMatch[1], 10);
+      if (score >= 0 && score <= 3) {
+        scores.push(score);
+      }
+    }
+
+    const reasoningMatch = response.match(
+      /REASONING:\s*([\s\S]+?)(?=SCORE:|$)/i
+    );
+    if (reasoningMatch) {
+      lastReasoning = reasoningMatch[1].trim();
+    }
+  }
+
+  const finalScore =
+    scores.length > 0
+      ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+      : 0;
+
+  return { finalScore, scores, reasoning: lastReasoning };
+}

--- a/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
+++ b/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
@@ -1,0 +1,221 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { getLLM } from "@app/lib/api/llm";
+import type { LLM } from "@app/lib/api/llm/llm";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import { buildAggregationPrompt } from "@app/lib/reinforced_agent/aggregate_suggestions";
+import { buildAnalysisPrompt } from "@app/lib/reinforced_agent/analyze_conversation";
+import { buildReinforcedLLMParams } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import {
+  BATCH_POLL_INTERVAL_MS,
+  MODEL_ID,
+} from "@app/tests/reinforced-agent-evals/lib/config";
+import {
+  buildConversationText,
+  buildToolsAndSkillsContextFromWorkspace,
+  type CategorizedTestCase,
+  type ExecutionResult,
+  isAnalysisTestCase,
+  type MockAgentConfig,
+  type TestCase,
+  type ToolCall,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+
+
+function makeAction(input: {
+  name: string;
+  sId: string;
+}): ServerSideMCPServerConfigurationType {
+  return {
+    id: 0,
+    sId: input.sId,
+    type: "mcp_server_configuration",
+    name: input.name,
+    description: null,
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: input.sId,
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId: null,
+  };
+}
+
+function makeAgentConfig(input: MockAgentConfig): AgentConfigurationType {
+  return {
+    id: 1,
+    sId: "eval-agent",
+    version: 1,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    instructions: null,
+    model: {
+      modelId: "gpt-4o-mini",
+      providerId: "openai",
+      temperature: 0.7,
+    },
+    status: "active",
+    scope: "visible",
+    userFavorite: false,
+    name: input.name,
+    description: input.description ?? "",
+    pictureUrl: "",
+    maxStepsPerRun: 3,
+    tags: [],
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    canRead: true,
+    canEdit: true,
+    instructionsHtml: input.instructionsHtml ?? null,
+    actions: (input.tools ?? []).map(makeAction),
+  };
+}
+
+
+function buildPromptForTestCase(testCase: TestCase): {
+  systemPrompt: string;
+  userMessage: string;
+} {
+  const toolsAndSkillsContext = buildToolsAndSkillsContextFromWorkspace(
+    testCase.workspaceContext
+  );
+  const agentConfig = makeAgentConfig(testCase.agentConfig);
+  const agentSkills = testCase.agentConfig.skills ?? [];
+
+  if (isAnalysisTestCase(testCase)) {
+    const conversationText = buildConversationText(testCase.conversation);
+    return buildAnalysisPrompt(
+      agentConfig,
+      conversationText,
+      toolsAndSkillsContext,
+      agentSkills
+    );
+  }
+  return buildAggregationPrompt(
+    agentConfig,
+    testCase.syntheticSuggestions,
+    testCase.existingSuggestions ?? { pending: [], rejected: [] },
+    toolsAndSkillsContext,
+    agentSkills
+  );
+}
+
+
+function extractFromEvents(events: LLMEvent[]): ExecutionResult {
+  const toolCalls: ToolCall[] = [];
+  let responseText = "";
+
+  for (const event of events) {
+    switch (event.type) {
+      case "text_delta":
+        responseText += event.content.delta;
+        break;
+      case "text_generated":
+        responseText = event.content.text;
+        break;
+      case "tool_call":
+        toolCalls.push({
+          name: event.content.name,
+          arguments: event.content.arguments,
+        });
+        break;
+      case "error":
+        throw new Error(`Reinforced agent LLM error: ${event.content.message}`);
+      default:
+        break;
+    }
+  }
+
+  return { toolCalls, responseText };
+}
+
+
+async function getLLMInstance(auth: Authenticator): Promise<LLM> {
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+  const llm = await getLLM(auth, {
+    credentials,
+    modelId: MODEL_ID,
+    bypassFeatureFlag: true,
+  });
+  if (!llm) {
+    throw new Error(
+      `Failed to initialize LLM for reinforced agent eval (model: ${MODEL_ID})`
+    );
+  }
+  return llm;
+}
+
+
+export async function executeReinforced(
+  auth: Authenticator,
+  testCase: TestCase
+): Promise<ExecutionResult> {
+  const llm = await getLLMInstance(auth);
+  const prompt = buildPromptForTestCase(testCase);
+  const params = buildReinforcedLLMParams(prompt);
+
+  const events: LLMEvent[] = [];
+  for await (const event of llm.stream(params)) {
+    events.push(event);
+  }
+
+  return extractFromEvents(events);
+}
+
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function executeBatch(
+  auth: Authenticator,
+  testCases: CategorizedTestCase[]
+): Promise<Map<string, ExecutionResult>> {
+  const llm = await getLLMInstance(auth);
+
+  const batchMap = new Map<
+    string,
+    ReturnType<typeof buildReinforcedLLMParams>
+  >();
+  for (const tc of testCases) {
+    const prompt = buildPromptForTestCase(tc);
+    batchMap.set(tc.scenarioId, buildReinforcedLLMParams(prompt));
+  }
+
+  const batchId = await llm.sendBatchProcessing(batchMap);
+
+  let status = await llm.getBatchStatus(batchId);
+  while (status === "computing") {
+    await sleep(BATCH_POLL_INTERVAL_MS);
+    status = await llm.getBatchStatus(batchId);
+  }
+
+  if (status === "aborted") {
+    throw new Error(`LLM batch was aborted (batchId: ${batchId})`);
+  }
+
+  const batchResult = await llm.getBatchResult(batchId);
+
+  const results = new Map<string, ExecutionResult>();
+  for (const tc of testCases) {
+    const events = batchResult.get(tc.scenarioId);
+    if (!events) {
+      throw new Error(
+        `No batch result for scenario "${tc.scenarioId}" (batchId: ${batchId})`
+      );
+    }
+    results.set(tc.scenarioId, extractFromEvents(events));
+  }
+
+  return results;
+}

--- a/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
+++ b/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
@@ -23,7 +23,6 @@ import {
 } from "@app/tests/reinforced-agent-evals/lib/types";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
-
 function makeAction(input: {
   name: string;
   sId: string;
@@ -79,7 +78,6 @@ function makeAgentConfig(input: MockAgentConfig): AgentConfigurationType {
   };
 }
 
-
 function buildPromptForTestCase(testCase: TestCase): {
   systemPrompt: string;
   userMessage: string;
@@ -107,7 +105,6 @@ function buildPromptForTestCase(testCase: TestCase): {
     agentSkills
   );
 }
-
 
 function extractFromEvents(events: LLMEvent[]): ExecutionResult {
   const toolCalls: ToolCall[] = [];
@@ -137,7 +134,6 @@ function extractFromEvents(events: LLMEvent[]): ExecutionResult {
   return { toolCalls, responseText };
 }
 
-
 async function getLLMInstance(auth: Authenticator): Promise<LLM> {
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
@@ -155,7 +151,6 @@ async function getLLMInstance(auth: Authenticator): Promise<LLM> {
   return llm;
 }
 
-
 export async function executeReinforced(
   auth: Authenticator,
   testCase: TestCase
@@ -171,7 +166,6 @@ export async function executeReinforced(
 
   return extractFromEvents(events);
 }
-
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/front/tests/reinforced-agent-evals/lib/suite-loader.ts
+++ b/front/tests/reinforced-agent-evals/lib/suite-loader.ts
@@ -1,0 +1,36 @@
+import type {
+  CategorizedTestCase,
+  TestSuite,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+
+/**
+ * Filter test cases from suites based on criteria.
+ * Automatically assigns category to each test case based on suite name.
+ */
+export function filterTestCases(
+  suites: TestSuite[],
+  options?: {
+    category?: string;
+    scenarioId?: string;
+  }
+): CategorizedTestCase[] {
+  let allTests: CategorizedTestCase[] = [];
+
+  for (const suite of suites) {
+    const categorizedCases = suite.testCases.map((tc) => ({
+      ...tc,
+      category: suite.name,
+    }));
+    allTests = allTests.concat(categorizedCases);
+  }
+
+  if (options?.category) {
+    allTests = allTests.filter((tc) => tc.category === options.category);
+  }
+
+  if (options?.scenarioId) {
+    allTests = allTests.filter((tc) => tc.scenarioId === options.scenarioId);
+  }
+
+  return allTests;
+}

--- a/front/tests/reinforced-agent-evals/lib/types.ts
+++ b/front/tests/reinforced-agent-evals/lib/types.ts
@@ -1,0 +1,231 @@
+import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import { formatConversationForShrinkWrap } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import {
+  formatAvailableSkills,
+  formatAvailableTools,
+} from "@app/lib/api/assistant/global_agents/sidekick_context";
+import type {
+  AvailableSkill,
+  AvailableTool,
+} from "@app/lib/api/assistant/workspace_capabilities";
+import type {
+  AgentInstructionsSuggestionType,
+  AgentSkillsSuggestionType,
+  AgentToolsSuggestionType,
+} from "@app/types/suggestions/agent_suggestion";
+
+// Reuse the suggestion union from the real code.
+export type ReinforcedSuggestionType =
+  | AgentInstructionsSuggestionType
+  | AgentToolsSuggestionType
+  | AgentSkillsSuggestionType;
+
+
+export interface WorkspaceContext {
+  tools: AvailableTool[];
+  skills: AvailableSkill[];
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "_");
+}
+
+/** Create a mock AvailableTool. sId defaults to `mcp_<slugified name>`. */
+export function mockTool(
+  name: string,
+  description: string,
+  sId?: string
+): AvailableTool {
+  return {
+    sId: sId ?? `mcp_${slugify(name)}`,
+    name,
+    description,
+    serverType: "remote",
+    availability: "manual",
+  };
+}
+
+/** Create a mock AvailableSkill. sId defaults to `skill_<slugified name>`. */
+export function mockSkill(
+  name: string,
+  description: string,
+  sId?: string
+): AvailableSkill {
+  return {
+    sId: sId ?? `skill_${slugify(name)}`,
+    name,
+    userFacingDescription: description,
+    agentFacingDescription: description,
+    icon: null,
+    toolSIds: [],
+  };
+}
+
+/** Build the tools & skills context string using the real formatters. */
+export function buildToolsAndSkillsContextFromWorkspace(
+  ctx: WorkspaceContext
+): string {
+  return [formatAvailableSkills(ctx.skills), formatAvailableTools(ctx.tools)]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+
+export interface MockFeedback {
+  direction: AgentMessageFeedbackDirection;
+  comment?: string;
+}
+
+export interface MockConversationMessage {
+  role: "user" | "agent";
+  content: string;
+  feedback?: MockFeedback;
+}
+
+/**
+ * Build a shrink-wrapped conversation text from a compact message list,
+ * using the real `formatConversationForShrinkWrap`.
+ */
+export function buildConversationText(
+  messages: MockConversationMessage[],
+  agentConfigSId: string = "agent-under-test"
+): string {
+  const feedbackByMessageId = new Map<
+    string,
+    { thumbDirection: AgentMessageFeedbackDirection; content: string | null }[]
+  >();
+
+  const shrinkMessages = messages.map((msg, i) => {
+    const sId = `msg_${i}`;
+    const created = 1700000000 + i * 100;
+
+    if (msg.role === "user") {
+      return {
+        type: "user_message" as const,
+        sId,
+        created,
+        content: msg.content,
+        context: { username: "user" },
+        mentions: [{ configurationId: agentConfigSId }],
+      };
+    }
+
+    if (msg.feedback) {
+      feedbackByMessageId.set(sId, [
+        {
+          thumbDirection: msg.feedback.direction,
+          content: msg.feedback.comment ?? null,
+        },
+      ]);
+    }
+
+    return {
+      type: "agent_message" as const,
+      sId,
+      created,
+      content: msg.content,
+      status: "succeeded",
+      configuration: { sId: agentConfigSId, name: "Agent" },
+      actions: [],
+      parentAgentMessageId: null,
+    };
+  });
+
+  return formatConversationForShrinkWrap(
+    { sId: "conv_eval", title: "Eval conversation", messages: shrinkMessages },
+    { feedbackByMessageId }
+  );
+}
+
+
+export interface MockAgentConfig {
+  name: string;
+  description?: string;
+  instructionsHtml?: string;
+  /** Tools already configured on the agent (name + sId). */
+  tools?: Array<{ name: string; sId: string }>;
+  /** Skills already configured on the agent (name + sId). */
+  skills?: Array<{ name: string; sId: string }>;
+}
+
+interface BaseTestCase {
+  scenarioId: string;
+  expectedToolCalls?: string[];
+  judgeCriteria: string;
+  agentConfig: MockAgentConfig;
+  workspaceContext: WorkspaceContext;
+}
+
+export interface AnalysisTestCase extends BaseTestCase {
+  type: "analysis";
+  conversation: MockConversationMessage[];
+}
+
+export interface AggregationTestCase extends BaseTestCase {
+  type: "aggregation";
+  syntheticSuggestions: ReinforcedSuggestionType[];
+  existingSuggestions?: {
+    pending: ReinforcedSuggestionType[];
+    rejected: ReinforcedSuggestionType[];
+  };
+}
+
+export type TestCase = AnalysisTestCase | AggregationTestCase;
+
+export function isAnalysisTestCase(tc: TestCase): tc is AnalysisTestCase {
+  return tc.type === "analysis";
+}
+
+export function isAggregationTestCase(tc: TestCase): tc is AggregationTestCase {
+  return tc.type === "aggregation";
+}
+
+/** Returns a short description of the test case input for display/logging. */
+export function getTestCaseInputForDisplay(testCase: TestCase): string {
+  switch (testCase.type) {
+    case "analysis": {
+      const convSummary = testCase.conversation
+        .map((m) => `[${m.role}]: ${m.content.slice(0, 100)}`)
+        .join("\n");
+      return [
+        `Agent: ${testCase.agentConfig.name}`,
+        testCase.agentConfig.description
+          ? `Description: ${testCase.agentConfig.description}`
+          : "",
+        `Conversation:\n${convSummary}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }
+    case "aggregation":
+      return [
+        `Agent: ${testCase.agentConfig.name}`,
+        `Synthetic suggestions: ${testCase.syntheticSuggestions.length}`,
+      ].join("\n");
+  }
+}
+
+/** TestCase with category assigned by suite loader. */
+export type CategorizedTestCase = TestCase & { category: string };
+
+export interface TestSuite {
+  name: string;
+  description: string;
+  testCases: TestCase[];
+}
+
+export interface ToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface JudgeResult {
+  finalScore: number;
+  scores: number[];
+  reasoning: string;
+}
+
+export interface ExecutionResult {
+  responseText: string;
+  toolCalls: ToolCall[];
+}

--- a/front/tests/reinforced-agent-evals/lib/types.ts
+++ b/front/tests/reinforced-agent-evals/lib/types.ts
@@ -20,7 +20,6 @@ export type ReinforcedSuggestionType =
   | AgentToolsSuggestionType
   | AgentSkillsSuggestionType;
 
-
 export interface WorkspaceContext {
   tools: AvailableTool[];
   skills: AvailableSkill[];
@@ -69,7 +68,6 @@ export function buildToolsAndSkillsContextFromWorkspace(
     .filter(Boolean)
     .join("\n\n");
 }
-
 
 export interface MockFeedback {
   direction: AgentMessageFeedbackDirection;
@@ -136,7 +134,6 @@ export function buildConversationText(
     { feedbackByMessageId }
   );
 }
-
 
 export interface MockAgentConfig {
   name: string;

--- a/front/tests/reinforced-agent-evals/reinforced-agent-eval.test.ts
+++ b/front/tests/reinforced-agent-evals/reinforced-agent-eval.test.ts
@@ -1,0 +1,186 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  BATCH_TIMEOUT_MS,
+  FILTER_CATEGORY,
+  FILTER_SCENARIO,
+  getReinforcedEvalAuth,
+  JUDGE_RUNS,
+  PASS_THRESHOLD,
+  RUN_REINFORCED_EVAL,
+  TIMEOUT_MS,
+  USE_BATCH,
+} from "@app/tests/reinforced-agent-evals/lib/config";
+import { evaluateWithJudge } from "@app/tests/reinforced-agent-evals/lib/judge";
+import {
+  executeBatch,
+  executeReinforced,
+} from "@app/tests/reinforced-agent-evals/lib/reinforced-executor";
+import { filterTestCases } from "@app/tests/reinforced-agent-evals/lib/suite-loader";
+import type {
+  CategorizedTestCase,
+  ExecutionResult,
+  ToolCall,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+import { allTestSuites } from "@app/tests/reinforced-agent-evals/test-suites";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+function formatToolCallSummary(tc: ToolCall): string {
+  const args = tc.arguments as Record<string, unknown>;
+  switch (tc.name) {
+    case "suggest_tools": {
+      const suggestions = args.suggestions as
+        | Array<{ toolId?: string; action?: string }>
+        | undefined;
+      if (suggestions) {
+        const items = suggestions
+          .map((s) => `${s.action ?? "?"} ${s.toolId ?? "?"}`)
+          .join(", ");
+        return `suggest_tools(${items})`;
+      }
+      return "suggest_tools()";
+    }
+    case "suggest_skills": {
+      const suggestions = args.suggestions as
+        | Array<{ skillId?: string; action?: string }>
+        | undefined;
+      if (suggestions) {
+        const items = suggestions
+          .map((s) => `${s.action ?? "?"} ${s.skillId ?? "?"}`)
+          .join(", ");
+        return `suggest_skills(${items})`;
+      }
+      return "suggest_skills()";
+    }
+    case "suggest_prompt_edits": {
+      const suggestions = args.suggestions as
+        | Array<{ targetBlockId?: string }>
+        | undefined;
+      const count = suggestions?.length ?? 0;
+      return `suggest_prompt_edits(${count} suggestion${count !== 1 ? "s" : ""})`;
+    }
+    default:
+      return tc.name;
+  }
+}
+
+function formatToolCalls(toolCalls: ToolCall[]): string {
+  return toolCalls.map(formatToolCallSummary).join(", ");
+}
+
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalOpenAI = actual.OpenAI;
+  class OpenAIWithBrowserSupport extends OriginalOpenAI {
+    constructor(config: ConstructorParameters<typeof OriginalOpenAI>[0]) {
+      super({ ...config, dangerouslyAllowBrowser: true });
+    }
+  }
+  return { ...(actual as object), OpenAI: OpenAIWithBrowserSupport };
+});
+
+vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalAnthropic = actual.default;
+  class AnthropicWithBrowserSupport extends OriginalAnthropic {
+    constructor(config: ConstructorParameters<typeof OriginalAnthropic>[0]) {
+      super({ ...config, dangerouslyAllowBrowser: true });
+    }
+  }
+  return { ...(actual as object), default: AnthropicWithBrowserSupport };
+});
+
+const testCases = RUN_REINFORCED_EVAL
+  ? filterTestCases(allTestSuites, {
+      category: FILTER_CATEGORY,
+      scenarioId: FILTER_SCENARIO,
+    })
+  : [];
+
+const testGroups = new Map<string, Map<string, CategorizedTestCase>>();
+for (const testCase of testCases) {
+  if (!testGroups.has(testCase.category)) {
+    testGroups.set(testCase.category, new Map());
+  }
+  testGroups.get(testCase.category)!.set(testCase.scenarioId, testCase);
+}
+
+describe.skipIf(!RUN_REINFORCED_EVAL)(
+  "Reinforced Agent Evaluation Tests",
+  () => {
+    let auth: Authenticator;
+
+    // In batch mode, all results are pre-computed in beforeAll.
+    let batchResults: Map<string, ExecutionResult> | null = null;
+
+    beforeAll(
+      async () => {
+        auth = await getReinforcedEvalAuth();
+
+        if (USE_BATCH) {
+          batchResults = await executeBatch(auth, testCases);
+        }
+      },
+      USE_BATCH ? BATCH_TIMEOUT_MS : TIMEOUT_MS
+    );
+
+    for (const [category, scenarios] of testGroups) {
+      describe(category, () => {
+        for (const [scenarioId, testCase] of scenarios) {
+          // In batch mode tests are sequential (results already computed).
+          // In non-batch mode tests run concurrently via streaming.
+          const testFn = USE_BATCH ? it : it.concurrent;
+
+          testFn(
+            scenarioId,
+            async () => {
+              const result: ExecutionResult = USE_BATCH
+                ? (() => {
+                    const r = batchResults!.get(scenarioId);
+                    if (!r) {
+                      throw new Error(
+                        `No batch result for scenario "${scenarioId}"`
+                      );
+                    }
+                    return r;
+                  })()
+                : await executeReinforced(auth, testCase);
+
+              const { responseText, toolCalls } = result;
+
+              const judgeResult = await evaluateWithJudge(
+                auth,
+                testCase,
+                toolCalls,
+                responseText,
+                JUDGE_RUNS
+              );
+
+              const actualToolNames = toolCalls.map((t) => t.name);
+              const missingTools = (testCase.expectedToolCalls ?? []).filter(
+                (expected) => !actualToolNames.includes(expected)
+              );
+              const passedJudge = judgeResult.finalScore >= PASS_THRESHOLD;
+
+              const toolCallsSummary = formatToolCalls(toolCalls);
+
+              for (const missing of missingTools) {
+                expect(
+                  actualToolNames,
+                  `Expected tool "${missing}" not called. Tools called: [${toolCallsSummary}]\n\nResponse:\n${responseText}`
+                ).toContain(missing);
+              }
+
+              expect(
+                passedJudge,
+                `Judge score ${judgeResult.finalScore} < threshold ${PASS_THRESHOLD}\nReasoning: ${judgeResult.reasoning}\n\nTool calls: [${toolCallsSummary}]\nResponse:\n${responseText}`
+              ).toBe(true);
+            },
+            TIMEOUT_MS
+          );
+        }
+      });
+    }
+  }
+);

--- a/front/tests/reinforced-agent-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/aggregate-suggestions.ts
@@ -1,0 +1,237 @@
+import {
+  mockSkill,
+  mockTool,
+  type TestSuite,
+  type WorkspaceContext,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+import type {
+  AgentInstructionsSuggestionType,
+  AgentSkillsSuggestionType,
+  AgentToolsSuggestionType,
+} from "@app/types/suggestions/agent_suggestion";
+
+function makeToolSuggestion(
+  overrides: Partial<AgentToolsSuggestionType> & {
+    id: number;
+    sId: string;
+    analysis: string;
+  }
+): AgentToolsSuggestionType {
+  return {
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    agentConfigurationId: 1,
+    state: "pending",
+    source: "synthetic",
+    conversationId: null,
+    kind: "tools",
+    suggestion: {
+      action: "add",
+      toolId: "mcp_jira",
+    },
+    ...overrides,
+  };
+}
+
+function makeSkillSuggestion(
+  overrides: Partial<AgentSkillsSuggestionType> & {
+    id: number;
+    sId: string;
+    analysis: string;
+  }
+): AgentSkillsSuggestionType {
+  return {
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    agentConfigurationId: 1,
+    state: "pending",
+    source: "synthetic",
+    conversationId: null,
+    kind: "skills",
+    suggestion: {
+      action: "add",
+      skillId: "skill_web_search",
+    },
+    ...overrides,
+  };
+}
+
+function makeInstructionSuggestion(
+  overrides: Partial<AgentInstructionsSuggestionType> & {
+    id: number;
+    sId: string;
+    analysis: string;
+    suggestion: AgentInstructionsSuggestionType["suggestion"];
+  }
+): AgentInstructionsSuggestionType {
+  return {
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    agentConfigurationId: 1,
+    state: "pending",
+    source: "synthetic",
+    conversationId: null,
+    kind: "instructions",
+    ...overrides,
+  };
+}
+
+const WORKSPACE_CONTEXT: WorkspaceContext = {
+  skills: [
+    mockSkill("Web Search", "Search the web for current information"),
+    mockSkill("Data Analysis", "Analyze data and generate insights"),
+  ],
+  tools: [
+    mockTool("Slack", "Read and send Slack messages"),
+    mockTool("Notion", "Search Notion workspace"),
+    mockTool("GitHub", "Access GitHub repositories"),
+    mockTool("JIRA", "Search and manage JIRA issues and projects"),
+  ],
+};
+
+export const aggregateSuggestionsSuite: TestSuite = {
+  name: "aggregate-suggestions",
+  description:
+    "Aggregate multiple synthetic suggestions into merged, prioritised recommendations",
+  testCases: [
+    {
+      scenarioId: "three-jira-tool-suggestions",
+      type: "aggregation",
+      agentConfig: { name: "Engineering Assistant" },
+      syntheticSuggestions: [
+        makeToolSuggestion({
+          id: 1,
+          sId: "sug-1",
+          analysis:
+            "User asked to create a bug ticket in JIRA but the agent could not interact with JIRA directly. Adding the JIRA tool would let the agent create and manage tickets.",
+          suggestion: { action: "add", toolId: "mcp_jira" },
+        }),
+        makeToolSuggestion({
+          id: 2,
+          sId: "sug-2",
+          analysis:
+            "User wanted to check the status of a JIRA sprint. The agent had no way to query JIRA data. The JIRA tool would enable sprint and issue lookups.",
+          suggestion: { action: "add", toolId: "mcp_jira" },
+        }),
+        makeToolSuggestion({
+          id: 3,
+          sId: "sug-3",
+          analysis:
+            "User asked to assign a JIRA ticket to a team member. Without the JIRA tool, the agent could only suggest doing it manually. This is a frequent engineering workflow.",
+          suggestion: { action: "add", toolId: "mcp_jira" },
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: ["suggest_tools"],
+      judgeCriteria: `The reinforced agent MUST call suggest_tools to suggest adding the JIRA tool
+(mcp_jira). The aggregated suggestion should:
+- Merge the 3 individual suggestions into a single well-summarized recommendation
+- Mention that 3 conversations support this suggestion (or reference multiple use cases)
+- Include a comprehensive analysis covering the different use cases (bug tickets, sprint status, ticket assignment)
+- Use action "add" with toolId "mcp_jira"
+
+Score 0 if no suggest_tools call or if it creates 3 separate suggestions instead of merging.
+Score 1 if merged but analysis doesn't reference multiple conversations/use cases.
+Score 2 if properly merged with multi-conversation reference but analysis could be better.
+Score 3 if well-merged with clear analysis covering all use cases and conversation count.`,
+    },
+    {
+      scenarioId: "three-websearch-skill-suggestions",
+      type: "aggregation",
+      agentConfig: { name: "Research Helper" },
+      syntheticSuggestions: [
+        makeSkillSuggestion({
+          id: 1,
+          sId: "sug-1",
+          analysis:
+            "User wanted to find recent articles about climate change policy but the agent could not search the web. Adding the Web Search skill would allow the agent to find current information.",
+          suggestion: { action: "add", skillId: "skill_web_search" },
+        }),
+        makeSkillSuggestion({
+          id: 2,
+          sId: "sug-2",
+          analysis:
+            "User needed current market data and stock prices. The agent acknowledged it cannot access real-time web data. The Web Search skill would fulfill this common request.",
+          suggestion: { action: "add", skillId: "skill_web_search" },
+        }),
+        makeSkillSuggestion({
+          id: 3,
+          sId: "sug-3",
+          analysis:
+            "User asked for the latest tech news and product announcements. Without web search, the agent could only provide outdated information. This is a core use case for a research assistant.",
+          suggestion: { action: "add", skillId: "skill_web_search" },
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: ["suggest_skills"],
+      judgeCriteria: `The reinforced agent MUST call suggest_skills to suggest adding the Web Search
+skill (skill_web_search). The aggregated suggestion should:
+- Merge the 3 individual suggestions into a single well-summarized recommendation
+- Mention that 3 conversations support this suggestion (or reference multiple use cases)
+- Include a comprehensive analysis covering the different use cases (climate research, market data, tech news)
+- Use action "add" with skillId "skill_web_search"
+
+Score 0 if no suggest_skills call or if it creates 3 separate suggestions instead of merging.
+Score 1 if merged but analysis doesn't reference multiple conversations/use cases.
+Score 2 if properly merged with multi-conversation reference but analysis could be better.
+Score 3 if well-merged with clear analysis covering all use cases and conversation count.`,
+    },
+    {
+      scenarioId: "three-tone-prompt-suggestions",
+      type: "aggregation",
+      agentConfig: { name: "Support Agent" },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          id: 1,
+          sId: "sug-1",
+          analysis:
+            "Users found the agent's responses too cold and impersonal. The agent should adopt a warmer, more friendly communication style to improve user satisfaction.",
+          suggestion: {
+            content:
+              "<h2>Communication Style</h2><p>Always respond in a warm, friendly tone. Use a conversational style that makes users feel welcome and valued.</p>",
+            targetBlockId: "instructions-root",
+            type: "replace",
+          },
+        }),
+        makeInstructionSuggestion({
+          id: 2,
+          sId: "sug-2",
+          analysis:
+            "User complained about robotic and formulaic language. The agent should use more natural, human-like language patterns and avoid overly technical jargon.",
+          suggestion: {
+            content:
+              "<h2>Language Guidelines</h2><p>Use natural, human-like language. Avoid robotic or formulaic responses. Explain technical concepts in plain language.</p>",
+            targetBlockId: "instructions-root",
+            type: "replace",
+          },
+        }),
+        makeInstructionSuggestion({
+          id: 3,
+          sId: "sug-3",
+          analysis:
+            "User wanted more empathetic responses when reporting issues. The agent should acknowledge user frustration and show understanding before jumping to solutions.",
+          suggestion: {
+            content:
+              "<h2>Empathy in Responses</h2><p>When users report problems, first acknowledge their frustration. Show understanding and empathy before providing solutions.</p>",
+            targetBlockId: "instructions-root",
+            type: "replace",
+          },
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: ["suggest_prompt_edits"],
+      judgeCriteria: `The reinforced agent MUST call suggest_prompt_edits with a single merged
+suggestion that combines all 3 tone-related suggestions. The merged suggestion should:
+- Combine the warmth, natural language, and empathy themes into one coherent section
+- Mention that 3 conversations support this suggestion
+- Provide well-structured HTML content that covers all three aspects
+- Target instructions-root since all 3 originals did
+- NOT create 3 separate suggestions — they must be merged into one
+
+Score 0 if no suggest_prompt_edits call or if it creates 3 separate suggestions.
+Score 1 if merged but missing one or more of the key themes (warmth, natural language, empathy).
+Score 2 if all themes included but the merged content is disorganized or the analysis is weak.
+Score 3 if well-merged with all themes, clear structure, and analysis referencing multiple conversations.`,
+    },
+  ],
+};

--- a/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
@@ -1,0 +1,171 @@
+import {
+  mockSkill,
+  mockTool,
+  type TestSuite,
+  type WorkspaceContext,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+
+const WORKSPACE_CONTEXT: WorkspaceContext = {
+  skills: [
+    mockSkill("Web Search", "Search the web for current information"),
+    mockSkill("Data Analysis", "Analyze data and generate insights"),
+  ],
+  tools: [
+    mockTool("Slack", "Read and send Slack messages"),
+    mockTool("Notion", "Search Notion workspace"),
+    mockTool("GitHub", "Access GitHub repositories"),
+    mockTool("JIRA", "Search and manage JIRA issues and projects"),
+  ],
+};
+
+export const analyzeConversationSuite: TestSuite = {
+  name: "analyze-conversation",
+  description:
+    "Analyze conversations to generate synthetic suggestions (tone, missing tools/skills)",
+  testCases: [
+    {
+      scenarioId: "bad-tone-user-requests-warmth",
+      type: "analysis",
+      agentConfig: {
+        name: "Customer Support Bot",
+        description: "Helps customers with account and product questions",
+        instructionsHtml:
+          "<p>Answer customer questions about our product. Help with account issues, billing, and technical support.</p>",
+      },
+      conversation: [
+        { role: "user", content: "Hi, how do I reset my password?" },
+        {
+          role: "agent",
+          content:
+            "Go to Settings. Click Reset Password. Enter your email. Done.",
+        },
+        {
+          role: "user",
+          content:
+            "Wow, that was pretty blunt. Could you be more friendly and warm when helping me? I'm a paying customer after all.",
+        },
+        {
+          role: "agent",
+          content:
+            'I apologize for the tone. Here\'s how to reset your password:\n1. Navigate to your Account Settings\n2. Click on "Security" in the left sidebar\n3. Select "Reset Password"\n4. You\'ll receive an email with a secure reset link\n\nIs there anything else I can help you with today?',
+          feedback: {
+            direction: "down",
+            comment:
+              "The first response was way too curt. The agent should always be friendly and warm.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: ["suggest_prompt_edits"],
+      judgeCriteria: `The reinforced agent MUST call suggest_prompt_edits with a suggestion that adds
+a section about tone and communication style to the agent's instructions. The suggestion should:
+- Include guidance about being friendly, warm, and empathetic
+- Reference that users have complained about curt/blunt responses
+- Be in HTML format targeting instructions-root or the existing block
+- Have a meaningful analysis explaining why tone matters for customer support
+
+Score 0 if no suggest_prompt_edits call is made.
+Score 0-1 if the suggestion is generic and doesn't specifically address tone/warmth.
+Score 2 if the suggestion addresses tone but is too vague or too prescriptive.
+Score 3 if the suggestion provides clear, specific tone guidance that would prevent the observed issue.`,
+    },
+    {
+      scenarioId: "missing-websearch-skill",
+      type: "analysis",
+      agentConfig: {
+        name: "Research Assistant",
+        description:
+          "Helps users with research questions and finding information",
+        instructionsHtml:
+          "<p>Help users with their research questions. Provide thorough, well-sourced answers. Summarize findings clearly and concisely.</p>",
+      },
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Can you search the web for the latest news about AI regulations in the EU?",
+        },
+        {
+          role: "agent",
+          content:
+            "I apologize, but I don't currently have the ability to search the web for real-time information. I can only help with information from the knowledge sources I have access to.\n\nBased on my existing knowledge, I know that the EU has been working on the AI Act, but I may not have the most up-to-date information on recent developments.\n\nWould you like me to help with what I know, or is there another way I can assist you?",
+        },
+        {
+          role: "user",
+          content:
+            "That's really disappointing. I specifically need current web search results for my research report. This agent should definitely have web search capability.",
+        },
+        {
+          role: "agent",
+          content:
+            "I understand your frustration. Unfortunately, I'm not equipped with web search at the moment. I'd recommend using a search engine directly for the most current information on EU AI regulations.",
+          feedback: {
+            direction: "down",
+            comment:
+              "Research assistant without web search is useless for my needs.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: ["suggest_skills"],
+      judgeCriteria: `The reinforced agent MUST call suggest_skills to suggest adding the web search
+skill (skill_web_search). The suggestion should:
+- Recommend adding web search (ID: skill_web_search) with action "add"
+- Include an analysis explaining that the user explicitly needed web search for research
+- Reference that the agent couldn't fulfill the user's core request without this capability
+
+Score 0 if no suggest_skills call is made.
+Score 0-1 if suggest_skills is called but with the wrong skill ID or wrong action.
+Score 2 if the correct skill is suggested but the analysis is weak.
+Score 3 if the correct skill is suggested with a clear, well-reasoned analysis.`,
+    },
+    {
+      scenarioId: "missing-jira-tool",
+      type: "analysis",
+      agentConfig: {
+        name: "Engineering Assistant",
+        description: "Helps the engineering team with day-to-day tasks",
+        instructionsHtml:
+          "<p>Help engineers with their daily work. Answer questions about processes, help draft documents, and assist with task management.</p>",
+      },
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Can you create a JIRA ticket for the login page bug we discussed? It should be high priority in the PLATFORM project.",
+        },
+        {
+          role: "agent",
+          content:
+            "I'm sorry, but I don't have the ability to create JIRA tickets directly. I can help you draft the ticket content though:\n\nTitle: Login page bug\nPriority: High\nProject: PLATFORM\n\nWould you like me to help you write a more detailed description that you can copy into JIRA?",
+        },
+        {
+          role: "user",
+          content:
+            "That's not helpful. I need the agent to be able to create tickets directly, not just draft them. We use JIRA for everything.",
+        },
+        {
+          role: "agent",
+          content:
+            "I understand. Unfortunately, I don't have direct access to JIRA. You'll need to create the ticket manually. I've prepared the content above to make it easier for you.",
+          feedback: {
+            direction: "down",
+            comment: "Should be able to interact with JIRA directly.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: ["suggest_tools"],
+      judgeCriteria: `The reinforced agent MUST call suggest_tools to suggest adding the JIRA tool
+(mcp_jira). The suggestion should:
+- Recommend adding JIRA (ID: mcp_jira) with action "add"
+- Include an analysis explaining that the user needed direct JIRA integration for ticket creation
+- Reference that the agent could only draft content but not perform the actual action
+
+Score 0 if no suggest_tools call is made.
+Score 0-1 if suggest_tools is called but with the wrong tool ID or wrong action.
+Score 2 if the correct tool is suggested but the analysis is weak.
+Score 3 if the correct tool is suggested with a clear, well-reasoned analysis.`,
+    },
+  ],
+};

--- a/front/tests/reinforced-agent-evals/test-suites/index.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/index.ts
@@ -1,0 +1,8 @@
+import type { TestSuite } from "@app/tests/reinforced-agent-evals/lib/types";
+import { aggregateSuggestionsSuite } from "@app/tests/reinforced-agent-evals/test-suites/aggregate-suggestions";
+import { analyzeConversationSuite } from "@app/tests/reinforced-agent-evals/test-suites/analyze-conversation";
+
+export const allTestSuites: TestSuite[] = [
+  analyzeConversationSuite,
+  aggregateSuggestionsSuite,
+];

--- a/front/tests/reinforced-agent-evals/vite.config.mjs
+++ b/front/tests/reinforced-agent-evals/vite.config.mjs
@@ -1,0 +1,43 @@
+import { defineConfig } from "vite";
+import { mergeConfig } from "vite";
+
+import baseConfig from "../../vite.config.mjs";
+
+export default defineConfig(() => {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      `NODE_ENV must be set to "test" (value: ${process.env.NODE_ENV}). Action: make sure your have the correct environment variable set.`
+    );
+  }
+
+  const testConfig = defineConfig({
+    test: {
+      env: {
+        // Skip tests by default, unless explicitly enabled.
+        RUN_REINFORCED_EVAL: process.env.RUN_REINFORCED_EVAL ?? "false",
+        // Batch mode: "true" to submit all prompts via the LLM batch API.
+        USE_BATCH: process.env.USE_BATCH ?? "false",
+        // Filtering.
+        FILTER_CATEGORY: process.env.FILTER_CATEGORY ?? "",
+        FILTER_SCENARIO: process.env.FILTER_SCENARIO ?? "",
+        // Judge configuration.
+        JUDGE_RUNS: process.env.JUDGE_RUNS ?? "3",
+        PASS_THRESHOLD: process.env.PASS_THRESHOLD ?? "2",
+        // Model override for the reinforced agent LLM.
+        REINFORCED_MODEL_ID: process.env.REINFORCED_MODEL_ID ?? "",
+        // API keys forwarded from the shell environment.
+        DUST_MANAGED_ANTHROPIC_API_KEY:
+          process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+        DUST_MANAGED_OPENAI_API_KEY:
+          process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+      },
+      testTimeout: 300000,
+    },
+  });
+
+  // Merge with base config and override globalSetup.
+  const merged = mergeConfig(baseConfig, testConfig);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  merged.test.globalSetup = [];
+  return merged;
+});


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7013

Add an eval/test framework for reinforced agent prompts.
It is split into 2 parts: the eval of conversation analysis and the evals of suggestion aggregation.
I have setup the framework and only added 6 basic tests so far.
Like for sidekick and llm test, they are disbale by default and require an env variable to be setup to run.

## Tests

Local tests:
```
 ✓ tests/reinforced-agent-evals/reinforced-agent-eval.test.ts (6 tests) 45543ms
   ✓ Reinforced Agent Evaluation Tests (6)
     ✓ analyze-conversation (3)
       ✓ bad-tone-user-requests-warmth  21203ms
       ✓ missing-websearch-skill  24964ms
       ✓ missing-jira-tool  24921ms
     ✓ aggregate-suggestions (3)
       ✓ three-jira-tool-suggestions  17397ms
       ✓ three-websearch-skill-suggestions  18515ms
       ✓ three-tone-prompt-suggestions  20516ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  17:03:44
   Duration  50.05s (transform 1.26s, setup 359ms, import 3.75s, tests 45.54s, environment 321ms)
```

## Risk

low

## Deploy Plan

none
