### PR TITLE
[Email Agents] Cap reply recipients at 15 to prevent bulk relay

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -2,6 +2,7 @@ import {
   ASSISTANT_EMAIL_SUBDOMAIN,
   buildReplyThreadingHeaders,
   buildSuccessReplyRecipients,
+  MAX_REPLY_RECIPIENTS,
 } from "@app/lib/api/assistant/email/email_trigger";
 import { describe, expect, it } from "vitest";
 
@@ -82,6 +83,37 @@ describe("buildSuccessReplyRecipients", () => {
       to: ["sender@dust.tt", "teammate@dust.tt"],
       cc: ["observer@dust.tt"],
     });
+  });
+
+  it("caps total recipients at MAX_REPLY_RECIPIENTS, dropping cc first", () => {
+    const manyCC = Array.from(
+      { length: MAX_REPLY_RECIPIENTS },
+      (_, i) => `cc${i}@dust.tt`
+    );
+    const recipients = buildSuccessReplyRecipients({
+      subject: "Test",
+      text: "Hello",
+      auth: { SPF: "pass", dkim: "pass" },
+      threadingHeaders: {
+        messageId: null,
+        inReplyTo: null,
+        references: null,
+      },
+      envelope: {
+        from: "sender@dust.tt",
+        full: "Sender <sender@dust.tt>",
+        to: ["teammate@dust.tt"],
+        cc: manyCC,
+        bcc: [],
+      },
+      attachments: [],
+    });
+
+    expect(recipients.to).toEqual(["sender@dust.tt", "teammate@dust.tt"]);
+    expect(recipients.to.length + recipients.cc.length).toBe(
+      MAX_REPLY_RECIPIENTS
+    );
+    expect(recipients.cc).toEqual(manyCC.slice(0, MAX_REPLY_RECIPIENTS - 2));
   });
 });
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -336,6 +336,10 @@ export function buildSuccessReplyRecipients(email: InboundEmail): {
     return { to, cc };
   }
   const cappedCc = cc.slice(0, Math.max(0, MAX_REPLY_RECIPIENTS - to.length));
+  logger.warn(
+    { totalRecipients: total, cappedTo: to.length, cappedCc: cappedCc.length },
+    "[email] Reply recipient list truncated to MAX_REPLY_RECIPIENTS."
+  );
   return { to, cc: cappedCc };
 }
 export async function userAndWorkspaceFromEmail({

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -255,6 +255,11 @@ function isAssistantRecipient(email: string): boolean {
   return normalizeEmailAddress(email).endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`);
 }
 
+// Cap on total reply recipients (to + cc combined). To/Cc are sourced from raw email headers,
+// which a sender can freely forge to list arbitrary addresses. The cap prevents using the agent
+// as a bulk relay while leaving no impact on legitimate threads (nobody CCs 15+ people normally).
+export const MAX_REPLY_RECIPIENTS = 15;
+
 function buildReferencesHeaderValue({
   inReplyTo,
   references,
@@ -325,7 +330,13 @@ export function buildSuccessReplyRecipients(email: InboundEmail): {
     })
   );
 
-  return { to, cc };
+  // Enforce recipient cap: sender (envelope.from) is always kept, extras are dropped from cc first.
+  const total = to.length + cc.length;
+  if (total <= MAX_REPLY_RECIPIENTS) {
+    return { to, cc };
+  }
+  const cappedCc = cc.slice(0, Math.max(0, MAX_REPLY_RECIPIENTS - to.length));
+  return { to, cc: cappedCc };
 }
 export async function userAndWorkspaceFromEmail({
   email,


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/23194

To/Cc recipients for email agent replies are sourced from raw email headers, which a sender can freely forge to list arbitrary addresses. This caps the total reply recipients (to + cc) at 15 to prevent using the agent as a bulk relay.

No impact on legitimate threads — nobody CCs 15+ people on a normal email thread. The sender (`envelope.from`) is always preserved in `to`; extras are dropped from `cc` first.

## Risks

Blast radius: inbound email agent replies (recipient count)
Risk: none

## Deploy Plan
- pmrr (2 small ones, double 🙏 )
- deploy front