### PR TITLE
Add poke plugin to delete slack conversation

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -64,6 +64,10 @@ const whitelistedCommands = [
     command: "check-channel",
   },
   {
+    majorCommand: "slack",
+    command: "delete-conversation",
+  },
+  {
     majorCommand: "connectors",
     command: "set-error",
   },

--- a/front/lib/api/poke/plugins/data_sources/delete_slack_conversation.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_slack_conversation.ts
@@ -1,0 +1,85 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger from "@app/logger/logger";
+import type { AdminCommandType } from "@app/types/connectors/admin/cli";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const deleteSlackConversationPlugin = createPlugin({
+  manifest: {
+    id: "delete-slack-conversation",
+    name: "Delete Slack Conversation",
+    description:
+      "Delete a Slack conversation thread from the data source. This removes the thread document from both the core data source and the connectors database.",
+    warning:
+      "The thread must be first deleted from the customer's Slack, otherwise it will get re-indexed on next full sync.",
+    resourceTypes: ["data_sources"],
+    args: {
+      channelId: {
+        type: "string",
+        label: "Channel ID",
+        description: "Slack channel ID (e.g., CXXXXXXXXXX)",
+      },
+      threadTs: {
+        type: "string",
+        label: "Thread Timestamp",
+        description:
+          "Timestamp of the thread to delete (e.g., 1234567890.123456)",
+      },
+    },
+  },
+  isApplicableTo: (auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+
+    return resource.connectorProvider === "slack";
+  },
+  execute: async (auth, dataSource, args) => {
+    const owner = auth.getNonNullableWorkspace();
+    const { channelId, threadTs } = args;
+
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (dataSource.connectorProvider !== "slack") {
+      return new Err(new Error("Data source is not a Slack connector."));
+    }
+
+    if (!channelId.trim()) {
+      return new Err(new Error("Channel ID is required."));
+    }
+
+    if (!threadTs.trim()) {
+      return new Err(new Error("Thread Timestamp is required."));
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const deleteConversationCmd: AdminCommandType = {
+      majorCommand: "slack",
+      command: "delete-conversation",
+      args: {
+        wId: owner.sId,
+        channelId: channelId.trim(),
+        threadTs: threadTs.trim(),
+      },
+    };
+
+    const result = await connectorsAPI.admin(deleteConversationCmd);
+    if (result.isErr()) {
+      return new Err(
+        new Error(`Failed to delete conversation: ${result.error.message}`)
+      );
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Conversation thread ${threadTs} in channel ${channelId} has been deleted from the data source.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -3,6 +3,7 @@ export * from "./check_slack_channel";
 export * from "./compute_statistics";
 export * from "./confluence_page_checker";
 export * from "./delete_data_source";
+export * from "./delete_slack_conversation";
 export * from "./garbage_collect_google_drive_document";
 export * from "./get_access_token";
 export * from "./google_drive_sync_file";

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -580,6 +580,7 @@ export const SlackCommandSchema = t.type({
     t.literal("run-auto-join"),
     t.literal("whitelist-domains"),
     t.literal("check-channel"),
+    t.literal("delete-conversation"),
   ]),
   args: t.record(
     t.string,


### PR DESCRIPTION
## Description

We have seen 2 occurences now of someone leaking private info into an indexed slack thread.
We have already added a CLI to manage such issue, this PR also add a poke plugin.

To be considered if the problem is recurrent: add a delete button from the datasource configuration.

## Tests

<img width="2386" height="1410" alt="image" src="https://github.com/user-attachments/assets/0f7c5085-7e18-4125-a2ff-9f647e3ab246" />

cannot test running the command from front-edge as it required deploying connector first.

## Risk

People may delete the indexed conversation without deleting the actual slack thread, making it reindaxable and not actually fixing the underlying issue.

## Deploy Plan

deploy connector
deploy front
