### PR TITLE
fix: tracking creating too many profiles

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -11,6 +11,7 @@ import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import {
   DUST_ANONYMOUS_ID_COOKIE,
   getOrCreateAnonymousId,
+  getPostHogCookieDomain,
 } from "@app/lib/utils/anonymous_id";
 import { getStoredUTMParams, MARKETING_PARAMS } from "@app/lib/utils/utm";
 import { isString } from "@app/types/shared/utils/general";
@@ -149,11 +150,17 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
       return;
     }
 
+    const cookieDomain = getPostHogCookieDomain();
+
     posthog.init(POSTHOG_KEY, {
       api_host: `${config.getApiBaseUrl()}/subtle1`,
       person_profiles: "identified_only",
       defaults: "2025-05-24",
       persistence: "memory",
+      // Share PostHog cookies (including distinct_id) across all *.dust.tt
+      // subdomains so the same identity persists through dust.tt → signin →
+      // app.dust.tt. Takes effect when persistence upgrades to cookie in Phase 2.
+      ...(cookieDomain ? { cookie_domain: cookieDomain } : {}),
       capture_pageview: true,
       capture_pageleave: false,
       autocapture: false,
@@ -217,6 +224,9 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
 
     posthog.set_config({
       persistence: "localStorage+cookie",
+      ...(getPostHogCookieDomain()
+        ? { cookie_domain: getPostHogCookieDomain() }
+        : {}),
       disable_session_recording: false,
     });
     posthog.startSessionRecording();

--- a/front/lib/tracking/posthog/server.ts
+++ b/front/lib/tracking/posthog/server.ts
@@ -87,33 +87,35 @@ export class PostHogServerSideTracking {
         }
       }
 
-      client.identify({
+      /* Set person properties and first-touch attribution via $set/$set_once.
+      We intentionally avoid client.identify() here because it generates a
+        server-side distinct_id that would create an extra "person".
+      The identify() call happens from the frontend (posthog-js)
+        which naturally merges the browser's anonymous distinct_id with user.sId.
+      */
+      const setProps: Record<string, string> = {
+        first_name: user.firstName,
+        last_name: user.lastName ?? "",
+        name: user.fullName,
+        ...(user.provider ? { provider: user.provider } : {}),
+        ...utmProperties,
+      };
+
+      const setOnceProps: Record<string, string> = {};
+      for (const [key, value] of Object.entries(utmProperties)) {
+        setOnceProps[`first_${key}`] = value;
+      }
+
+      client.capture({
         distinctId: user.sId,
+        event: "$set",
         properties: {
-          first_name: user.firstName,
-          last_name: user.lastName,
-          name: user.fullName,
-          provider: user.provider,
-          ...utmProperties,
+          $set: setProps,
+          ...(Object.keys(setOnceProps).length > 0
+            ? { $set_once: setOnceProps }
+            : {}),
         },
       });
-
-      // Set first-touch attribution as $set_once person properties so the
-      // very first UTM/click-ID values are permanently recorded.
-      if (Object.keys(utmProperties).length > 0) {
-        const firstTouchProps: Record<string, string> = {};
-        for (const [key, value] of Object.entries(utmProperties)) {
-          firstTouchProps[`first_${key}`] = value;
-        }
-
-        client.capture({
-          distinctId: user.sId,
-          event: "$set",
-          properties: {
-            $set_once: firstTouchProps,
-          },
-        });
-      }
 
       if (userCreated) {
         client.capture({

--- a/front/lib/utils/anonymous_id.ts
+++ b/front/lib/utils/anonymous_id.ts
@@ -22,6 +22,15 @@ function getRootCookieDomain(): string | null {
 }
 
 /**
+ * Returns the root cookie domain for PostHog cross-subdomain tracking.
+ * On production returns `.dust.tt`; on localhost/dev returns `undefined`.
+ */
+export function getPostHogCookieDomain(): string | undefined {
+  const domain = getRootCookieDomain();
+  return domain ?? undefined;
+}
+
+/**
  * Builds the cookie string for `_dust_aid` including the domain attribute
  * when applicable (production multi-subdomain setup).
  */


### PR DESCRIPTION
## Description

Fixes the broken identity chain across dust.tt → signin.dust.tt → app.dust.tt.

- Add `cookie_domain: ".dust.tt"` to PostHog init and persistence upgrade; PostHog cookies now shared across all subdomains
- Replace server-side `client.identify()` with `$set`/`$set_once` capture; sets person properties without creating an extra identity

## Tests
 
## Risk 

Low, changes are additive config (`cookie_domain`) and a simplification of the server-side tracking call. Safe to rollback.

## Deploy Plan
