### PR TITLE
[front] feat: add `discover_skills` to deep-dive

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -579,7 +579,7 @@ export function _getDeepDiveGlobalAgent(
     ...deepAgent,
     status,
     actions,
-    skills: hasSandbox ? ["frames", "sandbox"] : ["frames"],
+    skills: hasSandbox ? ["frames", "discover_skills", "sandbox"] : ["frames", "discover_skills"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -579,7 +579,9 @@ export function _getDeepDiveGlobalAgent(
     ...deepAgent,
     status,
     actions,
-    skills: hasSandbox ? ["frames", "discover_skills", "sandbox"] : ["frames", "discover_skills"],
+    skills: hasSandbox
+      ? ["frames", "discover_skills", "sandbox"]
+      : ["frames", "discover_skills"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }


### PR DESCRIPTION
## Description

- This PR adds the ability to discover skills to the deep-dive global agent.
- Gated behind the `discover_skills` feature flag.

## Tests

- Tested locally.

## Risk

- Low, behind feature flag.

## Deploy Plan

- Deploy front.
