### PR TITLE
[front] chore: fix query param validation in `api/v1` mentions suggestion endpoint

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/mentions/suggestions.ts
@@ -85,8 +85,24 @@ async function handler(
     });
   }
 
-  const parsedQuery = GetMentionSuggestionsRequestQuerySchema.parse(req.query);
-  const { query, select: selectParam, current } = parsedQuery;
+  const parsedQuery = GetMentionSuggestionsRequestQuerySchema.safeParse(
+    req.query
+  );
+  if (!parsedQuery.success) {
+    const errorMessages = parsedQuery.error.errors
+      .map((e) => `${e.path.join(".")}: ${e.message}`)
+      .join(", ");
+
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid query parameters: ${errorMessages}`,
+      },
+    });
+  }
+
+  const { query, select: selectParam, current } = parsedQuery.data;
 
   // Parse select parameter: can be "agents", "users", ["agents", "users"], or undefined.
   const select = (() => {


### PR DESCRIPTION
## Description

- The schema validation in the `api/v1/w/[wId]/assistant/mentions/suggestions.ts` endpoint throws if the query params provided are invalid.
- This PR fixes this to 400 instead.
- Log [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ0CpPPHrOrZ8AAAABhBWjBDcFFPakFBRGJPVVRWbG1iSmpnQUgAAAAkMDE5ZDAyYmUtMjNhNi00YmRkLWE5MDktNTZhNTkyYzZlZTFmAABecg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1773865632000&to_ts=1773866232000&live=false).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
