### PR TITLE
Add parentId support to google doc new file calls

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -263,9 +263,16 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
 
 export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
   create_document: {
-    description: "Create a new Google Docs document in the user's Drive.",
+    description:
+      "Create a new Google Docs document. Optionally specify a folder to create it in.",
     schema: {
       title: z.string().describe("The title of the new document."),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the folder to create the file in. If not provided, creates in the user's root Drive. Use the search_files tool with `mimeType = 'application/vnd.google-apps.folder'` to find folder IDs."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -274,9 +281,16 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_spreadsheet: {
-    description: "Create a new Google Sheets spreadsheet in the user's Drive.",
+    description:
+      "Create a new Google Sheets spreadsheet. Optionally specify a folder to create it in.",
     schema: {
       title: z.string().describe("The title of the new spreadsheet."),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the folder to create the file in. If not provided, creates in the user's root Drive. Use the search_files tool with `mimeType = 'application/vnd.google-apps.folder'` to find folder IDs."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -285,9 +299,16 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_presentation: {
-    description: "Create a new Google Slides presentation in the user's Drive.",
+    description:
+      "Create a new Google Slides presentation. Optionally specify a folder to create it in.",
     schema: {
       title: z.string().describe("The title of the new presentation."),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the folder to create the file in. If not provided, creates in the user's root Drive. Use the search_files tool with `mimeType = 'application/vnd.google-apps.folder'` to find folder IDs."
+        ),
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -642,49 +642,29 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 const readOnlyTools = buildTools(GOOGLE_DRIVE_TOOLS_METADATA, handlers);
 
 const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
-  create_document: async ({ title }, { authInfo }) => {
-    const docs = await getDocsClient(authInfo);
-    if (!docs) {
-      return new Err(new MCPError("Failed to authenticate with Google Docs"));
+  create_document: async ({ title, parentId }, { authInfo }) => {
+    const drive = await getDriveClient(authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
     try {
-      const res = await docs.documents.create({ requestBody: { title } });
-      return new Ok([
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              documentId: res.data.documentId,
-              title: res.data.title,
-              url: `https://docs.google.com/document/d/${res.data.documentId}/edit`,
-            },
-            null,
-            2
-          ),
+      const res = await drive.files.create({
+        requestBody: {
+          name: title,
+          mimeType: "application/vnd.google-apps.document",
+          ...(parentId ? { parents: [parentId] } : {}),
         },
-      ]);
-    } catch (err) {
-      return handleDriveAccessError(err);
-    }
-  },
-
-  create_spreadsheet: async ({ title }, { authInfo }) => {
-    const sheets = await getSheetsClient(authInfo);
-    if (!sheets) {
-      return new Err(new MCPError("Failed to authenticate with Google Sheets"));
-    }
-    try {
-      const res = await sheets.spreadsheets.create({
-        requestBody: { properties: { title } },
+        fields: "id, name, webViewLink",
+        supportsAllDrives: true,
       });
       return new Ok([
         {
           type: "text" as const,
           text: JSON.stringify(
             {
-              spreadsheetId: res.data.spreadsheetId,
-              title: res.data.properties?.title,
-              url: res.data.spreadsheetUrl,
+              documentId: res.data.id,
+              title: res.data.name,
+              url: res.data.webViewLink,
             },
             null,
             2
@@ -696,21 +676,63 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
   },
 
-  create_presentation: async ({ title }, { authInfo }) => {
-    const slides = await getSlidesClient(authInfo);
-    if (!slides) {
-      return new Err(new MCPError("Failed to authenticate with Google Slides"));
+  create_spreadsheet: async ({ title, parentId }, { authInfo }) => {
+    const drive = await getDriveClient(authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
     try {
-      const res = await slides.presentations.create({ requestBody: { title } });
+      const res = await drive.files.create({
+        requestBody: {
+          name: title,
+          mimeType: "application/vnd.google-apps.spreadsheet",
+          ...(parentId ? { parents: [parentId] } : {}),
+        },
+        fields: "id, name, webViewLink",
+        supportsAllDrives: true,
+      });
       return new Ok([
         {
           type: "text" as const,
           text: JSON.stringify(
             {
-              presentationId: res.data.presentationId,
-              title: res.data.title,
-              url: `https://docs.google.com/presentation/d/${res.data.presentationId}/edit`,
+              spreadsheetId: res.data.id,
+              title: res.data.name,
+              url: res.data.webViewLink,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      return handleDriveAccessError(err);
+    }
+  },
+
+  create_presentation: async ({ title, parentId }, { authInfo }) => {
+    const drive = await getDriveClient(authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+    try {
+      const res = await drive.files.create({
+        requestBody: {
+          name: title,
+          mimeType: "application/vnd.google-apps.presentation",
+          ...(parentId ? { parents: [parentId] } : {}),
+        },
+        fields: "id, name, webViewLink",
+        supportsAllDrives: true,
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              presentationId: res.data.id,
+              title: res.data.name,
+              url: res.data.webViewLink,
             },
             null,
             2


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/7029
## Description
We've gotten a few customer requests to support a `parentId` field field in google drive so they can specify a specific folder. We have the ability to access this info on search but the api calls we were making for creation are specific to docs/sheets/slides and only accept a `title` but there is an equivalent `drive.files.create` api call we can use with a mimetype that supports this param.
Decided not to consolidate these into one tool to make this more backwards compatible
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
