### PR TITLE
[front] fix: fix request body parsing in `text_as_cron_rule` and `webhook_filter_generator` endpoints

### DIFF
--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -139,6 +139,9 @@ export function useTextAsCronRule({
           `/api/w/${workspace.sId}/assistant/agent_configurations/text_as_cron_rule`,
           {
             method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
             body: JSON.stringify({
               naturalDescription,
               defaultTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -180,6 +183,9 @@ export function useWebhookFilterGenerator({
         `/api/w/${workspace.sId}/assistant/agent_configurations/webhook_filter_generator`,
         {
           method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
           body: JSON.stringify({
             naturalDescription,
             event,

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -142,7 +142,7 @@ export function useTextAsCronRule({
             body: JSON.stringify({
               naturalDescription,
               defaultTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            } as PostTextAsCronRuleRequestBody),
+            } satisfies PostTextAsCronRuleRequestBody),
             signal,
           }
         );
@@ -422,7 +422,7 @@ export function useTriggerEstimation({
   );
 
   return {
-    estimation: (data as GetTriggerEstimationResponseBody | undefined) ?? null,
+    estimation: data ?? null,
     isEstimationLoading: !!webhookSourceId && !error && !data,
     isEstimationError: error,
     isEstimationValidating: isValidating,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -9,6 +9,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -33,9 +34,26 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST": {
-      const bodyValidation = PostTextAsCronRuleRequestBodySchema.safeParse(
-        JSON.parse(req.body)
-      );
+      let { body } = req;
+
+      // String check for retro-compatibility w.r.t. old clients.
+      // TODO(2026-03-18 aubin): remove this once we do not get calls from clients that predate the front-end change.
+      if (isString(body)) {
+        try {
+          body = JSON.parse(req.body);
+        } catch {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Invalid request body, expected JSON.",
+            },
+          });
+        }
+      }
+
+      const bodyValidation =
+        PostTextAsCronRuleRequestBodySchema.safeParse(body);
 
       if (!bodyValidation.success) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -40,7 +40,7 @@ async function handler(
       // TODO(2026-03-18 aubin): remove this once we do not get calls from clients that predate the front-end change.
       if (isString(body)) {
         try {
-          body = JSON.parse(req.body);
+          body = JSON.parse(body);
         } catch {
           return apiError(req, res, {
             status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -4,6 +4,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import {
   WEBHOOK_PRESETS,
   WEBHOOK_PROVIDERS,
@@ -34,10 +35,26 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST": {
+      let { body } = req;
+
+      // String check for retro-compatibility w.r.t. old clients.
+      // TODO(2026-03-18 aubin): remove this once we do not get calls from clients that predate the front-end change.
+      if (isString(body)) {
+        try {
+          body = JSON.parse(req.body);
+        } catch {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Invalid request body, expected JSON.",
+            },
+          });
+        }
+      }
+
       const bodyValidation =
-        PostWebhookFilterGeneratorRequestBodySchema.safeParse(
-          JSON.parse(req.body)
-        );
+        PostWebhookFilterGeneratorRequestBodySchema.safeParse(body);
 
       if (!bodyValidation.success) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -41,7 +41,7 @@ async function handler(
       // TODO(2026-03-18 aubin): remove this once we do not get calls from clients that predate the front-end change.
       if (isString(body)) {
         try {
-          body = JSON.parse(req.body);
+          body = JSON.parse(body);
         } catch {
           return apiError(req, res, {
             status_code: 400,


### PR DESCRIPTION
## Description

- Some context in the [incident thread](https://dust4ai.slack.com/archives/C0AN923DYCQ/p1773854224817509) and in [logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ0CqhryR0BC6gAAABhBWjBDcWl4MEFBQ01jR3JVRGRhVWxBQXgAAAAkMDE5ZDAyYmUtMjNhNi00YmRkLWE5MDktNTZhNTkyYzZlZTFmAABaaw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1773865932000&to_ts=1773866532000&live=false).
- This PR updates the body parsing of the requests made to the `text_as_cron_rule` and `webhook_filter_generator` endpoints to pass the `"Content-Type": "application/json"` header and have next parse the body by default.
- Keeps a try-caught `JSON.parse` for retrocompability.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
