### PR TITLE
[front] feat: add support for file attachments from skills in zip files

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -69,7 +69,6 @@ export async function importSkillsFromFiles(
     }
     const reader = readerResult.value;
 
-  
     for (const skill of detectResult.value) {
       allSkills.push(skill);
       readerBySkill.set(skill, reader);

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -64,6 +64,7 @@ export async function importSkillsFromFiles(
 
     const readerResult = createZipAttachmentReader(buffer);
     if (readerResult.isErr()) {
+      await cleanupTempFiles(uploadedFiles);
       return new Err(readerResult.error);
     }
     const reader = readerResult.value;

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -1,6 +1,12 @@
-import { detectSkillsFromUploadedFiles } from "@app/lib/api/skills/detection/files/detect_skills";
+import { uploadBase64DataToFileStorage } from "@app/lib/api/files/upload";
+import {
+  createZipAttachmentReader,
+  detectSkillsFromZip,
+} from "@app/lib/api/skills/detection/zip/detect_skills";
+import type { ZipDetectedSkill } from "@app/lib/api/skills/detection/zip/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -8,6 +14,8 @@ import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type formidable from "formidable";
+import { readFile, unlink } from "fs/promises";
+import path from "path";
 
 const IMPORT_CONCURRENCY = 4;
 
@@ -21,7 +29,7 @@ type ImportSkillsResult = {
 
 /**
  * Imports skills from uploaded files. Detects skills from the files,
- * then creates or updates SkillResource objects.
+ * uploads their attachments, then creates or updates SkillResource objects.
  */
 export async function importSkillsFromFiles(
   auth: Authenticator,
@@ -35,22 +43,40 @@ export async function importSkillsFromFiles(
     source?: FileImportSource;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
-  const detectResult = await detectSkillsFromUploadedFiles(uploadedFiles);
-  if (detectResult.isErr()) {
-    return detectResult;
-  }
+  const allSkills: ZipDetectedSkill[] = [];
 
-  const detectedSkills = detectResult.value;
-  if (detectedSkills.length === 0) {
-    return new Err(
-      new Error(
-        "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification)."
-      )
-    );
+  // Readers are keyed by skill to avoid re-opening the same zip for each
+  // attachment. Each zip buffer produces one reader shared across its skills.
+  const readerBySkill = new Map<
+    ZipDetectedSkill,
+    (originalEntryName: string) => Result<Buffer, Error>
+  >();
+
+  for (const file of uploadedFiles) {
+    const buffer = await readFile(file.filepath);
+    await unlink(file.filepath).catch(() => {});
+
+    const detectResult = detectSkillsFromZip({ zipBuffer: buffer });
+    if (detectResult.isErr()) {
+      await cleanupTempFiles(uploadedFiles);
+      return new Err(new Error(detectResult.error.message));
+    }
+
+    const readerResult = createZipAttachmentReader(buffer);
+    if (readerResult.isErr()) {
+      return new Err(readerResult.error);
+    }
+    const reader = readerResult.value;
+
+  
+    for (const skill of detectResult.value) {
+      allSkills.push(skill);
+      readerBySkill.set(skill, reader);
+    }
   }
 
   const requestedNames = names ? new Set(names) : null;
-  const selectedSkills = detectedSkills.filter(
+  const selectedSkills = allSkills.filter(
     (skill) =>
       skill.name &&
       skill.instructions.trim() &&
@@ -78,6 +104,32 @@ export async function importSkillsFromFiles(
         return;
       }
 
+      const readEntry = readerBySkill.get(skill);
+      if (!readEntry) {
+        errored.push({
+          name: skill.name,
+          message: "Internal error: no zip reader for skill.",
+        });
+        return;
+      }
+
+      const skillDirPath = path.dirname(skill.skillMdPath);
+      const uploadResults = await concurrentExecutor(
+        skill.attachments,
+        (attachment) =>
+          uploadAttachment(auth, {
+            originalEntryName: attachment.originalEntryName,
+            contentType: attachment.contentType,
+            fileName: path.relative(skillDirPath, attachment.path),
+            readEntry,
+          }),
+        { concurrency: IMPORT_CONCURRENCY }
+      );
+
+      const fileAttachments = uploadResults.filter(
+        (r): r is FileResource => r !== null
+      );
+
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
 
@@ -90,8 +142,13 @@ export async function importSkillsFromFiles(
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
+          fileAttachments,
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
+        });
+
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: existing.sId,
         });
 
         updated.push(existing);
@@ -127,8 +184,12 @@ export async function importSkillsFromFiles(
             sourceMetadata: { filePath: skill.skillMdPath },
             isDefault: false,
           },
-          { mcpServerViews: [] }
+          { mcpServerViews: [], fileAttachments }
         );
+
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: skillResource.sId,
+        });
 
         imported.push(skillResource);
       }
@@ -137,4 +198,50 @@ export async function importSkillsFromFiles(
   );
 
   return new Ok({ imported, updated, errored });
+}
+
+async function uploadAttachment(
+  auth: Authenticator,
+  {
+    originalEntryName,
+    contentType,
+    fileName,
+    readEntry,
+  }: {
+    originalEntryName: string;
+    contentType: ZipDetectedSkill["attachments"][number]["contentType"];
+    fileName: string;
+    readEntry: (originalEntryName: string) => Result<Buffer, Error>;
+  }
+): Promise<FileResource | null> {
+  const contentResult = readEntry(originalEntryName);
+  if (contentResult.isErr()) {
+    logger.error(
+      { error: contentResult.error, originalEntryName },
+      "Failed to read attachment from ZIP."
+    );
+    return null;
+  }
+
+  const uploadResult = await uploadBase64DataToFileStorage(auth, {
+    base64: contentResult.value.toString("base64"),
+    contentType,
+    fileName,
+    useCase: "skill_attachment",
+  });
+  if (uploadResult.isErr()) {
+    logger.error(
+      { error: uploadResult.error, originalEntryName },
+      "Failed to upload attachment to file storage."
+    );
+    return null;
+  }
+
+  return uploadResult.value;
+}
+
+async function cleanupTempFiles(files: formidable.File[]): Promise<void> {
+  await concurrentExecutor(files, (f) => unlink(f.filepath).catch(() => {}), {
+    concurrency: 8,
+  });
 }

--- a/front/lib/api/skills/detection/zip/detect_skills.ts
+++ b/front/lib/api/skills/detection/zip/detect_skills.ts
@@ -3,9 +3,12 @@ import {
   findSkillDirectories,
   parseSkillMarkdown,
 } from "@app/lib/api/skills/detection/parsing";
-import type { DetectedSkill } from "@app/lib/api/skills/detection/types";
 import { stripCommonZipPrefix } from "@app/lib/api/skills/detection/zip/parsing";
-import type { ZipEntry } from "@app/lib/api/skills/detection/zip/types";
+import type {
+  ZipDetectedSkill,
+  ZipDetectedSkillAttachment,
+  ZipEntry,
+} from "@app/lib/api/skills/detection/zip/types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -60,15 +63,12 @@ function readZipFileContent(
 }
 
 /**
- * Detects Agent Skills (https://agentskills.io/specification) in a ZIP archive
- * by scanning for SKILL.md files. Same logic as the GitHub detection but
- * operating on a ZIP buffer instead of the GitHub API.
+ * Validates zip size limits and extracts entries + the AdmZip instance.
+ * Shared between detection and attachment reading.
  */
-export function detectSkillsFromZip({
-  zipBuffer,
-}: {
-  zipBuffer: Buffer;
-}): Result<DetectedSkill[], Error> {
+function openAndValidateZip(
+  zipBuffer: Buffer
+): Result<{ entries: ZipEntry[]; zip: AdmZip }, Error> {
   if (zipBuffer.length > MAX_ZIP_SIZE_BYTES) {
     return new Err(
       new Error(
@@ -98,6 +98,26 @@ export function detectSkillsFromZip({
     );
   }
 
+  return new Ok({ entries: rawEntries, zip });
+}
+
+/**
+ * Detects Agent Skills (https://agentskills.io/specification) in a ZIP archive
+ * by scanning for SKILL.md files. Returns ZipDetectedSkill[] where each
+ * attachment carries an `originalEntryName` (the raw zip path before prefix
+ * stripping), analogous to the `sha` in GitHubDetectedSkillAttachment.
+ */
+export function detectSkillsFromZip({
+  zipBuffer,
+}: {
+  zipBuffer: Buffer;
+}): Result<ZipDetectedSkill[], Error> {
+  const openResult = openAndValidateZip(zipBuffer);
+  if (openResult.isErr()) {
+    return openResult;
+  }
+  const { entries: rawEntries, zip } = openResult.value;
+
   const entries = stripCommonZipPrefix(rawEntries);
   // Map stripped path -> entry (preserves originalEntryName) for adm-zip lookup.
   const entryByPath = new Map<string, ZipEntry>();
@@ -114,7 +134,7 @@ export function detectSkillsFromZip({
     return new Ok([]);
   }
 
-  const allSkills: DetectedSkill[] = [];
+  const allSkills: ZipDetectedSkill[] = [];
 
   for (const skillDir of skillDirs) {
     const skillMdEntry = entryByPath.get(skillDir.skillMdPath);
@@ -135,14 +155,48 @@ export function detectSkillsFromZip({
     }
 
     const parsed = parseSkillMarkdown(contentResult.value);
+
+    // Enrich each attachment with originalEntryName so the import flow can
+    // extract content without re-parsing the zip structure.
+    const baseAttachments = collectAttachments(fileEntries, skillDir);
+    const attachments: ZipDetectedSkillAttachment[] = baseAttachments.map(
+      (a) => ({
+        ...a,
+        originalEntryName: entryByPath.get(a.path)?.originalEntryName ?? a.path,
+      })
+    );
+
     allSkills.push({
       name: parsed.name,
       skillMdPath: skillDir.skillMdPath,
       description: parsed.description,
       instructions: parsed.instructions,
-      attachments: collectAttachments(fileEntries, skillDir),
+      attachments,
     });
   }
 
   return new Ok(allSkills.filter((s) => s.name.length > 0));
+}
+
+/**
+ * Returns a reader function that reads a zip entry's raw bytes by
+ * originalEntryName. Open this once per buffer; pass it to the import flow
+ * to extract attachment content without re-parsing the zip structure.
+ */
+export function createZipAttachmentReader(
+  zipBuffer: Buffer
+): Result<(originalEntryName: string) => Result<Buffer, Error>, Error> {
+  const openResult = openAndValidateZip(zipBuffer);
+  if (openResult.isErr()) {
+    return openResult;
+  }
+  const { zip } = openResult.value;
+
+  return new Ok((originalEntryName: string): Result<Buffer, Error> => {
+    const entry = zip.getEntry(originalEntryName);
+    if (!entry) {
+      return new Err(new Error(`ZIP entry not found: "${originalEntryName}"`));
+    }
+    return new Ok(entry.getData());
+  });
 }

--- a/front/lib/api/skills/detection/zip/types.ts
+++ b/front/lib/api/skills/detection/zip/types.ts
@@ -1,6 +1,23 @@
+import type {
+  DetectedSkill,
+  DetectedSkillAttachment,
+} from "@app/lib/api/skills/detection/types";
+
 export type ZipEntry = {
   path: string;
   originalEntryName: string;
   sizeBytes: number;
   isDirectory: boolean;
+};
+
+/**
+ * Zip-specific attachment: extends the base with `originalEntryName`, the
+ * raw zip path (before prefix stripping) needed to extract the file content.
+ */
+export type ZipDetectedSkillAttachment = DetectedSkillAttachment & {
+  originalEntryName: string;
+};
+
+export type ZipDetectedSkill = DetectedSkill & {
+  attachments: ZipDetectedSkillAttachment[];
 };


### PR DESCRIPTION
## Description

- When importing skills from a ZIP file, any file attachments bundled inside the skill (images, etc.) are now extracted and uploaded as a file attachments of the skill.
- The detection flow scans the zip and records a lightweight descriptor per attachment (`originalEntryName`, which is the raw path inside the ZIP). The import flow then re-opens the ZIP, uses those descriptors to extract attachment content and uploads each one via the file api + attaches them to the skill.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
