### PR TITLE
[front] chore: improve error message for Ashby report generation errors

### DIFF
--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -141,7 +141,8 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     if (!success || !results) {
       const fallbackReason =
-        "unknown error, the ID extracted from the URL may not map to an existing report";
+        "unknown error, the ID extracted from the URL may not map to an existing report. " +
+        "Dashboards and saved views are not supported.";
       return new Err(
         new MCPError(
           `Report retrieval failed: ${response.results?.failureReason ?? fallbackReason} ` +

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -140,9 +140,12 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const { success, results } = response;
 
     if (!success || !results) {
+      const fallbackReason =
+        "unknown error, the ID extracted from the URL may not map to an existing report";
       return new Err(
         new MCPError(
-          `Report retrieval failed: ${response.results?.failureReason ?? "Unknown error"}`
+          `Report retrieval failed: ${response.results?.failureReason ?? fallbackReason} ` +
+            `(status: ${response.results?.status ?? "unknown"})`
         )
       );
     }


### PR DESCRIPTION
## Description

- The Ashby API sends opaque responses when the input is invalid or does map to anything that exists.
- If the ID provided does not map to anything existing, the API returns a 200 with an empty results object in the response.
- This PR adds a more adequate error message on the report generation endpoint.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
