### PR TITLE
Don't add client side mcp for initial sidekick message

### DIFF
--- a/front/components/agent_builder/SidekickPanelContext.tsx
+++ b/front/components/agent_builder/SidekickPanelContext.tsx
@@ -126,7 +126,9 @@ export const SidekickPanelProvider = ({
         mentions: [{ configurationId: GLOBAL_AGENTS_SID.SIDEKICK }],
         contentFragments: { uploaded: [], contentNodes: [] },
         origin: "agent_sidekick",
-        clientSideMCPServerIds,
+        // Don't pass clientSideMCPServerIds on the initial greeting - it doesn't use MCP tools,
+        // and doing so races with SSE setup.
+        clientSideMCPServerIds: [],
       },
       // TODO(sidekick 2026-01-23): same visibility as the 'Preview' tab conversation.
       // We should rename it.

--- a/front/components/agent_builder/SidekickPanelContext.tsx
+++ b/front/components/agent_builder/SidekickPanelContext.tsx
@@ -98,12 +98,6 @@ export const SidekickPanelProvider = ({
       return;
     }
 
-    // Wait for the client-side MCP server to be registered before starting
-    // the conversation. Without this, the sidekick won't have access to
-    // agent_builder_sidekick_client tools like get_agent_config.
-    if (clientSideMCPServerIds.length === 0) {
-      return;
-    }
     hasStartedRef.current = true;
 
     setIsCreatingConversation(true);
@@ -126,7 +120,7 @@ export const SidekickPanelProvider = ({
         mentions: [{ configurationId: GLOBAL_AGENTS_SID.SIDEKICK }],
         contentFragments: { uploaded: [], contentNodes: [] },
         origin: "agent_sidekick",
-        // Don't pass clientSideMCPServerIds on the initial greeting - it doesn't use MCP tools,
+        // Sidekick does not need the client-side MCP server on the first message it doesn't use MCP tools
         // and doing so races with SSE setup.
         clientSideMCPServerIds: [],
       },
@@ -156,7 +150,6 @@ export const SidekickPanelProvider = ({
 
     setIsCreatingConversation(false);
   }, [
-    clientSideMCPServerIds,
     createConversationWithMessage,
     getFirstMessage,
     useCase,


### PR DESCRIPTION
## Description

Hypothesis: The initial Sidekick greeting message is sent the moment serverId is available from registration, but before the SSE connection to /mcp/requests is fully established and subscribed to the Redis channel. The agent loop picks up the message within a second and publishes initialize, but the SSE handler isn't ready to forward it to the browser, so it times out after 5 seconds. This happens on every single agent builder page load, which is why the volume is so high, but users never notice because the greeting doesn't need MCP tools.

This is ok because we instruct sidekick to never call this on first message anyway.

## Tests

* validated nothing broke locally

## Risk

* Low

## Deploy Plan

* deploy front