### PR TITLE
Upgrade Notion MCP to latest API

### DIFF
--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -20,10 +20,10 @@ import {
 } from "@app/types/shared/utils/time_frame";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { Client, isFullDatabase, isFullPage } from "@notionhq/client";
+import { Client, isFullDataSource, isFullPage } from "@notionhq/client";
 import type {
   CreateCommentParameters,
-  QueryDatabaseParameters,
+  QueryDataSourceParameters,
   RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 import { APIResponseError } from "@notionhq/client/build/src/errors";
@@ -88,7 +88,7 @@ export function createNotionTools(
         query,
         filter: {
           property: "object",
-          value: type,
+          value: type === "database" ? "data_source" : type,
         },
         page_size: NOTION_SEARCH_ACTION_NUM_RESULTS,
       });
@@ -102,7 +102,7 @@ export function createNotionTools(
         const timestampInMs = timeFrameFromNow(timeFrame);
         const date = new Date(timestampInMs);
         results = rawResults.results.filter((result) => {
-          if (isFullPage(result) || isFullDatabase(result)) {
+          if (isFullPage(result) || isFullDataSource(result)) {
             const lastEditedTime = parseISO(result.last_edited_time);
             return lastEditedTime > date;
           }
@@ -167,7 +167,7 @@ export function createNotionTools(
                 provider: "notion",
               },
             } satisfies SearchResultResourceType;
-          } else if (isFullDatabase(result)) {
+          } else if (isFullDataSource(result)) {
             const title = result.title[0]?.plain_text ?? "Untitled Database";
             const description = result.description
               ?.map((d) => d?.plain_text)
@@ -219,7 +219,7 @@ export function createNotionTools(
 
     retrieve_database_schema: async ({ databaseId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.databases.retrieve({ database_id: databaseId }),
+        (notion) => notion.dataSources.retrieve({ data_source_id: databaseId }),
         authInfo
       );
     },
@@ -230,9 +230,9 @@ export function createNotionTools(
     ) => {
       return withNotionClient(
         (notion) =>
-          notion.databases.query({
-            database_id: databaseId,
-            filter: filter as QueryDatabaseParameters["filter"],
+          notion.dataSources.query({
+            data_source_id: databaseId,
+            filter: filter as QueryDataSourceParameters["filter"],
             sorts,
             start_cursor,
             page_size,
@@ -247,9 +247,9 @@ export function createNotionTools(
     ) => {
       return withNotionClient(
         (notion) =>
-          notion.databases.query({
-            database_id: databaseId,
-            filter: filter as QueryDatabaseParameters["filter"],
+          notion.dataSources.query({
+            data_source_id: databaseId,
+            filter: filter as QueryDataSourceParameters["filter"],
             sorts,
             start_cursor,
             page_size,
@@ -287,7 +287,13 @@ export function createNotionTools(
     ) => {
       return withNotionClient(
         (notion) =>
-          notion.databases.create({ parent, title, properties, icon, cover }),
+          notion.databases.create({
+            parent,
+            title,
+            initial_data_source: { properties },
+            icon,
+            cover,
+          }),
         authInfo
       );
     },
@@ -393,7 +399,10 @@ export function createNotionTools(
     ) => {
       return withNotionClient(
         (notion) =>
-          notion.databases.update({ database_id: databaseId, properties }),
+          notion.dataSources.update({
+            data_source_id: databaseId,
+            properties,
+          }),
         authInfo
       );
     },

--- a/front/package.json
+++ b/front/package.json
@@ -59,7 +59,7 @@
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@mistralai/mistralai": "^1.10.0",
     "@modelcontextprotocol/sdk": "^1.27.0",
-    "@notionhq/client": "^2.3.0",
+    "@notionhq/client": "^5.13.0",
     "@novu/api": "^3.13.0",
     "@novu/framework": "^2.9.0",
     "@novu/js": "^3.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,7 +367,7 @@
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@mistralai/mistralai": "^1.10.0",
         "@modelcontextprotocol/sdk": "^1.27.0",
-        "@notionhq/client": "^2.3.0",
+        "@notionhq/client": "^5.13.0",
         "@novu/api": "^3.13.0",
         "@novu/framework": "^2.9.0",
         "@novu/js": "^3.13.0",
@@ -602,6 +602,15 @@
       },
       "engines": {
         "node": ">=22.22.0"
+      }
+    },
+    "front/node_modules/@notionhq/client": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.13.0.tgz",
+      "integrity": "sha512-SWVaqYVNaecLzAAllups4vklxxomaFenEMEkoUs3ylvhK1KFTU5Jevgu9Uwm/TSdhsErV0ru5YHcLd3SNyPi6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "front/node_modules/@slack/web-api": {


### PR DESCRIPTION
## Description

The goal is to support multi-data source DBs. Note that this is only for the MCP. The Connector needs to stay on the old version since it's much harder to upgrade it.

Note that we could probably take this further and give the MCP first class understanding of the separate concepts of databases and data sources, which used to be 1-1. But this is a first step.

## Tests

Manual, tried various scenarios:
- Modify existing multi-source DB
- Create new single DS DB and add data

## Risk

Could potentially regress some scenarios that worked before.

## Deploy Plan

Front.