### PR TITLE
[front] chore: update copy for agent error message

### DIFF
--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -25,8 +25,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
 
   return (
     <ContentMessage
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      title={`${error.metadata?.errorTitle || "Agent error"}`}
+      title={`${error.metadata?.errorTitle ?? "Something went wrong"}`}
       variant={errorIsRetryable ? "golden" : "warning"}
       className="flex flex-col gap-3"
       icon={InformationCircleIcon}

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -294,7 +294,7 @@ export const getUserFacingLLMErrorMessage = (
       return "The request timed out. Please try again.";
     }
     case "server_error": {
-      return `${userFacingProvider} encountered an internal error. Please try again.`;
+      return `The AI provider (${userFacingProvider}) ran into an issue. Please try again in a moment.`;
     }
     case "stream_error": {
       return `Connection interrupted while receiving the response. Please try again.`;


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7179.
- This PR updates the error message shown for agent errors in stead of the `AgentMessage`.
- Updates the title from `"Agent error"` to `"Something went wrong"`
- Updates the content for generic errors from `${userFacingProvider} encountered an internal error. Please try again.` to `The AI provider (${userFacingProvider}) ran into an issue. Please try again in a moment.`.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
