### PR TITLE
[front] enh: Harden sandbox security

### DIFF
--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -19,16 +19,10 @@ RUN GCSFUSE_REPO=$(lsb_release -c -s) \
 RUN apt-get update && apt-get install -y --no-install-recommends gcsfuse \
   && rm -rf /var/lib/apt/lists/*
 
-# Rename ubuntu -> user (keeps uid 1000, E2B expects 'user' account)
-RUN usermod -l user -d /home/user -m ubuntu \
-  && groupmod -n user ubuntu
-
 # Fluent Bit for telemetry
 RUN curl -fsSL https://packages.fluentbit.io/fluentbit.key | gpg --dearmor -o /usr/share/keyrings/fluentbit-keyring.gpg \
   && echo 'deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/noble noble main' > /etc/apt/sources.list.d/fluent-bit.list \
   && apt-get update && apt-get install -y --no-install-recommends fluent-bit \
-  && (getent group systemd-journal || groupadd -r systemd-journal) \
-  && usermod -aG systemd-journal user \
   && rm -rf /var/lib/apt/lists/*
 
 # Python via uv (official Astral approach)
@@ -52,8 +46,6 @@ RUN ARCH=$(dpkg --print-architecture) && \
   tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
   rm node.tar.xz SHASUMS256.txt
 
-# Create user home directory and uv cache with proper permissions
-RUN mkdir -p /home/user/.cache/uv && chmod -R 777 /home/user
 
 # Set permissions for venv, npm global, and bin directories
 RUN chmod -R 777 /opt/venv && mkdir -p /opt/npm-global /opt/bin && chmod -R 777 /opt/npm-global /opt/bin
@@ -64,5 +56,3 @@ RUN printf '%s\n' \
   'export VIRTUAL_ENV="/opt/venv"' \
   'export NPM_CONFIG_PREFIX="/opt/npm-global"' \
   > /etc/profile.d/dust-env.sh
-
-WORKDIR /home/user

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -21,12 +21,13 @@ import {
 } from "@app/lib/api/sandbox/image";
 import { wrapCommand } from "@app/lib/api/sandbox/image/profile";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
+import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 
-const DEFAULT_WORKING_DIRECTORY = "/home/user";
+const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
 const MAX_OUTPUT_LINES = 2_000;
 const MAX_OUTPUT_BYTES = 50_000;
@@ -110,6 +111,10 @@ export function createSandboxTools(
       const imageResult = getSandboxImage(auth);
       if (imageResult.isOk()) {
         const image = imageResult.value;
+
+        void startTelemetry(auth, sandbox, conversation).catch((err) =>
+          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
+        );
 
         if (freshlyCreated || wokeFromSleep) {
           void mountConversationFiles(auth, sandbox, conversation, image).catch(

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -87,7 +87,7 @@ export async function mountConversationFiles(
   // Start in background, then verify with a separate exec (matching PoC).
   const startResult = await sandbox.exec(
     auth,
-    "bash /home/user/.bin/token-server.sh > /tmp/server.log 2>&1 &"
+    "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
   );
   if (startResult.isErr()) {
     childLogger.error(
@@ -107,10 +107,11 @@ export async function mountConversationFiles(
     return new Err(new Error(msg));
   }
 
-  // 4. Mount via gcsfuse.
+  // 4. Mount via gcsfuse (runs as root for FUSE permissions).
   const mountCmd = buildMountCommand({ bucket, prefix });
   const mountResult = await sandbox.exec(auth, mountCmd, {
     timeoutMs: MOUNT_TIMEOUT_MS,
+    user: "root",
   });
   if (mountResult.isErr()) {
     childLogger.error(
@@ -206,7 +207,7 @@ function buildMountCommand({
     `--enable-hns=false`,
   ].join(" ");
 
-  return `timeout 30 sudo gcsfuse ${flags} ${bucket} ${MOUNT_POINT} 2>&1`;
+  return `timeout 30 gcsfuse ${flags} ${bucket} ${MOUNT_POINT} 2>&1`;
 }
 
 function escapeSingleQuotes(s: string): string {

--- a/front/lib/api/sandbox/image/profile/list_dir.sh
+++ b/front/lib/api/sandbox/image/profile/list_dir.sh
@@ -17,7 +17,7 @@ Output: File and directory paths, one per line. Limited to 200 entries.
 
 Examples:
   list_dir                    # List current dir, depth 2
-  list_dir /home/user         # List specific directory
+  list_dir /home/agent        # List specific directory
   list_dir . 1                # List current dir, no recursion
   list_dir src/ 3             # List src/ with depth 3
 EOF

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -79,59 +79,63 @@ function getLocalContent(dir: string, filename: string): () => string {
   return () => fs.readFileSync(path.join(dir, filename), "utf-8");
 }
 
-const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.2.0")
+const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.3.0")
+  // Create agent user first so e2b creates /home/agent with correct ownership.
+  .setUser("agent")
   // Conversation files bootstrap
   // Pre-create workspace directory for faster GCS mounts.
-  .runCmd(
-    "sudo mkdir -p /files/conversation && sudo chmod 777 /files/conversation"
-  )
+  .runCmd("mkdir -p /files/conversation && chmod 777 /files/conversation", {
+    user: "root",
+  })
   // Create simple netcat-based token server script.
-  .runCmd("sudo mkdir -p /home/user/.bin")
+  .runCmd("mkdir -p /home/agent/.bin", { user: "root" })
   // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.
-  .runCmd(`sudo tee /home/user/.bin/token-server.sh > /dev/null << 'SHELLEOF'
+  .runCmd(
+    `tee /home/agent/.bin/token-server.sh > /dev/null << 'SHELLEOF'
 #!/bin/bash
 while true; do
   (echo -ne "HTTP/1.1 200 OK\\r\\nContent-Type: application/json\\r\\nContent-Length: $(stat -c %s /tmp/token.json 2>/dev/null || echo 0)\\r\\n\\r\\n"; cat /tmp/token.json 2>/dev/null) | nc -l -p 9876 -q 1
 done
-SHELLEOF`)
-  .runCmd("sudo chmod 755 /home/user/.bin/token-server.sh")
-  // Add sentinel file to indicate when mounts are pending.
-  .runCmd("sudo touch /files/conversation/.mount-pending")
-  // Hidden tools: installed but not in manifest (back profile functions)
-  .runCmd("sudo apt-get update && sudo apt-get install -y ripgrep fd-find sd")
-  // Create profile directory and copy profile scripts
-  .registerTool(
-    [
-      { name: "git", description: "Version control system", runtime: "system" },
-      { name: "curl", description: "HTTP client", runtime: "system" },
-      { name: "wget", description: "Network downloader", runtime: "system" },
-      { name: "jq", description: "JSON processor", runtime: "system" },
-      { name: "sqlite3", description: "SQLite database", runtime: "system" },
-      { name: "pandoc", description: "Document converter", runtime: "system" },
-      {
-        name: "imagemagick",
-        description: "Image manipulation",
-        runtime: "system",
-      },
-      { name: "ffmpeg", description: "Media processing", runtime: "system" },
-      { name: "unzip", description: "Archive extraction", runtime: "system" },
-      {
-        name: "lsb-release",
-        description: "Linux distribution info",
-        runtime: "system",
-      },
-      {
-        name: "file",
-        description: "Determine file type",
-        runtime: "system",
-      },
-    ],
-    {
-      // the other tools are installed in bedrock
-      installCmd:
-        "sudo apt-get install -y jq pandoc imagemagick ffmpeg unzip file",
-    }
+SHELLEOF`,
+    { user: "root" }
   )
+  .runCmd("chmod 755 /home/agent/.bin/token-server.sh", { user: "root" })
+  // Add sentinel file to indicate when mounts are pending.
+  .runCmd("touch /files/conversation/.mount-pending", { user: "root" })
+  // Hidden tools: installed but not in manifest (back profile functions)
+  .runCmd("apt-get update && apt-get install -y ripgrep fd-find sd", {
+    user: "root",
+  })
+  // Create profile directory and copy profile scripts
+  // The other tools are installed in bedrock
+  .runCmd("apt-get install -y jq pandoc imagemagick ffmpeg unzip file", {
+    user: "root",
+  })
+  .registerTool([
+    { name: "git", description: "Version control system", runtime: "system" },
+    { name: "curl", description: "HTTP client", runtime: "system" },
+    { name: "wget", description: "Network downloader", runtime: "system" },
+    { name: "jq", description: "JSON processor", runtime: "system" },
+    { name: "sqlite3", description: "SQLite database", runtime: "system" },
+    { name: "pandoc", description: "Document converter", runtime: "system" },
+    {
+      name: "imagemagick",
+      description: "Image manipulation",
+      runtime: "system",
+    },
+    { name: "ffmpeg", description: "Media processing", runtime: "system" },
+    { name: "unzip", description: "Archive extraction", runtime: "system" },
+    {
+      name: "lsb-release",
+      description: "Linux distribution info",
+      runtime: "system",
+    },
+    {
+      name: "file",
+      description: "Determine file type",
+      runtime: "system",
+    },
+  ])
   .registerTool({
     name: "python",
     description: "Python interpreter",
@@ -149,39 +153,35 @@ SHELLEOF`)
     ],
     { installCmd: "npm install -g typescript tsx" }
   )
-  .registerTool(
-    { name: "dsbx", description: "Dust CLI", runtime: "system" },
-    {
-      installCmd:
-        `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64 -o /tmp/dsbx && ` +
-        `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/checksums-sha256.txt -o /tmp/checksums-sha256.txt && ` +
-        "grep dsbx-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/dsbx\"}' | sha256sum -c - && " +
-        "chmod +x /tmp/dsbx && " +
-        "sudo mv /tmp/dsbx /opt/bin/dsbx",
-    }
+  .runCmd(
+    `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64 -o /tmp/dsbx && ` +
+      `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/checksums-sha256.txt -o /tmp/checksums-sha256.txt && ` +
+      "grep dsbx-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/dsbx\"}' | sha256sum -c - && " +
+      "chmod +x /tmp/dsbx && " +
+      "mv /tmp/dsbx /opt/bin/dsbx",
+    { user: "root" }
   )
-  .runCmd("sudo mkdir -p /skills && sudo chmod 755 /skills")
-  .registerTool(
-    {
-      name: "apply_patch",
-      description:
-        "Apply V4A diffs to files. Supports add, update, and delete operations",
-      usage:
-        "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
-      returns: "Summary of applied changes (A/M/D per file)",
-      runtime: "system",
-      profile: "openai",
-    },
-    {
-      installCmd:
-        `curl -fsSL https://github.com/dust-tt/dust/releases/download/apply-patch-v${APPLY_PATCH_VERSION}/apply_patch-linux-x86_64 -o /tmp/apply_patch && ` +
-        `curl -fsSL https://github.com/dust-tt/dust/releases/download/apply-patch-v${APPLY_PATCH_VERSION}/checksums-sha256.txt -o /tmp/checksums-sha256.txt && ` +
-        "grep apply_patch-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/apply_patch\"}' | sha256sum -c - && " +
-        "chmod +x /tmp/apply_patch && " +
-        "sudo mv /tmp/apply_patch /opt/bin/apply_patch",
-    }
+  .registerTool({ name: "dsbx", description: "Dust CLI", runtime: "system" })
+  .runCmd("mkdir -p /skills && chmod 755 /skills", { user: "root" })
+  .runCmd(
+    `curl -fsSL https://github.com/dust-tt/dust/releases/download/apply-patch-v${APPLY_PATCH_VERSION}/apply_patch-linux-x86_64 -o /tmp/apply_patch && ` +
+      `curl -fsSL https://github.com/dust-tt/dust/releases/download/apply-patch-v${APPLY_PATCH_VERSION}/checksums-sha256.txt -o /tmp/checksums-sha256.txt && ` +
+      "grep apply_patch-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/apply_patch\"}' | sha256sum -c - && " +
+      "chmod +x /tmp/apply_patch && " +
+      "mv /tmp/apply_patch /opt/bin/apply_patch",
+    { user: "root" }
   )
-  .runCmd(`sudo mkdir -p ${PROFILE_DIR}`)
+  .registerTool({
+    name: "apply_patch",
+    description:
+      "Apply V4A diffs to files. Supports add, update, and delete operations",
+    usage:
+      "apply_patch '*** Begin Patch\\n*** Update File: <path>\\n@@ [context]\\n-old\\n+new\\n*** End Patch'",
+    returns: "Summary of applied changes (A/M/D per file)",
+    runtime: "system",
+    profile: "openai",
+  })
+  .runCmd(`mkdir -p ${PROFILE_DIR}`, { user: "root" })
   .copy(
     getLocalContent(PROFILE_LOCAL_DIR, "common.sh"),
     `${PROFILE_DIR}/common.sh`
@@ -218,16 +218,26 @@ SHELLEOF`)
   // Telemetry configs for fluent-bit
   .copy(
     getLocalContent(TELEMETRY_LOCAL_DIR, "fluent-bit.conf"),
-    "/etc/fluent-bit/fluent-bit.conf"
+    "/etc/fluent-bit/fluent-bit.conf",
+    { user: "root" }
   )
   .copy(
     getLocalContent(TELEMETRY_LOCAL_DIR, "parsers.conf"),
-    "/etc/fluent-bit/parsers.conf"
+    "/etc/fluent-bit/parsers.conf",
+    { user: "root" }
   )
   .copy(
     getLocalContent(TELEMETRY_LOCAL_DIR, "enrich.lua"),
-    "/etc/fluent-bit/enrich.lua"
+    "/etc/fluent-bit/enrich.lua",
+    { user: "root" }
   )
+  // fluent-bit systemd service (started at runtime with env vars)
+  .copy(
+    getLocalContent(TELEMETRY_LOCAL_DIR, "fluent-bit.service"),
+    "/etc/systemd/system/fluent-bit.service",
+    { user: "root" }
+  )
+  .runCmd("systemctl daemon-reload", { user: "root" })
   // Profile functions (no install needed, provided by profile scripts)
   .registerTool([
     {
@@ -287,11 +297,11 @@ SHELLEOF`)
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(ALLOWLIST_NETWORK_POLICY)
-  .setWorkdir("/home/user")
+  .setWorkdir("/home/agent")
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.6.0",
+    tag: "0.7.0",
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];

--- a/front/lib/api/sandbox/image/sandbox_image.test.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.test.ts
@@ -348,7 +348,7 @@ describe("SandboxImage.withToolManifest()", () => {
     expect(image.operations[0].type).toBe("copy");
     if (image.operations[0].type === "copy") {
       expect(image.operations[0].src.type).toBe("content");
-      expect(image.operations[0].dest).toBe("/home/user/tool-manifest.yaml");
+      expect(image.operations[0].dest).toBe("/tool-manifest.yaml");
       if (image.operations[0].src.type === "content") {
         const content = image.operations[0].src.getContent();
         expect(typeof content).toBe("string");
@@ -379,9 +379,7 @@ describe("SandboxImage.withToolManifest()", () => {
     });
 
     if (jsonImage.operations[0].type === "copy") {
-      expect(jsonImage.operations[0].dest).toBe(
-        "/home/user/tool-manifest.json"
-      );
+      expect(jsonImage.operations[0].dest).toBe("/tool-manifest.json");
     }
   });
 

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -86,16 +86,28 @@ export class SandboxImage {
       tools: [],
       resources: DEFAULT_RESOURCES,
       network: DEFAULT_NETWORK,
-      workdir: "/home/user",
+      workdir: "", // No default, set via setWorkdir in registry
       runEnv: {},
       capabilities: new Set(),
     });
   }
 
-  runCmd(command: string): SandboxImage {
+  runCmd(command: string, options?: { user?: string }): SandboxImage {
     const operation: Operation = {
       type: "run",
       command,
+      user: options?.user,
+    };
+
+    return this.clone({
+      operations: [...this.operations, operation],
+    });
+  }
+
+  setUser(user: string): SandboxImage {
+    const operation: Operation = {
+      type: "user",
+      user,
     };
 
     return this.clone({
@@ -122,9 +134,17 @@ export class SandboxImage {
     });
   }
 
-  copy(src: string, dest: string): SandboxImage;
-  copy(src: ContentGenerator, dest: string): SandboxImage;
-  copy(src: string | ContentGenerator, dest: string): SandboxImage {
+  copy(src: string, dest: string, options?: { user?: string }): SandboxImage;
+  copy(
+    src: ContentGenerator,
+    dest: string,
+    options?: { user?: string }
+  ): SandboxImage;
+  copy(
+    src: string | ContentGenerator,
+    dest: string,
+    options?: { user?: string }
+  ): SandboxImage {
     const srcValue: CopySource =
       typeof src === "string"
         ? { type: "path", path: src }
@@ -134,6 +154,7 @@ export class SandboxImage {
       type: "copy",
       src: srcValue,
       dest,
+      user: options?.user,
     };
 
     return this.clone({

--- a/front/lib/api/sandbox/image/telemetry/fluent-bit.service
+++ b/front/lib/api/sandbox/image/telemetry/fluent-bit.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fluent Bit log processor
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -50,9 +50,15 @@ export type CopySource =
   | { readonly type: "content"; readonly getContent: ContentGenerator };
 
 export type Operation =
-  | { readonly type: "run"; readonly command: string }
-  | { readonly type: "copy"; readonly src: CopySource; readonly dest: string }
+  | { readonly type: "run"; readonly command: string; readonly user?: string }
+  | {
+      readonly type: "copy";
+      readonly src: CopySource;
+      readonly dest: string;
+      readonly user?: string;
+    }
   | { readonly type: "workdir"; readonly path: string }
+  | { readonly type: "user"; readonly user: string }
   | {
       readonly type: "env";
       readonly vars: Readonly<Record<string, string>>;

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -58,6 +58,8 @@ export interface ExecOptions {
   timeoutMs?: number;
   /** Additional environment variables for this execution only. */
   envVars?: Record<string, string>;
+  /** User to run the command as (e.g., "root" for privileged tasks). */
+  user?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -201,6 +201,7 @@ export class E2BSandboxProvider implements SandboxProvider {
         cwd: opts?.workingDirectory,
         envs: opts?.envVars,
         timeoutMs: opts?.timeoutMs,
+        user: opts?.user,
       });
 
       return new Ok({

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -117,12 +117,18 @@ class E2BTemplateBuilder {
   private applyOperation(op: Operation): void {
     switch (op.type) {
       case "run":
-        this.builder = this.builder.runCmd(op.command);
+        if (op.user) {
+          this.builder = this.builder.runCmd(op.command, { user: op.user });
+        } else {
+          this.builder = this.builder.runCmd(op.command);
+        }
         break;
 
       case "copy":
         if (op.src.type === "path") {
-          this.builder = this.builder.copy(op.src.path, op.dest);
+          this.builder = this.builder.copy(op.src.path, op.dest, {
+            user: op.user,
+          });
         } else {
           // E2B copy works with directories, so we create a temp dir containing
           // a file with the destination's filename, then copy to dest's parent.
@@ -131,12 +137,16 @@ class E2BTemplateBuilder {
             op.dest
           );
           const destDir = path.dirname(op.dest);
-          this.builder = this.builder.copy(tempDir, destDir);
+          this.builder = this.builder.copy(tempDir, destDir, { user: op.user });
         }
         break;
 
       case "workdir":
         this.builder = this.builder.setWorkdir(op.path);
+        break;
+
+      case "user":
+        this.builder = this.builder.setUser(op.user);
         break;
 
       case "env":

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -1,0 +1,53 @@
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+/**
+ * Start fluent-bit telemetry in a sandbox.
+ *
+ * Sets up systemd environment variables and starts the fluent-bit service.
+ * Designed to be called fire-and-forget after sandbox creation or wake.
+ *
+ * Environment variables are passed via envVars to avoid exposing sensitive
+ * values (like DD_API_KEY) in journalctl command logs.
+ */
+export async function startTelemetry(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  conversation: ConversationType
+): Promise<Result<void, Error>> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+
+  const childLogger = logger.child({
+    sandboxId: sandbox.sId,
+    workspaceId,
+    conversationId: conversation.sId,
+  });
+
+  const result = await sandbox.exec(
+    auth,
+    `systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && systemctl start fluent-bit`,
+    {
+      user: "root",
+      envVars: {
+        DD_HOST: "http-intake.logs.datadoghq.eu",
+        DD_API_KEY: config.getDatadogApiKey() ?? "",
+        E2B_SANDBOX_ID: sandbox.providerId,
+        CONVERSATION_ID: conversation.sId,
+        WORKSPACE_ID: workspaceId,
+      },
+    }
+  );
+
+  if (result.isErr()) {
+    childLogger.error({ err: result.error }, "Failed to start telemetry");
+    return result;
+  }
+
+  childLogger.info({}, "Telemetry started successfully");
+  return new Ok(undefined);
+}

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,4 +1,3 @@
-import config from "@app/lib/api/config";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import type {
@@ -304,8 +303,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           ...createConfig,
           envVars: {
             ...createConfig.envVars,
-            DD_API_KEY: config.getDatadogApiKey() ?? "",
-            DD_HOST: "http-intake.logs.datadoghq.eu",
             CONVERSATION_ID: conversation.sId,
             WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
           },
@@ -319,17 +316,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           providerId: createResult.value.providerId,
           status: "running",
         });
-
-        const startTelemetry = await provider.exec(
-          createResult.value.providerId,
-          "systemd-cat -t fluent-bit /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf &"
-        );
-        if (startTelemetry.isErr()) {
-          logger.warn(
-            { error: startTelemetry.error.message },
-            "Failed to start fluent-bit telemetry"
-          );
-        }
 
         logger.info(
           { sandbox: sandbox.toLogJSON() },
@@ -380,8 +366,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             ...createConfig,
             envVars: {
               ...createConfig.envVars,
-              DD_API_KEY: config.getDatadogApiKey() ?? "",
-              DD_HOST: "http-intake.logs.datadoghq.eu",
               CONVERSATION_ID: conversation.sId,
               WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
             },
@@ -391,17 +375,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
           await existing.update({ providerId: createResult.value.providerId });
           freshlyCreated = true;
-
-          const startTelemetry = await provider.exec(
-            createResult.value.providerId,
-            "systemd-cat -t fluent-bit /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf &"
-          );
-          if (startTelemetry.isErr()) {
-            logger.warn(
-              { error: startTelemetry.error.message },
-              "Failed to start fluent-bit telemetry"
-            );
-          }
 
           logger.info(
             {

--- a/front/scripts/sandbox_debug.ts
+++ b/front/scripts/sandbox_debug.ts
@@ -1,0 +1,47 @@
+import config from "@app/lib/api/config";
+import { makeScript } from "@app/scripts/helpers";
+import { Sandbox } from "e2b";
+
+makeScript(
+  {
+    sandboxId: {
+      type: "string",
+      alias: "s",
+      description: "The E2B sandbox ID to connect to",
+      required: true,
+    },
+    user: {
+      type: "string",
+      alias: "u",
+      description: "User to run as",
+      default: "root",
+    },
+    command: {
+      type: "string",
+      alias: "c",
+      description: "Command to run",
+      default: "bash",
+    },
+  },
+  async ({ sandboxId, user, command }, logger) => {
+    const e2bConfig = config.getE2BSandboxConfig();
+    const sandbox = await Sandbox.connect(sandboxId, {
+      apiKey: e2bConfig.apiKey,
+      domain: e2bConfig.domain,
+    });
+
+    logger.info({ sandboxId, user, command }, "Running command in sandbox");
+
+    const result = await sandbox.commands.run(command, { user });
+    if (result.stdout) {
+      console.log(result.stdout);
+    }
+    if (result.stderr) {
+      console.error(result.stderr);
+    }
+
+    if (result.exitCode !== 0) {
+      throw new Error(`Command exited with code ${result.exitCode}`);
+    }
+  }
+);


### PR DESCRIPTION
## Description

Tl;Dr we're using E2B's layers for user provisioning, use systemd + root for datadog logs collection and gcs fuse mounting.

In details
- Create a new user called "agent" (done in sandbox image part instead of docker img) with /home/agent
- Add a "user" option for `execute` in `SandboxProvider` and `runCmd` + `copy` in `SandboxImage`
- use these new options to start telemetry and mount gcs as root user
- make fluent-bit start as systemd service. It's easier to manage injection of DD_API with `systemctl set-environment`


## Tests

- Tested locally

## Risk

Low


## Deploy Plan

- [ ] Deploy front