### PR TITLE
[front] fix: update design for large skills warning `ContentMessage`

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -64,7 +64,7 @@ export function SkillBuilderInstructionsSection() {
       {(currentInstructions?.length ?? 0) >
         LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD && (
         <ContentMessage
-          variant="warning"
+          variant="info"
           size="lg"
           title="This skill is noticeably large"
         >

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -65,6 +65,7 @@ export function SkillBuilderInstructionsSection() {
         LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD && (
         <ContentMessage
           variant="info"
+          icon={InformationCircleIcon}
           size="lg"
           title="This skill is noticeably large"
         >

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -6,6 +6,7 @@ import {
   BookOpenIcon,
   Button,
   ContentMessage,
+  InformationCircleIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";


### PR DESCRIPTION
## Description

- In Skill Builder we display a warning in the form of a `ContentMessage` when the skill's guideline section is overly large.
- This PR adds an information circle icon and changes the color from red to yellow.
- Now matches the design in [Figma](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=4256-96957&t=YquTRI47kc5dgLTl-0).

## Tests

- Checked locally

## Risk

- Low.

## Deploy Plan

- Deploy front.
