### PR TITLE
Extension: fix Datadog logging and centralize init

### DIFF
--- a/extension/platforms/chrome/main.tsx
+++ b/extension/platforms/chrome/main.tsx
@@ -6,26 +6,25 @@ import "@dust-tt/sparkle/dist/sparkle.css";
 import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
+import { initDatadogLogs } from "@app/logger/datadogLogger";
 import { datadogLogs } from "@datadog/browser-logs";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { ChromeApp } from "./ChromeApp";
 
 if (process.env.DATADOG_CLIENT_TOKEN) {
-  datadogLogs.init({
+  initDatadogLogs({
     clientToken: process.env.DATADOG_CLIENT_TOKEN,
-    site: "datadoghq.eu",
     service: "dust-chrome-extension",
     env: process.env.DATADOG_ENV,
     version: process.env.DUST_EXTENSION_VERSION,
     forwardConsoleLogs: ["error"],
-    forwardErrorsToLogs: true,
-    sessionSampleRate: 100,
+  });
+  datadogLogs.setGlobalContext({
+    extensionVersion: process.env.DUST_EXTENSION_VERSION,
+    commitHash: process.env.COMMIT_HASH,
   });
 }
-
-const logger = datadogLogs.logger;
-logger.info("Dust extension loaded");
 
 const rootElement = document.getElementById("root");
 if (rootElement) {

--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -1,3 +1,4 @@
+import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { datadogLogs } from "@datadog/browser-logs";
@@ -14,8 +15,6 @@ import {
 } from "@extension/shared/services/auth";
 import type { StorageService } from "@extension/shared/services/storage";
 import { jwtDecode } from "jwt-decode";
-
-const log = console.error;
 
 export class ChromeAuthService extends AuthService {
   constructor(storage: StorageService) {
@@ -35,13 +34,11 @@ export class ChromeAuthService extends AuthService {
       }
       const response = await sendRefreshTokenMessage(this, tokens.refreshToken);
       if (!response.success) {
-        datadogLogs.logger.error("Refresh token failed", {
-          response: response.error,
-        });
+        logger.error({ response: response.error }, "Refresh token failed");
         return new Err(new AuthError("not_authenticated", response.error));
       }
       if (!response?.accessToken) {
-        datadogLogs.logger.error("Refresh failed: No access token received");
+        logger.error("Refresh failed: No access token received");
 
         return new Err(
           new AuthError("not_authenticated", "No access token received")
@@ -69,11 +66,11 @@ export class ChromeAuthService extends AuthService {
     try {
       const response = await sendAuthMessage(forcedConnection, organizationId);
       if (!response.success) {
-        log(`Authentication error: ${response.error}`);
+        logger.error({ error: response.error }, "Authentication error");
         throw new Error(response.error);
       }
       if (!response.accessToken) {
-        datadogLogs.logger.error("Login failed: No access token received");
+        logger.error("Login failed: No access token received");
         throw new Error("No access token received.");
       }
       const tokens = await this.saveTokens(response);
@@ -101,11 +98,14 @@ export class ChromeAuthService extends AuthService {
 
       return true;
     } catch (error) {
-      log("Logout failed: Unknown error.", error);
+      logger.error({ err: error }, "Logout failed: Unknown error.");
       return false;
     } finally {
       datadogLogs.clearUser();
-      datadogLogs.setGlobalContext({});
+      datadogLogs.setGlobalContext({
+        extensionVersion: process.env.DUST_EXTENSION_VERSION,
+        commitHash: process.env.COMMIT_HASH,
+      });
       await this.storage.clear();
     }
   }

--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -1,4 +1,5 @@
 import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
+import logger from "@app/logger/logger";
 import type { WorkspaceType } from "@app/types/user";
 import { registerAllTools } from "@extension/platforms/chrome/tools";
 import type { CaptureService } from "@extension/shared/services/capture";
@@ -45,7 +46,7 @@ export class ChromeMcpService extends McpService {
 
       return server;
     } catch (error) {
-      console.error("Error creating MCP server:", error);
+      logger.error({ err: error }, "Error creating MCP server.");
       return null;
     }
   }
@@ -78,7 +79,7 @@ export class ChromeMcpService extends McpService {
       this.server = server;
       this.transport = transport;
     } catch (error) {
-      console.error("Failed to connect MCP server:", error);
+      logger.error({ err: error }, "Failed to connect MCP server.");
       throw error;
     }
   }
@@ -100,7 +101,7 @@ export class ChromeMcpService extends McpService {
       await this.connectServer(server, owner, onServerIdReceived);
       return { server: this.server, serverId: this.serverId };
     } catch (error) {
-      console.error("Error getting or creating MCP server:", error);
+      logger.error({ err: error }, "Error getting or creating MCP server.");
       return { server: null, serverId: undefined };
     }
   }

--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -105,6 +105,10 @@ export const getConfig = async ({
       extensions: [".js", ".json", ".mjs", ".jsx", ".ts", ".tsx"],
       alias: {
         "@extension": path.resolve(__dirname, "../../"),
+        "@app/logger/logger": path.resolve(
+          __dirname,
+          "../../../front/logger/datadogLogger.ts"
+        ),
         "@app/lib/platform": path.resolve(__dirname, "../../shared/platform"),
         "@app": path.resolve(__dirname, "../../../front"),
         redis: false,

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -7,9 +7,26 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
+import { initDatadogLogs } from "@app/logger/datadogLogger";
+import logger from "@app/logger/logger";
+import { datadogLogs } from "@datadog/browser-logs";
 import { FrontApp } from "@extension/platforms/front/FrontApp";
 import React from "react";
 import ReactDOM from "react-dom/client";
+
+if (process.env.DATADOG_CLIENT_TOKEN) {
+  initDatadogLogs({
+    clientToken: process.env.DATADOG_CLIENT_TOKEN,
+    service: "dust-front-extension",
+    env: process.env.DATADOG_ENV,
+    version: process.env.DUST_EXTENSION_VERSION,
+    forwardConsoleLogs: ["error"],
+  });
+  datadogLogs.setGlobalContext({
+    extensionVersion: process.env.DUST_EXTENSION_VERSION,
+    commitHash: process.env.COMMIT_HASH,
+  });
+}
 
 // Render the app.
 const rootElement = document.getElementById("root");
@@ -22,8 +39,8 @@ if (rootElement) {
       </React.StrictMode>
     );
   } catch (error) {
-    console.error("Error rendering Dust app:", error);
+    logger.error({ err: error }, "Error rendering Dust app.");
   }
 } else {
-  console.error("Root element not found");
+  logger.error("Root element not found.");
 }

--- a/extension/platforms/front/services/mcp.ts
+++ b/extension/platforms/front/services/mcp.ts
@@ -1,4 +1,5 @@
 import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
+import logger from "@app/logger/logger";
 import type { WorkspaceType } from "@app/types/user";
 import { registerAllTools } from "@extension/platforms/front/tools";
 import { McpService } from "@extension/shared/services/mcp";
@@ -54,7 +55,7 @@ export class FrontMcpService extends McpService {
 
       return server;
     } catch (error) {
-      console.error("Error creating MCP server:", error);
+      logger.error({ err: error }, "Error creating MCP server.");
       return null;
     }
   }
@@ -95,7 +96,7 @@ export class FrontMcpService extends McpService {
       this.server = server;
       this.transport = transport;
     } catch (error) {
-      console.error("Failed to connect MCP server:", error);
+      logger.error({ err: error }, "Failed to connect MCP server.");
       throw error;
     }
   }
@@ -125,7 +126,7 @@ export class FrontMcpService extends McpService {
 
       return { server: this.server, serverId: this.serverId };
     } catch (error) {
-      console.error("Error getting or creating MCP server:", error);
+      logger.error({ err: error }, "Error getting or creating MCP server.");
       return { server: null, serverId: undefined };
     }
   }

--- a/extension/platforms/front/webpack.config.ts
+++ b/extension/platforms/front/webpack.config.ts
@@ -88,6 +88,10 @@ export const getConfig = ({ env }: { env: Environment }) => {
       extensions: [".tsx", ".ts", ".js"],
       alias: {
         "@extension": path.resolve(__dirname, "../../"),
+        "@app/logger/logger": path.resolve(
+          __dirname,
+          "../../../front/logger/datadogLogger.ts"
+        ),
         "@app/lib/platform": path.resolve(__dirname, "../../shared/platform"),
         "@app": path.resolve(__dirname, "../../../front"),
       },

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,3 +1,4 @@
+import logger from "@app/logger/logger";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { normalizeError } from "@extension/shared/lib/utils";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
@@ -25,7 +26,7 @@ export function useMcpServer() {
         await platform.mcp.disconnect();
         setIsConnected(false);
       } catch (err) {
-        console.error("Error disconnecting MCP server:", err);
+        logger.error({ err }, "Error disconnecting MCP server.");
       }
     }
   }, [platform.mcp]);
@@ -80,7 +81,7 @@ export function useMcpServer() {
         setIsConnected(true);
         setError(null);
       } catch (err) {
-        console.error("Error setting up MCP server:", err);
+        logger.error({ err }, "Error setting up MCP server.");
         if (isMounted) {
           setError(normalizeError(err));
           setIsConnected(false);

--- a/extension/shared/lib/fetcher.ts
+++ b/extension/shared/lib/fetcher.ts
@@ -1,5 +1,6 @@
 import { clientFetch } from "@app/lib/egress/client";
 import type { FetcherFn, FetcherWithBodyFn } from "@app/lib/swr/fetcher";
+import logger from "@app/logger/logger";
 
 export class APIError extends Error {
   type: string;
@@ -35,15 +36,13 @@ export const resHandler = async (res: Response) => {
     }
     errorMessage = error?.message ?? JSON.stringify(error);
   } catch (e) {
-    console.error("Error parsing response: ", e);
+    logger.error({ err: e }, "Error parsing response.");
     errorMessage = await res.text();
   }
 
-  console.error(
-    "Error returned by the front API: ",
-    res.status,
-    res.headers,
-    errorMessage
+  logger.error(
+    { status: res.status, errorMessage },
+    "Error returned by the front API."
   );
   throw new APIError(errorType, errorMessage);
 };

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -1,8 +1,10 @@
 import { setDefaultInitResolver } from "@app/lib/api/config";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
+import logger from "@app/logger/logger";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
+import { datadogLogs } from "@datadog/browser-logs";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import type { StoredTokens } from "@extension/shared/services/auth";
 import {
@@ -12,7 +14,6 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const PROACTIVE_REFRESH_WINDOW_MS = 1000 * 60; // 1 minute
-const log = console.error;
 
 export const useAuthHook = () => {
   const platform = usePlatform();
@@ -136,7 +137,7 @@ export const useAuthHook = () => {
   useEffect(() => {
     const unsub = platform.storage.onChanged((changes) => {
       if ("accessToken" in changes && !changes.accessToken) {
-        log("Access token removed from storage.");
+        logger.info("Access token removed from storage.");
         setTokens(null);
         setUser(null);
       }
@@ -158,6 +159,10 @@ export const useAuthHook = () => {
           const data = await res.json();
           const fetchedUser = data.user as UserTypeWithWorkspaces;
           setUser(fetchedUser);
+          datadogLogs.setUser({
+            id: fetchedUser.sId,
+            email: fetchedUser.email,
+          });
 
           const ws = fetchedUser.selectedWorkspace
             ? fetchedUser.workspaces.find(
@@ -166,6 +171,7 @@ export const useAuthHook = () => {
             : fetchedUser.workspaces[0];
           setWorkspace(ws);
           if (ws) {
+            datadogLogs.setGlobalContextProperty("workspaceSId", ws.sId);
             await platform.storage.set("selectedWorkspace", ws.sId);
           }
         }
@@ -225,7 +231,7 @@ export const useAuthHook = () => {
 
   const redirectToSSOLogin = useCallback(
     async (workspace: WorkspaceType) => {
-      log("Enforcing SSO for", workspace);
+      logger.info({ workspaceSId: workspace.sId }, "Enforcing SSO.");
       setAuthError(
         new AuthError(
           "sso_enforced",

--- a/front-spa/src/app/main.tsx
+++ b/front-spa/src/app/main.tsx
@@ -8,12 +8,12 @@ import "@dust-tt/front/styles/components.css";
 import "@spa/index.css";
 
 import App from "@spa/app/App";
-import { initDatadogLogs, initDatadogRUM } from "@spa/lib/initDatadog";
+import { initDatadogForSpa, initDatadogRUM } from "@spa/lib/initDatadog";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
 // Initialize Datadog before rendering
-initDatadogLogs();
+initDatadogForSpa();
 initDatadogRUM();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/front-spa/src/lib/initDatadog.ts
+++ b/front-spa/src/lib/initDatadog.ts
@@ -1,40 +1,21 @@
-import { datadogLogs } from "@datadog/browser-logs";
-
-// Benign errors filtered from Datadog Logs.
-// See: https://github.com/DataDog/browser-sdk/issues/1616
-const IGNORED_LOG_MESSAGES = [
-  "ResizeObserver loop completed with undelivered notifications",
-  "ResizeObserver loop limit exceeded",
-];
+import { initDatadogLogs } from "@app/logger/datadogLogger";
 
 /**
  * Initialize Datadog Logs so that `datadogLogger` calls from front components
  * are forwarded to Datadog instead of being silently swallowed.
  */
-export function initDatadogLogs() {
+export function initDatadogForSpa() {
   const clientToken = import.meta.env?.VITE_DATADOG_CLIENT_TOKEN;
 
   if (!clientToken) {
     return;
   }
 
-  datadogLogs.init({
+  initDatadogLogs({
     clientToken,
-    site: "datadoghq.eu",
     service: `${import.meta.env?.VITE_DATADOG_SERVICE || "front"}-browser`,
     env: import.meta.env?.MODE === "production" ? "prod" : "dev",
     version: import.meta.env?.VITE_COMMIT_HASH || "",
-    forwardErrorsToLogs: true,
-    sessionSampleRate: 100,
-    beforeSend: (log) => {
-      if (
-        typeof log.message === "string" &&
-        IGNORED_LOG_MESSAGES.some((m) => log.message.includes(m))
-      ) {
-        return false;
-      }
-      return true;
-    },
   });
 }
 

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -1,5 +1,6 @@
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 import { clientEventSource } from "@app/lib/egress/client";
+import logger from "@app/logger/logger";
 import {
   EventSourcePolyfill,
   type Event as PolyfillEvent,
@@ -155,15 +156,12 @@ export function useEventSource(
       };
 
       source.onerror = (event: PolyfillEvent) => {
-        console.error("EventSource error", event);
         source.close();
 
         reconnectAttempts.current++;
 
         if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
-          console.log(
-            "Too many errors, not reconnecting. Please refresh the page."
-          );
+          logger.error("EventSource: too many errors, not reconnecting.");
           setIsError(new Error("Too many errors, closing connection."));
 
           return;
@@ -173,8 +171,9 @@ export function useEventSource(
         const reconnectDelayMs =
           RECONNECT_DELAY_BASE_MS + Math.random() * RECONNECT_DELAY_JITTER_MS;
 
-        console.error(
-          `Connection error. Attempting to reconnect in ${Math.round(reconnectDelayMs)}ms`
+        logger.warn(
+          { event, reconnectDelayMs: Math.round(reconnectDelayMs) },
+          "EventSource connection error, reconnecting."
         );
 
         // Set timeout to reconnect after a jittered delay.

--- a/front/logger/datadogLogger.ts
+++ b/front/logger/datadogLogger.ts
@@ -3,6 +3,54 @@ import { datadogLogs } from "@datadog/browser-logs";
 // Keep the exported Logger type for compatibility with existing imports.
 export type { Logger } from "pino";
 
+// Benign error messages that should not be forwarded to Datadog.
+// - ResizeObserver: https://github.com/DataDog/browser-sdk/issues/1616
+// - "No activity within": EventSource polyfill heartbeat timeout (normal reconnection)
+export const IGNORED_LOG_MESSAGES = [
+  "ResizeObserver loop completed with undelivered notifications",
+  "ResizeObserver loop limit exceeded",
+  "No activity within",
+];
+
+interface InitDatadogLogsOptions {
+  clientToken: string;
+  service: string;
+  env?: string;
+  version?: string;
+  forwardConsoleLogs?: ("error" | "warn" | "info" | "debug" | "log")[];
+}
+
+/**
+ * Shared Datadog Logs initialization used by front, front-spa, and extensions.
+ */
+export function initDatadogLogs({
+  clientToken,
+  service,
+  env,
+  version,
+  forwardConsoleLogs,
+}: InitDatadogLogsOptions) {
+  datadogLogs.init({
+    clientToken,
+    site: "datadoghq.eu",
+    service,
+    env,
+    version,
+    forwardErrorsToLogs: true,
+    sessionSampleRate: 100,
+    forwardConsoleLogs,
+    beforeSend: (log) => {
+      if (
+        typeof log.message === "string" &&
+        IGNORED_LOG_MESSAGES.some((m) => log.message.includes(m))
+      ) {
+        return false;
+      }
+      return true;
+    },
+  });
+}
+
 // Pino-like levels we expose
 type Level = "trace" | "debug" | "info" | "warn" | "error";
 

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -5,7 +5,6 @@ import "@dust-tt/sparkle/dist/sparkle.css";
 // Local tailwind components override sparkle styles
 import "@app/styles/components.css";
 
-import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
 import Script from "next/script";
@@ -25,37 +24,17 @@ import { PostHogTracker } from "@app/components/app/PostHogTracker";
 import { NextLinkWrapper } from "@app/lib/platform/NextLinkWrapper";
 import { FetcherProvider } from "@app/lib/swr/FetcherContext";
 import { fetcher, fetcherWithBody } from "@app/lib/swr/fetcher";
+import { initDatadogLogs } from "@app/logger/datadogLogger";
 import { SparkleContext } from "@dust-tt/sparkle";
 
 if (DATADOG_CLIENT_TOKEN) {
-  datadogLogs.init({
+  initDatadogLogs({
     clientToken: DATADOG_CLIENT_TOKEN,
     env: NODE_ENV === "production" ? "prod" : "dev",
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     service: `${DATADOG_SERVICE || "front"}-browser`,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     version: COMMIT_HASH || "",
-    site: "datadoghq.eu",
-    forwardErrorsToLogs: true,
-    sessionSampleRate: 100,
-    beforeSend: (log) => {
-      // Filter out benign ResizeObserver errors that have no user impact.
-      // Different browsers use different messages:
-      // - Safari/Firefox: "ResizeObserver loop completed with undelivered notifications"
-      // - Chrome: "ResizeObserver loop limit exceeded"
-      // See: https://github.com/DataDog/browser-sdk/issues/1616
-      if (log.message && typeof log.message === "string") {
-        if (
-          log.message.includes(
-            "ResizeObserver loop completed with undelivered notifications"
-          ) ||
-          log.message.includes("ResizeObserver loop limit exceeded")
-        ) {
-          return false;
-        }
-      }
-      return true;
-    },
   });
 }
 


### PR DESCRIPTION
## Description

Fixes Datadog logging in the Chrome and Front extensions:

- **Wire `@app/logger/logger` to `datadogLogger` in extensions**: Added webpack alias so shared components importing `@app/logger/logger` route through the Datadog bridge (`datadogLogger.ts`) instead of the server-side Pino logger (which is a no-op in browser context). This was already done in front-spa via Vite alias but missing in extensions.
- **Set Datadog user context**: `datadogLogs.setUser()` is now called after login with user `sId` and `email`, and `workspaceSId` is added to global context — previously `usr.id` was never set.
- **Add `extensionVersion` and `commitHash` to global context**: Every log now includes the extension version and commit hash for debugging.
- **Migrate `console.error` to `logger.error`** in key extension files (MCP services, fetcher, auth) per GEN8 coding rule.
- **Filter EventSource heartbeat noise**: The `event-source-polyfill` fires error events on idle SSE connections ("No activity within 90000 milliseconds"). These are normal reconnections, not real errors. Added `beforeSend` filter to drop them, and downgraded `useEventSource` error handler from `console.error` to `logger.warn`.
- **Centralize `initDatadogLogs`**: Extracted a shared `initDatadogLogs()` function and `IGNORED_LOG_MESSAGES` constant in `front/logger/datadogLogger.ts`, reused by `front/_app.tsx`, `front-spa`, and both extension platforms — removing duplicated init logic.
- **Add Datadog init to Front extension**: `extension/platforms/front/main.tsx` was missing Datadog initialization entirely.

## Tests

- Built Chrome extension with `DATADOG_CLIENT_TOKEN=fake npm run package:chrome:production` — compiles successfully
- Verified logs appear in Datadog with correct `usr.id`, `extensionVersion`, `commitHash`, and `workspaceSId`
- Verified "No activity within" errors no longer appear in Datadog

## Risk

Low — logging-only changes, no business logic affected. The webpack alias change could theoretically affect logger behavior in shared components, but it matches the existing front-spa Vite alias exactly.

## Deploy Plan

Standard deploy, no special steps needed.