### PR TITLE
fix: autoclosing dropdowns in firefox extension

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -317,7 +317,7 @@ export function ConversationMenu({
         ) : (
           <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         )}
-        <DropdownMenuContent>
+        <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
           <DropdownMenuItem
             label="Rename conversation"
             onClick={() => setShowRenameDialog(true)}

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -237,7 +237,7 @@ export function ProjectMenu({
         ) : (
           <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         )}
-        <DropdownMenuContent>
+        <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
           {canRename && (
             <DropdownMenuItem
               label="Rename"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -335,7 +335,7 @@ function SearchResults({
                     }}
                   />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
+                <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
                   <DropdownMenuLabel label="Conversations" />
                   <DropdownMenuItem
                     label={
@@ -1433,7 +1433,7 @@ function NavigationListWithInbox({
                     }}
                   />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent>
+                <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
                   <DropdownMenuLabel label="Conversations" />
                   <DropdownMenuItem
                     label={


### PR DESCRIPTION
## Description

This PR fixes auto-closing dropdown behavior in the Firefox extension.
This is a known Radix bug see https://github.com/radix-ui/primitives/issues/2754

- Added `onFocusOutside={(e) => e.preventDefault()}` to `DropdownMenuContent` components in ConversationMenu, ProjectMenu, and SidebarMenu to prevent dropdowns from closing unexpectedly as soon as they are opened in the firefox extension.

## Tests

Manually tested in Firefox extension.

## Risks

Low risk.

## Deploy Plan

Standard deployment.
