### PR TITLE
feat: firefox extension voice

### DIFF
--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -4,6 +4,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import {
   isBrowserExtension,
   isChromeExtension,
+  isFirefoxExtension,
 } from "@app/lib/utils/extension";
 
 import type { AugmentedMessage } from "@app/lib/utils/find_agents_in_message";
@@ -410,10 +411,41 @@ const extensionRequestMicrophonePermission = async (): Promise<MediaStream> => {
   if (state === "prompt") {
     // Side panel can't show the prompt — fall back to popup window
     await openMicrophoneAccessPopup();
+    const newState = await getMicrophonePermissionState();
+    if (newState !== "granted") {
+      throw new DOMException(
+        "Microphone permission not granted",
+        "NotAllowedError"
+      );
+    }
     return navigator.mediaDevices.getUserMedia({ audio: true });
   }
   // Permission is already granted
-  return navigator.mediaDevices.getUserMedia({ audio: true });
+  try {
+    return await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (error) {
+    // Firefox bug: when the microphone permission is set to "Always Ask",
+    // navigator.permissions.query incorrectly reports the state as "granted"
+    // instead of "prompt". This causes getUserMedia to fail in the side panel
+    // (which cannot display the native permission prompt). We fall back to the
+    // popup flow so the user can still grant access.
+    if (
+      isFirefoxExtension() &&
+      error instanceof DOMException &&
+      error.name === "NotAllowedError"
+    ) {
+      await openMicrophoneAccessPopup();
+      const newState = await getMicrophonePermissionState();
+      if (newState !== "granted") {
+        throw new DOMException(
+          "Microphone permission not granted",
+          "NotAllowedError"
+        );
+      }
+      return navigator.mediaDevices.getUserMedia({ audio: true });
+    }
+    throw error;
+  }
 };
 
 export const requestMicrophone = async (): Promise<MediaStream> => {

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -1,7 +1,11 @@
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { isChromeExtension } from "@app/lib/utils/extension";
+import {
+  isBrowserExtension,
+  isChromeExtension,
+} from "@app/lib/utils/extension";
+
 import type { AugmentedMessage } from "@app/lib/utils/find_agents_in_message";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -358,7 +362,7 @@ const getMicrophonePermissionState = async (): Promise<PermissionState> => {
 
 const openMicrophoneAccessPopup = async (): Promise<void> => {
   const createdWindow = await chrome.windows.create({
-    url: `chrome-extension://${chrome.runtime.id}/request-mic.html`,
+    url: chrome.runtime.getURL("request-mic.html"),
     type: "popup",
     width: 400,
     height: 400,
@@ -393,10 +397,13 @@ const extensionRequestMicrophonePermission = async (): Promise<MediaStream> => {
   const state = await getMicrophonePermissionState();
 
   if (state === "denied") {
-    // Open extension settings so user can manually re-enable microphone
-    await chrome.tabs.create({
-      url: `chrome://settings/content/siteDetails?site=chrome-extension%3A%2F%2F${chrome.runtime.id}%2F`,
-    });
+    if (isChromeExtension()) {
+      // Open Chrome extension settings so user can manually re-enable microphone.
+      await chrome.tabs.create({
+        url: `chrome://settings/content/siteDetails?site=chrome-extension%3A%2F%2F${chrome.runtime.id}%2F`,
+      });
+    }
+    // Firefox has no deep link to extension site settings
     throw new DOMException("Microphone permission denied", "NotAllowedError");
   }
 
@@ -410,7 +417,7 @@ const extensionRequestMicrophonePermission = async (): Promise<MediaStream> => {
 };
 
 export const requestMicrophone = async (): Promise<MediaStream> => {
-  if (isChromeExtension()) {
+  if (isBrowserExtension()) {
     return extensionRequestMicrophonePermission();
   }
   return navigator.mediaDevices.getUserMedia({ audio: true });

--- a/front/lib/utils/extension.ts
+++ b/front/lib/utils/extension.ts
@@ -5,7 +5,7 @@ export function isChromeExtension(): boolean {
   );
 }
 
-function isFirefoxExtension(): boolean {
+export function isFirefoxExtension(): boolean {
   return (
     typeof window !== "undefined" &&
     window.location?.protocol === "moz-extension:"

--- a/front/lib/utils/extension.ts
+++ b/front/lib/utils/extension.ts
@@ -4,3 +4,14 @@ export function isChromeExtension(): boolean {
     window.location?.protocol === "chrome-extension:"
   );
 }
+
+function isFirefoxExtension(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.location?.protocol === "moz-extension:"
+  );
+}
+
+export function isBrowserExtension(): boolean {
+  return isChromeExtension() || isFirefoxExtension();
+}


### PR DESCRIPTION
## Description

This PR adds Firefox extension support for voice transcription functionality.

- Updates microphone permission handling to work with Firefox by using `chrome.runtime.getURL()` 
- Removes Chrome-specific settings deeplink when microphone permission is denied on Firefox (as Firefox has no equivalent deeplink)

## Tests

Manually

## Risks

Low - This change only affects browser extension contexts and maintains backward compatibility with Chrome while adding Firefox support.

## Deploy Plan

Standard deployment.
