### PR TITLE
feat: firefox extension interact with page validation

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -37,6 +37,13 @@ const MCP_TOOL_OVERRIDES: Partial<
         "Allow all the interactions with this tab",
     },
   },
+  "dust-firefox-extension": {
+    interact_with_page: {
+      title: (agentName, inputs) =>
+        `Allow ${asDisplayName(agentName)} to ${inputs.humanReadableDescription}?`,
+      alwaysAllowLabel: () => "Allow all the interactions with this tab",
+    },
+  },
 };
 
 interface MCPToolValidationRequiredProps {


### PR DESCRIPTION
## Description

This PR adds MCP tool validation configuration for the Firefox extension's "interact_with_page" capability as for the chrome one.

## Tests

Manually

## Risks

Low risk. This change only adds UI configuration for displaying validation prompts for the Firefox extension's page interaction feature.

## Deploy Plan

Standard deployment.
