### PR TITLE
Add test to make sure we don't suggest duplicate suggestion

### DIFF
--- a/front/tests/reinforced-agent-evals/lib/assertions.ts
+++ b/front/tests/reinforced-agent-evals/lib/assertions.ts
@@ -37,6 +37,19 @@ function isSkillSuggestionItem(value: unknown): value is SkillSuggestionItem {
   );
 }
 
+interface PromptSuggestionItem {
+  targetBlockId: string;
+}
+
+function isPromptSuggestionItem(value: unknown): value is PromptSuggestionItem {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "targetBlockId" in value &&
+    typeof value.targetBlockId === "string"
+  );
+}
+
 function getSuggestions(args: Record<string, unknown>): unknown[] | undefined {
   const suggestions = args.suggestions;
   if (!Array.isArray(suggestions)) {
@@ -55,6 +68,12 @@ function getSkillSuggestions(
   args: Record<string, unknown>
 ): SkillSuggestionItem[] {
   return (getSuggestions(args) ?? []).filter(isSkillSuggestionItem);
+}
+
+function getPromptSuggestions(
+  args: Record<string, unknown>
+): PromptSuggestionItem[] {
+  return (getSuggestions(args) ?? []).filter(isPromptSuggestionItem);
 }
 
 /**
@@ -107,12 +126,21 @@ export function validateToolCallAssertion(
           error: "Expected suggest_prompt_edits to be called, but it was not",
         };
       }
-      const suggestions = getSuggestions(call.arguments);
-      if (!suggestions || suggestions.length === 0) {
+      const suggestions = getPromptSuggestions(call.arguments);
+      if (suggestions.length === 0) {
         return {
           success: false,
           error:
             "Expected suggest_prompt_edits to contain at least one suggestion, but got none",
+        };
+      }
+      if (
+        assertion.targetBlockId &&
+        !suggestions.some((s) => s.targetBlockId === assertion.targetBlockId)
+      ) {
+        return {
+          success: false,
+          error: `Expected suggest_prompt_edits to contain targetBlockId "${assertion.targetBlockId}", but got: ${JSON.stringify(suggestions.map((s) => s.targetBlockId))}`,
         };
       }
       return { success: true };

--- a/front/tests/reinforced-agent-evals/lib/assertions.ts
+++ b/front/tests/reinforced-agent-evals/lib/assertions.ts
@@ -1,0 +1,141 @@
+import type {
+  ToolCall,
+  ToolCallAssertion,
+} from "@app/tests/reinforced-agent-evals/lib/types";
+
+type AssertionResult = { success: true } | { success: false; error: string };
+
+interface ToolSuggestionItem {
+  toolId: string;
+  action: string;
+}
+
+interface SkillSuggestionItem {
+  skillId: string;
+  action: string;
+}
+
+function isToolSuggestionItem(value: unknown): value is ToolSuggestionItem {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "toolId" in value &&
+    typeof value.toolId === "string" &&
+    "action" in value &&
+    typeof value.action === "string"
+  );
+}
+
+function isSkillSuggestionItem(value: unknown): value is SkillSuggestionItem {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "skillId" in value &&
+    typeof value.skillId === "string" &&
+    "action" in value &&
+    typeof value.action === "string"
+  );
+}
+
+function getSuggestions(args: Record<string, unknown>): unknown[] | undefined {
+  const suggestions = args.suggestions;
+  if (!Array.isArray(suggestions)) {
+    return undefined;
+  }
+  return suggestions;
+}
+
+function getToolSuggestions(
+  args: Record<string, unknown>
+): ToolSuggestionItem[] {
+  return (getSuggestions(args) ?? []).filter(isToolSuggestionItem);
+}
+
+function getSkillSuggestions(
+  args: Record<string, unknown>
+): SkillSuggestionItem[] {
+  return (getSuggestions(args) ?? []).filter(isSkillSuggestionItem);
+}
+
+/**
+ * Validate a single assertion against the actual tool calls.
+ */
+export function validateToolCallAssertion(
+  assertion: ToolCallAssertion,
+  toolCalls: ToolCall[]
+): AssertionResult {
+  switch (assertion.type) {
+    case "toolSuggestion": {
+      const call = toolCalls.find((tc) => tc.name === "suggest_tools");
+      if (!call) {
+        return {
+          success: false,
+          error: `Expected suggest_tools to be called with toolId "${assertion.toolId}", but suggest_tools was not called`,
+        };
+      }
+      const suggestions = getToolSuggestions(call.arguments);
+      if (!suggestions.some((s) => s.toolId === assertion.toolId)) {
+        return {
+          success: false,
+          error: `Expected suggest_tools to contain toolId "${assertion.toolId}", but got: ${JSON.stringify(suggestions)}`,
+        };
+      }
+      return { success: true };
+    }
+    case "skillSuggestion": {
+      const call = toolCalls.find((tc) => tc.name === "suggest_skills");
+      if (!call) {
+        return {
+          success: false,
+          error: `Expected suggest_skills to be called with skillId "${assertion.skillId}", but suggest_skills was not called`,
+        };
+      }
+      const suggestions = getSkillSuggestions(call.arguments);
+      if (!suggestions.some((s) => s.skillId === assertion.skillId)) {
+        return {
+          success: false,
+          error: `Expected suggest_skills to contain skillId "${assertion.skillId}", but got: ${JSON.stringify(suggestions)}`,
+        };
+      }
+      return { success: true };
+    }
+    case "promptSuggestion": {
+      const call = toolCalls.find((tc) => tc.name === "suggest_prompt_edits");
+      if (!call) {
+        return {
+          success: false,
+          error: "Expected suggest_prompt_edits to be called, but it was not",
+        };
+      }
+      const suggestions = getSuggestions(call.arguments);
+      if (!suggestions || suggestions.length === 0) {
+        return {
+          success: false,
+          error:
+            "Expected suggest_prompt_edits to contain at least one suggestion, but got none",
+        };
+      }
+      return { success: true };
+    }
+    case "noSuggestion": {
+      const suggestionToolNames = new Set([
+        "suggest_tools",
+        "suggest_skills",
+        "suggest_prompt_edits",
+      ]);
+      for (const tc of toolCalls) {
+        if (!suggestionToolNames.has(tc.name)) {
+          continue;
+        }
+        const suggestions = getSuggestions(tc.arguments);
+        if (suggestions && suggestions.length > 0) {
+          return {
+            success: false,
+            error: `Expected no suggestions, but ${tc.name} was called with ${suggestions.length} suggestion(s)`,
+          };
+        }
+      }
+      return { success: true };
+    }
+  }
+}

--- a/front/tests/reinforced-agent-evals/lib/types.ts
+++ b/front/tests/reinforced-agent-evals/lib/types.ts
@@ -147,7 +147,7 @@ export interface MockAgentConfig {
 
 interface BaseTestCase {
   scenarioId: string;
-  expectedToolCalls?: string[];
+  expectedToolCalls?: ToolCallAssertion[];
   judgeCriteria: string;
   agentConfig: MockAgentConfig;
   workspaceContext: WorkspaceContext;
@@ -214,6 +214,28 @@ export interface TestSuite {
 export interface ToolCall {
   name: string;
   arguments: Record<string, unknown>;
+}
+
+export type ToolCallAssertion =
+  | { type: "toolSuggestion"; toolId: string }
+  | { type: "skillSuggestion"; skillId: string }
+  | { type: "promptSuggestion" }
+  | { type: "noSuggestion" };
+
+export function toolSuggestion(toolId: string): ToolCallAssertion {
+  return { type: "toolSuggestion", toolId };
+}
+
+export function skillSuggestion(skillId: string): ToolCallAssertion {
+  return { type: "skillSuggestion", skillId };
+}
+
+export function promptSuggestion(): ToolCallAssertion {
+  return { type: "promptSuggestion" };
+}
+
+export function noSuggestion(): ToolCallAssertion {
+  return { type: "noSuggestion" };
 }
 
 export interface JudgeResult {

--- a/front/tests/reinforced-agent-evals/lib/types.ts
+++ b/front/tests/reinforced-agent-evals/lib/types.ts
@@ -219,7 +219,7 @@ export interface ToolCall {
 export type ToolCallAssertion =
   | { type: "toolSuggestion"; toolId: string }
   | { type: "skillSuggestion"; skillId: string }
-  | { type: "promptSuggestion" }
+  | { type: "promptSuggestion"; targetBlockId?: string }
   | { type: "noSuggestion" };
 
 export function toolSuggestion(toolId: string): ToolCallAssertion {
@@ -230,8 +230,8 @@ export function skillSuggestion(skillId: string): ToolCallAssertion {
   return { type: "skillSuggestion", skillId };
 }
 
-export function promptSuggestion(): ToolCallAssertion {
-  return { type: "promptSuggestion" };
+export function promptSuggestion(targetBlockId?: string): ToolCallAssertion {
+  return { type: "promptSuggestion", targetBlockId };
 }
 
 export function noSuggestion(): ToolCallAssertion {

--- a/front/tests/reinforced-agent-evals/reinforced-agent-eval.test.ts
+++ b/front/tests/reinforced-agent-evals/reinforced-agent-eval.test.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { validateToolCallAssertion } from "@app/tests/reinforced-agent-evals/lib/assertions";
 import {
   BATCH_TIMEOUT_MS,
   FILTER_CATEGORY,
@@ -157,19 +158,15 @@ describe.skipIf(!RUN_REINFORCED_EVAL)(
                 JUDGE_RUNS
               );
 
-              const actualToolNames = toolCalls.map((t) => t.name);
-              const missingTools = (testCase.expectedToolCalls ?? []).filter(
-                (expected) => !actualToolNames.includes(expected)
-              );
               const passedJudge = judgeResult.finalScore >= PASS_THRESHOLD;
-
               const toolCallsSummary = formatToolCalls(toolCalls);
 
-              for (const missing of missingTools) {
+              for (const assertion of testCase.expectedToolCalls ?? []) {
+                const result = validateToolCallAssertion(assertion, toolCalls);
                 expect(
-                  actualToolNames,
-                  `Expected tool "${missing}" not called. Tools called: [${toolCallsSummary}]\n\nResponse:\n${responseText}`
-                ).toContain(missing);
+                  result.success,
+                  `${!result.success ? result.error : ""}\n\nTool calls: [${toolCallsSummary}]\nResponse:\n${responseText}`
+                ).toBe(true);
               }
 
               expect(

--- a/front/tests/reinforced-agent-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/aggregate-suggestions.ts
@@ -1,7 +1,11 @@
 import {
   mockSkill,
   mockTool,
+  noSuggestion,
+  promptSuggestion,
+  skillSuggestion,
   type TestSuite,
+  toolSuggestion,
   type WorkspaceContext,
 } from "@app/tests/reinforced-agent-evals/lib/types";
 import type {
@@ -122,7 +126,7 @@ export const aggregateSuggestionsSuite: TestSuite = {
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: ["suggest_tools"],
+      expectedToolCalls: [toolSuggestion("mcp_jira")],
       judgeCriteria: `The reinforced agent MUST call suggest_tools to suggest adding the JIRA tool
 (mcp_jira). The aggregated suggestion should:
 - Merge the 3 individual suggestions into a single well-summarized recommendation
@@ -163,7 +167,7 @@ Score 3 if well-merged with clear analysis covering all use cases and conversati
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: ["suggest_skills"],
+      expectedToolCalls: [skillSuggestion("skill_web_search")],
       judgeCriteria: `The reinforced agent MUST call suggest_skills to suggest adding the Web Search
 skill (skill_web_search). The aggregated suggestion should:
 - Merge the 3 individual suggestions into a single well-summarized recommendation
@@ -219,7 +223,7 @@ Score 3 if well-merged with clear analysis covering all use cases and conversati
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: ["suggest_prompt_edits"],
+      expectedToolCalls: [promptSuggestion()],
       judgeCriteria: `The reinforced agent MUST call suggest_prompt_edits with a single merged
 suggestion that combines all 3 tone-related suggestions. The merged suggestion should:
 - Combine the warmth, natural language, and empathy themes into one coherent section
@@ -232,6 +236,96 @@ Score 0 if no suggest_prompt_edits call or if it creates 3 separate suggestions.
 Score 1 if merged but missing one or more of the key themes (warmth, natural language, empathy).
 Score 2 if all themes included but the merged content is disorganized or the analysis is weak.
 Score 3 if well-merged with all themes, clear structure, and analysis referencing multiple conversations.`,
+    },
+    {
+      scenarioId: "no-duplicate-of-pending-prompt-suggestion",
+      type: "aggregation",
+      agentConfig: { name: "Support Agent" },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          id: 1,
+          sId: "sug-1",
+          analysis:
+            "User complained about the agent's tone being too cold. The agent should adopt a warmer communication style with more empathy.",
+          suggestion: {
+            content:
+              "<h2>Communication Style</h2><p>Always respond in a warm, friendly tone. Show empathy and make users feel welcome.</p>",
+            targetBlockId: "instructions-root",
+            type: "replace",
+          },
+        }),
+      ],
+      existingSuggestions: {
+        pending: [
+          makeInstructionSuggestion({
+            id: 100,
+            sId: "existing-pending-1",
+            analysis:
+              "Multiple users found the agent's responses impersonal. Adding warmth and a friendlier tone would improve user satisfaction.",
+            source: "reinforcement",
+            suggestion: {
+              content:
+                "<h2>Tone Guidelines</h2><p>Use a warm, conversational tone. Be friendly and approachable in all responses. Show genuine care for the user's needs.</p>",
+              targetBlockId: "instructions-root",
+              type: "replace",
+            },
+          }),
+        ],
+        rejected: [],
+      },
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [noSuggestion()],
+      judgeCriteria: `The synthetic suggestion about tone/warmth is essentially the same as the existing pending
+suggestion already targeting instructions-root. The agent must not duplicate it.
+
+Score 0 if it creates a suggestion similar to the existing pending one (tone/warmth/friendliness).
+Score 1 if it creates an unrelated suggestion.
+Score 3 if no suggestion is created.`,
+    },
+    {
+      scenarioId: "no-duplicate-of-rejected-prompt-suggestion",
+      type: "aggregation",
+      agentConfig: { name: "Support Agent" },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          id: 1,
+          sId: "sug-1",
+          analysis:
+            "User was frustrated that the agent didn't acknowledge their problem before jumping to solutions. The agent should show empathy first.",
+          suggestion: {
+            content:
+              "<h2>Empathy First</h2><p>When users report issues, always acknowledge their frustration and show understanding before providing a solution.</p>",
+            targetBlockId: "instructions-root",
+            type: "replace",
+          },
+        }),
+      ],
+      existingSuggestions: {
+        pending: [],
+        rejected: [
+          makeInstructionSuggestion({
+            id: 200,
+            sId: "existing-rejected-1",
+            analysis:
+              "Users wanted more empathetic responses. The agent should acknowledge frustration and show understanding before jumping to solutions.",
+            source: "reinforcement",
+            suggestion: {
+              content:
+                "<h2>Empathetic Responses</h2><p>When users report problems, first acknowledge their frustration. Show understanding and empathy before providing solutions.</p>",
+              targetBlockId: "instructions-root",
+              type: "replace",
+            },
+          }),
+        ],
+      },
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [noSuggestion()],
+      judgeCriteria: `The synthetic suggestion about empathy/acknowledging frustration is essentially the same
+as a previously rejected suggestion targeting instructions-root. The agent must not recreate it.
+
+Score 0 if it creates a suggestion similar to the rejected one (empathy/acknowledging frustration).
+Score 1 if it creates an unrelated suggestion.
+Score 3 if no suggestion is created.`,
     },
   ],
 };

--- a/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
@@ -1,7 +1,10 @@
 import {
   mockSkill,
   mockTool,
+  promptSuggestion,
+  skillSuggestion,
   type TestSuite,
+  toolSuggestion,
   type WorkspaceContext,
 } from "@app/tests/reinforced-agent-evals/lib/types";
 
@@ -56,7 +59,7 @@ export const analyzeConversationSuite: TestSuite = {
         },
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: ["suggest_prompt_edits"],
+      expectedToolCalls: [promptSuggestion()],
       judgeCriteria: `The reinforced agent MUST call suggest_prompt_edits with a suggestion that adds
 a section about tone and communication style to the agent's instructions. The suggestion should:
 - Include guidance about being friendly, warm, and empathetic
@@ -107,7 +110,7 @@ Score 3 if the suggestion provides clear, specific tone guidance that would prev
         },
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: ["suggest_skills"],
+      expectedToolCalls: [skillSuggestion("skill_web_search")],
       judgeCriteria: `The reinforced agent MUST call suggest_skills to suggest adding the web search
 skill (skill_web_search). The suggestion should:
 - Recommend adding web search (ID: skill_web_search) with action "add"
@@ -155,7 +158,7 @@ Score 3 if the correct skill is suggested with a clear, well-reasoned analysis.`
         },
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: ["suggest_tools"],
+      expectedToolCalls: [toolSuggestion("mcp_jira")],
       judgeCriteria: `The reinforced agent MUST call suggest_tools to suggest adding the JIRA tool
 (mcp_jira). The suggestion should:
 - Recommend adding JIRA (ID: mcp_jira) with action "add"


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7181

 - slightly change how we assert the tool call result to be more detailed
 - Add 2 new tests to make sure we don't produce new suggestion when we already have a similar suggestion which is pending or rejected.

## Tests

```
 RUN  v4.0.18 /Users/fabiencelier/spaces/dust/.hives/ra--duplicate/front

 ✓ tests/reinforced-agent-evals/reinforced-agent-eval.test.ts (8 tests) 52450ms
   ✓ Reinforced Agent Evaluation Tests (8)
     ✓ analyze-conversation (3)
       ✓ bad-tone-user-requests-warmth  19447ms
       ✓ missing-websearch-skill  20284ms
       ✓ missing-jira-tool  27075ms
     ✓ aggregate-suggestions (5)
       ✓ three-jira-tool-suggestions  15236ms
       ✓ three-websearch-skill-suggestions  16079ms
       ✓ three-tone-prompt-suggestions  25313ms
       ✓ no-duplicate-of-pending-prompt-suggestion  14121ms
       ✓ no-duplicate-of-rejected-prompt-suggestion  13339ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  11:29:38
   Duration  57.00s (transform 1.23s, setup 373ms, import 3.77s, tests 52.45s, environment 332ms)
```

## Risk

low, still feature flagged

## Deploy Plan

deploy front https://github.com/dust-tt/tasks/issues/7181
