### PR TITLE
[front] chore: bump large skill char count from 10k to 40k

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -10,7 +10,7 @@ import {
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
-const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 10_000;
+const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 40_000;
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 


### PR DESCRIPTION
## Description

- This PR bumps the threshold for displaying the large skill warning from 10k characters to 40k.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
