### PR TITLE
fix: extension attach content from project input bar

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -1,18 +1,14 @@
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { InputBarContextProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { Button, MenuIcon } from "@dust-tt/sparkle";
-import {
-  type AttachSelectionMessage,
-  sendGetSessionInfoMessage,
-} from "@extension/platforms/chrome/messages";
+import { sendGetSessionInfoMessage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
-import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import { ExtensionInputBarProvider } from "@extension/ui/components/conversation/ExtensionInputBarProvider";
 import { useContext, useEffect, useMemo, useState } from "react";
 
 interface ConversationContainerProps {
@@ -48,30 +44,11 @@ export const ConversationContainer = ({
   const platform = usePlatform();
   const { currentPanel } = useConversationSidePanelContext();
   const { setSidebarOpen } = useContext(SidebarContext);
-  const fileUploaderService = useFileUploaderService(
-    platform.capture,
-    conversationId
-  );
-
-  const captureActions = platform.useCaptureActions(
-    workspace,
-    fileUploaderService.uploadContentTab,
-    fileUploaderService.isCapturing
-  );
 
   const clientSideMCPServerIds = useMemo(
     () => (serverId ? [serverId] : undefined),
     [serverId]
   );
-
-  // Reset fileBlobs when conversationId changes.
-  // We intentionally avoid using a key prop as it would remount
-  // the entire page subtree just to reset a single array.
-  const [prevConversationId, setPrevConversationId] = useState(conversationId);
-  if (conversationId !== prevConversationId) {
-    setPrevConversationId(conversationId);
-    fileUploaderService.resetUpload();
-  }
 
   const [suggestion, setSuggestion] = useState<
     | {
@@ -81,29 +58,6 @@ export const ConversationContainer = ({
       }
     | undefined
   >(undefined);
-
-  useEffect(() => {
-    void platform.messaging?.sendMessage({
-      type: "INPUT_BAR_STATUS",
-      available: true,
-    });
-
-    const cleanup = platform.messaging?.addMessageListener(
-      (message: AttachSelectionMessage) => {
-        if (message.type === "EXT_ATTACH_TAB") {
-          void fileUploaderService.uploadContentTab(message);
-        }
-      }
-    );
-
-    return () => {
-      void platform.messaging?.sendMessage({
-        type: "INPUT_BAR_STATUS",
-        available: false,
-      });
-      cleanup?.();
-    };
-  }, [platform.messaging, fileUploaderService.uploadContentTab]);
 
   const handleDismissSuggestion = async (id: string) => {
     const dismissed = await platform.storage.get<string[]>(
@@ -144,9 +98,9 @@ export const ConversationContainer = ({
   }, []);
 
   return (
-    <InputBarContextProvider
-      captureActions={captureActions}
-      fileUploaderService={fileUploaderService}
+    <ExtensionInputBarProvider
+      workspace={workspace}
+      conversationId={conversationId}
     >
       <div className={currentPanel ? "hidden" : "flex flex-col h-full w-full"}>
         <ConversationContainerVirtuoso
@@ -176,6 +130,6 @@ export const ConversationContainer = ({
           />
         </div>
       )}
-    </InputBarContextProvider>
+    </ExtensionInputBarProvider>
   );
 };

--- a/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
+++ b/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
@@ -1,0 +1,72 @@
+import { InputBarContextProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { AttachSelectionMessage } from "@extension/platforms/chrome/messages";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+interface ExtensionInputBarProviderProps {
+  workspace: LightWorkspaceType;
+  conversationId?: string | null;
+  children: ReactNode;
+}
+
+export function ExtensionInputBarProvider({
+  workspace,
+  conversationId = null,
+  children,
+}: ExtensionInputBarProviderProps) {
+  const platform = usePlatform();
+  const fileUploaderService = useFileUploaderService(
+    platform.capture,
+    conversationId
+  );
+
+  const captureActions = platform.useCaptureActions(
+    workspace,
+    fileUploaderService.uploadContentTab,
+    fileUploaderService.isCapturing
+  );
+
+  // Reset fileBlobs when conversationId changes.
+  // We intentionally avoid using a key prop as it would remount
+  // the entire page subtree just to reset a single array.
+  const [prevConversationId, setPrevConversationId] = useState(conversationId);
+  if (conversationId !== prevConversationId) {
+    setPrevConversationId(conversationId);
+    fileUploaderService.resetUpload();
+  }
+
+  useEffect(() => {
+    void platform.messaging?.sendMessage({
+      type: "INPUT_BAR_STATUS",
+      available: true,
+    });
+
+    const cleanup = platform.messaging?.addMessageListener(
+      (message: AttachSelectionMessage) => {
+        if (message.type === "EXT_ATTACH_TAB") {
+          void fileUploaderService.uploadContentTab(message);
+        }
+      }
+    );
+
+    return () => {
+      void platform.messaging?.sendMessage({
+        type: "INPUT_BAR_STATUS",
+        available: false,
+      });
+      cleanup?.();
+    };
+  }, [platform.messaging, fileUploaderService.uploadContentTab]);
+
+  return (
+    <InputBarContextProvider
+      captureActions={captureActions}
+      fileUploaderService={fileUploaderService}
+    >
+      {children}
+    </InputBarContextProvider>
+  );
+}

--- a/extension/ui/pages/ProjectMainPage.tsx
+++ b/extension/ui/pages/ProjectMainPage.tsx
@@ -1,8 +1,8 @@
-import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
+import { ExtensionInputBarProvider } from "@extension/ui/components/conversation/ExtensionInputBarProvider";
 import { useParams } from "react-router-dom";
 
 export const ProjectMainPage = () => {
@@ -16,9 +16,9 @@ export const ProjectMainPage = () => {
 
   return (
     <ConversationLayout title={spaceInfo?.name ?? ""}>
-      <InputBarProvider>
+      <ExtensionInputBarProvider workspace={workspace}>
         <SpaceConversationsPage />
-      </InputBarProvider>
+      </ExtensionInputBarProvider>
     </ConversationLayout>
   );
 };


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7185

This PR fixes content attachment from the extension's project input bar which was not displaying the "Attach page content" and "Take screenshot" options.

- Created a new `ExtensionInputBarProvider` component that wraps `InputBarContextProvider` with extension-specific functionality (file uploader service, capture actions, and message listeners for tab attachment)
- Refactored `ConversationContainer` to use the new provider, removing duplicated extension logic
- Updated `ProjectMainPage` to use `ExtensionInputBarProvider` instead of the generic `InputBarProvider`, enabling proper content attachment in project views
<img width="643" height="455" alt="Capture d’écran 2026-03-19 à 13 18 20" src="https://github.com/user-attachments/assets/ceec8def-227a-433c-aa4d-a63e42935440" />



## Tests

Manually

## Risks

Low - This is a refactoring that extracts existing logic into a reusable component without changing functionality.

## Deploy Plan

Standard deployment - no special steps required.
