### PR TITLE
fix: extension hide create agent from agent picker

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -875,9 +875,10 @@ const InputBarContainer = ({
                       }}
                       agents={allAgents}
                       showDropdownArrow={false}
-                      showFooterButtons={actions.includes(
-                        "agents-list-with-actions"
-                      )}
+                      showFooterButtons={
+                        actions.includes("agents-list-with-actions") &&
+                        clientType !== "extension"
+                      }
                       disabled={disableInput}
                     />
                   )}


### PR DESCRIPTION
## Description

This PR hides the "Create Agent" button from the agent picker when using the browser extension.
<img width="250" height="183" alt="Capture d’écran 2026-03-19 à 13 39 21" src="https://github.com/user-attachments/assets/50d08a99-124a-49a7-aefc-6b5010603ee0" />
<img width="250" height="183" alt="Capture d’écran 2026-03-19 à 13 39 45" src="https://github.com/user-attachments/assets/2c22d3f1-a1ef-4b58-96db-d99d2e6fbe11" />

## Tests

Manually.

## Risks

Low risk. This is a UI-only change.

## Deploy Plan

Standard deployment.
