### PR TITLE
[Email] In dev, filter external recipients instead of blocking send

### DIFF
--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -253,27 +253,32 @@ export async function sendEmailToRecipients({
   cc?: string[];
   message: any;
 }) {
-  const recipients = [...to, ...(cc ?? [])];
-  const msg = {
-    ...message,
-    to,
-    ...(cc && cc.length > 0 ? { cc } : {}),
-  };
-
-  // In dev we want to make sure we don't send emails to real users.
-  // We prevent sending emails if any recipient is not in @dust.tt.
+  // In dev, filter out external recipients and warn rather than blocking the send entirely.
+  let filteredTo = to;
+  let filteredCc = cc;
   if (isDevelopment()) {
-    const externalRecipients = recipients.filter(
-      (recipient) => !recipient.endsWith("@dust.tt")
+    const isInternal = (r: string) => r.endsWith("@dust.tt");
+    filteredTo = to.filter(isInternal);
+    filteredCc = cc?.filter(isInternal);
+    const externalRecipients = [...to, ...(cc ?? [])].filter(
+      (r) => !isInternal(r)
     );
     if (externalRecipients.length > 0) {
-      logger.error(
+      logger.warn(
         { externalRecipients, subject: message.subject },
-        "Prevented sending email in development mode to external recipients."
+        "Dropping external recipients in development mode."
       );
+    }
+    if (filteredTo.length === 0) {
       return;
     }
   }
+
+  const msg = {
+    ...message,
+    to: filteredTo,
+    ...(filteredCc && filteredCc.length > 0 ? { cc: filteredCc } : {}),
+  };
 
   try {
     await getSgMailClient().send(msg);


### PR DESCRIPTION
## Description

In development, when an email would be sent to a mix of internal (`@dust.tt`) and external recipients, the current behaviour blocks the entire send and logs an error. This makes it impossible to test email features that involve external addresses.

New behaviour:
- External recipients are silently dropped
- A warning is logged listing the dropped addresses
- The email is still sent to internal (`@dust.tt`) recipients
- If no internal recipients remain after filtering, the send is skipped entirely (same as before)

## Risks

Blast radius: development mode only — no production impact
Risk: none

## Deploy Plan
- pmrr
- deploy front