### PR TITLE
[Agent Email] Make email-origin user messages explicit

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -1,6 +1,5 @@
 import {
   ASSISTANT_EMAIL_SUBDOMAIN,
-  buildEmailUserMessage,
   buildReplyThreadingHeaders,
   buildSuccessReplyRecipients,
   MAX_REPLY_RECIPIENTS,
@@ -195,99 +194,5 @@ describe("buildReplyThreadingHeaders", () => {
       inReplyTo: "<incoming-message-id@dust.tt>",
       references: "<older-message-id@dust.tt> <incoming-message-id@dust.tt>",
     });
-  });
-});
-
-describe("buildEmailUserMessage", () => {
-  it("includes the email envelope and reply audience", () => {
-    const message = buildEmailUserMessage({
-      email: {
-        subject: "Budget review",
-        text: "Can you take a look?",
-        auth: { SPF: "pass", dkim: "pass" },
-        threadingHeaders: {
-          messageId: null,
-          inReplyTo: null,
-          references: null,
-        },
-        envelope: {
-          from: "sender@dust.tt",
-          full: "Sender <sender@dust.tt>",
-          to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "teammate@dust.tt"],
-          cc: ["observer@dust.tt"],
-          bcc: [],
-        },
-        attachments: [],
-      },
-      userMessage: "Can you take a look?",
-      replyRecipients: {
-        to: ["sender@dust.tt", "teammate@dust.tt"],
-        cc: ["observer@dust.tt"],
-      },
-      hasThreadHistory: false,
-      attachmentCount: 0,
-    });
-
-    expect(message).toContain("I sent the following email:");
-    expect(message).toContain("<email_message>");
-    expect(message).toContain(
-      "<email_from>Sender &lt;sender@dust.tt&gt;</email_from>"
-    );
-    expect(message).toContain(
-      `<dust_agent_recipients>agent@${ASSISTANT_EMAIL_SUBDOMAIN}</dust_agent_recipients>`
-    );
-    expect(message).toContain(
-      `<email_to>agent@${ASSISTANT_EMAIL_SUBDOMAIN}, teammate@dust.tt</email_to>`
-    );
-    expect(message).toContain("<email_cc>observer@dust.tt</email_cc>");
-    expect(message).toContain(
-      "<email_body>\nCan you take a look?\n  </email_body>"
-    );
-    expect(message).toContain(
-      "<email_response_to>sender@dust.tt, teammate@dust.tt</email_response_to>"
-    );
-    expect(message).toContain(
-      "<email_response_cc>observer@dust.tt</email_response_cc>"
-    );
-    expect(message).toContain(
-      "You are in the recipients. Answer appropriately. Your response will be emailed back as-is to me and any other to/cc recipients."
-    );
-  });
-
-  it("mentions available thread history and attachments when present", () => {
-    const message = buildEmailUserMessage({
-      email: {
-        subject: "Fwd: Contract",
-        text: "Please summarize",
-        auth: { SPF: "pass", dkim: "pass" },
-        threadingHeaders: {
-          messageId: null,
-          inReplyTo: null,
-          references: null,
-        },
-        envelope: {
-          from: "sender@dust.tt",
-          full: "Sender <sender@dust.tt>",
-          to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`],
-          cc: [],
-          bcc: [],
-        },
-        attachments: [],
-      },
-      userMessage: "Please summarize",
-      replyRecipients: {
-        to: ["sender@dust.tt"],
-        cc: [],
-      },
-      hasThreadHistory: true,
-      attachmentCount: 2,
-    });
-
-    expect(message).toContain(
-      "<email_thread_history_may_be_available_in_conversation>true</email_thread_history_may_be_available_in_conversation>"
-    );
-    expect(message).toContain(
-      "<email_attachment_count_may_be_available_in_conversation>2</email_attachment_count_may_be_available_in_conversation>"
-    );
   });
 });

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -235,7 +235,7 @@ describe("buildEmailUserMessage", () => {
       `To: agent@${ASSISTANT_EMAIL_SUBDOMAIN}, teammate@dust.tt`
     );
     expect(message).toContain("Cc: observer@dust.tt");
-    expect(message).toContain("Body:\n---\nCan you take a look?\n---");
+    expect(message).toContain("Body:\n> Can you take a look?");
     expect(message).toContain(
       "If you respond, your response will be emailed back as-is to:"
     );
@@ -272,7 +272,7 @@ describe("buildEmailUserMessage", () => {
     });
 
     expect(message).toContain(
-      "The email thread history and 2 attachments are available below in this conversation."
+      "The email thread history may also be available in this conversation. The email included 2 attachments, which may also be available in this conversation."
     );
   });
 });

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -1,5 +1,6 @@
 import {
   ASSISTANT_EMAIL_SUBDOMAIN,
+  buildEmailUserMessage,
   buildReplyThreadingHeaders,
   buildSuccessReplyRecipients,
   MAX_REPLY_RECIPIENTS,
@@ -194,5 +195,84 @@ describe("buildReplyThreadingHeaders", () => {
       inReplyTo: "<incoming-message-id@dust.tt>",
       references: "<older-message-id@dust.tt> <incoming-message-id@dust.tt>",
     });
+  });
+});
+
+describe("buildEmailUserMessage", () => {
+  it("includes the email envelope and reply audience", () => {
+    const message = buildEmailUserMessage({
+      email: {
+        subject: "Budget review",
+        text: "Can you take a look?",
+        auth: { SPF: "pass", dkim: "pass" },
+        threadingHeaders: {
+          messageId: null,
+          inReplyTo: null,
+          references: null,
+        },
+        envelope: {
+          from: "sender@dust.tt",
+          full: "Sender <sender@dust.tt>",
+          to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "teammate@dust.tt"],
+          cc: ["observer@dust.tt"],
+          bcc: [],
+        },
+        attachments: [],
+      },
+      userMessage: "Can you take a look?",
+      replyRecipients: {
+        to: ["sender@dust.tt", "teammate@dust.tt"],
+        cc: ["observer@dust.tt"],
+      },
+      hasThreadHistory: false,
+      attachmentCount: 0,
+    });
+
+    expect(message).toContain(
+      `Dust agent recipients: agent@${ASSISTANT_EMAIL_SUBDOMAIN}`
+    );
+    expect(message).toContain(
+      `To: agent@${ASSISTANT_EMAIL_SUBDOMAIN}, teammate@dust.tt`
+    );
+    expect(message).toContain("Cc: observer@dust.tt");
+    expect(message).toContain("Body:\n---\nCan you take a look?\n---");
+    expect(message).toContain(
+      "If you respond, your response will be emailed back as-is to:"
+    );
+    expect(message).toContain("To: sender@dust.tt, teammate@dust.tt");
+  });
+
+  it("mentions available thread history and attachments when present", () => {
+    const message = buildEmailUserMessage({
+      email: {
+        subject: "Fwd: Contract",
+        text: "Please summarize",
+        auth: { SPF: "pass", dkim: "pass" },
+        threadingHeaders: {
+          messageId: null,
+          inReplyTo: null,
+          references: null,
+        },
+        envelope: {
+          from: "sender@dust.tt",
+          full: "Sender <sender@dust.tt>",
+          to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`],
+          cc: [],
+          bcc: [],
+        },
+        attachments: [],
+      },
+      userMessage: "Please summarize",
+      replyRecipients: {
+        to: ["sender@dust.tt"],
+        cc: [],
+      },
+      hasThreadHistory: true,
+      attachmentCount: 2,
+    });
+
+    expect(message).toContain(
+      "The email thread history and 2 attachments are available below in this conversation."
+    );
   });
 });

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -228,18 +228,30 @@ describe("buildEmailUserMessage", () => {
       attachmentCount: 0,
     });
 
+    expect(message).toContain("I sent the following email:");
+    expect(message).toContain("<email_message>");
     expect(message).toContain(
-      `Dust agent recipients: agent@${ASSISTANT_EMAIL_SUBDOMAIN}`
+      "<email_from>Sender &lt;sender@dust.tt&gt;</email_from>"
     );
     expect(message).toContain(
-      `To: agent@${ASSISTANT_EMAIL_SUBDOMAIN}, teammate@dust.tt`
+      `<dust_agent_recipients>agent@${ASSISTANT_EMAIL_SUBDOMAIN}</dust_agent_recipients>`
     );
-    expect(message).toContain("Cc: observer@dust.tt");
-    expect(message).toContain("Body:\n> Can you take a look?");
     expect(message).toContain(
-      "If you respond, your response will be emailed back as-is to:"
+      `<email_to>agent@${ASSISTANT_EMAIL_SUBDOMAIN}, teammate@dust.tt</email_to>`
     );
-    expect(message).toContain("To: sender@dust.tt, teammate@dust.tt");
+    expect(message).toContain("<email_cc>observer@dust.tt</email_cc>");
+    expect(message).toContain(
+      "<email_body>\nCan you take a look?\n  </email_body>"
+    );
+    expect(message).toContain(
+      "<email_response_to>sender@dust.tt, teammate@dust.tt</email_response_to>"
+    );
+    expect(message).toContain(
+      "<email_response_cc>observer@dust.tt</email_response_cc>"
+    );
+    expect(message).toContain(
+      "You are in the recipients. Answer appropriately. Your response will be emailed back as-is to me and any other to/cc recipients."
+    );
   });
 
   it("mentions available thread history and attachments when present", () => {
@@ -272,7 +284,10 @@ describe("buildEmailUserMessage", () => {
     });
 
     expect(message).toContain(
-      "The email thread history may also be available in this conversation. The email included 2 attachments, which may also be available in this conversation."
+      "<email_thread_history_may_be_available_in_conversation>true</email_thread_history_may_be_available_in_conversation>"
+    );
+    expect(message).toContain(
+      "<email_attachment_count_may_be_available_in_conversation>2</email_attachment_count_may_be_available_in_conversation>"
     );
   });
 });

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -453,7 +453,7 @@ export function buildEmailUserMessage({
       : []),
     "</email_message>",
     "",
-    "You are in the recipients. Answer appropriately. Your response will be emailed back as-is to me and any other to/cc recipients.",
+    "You are in the recipients. Answer appropriately. Your response will be emailed automatically to the recipients listed above (and me).",
   ].join("\n");
 }
 export async function userAndWorkspaceFromEmail({

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -260,6 +260,49 @@ function isAssistantRecipient(email: string): boolean {
 // as a bulk relay while leaving no impact on legitimate threads (nobody CCs 15+ people normally).
 export const MAX_REPLY_RECIPIENTS = 15;
 
+function formatEmailRecipients(recipients: string[]): string {
+  return recipients.length > 0 ? recipients.join(", ") : "(none)";
+}
+
+function formatEmailHeaderValue(value: string): string {
+  return value.replace(/\s*\n+\s*/g, " ").trim();
+}
+
+function escapeTagContent(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function buildEmailAdditionalContext({
+  hasThreadHistory,
+  attachmentCount,
+}: {
+  hasThreadHistory: boolean;
+  attachmentCount: number;
+}): string[] {
+  const additionalContext: string[] = [];
+
+  if (!hasThreadHistory && attachmentCount === 0) {
+    return additionalContext;
+  }
+
+  if (hasThreadHistory) {
+    additionalContext.push(
+      "<email_thread_history_may_be_available_in_conversation>true</email_thread_history_may_be_available_in_conversation>"
+    );
+  }
+
+  if (attachmentCount > 0) {
+    additionalContext.push(
+      `<email_attachment_count_may_be_available_in_conversation>${attachmentCount}</email_attachment_count_may_be_available_in_conversation>`
+    );
+  }
+
+  return additionalContext;
+}
+
 function buildReferencesHeaderValue({
   inReplyTo,
   references,
@@ -341,6 +384,57 @@ export function buildSuccessReplyRecipients(email: InboundEmail): {
     "[email] Reply recipient list truncated to MAX_REPLY_RECIPIENTS."
   );
   return { to, cc: cappedCc };
+}
+
+export function buildEmailUserMessage({
+  email,
+  userMessage,
+  replyRecipients,
+  hasThreadHistory,
+  attachmentCount,
+}: {
+  email: InboundEmail;
+  userMessage: string;
+  replyRecipients: {
+    to: string[];
+    cc: string[];
+  };
+  hasThreadHistory: boolean;
+  attachmentCount: number;
+}): string {
+  const assistantRecipients = deduplicateEmailAddresses(
+    [...email.envelope.to, ...email.envelope.cc, ...email.envelope.bcc].filter(
+      isAssistantRecipient
+    )
+  );
+  const toRecipients = deduplicateEmailAddresses(email.envelope.to);
+  const ccRecipients = deduplicateEmailAddresses(email.envelope.cc);
+  const availableContextLine = buildAvailableEmailContextLine({
+    hasThreadHistory,
+    attachmentCount,
+  });
+
+  return [
+    "You received the following email through Dust.",
+    "",
+    `Dust agent recipients: ${formatEmailRecipients(assistantRecipients)}`,
+    `Subject: ${email.subject}`,
+    `To: ${formatEmailRecipients(toRecipients)}`,
+    ...(ccRecipients.length > 0
+      ? [`Cc: ${formatEmailRecipients(ccRecipients)}`]
+      : []),
+    "",
+    "Body:",
+    "---",
+    userMessage,
+    "---",
+    ...(availableContextLine ? ["", availableContextLine] : []),
+    "If you respond, your response will be emailed back as-is to:",
+    `To: ${formatEmailRecipients(replyRecipients.to)}`,
+    ...(replyRecipients.cc.length > 0
+      ? [`Cc: ${formatEmailRecipients(replyRecipients.cc)}`]
+      : []),
+  ].join("\n");
 }
 export async function userAndWorkspaceFromEmail({
   email,
@@ -621,6 +715,7 @@ export async function triggerFromEmail({
   }
 
   // Process email attachments as content fragments.
+  let attachedContentCount = 0;
   for (const attachment of email.attachments) {
     try {
       const file = await FileResource.makeNew({
@@ -680,6 +775,7 @@ export async function triggerFromEmail({
         continue;
       }
 
+      attachedContentCount += 1;
       localLogger.info(
         { filename: attachment.filename },
         "[email] Added attachment as content fragment."
@@ -706,6 +802,7 @@ export async function triggerFromEmail({
     }
   }
 
+  const successReplyRecipients = buildSuccessReplyRecipients(email);
   const content =
     agentConfigurations
       .map((agent) => {
@@ -713,7 +810,13 @@ export async function triggerFromEmail({
       })
       .join(" ") +
     " " +
-    userMessage;
+    buildEmailUserMessage({
+      email,
+      userMessage,
+      replyRecipients: successReplyRecipients,
+      hasThreadHistory: restOfThread.length > 0,
+      attachmentCount: attachedContentCount,
+    });
 
   const mentions = agentConfigurations.map((agent) => {
     return { configurationId: agent.sId };
@@ -746,7 +849,6 @@ export async function triggerFromEmail({
   }
 
   const { agentMessages } = messageRes.value;
-  const successReplyRecipients = buildSuccessReplyRecipients(email);
 
   // Store email reply context in Redis for each agent message.
   // The finalization activity will use this to send the reply.

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -409,31 +409,51 @@ export function buildEmailUserMessage({
   );
   const toRecipients = deduplicateEmailAddresses(email.envelope.to);
   const ccRecipients = deduplicateEmailAddresses(email.envelope.cc);
-  const availableContextLine = buildAvailableEmailContextLine({
+  const additionalContext = buildEmailAdditionalContext({
     hasThreadHistory,
     attachmentCount,
   });
 
   return [
-    "You received the following email through Dust.",
+    "I sent the following email:",
     "",
-    `Dust agent recipients: ${formatEmailRecipients(assistantRecipients)}`,
-    `Subject: ${email.subject}`,
-    `To: ${formatEmailRecipients(toRecipients)}`,
+    "<email_message>",
+    `  <email_from>${escapeTagContent(
+      formatEmailHeaderValue(email.envelope.full)
+    )}</email_from>`,
+    `  <email_subject>${escapeTagContent(
+      formatEmailHeaderValue(email.subject)
+    )}</email_subject>`,
+    `  <email_to>${escapeTagContent(
+      formatEmailRecipients(toRecipients)
+    )}</email_to>`,
     ...(ccRecipients.length > 0
-      ? [`Cc: ${formatEmailRecipients(ccRecipients)}`]
+      ? [
+          `  <email_cc>${escapeTagContent(
+            formatEmailRecipients(ccRecipients)
+          )}</email_cc>`,
+        ]
       : []),
-    "",
-    "Body:",
-    "---",
-    userMessage,
-    "---",
-    ...(availableContextLine ? ["", availableContextLine] : []),
-    "If you respond, your response will be emailed back as-is to:",
-    `To: ${formatEmailRecipients(replyRecipients.to)}`,
+    `  <dust_agent_recipients>${escapeTagContent(
+      formatEmailRecipients(assistantRecipients)
+    )}</dust_agent_recipients>`,
+    "  <email_body>",
+    escapeTagContent(userMessage),
+    "  </email_body>",
+    ...additionalContext.map((line) => `  ${line}`),
+    `  <email_response_to>${escapeTagContent(
+      formatEmailRecipients(replyRecipients.to)
+    )}</email_response_to>`,
     ...(replyRecipients.cc.length > 0
-      ? [`Cc: ${formatEmailRecipients(replyRecipients.cc)}`]
+      ? [
+          `  <email_response_cc>${escapeTagContent(
+            formatEmailRecipients(replyRecipients.cc)
+          )}</email_response_cc>`,
+        ]
       : []),
+    "</email_message>",
+    "",
+    "You are in the recipients. Answer appropriately. Your response will be emailed back as-is to me and any other to/cc recipients.",
   ].join("\n");
 }
 export async function userAndWorkspaceFromEmail({


### PR DESCRIPTION
## Description
Explains better to the agent what it's receiving when

Rewrites Email-origin user messages to make their content more clear. Previously there was only the body with no metadata and no instructions on what was happening. We wrap with explicit email-related directives and context (agent recipients, subject, To/Cc, body, available thread/attachments, and reply audience) before posting them to the conversation.

## Risks
Blast radius: inbound email handling for agent conversations in front.
Risk: low

## Deploy Plan
- pmrr (not urgent)
- deploy front