### PR TITLE
Reinforced agent: add tool input/output to improve suggestions

### DIFF
--- a/front/lib/api/assistant/conversation/shrink_wrap.ts
+++ b/front/lib/api/assistant/conversation/shrink_wrap.ts
@@ -13,6 +13,7 @@ import { isString } from "@app/types/shared/utils/general";
 // Build the output messages, truncating content per message.
 const MAX_CONTENT_CHARS_PER_MESSAGE = 2_000;
 const MAX_TOTAL_CONTENT_CHARS = 20_000;
+export const MAX_ACTION_DETAIL_CHARS = 500;
 
 /**
  * Minimal types for the shrink-wrap conversation formatter.
@@ -33,6 +34,7 @@ export interface ShrinkWrapAction {
   status: string;
   internalMCPServerName: string | null;
   params: Record<string, unknown>;
+  output?: string | null;
 }
 
 export interface ShrinkWrapAgentMessage {
@@ -52,6 +54,22 @@ export interface ShrinkWrapConversationData {
   sId: string;
   title: string | null;
   messages: ShrinkWrapMessage[];
+}
+
+/**
+ * Serialize MCP tool output (array of content blocks) into a plain text string.
+ * Extracts text from "text" content blocks; non-text blocks are ignored.
+ */
+function serializeActionOutput(
+  output: Array<{ type: string; text?: string }> | null
+): string | null {
+  if (!output) {
+    return null;
+  }
+  const texts = output
+    .filter((block) => block.type === "text" && isString(block.text))
+    .map((block) => block.text);
+  return texts.length > 0 ? texts.join("\n") : null;
 }
 
 function truncateContent(content: string | null): {
@@ -82,6 +100,8 @@ export function formatConversationForShrinkWrap(
     fromMessageIndex?: number;
     toMessageIndex?: number;
     feedbackByMessageId?: Map<string, ShrinkWrapFeedback[]>;
+    /** When true, include tool input (params) and output for each action. */
+    includeActionDetails?: boolean;
   }
 ): string {
   const messages = conversation.messages;
@@ -168,6 +188,23 @@ export function formatConversationForShrinkWrap(
           }
         }
         lines.push(actionLine);
+
+        if (options?.includeActionDetails) {
+          const paramsStr = JSON.stringify(action.params);
+          const truncatedParams =
+            paramsStr.length > MAX_ACTION_DETAIL_CHARS
+              ? paramsStr.slice(0, MAX_ACTION_DETAIL_CHARS) + "…"
+              : paramsStr;
+          lines.push(`  Input: ${truncatedParams}`);
+
+          if (action.output) {
+            const truncatedOutput =
+              action.output.length > MAX_ACTION_DETAIL_CHARS
+                ? action.output.slice(0, MAX_ACTION_DETAIL_CHARS) + "…"
+                : action.output;
+            lines.push(`  Output: ${truncatedOutput}`);
+          }
+        }
       }
       lines.push("");
     }
@@ -206,11 +243,14 @@ export async function getShrinkWrappedConversation(
     fromMessageIndex,
     toMessageIndex,
     includeFeedback,
+    includeActionDetails,
   }: {
     conversationId: string;
     fromMessageIndex?: number;
     toMessageIndex?: number;
     includeFeedback?: boolean;
+    /** When true, include tool input (params) and output for each action. */
+    includeActionDetails?: boolean;
   }
 ): Promise<
   Result<
@@ -237,8 +277,19 @@ export async function getShrinkWrappedConversation(
       continue;
     }
     const lastVersion = messageVersions[messageVersions.length - 1];
-    if (isUserMessageType(lastVersion) || isAgentMessageType(lastVersion)) {
+    if (isUserMessageType(lastVersion)) {
       flatMessages.push(lastVersion);
+    } else if (isAgentMessageType(lastVersion)) {
+      flatMessages.push({
+        ...lastVersion,
+        actions: lastVersion.actions.map((a) => ({
+          functionCallName: a.functionCallName,
+          status: a.status,
+          internalMCPServerName: a.internalMCPServerName,
+          params: a.params,
+          output: serializeActionOutput(a.output),
+        })),
+      });
     }
   }
 
@@ -289,6 +340,7 @@ export async function getShrinkWrappedConversation(
       fromMessageIndex,
       toMessageIndex,
       feedbackByMessageId: feedbackByMessageId,
+      includeActionDetails,
     }
   );
 

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -86,6 +86,7 @@ export async function buildConversationAnalysisBatchMap(
     const conversationRes = await getShrinkWrappedConversation(auth, {
       conversationId,
       includeFeedback: true,
+      includeActionDetails: true,
     });
     if (conversationRes.isErr()) {
       logger.warn(

--- a/front/tests/reinforced-agent-evals/lib/assertions.ts
+++ b/front/tests/reinforced-agent-evals/lib/assertions.ts
@@ -135,12 +135,14 @@ export function validateToolCallAssertion(
         };
       }
       if (
-        assertion.targetBlockId &&
-        !suggestions.some((s) => s.targetBlockId === assertion.targetBlockId)
+        assertion.targetBlockIds &&
+        !suggestions.some((s) =>
+          assertion.targetBlockIds!.includes(s.targetBlockId)
+        )
       ) {
         return {
           success: false,
-          error: `Expected suggest_prompt_edits to contain targetBlockId "${assertion.targetBlockId}", but got: ${JSON.stringify(suggestions.map((s) => s.targetBlockId))}`,
+          error: `Expected suggest_prompt_edits to contain one of targetBlockIds ${JSON.stringify(assertion.targetBlockIds)}, but got: ${JSON.stringify(suggestions.map((s) => s.targetBlockId))}`,
         };
       }
       return { success: true };

--- a/front/tests/reinforced-agent-evals/lib/types.ts
+++ b/front/tests/reinforced-agent-evals/lib/types.ts
@@ -1,5 +1,8 @@
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
-import { formatConversationForShrinkWrap } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import {
+  formatConversationForShrinkWrap,
+  type ShrinkWrapAction,
+} from "@app/lib/api/assistant/conversation/shrink_wrap";
 import {
   formatAvailableSkills,
   formatAvailableTools,
@@ -74,10 +77,19 @@ export interface MockFeedback {
   comment?: string;
 }
 
+/** Lightweight action descriptor for mock conversations. */
+export interface MockAction {
+  functionCallName: string;
+  status: "succeeded" | "failed";
+  params?: Record<string, unknown>;
+  output?: string | null;
+}
+
 export interface MockConversationMessage {
   role: "user" | "agent";
   content: string;
   feedback?: MockFeedback;
+  actions?: MockAction[];
 }
 
 /**
@@ -117,6 +129,14 @@ export function buildConversationText(
       ]);
     }
 
+    const actions: ShrinkWrapAction[] = (msg.actions ?? []).map((a) => ({
+      functionCallName: a.functionCallName,
+      status: a.status,
+      internalMCPServerName: null,
+      params: a.params ?? {},
+      output: a.output ?? null,
+    }));
+
     return {
       type: "agent_message" as const,
       sId,
@@ -124,14 +144,14 @@ export function buildConversationText(
       content: msg.content,
       status: "succeeded",
       configuration: { sId: agentConfigSId, name: "Agent" },
-      actions: [],
+      actions,
       parentAgentMessageId: null,
     };
   });
 
   return formatConversationForShrinkWrap(
     { sId: "conv_eval", title: "Eval conversation", messages: shrinkMessages },
-    { feedbackByMessageId }
+    { feedbackByMessageId, includeActionDetails: true }
   );
 }
 
@@ -219,7 +239,7 @@ export interface ToolCall {
 export type ToolCallAssertion =
   | { type: "toolSuggestion"; toolId: string }
   | { type: "skillSuggestion"; skillId: string }
-  | { type: "promptSuggestion"; targetBlockId?: string }
+  | { type: "promptSuggestion"; targetBlockIds?: string[] }
   | { type: "noSuggestion" };
 
 export function toolSuggestion(toolId: string): ToolCallAssertion {
@@ -230,8 +250,13 @@ export function skillSuggestion(skillId: string): ToolCallAssertion {
   return { type: "skillSuggestion", skillId };
 }
 
-export function promptSuggestion(targetBlockId?: string): ToolCallAssertion {
-  return { type: "promptSuggestion", targetBlockId };
+export function promptSuggestion(
+  ...targetBlockIds: string[]
+): ToolCallAssertion {
+  return {
+    type: "promptSuggestion",
+    targetBlockIds: targetBlockIds.length > 0 ? targetBlockIds : undefined,
+  };
 }
 
 export function noSuggestion(): ToolCallAssertion {

--- a/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
@@ -18,6 +18,10 @@ const WORKSPACE_CONTEXT: WorkspaceContext = {
     mockTool("Notion", "Search Notion workspace"),
     mockTool("GitHub", "Access GitHub repositories"),
     mockTool("JIRA", "Search and manage JIRA issues and projects"),
+    mockTool(
+      "CRM",
+      "Search companies, manage contacts, and look up account ownership details using search-company, get-owner, and other CRM operations"
+    ),
   ],
 };
 
@@ -169,6 +173,72 @@ Score 0 if no suggest_tools call is made.
 Score 0-1 if suggest_tools is called but with the wrong tool ID or wrong action.
 Score 2 if the correct tool is suggested but the analysis is weak.
 Score 3 if the correct tool is suggested with a clear, well-reasoned analysis.`,
+    },
+    {
+      scenarioId: "improve-tool-usage-crm-owner-lookup",
+      type: "analysis",
+      agentConfig: {
+        name: "CRM Assistant",
+        description:
+          "Helps the sales team with CRM queries and account management",
+        instructionsHtml: `<div data-type="instructions-root" data-block-id="instructions-root">
+        <div data-block-id="cb63b301" data-instruction-type="role" data-collapsed="false" data-type="instruction-block">
+          <p data-block-id="75935445">You are a CRM assistant for the sales team. Help them look up account information, contacts, and ownership details. Always be concise and professional.</p>
+        </div>
+        <div data-block-id="0ff1016e" data-instruction-type="tools" data-collapsed="false" data-type="instruction-block">
+          <p data-block-id="b35e0731">Use the CRM tools to fetch data when answering user queries.</p>
+        </div>
+        </div>`,
+        tools: [{ name: "CRM", sId: "mcp_crm" }],
+      },
+      conversation: [
+        {
+          role: "user",
+          content: "Who is the owner for Acme Corp account?",
+        },
+        {
+          role: "agent",
+          content:
+            "The account owner for Acme Corp is Sarah Johnson (sarah.johnson@company.com), Senior Account Manager.",
+          actions: [
+            {
+              functionCallName: "get-owner",
+              status: "failed",
+              params: { companyId: "Acme Corp" },
+              output: 'No company with ID "Acme Corp"',
+            },
+            {
+              functionCallName: "search-company",
+              status: "succeeded",
+              params: { query: "Acme Corp" },
+              output:
+                '{"id": "comp_48291", "name": "Acme Corp", "industry": "Technology", "website": "acme.com"}',
+            },
+            {
+              functionCallName: "get-owner",
+              status: "succeeded",
+              params: { companyId: "comp_48291" },
+              output:
+                '{"owner": "Sarah Johnson", "email": "sarah.johnson@company.com", "title": "Senior Account Manager"}',
+            },
+          ],
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [promptSuggestion("0ff1016e", "b35e0731")],
+      judgeCriteria: `The reinforced agent MUST call suggest_prompt_edits with a suggestion that improves
+the "tools" instruction block. The suggestion should:
+- Target the tools section block ("0ff1016e") or its paragraph ("b35e0731"), NOT "role"/"cb63b301" or "instructions-root"
+- Include guidance to use search-company first to retrieve the company ID before calling get-owner
+- Explain that get-owner requires a company ID, not a company name
+- Preserve the existing content of the tools section while adding the new guidance
+- Have a meaningful analysis explaining why tool usage order matters
+
+Score 0 if no suggest_prompt_edits call is made.
+Score 0 if the suggestion targets the wrong block (e.g. "cb63b301" or "instructions-root" instead of "0ff1016e"/"b35e0731").
+Score 1 if the suggestion targets the correct block but is too vague or generic.
+Score 2 if the suggestion correctly targets the tools block and addresses the tool usage order but lacks specificity.
+Score 3 if the suggestion targets the tools block with clear, specific instructions about using search-company first to get the ID, then get-owner with the ID.`,
     },
   ],
 };


### PR DESCRIPTION
## Description

 - add tool input and output (truncated to 500 chars) into the shrink wrap conv of the reinforced agent 
 - improve targetBlock id check to allow multiple block id when the model can place the suggestion in different valid places
 - add a test to make sure the reinforcement can use this to suggest improvment

## Tests

```
 ✓ tests/reinforced-agent-evals/reinforced-agent-eval.test.ts (1 test) 19561ms
   ✓ Reinforced Agent Evaluation Tests (1)
     ✓ analyze-conversation (1)
       ✓ improve-tool-usage-crm-owner-lookup  19508ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  17:12:36
   Duration  24.05s (transform 1.24s, setup 393ms, import 3.71s, tests 19.56s, environment 309ms)
```

## Risk

low.
Conversation may get bigger but seems reasonable overall.

## Deploy Plan

deploy front
