### PR TITLE
feat: add new rule for import dust-tt/client/*

### DIFF
--- a/.grit/patterns/noClientDeepImports.grit
+++ b/.grit/patterns/noClientDeepImports.grit
@@ -1,0 +1,19 @@
+engine biome(1.0)
+language js
+
+// Forbids deep imports from @dust-tt/client subpaths (e.g. @dust-tt/client/src,
+// @dust-tt/client/src/toto.ts) in front/ code. Only the package root
+// @dust-tt/client should be imported.
+pattern client_deep_import() {
+    `"@dust-tt/client/$_"` where {
+        $filename <: r".*/front/.*"
+    }
+}
+
+client_deep_import() as $source where {
+    register_diagnostic(
+        span = $source,
+        message = "Deep imports from '@dust-tt/client/*' are not allowed. Import from '@dust-tt/client' instead.",
+        severity = "error"
+    )
+}

--- a/.grit/patterns/noClientDeepImports.md
+++ b/.grit/patterns/noClientDeepImports.md
@@ -1,0 +1,53 @@
+---
+tags: [lint, imports]
+level: error
+---
+
+# No deep imports from @dust-tt/client
+
+Forbids deep imports from `@dust-tt/client/*` subpaths in `front/` code.
+Only the package root `@dust-tt/client` should be imported.
+
+```grit
+language js
+
+client_deep_import() => `"CLIENT_DEEP_IMPORT_FORBIDDEN"`
+```
+
+## Should flag import from client/src
+
+```typescript
+// @filename: app/front/lib/utils.ts
+import { Foo } from "@dust-tt/client/src";
+```
+
+```typescript
+// @filename: app/front/lib/utils.ts
+import { Foo } from "CLIENT_DEEP_IMPORT_FORBIDDEN";
+```
+
+## Should flag import from client/src/toto.ts
+
+```typescript
+// @filename: app/front/lib/utils.ts
+import { Bar } from "@dust-tt/client/src/toto";
+```
+
+```typescript
+// @filename: app/front/lib/utils.ts
+import { Bar } from "CLIENT_DEEP_IMPORT_FORBIDDEN";
+```
+
+## Should not flag import from client root
+
+```typescript
+// @filename: app/front/lib/utils.ts
+import { Foo } from "@dust-tt/client";
+```
+
+## Should not flag deep import outside front
+
+```typescript
+// @filename: app/connectors/lib/utils.ts
+import { Foo } from "@dust-tt/client/src";
+```

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,8 @@
     "./.grit/patterns/enforceClientTypesInPublicApi.grit",
     "./.grit/patterns/nextjsPageComponentNaming.grit",
     "./.grit/patterns/nextjsNoDataFetchingInGetssp.grit",
-    "./.grit/patterns/tooLongIndexName.grit"
+    "./.grit/patterns/tooLongIndexName.grit",
+    "./.grit/patterns/noClientDeepImports.grit"
   ],
   "vcs": {
     "enabled": true,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -115,8 +115,6 @@ pre-commit:
 
     # Biome checks (all JS/TS files in monorepo)
     biome:
-      glob: "*.{js,jsx,ts,tsx,css,scss,md}"
-      # Rust projects' .md files are not covered by biome.
-      exclude: "{core,cli/dust-sandbox}/**"
+      glob: "*.{js,jsx,ts,tsx,css,scss}"
       run: npm run biome:lefthook -- {staged_files}
       stage_fixed: true


### PR DESCRIPTION
## Description

Add a linter rule to make sure we only import `dust-tt/client` and nothing below. As this doesn't exist in production code

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
