### PR TITLE
Zod migration : agent configurations

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
@@ -6,8 +6,6 @@ import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assist
 import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/types/api/internal/agent_configuration";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 /**
@@ -46,20 +44,18 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostOrPatchAgentConfigurationRequestBodySchema.decode(
-    req.body
-  );
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation =
+    PostOrPatchAgentConfigurationRequestBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${bodyValidation.error.message}`,
       },
     });
   }
-  const body = bodyValidation.right;
+  const body = bodyValidation.data;
 
   const result = await createOrUpgradeAgentConfiguration({
     auth,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -11,33 +11,25 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { UserType } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-// Changed schema to accept optional add/remove lists
-export const PatchAgentEditorsRequestBodySchema = t.intersection([
-  t.type({}),
-  t.partial({
-    addEditorIds: t.array(t.string),
-    removeEditorIds: t.array(t.string),
-  }),
-  // Refinement to ensure at least one of the arrays exists and is not empty
-  t.refinement(
-    t.type({
-      // Use t.type inside refinement for better type checking
-      addEditorIds: t.union([t.array(t.string), t.undefined]),
-      removeEditorIds: t.union([t.array(t.string), t.undefined]),
-    }),
+export const PatchAgentEditorsRequestBodySchema = z
+  .object({
+    addEditorIds: z.array(z.string()).optional(),
+    removeEditorIds: z.array(z.string()).optional(),
+  })
+  .refine(
     (body) =>
       (body.addEditorIds instanceof Array && body.addEditorIds.length > 0) ||
       (body.removeEditorIds instanceof Array &&
         body.removeEditorIds.length > 0),
-    "Either addEditorIds or removeEditorIds must be provided and contain at least one ID."
-  ),
-]);
-export type PatchAgentEditorsRequestBody = t.TypeOf<
+    {
+      message:
+        "Either addEditorIds or removeEditorIds must be provided and contain at least one ID.",
+    }
+  );
+export type PatchAgentEditorsRequestBody = z.infer<
   typeof PatchAgentEditorsRequestBodySchema
 >;
 
@@ -148,21 +140,20 @@ async function handler(
         });
       }
 
-      const bodyValidation = PatchAgentEditorsRequestBodySchema.decode(
+      const bodyValidation = PatchAgentEditorsRequestBodySchema.safeParse(
         req.body
       );
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
-      const { addEditorIds = [], removeEditorIds = [] } = bodyValidation.right;
+      const { addEditorIds = [], removeEditorIds = [] } = bodyValidation.data;
 
       const usersToAdd = await UserResource.fetchByIds(addEditorIds);
       const usersToRemove = await UserResource.fetchByIds(removeEditorIds);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -9,8 +9,6 @@ import { apiError } from "@app/logger/withlogging";
 import { GetAgentConfigurationsHistoryQuerySchema } from "@app/types/api/internal/agent_configuration";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetAgentConfigurationsResponseBody = {
@@ -53,25 +51,25 @@ async function handler(
   switch (req.method) {
     case "GET":
       // extract the limit from the query parameters
-      const queryValidation = GetAgentConfigurationsHistoryQuerySchema.decode({
-        ...req.query,
-        limit:
-          typeof req.query.limit === "string"
-            ? parseInt(req.query.limit, 10)
-            : undefined,
-      });
-      if (isLeft(queryValidation)) {
-        const pathError = reporter.formatValidationErrors(queryValidation.left);
+      const queryValidation =
+        GetAgentConfigurationsHistoryQuerySchema.safeParse({
+          ...req.query,
+          limit:
+            typeof req.query.limit === "string"
+              ? parseInt(req.query.limit, 10)
+              : undefined,
+        });
+      if (!queryValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid query parameters: ${pathError}`,
+            message: `Invalid query parameters: ${queryValidation.error.message}`,
           },
         });
       }
 
-      const { limit } = queryValidation.right;
+      const { limit } = queryValidation.data;
 
       let agentConfigurations = await listsAgentConfigurationVersions(auth, {
         agentId: aId,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -12,8 +12,6 @@ import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assist
 import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/types/api/internal/agent_configuration";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetAgentConfigurationResponseBody = {
@@ -62,14 +60,13 @@ async function handler(
 
     case "PATCH":
       const bodyValidation =
-        PostOrPatchAgentConfigurationRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        PostOrPatchAgentConfigurationRequestBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
@@ -103,7 +100,7 @@ async function handler(
 
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
         auth,
-        assistant: bodyValidation.right.assistant,
+        assistant: bodyValidation.data.assistant,
         agentConfigurationId: req.query.aId as string,
       });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -9,19 +9,17 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type PatchLinkedSlackChannelsResponseBody = {
   success: true;
 };
 
-export const PatchLinkedSlackChannelsRequestBodySchema = t.type({
-  slack_channel_internal_ids: t.array(t.string),
-  provider: t.union([t.literal("slack"), t.literal("slack_bot")]),
-  auto_respond_without_mention: t.union([t.boolean, t.undefined]),
+export const PatchLinkedSlackChannelsRequestBodySchema = z.object({
+  slack_channel_internal_ids: z.array(z.string()),
+  provider: z.enum(["slack", "slack_bot"]),
+  auto_respond_without_mention: z.boolean().optional(),
 });
 
 async function handler(
@@ -42,12 +40,11 @@ async function handler(
     });
   }
 
-  const bodyValidationResult = PatchLinkedSlackChannelsRequestBodySchema.decode(
-    req.body
-  );
+  const bodyValidationResult =
+    PatchLinkedSlackChannelsRequestBodySchema.safeParse(req.body);
   if (
-    bodyValidationResult._tag === "Right" &&
-    bodyValidationResult.right.auto_respond_without_mention
+    bodyValidationResult.success &&
+    bodyValidationResult.data.auto_respond_without_mention
   ) {
     const featureFlags = await getFeatureFlags(auth);
     if (!featureFlags.includes("slack_enhanced_default_agent")) {
@@ -72,23 +69,22 @@ async function handler(
     });
   }
 
-  const bodyValidation = PatchLinkedSlackChannelsRequestBodySchema.decode(
+  const bodyValidation = PatchLinkedSlackChannelsRequestBodySchema.safeParse(
     req.body
   );
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${bodyValidation.error.message}`,
       },
     });
   }
 
   const [slackDataSource] = await DataSourceResource.listByConnectorProvider(
     auth,
-    bodyValidation.right.provider,
+    bodyValidation.data.provider,
     { limit: 1 }
   );
 
@@ -142,9 +138,8 @@ async function handler(
   const connectorsApiRes = await connectorsAPI.linkSlackChannelsWithAgent({
     connectorId: connectorId.toString(),
     agentConfigurationId: agentConfiguration.sId,
-    slackChannelInternalIds: bodyValidation.right.slack_channel_internal_ids,
-    autoRespondWithoutMention:
-      bodyValidation.right.auto_respond_without_mention,
+    slackChannelInternalIds: bodyValidation.data.slack_channel_internal_ids,
+    autoRespondWithoutMention: bodyValidation.data.auto_respond_without_mention,
   });
 
   if (connectorsApiRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -5,16 +5,14 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export const PatchAgentMemoryRequestBodySchema = t.type({
-  content: t.string,
+export const PatchAgentMemoryRequestBodySchema = z.object({
+  content: z.string(),
 });
 
-export type PatchAgentMemoryRequestBody = t.TypeOf<
+export type PatchAgentMemoryRequestBody = z.infer<
   typeof PatchAgentMemoryRequestBodySchema
 >;
 
@@ -77,19 +75,20 @@ async function handler(
 
   switch (req.method) {
     case "PATCH": {
-      const bodyValidation = PatchAgentMemoryRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = PatchAgentMemoryRequestBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
-      const { content } = bodyValidation.right;
+      const { content } = bodyValidation.data;
 
       // Update the memory content
       await memory.updateContent(auth, content);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -8,29 +8,24 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { TagType } from "@app/types/tag";
 import { isBuilder } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-// Changed schema to accept optional add/remove lists
-export const PatchAgentTagsRequestBodySchema = t.intersection([
-  t.partial({
-    addTagIds: t.array(t.string),
-    removeTagIds: t.array(t.string),
-  }),
-  t.refinement(
-    t.partial({
-      addTagIds: t.array(t.string),
-      removeTagIds: t.array(t.string),
-    }),
+export const PatchAgentTagsRequestBodySchema = z
+  .object({
+    addTagIds: z.array(z.string()).optional(),
+    removeTagIds: z.array(z.string()).optional(),
+  })
+  .refine(
     (body) =>
       (body.addTagIds?.length ?? 0) > 0 || (body.removeTagIds?.length ?? 0) > 0,
-    "Either addTagIds or removeTagIds must be provided and contain at least one ID."
-  ),
-]);
+    {
+      message:
+        "Either addTagIds or removeTagIds must be provided and contain at least one ID.",
+    }
+  );
 
-export type PatchAgentTagsRequestBody = t.TypeOf<
+export type PatchAgentTagsRequestBody = z.infer<
   typeof PatchAgentTagsRequestBodySchema
 >;
 
@@ -72,19 +67,20 @@ async function handler(
         });
       }
 
-      const bodyValidation = PatchAgentTagsRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = PatchAgentTagsRequestBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
-      const { addTagIds = [], removeTagIds = [] } = bodyValidation.right;
+      const { addTagIds = [], removeTagIds = [] } = bodyValidation.data;
 
       const tagsToAdd = await TagResource.fetchByIds(auth, addTagIds);
       const tagsToRemove = await TagResource.fetchByIds(auth, removeTagIds);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -10,10 +10,8 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import { TriggerSchema } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export interface GetTriggersResponseBody {
   triggers: (TriggerType & {
@@ -23,24 +21,24 @@ export interface GetTriggersResponseBody {
   })[];
 }
 
-const DeleteTriggersRequestBodyCodec = t.type({
-  triggerIds: t.array(t.string),
+const DeleteTriggersRequestBodyCodec = z.object({
+  triggerIds: z.array(z.string()),
 });
-export type DeleteTriggersRequestBody = t.TypeOf<
+export type DeleteTriggersRequestBody = z.infer<
   typeof DeleteTriggersRequestBodyCodec
 >;
 
-const PatchTriggersRequestBodyCodec = t.type({
-  triggers: t.array(t.intersection([t.type({ sId: t.string }), TriggerSchema])),
+const PatchTriggersRequestBodyCodec = z.object({
+  triggers: z.array(z.object({ sId: z.string() }).and(TriggerSchema)),
 });
-export type PatchTriggersRequestBody = t.TypeOf<
+export type PatchTriggersRequestBody = z.infer<
   typeof PatchTriggersRequestBodyCodec
 >;
 
-const PostTriggersRequestBodyCodec = t.type({
-  triggers: t.array(TriggerSchema),
+const PostTriggersRequestBodyCodec = z.object({
+  triggers: z.array(TriggerSchema),
 });
-export type PostTriggersRequestBody = t.TypeOf<
+export type PostTriggersRequestBody = z.infer<
   typeof PostTriggersRequestBodyCodec
 >;
 
@@ -122,19 +120,18 @@ async function handler(
     }
 
     case "DELETE": {
-      const deleteDecoded = DeleteTriggersRequestBodyCodec.decode(req.body);
-      if (isLeft(deleteDecoded)) {
-        const pathError = reporter.formatValidationErrors(deleteDecoded.left);
+      const deleteDecoded = DeleteTriggersRequestBodyCodec.safeParse(req.body);
+      if (!deleteDecoded.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${deleteDecoded.error.message}`,
           },
         });
       }
 
-      const { triggerIds } = deleteDecoded.right;
+      const { triggerIds } = deleteDecoded.data;
       const workspace = auth.getNonNullableWorkspace();
 
       // Batch delete triggers
@@ -184,19 +181,18 @@ async function handler(
         });
       }
 
-      const patchDecoded = PatchTriggersRequestBodyCodec.decode(req.body);
-      if (isLeft(patchDecoded)) {
-        const pathError = reporter.formatValidationErrors(patchDecoded.left);
+      const patchDecoded = PatchTriggersRequestBodyCodec.safeParse(req.body);
+      if (!patchDecoded.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${patchDecoded.error.message}`,
           },
         });
       }
 
-      const { triggers } = patchDecoded.right;
+      const { triggers } = patchDecoded.data;
       const workspace = auth.getNonNullableWorkspace();
 
       // Batch update triggers
@@ -209,25 +205,22 @@ async function handler(
           continue; // Skip triggers that the user cannot edit
         }
 
-        const triggerValidation = TriggerSchema.decode({
+        const triggerValidation = TriggerSchema.safeParse({
           ...triggerData,
           editor: auth.getNonNullableUser().id,
         });
 
-        if (isLeft(triggerValidation)) {
-          const pathError = reporter.formatValidationErrors(
-            triggerValidation.left
-          );
+        if (!triggerValidation.success) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid trigger data: ${pathError}`,
+              message: `Invalid trigger data: ${triggerValidation.error.message}`,
             },
           });
         }
 
-        const validatedTrigger = triggerValidation.right;
+        const validatedTrigger = triggerValidation.data;
 
         const webhookSourceViewId = isWebhookTriggerData(validatedTrigger)
           ? getResourceIdFromSId(validatedTrigger.webhookSourceViewSId)
@@ -278,42 +271,38 @@ async function handler(
         });
       }
 
-      const postDecoded = PostTriggersRequestBodyCodec.decode(req.body);
-      if (isLeft(postDecoded)) {
-        const pathError = reporter.formatValidationErrors(postDecoded.left);
+      const postDecoded = PostTriggersRequestBodyCodec.safeParse(req.body);
+      if (!postDecoded.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${postDecoded.error.message}`,
           },
         });
       }
 
-      const { triggers } = postDecoded.right;
+      const { triggers } = postDecoded.data;
       const workspace = auth.getNonNullableWorkspace();
 
       // Batch create triggers
       for (const triggerData of triggers) {
-        const triggerValidation = TriggerSchema.decode({
+        const triggerValidation = TriggerSchema.safeParse({
           ...triggerData,
           editor: auth.getNonNullableUser().id,
         });
 
-        if (isLeft(triggerValidation)) {
-          const pathError = reporter.formatValidationErrors(
-            triggerValidation.left
-          );
+        if (!triggerValidation.success) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid trigger data: ${pathError}`,
+              message: `Invalid trigger data: ${triggerValidation.error.message}`,
             },
           });
         }
 
-        const validatedTrigger = triggerValidation.right;
+        const validatedTrigger = triggerValidation.data;
 
         const webhookSourceViewId = isWebhookTriggerData(validatedTrigger)
           ? getResourceIdFromSId(validatedTrigger.webhookSourceViewSId)

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -8,14 +8,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const BatchUpdateAgentScopeRequestBodySchema = t.type({
-  agentIds: t.array(t.string),
-  scope: t.union([t.literal("hidden"), t.literal("visible")]),
+const BatchUpdateAgentScopeRequestBodySchema = z.object({
+  agentIds: z.array(z.string()),
+  scope: z.enum(["hidden", "visible"]),
 });
 
 type BatchUpdateAgentTagsResponseBody = {
@@ -47,21 +45,20 @@ async function handler(
     });
   }
 
-  const bodyValidation = BatchUpdateAgentScopeRequestBodySchema.decode(
+  const bodyValidation = BatchUpdateAgentScopeRequestBodySchema.safeParse(
     req.body
   );
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.reporter(bodyValidation);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError.join(", ")}`,
+        message: `Invalid request body: ${bodyValidation.error.message}`,
       },
     });
   }
 
-  const { agentIds, scope } = bodyValidation.right;
+  const { agentIds, scope } = bodyValidation.data;
 
   // Process agents concurrently
   await concurrentExecutor(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -6,15 +6,13 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const BatchUpdateAgentTagsRequestBodySchema = t.type({
-  agentIds: t.array(t.string),
-  addTagIds: t.union([t.array(t.string), t.undefined]),
-  removeTagIds: t.union([t.array(t.string), t.undefined]),
+const BatchUpdateAgentTagsRequestBodySchema = z.object({
+  agentIds: z.array(z.string()),
+  addTagIds: z.array(z.string()).optional(),
+  removeTagIds: z.array(z.string()).optional(),
 });
 
 type BatchUpdateAgentTagsResponseBody = {
@@ -36,19 +34,20 @@ async function handler(
     });
   }
 
-  const bodyValidation = BatchUpdateAgentTagsRequestBodySchema.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.reporter(bodyValidation);
+  const bodyValidation = BatchUpdateAgentTagsRequestBodySchema.safeParse(
+    req.body
+  );
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError.join(", ")}`,
+        message: `Invalid request body: ${bodyValidation.error.message}`,
       },
     });
   }
 
-  const { agentIds, addTagIds = [], removeTagIds = [] } = bodyValidation.right;
+  const { agentIds, addTagIds = [], removeTagIds = [] } = bodyValidation.data;
 
   // Fetch all tags
   const tagsToAdd = await TagResource.fetchByIds(auth, addTagIds);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -7,17 +7,15 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type PostAgentConfigurationArchiveResponseBody = {
   archived: number;
 };
 
-export const PostAgentConfigurationArchive = t.type({
-  agentConfigurationIds: t.array(t.string),
+export const PostAgentConfigurationArchive = z.object({
+  agentConfigurationIds: z.array(z.string()),
 });
 
 async function handler(
@@ -29,20 +27,18 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST":
-      const bodyValidation = PostAgentConfigurationArchive.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      const bodyValidation = PostAgentConfigurationArchive.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
-      const { agentConfigurationIds } = bodyValidation.right;
+      const { agentConfigurationIds } = bodyValidation.data;
 
       const agentConfigurations = await getAgentConfigurations(auth, {
         agentIds: agentConfigurationIds,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -158,8 +158,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
 import uniq from "lodash/uniq";
@@ -188,20 +186,19 @@ async function handler(
   switch (req.method) {
     case "GET":
       // extract the view from the query parameters
-      const queryValidation = GetAgentConfigurationsQuerySchema.decode({
+      const queryValidation = GetAgentConfigurationsQuerySchema.safeParse({
         ...req.query,
         limit:
           typeof req.query.limit === "string"
             ? parseInt(req.query.limit, 10)
             : undefined,
       });
-      if (isLeft(queryValidation)) {
-        const pathError = reporter.formatValidationErrors(queryValidation.left);
+      if (!queryValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid query parameters: ${pathError}`,
+            message: `Invalid query parameters: ${queryValidation.error.message}`,
           },
         });
       }
@@ -214,7 +211,7 @@ async function handler(
         withFeedbacks,
         withEditors,
         sort,
-      } = queryValidation.right;
+      } = queryValidation.data;
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       let viewParam = view ? view : "all";
       // @ts-expect-error: added for backwards compatibility
@@ -332,21 +329,20 @@ async function handler(
         });
       }
       const bodyValidation =
-        PostOrPatchAgentConfigurationRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        PostOrPatchAgentConfigurationRequestBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
       const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
         auth,
-        assistant: bodyValidation.right.assistant,
+        assistant: bodyValidation.data.assistant,
       });
 
       if (agentConfigurationRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
@@ -4,13 +4,11 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const GetLookupRequestSchema = t.type({
-  handle: t.string,
+const GetLookupRequestSchema = z.object({
+  handle: z.string(),
 });
 
 type GetLookupResponseBody = {
@@ -24,20 +22,18 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const bodyValidation = GetLookupRequestSchema.decode(req.query);
+      const bodyValidation = GetLookupRequestSchema.safeParse(req.query);
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
-      const sId = await getAgentSIdFromName(auth, bodyValidation.right.handle);
+      const sId = await getAgentSIdFromName(auth, bodyValidation.data.handle);
       if (!sId) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -4,17 +4,15 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type GetAgentNameIsAvailableResponseBody = {
   available: boolean;
 };
 
-export const GetAgentConfigurationNameIsAvailable = t.type({
-  handle: t.string,
+export const GetAgentConfigurationNameIsAvailable = z.object({
+  handle: z.string(),
 });
 
 async function handler(
@@ -26,22 +24,20 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const bodyValidation = GetAgentConfigurationNameIsAvailable.decode(
+      const bodyValidation = GetAgentConfigurationNameIsAvailable.safeParse(
         req.query
       );
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
-      const sId = await getAgentSIdFromName(auth, bodyValidation.right.handle);
+      const sId = await getAgentSIdFromName(auth, bodyValidation.data.handle);
       const available = sId === null;
       return res.status(200).json({ available });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -7,17 +7,15 @@ import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import uniqueId from "lodash/uniqueId";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const PostAgentConfigurationFromYAMLRequestBodySchema = t.type({
-  yamlContent: t.string,
+const PostAgentConfigurationFromYAMLRequestBodySchema = z.object({
+  yamlContent: z.string(),
 });
 
-export type PostAgentConfigurationFromYAMLRequestBody = t.TypeOf<
+export type PostAgentConfigurationFromYAMLRequestBody = z.infer<
   typeof PostAgentConfigurationFromYAMLRequestBodySchema
 >;
 
@@ -58,21 +56,19 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostAgentConfigurationFromYAMLRequestBodySchema.decode(
-    req.body
-  );
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation =
+    PostAgentConfigurationFromYAMLRequestBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${bodyValidation.error.message}`,
       },
     });
   }
 
-  const { yamlContent } = bodyValidation.right;
+  const { yamlContent } = bodyValidation.data;
 
   const yamlConfigResult = AgentYAMLConverter.fromYAMLString(yamlContent);
   if (yamlConfigResult.isErr()) {

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -1,222 +1,198 @@
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import { isSupportedModel } from "@app/types/assistant/assistant";
-import { ModelIdCodec } from "@app/types/assistant/models/models";
-import { ModelProviderIdCodec } from "@app/types/assistant/models/providers";
-import { ReasoningEffortCodec } from "@app/types/assistant/models/reasoning";
+import { ModelIdSchema } from "@app/types/assistant/models/models";
+import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
+import { ReasoningEffortSchema } from "@app/types/assistant/models/reasoning";
 import type { SupportedModel } from "@app/types/assistant/models/types";
-import { createRangeCodec } from "@app/types/shared/utils/iots_utils";
-import { TimeframeUnitCodec } from "@app/types/shared/utils/time_frame";
-import * as t from "io-ts";
+import { TimeframeUnitSchema } from "@app/types/shared/utils/time_frame";
 import type { JSONSchema7 } from "json-schema";
+import { z } from "zod";
 
-const LimitCodec = createRangeCodec(0, 100);
+const LimitSchema = z.number().min(0).max(100);
 
 // Get schema for the url query parameters: a view parameter with all the types
 // of AgentGetViewType
-export const GetAgentConfigurationsQuerySchema = t.type({
-  view: t.union([
-    t.literal("admin_internal"),
-    t.literal("all"),
-    t.literal("archived"),
-    t.literal("current_user"),
-    t.literal("global"),
-    t.literal("list"),
-    t.literal("manage"),
-    t.literal("published"),
-    t.literal("workspace"),
-    t.undefined,
-  ]),
-  withUsage: t.union([t.literal("true"), t.literal("false"), t.undefined]),
-  withAuthors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
-  withEditors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
-  withFeedbacks: t.union([t.literal("true"), t.literal("false"), t.undefined]),
-  limit: t.union([LimitCodec, t.undefined]),
-  sort: t.union([
-    t.literal("priority"),
-    t.literal("alphabetical"),
-    t.undefined,
-  ]),
+export const GetAgentConfigurationsQuerySchema = z.object({
+  view: z
+    .enum([
+      "admin_internal",
+      "all",
+      "archived",
+      "current_user",
+      "global",
+      "list",
+      "manage",
+      "published",
+      "workspace",
+    ])
+    .optional(),
+  withUsage: z.enum(["true", "false"]).optional(),
+  withAuthors: z.enum(["true", "false"]).optional(),
+  withEditors: z.enum(["true", "false"]).optional(),
+  withFeedbacks: z.enum(["true", "false"]).optional(),
+  limit: LimitSchema.optional(),
+  sort: z.enum(["priority", "alphabetical"]).optional(),
 });
 
-export const GetAgentConfigurationsHistoryQuerySchema = t.type({
-  limit: t.union([LimitCodec, t.undefined]),
+export const GetAgentConfigurationsHistoryQuerySchema = z.object({
+  limit: LimitSchema.optional(),
 });
 
 // Data sources
 
-const DataSourceFilterParentsCodec = t.union([
-  t.type({
-    in: t.union([t.array(t.string), t.null]),
-    not: t.union([t.array(t.string), t.null]),
-  }),
-  t.null,
-]);
+const DataSourceFilterParentsSchema = z
+  .object({
+    in: z.array(z.string()).nullable(),
+    not: z.array(z.string()).nullable(),
+  })
+  .nullable();
 
-const OptionalDataSourceFilterTagsCodec = t.partial({
-  tags: t.union([
-    t.type({
-      in: t.array(t.string),
-      not: t.array(t.string),
-      mode: t.union([t.literal("custom"), t.literal("auto")]),
-    }),
-    t.null,
-  ]),
+const DataSourceFilterTagsSchema = z
+  .object({
+    in: z.array(z.string()),
+    not: z.array(z.string()),
+    mode: z.enum(["custom", "auto"]),
+  })
+  .nullable()
+  .optional();
+
+const DataSourceFilterSchema = z.object({
+  parents: DataSourceFilterParentsSchema,
+  tags: DataSourceFilterTagsSchema,
 });
 
-const DataSourceFilterCodec = t.intersection([
-  t.type({ parents: DataSourceFilterParentsCodec }),
-  OptionalDataSourceFilterTagsCodec,
-]);
-
-const DataSourcesConfigurationsCodec = t.array(
-  t.type({
-    dataSourceViewId: t.string,
-    workspaceId: t.string,
-    filter: DataSourceFilterCodec,
+const DataSourcesConfigurationsSchema = z.array(
+  z.object({
+    dataSourceViewId: z.string(),
+    workspaceId: z.string(),
+    filter: DataSourceFilterSchema,
   })
 );
-export type DataSourcesConfigurationsCodecType = t.TypeOf<
-  typeof DataSourcesConfigurationsCodec
+export type DataSourcesConfigurationsCodecType = z.infer<
+  typeof DataSourcesConfigurationsSchema
 >;
 
 // Tables
 
-const TablesConfigurationsCodec = t.array(
-  t.type({
-    dataSourceViewId: t.string,
-    tableId: t.string,
-    workspaceId: t.string,
+const TablesConfigurationsSchema = z.array(
+  z.object({
+    dataSourceViewId: z.string(),
+    tableId: z.string(),
+    workspaceId: z.string(),
   })
 );
 
 // Projects
 
-const ProjectConfigurationCodec = t.type({
-  workspaceId: t.string,
-  projectId: t.string,
+const ProjectConfigurationSchema = z.object({
+  workspaceId: z.string(),
+  projectId: z.string(),
 });
 
 // Actions
 
-const DustAppRunActionConfigurationSchema = t.type({
-  type: t.literal("dust_app_run_configuration"),
-  appWorkspaceId: t.string,
-  appId: t.string,
+const DustAppRunActionConfigurationSchema = z.object({
+  type: z.literal("dust_app_run_configuration"),
+  appWorkspaceId: z.string(),
+  appId: z.string(),
 });
 
-const JsonSchemaCodec = new t.Type<JSONSchema7, unknown, unknown>(
-  "JsonSchema",
-  (u): u is JSONSchema7 => {
-    if (typeof u !== "object" || u === null) {
+const JsonSchemaSchema = z.custom<JSONSchema7>(
+  (val) => {
+    if (typeof val !== "object" || val === null) {
       return false;
     }
-    return validateJsonSchema(JSON.stringify(u)).isValid;
+    return validateJsonSchema(JSON.stringify(val)).isValid;
   },
-  (u, c) => {
-    if (typeof u !== "object" || u === null) {
-      return t.failure(u, c, "Invalid JSON schema");
-    }
-    const validation = validateJsonSchema(JSON.stringify(u));
-    return validation.isValid
-      ? t.success(u as JSONSchema7)
-      : t.failure(u, c, validation.error ?? "Invalid JSON schema");
-  },
-  t.identity
+  { message: "Invalid JSON schema" }
 );
 
-const MCPServerActionConfigurationSchema = t.type({
-  type: t.literal("mcp_server_configuration"),
-  mcpServerViewId: t.string,
-  name: t.string,
-  description: t.union([t.string, t.null]),
-  dataSources: t.union([t.null, DataSourcesConfigurationsCodec]),
-  tables: t.union([t.null, TablesConfigurationsCodec]),
-  childAgentId: t.union([t.null, t.string]),
-  timeFrame: t.union([
-    t.null,
-    t.type({
-      duration: t.number,
-      unit: TimeframeUnitCodec,
-    }),
-  ]),
-  jsonSchema: t.union([JsonSchemaCodec, t.null]),
-  additionalConfiguration: t.record(
-    t.string,
-    t.union([t.boolean, t.number, t.string, t.array(t.string), t.null])
+const MCPServerActionConfigurationSchema = z.object({
+  type: z.literal("mcp_server_configuration"),
+  mcpServerViewId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  dataSources: DataSourcesConfigurationsSchema.nullable(),
+  tables: TablesConfigurationsSchema.nullable(),
+  childAgentId: z.string().nullable(),
+  timeFrame: z
+    .object({
+      duration: z.number(),
+      unit: TimeframeUnitSchema,
+    })
+    .nullable(),
+  jsonSchema: JsonSchemaSchema.nullable(),
+  additionalConfiguration: z.record(
+    z.string(),
+    z.union([
+      z.boolean(),
+      z.number(),
+      z.string(),
+      z.array(z.string()),
+      z.null(),
+    ])
   ),
-  dustAppConfiguration: t.union([DustAppRunActionConfigurationSchema, t.null]),
-  secretName: t.union([t.string, t.null]),
-  dustProject: t.union([t.null, ProjectConfigurationCodec]),
+  dustAppConfiguration: DustAppRunActionConfigurationSchema.nullable(),
+  secretName: z.string().nullable(),
+  dustProject: ProjectConfigurationSchema.nullable(),
 });
 
-const multiActionsCommonFields = {
-  name: t.union([t.string, t.null]),
-  description: t.union([t.string, t.null]),
-};
+const ModelConfigurationSchema = z
+  .object({
+    modelId: ModelIdSchema,
+    providerId: ModelProviderIdSchema,
+    temperature: z.number(),
+  })
+  .extend({
+    // TODO(2024-11-04 flav) Clean up this legacy type.
+    name: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    reasoningEffort: ReasoningEffortSchema.optional(),
+    responseFormat: z.string().optional(),
+  });
 
-const ModelConfigurationSchema = t.intersection([
-  t.type({
-    modelId: ModelIdCodec,
-    providerId: ModelProviderIdCodec,
-    temperature: t.number,
-  }),
-  // TODO(2024-11-04 flav) Clean up this legacy type.
-  t.partial(multiActionsCommonFields),
-  t.partial({
-    reasoningEffort: ReasoningEffortCodec,
-  }),
-  t.partial({ responseFormat: t.string }),
-]);
-const IsSupportedModelSchema = new t.Type<SupportedModel>(
-  "SupportedModel",
-  isSupportedModel,
-  (i, c) => (isSupportedModel(i) ? t.success(i) : t.failure(i, c)),
-  t.identity
+const IsSupportedModelSchema = z.custom<SupportedModel>(
+  (val) => isSupportedModel(val),
+  { message: "Unsupported model" }
 );
 
-const TagSchema = t.type({
-  sId: t.string,
-  name: t.string,
-  kind: t.union([t.literal("standard"), t.literal("protected")]),
+const TagSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+  kind: z.enum(["standard", "protected"]),
 });
 
-const EditorSchema = t.type({
-  sId: t.string,
+const EditorSchema = z.object({
+  sId: z.string(),
 });
 
-const SkillSchema = t.type({
-  sId: t.string,
+const SkillSchema = z.object({
+  sId: z.string(),
 });
 
-export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
-  assistant: t.intersection([
-    t.type({
-      name: t.string,
-      description: t.string,
-      instructions: t.union([t.string, t.null]),
-      pictureUrl: t.string,
-      status: t.union([
-        t.literal("active"),
-        t.literal("archived"),
-        t.literal("draft"),
-        t.literal("pending"),
-      ]),
-      scope: t.union([t.literal("hidden"), t.literal("visible")]),
-      model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),
-      actions: t.array(MCPServerActionConfigurationSchema),
-      templateId: t.union([t.string, t.null, t.undefined]),
-      tags: t.array(TagSchema),
-      editors: t.array(EditorSchema),
-    }),
-    t.partial({
+export const PostOrPatchAgentConfigurationRequestBodySchema = z.object({
+  assistant: z
+    .object({
+      name: z.string(),
+      description: z.string(),
+      instructions: z.string().nullable(),
+      pictureUrl: z.string(),
+      status: z.enum(["active", "archived", "draft", "pending"]),
+      scope: z.enum(["hidden", "visible"]),
+      model: ModelConfigurationSchema.and(IsSupportedModelSchema),
+      actions: z.array(MCPServerActionConfigurationSchema),
+      templateId: z.string().nullable().optional(),
+      tags: z.array(TagSchema),
+      editors: z.array(EditorSchema),
+    })
+    .extend({
       // temporary partial so opened windows can save without refreshing
-      skills: t.array(SkillSchema),
-      additionalRequestedSpaceIds: t.array(t.string),
-      instructionsHtml: t.union([t.string, t.null]),
+      skills: z.array(SkillSchema).optional(),
+      additionalRequestedSpaceIds: z.array(z.string()).optional(),
+      instructionsHtml: z.string().nullable().optional(),
     }),
-  ]),
 });
 
-export type PostOrPatchAgentConfigurationRequestBody = t.TypeOf<
+export type PostOrPatchAgentConfigurationRequestBody = z.infer<
   typeof PostOrPatchAgentConfigurationRequestBodySchema
 >;

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -1,5 +1,6 @@
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { ioTsEnum } from "@app/types/shared/utils/iots_utils";
+import { z } from "zod";
 
 import {
   CLAUDE_3_5_HAIKU_20241022_MODEL_ID,
@@ -226,6 +227,13 @@ export const isModelId = (modelId: string): modelId is ModelIdType =>
   MODEL_IDS.includes(modelId as ModelIdType);
 
 export const ModelIdCodec = ioTsEnum<(typeof MODEL_IDS)[number]>(MODEL_IDS);
+
+// Note: MODEL_IDS includes dynamic custom models from GCS, so we use z.custom
+// with the isModelId guard rather than z.enum (which requires a static tuple).
+export const ModelIdSchema = z.custom<ModelIdType>(
+  (val) => typeof val === "string" && isModelId(val),
+  { message: "Invalid model ID" }
+);
 
 // Image generation model IDs (internal-only, not user-selectable)
 export const IMAGE_MODEL_IDS = [GEMINI_3_PRO_IMAGE_MODEL_ID] as const;

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -3,6 +3,7 @@ import type {
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
 import { ioTsEnum } from "@app/types/shared/utils/iots_utils";
+import { z } from "zod";
 
 /**
  * PROVIDER IDS
@@ -57,6 +58,7 @@ export const isModelProviderId = (
   MODEL_PROVIDER_IDS.includes(providerId as ModelProviderIdType);
 export const ModelProviderIdCodec =
   ioTsEnum<(typeof MODEL_PROVIDER_IDS)[number]>(MODEL_PROVIDER_IDS);
+export const ModelProviderIdSchema = z.enum(MODEL_PROVIDER_IDS);
 export const isByokProviderId = (
   providerId: ModelProviderIdType
 ): providerId is ByokModelProviderIdType =>

--- a/front/types/assistant/models/reasoning.ts
+++ b/front/types/assistant/models/reasoning.ts
@@ -1,5 +1,6 @@
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { ioTsEnum } from "@app/types/shared/utils/iots_utils";
+import { z } from "zod";
 
 export const REASONING_EFFORTS = ["none", "light", "medium", "high"] as const;
 
@@ -10,3 +11,4 @@ export const isReasoningEffort = (
 
 export const ReasoningEffortCodec =
   ioTsEnum<(typeof REASONING_EFFORTS)[number]>(REASONING_EFFORTS);
+export const ReasoningEffortSchema = z.enum(REASONING_EFFORTS);

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -1,7 +1,7 @@
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { UserType } from "@app/types/user";
-import * as t from "io-ts";
+import { z } from "zod";
 
 export type ScheduleConfig = {
   cron: string;
@@ -104,55 +104,38 @@ export function isScheduleTrigger(
   return trigger.kind === "schedule";
 }
 
-const ScheduleConfigSchema = t.type({
-  cron: t.string,
-  timezone: t.string,
+const ScheduleConfigSchema = z.object({
+  cron: z.string(),
+  timezone: z.string(),
 });
 
-const WebhookConfigSchema = t.intersection([
-  t.type({
-    includePayload: t.boolean,
-  }),
-  t.partial({
-    event: t.string,
-    filter: t.string,
-  }),
-]);
+const WebhookConfigSchema = z.object({
+  includePayload: z.boolean(),
+  event: z.string().optional(),
+  filter: z.string().optional(),
+});
 
-const TriggerStatusSchema = t.union([
-  t.literal("enabled"),
-  t.literal("disabled"),
-  t.literal("relocating"),
-  t.literal("downgraded"),
-]);
+const TriggerStatusSchema = z.enum(TRIGGER_STATUSES);
 
-export const TriggerSchema = t.union([
-  t.intersection([
-    t.type({
-      name: t.string,
-      kind: t.literal("schedule"),
-      customPrompt: t.string,
-      naturalLanguageDescription: t.union([t.string, t.null]),
-      configuration: ScheduleConfigSchema,
-      editor: t.union([t.number, t.undefined]),
-    }),
-    t.partial({
-      status: TriggerStatusSchema,
-    }),
-  ]),
-  t.intersection([
-    t.type({
-      name: t.string,
-      kind: t.literal("webhook"),
-      customPrompt: t.string,
-      naturalLanguageDescription: t.union([t.string, t.null]),
-      configuration: WebhookConfigSchema,
-      webhookSourceViewSId: t.string,
-      executionPerDayLimitOverride: t.number,
-      editor: t.union([t.number, t.undefined]),
-    }),
-    t.partial({
-      status: TriggerStatusSchema,
-    }),
-  ]),
+export const TriggerSchema = z.discriminatedUnion("kind", [
+  z.object({
+    name: z.string(),
+    kind: z.literal("schedule"),
+    customPrompt: z.string(),
+    naturalLanguageDescription: z.string().nullable(),
+    configuration: ScheduleConfigSchema,
+    editor: z.number().optional(),
+    status: TriggerStatusSchema.optional(),
+  }),
+  z.object({
+    name: z.string(),
+    kind: z.literal("webhook"),
+    customPrompt: z.string(),
+    naturalLanguageDescription: z.string().nullable(),
+    configuration: WebhookConfigSchema,
+    webhookSourceViewSId: z.string(),
+    executionPerDayLimitOverride: z.number(),
+    editor: z.number().optional(),
+    status: TriggerStatusSchema.optional(),
+  }),
 ]);

--- a/front/types/shared/utils/time_frame.ts
+++ b/front/types/shared/utils/time_frame.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { ioTsEnum } from "./iots_utils";
 
 export const TIME_FRAME_UNITS = [
@@ -9,6 +11,7 @@ export const TIME_FRAME_UNITS = [
 ] as const;
 export type TimeframeUnit = (typeof TIME_FRAME_UNITS)[number];
 export const TimeframeUnitCodec = ioTsEnum<TimeframeUnit>(TIME_FRAME_UNITS);
+export const TimeframeUnitSchema = z.enum(TIME_FRAME_UNITS);
 
 export type TimeFrame = {
   duration: number;


### PR DESCRIPTION
## Description

Part of the Dust API standalone server migration ([Notion](https://www.notion.so/dust-tt/Dust-API-as-a-standalone-server-2e928599d941809babd5e171169d364e)).

**Goal**: Define zod schemas for all API request/input validation in `agent_configurations` endpoints, as a prerequisite to:
1. Auto-generating Swagger/OpenAPI documentation from zod schemas
2. Using hono + zod-validator for type-safe route definitions

Replaces io-ts with zod for **request/input validation** across all `pages/api/w/[wId]/assistant/agent_configurations/` endpoints:

- Rewrites `types/api/internal/agent_configuration.ts` from io-ts to zod (`GetAgentConfigurationsQuerySchema`, `PostOrPatchAgentConfigurationRequestBodySchema`, etc.)
- Rewrites `types/assistant/triggers.ts` input `TriggerSchema` from io-ts to zod (using `z.discriminatedUnion`)
- Converts all 15 API route files from `codec.decode()` + `isLeft()` + `io-ts-reporters` to `schema.safeParse()` + `!success` + `error.message`
- Adds zod schema equivalents alongside existing io-ts codecs for shared dependencies (`ModelIdSchema`, `ModelProviderIdSchema`, `ReasoningEffortSchema`, `TimeframeUnitSchema`)
- Removes all `io-ts` / `fp-ts` imports from the converted files

## Tests

- `npx tsgo --noEmit` passes with zero errors
- No behavioral changes — validation logic is equivalent

## Risk

Low. Zod `safeParse` produces the same accept/reject behavior as io-ts `decode`. Error messages may be formatted slightly differently.

## Deploy Plan

Standard deploy — no migration needed.