### PR TITLE
Assistant API : Use zod schemas for return types

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -10,7 +10,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { UserType } from "@app/types/user";
+import { UserSchema } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -33,13 +33,19 @@ export type PatchAgentEditorsRequestBody = z.infer<
   typeof PatchAgentEditorsRequestBodySchema
 >;
 
-export interface GetAgentEditorsResponseBody {
-  editors: UserType[];
-}
+export const GetAgentEditorsResponseBodySchema = z.object({
+  editors: z.array(UserSchema),
+});
+export type GetAgentEditorsResponseBody = z.infer<
+  typeof GetAgentEditorsResponseBodySchema
+>;
 
-export interface PatchAgentEditorsResponseBody {
-  editors: UserType[];
-}
+export const PatchAgentEditorsResponseBodySchema = z.object({
+  editors: z.array(UserSchema),
+});
+export type PatchAgentEditorsResponseBody = z.infer<
+  typeof PatchAgentEditorsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
@@ -6,11 +6,15 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationYAMLExportResponseBody = {
-  yamlContent: string;
-  filename: string;
-};
+export const GetAgentConfigurationYAMLExportResponseBodySchema = z.object({
+  yamlContent: z.string(),
+  filename: z.string(),
+});
+export type GetAgentConfigurationYAMLExportResponseBody = z.infer<
+  typeof GetAgentConfigurationYAMLExportResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -1,8 +1,10 @@
 /** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
-import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import {
+  AgentMessageFeedbackSchema,
+  getAgentFeedbacks,
+} from "@app/lib/api/assistant/feedback";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,14 +12,18 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+export const GetAgentFeedbacksResponseBodySchema = z.object({
+  feedbacks: z.array(AgentMessageFeedbackSchema),
+});
+export type GetAgentFeedbacksResponseBody = z.infer<
+  typeof GetAgentFeedbacksResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<{
-      feedbacks: AgentMessageFeedbackType[];
-    }>
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentFeedbacksResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
   const { aId } = req.query;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -7,13 +7,17 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { GetAgentConfigurationsHistoryQuerySchema } from "@app/types/api/internal/agent_configuration";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { LightAgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationsResponseBody = {
-  history: LightAgentConfigurationType[];
-};
+export const GetAgentConfigurationsResponseBodySchema = z.object({
+  history: z.array(LightAgentConfigurationSchema),
+});
+export type GetAgentConfigurationsResponseBody = z.infer<
+  typeof GetAgentConfigurationsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -10,16 +10,24 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/types/api/internal/agent_configuration";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { AgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationResponseBody = {
-  agentConfiguration: AgentConfigurationType;
-};
-export type DeleteAgentConfigurationResponseBody = {
-  success: boolean;
-};
+export const GetAgentConfigurationResponseBodySchema = z.object({
+  agentConfiguration: AgentConfigurationSchema,
+});
+export type GetAgentConfigurationResponseBody = z.infer<
+  typeof GetAgentConfigurationResponseBodySchema
+>;
+
+export const DeleteAgentConfigurationResponseBodySchema = z.object({
+  success: z.boolean(),
+});
+export type DeleteAgentConfigurationResponseBody = z.infer<
+  typeof DeleteAgentConfigurationResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
@@ -5,12 +5,16 @@ import type { Authenticator } from "@app/lib/auth";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserType } from "@app/types/user";
+import { UserSchema } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentLastAuthorResponseBody = {
-  user: UserType | null;
-};
+export const GetAgentLastAuthorResponseBodySchema = z.object({
+  user: UserSchema.nullable(),
+});
+export type GetAgentLastAuthorResponseBody = z.infer<
+  typeof GetAgentLastAuthorResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -12,9 +12,12 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PatchLinkedSlackChannelsResponseBody = {
-  success: true;
-};
+export const PatchLinkedSlackChannelsResponseBodySchema = z.object({
+  success: z.literal(true),
+});
+export type PatchLinkedSlackChannelsResponseBody = z.infer<
+  typeof PatchLinkedSlackChannelsResponseBodySchema
+>;
 
 export const PatchLinkedSlackChannelsRequestBodySchema = z.object({
   slack_channel_internal_ids: z.array(z.string()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
@@ -1,16 +1,22 @@
 /** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { AgentMcpConfigurationSummary } from "@app/lib/api/assistant/mcp_configurations";
-import { listAgentMcpConfigurationsForAgent } from "@app/lib/api/assistant/mcp_configurations";
+import {
+  AgentMcpConfigurationSummarySchema,
+  listAgentMcpConfigurationsForAgent,
+} from "@app/lib/api/assistant/mcp_configurations";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentMcpConfigurationsResponseBody = {
-  configurations: AgentMcpConfigurationSummary[];
-};
+export const GetAgentMcpConfigurationsResponseBodySchema = z.object({
+  configurations: z.array(AgentMcpConfigurationSummarySchema),
+});
+export type GetAgentMcpConfigurationsResponseBody = z.infer<
+  typeof GetAgentMcpConfigurationsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -16,13 +16,16 @@ export type PatchAgentMemoryRequestBody = z.infer<
   typeof PatchAgentMemoryRequestBodySchema
 >;
 
-export interface PatchAgentMemoryResponseBody {
-  memory: {
-    sId: string;
-    lastUpdated: Date;
-    content: string;
-  };
-}
+export const PatchAgentMemoryResponseBodySchema = z.object({
+  memory: z.object({
+    sId: z.string(),
+    lastUpdated: z.date(),
+    content: z.string(),
+  }),
+});
+export type PatchAgentMemoryResponseBody = z.infer<
+  typeof PatchAgentMemoryResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
@@ -6,14 +6,20 @@ import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export interface GetAgentMemoriesResponseBody {
-  memories: Array<{
-    sId: string;
-    lastUpdated: Date;
-    content: string;
-  }>;
-}
+export const GetAgentMemoriesResponseBodySchema = z.object({
+  memories: z.array(
+    z.object({
+      sId: z.string(),
+      lastUpdated: z.date(),
+      content: z.string(),
+    })
+  ),
+});
+export type GetAgentMemoriesResponseBody = z.infer<
+  typeof GetAgentMemoriesResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -9,10 +9,14 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type RestoreAgentConfigurationResponseBody = {
-  success: true;
-};
+export const RestoreAgentConfigurationResponseBodySchema = z.object({
+  success: z.literal(true),
+});
+export type RestoreAgentConfigurationResponseBody = z.infer<
+  typeof RestoreAgentConfigurationResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -4,14 +4,18 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { SkillSchema } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export interface GetAgentSkillsResponseBody {
-  skills: SkillType[];
-}
+export const GetAgentSkillsResponseBodySchema = z.object({
+  skills: z.array(SkillSchema),
+});
+export type GetAgentSkillsResponseBody = z.infer<
+  typeof GetAgentSkillsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -7,10 +7,8 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type {
-  AgentSuggestionSource,
-  AgentSuggestionType,
-} from "@app/types/suggestions/agent_suggestion";
+import type { AgentSuggestionSource } from "@app/types/suggestions/agent_suggestion";
+import { AgentSuggestionSchema } from "@app/types/suggestions/agent_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -23,9 +21,12 @@ export type PatchSuggestionRequestBody = z.infer<
   typeof PatchSuggestionRequestBodySchema
 >;
 
-export interface PatchSuggestionResponseBody {
-  suggestions: AgentSuggestionType[];
-}
+export const PatchSuggestionResponseBodySchema = z.object({
+  suggestions: z.array(AgentSuggestionSchema),
+});
+export type PatchSuggestionResponseBody = z.infer<
+  typeof PatchSuggestionResponseBodySchema
+>;
 
 const StateSchema = z.enum(["pending", "approved", "rejected", "outdated"]);
 
@@ -43,9 +44,12 @@ const GetSuggestionsQuerySchema = z.object({
 
 export type GetSuggestionsQuery = z.infer<typeof GetSuggestionsQuerySchema>;
 
-export interface GetSuggestionsResponseBody {
-  suggestions: AgentSuggestionType[];
-}
+export const GetSuggestionsResponseBodySchema = z.object({
+  suggestions: z.array(AgentSuggestionSchema),
+});
+export type GetSuggestionsResponseBody = z.infer<
+  typeof GetSuggestionsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -6,7 +6,7 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { TagType } from "@app/types/tag";
+import { TagSchema } from "@app/types/tag";
 import { isBuilder } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -29,9 +29,12 @@ export type PatchAgentTagsRequestBody = z.infer<
   typeof PatchAgentTagsRequestBodySchema
 >;
 
-export interface PatchAgentTagsResponseBody {
-  tags: TagType[];
-}
+export const PatchAgentTagsResponseBodySchema = z.object({
+  tags: z.array(TagSchema),
+});
+export type PatchAgentTagsResponseBody = z.infer<
+  typeof PatchAgentTagsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -7,19 +7,28 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import type { TriggerType } from "@app/types/assistant/triggers";
-import { TriggerSchema } from "@app/types/assistant/triggers";
+import {
+  FullTriggerSchema,
+  TriggerSchema,
+} from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export interface GetTriggersResponseBody {
-  triggers: (TriggerType & {
-    isSubscriber: boolean;
-    isEditor: boolean;
-    editorName?: string;
-  })[];
-}
+export const GetTriggersResponseBodySchema = z.object({
+  triggers: z.array(
+    FullTriggerSchema.and(
+      z.object({
+        isSubscriber: z.boolean(),
+        isEditor: z.boolean(),
+        editorName: z.string().optional(),
+      })
+    )
+  ),
+});
+export type GetTriggersResponseBody = z.infer<
+  typeof GetTriggersResponseBodySchema
+>;
 
 const DeleteTriggersRequestBodyCodec = z.object({
   triggerIds: z.array(z.string()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -4,13 +4,17 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { AgentUsageType } from "@app/types/assistant/agent";
+import { AgentUsageSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentUsageResponseBody = {
-  agentUsage: AgentUsageType | null;
-};
+export const GetAgentUsageResponseBodySchema = z.object({
+  agentUsage: AgentUsageSchema.nullable(),
+});
+export type GetAgentUsageResponseBody = z.infer<
+  typeof GetAgentUsageResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -16,9 +16,12 @@ const BatchUpdateAgentScopeRequestBodySchema = z.object({
   scope: z.enum(["hidden", "visible"]),
 });
 
-type BatchUpdateAgentTagsResponseBody = {
-  success: boolean;
-};
+const BatchUpdateAgentTagsResponseBodySchema = z.object({
+  success: z.boolean(),
+});
+type BatchUpdateAgentTagsResponseBody = z.infer<
+  typeof BatchUpdateAgentTagsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
@@ -5,10 +5,14 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type PostPendingAgentResponseBody = {
-  sId: string;
-};
+export const PostPendingAgentResponseBodySchema = z.object({
+  sId: z.string(),
+});
+export type PostPendingAgentResponseBody = z.infer<
+  typeof PostPendingAgentResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -10,9 +10,12 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PostAgentConfigurationArchiveResponseBody = {
-  archived: number;
-};
+export const PostAgentConfigurationArchiveResponseBodySchema = z.object({
+  archived: z.number(),
+});
+export type PostAgentConfigurationArchiveResponseBody = z.infer<
+  typeof PostAgentConfigurationArchiveResponseBodySchema
+>;
 
 export const PostAgentConfigurationArchive = z.object({
   agentConfigurationIds: z.array(z.string()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -150,10 +150,8 @@ import {
   GetAgentConfigurationsQuerySchema,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@app/types/api/internal/agent_configuration";
-import type {
-  AgentConfigurationType,
-  LightAgentConfigurationType,
-} from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { LightAgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -162,13 +160,21 @@ import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationsResponseBody = {
-  agentConfigurations: LightAgentConfigurationType[];
-};
-export type PostAgentConfigurationResponseBody = {
-  agentConfiguration: LightAgentConfigurationType;
-};
+export const GetAgentConfigurationsResponseBodySchema = z.object({
+  agentConfigurations: z.array(LightAgentConfigurationSchema),
+});
+export type GetAgentConfigurationsResponseBody = z.infer<
+  typeof GetAgentConfigurationsResponseBodySchema
+>;
+
+export const PostAgentConfigurationResponseBodySchema = z.object({
+  agentConfiguration: LightAgentConfigurationSchema,
+});
+export type PostAgentConfigurationResponseBody = z.infer<
+  typeof PostAgentConfigurationResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
@@ -11,9 +11,10 @@ const GetLookupRequestSchema = z.object({
   handle: z.string(),
 });
 
-type GetLookupResponseBody = {
-  sId: string;
-};
+const GetLookupResponseBodySchema = z.object({
+  sId: z.string(),
+});
+type GetLookupResponseBody = z.infer<typeof GetLookupResponseBodySchema>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -7,9 +7,12 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type GetAgentNameIsAvailableResponseBody = {
-  available: boolean;
-};
+export const GetAgentNameIsAvailableResponseBodySchema = z.object({
+  available: z.boolean(),
+});
+export type GetAgentNameIsAvailableResponseBody = z.infer<
+  typeof GetAgentNameIsAvailableResponseBodySchema
+>;
 
 export const GetAgentConfigurationNameIsAvailable = z.object({
   handle: z.string(),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -5,7 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { AgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import uniqueId from "lodash/uniqueId";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -19,10 +19,15 @@ export type PostAgentConfigurationFromYAMLRequestBody = z.infer<
   typeof PostAgentConfigurationFromYAMLRequestBodySchema
 >;
 
-export type PostAgentConfigurationFromYAMLResponseBody = {
-  agentConfiguration: AgentConfigurationType;
-  skippedActions?: { name: string; reason: string }[];
-};
+export const PostAgentConfigurationFromYAMLResponseBodySchema = z.object({
+  agentConfiguration: AgentConfigurationSchema,
+  skippedActions: z
+    .array(z.object({ name: z.string(), reason: z.string() }))
+    .optional(),
+});
+export type PostAgentConfigurationFromYAMLResponseBody = z.infer<
+  typeof PostAgentConfigurationFromYAMLResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -13,10 +13,13 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PostTextAsCronRuleResponseBody = {
-  cronRule: string;
-  timezone: string;
-};
+export const PostTextAsCronRuleResponseBodySchema = z.object({
+  cronRule: z.string(),
+  timezone: z.string(),
+});
+export type PostTextAsCronRuleResponseBody = z.infer<
+  typeof PostTextAsCronRuleResponseBodySchema
+>;
 
 const PostTextAsCronRuleRequestBodySchema = z.object({
   naturalDescription: z.string(),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -12,9 +12,12 @@ import {
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PostWebhookFilterGeneratorResponseBody = {
-  filter: string;
-};
+export const PostWebhookFilterGeneratorResponseBodySchema = z.object({
+  filter: z.string(),
+});
+export type PostWebhookFilterGeneratorResponseBody = z.infer<
+  typeof PostWebhookFilterGeneratorResponseBodySchema
+>;
 
 const PostWebhookFilterGeneratorRequestBodySchema = z.object({
   naturalDescription: z.string(),


### PR DESCRIPTION
## Description

Part of the Dust API standalone server migration ([Notion](https://www.notion.so/dust-tt/Dust-API-as-a-standalone-server-2e928599d941809babd5e171169d364e)).

**Goal**: Define zod schemas for all API response bodies in `agent_configurations` endpoints. Together with the request schemas from PR #23250, this gives every endpoint a complete zod-based API contract (input + output), enabling:
1. Auto-generation of full Swagger/OpenAPI specs from zod (request params, request body, and response body)
2. Fully type-safe hono route definitions where both input validation and response typing come from zod schemas

### Response schemas added:
- `GetAgentConfigurationsResponseBodySchema`, `PostAgentConfigurationResponseBodySchema` (index.ts)
- `GetAgentConfigurationResponseBodySchema`, `DeleteAgentConfigurationResponseBodySchema` ([aId]/index.ts)
- `GetAgentConfigurationsResponseBodySchema` ([aId]/history/index.ts)
- `PostAgentConfigurationArchiveResponseBodySchema` (delete.ts)
- `GetAgentNameIsAvailableResponseBodySchema` (name_available.ts)
- `GetLookupResponseBodySchema` (lookup.ts)
- `BatchUpdateAgentTagsResponseBodySchema` (batch_update_scope.ts)
- `GetAgentEditorsResponseBodySchema`, `PatchAgentEditorsResponseBodySchema` (editors.ts)
- `PatchAgentTagsResponseBodySchema` (tags.ts)
- `PatchLinkedSlackChannelsResponseBodySchema` (linked_slack_channels.ts)
- `GetTriggersResponseBodySchema` (triggers/index.ts)
- `PatchAgentMemoryResponseBodySchema` (memories/[mId]/index.ts)
- `GetAgentMemoriesResponseBodySchema` (memories/index.ts)
- `GetAgentUsageResponseBodySchema` (usage.ts)
- `GetAgentLastAuthorResponseBodySchema` (last_author.ts)
- `RestoreAgentConfigurationResponseBodySchema` (restore.ts)
- `GetAgentMcpConfigurationsResponseBodySchema` (mcp_configurations.ts)
- `PostPendingAgentResponseBodySchema` (create-pending.ts)
- `PostTextAsCronRuleResponseBodySchema` (text_as_cron_rule.ts)
- `PostWebhookFilterGeneratorResponseBodySchema` (webhook_filter_generator.ts)
- `GetAgentConfigurationYAMLExportResponseBodySchema` (export/yaml.ts)
- `PostAgentConfigurationFromYAMLResponseBodySchema` (new/yaml.ts)
- `GetAgentSkillsResponseBodySchema` (skills.ts)
- `PatchSuggestionResponseBodySchema`, `GetSuggestionsResponseBodySchema` (suggestions.ts)
- `GetAgentFeedbacksResponseBodySchema` (feedbacks.ts)

All response schemas reference the shared type schemas from PR #23251 (e.g., `LightAgentConfigurationSchema`, `AgentConfigurationSchema`, `UserSchema`, `TagSchema`, etc.).

## Tests

- `npx tsgo --noEmit` passes with zero errors
- No behavioral changes — response types are structurally identical

## Risk

Low. Only adds schemas and changes type definitions to use `z.infer` — the actual response payloads are unchanged.

## Deploy Plan

Standard deploy — no migration needed.