### PR TITLE
[Connectors] fix(microsoft): refresh OAuth token in authProvider to prevent expiry during long delta syncs

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -724,8 +724,24 @@ export async function getMicrosoftConnectionData(connectionId: string) {
     connectionId,
   });
 
+  // AuthProvider is called on every Graph API request. We fetch the token
+  // inside the callback (rather than closing over tokenData.access_token) so
+  // that long-running operations like delta sync get a refreshed token when
+  // the original one expires. The underlying call is backed by a 5min
+  // in-memory cache, so this doesn't cause extra network requests.
   const client = Client.init({
-    authProvider: (done) => done(null, tokenData.access_token),
+    authProvider: async (done) => {
+      try {
+        const { access_token } = await getOAuthConnectionAccessTokenWithThrow({
+          logger,
+          provider: "microsoft",
+          connectionId,
+        });
+        done(null, access_token);
+      } catch (e) {
+        done(e, null);
+      }
+    },
   });
 
   return {


### PR DESCRIPTION
## Summary

- The Microsoft Graph client's `authProvider` was closing over a stale access token fetched once at client creation time. During long-running delta sync operations, the token would expire causing crashes.
- Changed `authProvider` to fetch the token lazily on each Graph API request. The underlying `getOAuthConnectionAccessTokenWithThrow` is backed by a 5min in-memory cache, so this doesn't cause extra network requests.

## Context

[Slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1773749298440829)

[Stuck workflow](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/microsoft-incrementalSync-39331/019cf70e-92b2-7284-bb41-57326fd0a8bc/timeline)

[DD logs](https://app.datadoghq.eu/logs?query=@connectorId:39331%20@activityName:fetchDeltaForRootNodesInDrive&agg_m=count&agg_m_source=base&agg_t=count&analyticsOptions=%5B%22bars%22,%22dog_classic%22,null,null,%22value%22%5D&clustering_pattern_field_path=message&cols=host,service,@workflowId&flat_group_bys=true&fromUser=true&messageDisplay=inline&sort_m=count&sort_t=count&storage=hot&stream_sort=time,desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1773934556052&to_ts=1773938156052&live=true)