### PR TITLE
Add suggestion content in Poke plugin

### DIFF
--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -3,10 +3,18 @@ import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Chip, IconButton, TrashIcon } from "@dust-tt/sparkle";
+import {
+  Chip,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  IconButton,
+  TrashIcon,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
 const MAX_ANALYSIS_LENGTH = 80;
+const MAX_CONTENT_LENGTH = 80;
 
 function truncate(text: string | null, maxLength: number): string {
   if (!text) {
@@ -16,6 +24,23 @@ function truncate(text: string | null, maxLength: number): string {
     return text;
   }
   return text.slice(0, maxLength) + "...";
+}
+
+interface CopySuggestionButtonProps {
+  suggestion: AgentSuggestionType;
+}
+
+function CopySuggestionButton({ suggestion }: CopySuggestionButtonProps) {
+  const [isCopied, copy] = useCopyToClipboard();
+  return (
+    <IconButton
+      icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+      size="xs"
+      variant="outline"
+      tooltip={isCopied ? "Copied!" : "Copy content"}
+      onClick={() => copy(JSON.stringify(suggestion.suggestion, null, 2))}
+    />
+  );
 }
 
 async function deleteSuggestion(
@@ -150,12 +175,13 @@ export function makeColumnsForSuggestions(
       },
     },
     {
-      accessorKey: "updatedAt",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Updated at" />
-      ),
+      id: "content",
+      header: "Content",
       cell: ({ row }) => {
-        return formatTimestampToFriendlyDate(row.original.updatedAt);
+        return truncate(
+          JSON.stringify(row.original.suggestion),
+          MAX_CONTENT_LENGTH
+        );
       },
     },
     {
@@ -163,19 +189,22 @@ export function makeColumnsForSuggestions(
       cell: ({ row }) => {
         const suggestion = row.original;
         return (
-          <IconButton
-            icon={TrashIcon}
-            size="xs"
-            variant="outline"
-            onClick={async () => {
-              await deleteSuggestion(
-                owner,
-                agentId,
-                suggestion,
-                onSuggestionDeleted
-              );
-            }}
-          />
+          <div className="flex items-center gap-1">
+            <CopySuggestionButton suggestion={suggestion} />
+            <IconButton
+              icon={TrashIcon}
+              size="xs"
+              variant="outline"
+              onClick={async () => {
+                await deleteSuggestion(
+                  owner,
+                  agentId,
+                  suggestion,
+                  onSuggestionDeleted
+                );
+              }}
+            />
+          </div>
         );
       },
     },


### PR DESCRIPTION
## Description

Update the poke plugin for suggestions:
 - add content
 - add copy button to copy the content when too long to display
 - remove useless createdAt column

<img width="3358" height="744" alt="image" src="https://github.com/user-attachments/assets/48ba60c5-5468-48e5-9c15-066f7aefc554" />


## Tests

tested locally

## Risk

no

## Deploy Plan

deploy front
