### PR TITLE
Add verbose flag for reinforced tests

### DIFF
--- a/front/tests/reinforced-agent-evals/README.md
+++ b/front/tests/reinforced-agent-evals/README.md
@@ -32,6 +32,7 @@ NODE_ENV=test \
 | `PASS_THRESHOLD` | `2` | Minimum judge score (0-3) required to pass. |
 | `FILTER_CATEGORY` | _(all)_ | Run only tests in the given category (suite name). |
 | `FILTER_SCENARIO` | _(all)_ | Run only the test with the given scenario ID. |
+| `VERBOSE` | `false` | Set to `true` to log full tool call arguments and response text for each scenario. |
 | `DUST_MANAGED_ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude models). |
 | `DUST_MANAGED_OPENAI_API_KEY` | — | OpenAI API key (required for GPT judge model). |
 

--- a/front/tests/reinforced-agent-evals/lib/config.ts
+++ b/front/tests/reinforced-agent-evals/lib/config.ts
@@ -9,6 +9,7 @@ export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
 export const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
 export const FILTER_CATEGORY = process.env.FILTER_CATEGORY;
 export const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
+export const VERBOSE = process.env.VERBOSE === "true";
 
 /** Model used for the reinforced agent LLM calls. */
 function resolveModelId(): ModelIdType {

--- a/front/tests/reinforced-agent-evals/reinforced-agent-eval.test.ts
+++ b/front/tests/reinforced-agent-evals/reinforced-agent-eval.test.ts
@@ -10,6 +10,7 @@ import {
   RUN_REINFORCED_EVAL,
   TIMEOUT_MS,
   USE_BATCH,
+  VERBOSE,
 } from "@app/tests/reinforced-agent-evals/lib/config";
 import { evaluateWithJudge } from "@app/tests/reinforced-agent-evals/lib/judge";
 import {
@@ -149,6 +150,14 @@ describe.skipIf(!RUN_REINFORCED_EVAL)(
                 : await executeReinforced(auth, testCase);
 
               const { responseText, toolCalls } = result;
+
+              if (VERBOSE) {
+                console.log(
+                  `[${scenarioId}] Tool calls:`,
+                  JSON.stringify(toolCalls, null, 2)
+                );
+                console.log(`[${scenarioId}] Response:`, responseText);
+              }
 
               const judgeResult = await evaluateWithJudge(
                 auth,

--- a/front/tests/reinforced-agent-evals/vite.config.mjs
+++ b/front/tests/reinforced-agent-evals/vite.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig(() => {
         JUDGE_RUNS: process.env.JUDGE_RUNS ?? "3",
         PASS_THRESHOLD: process.env.PASS_THRESHOLD ?? "2",
         // Model override for the reinforced agent LLM.
+        VERBOSE: process.env.VERBOSE ?? "false",
         REINFORCED_MODEL_ID: process.env.REINFORCED_MODEL_ID ?? "",
         // API keys forwarded from the shell environment.
         DUST_MANAGED_ANTHROPIC_API_KEY:


### PR DESCRIPTION
## Description

Example cmd line to run one test in verbose mode:

```
NODE_ENV=test \
  TEST_FRONT_DATABASE_URI="$FRONT_DATABASE_URI"_test \
  RUN_REINFORCED_EVAL=true \
  FILTER_SCENARIO=improve-tool-usage-crm-owner-lookup \
  VERBOSE=true \
  npm run test -- tests/reinforced-agent-evals/reinforced-agent-eval.test.ts --config tests/reinforced-agent-evals/vite.config.mjs
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
