### PR TITLE
Reinforced Agent: filter suggestion based on feature flag when building sidekick prompt

### DIFF
--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
@@ -6,6 +6,7 @@ import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overvie
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -239,13 +240,16 @@ async function handler(
         await Promise.all([
           fetchFeedbackMarkdown(auth, agentConfigurationId),
           fetchInsightsMarkdown(auth, agentConfigurationId),
-          AgentSuggestionResource.listByAgentConfigurationId(
-            auth,
-            agentConfigurationId,
-            {
-              states: ["pending"],
-              limit: MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE,
-            }
+          hasFeatureFlag(auth, "reinforced_agents").then((hasFlag) =>
+            AgentSuggestionResource.listByAgentConfigurationId(
+              auth,
+              agentConfigurationId,
+              {
+                states: ["pending"],
+                sources: hasFlag ? undefined : ["sidekick"],
+                limit: MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE,
+              }
+            )
           ),
         ]);
 


### PR DESCRIPTION
## Description

If the user is not supposed to see reinforced agent suggestions, we should base the prompt on it.
This will help run tests on agents where the flag is not yet activated

## Tests

none

## Risk

low

## Deploy Plan

deploy front
