### PR TITLE
feat: firefox extension frames

### DIFF
--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -486,7 +486,7 @@ function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
     }
     // Support wildcard for browser extension origins in dev (e.g. "moz-extension://*").
     // In production, use exact origins instead.
-    if (allowed.endsWith("://*")) {
+    if (isDevelopment() && allowed.endsWith("://*")) {
       const scheme = allowed.slice(0, -1); // e.g. "moz-extension://"
       return origin.startsWith(scheme);
     }

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -484,6 +484,12 @@ function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
       const suffix = allowed.slice("https://*".length); // e.g. ".preview.dust.tt"
       return origin.startsWith("https://") && origin.endsWith(suffix);
     }
+    // Support wildcard for browser extension origins in dev (e.g. "moz-extension://*").
+    // In production, use exact origins instead.
+    if (allowed.endsWith("://*")) {
+      const scheme = allowed.slice(0, -1); // e.g. "moz-extension://"
+      return origin.startsWith(scheme);
+    }
     return origin === allowed;
   });
 }


### PR DESCRIPTION



## Description

This PR adds support frames in the Firefox extension.

- Adds `moz-extension:` to the frame-ancestors CSP policy in development mode
- Implements wildcard origin matching for browser extensions (e.g., `moz-extension://*`) in the `isOriginAllowed` function to handle dynamic extension IDs during development

In development, Firefox extensions do not have a stable ID, which is why wildcard matching is necessary. In production, the extension will have a stable ID that will need to be added to the allowed origins list once known.


## TODO

- Add the stable Firefox extension ID to the production allowed origins list once the extension is published and the ID is known
<img width="665" height="873" alt="Capture d’écran 2026-03-20 à 11 24 24" src="https://github.com/user-attachments/assets/60921fc8-a476-459b-8654-b24849d9d79e" />

## Tests

Manually. To test, update the `ALLOWED_VISUALIZATION_ORIGIN` environment variable to include `moz-extension://*`:

## Risks

Low risk. Changes are primarily for development mode support.

## Deploy Plan

Standard deployment. No special considerations needed.

