### PR TITLE
feat: firefox extension screenshot

### DIFF
--- a/extension/platforms/chrome/ChromeApp.tsx
+++ b/extension/platforms/chrome/ChromeApp.tsx
@@ -5,6 +5,7 @@ import { SparkleContext } from "@dust-tt/sparkle";
 import { ChromeExtensionWrapper } from "@extension/platforms/chrome/ChromeExtensionWrapper";
 import { PortProvider } from "@extension/platforms/chrome/context/PortContext";
 import { ChromePlatformService } from "@extension/platforms/chrome/services/platform";
+import { AuthenticatedImage } from "@extension/shared/AuthenticatedImage";
 import { PlatformProvider } from "@extension/shared/context/PlatformContext";
 import { useCaptureActions } from "@extension/shared/hooks/useCaptureActions";
 import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
@@ -26,7 +27,12 @@ export const ChromeApp = () => {
             <ExtensionAuthProvider>
               <ExtensionFetcherProvider>
                 <SparkleContext.Provider
-                  value={{ components: { link: ReactRouterLinkWrapper } }}
+                  value={{
+                    components: {
+                      link: ReactRouterLinkWrapper,
+                      image: AuthenticatedImage,
+                    },
+                  }}
                 >
                   <RootLayout>
                     <ChromeExtensionWrapper>

--- a/extension/platforms/chrome/services/platform.ts
+++ b/extension/platforms/chrome/services/platform.ts
@@ -27,6 +27,10 @@ export class ChromePlatformService extends PlatformService {
     );
   }
 
+  captureVisibleTab(): Promise<string> {
+    return chrome.tabs.captureVisibleTab();
+  }
+
   // Chrome specific helpers.
 
   // Store version for force update.

--- a/extension/platforms/firefox/FirefoxApp.tsx
+++ b/extension/platforms/firefox/FirefoxApp.tsx
@@ -4,6 +4,7 @@ import { ClientTypeProvider } from "@app/lib/context/clientType";
 import { SparkleContext } from "@dust-tt/sparkle";
 import { PortProvider } from "@extension/platforms/firefox/context/PortContext";
 import { FirefoxPlatformService } from "@extension/platforms/firefox/services/platform";
+import { AuthenticatedImage } from "@extension/shared/AuthenticatedImage";
 import { PlatformProvider } from "@extension/shared/context/PlatformContext";
 import { useCaptureActions } from "@extension/shared/hooks/useCaptureActions";
 import { ExtensionFetcherProvider } from "@extension/shared/lib/ExtensionFetcherProvider";
@@ -26,7 +27,12 @@ export const FirefoxApp = () => {
             <ExtensionAuthProvider>
               <ExtensionFetcherProvider>
                 <SparkleContext.Provider
-                  value={{ components: { link: ReactRouterLinkWrapper } }}
+                  value={{
+                    components: {
+                      link: ReactRouterLinkWrapper,
+                      image: AuthenticatedImage,
+                    },
+                  }}
                 >
                   <RootLayout>
                     <FirefoxExtensionWrapper>

--- a/extension/platforms/firefox/services/platform.ts
+++ b/extension/platforms/firefox/services/platform.ts
@@ -4,6 +4,7 @@ import { ChromeFirefoxCaptureService } from "@extension/shared/services/browser_
 import { ChromeFirefoxBrowserMessagingService } from "@extension/shared/services/browser_messaging";
 import { ChromeFirefoxStorageService } from "@extension/shared/services/browser_storage";
 import { PlatformService } from "@extension/shared/services/platform";
+import browser from "webextension-polyfill";
 
 export interface PendingUpdate {
   detectedAt: number;
@@ -25,6 +26,10 @@ export class FirefoxPlatformService extends PlatformService {
       messaging,
       mcpService
     );
+  }
+
+  captureVisibleTab(): Promise<string> {
+    return browser.tabs.captureVisibleTab();
   }
 
   async savePendingUpdate(

--- a/extension/platforms/front/services/platform.ts
+++ b/extension/platforms/front/services/platform.ts
@@ -21,4 +21,8 @@ export class FrontPlatformService extends PlatformService {
       mcpService
     );
   }
+
+  captureVisibleTab(): Promise<string> {
+    throw new Error("captureVisibleTab is not supported on this platform.");
+  }
 }

--- a/extension/shared/AuthenticatedImage.tsx
+++ b/extension/shared/AuthenticatedImage.tsx
@@ -82,7 +82,7 @@ export const AuthenticatedImage: SparkleContextImageType = forwardRef<
         URL.revokeObjectURL(objectUrl);
       }
     };
-  }, [src, needsAuth]);
+  }, [src]);
 
   // For non-API URLs (external images, data:, blob:), render a plain img.
   if (!needsAuth) {

--- a/extension/shared/AuthenticatedImage.tsx
+++ b/extension/shared/AuthenticatedImage.tsx
@@ -1,0 +1,98 @@
+import { getBaseUrl } from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
+import type { SparkleContextImageType } from "@dust-tt/sparkle";
+import { forwardRef, type ImgHTMLAttributes, useEffect, useState } from "react";
+
+/**
+ * Check whether a URL points to our own API and therefore needs an
+ * Authorization header. Matches relative `/api/…` paths and absolute URLs
+ * whose origin equals the configured base URL (region-aware).
+ */
+function isDustApiUrl(url: string): boolean {
+  if (url.startsWith("/api/")) {
+    return true;
+  }
+
+  const baseUrl = getBaseUrl();
+  if (baseUrl && url.startsWith(baseUrl)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Image component for the extension that fetches images with the Authorization
+ * header (Bearer token) when the src points to our API.
+ * External images and data:/blob: URLs are rendered with a plain <img>.
+ *
+ * Uses clientFetch which already injects auth headers via the defaultInitResolver.
+ * Manages its own loading/error state internally so that parent components
+ * (ImagePreview, ImageZoomDialog) don't need any changes.
+ */
+export const AuthenticatedImage: SparkleContextImageType = forwardRef<
+  HTMLImageElement,
+  ImgHTMLAttributes<HTMLImageElement>
+>(function AuthenticatedImage({ src, ...props }, ref) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  const needsAuth = !!src && isDustApiUrl(src);
+
+  useEffect(() => {
+    if (!src || !needsAuth) {
+      setBlobUrl(null);
+      setError(false);
+      return;
+    }
+
+    let revoked = false;
+    let objectUrl: string | null = null;
+
+    (async () => {
+      try {
+        const res = await clientFetch(src);
+        if (revoked) {
+          return;
+        }
+
+        if (!res.ok) {
+          setError(true);
+          return;
+        }
+
+        const blob = await res.blob();
+        if (revoked) {
+          return;
+        }
+
+        objectUrl = URL.createObjectURL(blob);
+        setBlobUrl(objectUrl);
+        setError(false);
+      } catch {
+        if (!revoked) {
+          setError(true);
+        }
+      }
+    })();
+
+    return () => {
+      revoked = true;
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [src, needsAuth]);
+
+  // For non-API URLs (external images, data:, blob:), render a plain img.
+  if (!needsAuth) {
+    return <img ref={ref} src={src} {...props} />;
+  }
+
+  // While fetching or on error, render an img without src so the layout is preserved.
+  if (!blobUrl || error) {
+    return <img ref={ref} {...props} />;
+  }
+
+  return <img ref={ref} src={blobUrl} {...props} />;
+});

--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -40,6 +40,26 @@ import { jwtDecode } from "jwt-decode";
 
 const log = console.error;
 
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(message)), ms);
+    promise.then(
+      (val) => {
+        clearTimeout(timeout);
+        resolve(val);
+      },
+      (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      }
+    );
+  });
+}
+
 // Mutex to serialize tab capture operations. captureVisibleTab only captures
 // the currently visible tab, so concurrent captures would produce duplicates.
 let tabOpMutex: Promise<void> = Promise.resolve();
@@ -462,8 +482,11 @@ const logout = async (
   }
 };
 
-function capture(sendResponse: (x: CaptureResponse) => void) {
-  return chrome.tabs.captureVisibleTab(function (dataURI) {
+function capture(
+  platform: PlatformService,
+  sendResponse: (x: CaptureResponse) => void
+) {
+  void platform.captureVisibleTab().then((dataURI) => {
     if (dataURI) {
       sendResponse({ dataURI });
     }
@@ -524,7 +547,7 @@ export const registerMessageListener = (platform: PlatformService) => {
           return true;
 
         case "CAPTURE":
-          capture(sendResponse);
+          capture(platform, sendResponse);
           return true;
 
         case "GET_ACTIVE_TAB":
@@ -732,33 +755,20 @@ export const registerMessageListener = (platform: PlatformService) => {
                           fetchError
                         );
                         resultCaptures = [
-                          await new Promise<string>((resolve, reject) => {
-                            const timeout = setTimeout(() => {
-                              reject(
-                                new Error("Timeout waiting for page screenshot")
-                              );
-                            }, 2000);
-                            chrome.tabs.captureVisibleTab((res) => {
-                              clearTimeout(timeout);
-                              resolve(res);
-                            });
-                          }),
+                          await withTimeout(
+                            platform.captureVisibleTab(),
+                            2000,
+                            "Timeout waiting for page screenshot"
+                          ),
                         ];
                       }
                     } else {
                       resultCaptures = [
-                        await new Promise<string>((resolve, reject) => {
-                          const timeout = setTimeout(() => {
-                            console.error("Timeout waiting for capture");
-                            reject(
-                              new Error("Timeout waiting for page screenshot")
-                            );
-                          }, 2000);
-                          chrome.tabs.captureVisibleTab((res) => {
-                            clearTimeout(timeout);
-                            resolve(res);
-                          });
-                        }),
+                        await withTimeout(
+                          platform.captureVisibleTab(),
+                          2000,
+                          "Timeout waiting for page screenshot"
+                        ),
                       ];
                     }
                   } finally {

--- a/extension/shared/services/platform.ts
+++ b/extension/shared/services/platform.ts
@@ -57,6 +57,8 @@ export abstract class PlatformService {
     this.mcp = mcp;
   }
 
+  abstract captureVisibleTab(): Promise<string>;
+
   async clearStoredData(): Promise<void> {
     await Promise.all([
       this.storage.delete("accessToken"),

--- a/sparkle/src/components/ImagePreview.tsx
+++ b/sparkle/src/components/ImagePreview.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@sparkle/components/Button";
+import { ImageWrapper } from "@sparkle/components/ImageWrapper";
 import {
   downloadFile,
   ImageZoomDialog,
@@ -171,7 +172,7 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
             </div>
           ) : (
             <>
-              <img
+              <ImageWrapper
                 src={imgSrc}
                 alt={alt}
                 className={cn(

--- a/sparkle/src/components/ImageWrapper.tsx
+++ b/sparkle/src/components/ImageWrapper.tsx
@@ -1,0 +1,16 @@
+import { SparkleContext } from "@sparkle/context";
+import React, { type ImgHTMLAttributes } from "react";
+
+export const ImageWrapper = React.forwardRef<
+  HTMLImageElement,
+  ImgHTMLAttributes<HTMLImageElement>
+>((props, ref) => {
+  const { components } = React.useContext(SparkleContext);
+  const Image = components.image;
+
+  if (Image) {
+    return <Image ref={ref} {...props} />;
+  }
+
+  return <img ref={ref} {...props} />;
+});

--- a/sparkle/src/components/ImageZoomDialog.tsx
+++ b/sparkle/src/components/ImageZoomDialog.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@sparkle/components/Button";
 import { Dialog, DialogClose, DialogContent } from "@sparkle/components/Dialog";
+import { ImageWrapper } from "@sparkle/components/ImageWrapper";
 import { Spinner } from "@sparkle/components/Spinner";
 import {
   ArrowDownOnSquareIcon,
@@ -91,7 +92,7 @@ function ImageZoomDialog({
               </div>
             ) : (
               <>
-                <img
+                <ImageWrapper
                   src={image.src}
                   alt={image.alt ?? ""}
                   className="s-max-h-full s-max-w-full s-object-contain"

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -1,5 +1,6 @@
 import React, {
   type ComponentType,
+  type ImgHTMLAttributes,
   type MouseEvent,
   type ReactNode,
 } from "react";
@@ -33,9 +34,14 @@ export type SparkleContextLinkType = ComponentType<
   SparkleLinkProps & React.RefAttributes<HTMLAnchorElement>
 >;
 
+export type SparkleContextImageType = ComponentType<
+  ImgHTMLAttributes<HTMLImageElement> & React.RefAttributes<HTMLImageElement>
+>;
+
 export type SparkleContextType = {
   components: {
     link: SparkleContextLinkType;
+    image?: SparkleContextImageType;
   };
 };
 
@@ -90,8 +96,14 @@ export const noHrefLink: SparkleContextLinkType = React.forwardRef<
   )
 );
 
+export const defaultImage: SparkleContextImageType = React.forwardRef<
+  HTMLImageElement,
+  ImgHTMLAttributes<HTMLImageElement>
+>((props, ref) => <img ref={ref} {...props} />);
+
 export const SparkleContext = React.createContext<SparkleContextType>({
   components: {
     link: aLink,
+    image: defaultImage,
   },
 });

--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -96,14 +96,8 @@ export const noHrefLink: SparkleContextLinkType = React.forwardRef<
   )
 );
 
-export const defaultImage: SparkleContextImageType = React.forwardRef<
-  HTMLImageElement,
-  ImgHTMLAttributes<HTMLImageElement>
->((props, ref) => <img ref={ref} {...props} />);
-
 export const SparkleContext = React.createContext<SparkleContextType>({
   components: {
     link: aLink,
-    image: defaultImage,
   },
 });

--- a/sparkle/src/index.ts
+++ b/sparkle/src/index.ts
@@ -1,6 +1,10 @@
 export * from "./components";
 export * from "./components/WindowUtility";
-export { SparkleContext, type SparkleLinkProps } from "./context";
+export {
+  SparkleContext,
+  type SparkleContextImageType,
+  type SparkleLinkProps,
+} from "./context";
 export * from "./hooks";
 export * from "./icons";
 export * from "./lib";


### PR DESCRIPTION
## Description

This PR abstracts the tab screenshot capture functionality into the platform service layer to support both Chrome and Firefox browsers.

- Implements the method for Chrome using `chrome.tabs.captureVisibleTab()`
- Implements the method for Firefox using `browser.tabs.captureVisibleTab()` 
- Refactors `background.ts` to use the platform service method instead of direct Chrome API calls

Moreover it adds an image component to the sparkle context to display images correctly in the chrome and firefox extension. In fact if we simple use an <img /> tag with a `src` we do not send the authorization headers which are needed by the extension to authenticate and display the image previews correctly.

<img width="665" height="873" alt="Capture d’écran 2026-03-20 à 14 41 11" src="https://github.com/user-attachments/assets/640ce6b2-9da9-4fed-aa8d-d684ab1c2ea6" />

## Tests

Manually

## Risks

Low - The change abstracts existing functionality behind the platform service without changing the core behavior. 

## Deploy Plan

Standard deployment - no special considerations needed.
