### PR TITLE
Pop up a suggestion details dialog in Poke

### DIFF
--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -3,14 +3,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  Chip,
-  ClipboardCheckIcon,
-  ClipboardIcon,
-  IconButton,
-  TrashIcon,
-  useCopyToClipboard,
-} from "@dust-tt/sparkle";
+import { Chip, IconButton, TrashIcon } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
 const MAX_ANALYSIS_LENGTH = 80;
@@ -24,23 +17,6 @@ function truncate(text: string | null, maxLength: number): string {
     return text;
   }
   return text.slice(0, maxLength) + "...";
-}
-
-interface CopySuggestionButtonProps {
-  suggestion: AgentSuggestionType;
-}
-
-function CopySuggestionButton({ suggestion }: CopySuggestionButtonProps) {
-  const [isCopied, copy] = useCopyToClipboard();
-  return (
-    <IconButton
-      icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-      size="xs"
-      variant="outline"
-      tooltip={isCopied ? "Copied!" : "Copy content"}
-      onClick={() => copy(JSON.stringify(suggestion.suggestion, null, 2))}
-    />
-  );
 }
 
 function ClickableCell({
@@ -222,22 +198,19 @@ export function makeColumnsForSuggestions(
       cell: ({ row }) => {
         const suggestion = row.original;
         return (
-          <div className="flex items-center gap-1">
-            <CopySuggestionButton suggestion={suggestion} />
-            <IconButton
-              icon={TrashIcon}
-              size="xs"
-              variant="outline"
-              onClick={async () => {
-                await deleteSuggestion(
-                  owner,
-                  agentId,
-                  suggestion,
-                  onSuggestionDeleted
-                );
-              }}
-            />
-          </div>
+          <IconButton
+            icon={TrashIcon}
+            size="xs"
+            variant="outline"
+            onClick={async () => {
+              await deleteSuggestion(
+                owner,
+                agentId,
+                suggestion,
+                onSuggestionDeleted
+              );
+            }}
+          />
         );
       },
     },

--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -43,6 +43,28 @@ function CopySuggestionButton({ suggestion }: CopySuggestionButtonProps) {
   );
 }
 
+function ClickableCell({
+  text,
+  maxLength,
+  onClick,
+}: {
+  text: string | null;
+  maxLength: number;
+  onClick: () => void;
+}) {
+  const truncated = truncate(text, maxLength);
+  const isTruncated = text && text.length > maxLength;
+  return (
+    <span
+      onClick={isTruncated ? onClick : undefined}
+      className={isTruncated ? "cursor-pointer hover:underline" : ""}
+      title={isTruncated ? "Click to see full content" : undefined}
+    >
+      {truncated}
+    </span>
+  );
+}
+
 async function deleteSuggestion(
   owner: LightWorkspaceType,
   agentId: string,
@@ -79,7 +101,8 @@ async function deleteSuggestion(
 export function makeColumnsForSuggestions(
   owner: LightWorkspaceType,
   agentId: string,
-  onSuggestionDeleted: () => Promise<void>
+  onSuggestionDeleted: () => Promise<void>,
+  onSuggestionClick: (suggestion: AgentSuggestionType) => void
 ): ColumnDef<AgentSuggestionType>[] {
   return [
     {
@@ -162,7 +185,13 @@ export function makeColumnsForSuggestions(
         <PokeColumnSortableHeader column={column} label="Analysis" />
       ),
       cell: ({ row }) => {
-        return truncate(row.original.analysis, MAX_ANALYSIS_LENGTH);
+        return (
+          <ClickableCell
+            text={row.original.analysis}
+            maxLength={MAX_ANALYSIS_LENGTH}
+            onClick={() => onSuggestionClick(row.original)}
+          />
+        );
       },
     },
     {
@@ -178,9 +207,13 @@ export function makeColumnsForSuggestions(
       id: "content",
       header: "Content",
       cell: ({ row }) => {
-        return truncate(
-          JSON.stringify(row.original.suggestion),
-          MAX_CONTENT_LENGTH
+        const content = JSON.stringify(row.original.suggestion);
+        return (
+          <ClickableCell
+            text={content}
+            maxLength={MAX_CONTENT_LENGTH}
+            onClick={() => onSuggestionClick(row.original)}
+          />
         );
       },
     },

--- a/front/components/poke/suggestions/table.tsx
+++ b/front/components/poke/suggestions/table.tsx
@@ -10,6 +10,84 @@ import {
   AGENT_SUGGESTION_STATES,
 } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  IconButton,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface SuggestionDetailsDialogProps {
+  onClose: () => void;
+  suggestion: AgentSuggestionType;
+}
+
+interface CopyButtonProps {
+  text: string;
+}
+
+function CopyButton({ text }: CopyButtonProps) {
+  const [isCopied, copy] = useCopyToClipboard();
+  return (
+    <IconButton
+      icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+      size="xs"
+      variant="outline"
+      tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
+      onClick={() => copy(text)}
+    />
+  );
+}
+
+function SuggestionDetailsDialog({
+  suggestion,
+  onClose,
+}: SuggestionDetailsDialogProps) {
+  const analysisText = suggestion.analysis ?? "No analysis";
+  const contentText = JSON.stringify(suggestion.suggestion, null, 2);
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-h-[80vh] max-w-4xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Suggestion Details - {suggestion.sId}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="space-y-6">
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="text-sm font-semibold">Analysis</h3>
+                <CopyButton text={analysisText} />
+              </div>
+              <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
+                <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
+                  {analysisText}
+                </pre>
+              </div>
+            </div>
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="text-sm font-semibold">Content</h3>
+                <CopyButton text={contentText} />
+              </div>
+              <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
+                <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
+                  {contentText}
+                </pre>
+              </div>
+            </div>
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 interface SuggestionDataTableProps {
   owner: LightWorkspaceType;
@@ -20,6 +98,9 @@ export function SuggestionDataTable({
   owner,
   agentId,
 }: SuggestionDataTableProps) {
+  const [selectedSuggestion, setSelectedSuggestion] =
+    useState<AgentSuggestionType | null>(null);
+
   const useSuggestionsWithAgent = (props: PokeConditionalFetchProps) =>
     usePokeSuggestions({ ...props, agentId });
 
@@ -43,24 +124,37 @@ export function SuggestionDataTable({
   ];
 
   return (
-    <PokeDataTableConditionalFetch
-      header="Suggestions"
-      owner={owner}
-      useSWRHook={useSuggestionsWithAgent}
-    >
-      {(suggestions, mutate) => {
-        const columns = makeColumnsForSuggestions(owner, agentId, async () => {
-          await mutate();
-        });
+    <>
+      {selectedSuggestion && (
+        <SuggestionDetailsDialog
+          suggestion={selectedSuggestion}
+          onClose={() => setSelectedSuggestion(null)}
+        />
+      )}
+      <PokeDataTableConditionalFetch
+        header="Suggestions"
+        owner={owner}
+        useSWRHook={useSuggestionsWithAgent}
+      >
+        {(suggestions, mutate) => {
+          const columns = makeColumnsForSuggestions(
+            owner,
+            agentId,
+            async () => {
+              await mutate();
+            },
+            setSelectedSuggestion
+          );
 
-        return (
-          <PokeDataTable<AgentSuggestionType, unknown>
-            columns={columns}
-            data={suggestions}
-            facets={facets}
-          />
-        );
-      }}
-    </PokeDataTableConditionalFetch>
+          return (
+            <PokeDataTable<AgentSuggestionType, unknown>
+              columns={columns}
+              data={suggestions}
+              facets={facets}
+            />
+          );
+        }}
+      </PokeDataTableConditionalFetch>
+    </>
   );
 }

--- a/front/components/poke/suggestions/table.tsx
+++ b/front/components/poke/suggestions/table.tsx
@@ -11,15 +11,11 @@ import {
 } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
-  ClipboardCheckIcon,
-  ClipboardIcon,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  IconButton,
-  useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -28,30 +24,10 @@ interface SuggestionDetailsDialogProps {
   suggestion: AgentSuggestionType;
 }
 
-interface CopyButtonProps {
-  text: string;
-}
-
-function CopyButton({ text }: CopyButtonProps) {
-  const [isCopied, copy] = useCopyToClipboard();
-  return (
-    <IconButton
-      icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-      size="xs"
-      variant="outline"
-      tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
-      onClick={() => copy(text)}
-    />
-  );
-}
-
 function SuggestionDetailsDialog({
   suggestion,
   onClose,
 }: SuggestionDetailsDialogProps) {
-  const analysisText = suggestion.analysis ?? "No analysis";
-  const contentText = JSON.stringify(suggestion.suggestion, null, 2);
-
   return (
     <Dialog open onOpenChange={onClose}>
       <DialogContent className="max-h-[80vh] max-w-4xl overflow-y-auto">
@@ -61,24 +37,18 @@ function SuggestionDetailsDialog({
         <DialogContainer>
           <div className="space-y-6">
             <div>
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-sm font-semibold">Analysis</h3>
-                <CopyButton text={analysisText} />
-              </div>
+              <h3 className="mb-2 text-sm font-semibold">Analysis</h3>
               <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
                 <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
-                  {analysisText}
+                  {suggestion.analysis ?? "No analysis"}
                 </pre>
               </div>
             </div>
             <div>
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-sm font-semibold">Content</h3>
-                <CopyButton text={contentText} />
-              </div>
+              <h3 className="mb-2 text-sm font-semibold">Content</h3>
               <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
                 <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
-                  {contentText}
+                  {JSON.stringify(suggestion.suggestion, null, 2)}
                 </pre>
               </div>
             </div>


### PR DESCRIPTION
## Description

Basically vibe coded, poke style. Clicking on the analysis or content cells of a row pops up a dialog like this:

<img width="858" height="390" alt="Screenshot 2026-03-20 at 12 35 19" src="https://github.com/user-attachments/assets/33b0a0ff-812d-49cf-9c96-a4f208ad2c55" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
