### PR TITLE
Migrate conversation endpoint to zod

### DIFF
--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,11 +1,11 @@
 import { useClientType } from "@app/lib/context/clientType";
 import { useFetcher } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
-import type {
-  InternalPostConversationsRequestBodySchema,
-  SupportedContentNodeContentType,
+import type { SupportedContentNodeContentType } from "@app/types/api/internal/assistant";
+import {
+  type InternalPostConversationsRequestBodySchema,
+  isSupportedContentNodeFragmentContentType,
 } from "@app/types/api/internal/assistant";
-import { isSupportedContentNodeFragmentContentType } from "@app/types/api/internal/assistant";
 import type {
   ClientMessageOrigin,
   ConversationMetadata,
@@ -19,8 +19,8 @@ import { isAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import type * as t from "io-ts";
 import { useCallback } from "react";
+import type { z } from "zod";
 
 export function useCreateConversationWithMessage({
   owner,
@@ -75,58 +75,56 @@ export function useCreateConversationWithMessage({
       } = messageData;
       const origin = messageOrigin ?? contextOrigin;
 
-      const body: t.TypeOf<typeof InternalPostConversationsRequestBodySchema> =
-        {
-          title: title ?? null,
-          visibility,
-          spaceId: spaceId ?? null,
-          metadata,
-          skipToolsValidation,
-          message: {
-            content: input,
-            context: {
-              timezone:
-                Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
-              profilePictureUrl: user.image,
-              clientSideMCPServerIds,
-              selectedMCPServerViewIds,
-              selectedSkillIds,
-              origin,
-            },
-            mentions,
+      const body: z.infer<typeof InternalPostConversationsRequestBodySchema> = {
+        title: title ?? null,
+        visibility,
+        spaceId: spaceId ?? null,
+        metadata,
+        skipToolsValidation,
+        message: {
+          content: input,
+          context: {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+            profilePictureUrl: user.image,
+            clientSideMCPServerIds,
+            selectedMCPServerViewIds,
+            selectedSkillIds,
+            origin,
           },
-          contentFragments: [
-            ...contentFragments.uploaded.map((cf) => ({
+          mentions,
+        },
+        contentFragments: [
+          ...contentFragments.uploaded.map((cf) => ({
+            title: cf.title,
+            url: cf.url,
+            context: {
+              profilePictureUrl: user.image,
+            },
+            fileId: cf.fileId,
+          })),
+          ...contentFragments.contentNodes.map((cf) => {
+            const contentType = isSupportedContentNodeFragmentContentType(
+              cf.mimeType
+            )
+              ? (cf.mimeType as SupportedContentNodeContentType)
+              : null;
+            if (!contentType) {
+              throw new Error(
+                `Unsupported content node fragment mime type: ${cf.mimeType}`
+              );
+            }
+
+            return {
               title: cf.title,
-              url: cf.url,
               context: {
                 profilePictureUrl: user.image,
               },
-              fileId: cf.fileId,
-            })),
-            ...contentFragments.contentNodes.map((cf) => {
-              const contentType = isSupportedContentNodeFragmentContentType(
-                cf.mimeType
-              )
-                ? (cf.mimeType as SupportedContentNodeContentType)
-                : null;
-              if (!contentType) {
-                throw new Error(
-                  `Unsupported content node fragment mime type: ${cf.mimeType}`
-                );
-              }
-
-              return {
-                title: cf.title,
-                context: {
-                  profilePictureUrl: user.image,
-                },
-                nodeId: cf.internalId,
-                nodeDataSourceViewId: cf.dataSourceView.sId,
-              };
-            }),
-          ],
-        };
+              nodeId: cf.internalId,
+              nodeDataSourceViewId: cf.dataSourceView.sId,
+            };
+          }),
+        ],
+      };
 
       // Create new conversation and post the initial message at the same time.
       try {

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -27,7 +27,10 @@ import type {
 } from "@app/types/core/content_node";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { SupportedFileContentType } from "@app/types/files";
+import type {
+  AllSupportedFileContentType,
+  SupportedFileContentType,
+} from "@app/types/files";
 import { extensionsForContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -65,11 +68,13 @@ export async function toFileContentFragment(
 ): Promise<
   Result<ContentFragmentInputWithFileIdType, ProcessAndStoreFileError>
 > {
+  // Safe cast: contentType is validated by the zod schema (getSupportedInlinedContentType).
+  const validatedContentType =
+    contentFragment.contentType as AllSupportedFileContentType;
   const file = await FileResource.makeNew({
-    contentType: contentFragment.contentType,
+    contentType: validatedContentType,
     fileName:
-      fileName ??
-      "content" + extensionsForContentType(contentFragment.contentType)[0],
+      fileName ?? "content" + extensionsForContentType(validatedContentType)[0],
     fileSize: contentFragment.content.length,
     userId: auth.user()?.id,
     workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -8,7 +8,6 @@ import type { ModelConversationTypeMultiActions } from "@app/types/assistant/gen
 import { GPT_3_5_TURBO_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { isLeft } from "fp-ts/lib/Either";
 
 const FUNCTION_NAME = "send_suggestions";
 
@@ -116,11 +115,12 @@ export async function getBuilderEmojiSuggestions(
   }
 
   if (res.value.actions?.[0]?.arguments?.suggestions) {
-    const suggestionsResult = BuilderEmojiSuggestionsResponseBodySchema.decode(
-      res.value.actions[0].arguments
-    );
+    const suggestionsResult =
+      BuilderEmojiSuggestionsResponseBodySchema.safeParse(
+        res.value.actions[0].arguments
+      );
 
-    if (isLeft(suggestionsResult)) {
+    if (!suggestionsResult.success) {
       return new Err(
         new Error(
           `Error retrieving suggestions from arguments: ${res.value.actions[0].arguments}`
@@ -130,7 +130,7 @@ export async function getBuilderEmojiSuggestions(
 
     return new Ok({
       status: "ok",
-      ...suggestionsResult.right,
+      ...suggestionsResult.data,
     });
   }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -10,7 +10,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { UserType } from "@app/types/user";
+import { UserSchema } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -33,13 +33,19 @@ export type PatchAgentEditorsRequestBody = z.infer<
   typeof PatchAgentEditorsRequestBodySchema
 >;
 
-export interface GetAgentEditorsResponseBody {
-  editors: UserType[];
-}
+export const GetAgentEditorsResponseBodySchema = z.object({
+  editors: z.array(UserSchema),
+});
+export type GetAgentEditorsResponseBody = z.infer<
+  typeof GetAgentEditorsResponseBodySchema
+>;
 
-export interface PatchAgentEditorsResponseBody {
-  editors: UserType[];
-}
+export const PatchAgentEditorsResponseBodySchema = z.object({
+  editors: z.array(UserSchema),
+});
+export type PatchAgentEditorsResponseBody = z.infer<
+  typeof PatchAgentEditorsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
@@ -6,11 +6,15 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationYAMLExportResponseBody = {
-  yamlContent: string;
-  filename: string;
-};
+export const GetAgentConfigurationYAMLExportResponseBodySchema = z.object({
+  yamlContent: z.string(),
+  filename: z.string(),
+});
+export type GetAgentConfigurationYAMLExportResponseBody = z.infer<
+  typeof GetAgentConfigurationYAMLExportResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -1,8 +1,10 @@
 /** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
-import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import {
+  AgentMessageFeedbackSchema,
+  getAgentFeedbacks,
+} from "@app/lib/api/assistant/feedback";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,14 +12,18 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+export const GetAgentFeedbacksResponseBodySchema = z.object({
+  feedbacks: z.array(AgentMessageFeedbackSchema),
+});
+export type GetAgentFeedbacksResponseBody = z.infer<
+  typeof GetAgentFeedbacksResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<{
-      feedbacks: AgentMessageFeedbackType[];
-    }>
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentFeedbacksResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
   const { aId } = req.query;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -7,13 +7,17 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { GetAgentConfigurationsHistoryQuerySchema } from "@app/types/api/internal/agent_configuration";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { LightAgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationsResponseBody = {
-  history: LightAgentConfigurationType[];
-};
+export const GetAgentConfigurationsResponseBodySchema = z.object({
+  history: z.array(LightAgentConfigurationSchema),
+});
+export type GetAgentConfigurationsResponseBody = z.infer<
+  typeof GetAgentConfigurationsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -10,16 +10,24 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/types/api/internal/agent_configuration";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { AgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationResponseBody = {
-  agentConfiguration: AgentConfigurationType;
-};
-export type DeleteAgentConfigurationResponseBody = {
-  success: boolean;
-};
+export const GetAgentConfigurationResponseBodySchema = z.object({
+  agentConfiguration: AgentConfigurationSchema,
+});
+export type GetAgentConfigurationResponseBody = z.infer<
+  typeof GetAgentConfigurationResponseBodySchema
+>;
+
+export const DeleteAgentConfigurationResponseBodySchema = z.object({
+  success: z.boolean(),
+});
+export type DeleteAgentConfigurationResponseBody = z.infer<
+  typeof DeleteAgentConfigurationResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
@@ -5,12 +5,16 @@ import type { Authenticator } from "@app/lib/auth";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserType } from "@app/types/user";
+import { UserSchema } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentLastAuthorResponseBody = {
-  user: UserType | null;
-};
+export const GetAgentLastAuthorResponseBodySchema = z.object({
+  user: UserSchema.nullable(),
+});
+export type GetAgentLastAuthorResponseBody = z.infer<
+  typeof GetAgentLastAuthorResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -12,9 +12,12 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PatchLinkedSlackChannelsResponseBody = {
-  success: true;
-};
+export const PatchLinkedSlackChannelsResponseBodySchema = z.object({
+  success: z.literal(true),
+});
+export type PatchLinkedSlackChannelsResponseBody = z.infer<
+  typeof PatchLinkedSlackChannelsResponseBodySchema
+>;
 
 export const PatchLinkedSlackChannelsRequestBodySchema = z.object({
   slack_channel_internal_ids: z.array(z.string()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
@@ -1,16 +1,22 @@
 /** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { AgentMcpConfigurationSummary } from "@app/lib/api/assistant/mcp_configurations";
-import { listAgentMcpConfigurationsForAgent } from "@app/lib/api/assistant/mcp_configurations";
+import {
+  AgentMcpConfigurationSummarySchema,
+  listAgentMcpConfigurationsForAgent,
+} from "@app/lib/api/assistant/mcp_configurations";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentMcpConfigurationsResponseBody = {
-  configurations: AgentMcpConfigurationSummary[];
-};
+export const GetAgentMcpConfigurationsResponseBodySchema = z.object({
+  configurations: z.array(AgentMcpConfigurationSummarySchema),
+});
+export type GetAgentMcpConfigurationsResponseBody = z.infer<
+  typeof GetAgentMcpConfigurationsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -16,13 +16,16 @@ export type PatchAgentMemoryRequestBody = z.infer<
   typeof PatchAgentMemoryRequestBodySchema
 >;
 
-export interface PatchAgentMemoryResponseBody {
-  memory: {
-    sId: string;
-    lastUpdated: Date;
-    content: string;
-  };
-}
+export const PatchAgentMemoryResponseBodySchema = z.object({
+  memory: z.object({
+    sId: z.string(),
+    lastUpdated: z.date(),
+    content: z.string(),
+  }),
+});
+export type PatchAgentMemoryResponseBody = z.infer<
+  typeof PatchAgentMemoryResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
@@ -6,14 +6,20 @@ import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export interface GetAgentMemoriesResponseBody {
-  memories: Array<{
-    sId: string;
-    lastUpdated: Date;
-    content: string;
-  }>;
-}
+export const GetAgentMemoriesResponseBodySchema = z.object({
+  memories: z.array(
+    z.object({
+      sId: z.string(),
+      lastUpdated: z.date(),
+      content: z.string(),
+    })
+  ),
+});
+export type GetAgentMemoriesResponseBody = z.infer<
+  typeof GetAgentMemoriesResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -9,10 +9,14 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type RestoreAgentConfigurationResponseBody = {
-  success: true;
-};
+export const RestoreAgentConfigurationResponseBodySchema = z.object({
+  success: z.literal(true),
+});
+export type RestoreAgentConfigurationResponseBody = z.infer<
+  typeof RestoreAgentConfigurationResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -4,14 +4,18 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { SkillSchema } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export interface GetAgentSkillsResponseBody {
-  skills: SkillType[];
-}
+export const GetAgentSkillsResponseBodySchema = z.object({
+  skills: z.array(SkillSchema),
+});
+export type GetAgentSkillsResponseBody = z.infer<
+  typeof GetAgentSkillsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -7,10 +7,8 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type {
-  AgentSuggestionSource,
-  AgentSuggestionType,
-} from "@app/types/suggestions/agent_suggestion";
+import type { AgentSuggestionSource } from "@app/types/suggestions/agent_suggestion";
+import { AgentSuggestionSchema } from "@app/types/suggestions/agent_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -23,9 +21,12 @@ export type PatchSuggestionRequestBody = z.infer<
   typeof PatchSuggestionRequestBodySchema
 >;
 
-export interface PatchSuggestionResponseBody {
-  suggestions: AgentSuggestionType[];
-}
+export const PatchSuggestionResponseBodySchema = z.object({
+  suggestions: z.array(AgentSuggestionSchema),
+});
+export type PatchSuggestionResponseBody = z.infer<
+  typeof PatchSuggestionResponseBodySchema
+>;
 
 const StateSchema = z.enum(["pending", "approved", "rejected", "outdated"]);
 
@@ -43,9 +44,12 @@ const GetSuggestionsQuerySchema = z.object({
 
 export type GetSuggestionsQuery = z.infer<typeof GetSuggestionsQuerySchema>;
 
-export interface GetSuggestionsResponseBody {
-  suggestions: AgentSuggestionType[];
-}
+export const GetSuggestionsResponseBodySchema = z.object({
+  suggestions: z.array(AgentSuggestionSchema),
+});
+export type GetSuggestionsResponseBody = z.infer<
+  typeof GetSuggestionsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -6,7 +6,7 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { TagType } from "@app/types/tag";
+import { TagSchema } from "@app/types/tag";
 import { isBuilder } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -29,9 +29,12 @@ export type PatchAgentTagsRequestBody = z.infer<
   typeof PatchAgentTagsRequestBodySchema
 >;
 
-export interface PatchAgentTagsResponseBody {
-  tags: TagType[];
-}
+export const PatchAgentTagsResponseBodySchema = z.object({
+  tags: z.array(TagSchema),
+});
+export type PatchAgentTagsResponseBody = z.infer<
+  typeof PatchAgentTagsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -7,19 +7,28 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import type { TriggerType } from "@app/types/assistant/triggers";
-import { TriggerSchema } from "@app/types/assistant/triggers";
+import {
+  FullTriggerSchema,
+  TriggerSchema,
+} from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export interface GetTriggersResponseBody {
-  triggers: (TriggerType & {
-    isSubscriber: boolean;
-    isEditor: boolean;
-    editorName?: string;
-  })[];
-}
+export const GetTriggersResponseBodySchema = z.object({
+  triggers: z.array(
+    FullTriggerSchema.and(
+      z.object({
+        isSubscriber: z.boolean(),
+        isEditor: z.boolean(),
+        editorName: z.string().optional(),
+      })
+    )
+  ),
+});
+export type GetTriggersResponseBody = z.infer<
+  typeof GetTriggersResponseBodySchema
+>;
 
 const DeleteTriggersRequestBodyCodec = z.object({
   triggerIds: z.array(z.string()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -4,13 +4,17 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { AgentUsageType } from "@app/types/assistant/agent";
+import { AgentUsageSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentUsageResponseBody = {
-  agentUsage: AgentUsageType | null;
-};
+export const GetAgentUsageResponseBodySchema = z.object({
+  agentUsage: AgentUsageSchema.nullable(),
+});
+export type GetAgentUsageResponseBody = z.infer<
+  typeof GetAgentUsageResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -16,9 +16,12 @@ const BatchUpdateAgentScopeRequestBodySchema = z.object({
   scope: z.enum(["hidden", "visible"]),
 });
 
-type BatchUpdateAgentTagsResponseBody = {
-  success: boolean;
-};
+const BatchUpdateAgentTagsResponseBodySchema = z.object({
+  success: z.boolean(),
+});
+type BatchUpdateAgentTagsResponseBody = z.infer<
+  typeof BatchUpdateAgentTagsResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
@@ -5,10 +5,14 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type PostPendingAgentResponseBody = {
-  sId: string;
-};
+export const PostPendingAgentResponseBodySchema = z.object({
+  sId: z.string(),
+});
+export type PostPendingAgentResponseBody = z.infer<
+  typeof PostPendingAgentResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -10,9 +10,12 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PostAgentConfigurationArchiveResponseBody = {
-  archived: number;
-};
+export const PostAgentConfigurationArchiveResponseBodySchema = z.object({
+  archived: z.number(),
+});
+export type PostAgentConfigurationArchiveResponseBody = z.infer<
+  typeof PostAgentConfigurationArchiveResponseBodySchema
+>;
 
 export const PostAgentConfigurationArchive = z.object({
   agentConfigurationIds: z.array(z.string()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -150,10 +150,8 @@ import {
   GetAgentConfigurationsQuerySchema,
   PostOrPatchAgentConfigurationRequestBodySchema,
 } from "@app/types/api/internal/agent_configuration";
-import type {
-  AgentConfigurationType,
-  LightAgentConfigurationType,
-} from "@app/types/assistant/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { LightAgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -162,13 +160,21 @@ import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export type GetAgentConfigurationsResponseBody = {
-  agentConfigurations: LightAgentConfigurationType[];
-};
-export type PostAgentConfigurationResponseBody = {
-  agentConfiguration: LightAgentConfigurationType;
-};
+export const GetAgentConfigurationsResponseBodySchema = z.object({
+  agentConfigurations: z.array(LightAgentConfigurationSchema),
+});
+export type GetAgentConfigurationsResponseBody = z.infer<
+  typeof GetAgentConfigurationsResponseBodySchema
+>;
+
+export const PostAgentConfigurationResponseBodySchema = z.object({
+  agentConfiguration: LightAgentConfigurationSchema,
+});
+export type PostAgentConfigurationResponseBody = z.infer<
+  typeof PostAgentConfigurationResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/lookup.ts
@@ -11,9 +11,10 @@ const GetLookupRequestSchema = z.object({
   handle: z.string(),
 });
 
-type GetLookupResponseBody = {
-  sId: string;
-};
+const GetLookupResponseBodySchema = z.object({
+  sId: z.string(),
+});
+type GetLookupResponseBody = z.infer<typeof GetLookupResponseBodySchema>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/name_available.ts
@@ -7,9 +7,12 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type GetAgentNameIsAvailableResponseBody = {
-  available: boolean;
-};
+export const GetAgentNameIsAvailableResponseBodySchema = z.object({
+  available: z.boolean(),
+});
+export type GetAgentNameIsAvailableResponseBody = z.infer<
+  typeof GetAgentNameIsAvailableResponseBodySchema
+>;
 
 export const GetAgentConfigurationNameIsAvailable = z.object({
   handle: z.string(),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -5,7 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { AgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import uniqueId from "lodash/uniqueId";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -19,10 +19,15 @@ export type PostAgentConfigurationFromYAMLRequestBody = z.infer<
   typeof PostAgentConfigurationFromYAMLRequestBodySchema
 >;
 
-export type PostAgentConfigurationFromYAMLResponseBody = {
-  agentConfiguration: AgentConfigurationType;
-  skippedActions?: { name: string; reason: string }[];
-};
+export const PostAgentConfigurationFromYAMLResponseBodySchema = z.object({
+  agentConfiguration: AgentConfigurationSchema,
+  skippedActions: z
+    .array(z.object({ name: z.string(), reason: z.string() }))
+    .optional(),
+});
+export type PostAgentConfigurationFromYAMLResponseBody = z.infer<
+  typeof PostAgentConfigurationFromYAMLResponseBodySchema
+>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -13,10 +13,13 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PostTextAsCronRuleResponseBody = {
-  cronRule: string;
-  timezone: string;
-};
+export const PostTextAsCronRuleResponseBodySchema = z.object({
+  cronRule: z.string(),
+  timezone: z.string(),
+});
+export type PostTextAsCronRuleResponseBody = z.infer<
+  typeof PostTextAsCronRuleResponseBodySchema
+>;
 
 const PostTextAsCronRuleRequestBodySchema = z.object({
   naturalDescription: z.string(),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -12,9 +12,12 @@ import {
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type PostWebhookFilterGeneratorResponseBody = {
-  filter: string;
-};
+export const PostWebhookFilterGeneratorResponseBodySchema = z.object({
+  filter: z.string(),
+});
+export type PostWebhookFilterGeneratorResponseBody = z.infer<
+  typeof PostWebhookFilterGeneratorResponseBodySchema
+>;
 
 const PostWebhookFilterGeneratorRequestBodySchema = z.object({
   naturalDescription: z.string(),

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -9,7 +9,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { InternalPostBuilderGenerateSchemaRequestBodySchema } from "@app/types/api/internal/assistant";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { ioTsParsePayload } from "@app/types/shared/utils/iots_utils";
 import type { JSONSchema7 } from "json-schema";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -24,16 +23,14 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST":
-      const bodyRes = ioTsParsePayload(
-        req.body,
-        InternalPostBuilderGenerateSchemaRequestBodySchema
-      );
-      if (bodyRes.isErr()) {
+      const bodyRes =
+        InternalPostBuilderGenerateSchemaRequestBodySchema.safeParse(req.body);
+      if (!bodyRes.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${bodyRes.error.join(", ")}`,
+            message: `Invalid request body: ${bodyRes.error.message}`,
           },
         });
       }
@@ -52,7 +49,7 @@ async function handler(
       }
 
       const schemaRes = await getBuilderJsonSchemaGenerator(auth, {
-        instructions: bodyRes.value.instructions,
+        instructions: bodyRes.data.instructions,
         modelId: model.modelId,
         providerId: model.providerId,
       });

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -9,8 +9,6 @@ import type {
 } from "@app/types/api/internal/assistant";
 import { InternalPostBuilderSuggestionsRequestBodySchema } from "@app/types/api/internal/assistant";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 // TODO(sidekick): Remove useless suggestion types when sidekick is released.
@@ -24,20 +22,19 @@ async function handler(
   switch (req.method) {
     case "POST":
       const bodyValidation =
-        InternalPostBuilderSuggestionsRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        InternalPostBuilderSuggestionsRequestBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
-      const suggestionsType = bodyValidation.right.type;
-      const suggestionsInputs = bodyValidation.right.inputs;
+      const suggestionsType = bodyValidation.data.type;
+      const suggestionsInputs = bodyValidation.data.inputs;
 
       const suggestionsRes = await getBuilderSuggestions(
         auth,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -58,17 +58,15 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type PostMessageEventResponseBody = {
   success: true;
 };
-const PostMessageEventBodySchema = t.type({
-  action: t.literal("cancel"),
-  messageIds: t.array(t.string),
+const PostMessageEventBodySchema = z.object({
+  action: z.literal("cancel"),
+  messageIds: z.array(z.string()),
 });
 
 async function handler(
@@ -98,20 +96,18 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = PostMessageEventBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      const bodyValidation = PostMessageEventBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
       await cancelMessageGenerationEvent(auth, {
-        messageIds: bodyValidation.right.messageIds,
+        messageIds: bodyValidation.data.messageIds,
         conversationId,
       });
       return res.status(200).json({ success: true });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -74,8 +74,6 @@ import { apiError } from "@app/logger/withlogging";
 import { InternalPostContentFragmentRequestBodySchema } from "@app/types/api/internal/assistant";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 async function handler(
@@ -109,21 +107,19 @@ async function handler(
   switch (req.method) {
     case "POST":
       const bodyValidation =
-        InternalPostContentFragmentRequestBodySchema.decode(req.body);
+        InternalPostContentFragmentRequestBodySchema.safeParse(req.body);
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
-      const contentFragmentPayload = bodyValidation.right;
+      const contentFragmentPayload = bodyValidation.data;
       const baseContext = {
         username: user.username,
         fullName: user.fullName(),

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -131,24 +131,16 @@ import {
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const PatchConversationsRequestBodySchema = t.union([
-  t.type({
-    title: t.string,
-  }),
-  t.type({
-    read: t.literal(true),
-  }),
-  t.type({
-    spaceId: t.string,
-  }),
+const PatchConversationsRequestBodySchema = z.union([
+  z.object({ title: z.string() }),
+  z.object({ read: z.literal(true) }),
+  z.object({ spaceId: z.string() }),
 ]);
 
-export type PatchConversationsRequestBody = t.TypeOf<
+export type PatchConversationsRequestBody = z.infer<
   typeof PatchConversationsRequestBodySchema
 >;
 
@@ -224,28 +216,24 @@ async function handler(
         }
 
         const conversation = conversationRes.value;
-        const bodyValidation = PatchConversationsRequestBodySchema.decode(
+        const bodyValidation = PatchConversationsRequestBodySchema.safeParse(
           req.body
         );
 
-        if (isLeft(bodyValidation)) {
-          const pathError = reporter.formatValidationErrors(
-            bodyValidation.left
-          );
-
+        if (!bodyValidation.success) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: `Invalid request body: ${pathError}`,
+              message: `Invalid request body: ${bodyValidation.error.message}`,
             },
           });
         }
 
-        if ("title" in bodyValidation.right) {
+        if ("title" in bodyValidation.data) {
           const result = await updateConversationTitle(auth, {
             conversationId: conversation.sId,
-            title: bodyValidation.right.title,
+            title: bodyValidation.data.title,
           });
           await ConversationResource.markAsReadForAuthUser(auth, {
             conversation,
@@ -255,16 +243,16 @@ async function handler(
             return apiErrorForConversation(req, res, result.error);
           }
           return res.status(200).json({ success: true });
-        } else if ("read" in bodyValidation.right) {
+        } else if ("read" in bodyValidation.data) {
           await ConversationResource.markAsReadForAuthUser(auth, {
             conversation,
           });
 
           return res.status(200).json({ success: true });
-        } else if ("spaceId" in bodyValidation.right) {
+        } else if ("spaceId" in bodyValidation.data) {
           const r = await moveConversationToProject(auth, {
             conversation,
-            spaceId: bodyValidation.right.spaceId,
+            spaceId: bodyValidation.data.spaceId,
           });
           if (r.isOk()) {
             return res.status(200).json({ success: true });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -66,22 +66,20 @@ import { apiError } from "@app/logger/withlogging";
 import type { UserMessageType } from "@app/types/assistant/conversation";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const AgentMentionSchema = t.type({
-  configurationId: t.string,
+const AgentMentionSchema = z.object({
+  configurationId: z.string(),
 });
-const UserMentionSchema = t.type({
-  type: t.literal("user"),
-  userId: t.string,
+const UserMentionSchema = z.object({
+  type: z.literal("user"),
+  userId: z.string(),
 });
 
-const PostEditRequestBodySchema = t.type({
-  content: t.string,
-  mentions: t.array(t.union([AgentMentionSchema, UserMentionSchema])),
+const PostEditRequestBodySchema = z.object({
+  content: z.string(),
+  mentions: z.array(z.union([AgentMentionSchema, UserMentionSchema])),
 });
 
 async function handler(
@@ -156,16 +154,14 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = PostEditRequestBodySchema.decode(req.body);
+      const bodyValidation = PostEditRequestBodySchema.safeParse(req.body);
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
@@ -183,7 +179,7 @@ async function handler(
           },
         });
       }
-      const { content, mentions } = bodyValidation.right;
+      const { content, mentions } = bodyValidation.data;
 
       const editedMessageRes = await editUserMessage(auth, {
         conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -107,15 +107,13 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import { launchAgentMessageFeedbackWorkflow } from "@app/temporal/analytics_queue/client";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export const MessageFeedbackRequestBodySchema = t.type({
-  thumbDirection: t.string,
-  feedbackContent: t.union([t.string, t.undefined, t.null]),
-  isConversationShared: t.union([t.boolean, t.undefined]),
+export const MessageFeedbackRequestBodySchema = z.object({
+  thumbDirection: z.string(),
+  feedbackContent: z.string().nullable().optional(),
+  isConversationShared: z.boolean().optional(),
 });
 
 async function handler(
@@ -184,14 +182,15 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = MessageFeedbackRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = MessageFeedbackRequestBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
@@ -200,11 +199,11 @@ async function handler(
         messageId,
         conversation,
         user: user.toJSON(),
-        thumbDirection: bodyValidation.right
+        thumbDirection: bodyValidation.data
           .thumbDirection as AgentMessageFeedbackDirection,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        content: bodyValidation.right.feedbackContent || "",
-        isConversationShared: bodyValidation.right.isConversationShared,
+        content: bodyValidation.data.feedbackContent || "",
+        isConversationShared: bodyValidation.data.isConversationShared,
       });
 
       if (created.isErr()) {
@@ -228,7 +227,7 @@ async function handler(
         conversationId: conversation.sId,
         messageId,
         agentConfigurationId: created.value.agentConfigurationId,
-        thumbDirection: bodyValidation.right
+        thumbDirection: bodyValidation.data
           .thumbDirection as AgentMessageFeedbackDirection,
         feedbackId: created.value.feedbackId,
       });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -9,22 +9,20 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-const PostMentionActionRequestBodySchema = t.type({
-  type: t.union([t.literal("agent"), t.literal("user")]),
-  id: t.string,
-  action: t.union([
-    t.literal("approved"),
-    t.literal("rejected"),
-    t.literal("dismissed"),
+const PostMentionActionRequestBodySchema = z.object({
+  type: z.union([z.literal("agent"), z.literal("user")]),
+  id: z.string(),
+  action: z.union([
+    z.literal("approved"),
+    z.literal("rejected"),
+    z.literal("dismissed"),
   ]),
 });
 
-export type PostMentionActionRequestBody = t.TypeOf<
+export type PostMentionActionRequestBody = z.infer<
   typeof PostMentionActionRequestBodySchema
 >;
 
@@ -73,22 +71,20 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      const bodyValidation = PostMentionActionRequestBodySchema.decode(
+      const bodyValidation = PostMentionActionRequestBodySchema.safeParse(
         req.body
       );
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
-      const { type, id, action } = bodyValidation.right;
+      const { type, id, action } = bodyValidation.data;
 
       if (action === "dismissed") {
         const dismissMentionRes = await dismissMention(auth, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -28,13 +28,11 @@ import {
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export const MessageReactionRequestBodySchema = t.type({
-  reaction: t.string,
+export const MessageReactionRequestBodySchema = z.object({
+  reaction: z.string(),
 });
 
 async function handler(
@@ -97,14 +95,13 @@ async function handler(
   }
 
   const messageId = req.query.mId;
-  const bodyValidation = MessageReactionRequestBodySchema.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation = MessageReactionRequestBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${bodyValidation.error.message}`,
       },
     });
   }
@@ -130,7 +127,7 @@ async function handler(
           username: user.username,
           fullName: user.fullName(),
         },
-        reaction: bodyValidation.right.reaction,
+        reaction: bodyValidation.data.reaction,
       });
 
       if (created) {
@@ -155,7 +152,7 @@ async function handler(
           username: user.username,
           fullName: user.fullName(),
         },
-        reaction: bodyValidation.right.reaction,
+        reaction: bodyValidation.data.reaction,
       });
 
       if (deleted) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -143,8 +143,6 @@ import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type PostMessagesResponseBody = {
@@ -249,24 +247,22 @@ async function handler(
       break;
 
     case "POST":
-      const bodyValidation = InternalPostMessagesRequestBodySchema.decode(
+      const bodyValidation = InternalPostMessagesRequestBodySchema.safeParse(
         req.body
       );
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
 
       const { content, context, mentions, skipToolsValidation } =
-        bodyValidation.right;
+        bodyValidation.data;
 
       if (context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
@@ -8,16 +8,15 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type SuggestResponseBody = {
   agentConfigurations: LightAgentConfigurationType[];
 };
 
-const SuggestQuerySchema = t.type({
-  cId: t.string,
+const SuggestQuerySchema = z.object({
+  cId: z.string(),
 });
 
 async function handler(
@@ -35,8 +34,8 @@ async function handler(
     });
   }
 
-  const queryValidation = SuggestQuerySchema.decode(req.query);
-  if (isLeft(queryValidation)) {
+  const queryValidation = SuggestQuerySchema.safeParse(req.query);
+  if (!queryValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -46,7 +45,7 @@ async function handler(
     });
   }
 
-  const { cId } = queryValidation.right;
+  const { cId } = queryValidation.data;
 
   // Get the conversation.
   const conversationRes =

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -150,8 +150,6 @@ import type {
 import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationsResponseBody = {
@@ -221,18 +219,15 @@ async function handler(
         req.body.spaceId = null;
       }
 
-      const bodyValidation = InternalPostConversationsRequestBodySchema.decode(
-        req.body
-      );
+      const bodyValidation =
+        InternalPostConversationsRequestBodySchema.safeParse(req.body);
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${bodyValidation.error.message}`,
           },
         });
       }
@@ -245,7 +240,7 @@ async function handler(
         contentFragments,
         metadata,
         skipToolsValidation,
-      } = bodyValidation.right;
+      } = bodyValidation.data;
 
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -1,90 +1,72 @@
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
+import type { DustMimeType } from "@dust-tt/client";
+// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES_VALUES } from "@dust-tt/client";
-import * as t from "io-ts";
+import { z } from "zod";
 
+import type { SupportedNonImageContentType } from "../../files";
 import { getSupportedNonImageMimeTypes } from "../../files";
 
-const AgentMentionSchema = t.type({
+const AgentMentionSchema = z.object({
   // TODO: add a type="agent" but this requires to be backwards compatible with the old API, not doing for now
-  configurationId: t.string,
+  configurationId: z.string(),
 });
-const UserMentionSchema = t.type({ type: t.literal("user"), userId: t.string });
-
-const UserMessageOriginSchema = t.union([
-  t.literal("web"),
-  t.literal("agent_sidekick"),
-  t.literal("project_kickoff"),
-  t.literal("extension"),
-  t.literal("reinforced_agent_notification"),
-]);
-
-export const MessageBaseSchema = t.type({
-  content: t.refinement(
-    t.string,
-    (s): s is string => s.length > 0,
-    "NonEmptyString"
-  ),
-  mentions: t.array(t.union([AgentMentionSchema, UserMentionSchema])),
-  context: t.intersection([
-    t.type({
-      timezone: t.string,
-      profilePictureUrl: t.union([t.string, t.null]),
-    }),
-    t.partial({
-      clientSideMCPServerIds: t.array(t.string),
-      selectedMCPServerViewIds: t.array(t.string),
-      selectedSkillIds: t.array(t.string),
-      originMessageId: t.string,
-      origin: UserMessageOriginSchema,
-    }),
-  ]),
+const UserMentionSchema = z.object({
+  type: z.literal("user"),
+  userId: z.string(),
 });
 
-export const InternalPostMessagesRequestBodySchema = t.intersection([
-  MessageBaseSchema,
-  t.partial({
-    skipToolsValidation: t.boolean,
-  }),
+const UserMessageOriginSchema = z.enum([
+  "web",
+  "agent_sidekick",
+  "project_kickoff",
+  "extension",
+  "reinforced_agent_notification",
 ]);
 
-const ContentFragmentBaseSchema = t.intersection([
-  t.type({
-    title: t.string,
+export const MessageBaseSchema = z.object({
+  content: z.string().min(1),
+  mentions: z.array(z.union([AgentMentionSchema, UserMentionSchema])),
+  context: z.object({
+    timezone: z.string(),
+    profilePictureUrl: z.string().nullable(),
+    clientSideMCPServerIds: z.array(z.string()).optional(),
+    selectedMCPServerViewIds: z.array(z.string()).optional(),
+    selectedSkillIds: z.array(z.string()).optional(),
+    originMessageId: z.string().optional(),
+    origin: UserMessageOriginSchema.optional(),
   }),
-  t.partial({
-    url: t.union([t.string, t.null]),
-    supersededContentFragmentId: t.union([t.string, t.null]),
-  }),
-]);
+});
+
+export const InternalPostMessagesRequestBodySchema = MessageBaseSchema.extend({
+  skipToolsValidation: z.boolean().optional(),
+});
+
+const ContentFragmentBaseSchema = z.object({
+  title: z.string(),
+  url: z.string().nullable().optional(),
+  supersededContentFragmentId: z.string().nullable().optional(),
+});
 
 export const getSupportedInlinedContentType = () => {
-  const [first, second, ...rest] = getSupportedNonImageMimeTypes();
-  return t.union([
-    t.literal(first),
-    t.literal(second),
-    ...rest.map((value) => t.literal(value)),
-  ]);
+  const values = getSupportedNonImageMimeTypes();
+  return z.enum(values as [string, ...string[]]);
 };
 
-const [first, second, ...rest] = [
+const allContentNodeValues = [
   ...INTERNAL_MIME_TYPES_VALUES,
   ...getSupportedNonImageMimeTypes(),
 ];
 export const getSupportedContentNodeContentTypeSchema = () => {
-  return t.union([
-    t.literal(first),
-    t.literal(second),
-    ...rest.map((value) => t.literal(value)),
-  ]);
+  return z.enum(allContentNodeValues as [string, ...string[]]);
 };
 
-export type SupportedContentNodeContentType = t.TypeOf<
-  ReturnType<typeof getSupportedContentNodeContentTypeSchema>
->;
+export type SupportedContentNodeContentType =
+  | DustMimeType
+  | SupportedNonImageContentType;
 
-export type SupportedInlinedContentFragmentTypeSchema = t.TypeOf<
-  ReturnType<typeof getSupportedInlinedContentType>
->;
+export type SupportedInlinedContentFragmentTypeSchema =
+  SupportedNonImageContentType;
 
 export const isSupportedInlinedFragmentContentType = (
   contentType: string
@@ -109,38 +91,30 @@ export const isSupportedContentNodeFragmentContentType = (
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ContentFragmentInputWithContentSchema = t.intersection([
-  ContentFragmentBaseSchema,
-  t.type({
-    content: t.string,
-    contentType: getSupportedInlinedContentType(),
-  }),
-]);
+const ContentFragmentInputWithContentSchema = ContentFragmentBaseSchema.extend({
+  content: z.string(),
+  contentType: getSupportedInlinedContentType(),
+});
 
-export type ContentFragmentInputWithInlinedContent = t.TypeOf<
+export type ContentFragmentInputWithInlinedContent = z.infer<
   typeof ContentFragmentInputWithContentSchema
 >;
 
-const ContentFragmentInputWithContentNodeSchema = t.intersection([
-  ContentFragmentBaseSchema,
-  t.type({
-    nodeId: t.string,
-    nodeDataSourceViewId: t.string,
-  }),
-]);
+const ContentFragmentInputWithContentNodeSchema =
+  ContentFragmentBaseSchema.extend({
+    nodeId: z.string(),
+    nodeDataSourceViewId: z.string(),
+  });
 
-export type ContentFragmentInputWithContentNode = t.TypeOf<
+export type ContentFragmentInputWithContentNode = z.infer<
   typeof ContentFragmentInputWithContentNodeSchema
 >;
 
-const ContentFragmentInputWithFileIdSchema = t.intersection([
-  ContentFragmentBaseSchema,
-  t.type({
-    fileId: t.string,
-  }),
-]);
+const ContentFragmentInputWithFileIdSchema = ContentFragmentBaseSchema.extend({
+  fileId: z.string(),
+});
 
-export type ContentFragmentInputWithFileIdType = t.TypeOf<
+export type ContentFragmentInputWithFileIdType = z.infer<
   typeof ContentFragmentInputWithFileIdSchema
 >;
 
@@ -185,74 +159,66 @@ export function isContentFragmentInputWithContentNode(
   return "nodeId" in fragment && "nodeDataSourceViewId" in fragment;
 }
 
-export const InternalPostContentFragmentRequestBodySchema = t.intersection([
-  t.type({
-    context: t.type({
-      profilePictureUrl: t.union([t.string, t.null]),
+export const InternalPostContentFragmentRequestBodySchema = z
+  .object({
+    context: z.object({
+      profilePictureUrl: z.string().nullable(),
     }),
-  }),
-  t.union([
-    ContentFragmentInputWithFileIdSchema,
-    ContentFragmentInputWithContentNodeSchema,
-  ]),
-]);
+  })
+  .and(
+    z.union([
+      ContentFragmentInputWithFileIdSchema,
+      ContentFragmentInputWithContentNodeSchema,
+    ])
+  );
 
-export type InternalPostContentFragmentRequestBodyType = t.TypeOf<
+export type InternalPostContentFragmentRequestBodyType = z.infer<
   typeof InternalPostContentFragmentRequestBodySchema
 >;
 
-const ConversationMetadataSchema = t.UnknownRecord;
+export const InternalPostConversationsRequestBodySchema = z.object({
+  title: z.string().nullable(),
+  visibility: z.enum(["unlisted", "deleted", "test"]),
+  spaceId: z.string().nullable(),
+  message: MessageBaseSchema.nullable(),
+  contentFragments: z.array(InternalPostContentFragmentRequestBodySchema),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  skipToolsValidation: z.boolean().optional(),
+});
 
-export const InternalPostConversationsRequestBodySchema = t.intersection([
-  t.type({
-    title: t.union([t.string, t.null]),
-    visibility: t.union([
-      t.literal("unlisted"),
-      t.literal("deleted"),
-      t.literal("test"),
-    ]),
-    spaceId: t.union([t.string, t.null]),
-    message: t.union([MessageBaseSchema, t.null]),
-    contentFragments: t.array(InternalPostContentFragmentRequestBodySchema),
-  }),
-  t.partial({
-    metadata: ConversationMetadataSchema,
-    skipToolsValidation: t.boolean,
-  }),
-]);
-
-export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
-  t.type({
-    type: t.literal("name"),
-    inputs: t.type({ instructions: t.string, description: t.string }),
-  }),
-  t.type({
-    type: t.literal("emoji"),
-    inputs: t.type({ instructions: t.string }),
-  }),
-  t.type({
-    type: t.literal("instructions"),
-    inputs: t.type({
-      current_instructions: t.string,
-      former_suggestions: t.array(t.string),
+export const InternalPostBuilderSuggestionsRequestBodySchema =
+  z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("name"),
+      inputs: z.object({ instructions: z.string(), description: z.string() }),
     }),
-  }),
-  t.type({
-    type: t.literal("description"),
-    inputs: t.type({ instructions: t.string, name: t.string }),
-  }),
-  t.type({
-    type: t.literal("tags"),
-    inputs: t.type({
-      instructions: t.string,
-      description: t.string,
-      isAdmin: t.boolean,
-      tags: t.array(t.string),
+    z.object({
+      type: z.literal("emoji"),
+      inputs: z.object({ instructions: z.string() }),
     }),
-  }),
-]);
+    z.object({
+      type: z.literal("instructions"),
+      inputs: z.object({
+        current_instructions: z.string(),
+        former_suggestions: z.array(z.string()),
+      }),
+    }),
+    z.object({
+      type: z.literal("description"),
+      inputs: z.object({ instructions: z.string(), name: z.string() }),
+    }),
+    z.object({
+      type: z.literal("tags"),
+      inputs: z.object({
+        instructions: z.string(),
+        description: z.string(),
+        isAdmin: z.boolean(),
+        tags: z.array(z.string()),
+      }),
+    }),
+  ]);
 
-export type BuilderSuggestionsRequestType = t.TypeOf<
+export type BuilderSuggestionsRequestType = z.infer<
   typeof InternalPostBuilderSuggestionsRequestBodySchema
 >;
 
@@ -261,41 +227,42 @@ export type BuilderSuggestionInputType =
 
 export type BuilderSuggestionType = BuilderSuggestionsRequestType["type"];
 
-const BuilderTextSuggestionTypeSchema = t.union([
-  t.array(t.string),
-  t.null,
-  t.undefined,
-]);
+const BuilderTextSuggestionTypeSchema = z
+  .array(z.string())
+  .nullable()
+  .optional();
 
-export type BuilderTextSuggestionsType = t.TypeOf<
+export type BuilderTextSuggestionsType = z.infer<
   typeof BuilderTextSuggestionTypeSchema
 >;
 
-export const BuilderSuggestionsResponseBodySchema = t.union([
-  t.type({
-    status: t.literal("ok"),
-    suggestions: BuilderTextSuggestionTypeSchema,
-  }),
-  t.type({
-    status: t.literal("unavailable"),
-    reason: t.union([
-      t.literal("user_not_finished"), // The user has not finished inputing data for suggestions to make sense
-      t.literal("irrelevant"),
-    ]),
-  }),
-]);
+export const BuilderSuggestionsResponseBodySchema = z.discriminatedUnion(
+  "status",
+  [
+    z.object({
+      status: z.literal("ok"),
+      suggestions: BuilderTextSuggestionTypeSchema,
+    }),
+    z.object({
+      status: z.literal("unavailable"),
+      reason: z.enum(["user_not_finished", "irrelevant"]),
+    }),
+  ]
+);
 
-export type BuilderSuggestionsType = t.TypeOf<
+export type BuilderSuggestionsType = z.infer<
   typeof BuilderSuggestionsResponseBodySchema
 >;
 
-export const BuilderEmojiSuggestionsResponseBodySchema = t.type({
-  suggestions: t.array(t.type({ emoji: t.string, backgroundColor: t.string })),
+export const BuilderEmojiSuggestionsResponseBodySchema = z.object({
+  suggestions: z.array(
+    z.object({ emoji: z.string(), backgroundColor: z.string() })
+  ),
 });
-export type BuilderEmojiSuggestionsType = t.TypeOf<
+export type BuilderEmojiSuggestionsType = z.infer<
   typeof BuilderEmojiSuggestionsResponseBodySchema
 >;
 
-export const InternalPostBuilderGenerateSchemaRequestBodySchema = t.type({
-  instructions: t.string,
+export const InternalPostBuilderGenerateSchemaRequestBodySchema = z.object({
+  instructions: z.string(),
 });


### PR DESCRIPTION
## Description

Part of the Dust API standalone server migration ([Notion](https://www.notion.so/dust-tt/Dust-API-as-a-standalone-server-2e928599d941809babd5e171169d364e)).

**Goal**: Replace io-ts with zod for request validation in all `assistant/conversations` endpoints, as a prerequisite to auto-generating Swagger/OpenAPI docs and using hono + zod-validator for type-safe routes.

### Shared schema file converted:
- `types/api/internal/assistant.ts` — Full rewrite from io-ts to zod: `MessageBaseSchema`, `InternalPostMessagesRequestBodySchema`, `InternalPostContentFragmentRequestBodySchema`, `InternalPostConversationsRequestBodySchema`, `InternalPostBuilderSuggestionsRequestBodySchema`, `BuilderSuggestionsResponseBodySchema`, `BuilderEmojiSuggestionsResponseBodySchema`, `InternalPostBuilderGenerateSchemaRequestBodySchema`

### Conversation endpoint files converted (10):
- `[cId]/cancel.ts` — `PostMessageEventBodySchema`
- `[cId]/index.ts` — `PatchConversationsRequestBodySchema`
- `[cId]/suggest.ts` — `SuggestQuerySchema`
- `[cId]/messages/[mId]/edit.ts` — `PostEditRequestBodySchema`
- `[cId]/messages/[mId]/feedbacks/index.ts` — `MessageFeedbackRequestBodySchema`
- `[cId]/messages/[mId]/mentions.ts` — `PostMentionActionRequestBodySchema`
- `[cId]/messages/[mId]/reactions/index.ts` — `MessageReactionRequestBodySchema`
- `[cId]/content_fragment/index.ts` — uses shared `InternalPostContentFragmentRequestBodySchema`
- `[cId]/messages/index.ts` — uses shared `InternalPostMessagesRequestBodySchema`
- `index.ts` — uses shared `InternalPostConversationsRequestBodySchema`

### Other consumers updated:
- `builder/suggestions.ts`, `builder/process/generate_schema.ts` — `.decode()` → `.safeParse()`
- `lib/api/assistant/suggestions/emoji.ts` — `.decode()` → `.safeParse()`
- `hooks/useCreateConversationWithMessage.ts` — `t.TypeOf` → `z.infer`

All `io-ts` / `fp-ts` / `io-ts-reporters` imports removed from converted files.

## Tests

- `npx tsgo --noEmit` passes with zero errors
- No behavioral changes — validation logic is equivalent

## Risk

Low. Zod `safeParse` produces the same accept/reject behavior as io-ts `decode`. Error message formatting may differ slightly.

## Deploy Plan

Standard deploy — no migration needed.