### PR TITLE
[Connectors] fix(snowflake): handle invalid JWT token error as ExternalOAuthTokenError

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -150,6 +150,24 @@ function isSnowflakeInsufficientPrivilegesError(
   );
 }
 
+interface SnowflakeInvalidJwtError extends Error {
+  name: "OperationFailedError";
+}
+
+function isSnowflakeInvalidJwtError(
+  err: unknown
+): err is SnowflakeInvalidJwtError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    err.name === "OperationFailedError" &&
+    "message" in err &&
+    typeof err.message === "string" &&
+    err.message.includes("JWT token is invalid")
+  );
+}
+
 export class SnowflakeCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -169,7 +187,8 @@ export class SnowflakeCastKnownErrorsInterceptor
         isSnowflakeRoleNotFoundError(err) ||
         isSnowflakeSuspendedError(err) ||
         isSnowflakeUserAccessDisabledError(err) ||
-        isSnowflakeInsufficientPrivilegesError(err)
+        isSnowflakeInsufficientPrivilegesError(err) ||
+        isSnowflakeInvalidJwtError(err)
       ) {
         throw new ExternalOAuthTokenError(err);
       }


### PR DESCRIPTION
## Summary

- Handle Snowflake `OperationFailedError` with message "JWT token is invalid" as `ExternalOAuthTokenError`, so the sync fails gracefully with `oauth_token_revoked` instead of retrying indefinitely.

## Context

- [Temporal workflow](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/snowflake-sync-40434/caea94c3-944a-44d2-9d46-43d773778e07/timeline)

## Test plan

- [x] Type-checks (no new errors introduced)
- [ ] Verify on next occurrence that the sync fails gracefully with `oauth_token_revoked` status