### PR TITLE
[front] fix: attachment picker filter bar visibility during loading

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -525,24 +525,23 @@ export const InputBarAttachmentsPicker = ({
       >
         {searchQuery ? (
           <div ref={itemsContainerRef}>
-            {showLoader ||
-              (availableSources.length > 1 && (
-                <div className="flex flex-wrap items-center gap-0.5 p-2">
-                  {showLoader && (
-                    <div className="flex h-7 items-center justify-center last:grow">
-                      <Spinner size="xs" />
-                    </div>
-                  )}
-                  {availableSources.length > 1 && (
-                    <DropdownMenuFilters
-                      filters={availableSources}
-                      selectedValues={selectedFilterKeys}
-                      onSelectFilter={handleFilterClick}
-                      className="grow"
-                    />
-                  )}
-                </div>
-              ))}
+            {(showLoader || availableSources.length > 1) && (
+              <div className="flex flex-wrap items-center gap-0.5 p-2">
+                {showLoader && (
+                  <div className="flex h-7 items-center justify-center last:grow">
+                    <Spinner size="xs" />
+                  </div>
+                )}
+                {availableSources.length > 1 && (
+                  <DropdownMenuFilters
+                    filters={availableSources}
+                    selectedValues={selectedFilterKeys}
+                    onSelectFilter={handleFilterClick}
+                    className="grow"
+                  />
+                )}
+              </div>
+            )}
             {Object.keys(serversWithResults).length === 0 ? (
               // No tools results, show knowledge nodes as returned by the search.
               dataSourcesNodes
@@ -579,6 +578,7 @@ export const InputBarAttachmentsPicker = ({
                           attachedNodes={attachedNodes}
                           onNodeSelect={onNodeSelect}
                           onNodeUnselect={onNodeUnselect}
+                          spacesMap={spacesMap}
                         />
                       ))
                     : null;


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7051
- This PR the bugs on the attachment picker detailed in the issue: floating icons and content from deselected filter staying visible
  1. `||` operator bug (the root cause of both issues): `{showLoader || (availableSources.length > 1 &&` short-circuits to true (renders nothing) whenever `showLoader` is truthy. Since `isSearchLoading` stays true for the entire EventSource connection lifetime (cleared only in onerror which fires on normal close too), the filter bar was invisible during all loading. This caused floating icons (results shown without the filter header row) and the perception that filters weren't applying (users couldn't interact with filters mid-stream).
  2. Missing spacesMap prop in the "with tools" rendering branch, the location description in `KnowledgeNodeCheckboxItem` would render without space information.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.