### PR TITLE
[front] fix Anthropic terminated errors detection

### DIFF
--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -65,7 +65,10 @@ export function categorizeLLMError(
       ? error.status
       : undefined;
 
-  if (errorMessage.toLowerCase().startsWith("terminated")) {
+  if (
+    errorMessage.includes("terminated") ||
+    errorMessage.includes("other side closed")
+  ) {
     return {
       type: "terminated_error",
       message: `Terminated error for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -65,7 +65,7 @@ export function categorizeLLMError(
       ? error.status
       : undefined;
 
-  if (errorMessage === "terminated") {
+  if (errorMessage.toLowerCase().startsWith("terminated")) {
     return {
       type: "terminated_error",
       message: `Terminated error for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7199.
- This PR fixes how terminated errors from Anthropic's API are caught.
- The current check relies on the error message being equal to "terminated" when in fact it can be "terminated: other side closed".

## Tests

## Risk

- Low. Technically only an additive change.

## Deploy Plan

- Deploy front.
