### PR TITLE
[front] Convert types to zod

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,8 +1,4 @@
 import type {
-  CustomResourceIconType,
-  InternalAllowedIconType,
-} from "@app/components/resources/resources_icons";
-import type {
   MCPToolStakeLevelType,
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
@@ -19,25 +15,16 @@ import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction
 import type { FileAuthorizationInfo } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type {
-  DataSourceConfiguration,
-  ProjectConfiguration,
-  TableDataSourceConfiguration,
-} from "@app/lib/api/assistant/configuration/types";
-import type {
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
-import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import type { DustAppRunConfigurationType } from "@app/types/app";
-import type {
-  PersonalAuthenticationRequiredErrorContent,
-  ToolErrorEvent,
-} from "@app/types/assistant/agent";
-import { isPersonalAuthenticationRequiredErrorContent } from "@app/types/assistant/agent";
-import type { ModelId } from "@app/types/shared/model_id";
+import type { ToolErrorEvent } from "@app/types/assistant/agent";
+import {
+  isPersonalAuthenticationRequiredErrorContent,
+  type PersonalAuthenticationRequiredErrorContent,
+} from "@app/types/assistant/agent_error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 export type ActionApprovalStateType =
@@ -45,44 +32,20 @@ export type ActionApprovalStateType =
   | "rejected"
   | "always_approved";
 
-export type BaseMCPServerConfigurationType = {
-  id: ModelId;
+// Schemas are in mcp_schemas.ts to avoid pulling zod + heavy dependencies
+// into the Temporal workflow sandbox (which doesn't have Buffer, etc.).
+// Import schemas from "@app/lib/actions/mcp_schemas" directly.
+import type {
+  ClientSideMCPServerConfigurationType,
+  ServerSideMCPServerConfigurationType,
+} from "@app/lib/actions/mcp_schemas";
 
-  sId: string;
-
-  type: "mcp_server_configuration";
-
-  name: string;
-
-  description: string | null;
-  icon?: CustomResourceIconType | InternalAllowedIconType;
-};
-
-// Server-side MCP server = Remote MCP Server OR our own MCP server.
-export type ServerSideMCPServerConfigurationType =
-  BaseMCPServerConfigurationType & {
-    dataSources: DataSourceConfiguration[] | null;
-    tables: TableDataSourceConfiguration[] | null;
-    childAgentId: string | null;
-    timeFrame: TimeFrame | null;
-    jsonSchema: JSONSchema | null;
-    additionalConfiguration: AdditionalConfigurationType;
-    mcpServerViewId: string;
-    dustAppConfiguration: DustAppRunConfigurationType | null;
-    secretName: string | null;
-    dustProject: ProjectConfiguration | null;
-    // Out of convenience, we hold the sId of the internal server if it is an internal server.
-    internalMCPServerId: string | null;
-  };
-
-export type ClientSideMCPServerConfigurationType =
-  BaseMCPServerConfigurationType & {
-    clientSideMcpServerId: string;
-  };
-
-export type MCPServerConfigurationType =
-  | ServerSideMCPServerConfigurationType
-  | ClientSideMCPServerConfigurationType;
+export type {
+  BaseMCPServerConfigurationType,
+  ClientSideMCPServerConfigurationType,
+  MCPServerConfigurationType,
+  ServerSideMCPServerConfigurationType,
+} from "@app/lib/actions/mcp_schemas";
 
 export type ServerSideMCPToolType = Omit<
   ServerSideMCPServerConfigurationType,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -212,8 +212,7 @@ export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
 
 // Whether the server is available by default in the global space.
 // Hidden servers are available by default in the global space but are not visible in the assistant builder.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const MCP_SERVER_AVAILABILITY = [
+export const MCP_SERVER_AVAILABILITY = [
   "manual",
   "auto",
   "auto_hidden_builder",

--- a/front/lib/actions/mcp_schemas.ts
+++ b/front/lib/actions/mcp_schemas.ts
@@ -1,0 +1,73 @@
+import {
+  CUSTOM_RESOURCE_ALLOWED,
+  INTERNAL_ALLOWED_ICONS,
+} from "@app/components/resources/resources_icon_names";
+import {
+  DataSourceConfigurationSchema,
+  ProjectConfigurationSchema,
+  TableDataSourceConfigurationSchema,
+} from "@app/lib/api/assistant/configuration/types";
+import { DustAppRunConfigurationSchema } from "@app/types/app";
+import { DbModelIdSchema } from "@app/types/shared/model_id";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+
+const ResourceIconSchema = z.enum([
+  ...CUSTOM_RESOURCE_ALLOWED,
+  ...INTERNAL_ALLOWED_ICONS,
+]);
+
+export const BaseMCPServerConfigurationSchema = z.object({
+  id: DbModelIdSchema,
+  sId: z.string(),
+  type: z.literal("mcp_server_configuration"),
+  name: z.string(),
+  description: z.string().nullable(),
+  icon: ResourceIconSchema.optional(),
+});
+
+export const ServerSideMCPServerConfigurationSchema =
+  BaseMCPServerConfigurationSchema.extend({
+    dataSources: z.array(DataSourceConfigurationSchema).nullable(),
+    tables: z.array(TableDataSourceConfigurationSchema).nullable(),
+    childAgentId: z.string().nullable(),
+    timeFrame: z
+      .object({
+        duration: z.number(),
+        unit: z.enum(["hour", "day", "week", "month", "year"]),
+      })
+      .nullable(),
+    jsonSchema: z.custom<JSONSchema>().nullable(),
+    additionalConfiguration: z.record(
+      z.string(),
+      z.union([z.boolean(), z.number(), z.string(), z.array(z.string())])
+    ),
+    mcpServerViewId: z.string(),
+    dustAppConfiguration: DustAppRunConfigurationSchema.nullable(),
+    secretName: z.string().nullable(),
+    dustProject: ProjectConfigurationSchema.nullable(),
+    internalMCPServerId: z.string().nullable(),
+  });
+
+export const ClientSideMCPServerConfigurationSchema =
+  BaseMCPServerConfigurationSchema.extend({
+    clientSideMcpServerId: z.string(),
+  });
+
+export const MCPServerConfigurationSchema = z.union([
+  ServerSideMCPServerConfigurationSchema,
+  ClientSideMCPServerConfigurationSchema,
+]);
+
+export type BaseMCPServerConfigurationType = z.infer<
+  typeof BaseMCPServerConfigurationSchema
+>;
+export type ServerSideMCPServerConfigurationType = z.infer<
+  typeof ServerSideMCPServerConfigurationSchema
+>;
+export type ClientSideMCPServerConfigurationType = z.infer<
+  typeof ClientSideMCPServerConfigurationSchema
+>;
+export type MCPServerConfigurationType = z.infer<
+  typeof MCPServerConfigurationSchema
+>;

--- a/front/lib/api/assistant/configuration/types.ts
+++ b/front/lib/api/assistant/configuration/types.ts
@@ -1,30 +1,48 @@
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { TagsFilter } from "@app/types/data_source_view";
+import { TagsFilterSchema } from "@app/types/data_source_view";
 import type { Order } from "sequelize";
+import { z } from "zod";
 
-export type DataSourceFilter = {
-  parents: { in: string[] | null; not: string[] | null } | null;
-  tags: TagsFilter;
-};
+export const DataSourceFilterSchema = z.object({
+  parents: z
+    .object({
+      in: z.array(z.string()).nullable(),
+      not: z.array(z.string()).nullable(),
+    })
+    .nullable(),
+  tags: TagsFilterSchema,
+});
 
-export type DataSourceConfiguration = {
-  sId?: string; // The sId is not always available, for instance it is not in an unsaved state of the builder.
-  workspaceId: string;
-  dataSourceViewId: string;
-  filter: DataSourceFilter;
-};
+export type DataSourceFilter = z.infer<typeof DataSourceFilterSchema>;
 
-export type TableDataSourceConfiguration = {
-  sId?: string; // The sId is not always available, for instance it is not in an unsaved state of the builder.
-  workspaceId: string;
-  dataSourceViewId: string;
-  tableId: string;
-};
+export const DataSourceConfigurationSchema = z.object({
+  sId: z.string().optional(), // The sId is not always available, for instance it is not in an unsaved state of the builder.
+  workspaceId: z.string(),
+  dataSourceViewId: z.string(),
+  filter: DataSourceFilterSchema,
+});
 
-export type ProjectConfiguration = {
-  workspaceId: string; // The sId of the workspace (organization)
-  projectId: string; // The sId of the project (space)
-};
+export type DataSourceConfiguration = z.infer<
+  typeof DataSourceConfigurationSchema
+>;
+
+export const TableDataSourceConfigurationSchema = z.object({
+  sId: z.string().optional(), // The sId is not always available, for instance it is not in an unsaved state of the builder.
+  workspaceId: z.string(),
+  dataSourceViewId: z.string(),
+  tableId: z.string(),
+});
+
+export type TableDataSourceConfiguration = z.infer<
+  typeof TableDataSourceConfigurationSchema
+>;
+
+export const ProjectConfigurationSchema = z.object({
+  workspaceId: z.string(), // The sId of the workspace (organization)
+  projectId: z.string(), // The sId of the project (space)
+});
+
+export type ProjectConfiguration = z.infer<typeof ProjectConfigurationSchema>;
 
 export type SortStrategyType = "alphabetical" | "priority" | "updatedAt";
 

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -7,25 +7,30 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
+import { z } from "zod";
 
 /**
  * We retrieve the feedbacks for a whole conversation, not just a single message.
  */
 
-export type AgentMessageFeedbackType = {
-  id: number;
-  sId: string;
-  messageId: string;
-  agentMessageId: number;
-  userId: number;
-  thumbDirection: AgentMessageFeedbackDirection;
-  content: string | null;
-  createdAt: Date;
-  agentConfigurationId: string;
-  agentConfigurationVersion: number;
-  isConversationShared: boolean;
-  dismissed: boolean;
-};
+export const AgentMessageFeedbackSchema = z.object({
+  id: z.number(),
+  sId: z.string(),
+  messageId: z.string(),
+  agentMessageId: z.number(),
+  userId: z.number(),
+  thumbDirection: z.enum(["up", "down"]),
+  content: z.string().nullable(),
+  createdAt: z.date(),
+  agentConfigurationId: z.string(),
+  agentConfigurationVersion: z.number(),
+  isConversationShared: z.boolean(),
+  dismissed: z.boolean(),
+});
+
+export type AgentMessageFeedbackType = z.infer<
+  typeof AgentMessageFeedbackSchema
+>;
 
 export type FeedbackUserInfo = {
   userName: string;

--- a/front/lib/api/assistant/mcp_configurations.ts
+++ b/front/lib/api/assistant/mcp_configurations.ts
@@ -1,11 +1,16 @@
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { Op } from "sequelize";
+import { z } from "zod";
 
-export type AgentMcpConfigurationSummary = {
-  sId: string;
-  name: string | null;
-};
+export const AgentMcpConfigurationSummarySchema = z.object({
+  sId: z.string(),
+  name: z.string().nullable(),
+});
+
+export type AgentMcpConfigurationSummary = z.infer<
+  typeof AgentMcpConfigurationSummarySchema
+>;
 
 export async function listAgentMcpConfigurationsForAgent(params: {
   workspaceId: number;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,7 +1,7 @@
 import type {
   CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/components/resources/resources_icons";
+} from "@app/components/resources/resources_icon_names";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
   LightMCPToolConfigurationType,
@@ -42,6 +42,10 @@ export function getRetryPolicyFromToolConfiguration(
       DEFAULT_MCP_TOOL_RETRY_POLICY;
 }
 
+// Schemas are in mcp_schemas.ts to avoid pulling zod + heavy dependencies
+// into the Temporal workflow sandbox.
+// Import schemas from "@app/lib/api/mcp_schemas" directly.
+
 export type ToolDisplayLabels = {
   running: string; // e.g. "Searching data"
   done: string; // e.g. "Search data"
@@ -55,26 +59,6 @@ export type MCPToolType = {
   // Mandatory for internal MCP servers (enforced via ServerMetadata type).
   displayLabels?: ToolDisplayLabels;
 };
-
-export type MCPToolWithAvailabilityType = MCPToolType & {
-  availability: MCPServerAvailability;
-};
-
-export type WithStakeLevelType<T> = T & {
-  stakeLevel: MCPToolStakeLevelType;
-};
-
-export type ServerSideMCPToolTypeWithStakeAndRetryPolicy =
-  WithStakeLevelType<MCPToolWithAvailabilityType> & {
-    toolServerId: string;
-    timeoutMs?: number;
-    retryPolicy: MCPToolRetryPolicyType;
-  };
-
-export type ClientSideMCPToolTypeWithStakeLevel =
-  WithStakeLevelType<MCPToolWithAvailabilityType> & {
-    argumentsRequiringApproval?: string[];
-  };
 
 export type MCPServerType = {
   // This will be part of the MCP server metadata at the protocol level.
@@ -96,23 +80,13 @@ export type MCPServerType = {
   customHeaders?: Record<string, string> | null;
 };
 
-export type RemoteMCPServerType = MCPServerType & {
-  url?: string;
-  lastSyncAt?: Date | null;
-  lastError?: string | null;
-  icon: CustomResourceIconType | InternalAllowedIconType;
-  // Always manual and allow multiple instances.
-  availability: "manual";
-  allowMultipleInstances: true;
-};
-
 export type MCPServerViewTypeType = "remote" | "internal";
 
 export interface MCPServerViewType {
   id: ModelId;
   sId: string;
-  name: string | null; // Can be null if the user did not set a custom name.
-  description: string | null; // Can be null if the user did not set a custom description.
+  name: string | null;
+  description: string | null;
   createdAt: number;
   updatedAt: number;
   spaceId: string;
@@ -126,6 +100,36 @@ export interface MCPServerViewType {
     enabled: boolean;
   }[];
 }
+
+export type MCPToolWithAvailabilityType = MCPToolType & {
+  availability: MCPServerAvailability;
+};
+
+export type WithStakeLevelType<T> = T & {
+  stakeLevel: MCPToolStakeLevelType;
+};
+
+export type ServerSideMCPToolTypeWithStakeAndRetryPolicy =
+  WithStakeLevelType<MCPToolWithAvailabilityType> & {
+    toolServerId: string;
+    timeoutMs?: number;
+    retryPolicy: MCPToolRetryPolicyType;
+  };
+
+export type ClientSideMCPToolTypeWithStakeLevel =
+  WithStakeLevelType<MCPToolWithAvailabilityType> & {
+    argumentsRequiringApproval?: string[];
+  };
+
+export type RemoteMCPServerType = MCPServerType & {
+  url?: string;
+  lastSyncAt?: Date | null;
+  lastError?: string | null;
+  icon: CustomResourceIconType | InternalAllowedIconType;
+  // Always manual and allow multiple instances.
+  availability: "manual";
+  allowMultipleInstances: true;
+};
 
 export type MCPServerDefinitionType = Omit<
   MCPServerType,

--- a/front/lib/api/mcp_schemas.ts
+++ b/front/lib/api/mcp_schemas.ts
@@ -1,0 +1,81 @@
+import {
+  CUSTOM_RESOURCE_ALLOWED,
+  INTERNAL_ALLOWED_ICONS,
+} from "@app/components/resources/resources_icon_names";
+import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
+import { MCP_SERVER_AVAILABILITY } from "@app/lib/actions/mcp_internal_actions/constants";
+import { OAUTH_PROVIDERS } from "@app/types/oauth/lib";
+import { DbModelIdSchema } from "@app/types/shared/model_id";
+import { EditedByUserSchema } from "@app/types/user";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+
+const MCP_OAUTH_USE_CASES = ["platform_actions", "personal_actions"] as const;
+
+export const ToolDisplayLabelsSchema = z.object({
+  running: z.string(),
+  done: z.string(),
+});
+
+// Types are kept in lib/api/mcp.ts to avoid breaking the Temporal bundle.
+// Only schemas are exported from this file.
+
+export const MCPToolSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  inputSchema: z.custom<JSONSchema>().optional(),
+  displayLabels: ToolDisplayLabelsSchema.optional(),
+});
+
+const AuthorizationInfoSchema = z.object({
+  provider: z.enum(OAUTH_PROVIDERS),
+  supported_use_cases: z.array(z.enum(MCP_OAUTH_USE_CASES)),
+  scope: z.string().optional(),
+  workspace_connection: z
+    .object({
+      required: z.boolean(),
+      satisfied: z.boolean(),
+    })
+    .optional(),
+});
+
+export const MCPServerSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  description: z.string(),
+  sId: z.string(),
+  icon: z.enum([...CUSTOM_RESOURCE_ALLOWED, ...INTERNAL_ALLOWED_ICONS]),
+  authorization: AuthorizationInfoSchema.nullable(),
+  tools: z.array(MCPToolSchema),
+  availability: z.enum(MCP_SERVER_AVAILABILITY),
+  allowMultipleInstances: z.boolean(),
+  documentationUrl: z.string().nullable(),
+  developerSecretSelection: z
+    .enum(["required", "optional"])
+    .nullable()
+    .optional(),
+  developerSecretSelectionDescription: z.string().nullable().optional(),
+  sharedSecret: z.string().nullable().optional(),
+  customHeaders: z.record(z.string(), z.string()).nullable().optional(),
+});
+
+const ToolsMetadataSchema = z.object({
+  toolName: z.string(),
+  permission: z.enum(MCP_TOOL_STAKE_LEVELS),
+  enabled: z.boolean(),
+});
+
+export const MCPServerViewSchema = z.object({
+  id: DbModelIdSchema,
+  sId: z.string(),
+  name: z.string().nullable(),
+  description: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  spaceId: z.string(),
+  serverType: z.enum(["remote", "internal"]),
+  server: MCPServerSchema,
+  oAuthUseCase: z.enum(MCP_OAUTH_USE_CASES).nullable(),
+  editedByUser: EditedByUserSchema.nullable(),
+  toolsMetadata: z.array(ToolsMetadataSchema).optional(),
+});

--- a/front/types/app.ts
+++ b/front/types/app.ts
@@ -1,5 +1,7 @@
+import { z } from "zod";
 import type { BlockType } from "./run";
 import type { ModelId } from "./shared/model_id";
+import { DbModelIdSchema } from "./shared/model_id";
 import type { SpaceType } from "./space";
 
 export type AppVisibility = "private" | "deleted";
@@ -33,16 +35,17 @@ export type SpecificationBlockType = {
 
 export type SpecificationType = Array<SpecificationBlockType>;
 
+export const DustAppRunConfigurationSchema = z.object({
+  id: DbModelIdSchema,
+  sId: z.string(),
+  type: z.literal("dust_app_run_configuration"),
+  appWorkspaceId: z.string(),
+  appId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+});
+
 // TODO Daph refactor this we could simplify this.
-export type DustAppRunConfigurationType = {
-  id: ModelId;
-  sId: string;
-
-  type: "dust_app_run_configuration";
-
-  appWorkspaceId: string;
-  appId: string;
-
-  name: string;
-  description: string | null;
-};
+export type DustAppRunConfigurationType = z.infer<
+  typeof DustAppRunConfigurationSchema
+>;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -2,7 +2,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { GlobalSkillId } from "@app/lib/resources/skill/global/registry";
+import { MCPServerConfigurationSchema } from "@app/lib/actions/mcp_schemas";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentFunctionCallContentType,
@@ -10,23 +10,24 @@ import type {
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
-import { isOAuthProvider, isValidScope } from "@app/types/oauth/lib";
-import type { ModelId } from "@app/types/shared/model_id";
-import type { TagType } from "@app/types/tag";
-import type { UserType } from "@app/types/user";
+import type { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+import { DbModelIdSchema } from "@app/types/shared/model_id";
+import { TagSchema, type TagType } from "@app/types/tag";
+import { UserSchema } from "@app/types/user";
 import { z } from "zod";
-import type { OAuthProvider } from "../oauth/lib";
-import type { ModelIdType, ModelProviderIdType } from "./models/types";
 
 /**
  * Agent configuration
  */
 
-export type GlobalAgentStatus =
-  | "active"
-  | "disabled_by_admin"
-  | "disabled_missing_datasource"
-  | "disabled_free_workspace";
+export const GLOBAL_AGENT_STATUSES = [
+  "active",
+  "disabled_by_admin",
+  "disabled_missing_datasource",
+  "disabled_free_workspace",
+] as const;
+export type GlobalAgentStatus = (typeof GLOBAL_AGENT_STATUSES)[number];
 
 /**
  * Agent statuses:
@@ -39,8 +40,29 @@ export type GlobalAgentStatus =
  *   it is saved for the first time (allows capturing sId early). It allows having
  *   a sId before creating the agent.
  */
-export type AgentStatus = "active" | "archived" | "draft" | "pending";
-export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
+export const AGENT_STATUSES = [
+  "active",
+  "archived",
+  "draft",
+  "pending",
+] as const;
+export type AgentStatus = (typeof AGENT_STATUSES)[number];
+
+export const AGENT_CONFIGURATION_STATUSES = [
+  "active",
+  "archived",
+  "draft",
+  "pending",
+  "disabled_by_admin",
+  "disabled_missing_datasource",
+  "disabled_free_workspace",
+] as const;
+export const AgentConfigurationStatusSchema = z.enum(
+  AGENT_CONFIGURATION_STATUSES
+);
+export type AgentConfigurationStatus = z.infer<
+  typeof AgentConfigurationStatusSchema
+>;
 
 /**
  * Agent configuration scope
@@ -84,13 +106,6 @@ export type AgentsGetViewType =
   | "archived"
   | "favorites";
 
-export type AgentUsageType = {
-  messageCount: number;
-  conversationCount: number;
-  userCount: number;
-  timePeriodSec: number;
-};
-
 export type AgentRecentAuthors = readonly string[];
 
 export const AGENT_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
@@ -100,6 +115,15 @@ const AGENT_REASONING_EFFORTS = ["none", "light", "medium", "high"] as const;
 
 export const AgentReasoningEffortSchema = z.enum(AGENT_REASONING_EFFORTS);
 export type AgentReasoningEffort = z.infer<typeof AgentReasoningEffortSchema>;
+
+export const AgentUsageSchema = z.object({
+  messageCount: z.number(),
+  conversationCount: z.number(),
+  userCount: z.number(),
+  timePeriodSec: z.number(),
+});
+
+export type AgentUsageType = z.infer<typeof AgentUsageSchema>;
 
 // Constrains a reasoning effort to the [min, max] range supported by a model.
 export function clampReasoningEffort(
@@ -116,14 +140,23 @@ export function clampReasoningEffort(
   ];
 }
 
-export type AgentModelConfigurationType = {
-  providerId: ModelProviderIdType;
-  modelId: ModelIdType;
-  temperature: number;
-  reasoningEffort?: AgentReasoningEffort;
-  responseFormat?: string;
-  metaData?: Record<string, unknown>;
-};
+// ModelProviderIdSchema and ModelIdSchema are inlined here to avoid importing
+// from models/models.ts and models/providers.ts which have io-ts side effects
+// (ioTsEnum → uuid) that crash in the Temporal workflow sandbox.
+export const AgentModelConfigurationSchema = z.object({
+  providerId: z.custom<(typeof MODEL_PROVIDER_IDS)[number]>(
+    (val) => typeof val === "string"
+  ),
+  modelId: z.custom<ModelIdType>((val) => typeof val === "string"),
+  temperature: z.number(),
+  reasoningEffort: AgentReasoningEffortSchema.optional(),
+  responseFormat: z.string().optional(),
+  metaData: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type AgentModelConfigurationType = z.infer<
+  typeof AgentModelConfigurationSchema
+>;
 
 export type AgentFetchVariant = "light" | "full" | "extra_light";
 
@@ -136,73 +169,50 @@ export type GlobalAgentContext = {
   };
 };
 
+export const LightAgentConfigurationSchema = z.object({
+  id: DbModelIdSchema,
+  versionCreatedAt: z.string().nullable(),
+  sId: z.string(),
+  version: z.number(),
+  versionAuthorId: DbModelIdSchema.nullable(),
+  instructions: z.string().nullable(),
+  model: AgentModelConfigurationSchema,
+  status: AgentConfigurationStatusSchema,
+  scope: z.enum(AGENT_CONFIGURATION_SCOPES),
+  userFavorite: z.boolean(),
+  name: z.string(),
+  description: z.string(),
+  pictureUrl: z.string(),
+  lastAuthors: z.array(z.string()).readonly().optional(),
+  editors: z.array(UserSchema).optional(),
+  usage: AgentUsageSchema.optional(),
+  feedbacks: z.object({ up: z.number(), down: z.number() }).optional(),
+  maxStepsPerRun: z.number(),
+  tags: z.array(TagSchema),
+  templateId: z.string().nullable(),
+  visualizationEnabled: z.boolean().optional(),
+  requestedGroupIds: z.array(z.array(z.string())),
+  requestedSpaceIds: z.array(z.string()),
+  reinforcement: z.enum(AGENT_REINFORCEMENT_MODES).optional(),
+  canRead: z.boolean(),
+  canEdit: z.boolean(),
+  omittedThinking: z.boolean().optional(),
+});
+
 /**
  * @swaggerschema AgentConfiguration (swagger_schemas.ts), PrivateLightAgentConfiguration (swagger_private_schemas.ts)
  */
-export type LightAgentConfigurationType = {
-  id: ModelId;
+export type LightAgentConfigurationType = z.infer<
+  typeof LightAgentConfigurationSchema
+>;
 
-  versionCreatedAt: string | null;
+export const AgentConfigurationSchema = LightAgentConfigurationSchema.extend({
+  instructionsHtml: z.string().nullable(),
+  actions: z.array(MCPServerConfigurationSchema),
+  skills: z.array(z.string()).optional(),
+});
 
-  sId: string;
-  version: number;
-  // Global agents have a null authorId, others have a non-null authorId
-  versionAuthorId: ModelId | null;
-
-  instructions: string | null;
-
-  model: AgentModelConfigurationType;
-
-  status: AgentConfigurationStatus;
-  scope: AgentConfigurationScope;
-
-  // always false if not in the context of a user (API query)
-  userFavorite: boolean;
-
-  name: string;
-  description: string;
-  pictureUrl: string;
-
-  // `lastAuthors` is expensive to compute, so we only compute it when needed.
-  lastAuthors?: AgentRecentAuthors;
-  editors?: UserType[];
-  usage?: AgentUsageType;
-  feedbacks?: { up: number; down: number };
-
-  maxStepsPerRun: number;
-  tags: TagType[];
-
-  templateId: string | null;
-
-  // TODO(2025-10-20 flav): Remove once SDK JS does not rely on it anymore.
-  visualizationEnabled?: boolean;
-
-  // Remove this once we have completely removed from the sdk.
-  requestedGroupIds: string[][];
-
-  // Space restrictions for accessing the agent/conversation - replaces group restrictions.
-  // The array represents permission requirements:
-  // - If empty, no restrictions apply
-  // - Each element represents an AND condition (user must belong to ALL spaces)
-  //
-  // Example: [1,2] means (1 AND 2)
-  requestedSpaceIds: string[];
-
-  reinforcement?: AgentReinforcementMode;
-
-  canRead: boolean;
-  canEdit: boolean;
-  // TODO (Pierre): Remove after omitted thinking evals
-  omittedThinking?: boolean;
-};
-
-export type AgentConfigurationType = LightAgentConfigurationType & {
-  instructionsHtml: string | null;
-
-  // If empty, no actions are performed, otherwise the actions are performed.
-  actions: MCPServerConfigurationType[];
-  skills?: GlobalSkillId[];
-};
+export type AgentConfigurationType = z.infer<typeof AgentConfigurationSchema>;
 
 export interface TemplateAgentConfigurationType {
   name: string;
@@ -287,50 +297,13 @@ export type GenericErrorContent = {
   metadata: Record<string, string | number | boolean> | null;
 };
 
-export type MCPServerPersonalAuthenticationRequiredMetadata = {
-  mcp_server_id: string;
-  provider: OAuthProvider;
-  scope?: string;
-  conversationId: string;
-  messageId: string;
-};
+import type { PersonalAuthenticationRequiredErrorContent } from "@app/types/assistant/agent_error";
 
-function isMCPServerPersonalAuthenticationRequiredMetadata(
-  metadata: unknown
-): metadata is MCPServerPersonalAuthenticationRequiredMetadata {
-  return (
-    typeof metadata === "object" &&
-    metadata !== null &&
-    "mcp_server_id" in metadata &&
-    typeof metadata.mcp_server_id === "string" &&
-    "provider" in metadata &&
-    isOAuthProvider(metadata?.provider) &&
-    (!("scope" in metadata) || isValidScope(metadata.scope)) &&
-    "conversationId" in metadata &&
-    typeof metadata.conversationId === "string" &&
-    "messageId" in metadata &&
-    typeof metadata.messageId === "string"
-  );
-}
-
-export type PersonalAuthenticationRequiredErrorContent = {
-  code: "mcp_server_personal_authentication_required";
-  message: string;
-  metadata: MCPServerPersonalAuthenticationRequiredMetadata;
-};
-
-export function isPersonalAuthenticationRequiredErrorContent(
-  error: unknown
-): error is PersonalAuthenticationRequiredErrorContent {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "mcp_server_personal_authentication_required" &&
-    "metadata" in error &&
-    isMCPServerPersonalAuthenticationRequiredMetadata(error.metadata)
-  );
-}
+export type {
+  MCPServerPersonalAuthenticationRequiredMetadata,
+  PersonalAuthenticationRequiredErrorContent,
+} from "@app/types/assistant/agent_error";
+export { isPersonalAuthenticationRequiredErrorContent } from "@app/types/assistant/agent_error";
 
 // Generic event sent when an error occurred during the model call.
 export type AgentErrorEvent = {

--- a/front/types/assistant/agent_error.ts
+++ b/front/types/assistant/agent_error.ts
@@ -1,0 +1,47 @@
+import type { OAuthProvider } from "@app/types/oauth/lib";
+import { isOAuthProvider, isValidScope } from "@app/types/oauth/lib";
+
+export type MCPServerPersonalAuthenticationRequiredMetadata = {
+  mcp_server_id: string;
+  provider: OAuthProvider;
+  scope?: string;
+  conversationId: string;
+  messageId: string;
+};
+
+function isMCPServerPersonalAuthenticationRequiredMetadata(
+  metadata: unknown
+): metadata is MCPServerPersonalAuthenticationRequiredMetadata {
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    "mcp_server_id" in metadata &&
+    typeof metadata.mcp_server_id === "string" &&
+    "provider" in metadata &&
+    isOAuthProvider(metadata?.provider) &&
+    (!("scope" in metadata) || isValidScope(metadata.scope)) &&
+    "conversationId" in metadata &&
+    typeof metadata.conversationId === "string" &&
+    "messageId" in metadata &&
+    typeof metadata.messageId === "string"
+  );
+}
+
+export type PersonalAuthenticationRequiredErrorContent = {
+  code: "mcp_server_personal_authentication_required";
+  message: string;
+  metadata: MCPServerPersonalAuthenticationRequiredMetadata;
+};
+
+export function isPersonalAuthenticationRequiredErrorContent(
+  error: unknown
+): error is PersonalAuthenticationRequiredErrorContent {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "mcp_server_personal_authentication_required" &&
+    "metadata" in error &&
+    isMCPServerPersonalAuthenticationRequiredMetadata(error.metadata)
+  );
+}

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -1,43 +1,51 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { MCPServerViewSchema } from "@app/lib/api/mcp_schemas";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { UserType } from "@app/types/user";
+import { z } from "zod";
 
-export type SkillStatus = "active" | "archived" | "suggested";
+export const SKILL_STATUSES = ["active", "archived", "suggested"] as const;
+export type SkillStatus = (typeof SKILL_STATUSES)[number];
 
 export const SKILL_SOURCES = ["web_app", "github", "local_file"] as const;
 
 export type SkillSourceType = (typeof SKILL_SOURCES)[number];
 
-export type SkillSourceMetadata = {
-  repoUrl?: string;
-  filePath: string;
-};
+export const SkillSourceMetadataSchema = z.object({
+  repoUrl: z.string().optional(),
+  filePath: z.string(),
+});
 
-export type SkillType = {
-  id: number;
-  sId: string;
-  createdAt: number | null;
-  updatedAt: number | null;
-  editedBy: number | null;
-  status: SkillStatus;
-  name: string;
-  agentFacingDescription: string;
-  userFacingDescription: string;
-  instructions: string | null;
-  icon: string | null;
-  source: SkillSourceType | null;
-  sourceMetadata: SkillSourceMetadata | null;
-  requestedSpaceIds: string[];
-  tools: MCPServerViewType[];
-  fileAttachments: {
-    fileId: string;
-    fileName: string;
-  }[];
-  canWrite: boolean;
-  isExtendable: boolean;
-  isDefault: boolean;
-  extendedSkillId: string | null;
-};
+export type SkillSourceMetadata = z.infer<typeof SkillSourceMetadataSchema>;
+
+export const SkillSchema = z.object({
+  id: z.number(),
+  sId: z.string(),
+  createdAt: z.number().nullable(),
+  updatedAt: z.number().nullable(),
+  editedBy: z.number().nullable(),
+  status: z.enum(SKILL_STATUSES),
+  name: z.string(),
+  agentFacingDescription: z.string(),
+  userFacingDescription: z.string(),
+  instructions: z.string().nullable(),
+  icon: z.string().nullable(),
+  source: z.enum(SKILL_SOURCES).nullable(),
+  sourceMetadata: SkillSourceMetadataSchema.nullable(),
+  requestedSpaceIds: z.array(z.string()),
+  tools: z.array(MCPServerViewSchema),
+  fileAttachments: z.array(
+    z.object({
+      fileId: z.string(),
+      fileName: z.string(),
+    })
+  ),
+  canWrite: z.boolean(),
+  isExtendable: z.boolean(),
+  isDefault: z.boolean(),
+  extendedSkillId: z.string().nullable(),
+});
+
+export type SkillType = z.infer<typeof SkillSchema>;
 
 export type SkillRelations = {
   usage: AgentsUsageType;

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -1,18 +1,19 @@
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { ModelId } from "@app/types/shared/model_id";
-import type { UserType } from "@app/types/user";
 import { z } from "zod";
 
-export type ScheduleConfig = {
-  cron: string;
-  timezone: string;
-};
+export const ScheduleConfigSchema = z.object({
+  cron: z.string(),
+  timezone: z.string(),
+});
 
-export type WebhookConfig = {
-  includePayload: boolean;
-  event?: string;
-  filter?: string;
-};
+export type ScheduleConfig = z.infer<typeof ScheduleConfigSchema>;
+
+export const WebhookConfigSchema = z.object({
+  includePayload: z.boolean(),
+  event: z.string().optional(),
+  filter: z.string().optional(),
+});
+
+export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
 
 export type TriggerConfigurationType = ScheduleConfig | WebhookConfig;
 
@@ -30,25 +31,6 @@ export type TriggerConfiguration =
     };
 
 export const DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT = 42;
-
-export type TriggerType = {
-  id: ModelId;
-  sId: string;
-  name: string;
-  agentConfigurationId: AgentConfigurationType["sId"];
-  editor: UserType["id"];
-  customPrompt: string | null;
-  status: TriggerStatus;
-  createdAt: number;
-  naturalLanguageDescription: string | null;
-  origin: TriggerOrigin;
-} & TriggerConfiguration;
-
-export type TriggerKind = TriggerType["kind"];
-
-export function isValidTriggerKind(kind: string): kind is TriggerKind {
-  return ["schedule", "webhook"].includes(kind);
-}
 
 export type TriggerExecutionMode = "fair_use" | "programmatic";
 
@@ -80,41 +62,6 @@ export function isValidTriggerOrigin(origin: string): origin is TriggerOrigin {
   return ["user", "agent"].includes(origin);
 }
 
-export type WebhookTriggerType = TriggerType & {
-  kind: "webhook";
-  webhookSourceViewSId: string;
-  executionMode: TriggerExecutionMode | null;
-  executionPerDayLimitOverride: number | null;
-};
-
-export type ScheduleTriggerType = TriggerType & {
-  kind: "schedule";
-  configuration: ScheduleConfig;
-};
-
-export function isWebhookTrigger(
-  trigger: TriggerType
-): trigger is WebhookTriggerType {
-  return trigger.kind === "webhook";
-}
-
-export function isScheduleTrigger(
-  trigger: TriggerType
-): trigger is ScheduleTriggerType {
-  return trigger.kind === "schedule";
-}
-
-const ScheduleConfigSchema = z.object({
-  cron: z.string(),
-  timezone: z.string(),
-});
-
-const WebhookConfigSchema = z.object({
-  includePayload: z.boolean(),
-  event: z.string().optional(),
-  filter: z.string().optional(),
-});
-
 const TriggerStatusSchema = z.enum(TRIGGER_STATUSES);
 
 export const TriggerSchema = z.discriminatedUnion("kind", [
@@ -139,3 +86,62 @@ export const TriggerSchema = z.discriminatedUnion("kind", [
     status: TriggerStatusSchema.optional(),
   }),
 ]);
+
+const TriggerBaseSchema = z.object({
+  id: z.number(),
+  sId: z.string(),
+  name: z.string(),
+  agentConfigurationId: z.string(),
+  editor: z.number(),
+  customPrompt: z.string().nullable(),
+  status: z.enum(TRIGGER_STATUSES),
+  createdAt: z.number(),
+  naturalLanguageDescription: z.string().nullable(),
+  origin: z.enum(["user", "agent"]),
+});
+
+export const FullTriggerSchema = z.discriminatedUnion("kind", [
+  TriggerBaseSchema.extend({
+    kind: z.literal("schedule"),
+    configuration: ScheduleConfigSchema,
+  }),
+  TriggerBaseSchema.extend({
+    kind: z.literal("webhook"),
+    configuration: WebhookConfigSchema,
+    executionPerDayLimitOverride: z.number().nullable(),
+    webhookSourceViewSId: z.string().nullable(),
+    executionMode: z.enum(["fair_use", "programmatic"]).nullable(),
+  }),
+]);
+
+export type TriggerType = z.infer<typeof FullTriggerSchema>;
+
+export type TriggerKind = TriggerType["kind"];
+
+export function isValidTriggerKind(kind: string): kind is TriggerKind {
+  return ["schedule", "webhook"].includes(kind);
+}
+
+export type WebhookTriggerType = TriggerType & {
+  kind: "webhook";
+  webhookSourceViewSId: string;
+  executionMode: TriggerExecutionMode | null;
+  executionPerDayLimitOverride: number | null;
+};
+
+export type ScheduleTriggerType = TriggerType & {
+  kind: "schedule";
+  configuration: ScheduleConfig;
+};
+
+export function isWebhookTrigger(
+  trigger: TriggerType
+): trigger is WebhookTriggerType {
+  return trigger.kind === "webhook";
+}
+
+export function isScheduleTrigger(
+  trigger: TriggerType
+): trigger is ScheduleTriggerType {
+  return trigger.kind === "schedule";
+}

--- a/front/types/data_source_view.ts
+++ b/front/types/data_source_view.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type { DataSourceViewCategory } from "./api/public/spaces";
 import type { ContentNodeWithParent } from "./connectors/connectors_api";
 import type {
@@ -48,12 +50,17 @@ export type DataSourceViewSelectionConfiguration = {
   tagsFilter: TagsFilter;
 };
 
-export type TagsFilterMode = "custom" | "auto";
-export type TagsFilter = {
-  in: string[];
-  not: string[];
-  mode: TagsFilterMode;
-} | null;
+const TAGS_FILTER_MODES = ["custom", "auto"] as const;
+export type TagsFilterMode = (typeof TAGS_FILTER_MODES)[number];
+
+export const TagsFilterSchema = z
+  .object({
+    in: z.array(z.string()),
+    not: z.array(z.string()),
+    mode: z.enum(TAGS_FILTER_MODES),
+  })
+  .nullable();
+export type TagsFilter = z.infer<typeof TagsFilterSchema>;
 
 export function defaultSelectionConfiguration(
   dataSourceView: DataSourceViewType

--- a/front/types/shared/model_id.ts
+++ b/front/types/shared/model_id.ts
@@ -1,1 +1,5 @@
+import { z } from "zod";
+
 export type ModelId = number;
+
+export const DbModelIdSchema = z.number();

--- a/front/types/tag.ts
+++ b/front/types/tag.ts
@@ -5,11 +5,13 @@ const TAG_KINDS = ["standard", "protected"] as const;
 
 export type TagKind = (typeof TAG_KINDS)[number];
 
-export type TagType = {
-  sId: string;
-  name: string;
-  kind: TagKind;
-};
+export const TagSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+  kind: z.enum(["standard", "protected"]),
+});
+
+export type TagType = z.infer<typeof TagSchema>;
 
 export type TagTypeWithUsage = TagType & {
   usage: number;

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -1,13 +1,14 @@
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import type { WorkOSOrganizationType } from "@dust-tt/client";
 import * as t from "io-ts";
-
+import { z } from "zod";
 import type {
   EmbeddingProviderIdType,
   ModelProviderIdType,
 } from "./assistant/models/types";
 import type { MembershipOriginType } from "./memberships";
 import type { ModelId } from "./shared/model_id";
+import { DbModelIdSchema } from "./shared/model_id";
 import { assertNever } from "./shared/utils/assert_never";
 
 export type WorkspaceSegmentationType = "interesting" | null;
@@ -73,31 +74,30 @@ export type ExtensionWorkspaceType = WorkspaceType & {
   blacklistedDomains: string[] | null;
 };
 
-export type UserProviderType =
-  | "auth0"
-  | "github"
-  | "google"
-  | "okta"
-  | "samlp"
-  | "waad"
-  | null;
+export const UserProviderSchema = z
+  .enum(["auth0", "github", "google", "okta", "samlp", "waad"])
+  .nullable();
+
+export type UserProviderType = z.infer<typeof UserProviderSchema>;
+
+export const UserSchema = z.object({
+  sId: z.string(),
+  id: DbModelIdSchema,
+  createdAt: z.number(),
+  provider: UserProviderSchema,
+  username: z.string(),
+  email: z.string(),
+  firstName: z.string(),
+  lastName: z.string().nullable(),
+  fullName: z.string(),
+  image: z.string().nullable(),
+  lastLoginAt: z.number().nullable(),
+});
 
 /**
  * @swaggerschema User (swagger_schemas.ts)
  */
-export type UserType = {
-  sId: string;
-  id: ModelId;
-  createdAt: number;
-  provider: UserProviderType;
-  username: string;
-  email: string;
-  firstName: string;
-  lastName: string | null;
-  fullName: string;
-  image: string | null;
-  lastLoginAt: number | null;
-};
+export type UserType = z.infer<typeof UserSchema>;
 
 export type UserTypeWithWorkspace = UserType & {
   workspace: WorkspaceType;
@@ -131,13 +131,14 @@ export type UserMetadataType = {
   value: string;
 };
 
-export type EditedByUser = {
-  editedAt: number | null;
-  fullName: string | null;
-  imageUrl: string | null;
-  email: string | null;
-  userId: string | null;
-};
+export const EditedByUserSchema = z.object({
+  editedAt: z.number().nullable(),
+  fullName: z.string().nullable(),
+  imageUrl: z.string().nullable(),
+  email: z.string().nullable(),
+  userId: z.string().nullable(),
+});
+export type EditedByUser = z.infer<typeof EditedByUserSchema>;
 
 export function formatUserFullName(user: {
   firstName?: string;


### PR DESCRIPTION
## Description

Part of the Dust API standalone server migration ([Notion](https://www.notion.so/dust-tt/Dust-API-as-a-standalone-server-2e928599d941809babd5e171169d364e)).

**Goal**: Make zod schemas the single source of truth for all types used in API request and response bodies. This is required so that:
1. Swagger/OpenAPI specs can be auto-generated from the zod schemas (both request and response)
2. Hono route definitions can use these schemas for fully type-safe endpoints

All types are now inferred from their schema via `z.infer<typeof Schema>` instead of being manually defined alongside.

### Types migrated (schema → inferred type):
- `TagSchema` → `TagType`, `TagsFilterSchema` → `TagsFilter`
- `UserSchema` → `UserType`, `UserProviderSchema` → `UserProviderType`, `EditedByUserSchema` → `EditedByUser`
- `AgentUsageSchema` → `AgentUsageType`, `AgentModelConfigurationSchema` → `AgentModelConfigurationType`
- `AgentConfigurationStatusSchema` → `AgentConfigurationStatus` (new const array + enum)
- `LightAgentConfigurationSchema` → `LightAgentConfigurationType`
- `AgentConfigurationSchema` → `AgentConfigurationType` (uses `.extend()` on Light schema)
- `MCPServerConfigurationSchema` → `MCPServerConfigurationType` (Base, ServerSide, ClientSide)
- `SkillSchema` → `SkillType`, `SkillSourceMetadataSchema` → `SkillSourceMetadata`
- `FullTriggerSchema` → `TriggerType`, `ScheduleConfigSchema` → `ScheduleConfig`, `WebhookConfigSchema` → `WebhookConfig`
- `DustAppRunConfigurationSchema` → `DustAppRunConfigurationType`
- `AgentMessageFeedbackSchema` → `AgentMessageFeedbackType`
- `AgentMcpConfigurationSummarySchema` → `AgentMcpConfigurationSummary`
- `DataSourceFilterSchema`, `DataSourceConfigurationSchema`, `TableDataSourceConfigurationSchema`, `ProjectConfigurationSchema` → respective types

### New schema files for MCP types:
- **`lib/actions/mcp_schemas.ts`** — `BaseMCPServerConfigurationSchema`, `ServerSideMCPServerConfigurationSchema`, `ClientSideMCPServerConfigurationSchema`, `MCPServerConfigurationSchema`
- **`lib/api/mcp_schemas.ts`** — `ToolDisplayLabelsSchema`, `MCPToolSchema`, `MCPServerSchema`, `MCPServerViewSchema`

These are in separate files to avoid pulling zod + heavy transitive dependencies (`uuid`, `@dust-tt/client`) into the Temporal workflow sandbox, which runs in an isolated environment without `Buffer` or `crypto.getRandomValues()`. The original `mcp.ts` / `lib/api/mcp.ts` files keep manually-defined types and only type-only imports — schemas are imported directly from the `_schemas.ts` files where needed.

### Breaking circular dependency:
- Extracted `isPersonalAuthenticationRequiredErrorContent` + related types from `agent.ts` into `agent_error.ts` to break the `agent.ts ↔ mcp.ts` import cycle
- `agent.ts` re-exports for backward compatibility

### Other:
- Renamed `ModelIdSchema` → `DbModelIdSchema` (in `shared/model_id.ts`) to distinguish from the string model ID schema in `models/models.ts`
- Exported `MCP_SERVER_AVAILABILITY` const from `constants.ts`
- All schemas use exact enums where possible (no `z.string()` widening)

## Tests

- `npx tsgo --noEmit` passes with zero errors
- Temporal workers start successfully (verified: no `Buffer`/`crypto` errors in workflow sandbox)

## Risk

Low. Types are inferred from schemas that match the previous manual definitions. Types heavily used by Temporal (`MCPServerType`, `MCPServerViewType`, `MCPToolType`) are kept as manual definitions in their original files to preserve the bundle graph.

## Deploy Plan

Standard deploy — no migration needed.