### PR TITLE
Only process agents set to 'on' + poke plugin to set flag

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1735,3 +1735,20 @@ export async function filterAgentsByRequestedSpaces(
 
   return allowedBySpaceIds;
 }
+
+export async function updateAgentReinforcementMode(
+  auth: Authenticator,
+  agentSId: string,
+  reinforcement: AgentReinforcementMode
+): Promise<void> {
+  await AgentConfigurationModel.update(
+    { reinforcement },
+    {
+      where: {
+        sId: agentSId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        status: "active",
+      },
+    }
+  );
+}

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -524,6 +524,7 @@ export async function createAgentConfiguration(
               "authorId",
               "workspaceId",
               "createdAt",
+              "reinforcement",
             ],
             order: [["version", "DESC"]],
             transaction: t,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -607,7 +607,8 @@ export async function createAgentConfiguration(
             templateId: template?.id,
             requestedSpaceIds: requestedSpaceIds,
             responseFormat: model.responseFormat,
-            reinforcement: reinforcement ?? "auto",
+            reinforcement:
+              reinforcement ?? existingAgent.reinforcement ?? "auto",
           },
           {
             where: {
@@ -652,7 +653,8 @@ export async function createAgentConfiguration(
             templateId: template?.id,
             requestedSpaceIds: requestedSpaceIds,
             responseFormat: model.responseFormat,
-            reinforcement: reinforcement ?? "auto",
+            reinforcement:
+              reinforcement ?? existingAgent?.reinforcement ?? "auto",
           },
           {
             transaction: t,

--- a/front/lib/api/poke/plugins/agents/agent_reinforcement.ts
+++ b/front/lib/api/poke/plugins/agents/agent_reinforcement.ts
@@ -1,0 +1,77 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { AgentReinforcementMode } from "@app/types/assistant/agent";
+import { AGENT_REINFORCEMENT_MODES } from "@app/types/assistant/agent";
+import { Err, Ok } from "@app/types/shared/result";
+
+function isAgentReinforcementMode(
+  value: string
+): value is AgentReinforcementMode {
+  return (AGENT_REINFORCEMENT_MODES as readonly string[]).includes(value);
+}
+
+export const agentReinforcementPlugin = createPlugin({
+  manifest: {
+    id: "agent-reinforcement",
+    name: "Change Agent Reinforcement",
+    description: "Change the reinforcement mode for this agent (on, off, auto)",
+    resourceTypes: ["agents"],
+    args: {
+      reinforcement: {
+        type: "enum",
+        label: "Reinforcement Mode",
+        description: "The reinforcement mode for this agent",
+        async: true,
+        values: [],
+        multiple: false,
+      },
+    },
+  },
+  populateAsyncArgs: async (auth, resource) => {
+    if (!resource) {
+      return new Err(new Error("Agent configuration not found"));
+    }
+
+    const currentMode = resource.reinforcement ?? "auto";
+
+    return new Ok({
+      reinforcement: AGENT_REINFORCEMENT_MODES.map((mode) => ({
+        label: mode,
+        value: mode,
+        checked: mode === currentMode,
+      })),
+    });
+  },
+  execute: async (auth, resource, args) => {
+    if (!resource) {
+      return new Err(new Error("Agent configuration not found"));
+    }
+
+    const reinforcement = args.reinforcement?.[0];
+    if (!reinforcement || !isAgentReinforcementMode(reinforcement)) {
+      return new Err(new Error("Invalid reinforcement mode"));
+    }
+
+    await AgentConfigurationModel.update(
+      { reinforcement },
+      {
+        where: {
+          sId: resource.sId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+
+    return new Ok({
+      display: "text",
+      value: `Agent reinforcement mode set to "${reinforcement}".`,
+    });
+  },
+  isApplicableTo: (auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+
+    return resource.status === "active";
+  },
+});

--- a/front/lib/api/poke/plugins/agents/agent_reinforcement.ts
+++ b/front/lib/api/poke/plugins/agents/agent_reinforcement.ts
@@ -1,5 +1,5 @@
+import { updateAgentReinforcementMode } from "@app/lib/api/assistant/configuration/agent";
 import { createPlugin } from "@app/lib/api/poke/types";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { AgentReinforcementMode } from "@app/types/assistant/agent";
 import { AGENT_REINFORCEMENT_MODES } from "@app/types/assistant/agent";
 import { Err, Ok } from "@app/types/shared/result";
@@ -52,16 +52,7 @@ export const agentReinforcementPlugin = createPlugin({
       return new Err(new Error("Invalid reinforcement mode"));
     }
 
-    await AgentConfigurationModel.update(
-      { reinforcement },
-      {
-        where: {
-          sId: resource.sId,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          status: "active",
-        },
-      }
-    );
+    await updateAgentReinforcementMode(auth, resource.sId, reinforcement);
 
     return new Ok({
       display: "text",

--- a/front/lib/api/poke/plugins/agents/agent_reinforcement.ts
+++ b/front/lib/api/poke/plugins/agents/agent_reinforcement.ts
@@ -58,6 +58,7 @@ export const agentReinforcementPlugin = createPlugin({
         where: {
           sId: resource.sId,
           workspaceId: auth.getNonNullableWorkspace().id,
+          status: "active",
         },
       }
     );

--- a/front/lib/api/poke/plugins/agents/index.ts
+++ b/front/lib/api/poke/plugins/agents/index.ts
@@ -1,3 +1,4 @@
 export * from "./agent_editors";
+export * from "./agent_reinforcement";
 export * from "./agent_retention";
 export * from "./run_reinforced_agent";

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -68,6 +68,7 @@ export async function getAgentConfigurationsActivity({
     variant: "extra_light",
   });
 
+  // TODO(reinforced agent): for now, we only process those that are on, because we have not yet implemented 'auto' mode
   return agents
     .filter((a) => a.id > 0 && a.reinforcement === "on")
     .map((a) => a.sId);

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -69,7 +69,7 @@ export async function getAgentConfigurationsActivity({
   });
 
   return agents
-    .filter((a) => a.id > 0 && a.reinforcement !== "off")
+    .filter((a) => a.id > 0 && a.reinforcement === "on")
     .map((a) => a.sId);
 }
 


### PR DESCRIPTION
## Description

- Only run reinforced agent workflows for agents with reinforcement explicitly set to "on" (previously also ran for "auto")
- Add poke plugin to change an agent's reinforcement mode (on, off, auto) — only updates the active version
- Fix agent builder losing the reinforcement value on save: the reinforcement attribute wasn't fetched when loading the existing agent, so it always fell back to "auto" when creating a new version

Covers most items from https://github.com/dust-tt/tasks/issues/7200

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front