### PR TITLE
[front] add script to migrate MCP servers on agents

### DIFF
--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -13,7 +13,10 @@ import { isString } from "@app/types/shared/utils/general";
 
 function loadAgentIds(agentsFile: string): string[] {
   const agentIds: unknown = JSON.parse(fs.readFileSync(agentsFile, "utf-8"));
-  assert(Array.isArray(agentIds) && agentIds.every((id) => isString(id)), "agentsFile must contain a JSON array of agent IDs");
+  assert(
+    Array.isArray(agentIds) && agentIds.every((id) => isString(id)),
+    "agentsFile must contain a JSON array of agent IDs"
+  );
 
   return agentIds;
 }
@@ -49,23 +52,28 @@ makeScript(
     originRemoteServerId: {
       type: "string",
       demandOption: true,
-      description:
-        "The mcpServerId of the remote MCP server to migrate from",
+      description: "The mcpServerId of the remote MCP server to migrate from",
     },
     destinationInternalServerId: {
       type: "string",
       demandOption: true,
-      description:
-        "The mcpServerId of the internal MCP server to migrate to",
+      description: "The mcpServerId of the internal MCP server to migrate to",
     },
     agentsFile: {
       type: "string",
       demandOption: true,
-      description: "Path to a JSON file containing an array of agent IDs to migrate",
+      description:
+        "Path to a JSON file containing an array of agent IDs to migrate",
     },
   },
   async (
-    { workspaceId, originRemoteServerId, destinationInternalServerId, agentsFile, execute },
+    {
+      workspaceId,
+      originRemoteServerId,
+      destinationInternalServerId,
+      agentsFile,
+      execute,
+    },
     logger
   ) => {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -73,15 +81,36 @@ makeScript(
 
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
-    const originView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, originRemoteServerId);
-    assert(originView, `No remote MCP server view found for: ${originRemoteServerId}`);
+    const originView =
+      await MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        originRemoteServerId
+      );
+    assert(
+      originView,
+      `No remote MCP server view found for: ${originRemoteServerId}`
+    );
 
-    const destinationView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, destinationInternalServerId);
-    assert(destinationView, `No internal MCP server view found for: ${destinationInternalServerId}`);
+    const destinationView =
+      await MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        destinationInternalServerId
+      );
+    assert(
+      destinationView,
+      `No internal MCP server view found for: ${destinationInternalServerId}`
+    );
 
     const agentIds = loadAgentIds(agentsFile);
 
-    logger.info({ originView: originView.toJSON(), destinationView: destinationView.toJSON(), count: agentIds.length }, "Loaded MCP server views and agent IDs.");
+    logger.info(
+      {
+        originView: originView.toJSON(),
+        destinationView: destinationView.toJSON(),
+        count: agentIds.length,
+      },
+      "Loaded MCP server views and agent IDs."
+    );
 
     const agentConfigs = await findAgentMCPConfigs(auth, agentIds, originView);
 
@@ -105,7 +134,9 @@ makeScript(
 
         if (execute) {
           const internalMCPServerId =
-            config.internalMCPServerId !== null ? `'${config.internalMCPServerId}'` : "NULL";
+            config.internalMCPServerId !== null
+              ? `'${config.internalMCPServerId}'`
+              : "NULL";
           revertSql += `UPDATE agent_mcp_server_configurations SET "mcpServerViewId" = ${config.mcpServerViewId}, "internalMCPServerId" = ${internalMCPServerId} WHERE id = ${config.id};\n`;
           await config.update({
             mcpServerViewId: destinationView.id,

--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -1,0 +1,112 @@
+import assert from "assert";
+import fs from "fs";
+import { Op } from "sequelize";
+
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+
+function loadAgentIds(agentsFile: string): string[] {
+  const agentIds: unknown = JSON.parse(fs.readFileSync(agentsFile, "utf-8"));
+  assert(Array.isArray(agentIds) && agentIds.every((id) => isString(id)), "agentsFile must contain a JSON array of agent IDs");
+
+  return agentIds;
+}
+
+async function findAgentMCPConfigs(
+  auth: Authenticator,
+  agentIds: string[],
+  oldView: MCPServerViewResource
+): Promise<AgentMCPServerConfigurationModel[]> {
+  const workspaceModelId = auth.getNonNullableWorkspace().id;
+
+  const agentConfigurations = await AgentConfigurationModel.findAll({
+    where: { workspaceId: workspaceModelId, sId: { [Op.in]: agentIds } },
+  });
+
+  const agentConfigurationModelIds = agentConfigurations.map((a) => a.id);
+
+  return AgentMCPServerConfigurationModel.findAll({
+    where: {
+      workspaceId: workspaceModelId,
+      agentConfigurationId: { [Op.in]: agentConfigurationModelIds },
+      mcpServerViewId: oldView.id,
+    },
+  });
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+    },
+    remoteServerId: {
+      type: "string",
+      demandOption: true,
+      description:
+        "The mcpServerId of the remote (open-source) Confluence view (rms_...)",
+    },
+    internalServerId: {
+      type: "string",
+      demandOption: true,
+      description:
+        "The mcpServerId of the internal Confluence view to migrate to (ims_...)",
+    },
+    agentsFile: {
+      type: "string",
+      demandOption: true,
+      description: "Path to a JSON file containing an array of agent IDs to migrate",
+    },
+  },
+  async (
+    { workspaceId, remoteServerId, internalServerId, agentsFile, execute },
+    logger
+  ) => {
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    assert(workspace, `Workspace not found: ${workspaceId}`);
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+    const oldView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, remoteServerId);
+    assert(oldView, `No remote Confluence MCP server view found for: ${remoteServerId}`);
+
+    const newView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, internalServerId);
+    assert(newView, `No internal Confluence MCP server view found for: ${internalServerId}`);
+
+    const agentIds = loadAgentIds(agentsFile);
+
+    logger.info({ oldView: oldView.toJSON(), newView: newView.toJSON(), count: agentIds.length }, "Loaded MCP server views and agent IDs.");
+
+    const agentConfigs = await findAgentMCPConfigs(auth, agentIds, oldView);
+
+    logger.info(
+      { count: agentConfigs.length },
+      execute
+        ? "Migrating agent MCP server configurations"
+        : "Would migrate agent MCP server configurations (dry run)"
+    );
+
+    for (const config of agentConfigs) {
+      logger.info(
+        { configId: config.sId, oldViewId: config.mcpServerViewId, newViewId: newView.id },
+        execute ? "Updating agent config" : "Would update agent config"
+      );
+
+      if (execute) {
+        await config.update({
+          mcpServerViewId: newView.id,
+          internalMCPServerId: internalServerId,
+        });
+      }
+    }
+
+    logger.info(
+      { migratedCount: agentConfigs.length, execute },
+      execute ? "Migration complete" : "Dry run complete"
+    );
+  }
+);

--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -25,22 +25,28 @@ async function findAgentMCPConfigs(
   auth: Authenticator,
   agentIds: string[],
   oldView: MCPServerViewResource
-): Promise<AgentMCPServerConfigurationModel[]> {
+): Promise<{
+  configs: AgentMCPServerConfigurationModel[];
+  matchedAgentIds: Set<string>;
+}> {
   const workspaceModelId = auth.getNonNullableWorkspace().id;
 
   const agentConfigurations = await AgentConfigurationModel.findAll({
-    where: { workspaceId: workspaceModelId, sId: { [Op.in]: agentIds } },
+    where: { workspaceId: workspaceModelId, sId: { [Op.in]: agentIds }, status: "active" },
   });
 
+  const matchedAgentIds = new Set(agentConfigurations.map((a) => a.sId));
   const agentConfigurationModelIds = agentConfigurations.map((a) => a.id);
 
-  return AgentMCPServerConfigurationModel.findAll({
+  const configs = await AgentMCPServerConfigurationModel.findAll({
     where: {
       workspaceId: workspaceModelId,
       agentConfigurationId: { [Op.in]: agentConfigurationModelIds },
       mcpServerViewId: oldView.id,
     },
   });
+
+  return { configs, matchedAgentIds };
 }
 
 makeScript(
@@ -112,7 +118,19 @@ makeScript(
       "Loaded MCP server views and agent IDs."
     );
 
-    const agentConfigs = await findAgentMCPConfigs(auth, agentIds, originView);
+    const { configs: agentConfigs, matchedAgentIds } = await findAgentMCPConfigs(
+      auth,
+      agentIds,
+      originView
+    );
+
+    const unmatchedAgentIds = agentIds.filter((id) => !matchedAgentIds.has(id));
+    if (unmatchedAgentIds.length > 0) {
+      logger.warn(
+        { unmatchedAgentIds, count: unmatchedAgentIds.length },
+        "Some agent IDs from the file had no matching MCP config for the origin view"
+      );
+    }
 
     logger.info(
       { count: agentConfigs.length },

--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { format } from "date-fns";
 import fs from "fs";
 import { Op } from "sequelize";
 
@@ -8,6 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { isString } from "@app/types/shared/utils/general";
 
 function loadAgentIds(agentsFile: string): string[] {
   const agentIds: unknown = JSON.parse(fs.readFileSync(agentsFile, "utf-8"));
@@ -44,17 +46,17 @@ makeScript(
       type: "string",
       demandOption: true,
     },
-    remoteServerId: {
+    originRemoteServerId: {
       type: "string",
       demandOption: true,
       description:
-        "The mcpServerId of the remote (open-source) Confluence view (rms_...)",
+        "The mcpServerId of the remote MCP server to migrate from",
     },
-    internalServerId: {
+    destinationInternalServerId: {
       type: "string",
       demandOption: true,
       description:
-        "The mcpServerId of the internal Confluence view to migrate to (ims_...)",
+        "The mcpServerId of the internal MCP server to migrate to",
     },
     agentsFile: {
       type: "string",
@@ -63,7 +65,7 @@ makeScript(
     },
   },
   async (
-    { workspaceId, remoteServerId, internalServerId, agentsFile, execute },
+    { workspaceId, originRemoteServerId, destinationInternalServerId, agentsFile, execute },
     logger
   ) => {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -71,17 +73,17 @@ makeScript(
 
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
-    const oldView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, remoteServerId);
-    assert(oldView, `No remote Confluence MCP server view found for: ${remoteServerId}`);
+    const originView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, originRemoteServerId);
+    assert(originView, `No remote MCP server view found for: ${originRemoteServerId}`);
 
-    const newView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, internalServerId);
-    assert(newView, `No internal Confluence MCP server view found for: ${internalServerId}`);
+    const destinationView = await MCPServerViewResource.getMCPServerViewForGlobalSpace(auth, destinationInternalServerId);
+    assert(destinationView, `No internal MCP server view found for: ${destinationInternalServerId}`);
 
     const agentIds = loadAgentIds(agentsFile);
 
-    logger.info({ oldView: oldView.toJSON(), newView: newView.toJSON(), count: agentIds.length }, "Loaded MCP server views and agent IDs.");
+    logger.info({ originView: originView.toJSON(), destinationView: destinationView.toJSON(), count: agentIds.length }, "Loaded MCP server views and agent IDs.");
 
-    const agentConfigs = await findAgentMCPConfigs(auth, agentIds, oldView);
+    const agentConfigs = await findAgentMCPConfigs(auth, agentIds, originView);
 
     logger.info(
       { count: agentConfigs.length },
@@ -90,22 +92,36 @@ makeScript(
         : "Would migrate agent MCP server configurations (dry run)"
     );
 
-    for (const config of agentConfigs) {
-      logger.info(
-        { configId: config.sId, oldViewId: config.mcpServerViewId, newViewId: newView.id },
-        execute ? "Updating agent config" : "Would update agent config"
-      );
+    const now = format(new Date(), "yyyy-MM-dd");
+    const revertFile = `${now}_migrate_mcp_revert.sql`;
+    let revertSql = "";
 
-      if (execute) {
-        await config.update({
-          mcpServerViewId: newView.id,
-          internalMCPServerId: internalServerId,
-        });
+    try {
+      for (const config of agentConfigs) {
+        logger.info(
+          { configId: config.sId, oldViewId: config.mcpServerViewId, newViewId: destinationView.id },
+          execute ? "Updating agent config" : "Would update agent config"
+        );
+
+        if (execute) {
+          const internalMCPServerId =
+            config.internalMCPServerId !== null ? `'${config.internalMCPServerId}'` : "NULL";
+          revertSql += `UPDATE agent_mcp_server_configurations SET "mcpServerViewId" = ${config.mcpServerViewId}, "internalMCPServerId" = ${internalMCPServerId} WHERE id = ${config.id};\n`;
+          await config.update({
+            mcpServerViewId: destinationView.id,
+            internalMCPServerId: destinationInternalServerId,
+          });
+        }
+      }
+    } finally {
+      if (execute && revertSql.length > 0) {
+        fs.writeFileSync(revertFile, revertSql);
+        logger.info({ revertFile }, "Revert SQL written");
       }
     }
 
     logger.info(
-      { migratedCount: agentConfigs.length, execute },
+      { migratedCount: agentConfigs.length },
       execute ? "Migration complete" : "Dry run complete"
     );
   }

--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -29,7 +29,11 @@ async function findAgentMCPConfigs(
   const workspaceModelId = auth.getNonNullableWorkspace().id;
 
   const agentConfigurations = await AgentConfigurationModel.findAll({
-    where: { workspaceId: workspaceModelId, sId: { [Op.in]: agentIds }, status: "active" },
+    where: {
+      workspaceId: workspaceModelId,
+      sId: { [Op.in]: agentIds },
+      status: "active",
+    },
   });
 
   const agentConfigurationModelIds = agentConfigurations.map((a) => a.id);

--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -99,7 +99,7 @@ makeScript(
     try {
       for (const config of agentConfigs) {
         logger.info(
-          { configId: config.sId, oldViewId: config.mcpServerViewId, newViewId: destinationView.id },
+          { configId: config.sId, configModelId: config.id },
           execute ? "Updating agent config" : "Would update agent config"
         );
 

--- a/front/migrations/20260319_migrate_confluence_mcp.ts
+++ b/front/migrations/20260319_migrate_confluence_mcp.ts
@@ -25,28 +25,22 @@ async function findAgentMCPConfigs(
   auth: Authenticator,
   agentIds: string[],
   oldView: MCPServerViewResource
-): Promise<{
-  configs: AgentMCPServerConfigurationModel[];
-  matchedAgentIds: Set<string>;
-}> {
+): Promise<AgentMCPServerConfigurationModel[]> {
   const workspaceModelId = auth.getNonNullableWorkspace().id;
 
   const agentConfigurations = await AgentConfigurationModel.findAll({
     where: { workspaceId: workspaceModelId, sId: { [Op.in]: agentIds }, status: "active" },
   });
 
-  const matchedAgentIds = new Set(agentConfigurations.map((a) => a.sId));
   const agentConfigurationModelIds = agentConfigurations.map((a) => a.id);
 
-  const configs = await AgentMCPServerConfigurationModel.findAll({
+  return AgentMCPServerConfigurationModel.findAll({
     where: {
       workspaceId: workspaceModelId,
       agentConfigurationId: { [Op.in]: agentConfigurationModelIds },
       mcpServerViewId: oldView.id,
     },
   });
-
-  return { configs, matchedAgentIds };
 }
 
 makeScript(
@@ -118,16 +112,11 @@ makeScript(
       "Loaded MCP server views and agent IDs."
     );
 
-    const { configs: agentConfigs, matchedAgentIds } = await findAgentMCPConfigs(
-      auth,
-      agentIds,
-      originView
-    );
+    const agentConfigs = await findAgentMCPConfigs(auth, agentIds, originView);
 
-    const unmatchedAgentIds = agentIds.filter((id) => !matchedAgentIds.has(id));
-    if (unmatchedAgentIds.length > 0) {
+    if (agentConfigs.length !== agentIds.length) {
       logger.warn(
-        { unmatchedAgentIds, count: unmatchedAgentIds.length },
+        { inputCount: agentIds.length, matchedCount: agentConfigs.length },
         "Some agent IDs from the file had no matching MCP config for the origin view"
       );
     }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7078.
- This PR adds a script that will be used to migrate agents (their IDs will be input from a JSON file) from one MCP server to another.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
