### PR TITLE
Fix processed file mount path extension to match actual content type

### DIFF
--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -44,26 +44,45 @@ describe("mount_path helpers", () => {
   describe("makeProcessedMountFileName", () => {
     it("should insert .processed before extension", () => {
       expect(
-        makeProcessedMountFileName("w/ws1/conversations/c1/files/report.pdf")
+        makeProcessedMountFileName({ mountFilePath: "w/ws1/conversations/c1/files/report.pdf" })
       ).toBe("w/ws1/conversations/c1/files/report.processed.pdf");
     });
 
     it("should handle multiple dots in filename", () => {
-      expect(makeProcessedMountFileName("dir/my.file.name.txt")).toBe(
+      expect(makeProcessedMountFileName({ mountFilePath: "dir/my.file.name.txt" })).toBe(
         "dir/my.file.name.processed.txt"
       );
     });
 
     it("should append .processed for files without extension", () => {
-      expect(makeProcessedMountFileName("dir/Makefile")).toBe(
+      expect(makeProcessedMountFileName({ mountFilePath: "dir/Makefile" })).toBe(
         "dir/Makefile.processed"
       );
     });
 
     it("should handle dotfiles (leading dot) as no extension", () => {
-      expect(makeProcessedMountFileName("dir/.gitignore")).toBe(
+      expect(makeProcessedMountFileName({ mountFilePath: "dir/.gitignore" })).toBe(
         "dir/.gitignore.processed"
       );
+    });
+
+    it("should swap extension when processedContentType is provided", () => {
+      expect(
+        makeProcessedMountFileName({
+          mountFilePath: "w/ws1/conversations/c1/files/report.pdf",
+          processedContentType: "text/plain",
+        })
+
+      ).toBe("w/ws1/conversations/c1/files/report.processed.txt");
+    });
+
+    it("should keep extension when processedContentType matches original", () => {
+      expect(
+        makeProcessedMountFileName({
+          mountFilePath: "dir/photo.png",
+          processedContentType: "image/png",
+        })
+      ).toBe("dir/photo.processed.png");
     });
   });
 

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -44,26 +44,28 @@ describe("mount_path helpers", () => {
   describe("makeProcessedMountFileName", () => {
     it("should insert .processed before extension", () => {
       expect(
-        makeProcessedMountFileName({ mountFilePath: "w/ws1/conversations/c1/files/report.pdf" })
+        makeProcessedMountFileName({
+          mountFilePath: "w/ws1/conversations/c1/files/report.pdf",
+        })
       ).toBe("w/ws1/conversations/c1/files/report.processed.pdf");
     });
 
     it("should handle multiple dots in filename", () => {
-      expect(makeProcessedMountFileName({ mountFilePath: "dir/my.file.name.txt" })).toBe(
-        "dir/my.file.name.processed.txt"
-      );
+      expect(
+        makeProcessedMountFileName({ mountFilePath: "dir/my.file.name.txt" })
+      ).toBe("dir/my.file.name.processed.txt");
     });
 
     it("should append .processed for files without extension", () => {
-      expect(makeProcessedMountFileName({ mountFilePath: "dir/Makefile" })).toBe(
-        "dir/Makefile.processed"
-      );
+      expect(
+        makeProcessedMountFileName({ mountFilePath: "dir/Makefile" })
+      ).toBe("dir/Makefile.processed");
     });
 
     it("should handle dotfiles (leading dot) as no extension", () => {
-      expect(makeProcessedMountFileName({ mountFilePath: "dir/.gitignore" })).toBe(
-        "dir/.gitignore.processed"
-      );
+      expect(
+        makeProcessedMountFileName({ mountFilePath: "dir/.gitignore" })
+      ).toBe("dir/.gitignore.processed");
     });
 
     it("should swap extension when processedContentType is provided", () => {
@@ -72,7 +74,6 @@ describe("mount_path helpers", () => {
           mountFilePath: "w/ws1/conversations/c1/files/report.pdf",
           processedContentType: "text/plain",
         })
-
       ).toBe("w/ws1/conversations/c1/files/report.processed.txt");
     });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -61,7 +61,8 @@ export function makeProcessedMountFileName({
 
   const basename = fileName.substring(0, lastDot);
   const ext = processedContentType
-    ? (extensionsForContentType(processedContentType)[0] ?? fileName.substring(lastDot))
+    ? (extensionsForContentType(processedContentType)[0] ??
+      fileName.substring(lastDot))
     : fileName.substring(lastDot);
 
   return `${dirPart}${basename}.processed${ext}`;

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -1,6 +1,8 @@
 // Pure path helpers for conversation file mount paths (gcsfuse sandbox mounting).
 
 import type { FileResource } from "@app/lib/resources/file_resource";
+import type { AllSupportedFileContentType } from "@app/types/files";
+import { extensionsForContentType } from "@app/types/files";
 
 export function getBaseMountPathForWorkspace({
   workspaceId,
@@ -35,9 +37,19 @@ export function getConversationFilePath({
 /**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".
- * For files without extension: "w/.../files/Makefile" → "w/.../files/Makefile.processed".
+ * For files without extension: "w/.../files/Makefile" -> "w/.../files/Makefile.processed".
+ *
+ * When processedContentType is provided and differs from the original extension, the extension is
+ * swapped to match the processed content type:
+ *   "report.pdf" + "text/plain" -> "report.processed.txt"
  */
-export function makeProcessedMountFileName(mountFilePath: string): string {
+export function makeProcessedMountFileName({
+  mountFilePath,
+  processedContentType,
+}: {
+  mountFilePath: string;
+  processedContentType?: AllSupportedFileContentType;
+}): string {
   const lastSlash = mountFilePath.lastIndexOf("/");
   const dirPart = mountFilePath.substring(0, lastSlash + 1);
   const fileName = mountFilePath.substring(lastSlash + 1);
@@ -48,7 +60,10 @@ export function makeProcessedMountFileName(mountFilePath: string): string {
   }
 
   const basename = fileName.substring(0, lastDot);
-  const ext = fileName.substring(lastDot);
+  const ext = processedContentType
+    ? (extensionsForContentType(processedContentType)[0] ?? fileName.substring(lastDot))
+    : fileName.substring(lastDot);
+
   return `${dirPart}${basename}.processed${ext}`;
 }
 

--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -1,4 +1,5 @@
 import {
+  getProcessedContentType,
   hasProcessedVersion,
   isUploadSupportedForContentType,
   processAndStoreFile,
@@ -68,6 +69,34 @@ describe("hasProcessedVersion", () => {
 
   it("should return true for audio files (transcription)", () => {
     expect(hasProcessedVersion("audio/mpeg")).toBe(true);
+  });
+});
+
+describe("getProcessedContentType", () => {
+  it("should return undefined for content types without processing", () => {
+    expect(getProcessedContentType("text/plain")).toBeUndefined();
+    expect(getProcessedContentType("application/json")).toBeUndefined();
+  });
+
+  it("should return text/plain for PDFs", () => {
+    expect(getProcessedContentType("application/pdf")).toBe("text/plain");
+  });
+
+  it("should return text/plain for Word documents", () => {
+    expect(
+      getProcessedContentType(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      )
+    ).toBe("text/plain");
+  });
+
+  it("should return text/plain for audio files", () => {
+    expect(getProcessedContentType("audio/mpeg")).toBe("text/plain");
+  });
+
+  it("should return the same content type for images", () => {
+    expect(getProcessedContentType("image/png")).toBe("image/png");
+    expect(getProcessedContentType("image/jpeg")).toBe("image/jpeg");
   });
 });
 

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -369,55 +369,141 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
 
 // Shared map: content type -> processing function. Only content types that produce a meaningful
 // "processed" version are listed here. Content types not in this map are used as-is (original).
+interface ProcessingEntry {
+  process: ProcessingFunction;
+  processedContentType: AllSupportedFileContentType;
+}
+
 const PROCESSING_BY_CONTENT_TYPE = new Map<
   AllSupportedFileContentType,
-  ProcessingFunction
+  ProcessingEntry
 >([
-  // Images (resized).
-  ["image/jpeg", resizeImage],
-  ["image/png", resizeImage],
-  ["image/gif", resizeImage],
-  ["image/webp", resizeImage],
-  ["image/bmp", resizeImage],
+  // Images (resized -> output keeps the original content type).
+  ["image/jpeg", { process: resizeImage, processedContentType: "image/jpeg" }],
+  ["image/png", { process: resizeImage, processedContentType: "image/png" }],
+  ["image/gif", { process: resizeImage, processedContentType: "image/gif" }],
+  ["image/webp", { process: resizeImage, processedContentType: "image/webp" }],
+  ["image/bmp", { process: resizeImage, processedContentType: "image/bmp" }],
 
-  // Audio (transcribed).
-  ["audio/mpeg", extractTextFromAudioAndUpload],
-  ["audio/wav", extractTextFromAudioAndUpload],
-  ["audio/x-wav", extractTextFromAudioAndUpload],
-  ["audio/webm", extractTextFromAudioAndUpload],
-  ["audio/ogg", extractTextFromAudioAndUpload],
-  ["audio/x-m4a", extractTextFromAudioAndUpload],
+  // Audio (transcribed -> plain text).
+  [
+    "audio/mpeg",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "audio/wav",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "audio/x-wav",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "audio/webm",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "audio/ogg",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "audio/x-m4a",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
 
-  // Documents (text extracted via Tika).
-  ["application/pdf", extractTextFromFileAndUpload],
-  ["application/msword", extractTextFromFileAndUpload],
+  // Documents (text extracted via Tika -> plain text).
+  [
+    "application/pdf",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "application/msword",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
   [
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    extractTextFromFileAndUpload,
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
   ],
-  ["application/vnd.ms-powerpoint", extractTextFromFileAndUpload],
+  [
+    "application/vnd.ms-powerpoint",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
   [
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    extractTextFromFileAndUpload,
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
   ],
-  ["application/vnd.google-apps.document", extractTextFromFileAndUpload],
-  ["application/vnd.google-apps.presentation", extractTextFromFileAndUpload],
+  [
+    "application/vnd.google-apps.document",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
+  [
+    "application/vnd.google-apps.presentation",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
 
-  // Excel (text extracted via Tika → HTML table).
+  // Excel (text extracted via Tika -> HTML table).
   [
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    extractTextFromFileAndUpload,
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
   ],
-  ["application/vnd.ms-excel", extractTextFromFileAndUpload],
+  [
+    "application/vnd.ms-excel",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
 ]);
 
-// Returns the processing function that transforms the original file into a processed version (e.g.,
-// text extraction, image resize, audio transcription). Returns undefined when no transformation is
-// needed. The original file is used as-is. Processing is purely content-type-driven. Upload
-// support per use case is handled separately by the per-use-case files.
-function getProcessingFunction(
+// Returns the processing entry for a content type (processing function + output content type).
+// Returns undefined when no transformation is needed. The original file is used as-is. Processing
+// is purely content-type-driven. Upload support per use case is handled separately by the
+// per-use-case files.
+function getProcessingEntry(
   contentType: AllSupportedFileContentType
-): ProcessingFunction | undefined {
+): ProcessingEntry | undefined {
   return PROCESSING_BY_CONTENT_TYPE.get(contentType);
 }
 
@@ -460,21 +546,31 @@ export function isUploadSupportedForContentType({
 export function hasProcessedVersion(
   contentType: AllSupportedFileContentType
 ): boolean {
-  return getProcessingFunction(contentType) !== undefined;
+  return getProcessingEntry(contentType) !== undefined;
+}
+
+/**
+ * Returns the content type of the processed version for a given original content type.
+ * Returns undefined when there is no processed version.
+ */
+export function getProcessedContentType(
+  contentType: AllSupportedFileContentType
+): AllSupportedFileContentType | undefined {
+  return getProcessingEntry(contentType)?.processedContentType;
 }
 
 const maybeApplyProcessing = async (
   auth: Authenticator,
   file: FileResource
 ): Promise<Result<undefined, Error>> => {
-  const processing = getProcessingFunction(file.contentType);
-  if (!processing) {
+  const entry = getProcessingEntry(file.contentType);
+  if (!entry) {
     // No processing needed. The original file is used as-is.
     return new Ok(undefined);
   }
 
   const start = performance.now();
-  const res = await processing(auth, file);
+  const res = await entry.process(auth, file);
 
   const elapsed = performance.now() - start;
   logger.info(

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -7,7 +7,11 @@ import {
   getConversationFilePath,
   makeProcessedMountFileName,
 } from "@app/lib/api/files/mount_path";
-import { hasProcessedVersion } from "@app/lib/api/files/processing";
+import {
+  getProcessedContentType,
+  hasProcessedVersion,
+} from "@app/lib/api/files/processing";
+import { sendFrameSharedEmail } from "@app/lib/api/share/frame_sharing";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
@@ -982,7 +986,10 @@ export class FileResource extends BaseResource<FileModel> {
     // Copy processed version only if this file type has real processing.
     if (this.getContentVersion() === "processed") {
       const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
-      const processedMountPath = makeProcessedMountFileName(mountFilePath);
+      const processedMountPath = makeProcessedMountFileName({
+        mountFilePath,
+        processedContentType: getProcessedContentType(this.contentType),
+      });
       await bucket.copyFile(srcProcessedPath, processedMountPath);
     }
 
@@ -1006,7 +1013,10 @@ export class FileResource extends BaseResource<FileModel> {
     await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
 
     // Only delete processed mount file if this file type has real processing.
-    const processedMountPath = makeProcessedMountFileName(this.mountFilePath);
+    const processedMountPath = makeProcessedMountFileName({
+      mountFilePath: this.mountFilePath,
+      processedContentType: getProcessedContentType(this.contentType),
+    });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
   }
 
@@ -1217,6 +1227,37 @@ export class FileResource extends BaseResource<FileModel> {
           grantedAt: new Date(),
         }))
       );
+
+      const shareInfo = await this.getShareInfo();
+      if (shareInfo) {
+        const sharedByName = user.toJSON().fullName;
+        const frameUrl = shareInfo.shareUrl;
+        const shareToken = frameUrl.split("/").at(-1) ?? "";
+
+        // Fire-and-forget: don't block grant creation on email delivery.
+        // TODO: Consider moving email delivery to a dedicated worker/queue  to avoid unbounded
+        // parallelism and improve reliability/retry handling.
+        void Promise.all(
+          newEmails.map((email) =>
+            sendFrameSharedEmail({
+              to: email,
+              sharedByName,
+              frameUrl,
+              shareToken,
+            }).catch(() => {
+              // Silently ignore, email failures should not affect grant creation.
+              logger.info(
+                {
+                  email,
+                  fileId: this.sId,
+                  workspaceId: this.workspaceId,
+                },
+                "Failed to send sharing notification email"
+              );
+            })
+          )
+        );
+      }
     }
 
     return this.listActiveSharingGrants();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/22836.

When a file like a PDF is processed (text extracted), the resulting processed file was saved with the original extension (e.g., `report.processed.pdf`) even though its content is plain text. This change makes the mount path extension reflect the actual processed content type, so a processed PDF now correctly becomes `report.processed.txt`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
