### PR TITLE
[front] enh: surface errors messages from Ashby API in tool results

### DIFF
--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -61,8 +61,7 @@ export class AshbyAPIError extends Error {
     errorInfo?: AshbyAPIErrorInfo;
     errors?: string[];
   }) {
-    const detail =
-      errorInfo?.message ?? errors?.join(", ") ?? errorInfo?.code;
+    const detail = errorInfo?.message ?? errors?.join(", ") ?? errorInfo?.code;
     super(`Ashby API error: ${detail ?? "unknown error"}`);
     this.errorInfo = errorInfo;
     this.errors = errors;

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -1,6 +1,8 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { untrustedFetch } from "@app/lib/egress/server";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
+  AshbyAPIErrorInfo,
   AshbyApplicationFeedbackListRequest,
   AshbyApplicationInfoRequest,
   AshbyCandidateCreateNoteRequest,
@@ -22,6 +24,8 @@ import type {
   AshbyUserSearchRequest,
 } from "@app/lib/api/actions/servers/ashby/types";
 import {
+  AshbyAPIErrorResponseSchema,
+  AshbyJobSchema,
   AshbyApplicationFeedbackListResponseSchema,
   AshbyApplicationInfoResponseSchema,
   AshbyCandidateCreateNoteResponseSchema,
@@ -29,7 +33,6 @@ import {
   AshbyCandidateListNotesResponseSchema,
   AshbyCandidateSearchResponseSchema,
   AshbyJobInfoResponseSchema,
-  AshbyJobListResponseSchema,
   AshbyJobPostingInfoResponseSchema,
   AshbyJobPostingListResponseSchema,
   AshbyJobPostingUpdateResponseSchema,
@@ -43,9 +46,37 @@ import {
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { z } from "zod";
+import { z } from "zod";
 
 const ASHBY_API_BASE_URL = "https://api.ashbyhq.com";
+
+export class AshbyAPIError extends Error {
+  readonly errorInfo: AshbyAPIErrorInfo | undefined;
+  readonly errors: string[] | undefined;
+
+  constructor({
+    errorInfo,
+    errors,
+  }: {
+    errorInfo?: AshbyAPIErrorInfo;
+    errors?: string[];
+  }) {
+    const parts: string[] = [];
+    if (errorInfo?.code) {
+      parts.push(errorInfo.code);
+    }
+    if (errorInfo?.message) {
+      parts.push(errorInfo.message);
+    } else if (errors?.length) {
+      parts.push(errors.join(", "));
+    }
+    super(
+      `Ashby API error: ${parts.length > 0 ? parts.join(": ") : "unknown error"}`
+    );
+    this.errorInfo = errorInfo;
+    this.errors = errors;
+  }
+}
 
 export function getAshbyClient(
   extra: ToolHandlerExtra
@@ -80,10 +111,9 @@ export class AshbyClient {
   private async postRequest<T extends z.Schema>(
     endpoint: string,
     data: unknown,
-    schema: T
+    resultsSchema: T
   ): Promise<Result<z.infer<T>, Error>> {
-    // eslint-disable-next-line no-restricted-globals
-    const response = await fetch(`${ASHBY_API_BASE_URL}/${endpoint}`, {
+    const response = await untrustedFetch(`${ASHBY_API_BASE_URL}/${endpoint}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -102,14 +132,24 @@ export class AshbyClient {
     }
 
     const rawData = await response.json();
-    const parseResult = schema.safeParse(rawData);
+
+    const errorCheck = AshbyAPIErrorResponseSchema.safeParse(rawData);
+    if (errorCheck.success) {
+      return new Err(
+        new AshbyAPIError({
+          errorInfo: errorCheck.data.errorInfo,
+          errors: errorCheck.data.errors,
+        })
+      );
+    }
+
+    const parseResult = z
+      .object({ success: z.literal(true), results: resultsSchema })
+      .safeParse(rawData);
 
     if (!parseResult.success) {
       logger.error(
-        {
-          endpoint,
-          error: parseResult.error.message,
-        },
+        { endpoint, error: parseResult.error.message },
         "[Ashby] Invalid API response format"
       );
       return new Err(
@@ -119,7 +159,71 @@ export class AshbyClient {
       );
     }
 
-    return new Ok(parseResult.data);
+    return new Ok(parseResult.data.results);
+  }
+
+  private async postPaginatedRequest<T extends z.ZodTypeAny>(
+    endpoint: string,
+    data: unknown,
+    resultsSchema: T
+  ): Promise<
+    Result<
+      { results: z.infer<T>; moreDataAvailable?: boolean; nextCursor?: string },
+      Error
+    >
+  > {
+    const response = await untrustedFetch(`${ASHBY_API_BASE_URL}/${endpoint}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.getAuthHeader(),
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Err(
+        new Error(
+          `Ashby API error (${response.status}): ${errorText || response.statusText}`
+        )
+      );
+    }
+
+    const rawData = await response.json();
+
+    const errorCheck = AshbyAPIErrorResponseSchema.safeParse(rawData);
+    if (errorCheck.success) {
+      return new Err(
+        new AshbyAPIError({
+          errorInfo: errorCheck.data.errorInfo,
+          errors: errorCheck.data.errors,
+        })
+      );
+    }
+
+    const parseResult = z
+      .object({
+        success: z.literal(true),
+        results: resultsSchema,
+        moreDataAvailable: z.boolean().optional(),
+        nextCursor: z.string().optional(),
+      })
+      .safeParse(rawData);
+    if (!parseResult.success) {
+      logger.error(
+        { endpoint, error: parseResult.error.message },
+        "[Ashby] Invalid API response format"
+      );
+      return new Err(
+        new Error(
+          `Invalid Ashby API response format: ${parseResult.error.message}`
+        )
+      );
+    }
+
+    const { results, moreDataAvailable, nextCursor } = parseResult.data;
+    return new Ok({ results, moreDataAvailable, nextCursor });
   }
 
   async getReportData(request: AshbyReportSynchronousRequest) {
@@ -141,16 +245,11 @@ export class AshbyClient {
   async listApplicationFeedback(
     request: AshbyApplicationFeedbackListRequest
   ): Promise<Result<AshbyFeedbackSubmission[], Error>> {
-    const response = await this.postRequest(
+    return this.postRequest(
       "applicationFeedback.list",
       request,
       AshbyApplicationFeedbackListResponseSchema
     );
-    if (response.isErr()) {
-      return response;
-    }
-
-    return new Ok(response.value.results);
   }
 
   async createCandidateNote(request: AshbyCandidateCreateNoteRequest) {
@@ -172,16 +271,11 @@ export class AshbyClient {
   async listCandidateNotes(
     request: AshbyCandidateListNotesRequest
   ): Promise<Result<AshbyCandidateNote[], Error>> {
-    const response = await this.postRequest(
+    return this.postRequest(
       "candidate.listNotes",
       request,
       AshbyCandidateListNotesResponseSchema
     );
-    if (response.isErr()) {
-      return response;
-    }
-
-    return new Ok(response.value.results);
   }
 
   async searchUser(request: AshbyUserSearchRequest) {
@@ -251,16 +345,11 @@ export class AshbyClient {
   async listOffers(
     request: AshbyOfferListRequest
   ): Promise<Result<AshbyOffer[], Error>> {
-    const response = await this.postRequest(
+    return this.postRequest(
       "offer.list",
       request,
       AshbyOfferListResponseSchema
     );
-    if (response.isErr()) {
-      return response;
-    }
-
-    return new Ok(response.value.results);
   }
 
   async getJobInfo(request: AshbyJobInfoRequest) {
@@ -272,19 +361,16 @@ export class AshbyClient {
     let cursor: string | undefined;
 
     do {
-      const response = await this.postRequest(
+      const response = await this.postPaginatedRequest(
         "job.list",
         { cursor },
-        AshbyJobListResponseSchema
+        z.array(AshbyJobSchema)
       );
       if (response.isErr()) {
         return response;
       }
-
       allJobs.push(...response.value.results);
-      cursor = response.value.moreDataAvailable
-        ? response.value.nextCursor
-        : undefined;
+      cursor = response.value.moreDataAvailable ? response.value.nextCursor : undefined;
     } while (cursor);
 
     return new Ok(allJobs);

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -123,7 +123,11 @@ export class AshbyClient {
   ): Promise<
     Result<
       | z.infer<T>
-      | { results: z.infer<T>; moreDataAvailable?: boolean; nextCursor?: string },
+      | {
+          results: z.infer<T>;
+          moreDataAvailable?: boolean;
+          nextCursor?: string;
+        },
       Error
     >
   > {

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -1,5 +1,4 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { untrustedFetch } from "@app/lib/egress/server";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
   AshbyAPIErrorInfo,
@@ -25,7 +24,6 @@ import type {
 } from "@app/lib/api/actions/servers/ashby/types";
 import {
   AshbyAPIErrorResponseSchema,
-  AshbyJobSchema,
   AshbyApplicationFeedbackListResponseSchema,
   AshbyApplicationInfoResponseSchema,
   AshbyCandidateCreateNoteResponseSchema,
@@ -36,6 +34,7 @@ import {
   AshbyJobPostingInfoResponseSchema,
   AshbyJobPostingListResponseSchema,
   AshbyJobPostingUpdateResponseSchema,
+  AshbyJobSchema,
   AshbyOfferInfoResponseSchema,
   AshbyOfferListResponseSchema,
   AshbyReferralCreateResponseSchema,
@@ -43,6 +42,7 @@ import {
   AshbyReportSynchronousResponseSchema,
   AshbyUserSearchResponseSchema,
 } from "@app/lib/api/actions/servers/ashby/types";
+import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -370,7 +370,9 @@ export class AshbyClient {
         return response;
       }
       allJobs.push(...response.value.results);
-      cursor = response.value.moreDataAvailable ? response.value.nextCursor : undefined;
+      cursor = response.value.moreDataAvailable
+        ? response.value.nextCursor
+        : undefined;
     } while (cursor);
 
     return new Ok(allJobs);

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -98,67 +98,32 @@ export class AshbyClient {
     return `Basic ${credentials}`;
   }
 
-  private async postRequest<T extends z.Schema>(
+  private async postRequest<T extends z.ZodTypeAny>(
     endpoint: string,
     data: unknown,
-    resultsSchema: T
-  ): Promise<Result<z.infer<T>, Error>> {
-    const response = await untrustedFetch(`${ASHBY_API_BASE_URL}/${endpoint}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: this.getAuthHeader(),
-      },
-      body: JSON.stringify(data),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Err(
-        new Error(
-          `Ashby API error (${response.status}): ${errorText || response.statusText}`
-        )
-      );
-    }
-
-    const rawData = await response.json();
-
-    const errorCheck = AshbyAPIErrorResponseSchema.safeParse(rawData);
-    if (errorCheck.success) {
-      return new Err(
-        new AshbyAPIError({
-          errorInfo: errorCheck.data.errorInfo,
-          errors: errorCheck.data.errors,
-        })
-      );
-    }
-
-    const parseResult = z
-      .object({ success: z.literal(true), results: resultsSchema })
-      .safeParse(rawData);
-
-    if (!parseResult.success) {
-      logger.error(
-        { endpoint, error: parseResult.error.message },
-        "[Ashby] Invalid API response format"
-      );
-      return new Err(
-        new Error(
-          `Invalid Ashby API response format: ${parseResult.error.message}`
-        )
-      );
-    }
-
-    return new Ok(parseResult.data.results);
-  }
-
-  private async postPaginatedRequest<T extends z.ZodTypeAny>(
-    endpoint: string,
-    data: unknown,
-    resultsSchema: T
+    resultsSchema: T,
+    options: { isPaginated: true }
   ): Promise<
     Result<
       { results: z.infer<T>; moreDataAvailable?: boolean; nextCursor?: string },
+      Error
+    >
+  >;
+  private async postRequest<T extends z.ZodTypeAny>(
+    endpoint: string,
+    data: unknown,
+    resultsSchema: T,
+    options?: { isPaginated?: false }
+  ): Promise<Result<z.infer<T>, Error>>;
+  private async postRequest<T extends z.ZodTypeAny>(
+    endpoint: string,
+    data: unknown,
+    resultsSchema: T,
+    options?: { isPaginated?: boolean }
+  ): Promise<
+    Result<
+      | z.infer<T>
+      | { results: z.infer<T>; moreDataAvailable?: boolean; nextCursor?: string },
       Error
     >
   > {
@@ -192,13 +157,33 @@ export class AshbyClient {
       );
     }
 
+    if (options?.isPaginated) {
+      const parseResult = z
+        .object({
+          success: z.literal(true),
+          results: resultsSchema,
+          moreDataAvailable: z.boolean().optional(),
+          nextCursor: z.string().optional(),
+        })
+        .safeParse(rawData);
+      if (!parseResult.success) {
+        logger.error(
+          { endpoint, error: parseResult.error.message },
+          "[Ashby] Invalid API response format"
+        );
+        return new Err(
+          new Error(
+            `Invalid Ashby API response format: ${parseResult.error.message}`
+          )
+        );
+      }
+      const { results, moreDataAvailable, nextCursor } = parseResult.data;
+
+      return new Ok({ results, moreDataAvailable, nextCursor });
+    }
+
     const parseResult = z
-      .object({
-        success: z.literal(true),
-        results: resultsSchema,
-        moreDataAvailable: z.boolean().optional(),
-        nextCursor: z.string().optional(),
-      })
+      .object({ success: z.literal(true), results: resultsSchema })
       .safeParse(rawData);
     if (!parseResult.success) {
       logger.error(
@@ -212,8 +197,7 @@ export class AshbyClient {
       );
     }
 
-    const { results, moreDataAvailable, nextCursor } = parseResult.data;
-    return new Ok({ results, moreDataAvailable, nextCursor });
+    return new Ok(parseResult.data.results);
   }
 
   async getReportData(request: AshbyReportSynchronousRequest) {
@@ -351,10 +335,11 @@ export class AshbyClient {
     let cursor: string | undefined;
 
     do {
-      const response = await this.postPaginatedRequest(
+      const response = await this.postRequest(
         "job.list",
         { cursor },
-        z.array(AshbyJobSchema)
+        z.array(AshbyJobSchema),
+        { isPaginated: true }
       );
       if (response.isErr()) {
         return response;

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -61,18 +61,9 @@ export class AshbyAPIError extends Error {
     errorInfo?: AshbyAPIErrorInfo;
     errors?: string[];
   }) {
-    const parts: string[] = [];
-    if (errorInfo?.code) {
-      parts.push(errorInfo.code);
-    }
-    if (errorInfo?.message) {
-      parts.push(errorInfo.message);
-    } else if (errors?.length) {
-      parts.push(errors.join(", "));
-    }
-    super(
-      `Ashby API error: ${parts.length > 0 ? parts.join(": ") : "unknown error"}`
-    );
+    const detail =
+      errorInfo?.message ?? errors?.join(", ") ?? errorInfo?.code;
+    super(`Ashby API error: ${detail ?? "unknown error"}`);
     this.errorInfo = errorInfo;
     this.errors = errors;
   }

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -45,10 +45,10 @@ export async function findHiredApplication(
       continue;
     }
 
-    if (appInfoResult.value.results.status === "Hired") {
+    if (appInfoResult.value.status === "Hired") {
       return new Ok({
         applicationId,
-        jobId: appInfoResult.value.results.job?.id,
+        jobId: appInfoResult.value.job?.id,
       });
     }
   }
@@ -80,7 +80,7 @@ export async function assertCandidateNotHired(
       );
     }
 
-    if (appInfoResult.value.results.status === "Hired") {
+    if (appInfoResult.value.status === "Hired") {
       return new Err(
         new MCPError(
           `Candidate ${candidate.name} was hired, this operation is not permitted for hired candidates.`,
@@ -115,7 +115,7 @@ export async function findUniqueCandidate(
     );
   }
 
-  const candidates = searchResult.value.results;
+  const candidates = searchResult.value;
   if (!candidates || candidates.length === 0) {
     return new Err(
       new MCPError("No candidates found matching the search criteria.", {
@@ -175,7 +175,7 @@ export async function resolveAshbyUser(
     );
   }
 
-  const ashbyUsers = ashbyUserResult.value.results;
+  const ashbyUsers = ashbyUserResult.value;
   if (ashbyUsers.length === 0) {
     return new Err(
       new MCPError(

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -30,19 +30,10 @@ export function renderCandidateList(candidates: AshbyCandidate[]): string {
 }
 
 export async function renderReport(
-  responseResults: NonNullable<AshbyReportSynchronousResponse["results"]>,
+  responseResults: Extract<NonNullable<AshbyReportSynchronousResponse>, { status: "complete" }>,
   { reportId }: { reportId: string }
 ): Promise<CallToolResult["content"]> {
-  const { reportData, status } = responseResults;
-
-  if (status !== "complete") {
-    return [
-      {
-        type: "text" as const,
-        text: `Generation of report ${reportId} is not complete (status: ${status}).`,
-      },
-    ];
-  }
+  const { reportData } = responseResults;
 
   if (reportData.data.length === 0) {
     return [
@@ -310,7 +301,7 @@ export function renderHireData({
 }: {
   candidateInfo: AshbyCandidateInfo;
   offerInfo: AshbyOfferInfo | null;
-  jobInfo: AshbyJobInfo | null;
+  jobInfo: AshbyJobInfo | undefined;
   applicationId: string;
 }): string {
   const lines: string[] = ["# Hire Data Summary", ""];

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -30,7 +30,10 @@ export function renderCandidateList(candidates: AshbyCandidate[]): string {
 }
 
 export async function renderReport(
-  responseResults: Extract<NonNullable<AshbyReportSynchronousResponse>, { status: "complete" }>,
+  responseResults: Extract<
+    NonNullable<AshbyReportSynchronousResponse>,
+    { status: "complete" }
+  >,
   { reportId }: { reportId: string }
 ): Promise<CallToolResult["content"]> {
   const { reportData } = responseResults;

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -2,7 +2,10 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AshbyClient } from "@app/lib/api/actions/servers/ashby/client";
-import { getAshbyClient } from "@app/lib/api/actions/servers/ashby/client";
+import {
+  AshbyAPIError,
+  getAshbyClient,
+} from "@app/lib/api/actions/servers/ashby/client";
 import {
   assertCandidateNotHired,
   diagnoseFieldSubmissions,
@@ -25,7 +28,10 @@ import {
   renderReferralForm,
   renderReport,
 } from "@app/lib/api/actions/servers/ashby/rendering";
-import type { AshbyFeedbackSubmission } from "@app/lib/api/actions/servers/ashby/types";
+import type {
+  AshbyFeedbackSubmission,
+  AshbyJobInfo,
+} from "@app/lib/api/actions/servers/ashby/types";
 import { Err, Ok } from "@app/types/shared/result";
 import sanitizeHtml from "sanitize-html";
 import { validate as validateUuid } from "uuid";
@@ -59,9 +65,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    const response = result.value;
+    const candidates = result.value;
 
-    if (!response.results || response.results.length === 0) {
+    if (!candidates || candidates.length === 0) {
       return new Ok([
         {
           type: "text" as const,
@@ -70,7 +76,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       ]);
     }
 
-    const candidatesText = renderCandidateList(response.results);
+    const candidatesText = renderCandidateList(candidates);
     const searchParams = [
       email ? `email: ${email}` : null,
       name ? `name: ${name}` : null,
@@ -78,9 +84,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       .filter(Boolean)
       .join(", ");
 
-    const resultText = `Found ${response.results.length} candidate(s) matching search (${searchParams}):\n\n${candidatesText}`;
+    const resultText = `Found ${candidates.length} candidate(s) matching search (${searchParams}):\n\n${candidatesText}`;
 
-    if (response.results.length === DEFAULT_SEARCH_LIMIT) {
+    if (candidates.length === DEFAULT_SEARCH_LIMIT) {
       return new Ok([
         {
           type: "text" as const,
@@ -135,18 +141,22 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    const response = result.value;
+    const results = result.value;
 
-    const { success, results } = response;
-
-    if (!success || !results) {
-      const fallbackReason =
-        "unknown error, the ID extracted from the URL may not map to an existing report. " +
-        "Dashboards and saved views are not supported.";
+    if (!results) {
       return new Err(
         new MCPError(
-          `Report retrieval failed: ${response.results?.failureReason ?? fallbackReason} ` +
-            `(status: ${response.results?.status ?? "unknown"})`
+          "Report retrieval failed: unknown error, the ID extracted from the URL may not map to " +
+            "an existing report. Dashboards and saved views are not supported."
+        )
+      );
+    }
+
+    if (results.status !== "complete") {
+      return new Err(
+        new MCPError(
+          `Report retrieval failed: ${results.failureReason ?? "unknown error"} ` +
+            `(status: ${results.status})`
         )
       );
     }
@@ -340,12 +350,6 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!noteResult.value.success) {
-      return new Err(
-        new MCPError("Failed to create note on candidate profile.")
-      );
-    }
-
     return new Ok([
       {
         type: "text" as const,
@@ -354,7 +358,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
           (candidate.primaryEmailAddress?.value
             ? `(${candidate.primaryEmailAddress?.value}) `
             : "") +
-          `profile.\n\nNote ID: ${noteResult.value.results.id}`,
+          `profile.\n\nNote ID: ${noteResult.value.id}`,
       },
     ]);
   },
@@ -379,12 +383,6 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!formResult.value.success) {
-      return new Err(
-        new MCPError("Failed to retrieve referral form from Ashby.")
-      );
-    }
-
     const jobsResult = await client.listJobs();
     if (jobsResult.isErr()) {
       return new Err(
@@ -397,7 +395,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: renderReferralForm(formResult.value.results, {
+        text: renderReferralForm(formResult.value, {
           jobs: jobsResult.value,
         }),
       },
@@ -431,7 +429,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const candidateInfoResult = await client.getCandidateInfo({
       id: candidate.id,
     });
-    if (candidateInfoResult.isErr() || !candidateInfoResult.value.results) {
+    if (candidateInfoResult.isErr() || !candidateInfoResult.value) {
       return new Err(
         new MCPError(
           "Failed to retrieve candidate info: " +
@@ -442,7 +440,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    const candidateInfo = candidateInfoResult.value.results;
+    const candidateInfo = candidateInfoResult.value;
 
     // Fetch offers for the hired application.
     const offersResult = await client.listOffers({ applicationId });
@@ -475,11 +473,11 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
           )
         );
       }
-      offerInfo = offerInfoResult.value.results ?? null;
+      offerInfo = offerInfoResult.value ?? null;
     }
 
     // Fetch job info if we have a jobId.
-    let jobInfo = null;
+    let jobInfo: AshbyJobInfo | undefined;
     if (jobId) {
       const jobInfoResult = await client.getJobInfo({ id: jobId });
       if (jobInfoResult.isErr()) {
@@ -492,7 +490,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
           )
         );
       }
-      jobInfo = jobInfoResult.value.results ?? null;
+      jobInfo = jobInfoResult.value;
     }
 
     const text = renderHireData({
@@ -530,11 +528,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!result.value.success) {
-      return new Err(new MCPError("Failed to list job postings from Ashby."));
-    }
-
-    const postings = result.value.results;
+    const postings = result.value;
 
     if (postings.length === 0) {
       return new Ok([
@@ -593,13 +587,13 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!infoResult.value.success || !infoResult.value.results) {
+    if (!infoResult.value) {
       return new Err(
         new MCPError("Failed to fetch job posting info from Ashby.")
       );
     }
 
-    const previousPosting = infoResult.value.results;
+    const previousPosting = infoResult.value;
 
     const updateResult = await client.updateJobPosting({
       jobPostingId,
@@ -620,13 +614,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!updateResult.value.success || !updateResult.value.results) {
-      const errorMessage =
-        updateResult.value.errorInfo?.message ??
-        updateResult.value.errors?.join(", ") ??
-        "Unknown error";
+    if (!updateResult.value) {
       return new Err(
-        new MCPError(`Failed to update job posting: ${errorMessage}`)
+        new MCPError("Failed to update job posting: no result returned.")
       );
     }
 
@@ -641,8 +631,8 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const lines = [
       `Successfully updated job posting ${updatedFields}.`,
       "",
-      `Job Posting ID: ${updateResult.value.results.id}`,
-      `Title: ${updateResult.value.results.title}`,
+      `Job Posting ID: ${updateResult.value.id}`,
+      `Title: ${updateResult.value.title}`,
     ];
 
     if (previousPosting.descriptionHtml) {
@@ -684,13 +674,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!formResult.value.success) {
-      return new Err(
-        new MCPError("Failed to retrieve referral form from Ashby.")
-      );
-    }
-
-    const form = formResult.value.results;
+    const form = formResult.value;
 
     const jobsResult = await client.listJobs();
     if (jobsResult.isErr()) {
@@ -717,25 +701,12 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     });
 
     if (referralResult.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to create referral: ${referralResult.error.message}`,
-          {
-            cause: referralResult.error,
-          }
-        )
-      );
-    }
-
-    if (!referralResult.value.success || !referralResult.value.results) {
-      const errorCode = referralResult.value.errorInfo?.code;
-      const errorMessage =
-        referralResult.value.errorInfo?.message ??
-        referralResult.value.errors?.join(", ") ??
-        "Unknown error";
-
-      // They have a catch all error `invalid_input`.
-      if (errorCode === "invalid_input") {
+      const { error } = referralResult;
+      // They have a catch-all error `invalid_input` - run field diagnosis to help the model fix it.
+      if (
+        error instanceof AshbyAPIError &&
+        error.errorInfo?.code === "invalid_input"
+      ) {
         const diagnosis = diagnoseFieldSubmissions(
           form,
           submissionsResult.value,
@@ -748,9 +719,16 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
           )
         );
       }
-
       return new Err(
-        new MCPError(`Failed to create referral: ${errorMessage}`)
+        new MCPError(`Failed to create referral: ${error.message}`, {
+          cause: error,
+        })
+      );
+    }
+
+    if (!referralResult.value) {
+      return new Err(
+        new MCPError("Failed to create referral: no result returned.")
       );
     }
 
@@ -760,8 +738,8 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
         text:
           `Successfully created referral.\n\n` +
           `Credited to: ${ashbyUser.firstName} ${ashbyUser.lastName} (${ashbyUser.email})\n` +
-          `Referral ID: ${referralResult.value.results.id}\n` +
-          `Status: ${referralResult.value.results.status}`,
+          `Referral ID: ${referralResult.value.id}\n` +
+          `Status: ${referralResult.value.status}`,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -97,7 +97,9 @@ export type AshbyCandidateSearchRequest = z.infer<
   typeof AshbyCandidateSearchRequestSchema
 >;
 
-export const AshbyCandidateSearchResponseSchema = z.array(AshbyCandidateSchema).optional();
+export const AshbyCandidateSearchResponseSchema = z
+  .array(AshbyCandidateSchema)
+  .optional();
 
 export type AshbyCandidateSearchResponse = z.infer<
   typeof AshbyCandidateSearchResponseSchema
@@ -168,7 +170,9 @@ export type AshbyFeedbackSubmission = z.infer<
   typeof AshbyFeedbackSubmissionSchema
 >;
 
-export const AshbyApplicationFeedbackListResponseSchema = z.array(AshbyFeedbackSubmissionSchema);
+export const AshbyApplicationFeedbackListResponseSchema = z.array(
+  AshbyFeedbackSubmissionSchema
+);
 
 export type AshbyApplicationFeedbackListResponse = z.infer<
   typeof AshbyApplicationFeedbackListResponseSchema
@@ -186,7 +190,9 @@ export type AshbyCandidateCreateNoteRequest = z.infer<
   typeof AshbyCandidateCreateNoteRequestSchema
 >;
 
-export const AshbyCandidateCreateNoteResponseSchema = z.object({ id: z.string() }).passthrough();
+export const AshbyCandidateCreateNoteResponseSchema = z
+  .object({ id: z.string() })
+  .passthrough();
 
 export type AshbyCandidateCreateNoteResponse = z.infer<
   typeof AshbyCandidateCreateNoteResponseSchema
@@ -219,7 +225,9 @@ export const AshbyCandidateNoteSchema = z
 
 export type AshbyCandidateNote = z.infer<typeof AshbyCandidateNoteSchema>;
 
-export const AshbyCandidateListNotesResponseSchema = z.array(AshbyCandidateNoteSchema);
+export const AshbyCandidateListNotesResponseSchema = z.array(
+  AshbyCandidateNoteSchema
+);
 
 export type AshbyCandidateListNotesResponse = z.infer<
   typeof AshbyCandidateListNotesResponseSchema
@@ -510,7 +518,8 @@ export const AshbyJobPostingInfoSchema = z
 
 export type AshbyJobPostingInfo = z.infer<typeof AshbyJobPostingInfoSchema>;
 
-export const AshbyJobPostingInfoResponseSchema = AshbyJobPostingInfoSchema.optional();
+export const AshbyJobPostingInfoResponseSchema =
+  AshbyJobPostingInfoSchema.optional();
 
 export type AshbyJobPostingInfoResponse = z.infer<
   typeof AshbyJobPostingInfoResponseSchema
@@ -662,7 +671,8 @@ export const AshbyCandidateInfoSchema = z
 
 export type AshbyCandidateInfo = z.infer<typeof AshbyCandidateInfoSchema>;
 
-export const AshbyCandidateInfoResponseSchema = AshbyCandidateInfoSchema.optional();
+export const AshbyCandidateInfoResponseSchema =
+  AshbyCandidateInfoSchema.optional();
 
 export type AshbyCandidateInfoResponse = z.infer<
   typeof AshbyCandidateInfoResponseSchema

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -1,5 +1,21 @@
 import z from "zod";
 
+export const AshbyAPIErrorInfoSchema = z
+  .object({
+    code: z.string(),
+    message: z.string().optional(),
+    requestId: z.string().optional(),
+  })
+  .passthrough();
+
+export type AshbyAPIErrorInfo = z.infer<typeof AshbyAPIErrorInfoSchema>;
+
+export const AshbyAPIErrorResponseSchema = z.object({
+  success: z.literal(false),
+  errors: z.array(z.string()).optional(),
+  errorInfo: AshbyAPIErrorInfoSchema.optional(),
+});
+
 export const AshbyCandidateSchema = z
   .object({
     id: z.string(),
@@ -42,34 +58,31 @@ export type AshbyReportSynchronousRequest = z.infer<
   typeof AshbyReportSynchronousRequestSchema
 >;
 
-export const AshbyReportSynchronousResponseSchema = z.object({
-  success: z.boolean(),
-  results: z
-    .union([
-      z.object({
-        requestId: z.string(),
-        status: z.literal("complete"),
-        reportData: z.object({
-          data: z.array(z.array(z.union([z.string(), z.number(), z.null()]))),
-          columnNames: z.array(z.string()),
-          metadata: z
-            .object({
-              updatedAt: z.string(),
-              title: z.string(),
-            })
-            .passthrough(),
-        }),
-        failureReason: z.string().nullable(),
+export const AshbyReportSynchronousResponseSchema = z
+  .union([
+    z.object({
+      requestId: z.string(),
+      status: z.literal("complete"),
+      reportData: z.object({
+        data: z.array(z.array(z.union([z.string(), z.number(), z.null()]))),
+        columnNames: z.array(z.string()),
+        metadata: z
+          .object({
+            updatedAt: z.string(),
+            title: z.string(),
+          })
+          .passthrough(),
       }),
-      z.object({
-        requestId: z.string(),
-        status: z.enum(["failed", "in_progress"]),
-        reportData: z.null(),
-        failureReason: z.string().nullable(),
-      }),
-    ])
-    .optional(),
-});
+      failureReason: z.string().nullable(),
+    }),
+    z.object({
+      requestId: z.string(),
+      status: z.enum(["failed", "in_progress"]),
+      reportData: z.null(),
+      failureReason: z.string().nullable(),
+    }),
+  ])
+  .optional();
 
 export type AshbyReportSynchronousResponse = z.infer<
   typeof AshbyReportSynchronousResponseSchema
@@ -84,9 +97,7 @@ export type AshbyCandidateSearchRequest = z.infer<
   typeof AshbyCandidateSearchRequestSchema
 >;
 
-export const AshbyCandidateSearchResponseSchema = z.object({
-  results: z.array(AshbyCandidateSchema).optional(),
-});
+export const AshbyCandidateSearchResponseSchema = z.array(AshbyCandidateSchema).optional();
 
 export type AshbyCandidateSearchResponse = z.infer<
   typeof AshbyCandidateSearchResponseSchema
@@ -157,9 +168,7 @@ export type AshbyFeedbackSubmission = z.infer<
   typeof AshbyFeedbackSubmissionSchema
 >;
 
-export const AshbyApplicationFeedbackListResponseSchema = z.object({
-  results: z.array(AshbyFeedbackSubmissionSchema),
-});
+export const AshbyApplicationFeedbackListResponseSchema = z.array(AshbyFeedbackSubmissionSchema);
 
 export type AshbyApplicationFeedbackListResponse = z.infer<
   typeof AshbyApplicationFeedbackListResponseSchema
@@ -177,14 +186,7 @@ export type AshbyCandidateCreateNoteRequest = z.infer<
   typeof AshbyCandidateCreateNoteRequestSchema
 >;
 
-export const AshbyCandidateCreateNoteResponseSchema = z.object({
-  success: z.boolean(),
-  results: z
-    .object({
-      id: z.string(),
-    })
-    .passthrough(),
-});
+export const AshbyCandidateCreateNoteResponseSchema = z.object({ id: z.string() }).passthrough();
 
 export type AshbyCandidateCreateNoteResponse = z.infer<
   typeof AshbyCandidateCreateNoteResponseSchema
@@ -217,10 +219,7 @@ export const AshbyCandidateNoteSchema = z
 
 export type AshbyCandidateNote = z.infer<typeof AshbyCandidateNoteSchema>;
 
-export const AshbyCandidateListNotesResponseSchema = z.object({
-  success: z.boolean(),
-  results: z.array(AshbyCandidateNoteSchema),
-});
+export const AshbyCandidateListNotesResponseSchema = z.array(AshbyCandidateNoteSchema);
 
 export type AshbyCandidateListNotesResponse = z.infer<
   typeof AshbyCandidateListNotesResponseSchema
@@ -245,17 +244,14 @@ export type AshbyApplicationStatus = z.infer<
   typeof AshbyApplicationStatusSchema
 >;
 
-export const AshbyApplicationInfoResponseSchema = z.object({
-  success: z.boolean(),
-  results: z
-    .object({
-      id: z.string(),
-      status: AshbyApplicationStatusSchema,
-      job: z.object({ id: z.string() }).passthrough().optional(),
-      candidateId: z.string().optional(),
-    })
-    .passthrough(),
-});
+export const AshbyApplicationInfoResponseSchema = z
+  .object({
+    id: z.string(),
+    status: AshbyApplicationStatusSchema,
+    job: z.object({ id: z.string() }).passthrough().optional(),
+    candidateId: z.string().optional(),
+  })
+  .passthrough();
 
 export type AshbyApplicationInfoResponse = z.infer<
   typeof AshbyApplicationInfoResponseSchema
@@ -272,15 +268,6 @@ export const AshbyJobSchema = z
   .passthrough();
 
 export type AshbyJob = z.infer<typeof AshbyJobSchema>;
-
-export const AshbyJobListResponseSchema = z.object({
-  success: z.boolean(),
-  results: z.array(AshbyJobSchema),
-  moreDataAvailable: z.boolean().optional(),
-  nextCursor: z.string().optional(),
-});
-
-export type AshbyJobListResponse = z.infer<typeof AshbyJobListResponseSchema>;
 
 // User search
 
@@ -305,10 +292,7 @@ export const AshbyUserSchema = z
 
 export type AshbyUser = z.infer<typeof AshbyUserSchema>;
 
-export const AshbyUserSearchResponseSchema = z.object({
-  success: z.boolean(),
-  results: z.array(AshbyUserSchema),
-});
+export const AshbyUserSearchResponseSchema = z.array(AshbyUserSchema);
 
 export type AshbyUserSearchResponse = z.infer<
   typeof AshbyUserSearchResponseSchema
@@ -369,10 +353,7 @@ export const AshbyReferralFormInfoSchema = z
 
 export type AshbyReferralFormInfo = z.infer<typeof AshbyReferralFormInfoSchema>;
 
-export const AshbyReferralFormInfoResponseSchema = z.object({
-  success: z.boolean(),
-  results: AshbyReferralFormInfoSchema,
-});
+export const AshbyReferralFormInfoResponseSchema = AshbyReferralFormInfoSchema;
 
 export type AshbyReferralFormInfoResponse = z.infer<
   typeof AshbyReferralFormInfoResponseSchema
@@ -424,24 +405,13 @@ export type AshbyReferralCreateRequest = z.infer<
   typeof AshbyReferralCreateRequestSchema
 >;
 
-export const AshbyReferralCreateResponseSchema = z.object({
-  success: z.boolean(),
-  results: z
-    .object({
-      id: z.string(),
-      status: z.string(),
-    })
-    .passthrough()
-    .optional(),
-  errors: z.array(z.string()).optional(),
-  errorInfo: z
-    .object({
-      code: z.string().optional(),
-      message: z.string().optional(),
-    })
-    .passthrough()
-    .optional(),
-});
+export const AshbyReferralCreateResponseSchema = z
+  .object({
+    id: z.string(),
+    status: z.string(),
+  })
+  .passthrough()
+  .optional();
 
 export type AshbyReferralCreateResponse = z.infer<
   typeof AshbyReferralCreateResponseSchema
@@ -501,10 +471,7 @@ export type AshbyJobPostingListRequest = z.infer<
   typeof AshbyJobPostingListRequestSchema
 >;
 
-export const AshbyJobPostingListResponseSchema = z.object({
-  success: z.boolean(),
-  results: z.array(AshbyJobPostingSchema),
-});
+export const AshbyJobPostingListResponseSchema = z.array(AshbyJobPostingSchema);
 
 export type AshbyJobPostingListResponse = z.infer<
   typeof AshbyJobPostingListResponseSchema
@@ -543,10 +510,7 @@ export const AshbyJobPostingInfoSchema = z
 
 export type AshbyJobPostingInfo = z.infer<typeof AshbyJobPostingInfoSchema>;
 
-export const AshbyJobPostingInfoResponseSchema = z.object({
-  success: z.boolean(),
-  results: AshbyJobPostingInfoSchema.optional(),
-});
+export const AshbyJobPostingInfoResponseSchema = AshbyJobPostingInfoSchema.optional();
 
 export type AshbyJobPostingInfoResponse = z.infer<
   typeof AshbyJobPostingInfoResponseSchema
@@ -602,24 +566,13 @@ export type AshbyJobPostingUpdateRequest = z.infer<
   typeof AshbyJobPostingUpdateRequestSchema
 >;
 
-export const AshbyJobPostingUpdateResponseSchema = z.object({
-  success: z.boolean(),
-  results: z
-    .object({
-      id: z.string(),
-      title: z.string(),
-    })
-    .passthrough()
-    .optional(),
-  errors: z.array(z.string()).optional(),
-  errorInfo: z
-    .object({
-      code: z.string().optional(),
-      message: z.string().optional(),
-    })
-    .passthrough()
-    .optional(),
-});
+export const AshbyJobPostingUpdateResponseSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+  })
+  .passthrough()
+  .optional();
 
 export type AshbyJobPostingUpdateResponse = z.infer<
   typeof AshbyJobPostingUpdateResponseSchema
@@ -709,10 +662,7 @@ export const AshbyCandidateInfoSchema = z
 
 export type AshbyCandidateInfo = z.infer<typeof AshbyCandidateInfoSchema>;
 
-export const AshbyCandidateInfoResponseSchema = z.object({
-  success: z.boolean(),
-  results: AshbyCandidateInfoSchema.optional(),
-});
+export const AshbyCandidateInfoResponseSchema = AshbyCandidateInfoSchema.optional();
 
 export type AshbyCandidateInfoResponse = z.infer<
   typeof AshbyCandidateInfoResponseSchema
@@ -780,12 +730,7 @@ export const AshbyOfferListRequestSchema = z.object({
 
 export type AshbyOfferListRequest = z.infer<typeof AshbyOfferListRequestSchema>;
 
-export const AshbyOfferListResponseSchema = z.object({
-  success: z.boolean(),
-  results: z.array(AshbyOfferSchema),
-  moreDataAvailable: z.boolean().optional(),
-  nextCursor: z.string().optional(),
-});
+export const AshbyOfferListResponseSchema = z.array(AshbyOfferSchema);
 
 export type AshbyOfferListResponse = z.infer<
   typeof AshbyOfferListResponseSchema
@@ -812,10 +757,7 @@ export const AshbyOfferInfoSchema = z
 
 export type AshbyOfferInfo = z.infer<typeof AshbyOfferInfoSchema>;
 
-export const AshbyOfferInfoResponseSchema = z.object({
-  success: z.boolean(),
-  results: AshbyOfferInfoSchema.optional(),
-});
+export const AshbyOfferInfoResponseSchema = AshbyOfferInfoSchema.optional();
 
 export type AshbyOfferInfoResponse = z.infer<
   typeof AshbyOfferInfoResponseSchema
@@ -853,9 +795,6 @@ export const AshbyJobInfoSchema = z
 
 export type AshbyJobInfo = z.infer<typeof AshbyJobInfoSchema>;
 
-export const AshbyJobInfoResponseSchema = z.object({
-  success: z.boolean(),
-  results: AshbyJobInfoSchema.optional(),
-});
+export const AshbyJobInfoResponseSchema = AshbyJobInfoSchema.optional();
 
 export type AshbyJobInfoResponse = z.infer<typeof AshbyJobInfoResponseSchema>;


### PR DESCRIPTION
## Description

- This PR allows exposing the error messages from the Ashby API to models when calling the internal Ashby tools.
- The schema of the error responses is always the same https://developers.ashbyhq.com/reference/jobinfo for instance.
- The API actually does not rely on error codes at all, it always sends an object that contains a boolean `success` field and either a `results` field or `errors` and `errorInfo`.
- This PR reflects this structure in the generic wrapper around all API calls to Ashby.

## Tests

- Tested locally.

## Risk

- Low. Only affects the Ashby tools.

## Deploy Plan

- Deploy front.