### PR TITLE
fix: hide agent details from all tab in extension

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -23,14 +23,15 @@ interface ConversationContainerProps {
 const SUGGESTIONS = {
   formHelper: {
     id: "form_helper",
-    title:
-      "Use the Dust extension to fill out forms directly, no more copy-pasting from agents",
-    description: "Ask an agent to get started",
+    title: "Fill forms with Dust extension",
+    description:
+      "No more copy-pasting. Fill out forms directly from your agents.",
   },
   multiTab: {
     id: "multi_tab",
-    title: "Dust can work across all your open tabs",
-    description: "Ask an agent to get started",
+    title: "Bring any tab into your conversation",
+    description:
+      "Ask an agent to read, summarize, or act on any of your open tabs.",
   },
 } as const;
 

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -23,7 +23,8 @@ interface ConversationContainerProps {
 const SUGGESTIONS = {
   formHelper: {
     id: "form_helper",
-    title: "Dust can help you fill out forms",
+    title:
+      "Use the Dust extension to fill out forms directly, no more copy-pasting from agents",
     description: "Ask an agent to get started",
   },
   multiTab: {

--- a/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
+++ b/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
@@ -1,10 +1,16 @@
-import { InputBarContextProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import {
+  InputBarContext,
+  InputBarContextProvider,
+} from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { AttachSelectionMessage } from "@extension/platforms/chrome/messages";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useSearchParam } from "@extension/shared/platform";
 import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 interface ExtensionInputBarProviderProps {
   workspace: LightWorkspaceType;
@@ -66,7 +72,29 @@ export function ExtensionInputBarProvider({
       captureActions={captureActions}
       fileUploaderService={fileUploaderService}
     >
+      <AgentQueryParamHandler workspaceId={workspace.sId} />
       {children}
     </InputBarContextProvider>
   );
+}
+
+/**
+ * Reads the ?agent= query param and pre-selects the agent in the input bar.
+ */
+function AgentQueryParamHandler({ workspaceId }: { workspaceId: string }) {
+  const agent = useSearchParam("agent");
+  const { setSelectedAgent } = useContext(InputBarContext);
+
+  const { agentConfiguration } = useAgentConfiguration({
+    workspaceId,
+    agentConfigurationId: agent,
+  });
+
+  useEffect(() => {
+    if (agentConfiguration) {
+      setSelectedAgent(toRichAgentMentionType(agentConfiguration));
+    }
+  }, [agentConfiguration, setSelectedAgent]);
+
+  return null;
 }

--- a/front/components/assistant/conversation/agent_browser/MobileOrExtensionAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/MobileOrExtensionAgentBrowser.tsx
@@ -92,6 +92,7 @@ export function MobileOrExtensionAgentBrowser({
           setDisplayedAssistantId={setDisplayedAssistantId}
           owner={owner}
           showTagHeadings={false}
+          canGetMore={false}
         />
       ) : (
         viewTab && (

--- a/front/components/assistant/conversation/agent_browser/shared.tsx
+++ b/front/components/assistant/conversation/agent_browser/shared.tsx
@@ -300,6 +300,7 @@ type AllTabContentProps = {
   setDisplayedAssistantId: (id: string) => void;
   owner: WorkspaceType;
   showTagHeadings: boolean;
+  canGetMore?: boolean;
 };
 
 export function AllTabContent({
@@ -312,6 +313,7 @@ export function AllTabContent({
   setDisplayedAssistantId,
   owner,
   showTagHeadings,
+  canGetMore = true,
 }: AllTabContentProps) {
   return (
     <>
@@ -359,6 +361,7 @@ export function AllTabContent({
                 handleAssistantClick={handleAgentClick}
                 handleMoreClick={setDisplayedAssistantId}
                 owner={owner}
+                canGetMore={canGetMore}
               />
             </React.Fragment>
           ))}

--- a/front/components/mentions/MentionDropdown.tsx
+++ b/front/components/mentions/MentionDropdown.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute, setQueryParam } from "@app/lib/utils/router";
 import { canShowAgentConversationActions } from "@app/types/assistant/assistant";
@@ -43,6 +44,7 @@ export const MentionDropdown = React.forwardRef<
   MentionDropdownProps
 >(({ mention, owner, children }, ref) => {
   const router = useAppRouter();
+  const clientType = useClientType();
   const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
   const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
 
@@ -73,11 +75,13 @@ export const MentionDropdown = React.forwardRef<
             icon={ChatBubbleBottomCenterPlusIcon}
             label={`New conversation with @${mention.label}`}
           />
-          <DropdownMenuItem
-            onClick={handleAgentSeeDetails}
-            icon={EyeIcon}
-            label={`About @${mention.label}`}
-          />
+          {clientType !== "extension" && (
+            <DropdownMenuItem
+              onClick={handleAgentSeeDetails}
+              icon={EyeIcon}
+              label={`About @${mention.label}`}
+            />
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     );


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7204

This PR hides the option to display agent details from the "All" tab when viewing in the browser extension

## Tests

Manually

## Risks

Low risk. The change is isolated to the extension/mobile view and defaults to the existing behavior (`true`) for all other contexts.

## Deploy Plan

Standard deployment.
