### PR TITLE
[front] feat: change sorting on skills in Agent Builder

### DIFF
--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -33,7 +33,16 @@ export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
 
   const value: SkillsContextType = useMemo(() => {
     return {
-      skills: skills.toSorted((a, b) => a.name.localeCompare(b.name)),
+      // Dust-managed non-default skills are displayed first: these are the baseline Discover capabilities.
+      // Default skills are the ones that are discoverable.
+      skills: skills.toSorted((a, b) => {
+        const aIsDiscover = a.editedBy === null && !a.isDefault;
+        const bIsDiscover = b.editedBy === null && !b.isDefault;
+        if (aIsDiscover !== bIsDiscover) {
+          return aIsDiscover ? -1 : 1;
+        }
+        return a.name.localeCompare(b.name);
+      }),
       isSkillsLoading,
       isSkillsError,
     };


### PR DESCRIPTION
## Description

- This PR changes the sorting order of skills in Agent Builder to move the Dust-managed non-discoverable skills first.
- Rationale is that Dust-managed skills that are non-discoverable hold a specific role: these are the Discover xxx skills that have specific behaviors that prohibits them from being discoverable but also make them more generalist than the other global skills.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
