### PR TITLE
[front] fix: improve display of failed secrets fetch

### DIFF
--- a/front/components/agent_builder/capabilities/shared/SecretSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/SecretSection.tsx
@@ -3,7 +3,14 @@ import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderForm
 import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
 import { useDustAppSecrets } from "@app/lib/swr/apps";
 import type { DustAppSecretType } from "@app/types/dust_app_secret";
-import { Button, Card, DataTable, Spinner } from "@dust-tt/sparkle";
+import {
+  Button,
+  Card,
+  ContentMessage,
+  DataTable,
+  InformationCircleIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { KeyIcon, PencilIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import sortBy from "lodash/sortBy";
@@ -99,13 +106,15 @@ export function SecretSection({
 
   if (isSecretsError) {
     return (
-      <ConfigurationSectionContainer
-        title="Select a Secret"
-        error={`Failed to load secrets: ${isSecretsError}`}
-      >
-        <div className="flex h-40 w-full items-center justify-center text-red-500">
-          Error loading secrets
-        </div>
+      <ConfigurationSectionContainer title="Select a Secret">
+        <ContentMessage
+          title="Failed to load secrets"
+          icon={InformationCircleIcon}
+          variant="warning"
+          size="sm"
+        >
+          {isSecretsError.message}
+        </ContentMessage>
       </ConfigurationSectionContainer>
     );
   }

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,6 +1,7 @@
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
@@ -135,7 +136,7 @@ export function useDustAppSecrets(owner: LightWorkspaceType | null) {
   return {
     secrets: data?.secrets ?? emptyArray(),
     isSecretsLoading: !error && !data && !!owner,
-    isSecretsError: error,
+    isSecretsError: error ? normalizeError(error) : undefined,
   };
 }
 

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,7 +1,6 @@
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
@@ -14,6 +13,7 @@ import type { PostRunCancelResponseBody } from "@app/pages/api/w/[wId]/spaces/[s
 import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status";
 import type { AppType } from "@app/types/app";
 import type { RunRunType } from "@app/types/run";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/7203
- This PR improves the UI for displaying error on the call to fetch developer secrets for the configuration of the HTTP client tool in Agent Builder.
- The current implementation displays a string `[Object object]` since we pass the entire error object to a string literal.
- Follows the same pattern as for the configuration of child agents.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
