### PR TITLE
[front] - chore(tailwind): extend color utility classes in Tailwind

### DIFF
--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -1008,7 +1008,7 @@ module.exports = {
     // Avatar bg classes are constructed dynamically.
     {
       pattern:
-        /^bg-(gray|blue|violet|pink|red|orange|golden|lime|emerald)-(100|200|300|400|500|600|700|800)$/,
+        /^(bg|text)-(gray|blue|violet|pink|red|orange|golden|lime|emerald)-(100|200|300|400|500|600|700|800|900)$/,
     },
     // MainNavigation grid rows are constructed dynamically.
     "grid-rows-2",


### PR DESCRIPTION
## Description

This PR adds a few colors to the tailwindconfig safelist so that color can be loaded automatically

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front