### PR TITLE
Migrate frame share scope from "workspace" to "workspace_and_emails"

### DIFF
--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -9,7 +9,10 @@ import {
   MAX_EMAILS_PER_INVITE,
   type SharingGrantType,
 } from "@app/types/files";
-import type { LightWorkspaceType, WorkspaceSharingPolicy } from "@app/types/user";
+import type {
+  LightWorkspaceType,
+  WorkspaceSharingPolicy,
+} from "@app/types/user";
 import {
   ArrowUpOnSquareIcon,
   Avatar,
@@ -67,7 +70,10 @@ const SCOPE_OPTIONS: {
 ];
 
 // Scopes allowed by each workspace sharing policy.
-const ALLOWED_SCOPES_BY_POLICY: Record<WorkspaceSharingPolicy, FileShareScope[]> = {
+const ALLOWED_SCOPES_BY_POLICY: Record<
+  WorkspaceSharingPolicy,
+  FileShareScope[]
+> = {
   emails_only: ["emails_only"],
   workspace_and_emails: ["emails_only", "workspace_and_emails"],
   all_scopes: ["emails_only", "workspace_and_emails", "public"],
@@ -135,7 +141,8 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
     reValidateMode: "onSubmit",
   });
 
-  const currentScope: FileShareScope = fileShare?.scope ?? "workspace_and_emails";
+  const currentScope: FileShareScope =
+    fileShare?.scope ?? "workspace_and_emails";
   const shareURL = fileShare?.shareUrl ?? "";
 
   const allowedScopes = ALLOWED_SCOPES_BY_POLICY[owner.sharingPolicy];

--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -9,7 +9,7 @@ import {
   MAX_EMAILS_PER_INVITE,
   type SharingGrantType,
 } from "@app/types/files";
-import type { LightWorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType, WorkspaceSharingPolicy } from "@app/types/user";
 import {
   ArrowUpOnSquareIcon,
   Avatar,
@@ -65,6 +65,13 @@ const SCOPE_OPTIONS: {
     value: "public",
   },
 ];
+
+// Scopes allowed by each workspace sharing policy.
+const ALLOWED_SCOPES_BY_POLICY: Record<WorkspaceSharingPolicy, FileShareScope[]> = {
+  emails_only: ["emails_only"],
+  workspace_and_emails: ["emails_only", "workspace_and_emails"],
+  all_scopes: ["emails_only", "workspace_and_emails", "public"],
+};
 
 const inviteFormSchema = z.object({
   emailsRaw: z
@@ -128,8 +135,13 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
     reValidateMode: "onSubmit",
   });
 
-  const currentScope = fileShare?.scope ?? "workspace";
+  const currentScope: FileShareScope = fileShare?.scope ?? "workspace_and_emails";
   const shareURL = fileShare?.shareUrl ?? "";
+
+  const allowedScopes = ALLOWED_SCOPES_BY_POLICY[owner.sharingPolicy];
+  const availableScopeOptions = SCOPE_OPTIONS.filter((o) =>
+    allowedScopes.includes(o.value)
+  );
 
   const showEmailSection =
     currentScope === "emails_only" || currentScope === "workspace_and_emails";
@@ -201,7 +213,7 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                     Who has access
                   </legend>
                   <div className="flex flex-col gap-1">
-                    {SCOPE_OPTIONS.map((option) => {
+                    {availableScopeOptions.map((option) => {
                       const isSelected = option.value === currentScope;
                       const inputId = `share-scope-${option.value}`;
                       return (

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -18,6 +18,7 @@ describe("buildEditorExtensions", () => {
           whiteListedProviders: null,
           defaultEmbeddingProvider: null,
           metadata: null,
+          sharingPolicy: "all_scopes",
         } satisfies WorkspaceType,
         conversationId: "cId",
         onInlineText: () => {},

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -26,6 +26,7 @@ const mockWorkspace: WorkspaceType = {
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
   metadata: {},
+  sharingPolicy: "all_scopes",
 };
 
 // Helper function to create a basic MCP tool configuration

--- a/front/lib/api/share/frame_sharing.ts
+++ b/front/lib/api/share/frame_sharing.ts
@@ -3,10 +3,27 @@ import { sendEmailWithTemplate } from "@app/lib/api/email";
 import { runOnRedis } from "@app/lib/api/redis";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
+import type { FileShareScope } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { WorkspaceSharingPolicy } from "@app/types/user";
 import crypto from "crypto";
 import { escape } from "html-escaper";
+
+export function getDefaultFrameShareScope(
+  sharingPolicy: WorkspaceSharingPolicy
+): FileShareScope {
+  switch (sharingPolicy) {
+    case "emails_only":
+      return "emails_only";
+    case "workspace_and_emails":
+    case "all_scopes":
+      return "workspace_and_emails";
+    default:
+      assertNever(sharingPolicy);
+  }
+}
 
 const OTP_TTL_SECONDS = 15 * 60; // 15 minutes.
 const OTP_MAX_ATTEMPTS = 5;

--- a/front/lib/api/workos/organization.test.ts
+++ b/front/lib/api/workos/organization.test.ts
@@ -51,6 +51,7 @@ function makeWorkspace(
     workOSOrganizationId: "org_123",
     metadata: null,
     role: "admin",
+    sharingPolicy: "all_scopes",
     ...overrides,
   };
 }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -946,6 +946,7 @@ export class Authenticator {
           whiteListedProviders: this._workspace.whiteListedProviders,
           defaultEmbeddingProvider: this._workspace.defaultEmbeddingProvider,
           metadata: this._workspace.metadata,
+          sharingPolicy: this._workspace.sharingPolicy ?? "all_scopes",
         }
       : null;
   }

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -78,6 +78,7 @@ function makeWorkspace(
     whiteListedProviders: null,
     defaultEmbeddingProvider: null,
     metadata: null,
+    sharingPolicy: "all_scopes",
     ...overrides,
   };
 }

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -184,7 +184,7 @@ describe("FileResource", () => {
       expect(result).not.toBeNull();
       expect(result?.file.id).toBe(frameFile.id);
       expect(result?.content).toEqual(expectedContent);
-      expect(result?.shareScope).toBe("workspace");
+      expect(result?.shareScope).toBe("workspace_and_emails");
     });
   });
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -11,7 +11,10 @@ import {
   getProcessedContentType,
   hasProcessedVersion,
 } from "@app/lib/api/files/processing";
-import { sendFrameSharedEmail } from "@app/lib/api/share/frame_sharing";
+import {
+  getDefaultFrameShareScope,
+  sendFrameSharedEmail,
+} from "@app/lib/api/share/frame_sharing";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
@@ -53,7 +56,11 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
+import type {
+  LightWorkspaceType,
+  UserType,
+  WorkspaceSharingPolicy,
+} from "@app/types/user";
 import type { File } from "@google-cloud/storage";
 import assert from "assert";
 import type {
@@ -509,11 +516,15 @@ export class FileResource extends BaseResource<FileModel> {
     const updateResult = await this.update({ status: "ready" });
 
     // For Interactive Content conversation files, automatically create a ShareableFileModel with
-    // default workspace scope.
+    // a default scope based on the workspace sharing policy.
     if (this.isInteractiveContent) {
+      const defaultScope = getDefaultFrameShareScope(
+        auth.getNonNullableWorkspace().sharingPolicy
+      );
+
       await FileResource.shareableFileModel.upsert({
         fileId: this.id,
-        shareScope: "workspace",
+        shareScope: defaultScope,
         sharedBy: this.userId ?? null,
         workspaceId: this.workspaceId,
         sharedAt: new Date(),
@@ -1155,15 +1166,19 @@ export class FileResource extends BaseResource<FileModel> {
     return null;
   }
 
-  static async revokePublicSharingInWorkspace(auth: Authenticator) {
-    const workspaceId = auth.getNonNullableWorkspace().id;
+  static async revokePublicSharingInWorkspace(
+    auth: Authenticator,
+    { newPolicy }: { newPolicy: WorkspaceSharingPolicy }
+  ) {
+    const fallbackScope = getDefaultFrameShareScope(newPolicy);
+
     return FileResource.shareableFileModel.update(
       {
-        shareScope: "workspace",
+        shareScope: fallbackScope,
       },
       {
         where: {
-          workspaceId,
+          workspaceId: auth.getNonNullableWorkspace().id,
           shareScope: "public",
         },
       }

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -822,7 +822,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
    */
 
   get canShareInteractiveContentPublicly(): boolean {
-    return this.blob.metadata?.allowContentCreationFileSharing !== false;
+    return this.sharingPolicy === "all_scopes";
   }
 
   async delete(

--- a/front/migrations/db/migration_547.sql
+++ b/front/migrations/db/migration_547.sql
@@ -1,0 +1,7 @@
+-- Migration created on Mar 20, 2026
+-- Migrate legacy "workspace" share scope to "workspace_and_emails".
+UPDATE "shareable_files"
+SET
+  "shareScope" = 'workspace_and_emails'
+WHERE
+  "shareScope" = 'workspace';

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -115,24 +115,16 @@ async function handler(
     workspace.sId
   );
 
-  // For workspace sharing, check authentication.
-  if (shareScope === "workspace") {
-    if (!auth) {
-      return apiError(req, res, {
-        status_code: 404,
-        api_error: {
-          type: "file_not_found",
-          message: "File not found.",
-        },
-      });
-    }
-  }
-
-  // Handle email-based share scopes.
-  if (shareScope === "emails_only" || shareScope === "workspace_and_emails") {
-    // For workspace_and_emails: workspace members are authorized directly.
+  // Handle email-based share scopes (treat legacy "workspace" as "workspace_and_emails").
+  if (
+    shareScope === "emails_only" ||
+    shareScope === "workspace_and_emails" ||
+    shareScope === "workspace"
+  ) {
+    // For workspace_and_emails (and legacy "workspace"): workspace members are authorized directly.
     const isWorkspaceMemberWithAccess =
-      shareScope === "workspace_and_emails" && auth;
+      (shareScope === "workspace_and_emails" || shareScope === "workspace") &&
+      auth;
 
     if (!isWorkspaceMemberWithAccess) {
       // Resolve the verified email: prefer Dust session, fall back to external viewer cookie.

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -174,9 +174,11 @@ async function handler(
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;
 
-        // if public sharing is disabled, downgrade share scope of all public files to workspace
+        // if public sharing is disabled, downgrade share scope of all public files
         if (!body.allowContentCreationFileSharing) {
-          await FileResource.revokePublicSharingInWorkspace(auth);
+          await FileResource.revokePublicSharingInWorkspace(auth, {
+            newPolicy: "workspace_and_emails",
+          });
         }
       } else if ("allowVoiceTranscription" in body) {
         const previousMetadata = owner.metadata ?? {};

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -59,7 +59,7 @@ export type LightWorkspaceType = {
   metadata?: {
     [key: string]: string | number | boolean | object | undefined;
   } | null;
-  sharingPolicy?: WorkspaceSharingPolicy;
+  sharingPolicy: WorkspaceSharingPolicy;
   workOSOrganizationId?: string | null;
   groups?: string[];
 };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The legacy "workspace" share scope on frames is being retired in favor of the new email-restricted sharing
scopes. This PR migrates all existing `shareable_files` rows from "workspace" to "workspace_and_emails", which
is functionally equivalent (workspace members can access the frame, and email invites can be added).

New frames now default to a scope derived from the workspace sharing policy via `getDefaultFrameShareScope`:
workspaces with "emails_only" policy get "emails_only" as the default, while "workspace_and_emails" and
"all_scopes" policies default to "workspace_and_emails". The `revokePublicSharingInWorkspace` method now takes
the target policy explicitly so it downgrades public frames to the correct scope rather than relying on the
auth object which may not reflect the just-updated policy.

The `canShareInteractiveContentPublicly` getter on `WorkspaceResource` now reads from the `sharingPolicy` column
directly instead of the legacy `metadata.allowContentCreationFileSharing` boolean. The dual-write in
`WorkspaceResource.update` ensures backward compatibility for old clients that still use the boolean field.

The `sharingPolicy` field on `LightWorkspaceType` is now non-optional since the database column has a default
value of "all_scopes" and is never null.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
