### PR TITLE
Add Audit log UI, api endpoint, and wrapper function

### DIFF
--- a/front/components/workspace/AuditLogsSection.tsx
+++ b/front/components/workspace/AuditLogsSection.tsx
@@ -1,0 +1,58 @@
+import { useAuditLogsStatus } from "@app/lib/swr/workos";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, DocumentTextIcon, LoadingBlock, Page } from "@dust-tt/sparkle";
+
+import { WorkspaceSection } from "./WorkspaceSection";
+
+interface AuditLogsSectionProps {
+  owner: LightWorkspaceType;
+}
+
+export function AuditLogsSection({ owner }: AuditLogsSectionProps) {
+  const { viewLogsLink, configureExportLink, isLoading, error } =
+    useAuditLogsStatus({ owner });
+
+  return (
+    <WorkspaceSection title="Audit Logs" icon={DocumentTextIcon}>
+      <div className="flex w-full flex-row items-center gap-2">
+        <div className="flex-1">
+          <Page.P variant="secondary">
+            {error
+              ? "Failed to load audit logs configuration. Please try again later."
+              : "View workspace activity logs or configure export to your security information and event management (SIEM) system."}
+          </Page.P>
+        </div>
+        <div className="flex justify-end gap-2">
+          {isLoading ? (
+            <LoadingBlock className="h-8 w-32 rounded-xl" />
+          ) : (
+            <>
+              <Button
+                label="View Logs"
+                size="sm"
+                variant="outline"
+                disabled={!viewLogsLink}
+                onClick={() => {
+                  if (viewLogsLink) {
+                    window.open(viewLogsLink, "_blank");
+                  }
+                }}
+              />
+              <Button
+                label="Configure Export"
+                size="sm"
+                variant="outline"
+                disabled={!configureExportLink}
+                onClick={() => {
+                  if (configureExportLink) {
+                    window.open(configureExportLink, "_blank");
+                  }
+                }}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </WorkspaceSection>
+  );
+}

--- a/front/components/workspace/AuditLogsSection.tsx
+++ b/front/components/workspace/AuditLogsSection.tsx
@@ -34,7 +34,7 @@ export function AuditLogsSection({ owner }: AuditLogsSectionProps) {
                 disabled={!viewLogsLink}
                 onClick={() => {
                   if (viewLogsLink) {
-                    window.open(viewLogsLink, "_blank");
+                    window.open(viewLogsLink, "_blank", "noopener,noreferrer");
                   }
                 }}
               />
@@ -45,7 +45,11 @@ export function AuditLogsSection({ owner }: AuditLogsSectionProps) {
                 disabled={!configureExportLink}
                 onClick={() => {
                   if (configureExportLink) {
-                    window.open(configureExportLink, "_blank");
+                    window.open(
+                      configureExportLink,
+                      "_blank",
+                      "noopener,noreferrer"
+                    );
                   }
                 }}
               />

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -1,7 +1,9 @@
 import { ConfirmContext } from "@app/components/Confirm";
+import { AuditLogsSection } from "@app/components/workspace/AuditLogsSection";
 import UserProvisioning from "@app/components/workspace/DirectorySync";
 import SSOConnection from "@app/components/workspace/SSOConnection";
 import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   useRemoveWorkspaceDomain,
   useWorkspaceDomains,
@@ -42,6 +44,8 @@ export default function WorkspaceAccessPanel({
   const { addDomainLink, domains, isDomainsLoading } = useWorkspaceDomains({
     owner,
   });
+  const { hasFeature } = useFeatureFlags();
+  const showAuditLogs = plan.isAuditLogsAllowed || hasFeature("audit_logs");
 
   return (
     <div className="flex flex-col gap-6">
@@ -64,6 +68,8 @@ export default function WorkspaceAccessPanel({
       {plan.limits.users.isSCIMAllowed && (
         <UserProvisioning owner={owner} plan={plan} />
       )}
+      {showAuditLogs && <Separator />}
+      {showAuditLogs && <AuditLogsSection owner={owner} />}
     </div>
   );
 }

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -1,0 +1,90 @@
+import type {
+  AuditLogActor,
+  AuditLogContext,
+  AuditLogTarget,
+} from "@app/lib/api/workos/organization";
+import { createAuditLogEvent } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export type EmitAuditLogEventParams = {
+  auth: Authenticator;
+  action: string;
+  targets: AuditLogTarget[];
+  context?: AuditLogContext;
+  metadata?: Record<string, string | number | boolean>;
+};
+
+/**
+ * Returns true if audit logs are enabled for the workspace,
+ * either via feature flag or plan setting.
+ */
+export async function isAuditLogsEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  if (await hasFeatureFlag(auth, "audit_logs")) {
+    return true;
+  }
+  return auth.getNonNullablePlan().isAuditLogsAllowed;
+}
+
+/**
+ * Emits an audit log event to WorkOS if the workspace has audit logs enabled.
+ * Enabled when the feature flag is set OR the plan allows audit logs.
+ * Does not throw errors — audit log failures should not break the main operation.
+ */
+export async function emitAuditLogEvent({
+  auth,
+  action,
+  targets,
+  context,
+  metadata,
+}: EmitAuditLogEventParams): Promise<void> {
+  try {
+    if (!(await isAuditLogsEnabled(auth))) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    if (!workspace.workOSOrganizationId) {
+      return;
+    }
+
+    await createAuditLogEvent({
+      workspace,
+      event: {
+        action,
+        actor: buildAuditActor(auth),
+        targets,
+        context: context ?? { location: auth.clientIp() ?? "internal" },
+        metadata,
+      },
+    });
+  } catch (error) {
+    logger.error(normalizeError(error), "Failed to emit audit log event");
+  }
+}
+
+/**
+ * Builds the audit actor from an Authenticator.
+ */
+export function buildAuditActor(auth: Authenticator): AuditLogActor {
+  const user = auth.getNonNullableUser();
+  return {
+    type: "user",
+    id: user.sId,
+    name: user.fullName() ?? undefined,
+  };
+}
+
+/**
+ * Builds a workspace audit target.
+ */
+export function buildWorkspaceTarget(workspace: {
+  sId: string;
+  name: string;
+}): AuditLogTarget {
+  return { type: "workspace", id: workspace.sId, name: workspace.name };
+}

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -86,6 +86,9 @@ export function buildAuditActor(auth: Authenticator): AuditLogActor {
     type: "user",
     id: user.sId,
     name: user.fullName() ?? undefined,
+    metadata: {
+      email: user.email,
+    },
   };
 }
 

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -9,9 +9,13 @@ import { hasFeatureFlag } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+// Audit actions will be added here as event emission is implemented per tier.
+// Using a union type ensures compile-time safety for action strings.
+type AuditAction = never;
+
 export type EmitAuditLogEventParams = {
   auth: Authenticator;
-  action: string;
+  action: AuditAction;
   targets: AuditLogTarget[];
   context?: AuditLogContext;
   metadata?: Record<string, string | number | boolean>;
@@ -63,7 +67,13 @@ export async function emitAuditLogEvent({
       },
     });
   } catch (error) {
-    logger.error(normalizeError(error), "Failed to emit audit log event");
+    logger.error(
+      {
+        ...normalizeError(error),
+        auditEvent: { action, targets, metadata },
+      },
+      "Failed to emit audit log event"
+    );
   }
 }
 

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getClientIp } from "@app/lib/utils/request";
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type {
@@ -20,6 +21,13 @@ import { Err } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
 import { getUserEmailFromHeaders } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+function setClientIpOnAuth(auth: Authenticator, req: NextApiRequest): void {
+  const ip = getClientIp(req);
+  if (ip !== "internal") {
+    auth.setClientIp(ip);
+  }
+}
 
 function getMaintenanceError(
   maintenance: string | number | true | object
@@ -273,6 +281,8 @@ export function withSessionAuthenticationForWorkspace<T>(
       // Session is either from cookies or synthesized from a bearer token by withLogging.
       const auth = await Authenticator.fromSession(session, wId);
 
+      setClientIpOnAuth(auth, req);
+
       if (opts.allowMissingWorkspace && (!auth.workspace() || !auth.plan())) {
         return handler(req, res, auth, session);
       }
@@ -381,6 +391,7 @@ export function withPublicAPIAuthentication<T>(
           return apiError(req, res, authRes.error);
         }
         const auth = authRes.value;
+        setClientIpOnAuth(auth, req);
 
         return handler(req, res, auth, null);
       }
@@ -416,6 +427,7 @@ export function withPublicAPIAuthentication<T>(
         }
 
         req.addResourceToLog?.(auth.getNonNullableUser());
+        setClientIpOnAuth(auth, req);
 
         return await handler(req, res, auth, null);
       }
@@ -487,6 +499,7 @@ export function withPublicAPIAuthentication<T>(
           monthlyCapMicroUsd: key.monthlyCapMicroUsd,
         });
       }
+      setClientIpOnAuth(workspaceAuth, req);
       return handler(req, res, workspaceAuth, null);
     },
     isStreaming
@@ -576,6 +589,8 @@ export async function getAuthForSharedEndpointWorkspaceMembersOnly(
   if (!auth.isUser()) {
     return null;
   }
+
+  setClientIpOnAuth(auth, req);
 
   return auth;
 }

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -373,6 +373,72 @@ export async function disableWorkOSSSOAndSCIM(
   }
 }
 
+/**
+ * Audit Logs.
+ */
+
+export type AuditLogActor = {
+  type: string;
+  id: string;
+  name?: string;
+  metadata?: Record<string, string | number | boolean>;
+};
+
+export type AuditLogTarget = {
+  type: string;
+  id: string;
+  name?: string;
+  metadata?: Record<string, string | number | boolean>;
+};
+
+export type AuditLogContext = {
+  location: string;
+  userAgent?: string;
+};
+
+export type CreateAuditLogEventParams = {
+  action: string;
+  occurredAt?: Date;
+  actor: AuditLogActor;
+  targets: AuditLogTarget[];
+  context: AuditLogContext;
+  metadata?: Record<string, string | number | boolean>;
+};
+
+export async function createAuditLogEvent({
+  workspace,
+  event,
+}: {
+  workspace: LightWorkspaceType;
+  event: CreateAuditLogEventParams;
+}): Promise<void> {
+  if (!workspace.workOSOrganizationId) {
+    throw new Error("WorkOS organization not found for this workspace.");
+  }
+
+  await getWorkOS().auditLogs.createEvent(workspace.workOSOrganizationId, {
+    action: event.action,
+    occurredAt: event.occurredAt ?? new Date(),
+    actor: {
+      type: event.actor.type,
+      id: event.actor.id,
+      name: event.actor.name,
+      metadata: event.actor.metadata ?? {},
+    },
+    targets: event.targets.map((target) => ({
+      type: target.type,
+      id: target.id,
+      name: target.name,
+      metadata: target.metadata,
+    })),
+    context: {
+      location: event.context.location,
+      userAgent: event.context.userAgent,
+    },
+    metadata: event.metadata,
+  });
+}
+
 export async function deleteWorksOSOrganizationWithWorkspace(
   workspaceId: string
 ): Promise<Result<undefined, Error>> {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -107,6 +107,7 @@ export class Authenticator {
   _workspace: WorkspaceResource | null;
   _authMethod: AuthMethodType;
   _providersHealth: ProvidersHealth | null;
+  _clientIp?: string;
 
   // Should only be called from the static methods below.
   constructor({
@@ -885,7 +886,7 @@ export class Authenticator {
   }
 
   exchangeKey(key: KeyAuthType) {
-    return new Authenticator({
+    const auth = new Authenticator({
       authMethod: this.authMethod(),
       key,
       role: this._role,
@@ -894,10 +895,22 @@ export class Authenticator {
       subscription: this._subscription,
       workspace: this._workspace,
     });
+    if (this._clientIp) {
+      auth.setClientIp(this._clientIp);
+    }
+    return auth;
   }
 
   providersHealth(): ProvidersHealth | null {
     return this._providersHealth;
+  }
+
+  clientIp(): string | undefined {
+    return this._clientIp;
+  }
+
+  setClientIp(ip: string) {
+    this._clientIp = ip;
   }
 
   role(): RoleType {

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -7,6 +7,7 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
+import type { AuditLogsSetupResponse } from "@app/pages/api/w/[wId]/audit-logs";
 import type { GetWorkspaceDomainsResponseBody } from "@app/pages/api/w/[wId]/domains";
 import type { GetProvisioningStatusResponseBody } from "@app/pages/api/w/[wId]/provisioning-status";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -249,5 +250,30 @@ export function useProvisioningStatus({
     roleProvisioningStatus,
     isProvisioningStatusLoading: !error && !data && !disabled,
     isProvisioningStatusError: error,
+  };
+}
+
+/**
+ * Audit Logs
+ */
+
+export function useAuditLogsStatus({
+  disabled,
+  owner,
+}: {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+}) {
+  const { fetcher } = useFetcher();
+  const { data, error, isLoading } = useSWRWithDefaults<
+    string,
+    AuditLogsSetupResponse
+  >(`/api/w/${owner.sId}/audit-logs`, fetcher, { disabled });
+
+  return {
+    viewLogsLink: data?.viewLogsLink,
+    configureExportLink: data?.configureExportLink,
+    isLoading,
+    error,
   };
 }

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -273,7 +273,7 @@ export function useAuditLogsStatus({
   return {
     viewLogsLink: data?.viewLogsLink,
     configureExportLink: data?.configureExportLink,
-    isLoading,
+    isLoading: !disabled && isLoading,
     error,
   };
 }

--- a/front/lib/utils/request.ts
+++ b/front/lib/utils/request.ts
@@ -1,0 +1,17 @@
+/**
+ * Extracts the client IP from request headers.
+ * Checks x-forwarded-for (for proxied requests) then falls back to socket address.
+ */
+export function getClientIp(req?: {
+  headers: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+}): string {
+  if (!req) {
+    return "internal";
+  }
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    return forwarded.split(",")[0].trim();
+  }
+  return req.socket?.remoteAddress ?? "internal";
+}

--- a/front/lib/utils/request.ts
+++ b/front/lib/utils/request.ts
@@ -1,6 +1,7 @@
 /**
  * Extracts the client IP from request headers.
- * Checks x-forwarded-for (for proxied requests) then falls back to socket address.
+ * Uses Cloudflare IP where possible, falls back to x-forwarded-for where needed,
+ * then socket address.
  */
 export function getClientIp(req?: {
   headers: Record<string, string | string[] | undefined>;
@@ -9,9 +10,17 @@ export function getClientIp(req?: {
   if (!req) {
     return "internal";
   }
+
+  // Use Cloudflare IP where available, fall back to x-forwarded-for.
+  const cfIp = req.headers["cf-connecting-ip"];
+  if (typeof cfIp === "string") {
+    return cfIp.trim();
+  }
+
   const forwarded = req.headers["x-forwarded-for"];
   if (typeof forwarded === "string") {
     return forwarded.split(",")[0].trim();
   }
+
   return req.socket?.remoteAddress ?? "internal";
 }

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -6,6 +6,7 @@ import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import { getClientIp } from "@app/lib/utils/request";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import {
@@ -55,6 +56,10 @@ async function handler(
   session: SessionWithUser
 ): Promise<void> {
   let auth = await Authenticator.fromSuperUserSession(session, null);
+  const ip = getClientIp(req);
+  if (ip !== "internal") {
+    auth.setClientIp(ip);
+  }
   if (!auth.isDustSuperUser()) {
     return apiError(req, res, {
       status_code: 404,
@@ -94,6 +99,9 @@ async function handler(
       // If the run targets a specific workspace, use a workspace-scoped authenticator.
       if (workspaceId) {
         auth = await Authenticator.fromSuperUserSession(session, workspaceId);
+        if (ip !== "internal") {
+          auth.setClientIp(ip);
+        }
       }
 
       const plugin = pluginManager.getPluginById(pluginId);

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -44,7 +44,7 @@ async function handler(
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "workspace_not_found",
+        type: "workos_organization_not_found",
         message: "WorkOS organization not found for this workspace.",
       },
     });

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -1,0 +1,87 @@
+/** @ignoreswagger */
+import { isAuditLogsEnabled } from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { generateWorkOSAdminPortalUrl } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import { WorkOSPortalIntent } from "@app/lib/types/workos";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type AuditLogsSetupResponse = {
+  viewLogsLink: string;
+  configureExportLink: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<AuditLogsSetupResponse>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You are not authorized to perform this action.",
+      },
+    });
+  }
+
+  if (!(await isAuditLogsEnabled(auth))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Audit logs are not enabled for this workspace.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  if (!owner.workOSOrganizationId) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "WorkOS organization not found for this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const returnUrl = `${config.getAppUrl()}/w/${owner.sId}/members`;
+
+      const [viewLogsResult, configureExportResult] = await Promise.all([
+        generateWorkOSAdminPortalUrl({
+          organization: owner.workOSOrganizationId,
+          workOSIntent: WorkOSPortalIntent.AuditLogs,
+          returnUrl,
+        }),
+        generateWorkOSAdminPortalUrl({
+          organization: owner.workOSOrganizationId,
+          workOSIntent: WorkOSPortalIntent.LogStreams,
+          returnUrl,
+        }),
+      ]);
+
+      return res.status(200).json({
+        viewLogsLink: viewLogsResult.link,
+        configureExportLink: configureExportResult.link,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/7214 and https://github.com/dust-tt/tasks/issues/7215

## Description
Adds the foundational infrastructure for enterprise audit logging via WorkOS, gated behind the `audit_logs` feature flag and the `isAuditLogsAllowed` plan limit.

**Wrapper & types** (`front/lib/api/audit/workos_audit.ts`, `front/lib/api/workos/organization.ts`):
- `createAuditLogEvent`: typed wrapper around the WorkOS SDK `auditLogs.createEvent` call
- `emitAuditLogEvent(auth, event)`: fire-and-forget emitter that checks FF/plan gating, builds the actor from the `Authenticator`, attaches client IP from `auth.clientIp()`, and swallows errors (audit failures never break the main operation)
- `buildAuditActor(auth)` and `isAuditLogsEnabled(auth)` helpers

**Client IP tracking** (`front/lib/auth.ts`, `front/lib/api/auth_wrappers.ts`):
- Adds `_clientIp` field to `Authenticator`, propagated through `exchangeKey()`, `copyAsUser()`, and `copyAsNewUser()`
- `setClientIpOnAuth(auth, req)` wired into all auth entry points (`withSessionAuthenticationForWorkspace`, `withPublicAPIAuthentication`, `getAuthForSharedEndpointWorkspaceMembersOnly`, Poke plugin runner)

**API endpoint** (`front/pages/api/w/[wId]/audit-logs.ts`):
- Admin-only, plan/FF-gated
- Returns WorkOS portal URLs for "View Logs" and "Configure Export" in parallel

**UI** (`front/components/workspace/AuditLogsSection.tsx`, `front/components/workspace/WorkspaceAccessPanel.tsx`):
- "Audit Logs" section in the workspace admin panel with "View Logs" and "Configure Export" buttons
- SWR hook (`useAuditLogsStatus`) with loading and error states

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
With audit_log FF enabled, see that you have an audit log section in the admin panel
<img width="1139" height="153" alt="Screenshot 2026-03-20 at 12 33 21 PM" src="https://github.com/user-attachments/assets/95cd4df5-d152-4c2d-8354-3eff488b9c6c" />

Clicking directs to:
<img width="1108" height="805" alt="Screenshot 2026-03-20 at 12 33 46 PM" src="https://github.com/user-attachments/assets/2ec3e720-94a3-447d-8573-8b2a1edf43ab" />
<img width="1325" height="822" alt="Screenshot 2026-03-20 at 12 33 34 PM" src="https://github.com/user-attachments/assets/f2a0d0d6-6d34-43d5-a187-eae357fdd21e" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, behind FF and no events being emitted
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
