### PR TITLE
[front] enh: add offer custom fields in Ashby `get_hire_data` tool

### DIFF
--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -15,6 +15,7 @@ import type {
   AshbyJobPostingListRequest,
   AshbyJobPostingUpdateRequest,
   AshbyOffer,
+  AshbyOfferInfoRequest,
   AshbyOfferListRequest,
   AshbyReferralCreateRequest,
   AshbyReportSynchronousRequest,
@@ -32,6 +33,7 @@ import {
   AshbyJobPostingInfoResponseSchema,
   AshbyJobPostingListResponseSchema,
   AshbyJobPostingUpdateResponseSchema,
+  AshbyOfferInfoResponseSchema,
   AshbyOfferListResponseSchema,
   AshbyReferralCreateResponseSchema,
   AshbyReferralFormInfoResponseSchema,
@@ -235,6 +237,14 @@ export class AshbyClient {
       "candidate.info",
       request,
       AshbyCandidateInfoResponseSchema
+    );
+  }
+
+  async getOfferInfo(request: AshbyOfferInfoRequest) {
+    return this.postRequest(
+      "offer.info",
+      request,
+      AshbyOfferInfoResponseSchema
     );
   }
 

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -428,7 +428,9 @@ export function renderHireData({
         lines.push("");
         for (const field of version.customFields) {
           const title = field.title ?? field.id ?? "Unknown Field";
-          const displayValue = field.valueLabel ?? field.value;
+          const displayValue = Array.isArray(field.valueLabel)
+            ? field.valueLabel.join(", ")
+            : (field.valueLabel ?? field.value);
           lines.push(`**${title}:** ${formatFieldValue(displayValue)}`);
         }
       }

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -6,7 +6,7 @@ import type {
   AshbyJob,
   AshbyJobInfo,
   AshbyJobPosting,
-  AshbyOffer,
+  AshbyOfferInfo,
   AshbyReferralFormInfo,
   AshbyReportSynchronousResponse,
 } from "@app/lib/api/actions/servers/ashby/types";
@@ -304,12 +304,12 @@ function formatFieldValue(value: unknown): string {
 
 export function renderHireData({
   candidateInfo,
-  offers,
+  offerInfo,
   jobInfo,
   applicationId,
 }: {
   candidateInfo: AshbyCandidateInfo;
-  offers: AshbyOffer[];
+  offerInfo: AshbyOfferInfo | null;
   jobInfo: AshbyJobInfo | null;
   applicationId: string;
 }): string {
@@ -397,39 +397,41 @@ export function renderHireData({
   lines.push("## Offer Details");
   lines.push("");
 
-  if (offers.length === 0) {
+  if (!offerInfo) {
     lines.push("*No offers found for this application.*");
   } else {
-    for (const offer of offers) {
-      lines.push(`**Offer ID:** ${offer.id}`);
-      if (offer.status) {
-        lines.push(`**Offer Status:** ${offer.status}`);
+    lines.push(`**Offer ID:** ${offerInfo.id}`);
+    if (offerInfo.offerStatus) {
+      lines.push(`**Offer Status:** ${offerInfo.offerStatus}`);
+    }
+    if (offerInfo.acceptanceStatus) {
+      lines.push(`**Acceptance Status:** ${offerInfo.acceptanceStatus}`);
+    }
+    if (offerInfo.decidedAt) {
+      lines.push(`**Decided At:** ${offerInfo.decidedAt}`);
+    }
+
+    const version = offerInfo.latestVersion;
+    if (version) {
+      if (version.startDate) {
+        lines.push(`**Start Date:** ${version.startDate}`);
       }
-      if (offer.decidedAt) {
-        lines.push(`**Decided At:** ${offer.decidedAt}`);
+      if (version.salary) {
+        lines.push(
+          `**Salary:** ${version.salary.value} ${version.salary.currencyCode}`
+        );
       }
 
-      const version = offer.latestVersion;
-      if (version) {
-        if (version.startDate) {
-          lines.push(`**Start Date:** ${version.startDate}`);
+      if (version.customFields && version.customFields.length > 0) {
+        lines.push("");
+        lines.push("### Offer Custom Fields");
+        lines.push("");
+        for (const field of version.customFields) {
+          const title = field.title ?? field.id ?? "Unknown Field";
+          const displayValue = field.valueLabel ?? field.value;
+          lines.push(`**${title}:** ${formatFieldValue(displayValue)}`);
         }
-
-        if (version.formFieldValues && version.formFieldValues.length > 0) {
-          lines.push("");
-          lines.push("### Offer Form Fields");
-          lines.push(
-            "*Includes both standard and custom fields from the offer form.*"
-          );
-          lines.push("");
-          for (const field of version.formFieldValues) {
-            const title = field.title ?? "Unknown Field";
-            lines.push(`**${title}:** ${formatFieldValue(field.value)}`);
-          }
-        }
       }
-
-      lines.push("");
     }
   }
 

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -455,14 +455,11 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     }
 
     // Pick the latest offer by latestVersion.createdAt.
-    const latestOffer = offersResult.value.reduce(
-      (latest, offer) => {
-        const latestCreatedAt = latest?.latestVersion?.createdAt ?? "";
-        const offerCreatedAt = offer.latestVersion?.createdAt ?? "";
-        return offerCreatedAt > latestCreatedAt ? offer : latest;
-      },
-      offersResult.value[0] ?? null
-    );
+    const latestOffer = offersResult.value.reduce((latest, offer) => {
+      const latestCreatedAt = latest?.latestVersion?.createdAt ?? "";
+      const offerCreatedAt = offer.latestVersion?.createdAt ?? "";
+      return offerCreatedAt > latestCreatedAt ? offer : latest;
+    }, offersResult.value[0] ?? null);
 
     // Fetch detailed offer info for the latest offer.
     let offerInfo = null;

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -453,7 +453,33 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
         })
       );
     }
-    const offers = offersResult.value;
+
+    // Pick the latest offer by latestVersion.createdAt.
+    const latestOffer = offersResult.value.reduce(
+      (latest, offer) => {
+        const latestCreatedAt = latest?.latestVersion?.createdAt ?? "";
+        const offerCreatedAt = offer.latestVersion?.createdAt ?? "";
+        return offerCreatedAt > latestCreatedAt ? offer : latest;
+      },
+      offersResult.value[0] ?? null
+    );
+
+    // Fetch detailed offer info for the latest offer.
+    let offerInfo = null;
+    if (latestOffer) {
+      const offerInfoResult = await client.getOfferInfo({
+        offerId: latestOffer.id,
+      });
+      if (offerInfoResult.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to get offer info for offer ${latestOffer.id}: ${offerInfoResult.error.message}`,
+            { cause: offerInfoResult.error }
+          )
+        );
+      }
+      offerInfo = offerInfoResult.value.results ?? null;
+    }
 
     // Fetch job info if we have a jobId.
     let jobInfo = null;
@@ -474,7 +500,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     const text = renderHireData({
       candidateInfo,
-      offers,
+      offerInfo,
       jobInfo,
       applicationId,
     });

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -731,11 +731,31 @@ export type AshbyOfferFormFieldValue = z.infer<
   typeof AshbyOfferFormFieldValueSchema
 >;
 
+export const AshbyOfferCustomFieldSchema = z
+  .object({
+    id: z.string().optional(),
+    isPrivate: z.boolean().optional(),
+    title: z.string().optional(),
+    value: z.unknown().optional(),
+    valueLabel: z.string().optional(),
+  })
+  .passthrough();
+
+export type AshbyOfferCustomField = z.infer<typeof AshbyOfferCustomFieldSchema>;
+
 export const AshbyOfferVersionSchema = z
   .object({
     id: z.string().optional(),
+    createdAt: z.string().nullish(),
     startDate: z.string().nullish(),
+    salary: z
+      .object({
+        value: z.number(),
+        currencyCode: z.string(),
+      })
+      .optional(),
     formFieldValues: z.array(AshbyOfferFormFieldValueSchema).optional(),
+    customFields: z.array(AshbyOfferCustomFieldSchema).optional(),
   })
   .passthrough();
 
@@ -768,6 +788,36 @@ export const AshbyOfferListResponseSchema = z.object({
 
 export type AshbyOfferListResponse = z.infer<
   typeof AshbyOfferListResponseSchema
+>;
+
+// Offer info
+
+export const AshbyOfferInfoRequestSchema = z.object({
+  offerId: z.string(),
+});
+
+export type AshbyOfferInfoRequest = z.infer<typeof AshbyOfferInfoRequestSchema>;
+
+export const AshbyOfferInfoSchema = z
+  .object({
+    id: z.string(),
+    decidedAt: z.string().nullish(),
+    applicationId: z.string().optional(),
+    acceptanceStatus: z.string().optional(),
+    offerStatus: z.string().optional(),
+    latestVersion: AshbyOfferVersionSchema.nullish(),
+  })
+  .passthrough();
+
+export type AshbyOfferInfo = z.infer<typeof AshbyOfferInfoSchema>;
+
+export const AshbyOfferInfoResponseSchema = z.object({
+  success: z.boolean(),
+  results: AshbyOfferInfoSchema.optional(),
+});
+
+export type AshbyOfferInfoResponse = z.infer<
+  typeof AshbyOfferInfoResponseSchema
 >;
 
 // Job info (detailed)

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -737,7 +737,7 @@ export const AshbyOfferCustomFieldSchema = z
     isPrivate: z.boolean().optional(),
     title: z.string().optional(),
     value: z.unknown().optional(),
-    valueLabel: z.string().optional(),
+    valueLabel: z.union([z.string(), z.array(z.string())]).optional(),
   })
   .passthrough();
 

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -765,7 +765,8 @@ export const AshbyOfferSchema = z
   .object({
     id: z.string(),
     applicationId: z.string().optional(),
-    status: z.string().optional(),
+    acceptanceStatus: z.string().optional(),
+    offerStatus: z.string().optional(),
     decidedAt: z.string().nullish(),
     latestVersion: AshbyOfferVersionSchema.nullish(),
   })


### PR DESCRIPTION
## Description

- This PR improves the output of the `get_hire_data` tool on the Ashby MCP server to add the custom fields of the offer form.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
