### PR TITLE
[cli] feat: add `--with-tools` flag for file system tools in non-interactive mode

### DIFF
--- a/cli/dust-cli/package.json
+++ b/cli/dust-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "engines": {
     "node": ">=22.22.0"
   },

--- a/cli/dust-cli/src/index.tsx
+++ b/cli/dust-cli/src/index.tsx
@@ -97,6 +97,12 @@ const cli = meow({
       type: "string",
       description: "Create conversation in a project by space ID",
     },
+    withTools: {
+      type: "boolean",
+      shortFlag: "t",
+      description:
+        "Enable file system tools in non-interactive mode (requires OAuth). WARNING: automatically approves ALL tool executions without prompting.",
+    },
   },
 });
 

--- a/cli/dust-cli/src/ui/App.tsx
+++ b/cli/dust-cli/src/ui/App.tsx
@@ -79,6 +79,9 @@ interface AppProps {
     projectId: {
       type: "string";
     };
+    withTools: {
+      type: "boolean";
+    };
   }>;
 }
 
@@ -133,6 +136,7 @@ const App: FC<AppProps> = ({ cli }) => {
             details={flags.details}
             projectName={flags.projectName}
             projectId={flags.projectId}
+            withTools={flags.withTools}
           />
         );
       }

--- a/cli/dust-cli/src/ui/Help.tsx
+++ b/cli/dust-cli/src/ui/Help.tsx
@@ -84,6 +84,16 @@ const Help: FC = () => {
       </Box>
       <Box marginLeft={2}>
         <Text>
+          <Text bold>-t, --with-tools</Text> Enable file system tools in
+          non-interactive mode (requires OAuth, use with -m).{" "}
+          <Text bold color="yellow">
+            WARNING: automatically approves ALL tool executions without
+            prompting, including file edits and shell commands.
+          </Text>
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
           <Text bold>-c, --conversationId</Text> Conversation ID (use with
           --agent and --message, or with --messageId)
         </Text>

--- a/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 
 import { getDustClient } from "../../utils/dustClient.js";
 import { normalizeError } from "../../utils/errors.js";
+import { useFileSystemServer } from "../../mcp/servers/fsServer.js";
 import {
   fetchAgentMessageFromConversation,
   sendNonInteractiveMessage,
@@ -18,6 +19,7 @@ interface NonInteractiveChatProps {
   details?: boolean;
   projectName?: string;
   projectId?: string;
+  withTools?: boolean;
 }
 
 const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
@@ -28,6 +30,7 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
   details,
   projectName,
   projectId,
+  withTools,
 }) => {
   const [error, setError] = useState<string | null>(null);
 
@@ -135,6 +138,23 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
           }
         }
 
+        // Initialize file system MCP server if requested
+        let fileSystemServerId: string | undefined;
+        if (withTools) {
+          const fsResult = await useFileSystemServer(
+            dustClient,
+            (serverId) => {
+              fileSystemServerId = serverId;
+            }
+          );
+          if (fsResult.isErr()) {
+            setError(
+              `Failed to initialize file system tools: ${fsResult.error.message}`
+            );
+            return;
+          }
+        }
+
         // Call the standalone function
         await sendNonInteractiveMessage(
           message,
@@ -144,7 +164,8 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
           details,
           projectName,
           projectId,
-          setError
+          setError,
+          fileSystemServerId
         );
       } catch (error) {
         setError(`Unexpected error: ${normalizeError(error).message}`);
@@ -160,6 +181,7 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
     details,
     projectName,
     projectId,
+    withTools,
   ]);
 
   if (error) {

--- a/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
@@ -141,12 +141,9 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
         // Initialize file system MCP server if requested
         let fileSystemServerId: string | undefined;
         if (withTools) {
-          const fsResult = await useFileSystemServer(
-            dustClient,
-            (serverId) => {
-              fileSystemServerId = serverId;
-            }
-          );
+          const fsResult = await useFileSystemServer(dustClient, (serverId) => {
+            fileSystemServerId = serverId;
+          });
           if (fsResult.isErr()) {
             setError(
               `Failed to initialize file system tools: ${fsResult.error.message}`

--- a/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/dust-cli/src/ui/commands/NonInteractiveChat.tsx
@@ -2,9 +2,9 @@ import { Box, Text } from "ink";
 import type { FC } from "react";
 import React, { useEffect, useState } from "react";
 
+import { useFileSystemServer } from "../../mcp/servers/fsServer.js";
 import { getDustClient } from "../../utils/dustClient.js";
 import { normalizeError } from "../../utils/errors.js";
-import { useFileSystemServer } from "../../mcp/servers/fsServer.js";
 import {
   fetchAgentMessageFromConversation,
   sendNonInteractiveMessage,

--- a/cli/dust-cli/src/ui/commands/chat/nonInteractive.ts
+++ b/cli/dust-cli/src/ui/commands/chat/nonInteractive.ts
@@ -113,7 +113,8 @@ export async function sendNonInteractiveMessage(
   showDetails?: boolean,
   projectName?: string,
   projectId?: string,
-  setError?: (error: string) => void
+  setError?: (error: string) => void,
+  fileSystemServerId?: string
 ): Promise<void> {
   const dustClientRes = await getDustClient();
   if (dustClientRes.isErr()) {
@@ -165,6 +166,9 @@ export async function sendNonInteractiveMessage(
             fullName: me.fullName,
             email: me.email,
             origin: "cli_programmatic",
+            clientSideMCPServerIds: fileSystemServerId
+              ? [fileSystemServerId]
+              : null,
           },
         },
       });
@@ -207,6 +211,9 @@ export async function sendNonInteractiveMessage(
             fullName: me.fullName,
             email: me.email,
             origin: "cli_programmatic",
+            clientSideMCPServerIds: fileSystemServerId
+              ? [fileSystemServerId]
+              : null,
           },
         },
         contentFragment: undefined,
@@ -282,6 +289,17 @@ export async function sendNonInteractiveMessage(
           return;
         }
         process.exit(1);
+      } else if (
+        event.type === "tool_approve_execution" &&
+        fileSystemServerId
+      ) {
+        // Auto-approve all tool executions: user explicitly opted in with --with-tools
+        await dustClient.validateAction({
+          conversationId: event.conversationId,
+          messageId: event.messageId,
+          actionId: event.actionId,
+          approved: "approved",
+        });
       } else if (event.type === "agent_generation_cancelled") {
         // Handle generation cancellation
         const output: NonInteractiveOutput = {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/23230
- Add -t, --with-tools flag to non-interactive mode (-m) that initializes the local MCP file system server and injects its ID into the message context
- Auto-approve all `tool_approve_execution` events in the event stream (user explicitly opts in by using the flag)
- No behavior change when the flag is not used
- Requires OAuth authentication (dust login), API keys are rejected with an explicit error message

## Tests

- Tested locally.

## Risk

- Low. Mostly additive.

## Deploy Plan

- Publish CLI.
