### PR TITLE
Rely on `path.posix.normalize` vs just presence of `..`

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download.test.ts
@@ -109,6 +109,23 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download
     expect(res._getJSONData().error.type).toBe("workspace_auth_error");
   });
 
+  it("should normalize triple slashes before GCS access", async () => {
+    const { req, res } = await setupTest();
+    // Triple slashes pass the old startsWith check and don't contain "..",
+    // but without normalization the raw path is sent to GCS as-is which could
+    // resolve to an unintended object.
+    req.body = {
+      filePath: `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files///report.pdf`,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetFileContentType).toHaveBeenCalledWith(
+      `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/report.pdf`
+    );
+  });
+
   it("should succeed for a valid file path", async () => {
     const { req, res } = await setupTest();
     req.body = {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download.ts
@@ -93,7 +93,10 @@ async function handler(
   const readStream = bucket.file(normalizedPath).createReadStream();
 
   readStream.on("error", (err) => {
-    logger.error({ err, filePath: normalizedPath }, "Error streaming sandbox file");
+    logger.error(
+      { err, filePath: normalizedPath },
+      "Error streaming sandbox file"
+    );
     readStream.destroy();
     res.end();
   });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download.ts
@@ -10,6 +10,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import path from "path";
 
 async function handler(
   req: NextApiRequest,
@@ -55,13 +56,14 @@ async function handler(
   }
 
   // Validate the requested path is within this conversation's files directory.
-  // Reject path traversal attempts (e.g. "../../other-convo/files/secret.txt").
+  // Normalize first to collapse any ".." or "." segments, then verify the prefix.
   const owner = auth.getNonNullableWorkspace();
   const expectedPrefix = getConversationFilesBasePath({
     workspaceId: owner.sId,
     conversationId: cId,
   });
-  if (filePath.includes("..") || !filePath.startsWith(expectedPrefix)) {
+  const normalizedPath = path.posix.normalize(filePath);
+  if (!normalizedPath.startsWith(expectedPrefix)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -74,7 +76,7 @@ async function handler(
   const bucket = getPrivateUploadBucket();
 
   try {
-    const contentType = await bucket.getFileContentType(filePath);
+    const contentType = await bucket.getFileContentType(normalizedPath);
     if (contentType) {
       res.setHeader("Content-Type", contentType);
     }
@@ -88,10 +90,10 @@ async function handler(
     });
   }
 
-  const readStream = bucket.file(filePath).createReadStream();
+  const readStream = bucket.file(normalizedPath).createReadStream();
 
   readStream.on("error", (err) => {
-    logger.error({ err, filePath }, "Error streaming sandbox file");
+    logger.error({ err, filePath: normalizedPath }, "Error streaming sandbox file");
     readStream.destroy();
     res.end();
   });


### PR DESCRIPTION
## Description

Same effect but also normalize the path which reduce risk of having a funky path that GCS may mis-interpret (like `//././test`)

## Tests

Covered by tests

## Risk

Low

## Deploy Plan

- deploy `front`