### PR TITLE
[front] misc fix for frame sharing UI 

### DIFF
--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -216,7 +216,7 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
             ) : (
               <div className="flex flex-col gap-6">
                 <fieldset className="flex flex-col gap-2 border-none p-0">
-                  <legend className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                  <legend className="text-sm font-semibold text-foreground dark:text-foreground-night mb-2">
                     Who has access
                   </legend>
                   <div className="flex flex-col gap-1">
@@ -227,10 +227,10 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                         <Label
                           key={option.value}
                           htmlFor={inputId}
-                          className={`flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 transition-colors ${
+                          className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors ${
                             isSelected
-                              ? "bg-muted-background dark:bg-muted-background-night"
-                              : "hover:bg-muted-background/50 dark:hover:bg-muted-background-night/50"
+                              ? "border-highlight-300 bg-muted-background dark:border-highlight-300-night dark:bg-muted-background-night"
+                              : "border-transparent hover:bg-muted-background/50 dark:hover:bg-muted-background-night/50"
                           }`}
                         >
                           <input
@@ -251,7 +251,7 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                             <span className="text-sm font-medium text-primary dark:text-primary-night">
                               {option.label}
                             </span>
-                            <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                            <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
                               {option.description}
                             </span>
                           </div>


### PR DESCRIPTION
## Description
Adjust the select size style, font weight and spacing 

light:
<img width="1140" height="914" alt="CleanShot 2026-03-20 at 18 09 14@2x" src="https://github.com/user-attachments/assets/7fdea752-546a-4986-9c47-8ec85c73b84c" />

dark:
<img width="1146" height="956" alt="CleanShot 2026-03-20 at 18 09 35@2x" src="https://github.com/user-attachments/assets/c650b2fa-4c9e-4416-ac53-1e105e367a07" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
