### PR TITLE
Introduce `GCSMountPoint` and `listGCSMountFiles`

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -14,7 +14,7 @@ import { useConversationSandboxStatus } from "@app/hooks/conversations/useConver
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { downloadSandboxFile } from "@app/lib/swr/files";
-import type { SandboxFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isInteractiveContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -88,7 +88,7 @@ export function ConversationFilesPanel({
   );
 
   const handleSandboxFileClick = useCallback(
-    async (entry: SandboxFileEntry) => {
+    async (entry: GCSMountFileEntry) => {
       if (entry.fileId) {
         openFile({
           fileId: entry.fileId,

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -8,7 +8,7 @@ import { useConversationSandboxFiles } from "@app/hooks/conversations/useConvers
 import { useDebounce } from "@app/hooks/useDebounce";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { downloadSandboxFile, getFileProcessedUrl } from "@app/lib/swr/files";
-import type { SandboxFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Card,
@@ -25,7 +25,7 @@ import { useEffect, useMemo, useState } from "react";
 interface SandboxImageCardProps {
   owner: LightWorkspaceType;
   conversationId: string;
-  entry: SandboxFileEntry;
+  entry: GCSMountFileEntry;
   onClick: () => void;
 }
 
@@ -116,7 +116,7 @@ interface SandboxTabProps {
   conversationId: string;
   disabled?: boolean;
   owner: LightWorkspaceType;
-  onFileClick: (entry: SandboxFileEntry) => void;
+  onFileClick: (entry: GCSMountFileEntry) => void;
 }
 
 export function SandboxTab({
@@ -155,7 +155,7 @@ export function SandboxTab({
   }, [files, debouncedSearch]);
 
   const groupedByCategory = useMemo(() => {
-    const groups = new Map<FilePanelCategory, SandboxFileEntry[]>();
+    const groups = new Map<FilePanelCategory, GCSMountFileEntry[]>();
     for (const file of filteredFiles) {
       const category = getCategoryFromContentType(file.contentType);
       const existing = groups.get(category);

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -6,7 +6,7 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
-import type { SandboxFileEntry } from "@app/lib/api/sandbox/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
 import {
   frameSlideshowContentType,
   isInteractiveContentType,
@@ -149,7 +149,7 @@ export function conversationAttachmentToRow(
  * tree paths start at the sandbox working directory root.
  */
 export function buildSandboxTree(
-  entries: SandboxFileEntry[]
+  entries: GCSMountFileEntry[]
 ): SandboxTreeNode[] {
   const root: SandboxTreeNode[] = [];
   const nodeMap = new Map<string, SandboxTreeNode>();

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -1,7 +1,7 @@
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
+  GCSMountFileEntry,
   GetConversationSandboxFilesResponseBody,
-  SandboxFileEntry,
 } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -30,7 +30,7 @@ export function useConversationSandboxFiles({
   const disabled = options?.disabled;
 
   return {
-    sandboxFiles: data?.files ?? emptyArray<SandboxFileEntry>(),
+    sandboxFiles: data?.files ?? emptyArray<GCSMountFileEntry>(),
     isSandboxFilesLoading: !disabled && !error && !data,
     isSandboxFilesError: error,
     mutateSandboxFiles: mutate,

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -2,9 +2,10 @@ import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 
-export type SandboxFileEntry = {
+export type GCSMountFileEntry = {
   fileName: string;
   path: string;
   sizeBytes: number;
@@ -13,18 +14,31 @@ export type SandboxFileEntry = {
   fileId: string | null;
 };
 
+type GCSMountPoint = {
+  useCase: "conversation";
+  conversationId: string;
+};
+
 /**
- * List sandbox files from GCS (mounted bucket as source of truth).
+ * List files from a GCS mount point (mounted bucket as source of truth).
  */
-export async function listSandboxFiles(
+export async function listGCSMountFiles(
   auth: Authenticator,
-  conversationId: string
-): Promise<SandboxFileEntry[]> {
+  scope: GCSMountPoint
+): Promise<GCSMountFileEntry[]> {
   const owner = auth.getNonNullableWorkspace();
-  const prefix = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId,
-  });
+
+  let prefix: string;
+  switch (scope.useCase) {
+    case "conversation":
+      prefix = getConversationFilesBasePath({
+        workspaceId: owner.sId,
+        conversationId: scope.conversationId,
+      });
+      break;
+    default:
+      assertNever(scope.useCase);
+  }
 
   const bucket = getPrivateUploadBucket();
   const gcsFiles = await bucket.getFiles({ prefix, maxResults: 200 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/index.ts
@@ -3,19 +3,19 @@ import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch"
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
-  listSandboxFiles,
-  type SandboxFileEntry,
-} from "@app/lib/api/sandbox/files";
+  type GCSMountFileEntry,
+  listGCSMountFiles,
+} from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type { SandboxFileEntry };
+export type { GCSMountFileEntry };
 
 export type GetConversationSandboxFilesResponseBody = {
-  files: SandboxFileEntry[];
+  files: GCSMountFileEntry[];
 };
 
 async function handler(
@@ -51,7 +51,10 @@ async function handler(
     return apiErrorForConversation(req, res, conversationRes.error);
   }
 
-  const files = await listSandboxFiles(auth, cId);
+  const files = await listGCSMountFiles(auth, {
+    useCase: "conversation",
+    conversationId: cId,
+  });
 
   return res.status(200).json({ files });
 }


### PR DESCRIPTION
## Description

Rename `listSandboxFile` to `listGCSMountFiles` for more general applicability. Endpoints untouched for now.

Replaces raw conversationId parameter with a typed { useCase, conversationId } union to support future mount point types (e.g. project context). Adds assertNever for exhaustiveness checking.

Next steps: rename endpoints to remove "sandbox" and untangle sandbox/files stuff in the UI a bit more so that the file component can be fully reused elsewhere including Projects

## Tests

Tested locally. No endpoint change.

cc @flvndvd @fontanierh @Fraggle (as related to our discussion)

## Risk

Low

## Deploy Plan

- deploy `front`