### PR TITLE
[front] enh: improve tag display in agent search dropdown

### DIFF
--- a/front/components/assistant/conversation/agent_browser/shared.tsx
+++ b/front/components/assistant/conversation/agent_browser/shared.tsx
@@ -221,12 +221,22 @@ export function SearchDropdownContent({
   }
   return (
     <>
-      {filteredTags.length > 0 && <DropdownMenuLabel label="Tags" />}
-      {filteredTags.map((tag) => (
-        <DropdownMenuItem key={tag.sId} onClick={() => onTagClick(tag.sId)}>
-          <Chip label={tag.name} color="golden" size="xs" />
-        </DropdownMenuItem>
-      ))}
+      {filteredTags.length > 0 && (
+        <>
+          <DropdownMenuLabel label="Tags" />
+          <div className="flex flex-wrap gap-1 px-2 py-1">
+            {filteredTags.map((tag) => (
+              <Chip
+                key={tag.sId}
+                label={tag.name}
+                color="golden"
+                size="xs"
+                onClick={() => onTagClick(tag.sId)}
+              />
+            ))}
+          </div>
+        </>
+      )}
       {filteredAgents.length > 0 && <DropdownMenuLabel label="Agents" />}
       {filteredAgents.map((agent) => (
         <DropdownMenuItem


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7208.
- This PR improves the UI for rendering tags in the agent search bar by stacking them on the same line instead of displaying one tag per line.

Before
<img width="1001" height="562" alt="Screenshot 2026-03-20 at 6 39 53 PM" src="https://github.com/user-attachments/assets/744ca2e8-ee83-4c44-b38f-6a3af6388a62" />

After
<img width="1001" height="562" alt="Screenshot 2026-03-20 at 6 41 23 PM" src="https://github.com/user-attachments/assets/88185789-0c70-4a34-aeba-1a0ee2692300" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
