### PR TITLE
[Email Agents] Use header From mailbox for inbound identity

### DIFF
--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -39,12 +39,15 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
       inReplyTo: context.threadingInReplyTo,
       references: context.threadingReferences,
     },
+    sender: {
+      email: context.fromEmail,
+      full: context.fromFull,
+    },
     envelope: {
       to: [],
       cc: [],
       bcc: [],
       from: context.fromEmail,
-      full: context.fromFull,
     },
     attachments: [],
   };

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -17,9 +17,12 @@ describe("buildSuccessReplyRecipients", () => {
         inReplyTo: null,
         references: null,
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`],
         cc: [],
         bcc: ["hidden@dust.tt"],
@@ -43,9 +46,12 @@ describe("buildSuccessReplyRecipients", () => {
         inReplyTo: null,
         references: null,
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "teammate@dust.tt"],
         cc: [`other-agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "observer@dust.tt"],
         bcc: ["hidden@dust.tt"],
@@ -69,9 +75,12 @@ describe("buildSuccessReplyRecipients", () => {
         inReplyTo: null,
         references: null,
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: ["Sender@dust.tt", "teammate@dust.tt", "teammate@dust.tt"],
         cc: ["teammate@dust.tt", "observer@dust.tt", "observer@dust.tt"],
         bcc: [],
@@ -128,9 +137,12 @@ describe("buildReplyThreadingHeaders", () => {
         inReplyTo: null,
         references: null,
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: [],
         cc: [],
         bcc: [],
@@ -154,9 +166,12 @@ describe("buildReplyThreadingHeaders", () => {
         inReplyTo: null,
         references: "<older-message-id@dust.tt>",
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: [],
         cc: [],
         bcc: [],
@@ -180,9 +195,12 @@ describe("buildReplyThreadingHeaders", () => {
         inReplyTo: null,
         references: "<older-message-id@dust.tt> <incoming-message-id@dust.tt>",
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: [],
         cc: [],
         bcc: [],

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -108,9 +108,12 @@ describe("buildSuccessReplyRecipients", () => {
         inReplyTo: null,
         references: null,
       },
-      envelope: {
-        from: "sender@dust.tt",
+      sender: {
+        email: "sender@dust.tt",
         full: "Sender <sender@dust.tt>",
+      },
+      envelope: {
+        from: "bounce@mailer.dust.tt",
         to: ["teammate@dust.tt"],
         cc: manyCC,
         bcc: [],

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -206,12 +206,17 @@ export type InboundEmail = {
   text: string;
   auth: { SPF: string; dkim: string };
   threadingHeaders: EmailThreadingHeaders;
+  // Human-visible RFC 5322 From header.
+  sender: {
+    email: string;
+    full: string;
+  };
+  // SMTP envelope sender (MAIL FROM / return-path).
   envelope: {
     to: string[];
     cc: string[];
     bcc: string[];
     from: string;
-    full: string;
   };
   attachments: EmailAttachment[];
 };
@@ -315,7 +320,7 @@ export function buildSuccessReplyRecipients(email: InboundEmail): {
   cc: string[];
 } {
   const to = deduplicateEmailAddresses(
-    [email.envelope.from, ...email.envelope.to].filter(
+    [email.sender.email, ...email.envelope.to].filter(
       (recipient) => !isAssistantRecipient(recipient)
     )
   );
@@ -759,8 +764,8 @@ export async function triggerFromEmail({
       await storeEmailReplyContext(agentMessage.sId, {
         subject: email.subject,
         originalText: email.text,
-        fromEmail: email.envelope.from,
-        fromFull: email.envelope.full,
+        fromEmail: email.sender.email,
+        fromFull: email.sender.full,
         replyTo: successReplyRecipients.to,
         replyCc: successReplyRecipients.cc,
         threadingMessageId: email.threadingHeaders.messageId,
@@ -879,7 +884,7 @@ export async function sendToolValidationEmail({
     "<div>\n" +
     htmlContent +
     `<br/><br/>` +
-    `On ${new Date().toUTCString()} ${sanitizeHtml(email.envelope.full, { allowedTags: [], allowedAttributes: {} })} wrote:<br/>\n` +
+    `On ${new Date().toUTCString()} ${sanitizeHtml(email.sender.full, { allowedTags: [], allowedAttributes: {} })} wrote:<br/>\n` +
     `<blockquote class="quote" style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">\n` +
     `${quote}` +
     `</blockquote>\n` +
@@ -899,7 +904,7 @@ export async function sendToolValidationEmail({
   };
 
   try {
-    await sendEmail(email.envelope.from, msg);
+    await sendEmail(email.sender.email, msg);
     localLogger.info(
       { actionsCount: blockedActions.length },
       "[email] Sent tool validation email."
@@ -951,7 +956,7 @@ export async function replyToEmail({
     "<div>\n" +
     htmlContent +
     `<br/><br/>` +
-    `On ${new Date().toUTCString()} ${sanitizeHtml(email.envelope.full, { allowedTags: [], allowedAttributes: {} })} wrote:<br/>\n` +
+    `On ${new Date().toUTCString()} ${sanitizeHtml(email.sender.full, { allowedTags: [], allowedAttributes: {} })} wrote:<br/>\n` +
     `<blockquote class="quote" style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">\n` +
     `${quote}` +
     `</blockquote>\n` +

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -335,7 +335,8 @@ export function buildSuccessReplyRecipients(email: InboundEmail): {
     })
   );
 
-  // Enforce recipient cap: sender (envelope.from) is always kept, extras are dropped from cc first.
+  // Enforce recipient cap: the authenticated sender is always kept, extras are dropped from cc
+  // first.
   const total = to.length + cc.length;
   if (total <= MAX_REPLY_RECIPIENTS) {
     return { to, cc };

--- a/front/lib/api/assistant/email/header_parsing.test.ts
+++ b/front/lib/api/assistant/email/header_parsing.test.ts
@@ -1,0 +1,51 @@
+import {
+  extractSingleEmailAddressFromHeader,
+  parseHeaderValue,
+} from "@app/lib/api/assistant/email/header_parsing";
+import { describe, expect, it } from "vitest";
+
+describe("extractSingleEmailAddressFromHeader", () => {
+  it("extracts the single mailbox from a From header", () => {
+    const result = extractSingleEmailAddressFromHeader(
+      "From",
+      "Sender Name <Sender@dust.tt>"
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toBe("sender@dust.tt");
+  });
+
+  it("rejects a From header with multiple mailboxes", () => {
+    const result = extractSingleEmailAddressFromHeader(
+      "From",
+      "Sender <sender@dust.tt>, Other <other@dust.tt>"
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected multiple From mailboxes to be rejected");
+    }
+
+    expect(result.error.message).toBe(
+      "Expected exactly one mailbox in From header"
+    );
+  });
+});
+
+describe("parseHeaderValue", () => {
+  it("unfolds folded header values", () => {
+    const rawHeaders = [
+      "From: Sender Name",
+      " <sender@dust.tt>",
+      "To: agent@dust.team",
+    ].join("\r\n");
+
+    expect(parseHeaderValue(rawHeaders, "From")).toBe(
+      "Sender Name <sender@dust.tt>"
+    );
+  });
+});

--- a/front/lib/api/assistant/email/header_parsing.ts
+++ b/front/lib/api/assistant/email/header_parsing.ts
@@ -18,15 +18,20 @@ export function extractEmailAddressesFromHeader(
     }
   };
 
+  // First pass: extract addresses inside angle brackets (e.g., "Name <email@domain.com>").
+  // This correctly handles display names with special characters (apostrophes, quotes, etc.)
+  // and ensures case-insensitive matching by lowercasing here.
   const anglePattern = /<([^>]+)>/g;
   let match;
   while ((match = anglePattern.exec(headerValue)) !== null) {
     const content = match[1].trim();
+    // Basic validation: must contain exactly one "@" and no spaces.
     if (content.includes("@") && !content.includes(" ")) {
       addEmail(content);
     }
   }
 
+  // Second pass: extract bare email addresses from parts without angle brackets.
   const remaining = headerValue.replace(/<[^>]*>/g, " ");
   const barePattern = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
   while ((match = barePattern.exec(remaining)) !== null) {
@@ -56,6 +61,8 @@ export function parseHeaderValue(
   headerName: string
 ): string | null {
   const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match the header name at line start, capture the first line value then any
+  // RFC 5322 folded continuation lines (lines starting with whitespace).
   const headerPattern = new RegExp(
     `^${escapedHeaderName}:\\s*((?:.*(?:\\r?\\n[ \\t]+.*)*))`,
     "im"
@@ -65,6 +72,7 @@ export function parseHeaderValue(
     return null;
   }
 
+  // Unfold RFC 5322 continuation lines (CRLF/LF followed by spaces/tabs).
   const unfoldedHeaderValue = match[1].replace(/\r?\n[ \t]+/g, " ").trim();
 
   return unfoldedHeaderValue.length > 0 ? unfoldedHeaderValue : null;

--- a/front/lib/api/assistant/email/header_parsing.ts
+++ b/front/lib/api/assistant/email/header_parsing.ts
@@ -1,0 +1,71 @@
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export function extractEmailAddressesFromHeader(
+  headerValue: string | null
+): string[] {
+  if (!headerValue) {
+    return [];
+  }
+  const addresses: string[] = [];
+  const seen = new Set<string>();
+
+  const addEmail = (raw: string) => {
+    const email = raw.trim().toLowerCase();
+    if (!seen.has(email)) {
+      seen.add(email);
+      addresses.push(email);
+    }
+  };
+
+  const anglePattern = /<([^>]+)>/g;
+  let match;
+  while ((match = anglePattern.exec(headerValue)) !== null) {
+    const content = match[1].trim();
+    if (content.includes("@") && !content.includes(" ")) {
+      addEmail(content);
+    }
+  }
+
+  const remaining = headerValue.replace(/<[^>]*>/g, " ");
+  const barePattern = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+  while ((match = barePattern.exec(remaining)) !== null) {
+    addEmail(match[0]);
+  }
+
+  return addresses;
+}
+
+export function extractSingleEmailAddressFromHeader(
+  headerName: string,
+  headerValue: string | null
+): Result<string, Error> {
+  const addresses = extractEmailAddressesFromHeader(headerValue);
+
+  if (addresses.length !== 1) {
+    return new Err(
+      new Error(`Expected exactly one mailbox in ${headerName} header`)
+    );
+  }
+
+  return new Ok(addresses[0]);
+}
+
+export function parseHeaderValue(
+  rawHeaders: string,
+  headerName: string
+): string | null {
+  const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const headerPattern = new RegExp(
+    `^${escapedHeaderName}:\\s*((?:.*(?:\\r?\\n[ \\t]+.*)*))`,
+    "im"
+  );
+  const match = rawHeaders.match(headerPattern);
+  if (!match) {
+    return null;
+  }
+
+  const unfoldedHeaderValue = match[1].replace(/\r?\n[ \t]+/g, " ").trim();
+
+  return unfoldedHeaderValue.length > 0 ? unfoldedHeaderValue : null;
+}

--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -1,0 +1,46 @@
+import { isAuthenticatedInboundSender } from "@app/lib/api/assistant/email/inbound_auth";
+import { describe, expect, it } from "vitest";
+
+describe("isAuthenticatedInboundSender", () => {
+  it("accepts aligned sender and envelope domains when SPF and DKIM pass", () => {
+    expect(
+      isAuthenticatedInboundSender({
+        auth: {
+          SPF: "pass",
+          dkim: "{@company.com : pass}",
+        },
+        sender: {
+          email: "alice@company.com",
+          full: "Alice <alice@company.com>",
+        },
+        envelope: {
+          from: "bounce@company.com",
+          to: [],
+          cc: [],
+          bcc: [],
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a sender whose domain does not align with the authenticated envelope", () => {
+    expect(
+      isAuthenticatedInboundSender({
+        auth: {
+          SPF: "pass",
+          dkim: "{@company.com : pass}",
+        },
+        sender: {
+          email: "alice@other-company.com",
+          full: "Alice <alice@other-company.com>",
+        },
+        envelope: {
+          from: "bounce@company.com",
+          to: [],
+          cc: [],
+          bcc: [],
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -1,0 +1,24 @@
+import type { InboundEmail } from "@app/lib/api/assistant/email/email_trigger";
+
+function getEmailDomain(email: string): string {
+  const [, domain] = email.split("@");
+
+  if (!domain) {
+    throw new Error(`Invalid email address: ${email}`);
+  }
+
+  return domain;
+}
+
+export function isAuthenticatedInboundSender(
+  email: Pick<InboundEmail, "auth" | "sender" | "envelope">
+): boolean {
+  const senderDomain = getEmailDomain(email.sender.email);
+  const envelopeDomain = getEmailDomain(email.envelope.from);
+
+  return (
+    email.auth.SPF === "pass" &&
+    senderDomain === envelopeDomain &&
+    email.auth.dkim === `{@${envelopeDomain} : pass}`
+  );
+}

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -16,6 +16,7 @@ import {
   extractSingleEmailAddressFromHeader,
   parseHeaderValue,
 } from "@app/lib/api/assistant/email/header_parsing";
+import { isAuthenticatedInboundSender } from "@app/lib/api/assistant/email/inbound_auth";
 import apiConfig from "@app/lib/api/config";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -232,11 +233,7 @@ async function handler(
       // possible below this point, errors should be reported to the sender.
       res.status(200).json({ success: true });
 
-      // Check SPF is pass.
-      if (
-        email.auth.SPF !== "pass" ||
-        email.auth.dkim !== `{@${email.envelope.from.split("@")[1]} : pass}`
-      ) {
+      if (!isAuthenticatedInboundSender(email)) {
         await replyToError(email, {
           type: "unauthenticated_error",
           message:

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -11,6 +11,11 @@ import {
   triggerFromEmail,
   userAndWorkspaceFromEmail,
 } from "@app/lib/api/assistant/email/email_trigger";
+import {
+  extractEmailAddressesFromHeader,
+  extractSingleEmailAddressFromHeader,
+  parseHeaderValue,
+} from "@app/lib/api/assistant/email/header_parsing";
 import apiConfig from "@app/lib/api/config";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -29,66 +34,6 @@ export const config = {
     bodyParser: false,
   },
 };
-
-function extractEmailAddressesFromHeader(headerValue: string | null): string[] {
-  if (!headerValue) {
-    return [];
-  }
-  const addresses: string[] = [];
-  const seen = new Set<string>();
-
-  const addEmail = (raw: string) => {
-    const email = raw.trim().toLowerCase();
-    if (!seen.has(email)) {
-      seen.add(email);
-      addresses.push(email);
-    }
-  };
-
-  // First pass: extract addresses inside angle brackets (e.g., "Name <email@domain.com>").
-  // This correctly handles display names with special characters (apostrophes, quotes, etc.)
-  // and ensures case-insensitive matching by lowercasing here.
-  const anglePattern = /<([^>]+)>/g;
-  let match;
-  while ((match = anglePattern.exec(headerValue)) !== null) {
-    const content = match[1].trim();
-    // Basic validation: must contain exactly one "@" and no spaces.
-    if (content.includes("@") && !content.includes(" ")) {
-      addEmail(content);
-    }
-  }
-
-  // Second pass: extract bare email addresses from parts without angle brackets.
-  const remaining = headerValue.replace(/<[^>]*>/g, " ");
-  const barePattern = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
-  while ((match = barePattern.exec(remaining)) !== null) {
-    addEmail(match[0]);
-  }
-
-  return addresses;
-}
-
-function parseHeaderValue(
-  rawHeaders: string,
-  headerName: string
-): string | null {
-  const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Match the header name at line start, capture the first line value then any
-  // RFC 5322 folded continuation lines (lines starting with whitespace).
-  const headerPattern = new RegExp(
-    `^${escapedHeaderName}:\\s*((?:.*(?:\\r?\\n[ \\t]+.*)*))`,
-    "im"
-  );
-  const match = rawHeaders.match(headerPattern);
-  if (!match) {
-    return null;
-  }
-
-  // Unfold RFC 5322 continuation lines (CRLF/LF followed by spaces/tabs).
-  const unfoldedHeaderValue = match[1].replace(/\r?\n[ \t]+/g, " ").trim();
-
-  return unfoldedHeaderValue.length > 0 ? unfoldedHeaderValue : null;
-}
 
 function parseThreadingHeaders(rawHeaders: string | null) {
   if (!rawHeaders) {
@@ -116,7 +61,7 @@ const parseSendgridWebhookContent = async (
   try {
     const subject = fields["subject"] ? fields["subject"][0] : null;
     const text = fields["text"] ? fields["text"][0] : null;
-    const full = fields["from"] ? fields["from"][0] : null;
+    const senderFull = fields["from"] ? fields["from"][0] : null;
     const SPF = fields["SPF"] ? fields["SPF"][0] : null;
     const dkim = fields["dkim"] ? fields["dkim"][0] : null;
     const rawHeaders = fields["headers"] ? fields["headers"][0] : null;
@@ -133,8 +78,19 @@ const parseSendgridWebhookContent = async (
     if (!from || typeof from !== "string") {
       return new Err(new Error("Failed to parse envelope.from"));
     }
-    if (!full || typeof full !== "string") {
+    if (!senderFull || typeof senderFull !== "string") {
       return new Err(new Error("Failed to parse from"));
+    }
+
+    const senderHeaderValue =
+      (isString(rawHeaders) ? parseHeaderValue(rawHeaders, "From") : null) ??
+      senderFull;
+    const senderRes = extractSingleEmailAddressFromHeader(
+      "From",
+      senderHeaderValue
+    );
+    if (senderRes.isErr()) {
+      return senderRes;
     }
 
     // Extract attachments from files, filtering to supported content types.
@@ -165,6 +121,10 @@ const parseSendgridWebhookContent = async (
       threadingHeaders: parseThreadingHeaders(
         isString(rawHeaders) ? rawHeaders : null
       ),
+      sender: {
+        email: senderRes.value,
+        full: senderHeaderValue,
+      },
       envelope: {
         // Use raw headers to get all To/Cc recipients: Sendgrid's envelope.to only
         // contains addresses matching the inbound-parse domain, omitting human recipients.
@@ -183,7 +143,6 @@ const parseSendgridWebhookContent = async (
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         bcc: envelope.bcc || [],
         from,
-        full,
       },
       attachments,
     });
@@ -209,7 +168,7 @@ const replyToError = async (
     email,
     htmlContent,
     recipients: {
-      to: [email.envelope.from],
+      to: [email.sender.email],
       cc: [],
     },
   });
@@ -287,7 +246,7 @@ async function handler(
       }
 
       const userRes = await userAndWorkspaceFromEmail({
-        email: email.envelope.from,
+        email: email.sender.email,
       });
       if (userRes.isErr()) {
         await replyToError(email, userRes.error);


### PR DESCRIPTION
## Description
- Parse the inbound header `From:` into exactly one mailbox and keep it separate from the SMTP envelope sender.
- Use that parsed mailbox as the Dust user identity, reply target, and quoted sender.
- Require the `From:` domain to align with the currently authenticated envelope domain before trusting that sender, and preserve the existing reply-recipient cap while doing so.

Various other fixes will follow: https://github.com/dust-tt/tasks/issues/7232 https://github.com/dust-tt/tasks/issues/7233 https://github.com/dust-tt/tasks/issues/7230 https://github.com/dust-tt/tasks/issues/7231

## Risks
Blast radius: inbound email agent sender resolution and outbound replies from email-triggered conversations.
Risk: low right now (gated); standard moving on; ccing @zmarouf FYI

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/api/assistant/email/inbound_auth.test.ts lib/api/assistant/email/header_parsing.test.ts lib/api/assistant/email/email_trigger.test.ts`