### PR TITLE
[Email Agents] Switch inbound sender auth to DMARC-style alignment

### DIFF
--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -1,8 +1,37 @@
+import type { InboundEmail } from "@app/lib/api/assistant/email/email_trigger";
 import {
-  isAuthenticatedInboundSender,
+  domainsAlign,
+  evaluateInboundAuth,
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
 import { describe, expect, it } from "vitest";
+
+function makeEmail(
+  overrides: Partial<{
+    senderEmail: string;
+    envelopeFrom: string;
+    SPF: string;
+    dkim: { domain: string; result: string }[];
+  }> = {}
+): Pick<InboundEmail, "auth" | "sender" | "envelope"> {
+  return {
+    auth: {
+      SPF: overrides.SPF ?? "pass",
+      dkim: overrides.dkim ?? [{ domain: "company.com", result: "pass" }],
+      dkimRaw: "",
+    },
+    sender: {
+      email: overrides.senderEmail ?? "alice@company.com",
+      full: `Alice <${overrides.senderEmail ?? "alice@company.com"}>`,
+    },
+    envelope: {
+      from: overrides.envelopeFrom ?? "bounce@company.com",
+      to: [],
+      cc: [],
+      bcc: [],
+    },
+  };
+}
 
 describe("parseSendgridDkimResults", () => {
   it("parses a single passing signature", () => {
@@ -44,75 +73,161 @@ describe("parseSendgridDkimResults", () => {
   });
 });
 
-describe("isAuthenticatedInboundSender", () => {
-  it("accepts aligned sender and envelope domains when SPF and DKIM pass", () => {
-    expect(
-      isAuthenticatedInboundSender({
-        auth: {
-          SPF: "pass",
-          dkim: [{ domain: "company.com", result: "pass" }],
-          dkimRaw: "{@company.com : pass}",
-        },
-        sender: {
-          email: "alice@company.com",
-          full: "Alice <alice@company.com>",
-        },
-        envelope: {
-          from: "bounce@company.com",
-          to: [],
-          cc: [],
-          bcc: [],
-        },
-      })
-    ).toBe(true);
+describe("domainsAlign", () => {
+  it("returns true for identical domains", () => {
+    expect(domainsAlign("company.com", "company.com")).toBe(true);
   });
 
-  it("rejects a sender whose domain does not align with the authenticated envelope", () => {
-    expect(
-      isAuthenticatedInboundSender({
-        auth: {
-          SPF: "pass",
-          dkim: [{ domain: "company.com", result: "pass" }],
-          dkimRaw: "{@company.com : pass}",
-        },
-        sender: {
-          email: "alice@other-company.com",
-          full: "Alice <alice@other-company.com>",
-        },
-        envelope: {
-          from: "bounce@company.com",
-          to: [],
-          cc: [],
-          bcc: [],
-        },
+  it("returns true when one is a subdomain of the other", () => {
+    expect(domainsAlign("mail.company.com", "company.com")).toBe(true);
+    expect(domainsAlign("company.com", "mail.company.com")).toBe(true);
+  });
+
+  it("returns false for unrelated domains", () => {
+    expect(domainsAlign("company.com", "other.com")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(domainsAlign("Company.COM", "company.com")).toBe(true);
+  });
+
+  it("does not align on partial suffix matches", () => {
+    // "evilcompany.com" should not align with "company.com".
+    expect(domainsAlign("evilcompany.com", "company.com")).toBe(false);
+  });
+});
+
+describe("evaluateInboundAuth", () => {
+  it("accepts when aligned DKIM passes, even if SPF fails", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        dkim: [{ domain: "company.com", result: "pass" }],
+        SPF: "fail",
       })
-    ).toBe(false);
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_dkim");
+  });
+
+  it("accepts when SPF passes with aligned envelope domain and no passing DKIM", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "bounce@company.com",
+        SPF: "pass",
+        dkim: [{ domain: "company.com", result: "fail" }],
+      })
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_spf");
+  });
+
+  it("rejects when DKIM passes for a non-aligned domain", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        dkim: [{ domain: "other.com", result: "pass" }],
+        SPF: "fail",
+        envelopeFrom: "bounce@other.com",
+      })
+    );
+
+    expect(decision.authenticated).toBe(false);
+    expect(decision.reason).toBeUndefined();
+  });
+
+  it("rejects when SPF passes for a non-aligned envelope domain", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "bounce@other.com",
+        SPF: "pass",
+        dkim: [],
+      })
+    );
+
+    expect(decision.authenticated).toBe(false);
+  });
+
+  it("accepts forwarded mail where SPF fails but aligned DKIM survives", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "forwarder@relay.net",
+        SPF: "fail",
+        dkim: [
+          { domain: "relay.net", result: "pass" },
+          { domain: "company.com", result: "pass" },
+        ],
+      })
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_dkim");
+  });
+
+  it("accepts when DKIM passes on a subdomain of the From: domain (relaxed alignment)", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        dkim: [{ domain: "mail.company.com", result: "pass" }],
+        SPF: "fail",
+      })
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_dkim");
+  });
+
+  it("accepts when envelope-from is a subdomain of the From: domain (relaxed SPF alignment)", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "bounce@mail.company.com",
+        SPF: "pass",
+        dkim: [],
+      })
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_spf");
   });
 
   it("accepts an aligned passing DKIM signature when other signatures fail", () => {
-    expect(
-      isAuthenticatedInboundSender({
-        auth: {
-          SPF: "pass",
-          dkim: [
-            { domain: "sendgrid.com", result: "pass" },
-            { domain: "company.com", result: "fail" },
-            { domain: "company.com", result: "pass" },
-          ],
-          dkimRaw:
-            "{@sendgrid.com : pass, @company.com : fail, @company.com : pass}",
-        },
-        sender: {
-          email: "alice@company.com",
-          full: "Alice <alice@company.com>",
-        },
-        envelope: {
-          from: "bounce@company.com",
-          to: [],
-          cc: [],
-          bcc: [],
-        },
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "bounce@company.com",
+        SPF: "pass",
+        dkim: [
+          { domain: "sendgrid.com", result: "pass" },
+          { domain: "company.com", result: "fail" },
+          { domain: "company.com", result: "pass" },
+        ],
       })
-    ).toBe(true);
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_dkim");
+  });
+
+  it("populates the decision with raw signals for debugging", () => {
+    const dkim = [{ domain: "company.com", result: "pass" }];
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "bounce@company.com",
+        SPF: "pass",
+        dkim,
+      })
+    );
+
+    expect(decision.headerFromDomain).toBe("company.com");
+    expect(decision.spfResult).toBe("pass");
+    expect(decision.spfEnvelopeDomain).toBe("company.com");
+    expect(decision.dkimEntries).toEqual(dkim);
   });
 });

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -8,6 +8,16 @@ export type InboundEmailDkimResult = {
   result: string;
 };
 
+export type InboundAuthDecision = {
+  authenticated: boolean;
+  // Which path granted authentication (undefined when rejected).
+  reason?: "aligned_dkim" | "aligned_spf";
+  headerFromDomain: string;
+  spfResult: string;
+  spfEnvelopeDomain: string;
+  dkimEntries: InboundEmailDkimResult[];
+};
+
 export function parseSendgridDkimResults(
   rawDkim: string | null
 ): InboundEmailDkimResult[] {
@@ -51,20 +61,66 @@ function getEmailDomain(email: string): string {
     throw new Error(`Invalid email address: ${email}`);
   }
 
-  return domain;
+  return domain.toLowerCase();
 }
 
-export function isAuthenticatedInboundSender(
+/**
+ * Relaxed domain alignment per DMARC RFC 7489 §3.1.
+ * Two domains are aligned when they share the same organizational domain,
+ * i.e. one is a subdomain of the other or they are equal.
+ *
+ * Limitation: this is suffix-based, not PSL-aware — domains under public
+ * suffixes like co.uk could incorrectly align (e.g. a.co.uk / b.co.uk).
+ * A PSL-aware check should replace this if false positives arise.
+ */
+export function domainsAlign(a: string, b: string): boolean {
+  const la = a.toLowerCase();
+  const lb = b.toLowerCase();
+
+  if (la === lb) {
+    return true;
+  }
+
+  // One is a subdomain of the other: "mail.example.com" aligns with "example.com".
+  return la.endsWith(`.${lb}`) || lb.endsWith(`.${la}`);
+}
+
+/**
+ * DMARC-style inbound sender authentication against the header From: domain.
+ * Accepts if:
+ * - At least one DKIM signature passes for a domain aligned with the From: domain, OR
+ * - SPF passes and the envelope-from domain aligns with the From: domain.
+ */
+export function evaluateInboundAuth(
   email: Pick<InboundEmail, "auth" | "sender" | "envelope">
-): boolean {
-  const senderDomain = getEmailDomain(email.sender.email);
+): InboundAuthDecision {
+  const headerFromDomain = getEmailDomain(email.sender.email);
   const envelopeDomain = getEmailDomain(email.envelope.from);
 
-  return (
-    email.auth.SPF === "pass" &&
-    senderDomain === envelopeDomain &&
-    email.auth.dkim.some(
-      ({ domain, result }) => domain === envelopeDomain && result === "pass"
-    )
+  const base = {
+    headerFromDomain,
+    spfResult: email.auth.SPF,
+    spfEnvelopeDomain: envelopeDomain,
+    dkimEntries: email.auth.dkim,
+  };
+
+  // Path 1: aligned DKIM pass.
+  const hasAlignedPassingDkim = email.auth.dkim.some(
+    (entry) =>
+      entry.result === "pass" && domainsAlign(entry.domain, headerFromDomain)
   );
+
+  if (hasAlignedPassingDkim) {
+    return { ...base, authenticated: true, reason: "aligned_dkim" };
+  }
+
+  // Path 2: SPF pass with aligned envelope domain.
+  const spfPasses = email.auth.SPF === "pass";
+  const spfDomainAligns = domainsAlign(envelopeDomain, headerFromDomain);
+
+  if (spfPasses && spfDomainAligns) {
+    return { ...base, authenticated: true, reason: "aligned_spf" };
+  }
+
+  return { ...base, authenticated: false };
 }

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -17,7 +17,7 @@ import {
   parseHeaderValue,
 } from "@app/lib/api/assistant/email/header_parsing";
 import {
-  isAuthenticatedInboundSender,
+  evaluateInboundAuth,
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
 import apiConfig from "@app/lib/api/config";
@@ -242,21 +242,27 @@ async function handler(
       // possible below this point, errors should be reported to the sender.
       res.status(200).json({ success: true });
 
-      if (!isAuthenticatedInboundSender(email)) {
-        logger.warn(
-          {
-            senderEmail: email.sender.email,
-            envelopeFrom: email.envelope.from,
-            SPF: email.auth.SPF,
-            dkim: email.auth.dkim,
-            targetEmails: [
-              ...(email.envelope.to ?? []),
-              ...(email.envelope.cc ?? []),
-              ...(email.envelope.bcc ?? []),
-            ].filter((e) => e.endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`)),
-          },
-          "[email] Dropping unauthenticated inbound mail (SPF/DKIM failure)"
-        );
+      const authDecision = evaluateInboundAuth(email);
+
+      logger.info(
+        {
+          authenticated: authDecision.authenticated,
+          reason: authDecision.reason,
+          headerFromDomain: authDecision.headerFromDomain,
+          spfResult: authDecision.spfResult,
+          spfEnvelopeDomain: authDecision.spfEnvelopeDomain,
+          dkimEntries: authDecision.dkimEntries,
+          senderEmail: email.sender.email,
+        },
+        "[email] Inbound sender auth decision"
+      );
+
+      if (!authDecision.authenticated) {
+        await replyToError(email, {
+          type: "unauthenticated_error",
+          message:
+            "Failed to authenticate your email (SPF/DKIM validation failed).",
+        });
         return;
       }
 

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -244,27 +244,36 @@ async function handler(
 
       const authDecision = evaluateInboundAuth(email);
 
-      logger.info(
-        {
-          authenticated: authDecision.authenticated,
-          reason: authDecision.reason,
-          headerFromDomain: authDecision.headerFromDomain,
-          spfResult: authDecision.spfResult,
-          spfEnvelopeDomain: authDecision.spfEnvelopeDomain,
-          dkimEntries: authDecision.dkimEntries,
-          senderEmail: email.sender.email,
-        },
-        "[email] Inbound sender auth decision"
-      );
-
       if (!authDecision.authenticated) {
-        await replyToError(email, {
-          type: "unauthenticated_error",
-          message:
-            "Failed to authenticate your email (SPF/DKIM validation failed).",
-        });
+        // Do not reply to unauthenticated mail — the sender may be spoofed,
+        // and replying would cause backscatter.
+        logger.warn(
+          {
+            reason: authDecision.reason,
+            headerFromDomain: authDecision.headerFromDomain,
+            spfResult: authDecision.spfResult,
+            spfEnvelopeDomain: authDecision.spfEnvelopeDomain,
+            dkimEntries: authDecision.dkimEntries,
+            senderEmail: email.sender.email,
+            targetEmails: [
+              ...(email.envelope.to ?? []),
+              ...(email.envelope.cc ?? []),
+              ...(email.envelope.bcc ?? []),
+            ].filter((e) => e.endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`)),
+          },
+          "[email] Dropping unauthenticated inbound mail (SPF/DKIM failure)"
+        );
         return;
       }
+
+      logger.info(
+        {
+          reason: authDecision.reason,
+          headerFromDomain: authDecision.headerFromDomain,
+          senderEmail: email.sender.email,
+        },
+        "[email] Inbound sender authenticated"
+      );
 
       const userRes = await userAndWorkspaceFromEmail({
         email: email.sender.email,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7231
Follows https://github.com/dust-tt/dust/pull/23316

Replaces the narrow inbound email auth (exact SPF + DKIM match against envelope sender) with DMARC-style evaluation against the header `From:` domain:

- **Aligned DKIM path**: accept if any DKIM signature passes for a domain aligned with the `From:` header domain (handles forwarded mail where SPF fails but original DKIM survives)
- **Aligned SPF path**: accept if SPF passes and the envelope-from domain aligns with the `From:` header domain
- Uses relaxed (suffix-based) alignment — documented limitation: not PSL-aware, so public suffixes like `.co.uk` could theoretically false-positive

Auth decisions are logged with all raw signals (SPF result, DKIM entries, domains) for production debugging. Unauthenticated mail is silently dropped (no reply to potentially spoofed senders, per #23316).

## Risks

Blast radius: inbound email authentication for email agents
Risk: standard -- relaxes acceptance criteria (forwarded mail now accepted), but adds structured logging to catch issues; 

## Deploy Plan
- pmrr
- deploy front