### PR TITLE
[NOVU] Allow missing NEXT_PUBLIC_NOVU_API_URL without throwing

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -502,11 +502,8 @@ const config = {
   getNovuSecretKey: (): string => {
     return EnvironmentConfig.getEnvVariable("NOVU_SECRET_KEY");
   },
-  getNovuApiUrl: (): string => {
-    // Using process.env here to make sure the function is usable on the client side.
-    if (!process.env.NEXT_PUBLIC_NOVU_API_URL) {
-      throw new Error("NEXT_PUBLIC_NOVU_API_URL is not set");
-    }
+  getNovuApiUrl: (): string | undefined => {
+    // Do not throw, we want to use the default URL if not set.
     return process.env.NEXT_PUBLIC_NOVU_API_URL;
   },
 };


### PR DESCRIPTION
## Description

`getNovuApiUrl` was throwing when `NEXT_PUBLIC_NOVU_API_URL` was not set, breaking environments that rely on Novu's default URL. It now returns `undefined` so callers can fall back gracefully.

## Tests

Not tested.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`