### PR TITLE
[hive] enh: add shell completion / working directory

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -1,0 +1,318 @@
+#compdef dust-hive dh
+
+# Zsh completion script for dust-hive (and dh alias)
+#
+# Install (pick one):
+#   1. Source directly in .zshrc:
+#        source /path/to/completions/dust-hive.zsh
+#   2. Symlink into a directory on your $fpath:
+#        ln -s /path/to/completions/dust-hive.zsh "${fpath[1]}/_dust-hive"
+#   3. Add the completions dir to fpath (before compinit):
+#        fpath=(/path/to/completions $fpath)
+#
+# Sourcing this file defines:
+#   dh    - alias for dust-hive
+#   dhs   - spawn -C -c "claude --dangerously-skip-permissions"
+#   dho   - open -C
+#   dhl   - list
+#   dhd   - destroy
+#   dhw   - warm
+#   dhc   - cool
+#   dhcd  - cd into environment worktree (changes dir in current shell)
+
+_dust_hive_services=(
+  sdk sparkle front core oauth connectors front-workers front-spa-poke front-spa-app viz
+)
+
+_dust_hive_current_env() {
+  # 1. Detect from cwd (inside a .hives/<name> worktree)
+  local cwd="$PWD"
+  if [[ "$cwd" == */.hives/* ]]; then
+    local after="${cwd##*/.hives/}"
+    echo "${after%%/*}"
+    return
+  fi
+  # 2. Fall back to last-active env from activity.json
+  local activity=~/.dust-hive/activity.json
+  if [[ -f "$activity" ]]; then
+    # Lightweight JSON parse — avoid external deps
+    local last
+    last="$(command grep -o '"lastEnv" *: *"[^"]*"' "$activity" 2>/dev/null | head -1)"
+    [[ -n "$last" ]] || return
+    # Extract value between the last pair of quotes
+    last="${last##*: \"}"
+    last="${last%\"}"
+    echo "$last"
+  fi
+}
+
+_dust_hive_envs() {
+  local -a envs
+  if [[ -d ~/.dust-hive/envs ]]; then
+    envs=(${(f)"$(ls ~/.dust-hive/envs 2>/dev/null)"})
+  fi
+  (( $#envs )) || return
+
+  local current
+  current="$(_dust_hive_current_env)"
+
+  if [[ -n "$current" ]] && (( ${envs[(Ie)$current]} )); then
+    # Show current/active env first in its own group so menu-select highlights it
+    local -a others=("${(@)envs:#$current}")
+    local -a active=("$current")
+    _describe -V 'current environment' active
+    (( $#others )) && _describe -V 'environment' others
+  else
+    _describe -V 'environment' envs
+  fi
+}
+
+_dust_hive_service() {
+  _describe 'service' _dust_hive_services
+}
+
+_dust-hive() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \
+    '1:command:->command' \
+    '*::args:->args'
+
+  case $state in
+    command)
+      local -a commands=(
+        'spawn:Create a new environment'
+        'open:Open environment terminal session'
+        'reload:Kill and reopen terminal session'
+        'restart:Restart a single service'
+        'warm:Start docker and all services'
+        'cool:Stop services, keep SDK watch'
+        'start:Resume stopped environment'
+        'stop:Stop all services in environment'
+        'up:Start managed services (temporal + test postgres + test redis)'
+        'down:Stop all envs, temporal, test postgres, test redis'
+        'destroy:Remove environment'
+        'list:Show all environments'
+        'status:Show service health'
+        'logs:Show service logs'
+        'url:Print front URL'
+        'cd:Print worktree path'
+        'setup:Check prerequisites and guide initial setup'
+        'doctor:Check prerequisites (non-interactive)'
+        'cache:Show binary cache status'
+        'refresh:Restore node_modules links in worktree'
+        'forward:Manage OAuth port forwarding'
+        'sync:Pull latest main, rebuild binaries, refresh deps'
+        'temporal:Manage Temporal server'
+        'seed-config:Extract user data from existing DB'
+        'feed:Run seed script for a scenario'
+        'flag:Toggle a feature flag on the workspace'
+        'help:Show help'
+      )
+      _describe 'command' commands
+      ;;
+    args)
+      case $words[1] in
+        spawn|s)
+          _arguments \
+            '1::name:' \
+            '-n[Environment name]:name:' \
+            '--name[Environment name]:name:' \
+            '-b[Git branch name]:branch:' \
+            '--branch-name[Git branch name]:branch:' \
+            '-r[Reuse existing local branch]' \
+            '--reuse-existing-branch[Reuse existing local branch]' \
+            '-O[Do not open terminal session]' \
+            '--no-open[Do not open terminal session]' \
+            '-A[Create session but do not attach]' \
+            '--no-attach[Create session but do not attach]' \
+            '-w[Open with warm tab]' \
+            '--warm[Open with warm tab]' \
+            '-W[Wait for SDK to build before opening]' \
+            '--wait[Wait for SDK to build before opening]' \
+            '-c[Run command in shell tab]:command:' \
+            '--command[Run command in shell tab]:command:' \
+            '-C[Use compact layout]' \
+            '--compact[Use compact layout]' \
+            '-u[Use single unified logs tab]' \
+            '--unified-logs[Use single unified logs tab]'
+          ;;
+        open|o)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '-C[Use compact layout]' \
+            '--compact[Use compact layout]' \
+            '-u[Use single unified logs tab]' \
+            '--unified-logs[Use single unified logs tab]'
+          ;;
+        reload)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '-u[Use single unified logs tab]' \
+            '--unified-logs[Use single unified logs tab]'
+          ;;
+        restart)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '2::service:_dust_hive_service'
+          ;;
+        warm|w)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '-F[Disable OAuth port forwarding]' \
+            '--no-forward[Disable OAuth port forwarding]' \
+            '-p[Kill processes blocking service ports]' \
+            '--force-ports[Kill processes blocking service ports]'
+          ;;
+        cool|c)
+          _arguments '1::name:_dust_hive_envs'
+          ;;
+        start)
+          _arguments '1::name:_dust_hive_envs'
+          ;;
+        stop|x)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '2::service:_dust_hive_service'
+          ;;
+        up)
+          _arguments \
+            '-a[Attach to main terminal session]' \
+            '--attach[Attach to main terminal session]' \
+            '-f[Force rebuild even if no changes]' \
+            '--force[Force rebuild even if no changes]' \
+            '-C[Use compact layout]' \
+            '--compact[Use compact layout]'
+          ;;
+        down)
+          _arguments \
+            '-f[Skip confirmation prompt]' \
+            '--force[Skip confirmation prompt]'
+          ;;
+        destroy|rm)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '-f[Force destroy even with uncommitted changes]' \
+            '--force[Force destroy even with uncommitted changes]' \
+            '-k[Keep the git branch]' \
+            '--keep-branch[Keep the git branch]'
+          ;;
+        list|ls|l)
+          ;;
+        status|st)
+          _arguments '1::name:_dust_hive_envs'
+          ;;
+        logs|log)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '2::service:_dust_hive_service' \
+            '-f[Follow log output]' \
+            '--follow[Follow log output]' \
+            '-i[Interactive TUI with service switching]' \
+            '--interactive[Interactive TUI with service switching]'
+          ;;
+        url|cd)
+          _arguments '1::name:_dust_hive_envs'
+          ;;
+        setup)
+          _arguments \
+            '-y[Run without prompts]' \
+            '--non-interactive[Run without prompts]'
+          ;;
+        doctor|cache)
+          ;;
+        refresh)
+          _arguments '1::name:_dust_hive_envs'
+          ;;
+        forward)
+          _arguments \
+            '1::name or subcommand:->forward_arg'
+          case $state in
+            forward_arg)
+              local -a subcmds=('status:Show current forwarding status' 'stop:Stop the port forwarder')
+              _describe 'subcommand' subcmds
+              _dust_hive_envs
+              ;;
+          esac
+          ;;
+        sync)
+          _arguments \
+            '-f[Force rebuild even if no changes]' \
+            '--force[Force rebuild even if no changes]'
+          ;;
+        temporal)
+          _arguments \
+            '1::subcommand:(start stop restart status logs)'
+          ;;
+        seed-config)
+          _arguments '1:postgres-uri:'
+          ;;
+        feed)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '2::scenario:'
+          ;;
+        flag)
+          _arguments \
+            '1::name:_dust_hive_envs' \
+            '2::flag name:' \
+            '-d[Disable the flag]' \
+            '--disable[Disable the flag]'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+# dh: simple alias for dust-hive
+alias dh=dust-hive
+
+# Shorthand aliases (use `function` keyword to avoid zsh alias expansion on the name)
+unalias dhs dho dhl dhd dhw dhc dhcd 2>/dev/null
+function dhs  { command dust-hive spawn -C -c "claude --dangerously-skip-permissions" "$@"; }
+function dho  { command dust-hive open -C "$@"; }
+function dhl  { command dust-hive list "$@"; }
+function dhd  { command dust-hive destroy "$@"; }
+function dhw  { command dust-hive warm "$@"; }
+function dhc  { command dust-hive cool "$@"; }
+
+# dhcd: cd into an environment's worktree in the current shell
+function dhcd {
+  local tmpfile="${TMPDIR:-/tmp}/dust-hive-cd.$$"
+  DUST_HIVE_CD_FILE="$tmpfile" command dust-hive cd "$@"
+  local rc=$?
+  if (( rc == 0 )) && [[ -f "$tmpfile" ]]; then
+    local dir
+    dir="$(<"$tmpfile")"
+    rm -f "$tmpfile"
+    [[ -d "$dir" ]] && cd "$dir"
+  else
+    rm -f "$tmpfile"
+    return $rc
+  fi
+}
+
+# Completions for shorthand aliases — complete remaining args for the underlying command
+function _dhs  { local words=("dust-hive" "spawn" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dho  { local words=("dust-hive" "open" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dhl  { :; }
+function _dhd  { local words=("dust-hive" "destroy" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dhw  { local words=("dust-hive" "warm" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dhc  { local words=("dust-hive" "cool" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dhcd { local words=("dust-hive" "cd" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+
+# When loaded via fpath, zsh calls the file as a function — invoke the completer.
+# When sourced manually, just register with compdef and skip the direct call.
+if [[ "$funcstack[1]" == _dust-hive ]]; then
+  _dust-hive "$@"
+else
+  compdef _dust-hive dust-hive dh
+  compdef _dhs dhs
+  compdef _dho dho
+  compdef _dhl dhl
+  compdef _dhd dhd
+  compdef _dhw dhw
+  compdef _dhc dhc
+  compdef _dhcd dhcd
+fi

--- a/x/henry/dust-hive/src/commands/cd.ts
+++ b/x/henry/dust-hive/src/commands/cd.ts
@@ -1,0 +1,23 @@
+import { requireEnvironment } from "../lib/commands";
+import { getWorktreeDir } from "../lib/paths";
+import { Ok, type Result } from "../lib/result";
+
+export async function cdCommand(nameArg: string | undefined): Promise<Result<void>> {
+  const envResult = await requireEnvironment(nameArg, "cd");
+  if (!envResult.ok) return envResult;
+
+  const env = envResult.value;
+  const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
+
+  // When called via the `dh cd` shell wrapper, DUST_HIVE_CD_FILE is set.
+  // Write the path to that file so the wrapper can cd without capturing stdout
+  // (which would swallow the interactive selection prompt).
+  const cdFile = process.env["DUST_HIVE_CD_FILE"];
+  if (cdFile) {
+    await Bun.write(cdFile, worktreePath);
+  } else {
+    process.stdout.write(`${worktreePath}\n`);
+  }
+
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -2,6 +2,7 @@
 
 import { cac } from "cac";
 import { cacheCommand } from "./commands/cache";
+import { cdCommand } from "./commands/cd";
 import { coolCommand } from "./commands/cool";
 import { destroyCommand } from "./commands/destroy";
 import { doctorCommand, setupCommand } from "./commands/doctor";
@@ -270,6 +271,12 @@ cli
 cli.command("url [name]", "Print front URL").action(async (name: string | undefined) => {
   await prepareAndRun(urlCommand(name));
 });
+
+cli
+  .command("cd [name]", "Print worktree path (use with: cd $(dust-hive cd <env>))")
+  .action(async (name: string | undefined) => {
+    await prepareAndRun(cdCommand(name));
+  });
 
 cli
   .command("setup", "Check prerequisites and guide initial setup (run this first!)")

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -213,7 +213,7 @@ export class TmuxAdapter implements MultiplexerAdapter {
       // Single unified logs window
       lines.push(
         "# Create unified logs window",
-        `tmux new-window -t "$SESSION_NAME" -n "logs"`,
+        `tmux new-window -t "$SESSION_NAME" -n "logs" -c "$WORKTREE_PATH"`,
         `tmux send-keys -t "$SESSION_NAME:logs" "dust-hive logs ${shellQuote(envName)} -i" Enter`,
         ""
       );
@@ -223,7 +223,7 @@ export class TmuxAdapter implements MultiplexerAdapter {
         const tabName = TAB_NAMES[service];
         lines.push(
           `# Create ${service} logs window`,
-          `tmux new-window -t "$SESSION_NAME" -n ${shellQuote(tabName)}`,
+          `tmux new-window -t "$SESSION_NAME" -n ${shellQuote(tabName)} -c "$WORKTREE_PATH"`,
           `tmux send-keys -t "$SESSION_NAME:${tabName}" "dust-hive logs ${shellQuote(envName)} ${shellQuote(service)} -f" Enter`,
           ""
         );

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -237,6 +237,7 @@ export class ZellijAdapter implements MultiplexerAdapter {
       // Single unified logs tab using dust-hive logs -i
       logsTabs = `    tab name="logs" {
         pane {
+            cwd "${kdlEscape(worktreePath)}"
             command "dust-hive"
             args "logs" "${kdlEscape(envName)}" "-i"
             start_suspended true
@@ -244,9 +245,9 @@ export class ZellijAdapter implements MultiplexerAdapter {
     }`;
     } else {
       // Individual service tabs (default)
-      logsTabs = ALL_SERVICES.map((service) => this.generateServiceTab(envName, service)).join(
-        "\n\n"
-      );
+      logsTabs = ALL_SERVICES.map((service) =>
+        this.generateServiceTab(envName, service, worktreePath)
+      ).join("\n\n");
     }
 
     // When compact mode is enabled, use bottom bar; otherwise use top bar
@@ -296,10 +297,11 @@ ${tabTemplate}
 `;
   }
 
-  private generateServiceTab(envName: string, service: ServiceName): string {
+  private generateServiceTab(envName: string, service: ServiceName, worktreePath: string): string {
     const tabName = TAB_NAMES[service];
     return `    tab name="${tabName}" {
         pane {
+            cwd "${kdlEscape(worktreePath)}"
             command "dust-hive"
             args "logs" "${kdlEscape(envName)}" "${kdlEscape(service)}" "-f"
             start_suspended true


### PR DESCRIPTION
## Description

Adds zsh shell completion and shorthand aliases for dust-hive, plus a `cd` command and improved multiplexer tab working directories.

### Shell completion (`completions/dust-hive.zsh`)
- Full zsh completion for all commands, flags, positional arguments (env names, service names, subcommands)
- Environment name completion reads from `~/.dust-hive/envs/` with the current/last-active env shown first (auto-highlighted in menu-select)
- Current env detection: from cwd (inside `.hives/<name>`) or fallback to `activity.json`

### Aliases & functions
| Alias | Expands to |
|-------|-----------|
| `dh` | `dust-hive` |
| `dhs` | `dust-hive spawn -C -c "claude --dangerously-skip-permissions"` |
| `dho` | `dust-hive open -C` |
| `dhl` | `dust-hive list` |
| `dhd` | `dust-hive destroy` |
| `dhw` | `dust-hive warm` |
| `dhc` | `dust-hive cool` |
| `dhcd` | cd into env worktree (changes dir in current shell) |

All aliases support tab-completion for their remaining args.

### `dust-hive cd [env]` command
- Prints the worktree path (for scripting: `cd $(dust-hive cd myenv)`)
- Supports `DUST_HIVE_CD_FILE` env var for the `dhcd` shell wrapper to avoid capturing interactive prompts in `$()`

### Multiplexer log tabs cwd
- Zellij: added `cwd` directive to all per-service and unified log panes
- Tmux: added `-c "$WORKTREE_PATH"` to all log window creation

## Tests

- `bun run check` passes (typecheck + lint + tests)
- Manual: sourced completion script, verified tab-completion for commands/envs/services, tested `dhcd` with and without env arg

## Risk

Low — additive changes only. Completion script is opt-in (user must source it). The multiplexer cwd change only affects newly created sessions.

## Deploy Plan

No deployment needed — CLI-only changes, distributed via the dust-hive tool.