### PR TITLE
[front] enh: batch fetch MCP server views in Agent Builder

### DIFF
--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -8,8 +8,6 @@ import {
 } from "@app/lib/api/mcp_oauth_prerequisites";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -84,22 +82,13 @@ async function handler(
         await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
       }
 
-      const serverViews = await concurrentExecutor(
-        query.spaceIds,
-        async (spaceId) => {
-          const space = await SpaceResource.fetchById(auth, spaceId);
-          if (!space) {
-            return null;
-          }
-          const views = await MCPServerViewResource.listBySpace(auth, space);
-          return views.map((v) => v.toJSON());
-        },
-        { concurrency: 10 }
+      const views = await MCPServerViewResource.listBySpaceIds(
+        auth,
+        query.spaceIds
       );
 
-      const flattenedServerViews = serverViews
-        .flat()
-        .filter((v): v is MCPServerViewType => v !== null)
+      const flattenedServerViews = views
+        .map((v) => v.toJSON())
         .filter(
           (v) =>
             isAllowedAvailability(v.server.availability) &&

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -46,8 +46,7 @@ async function handler(
 
   switch (method) {
     case "GET": {
-      const spaceIds = req.query.spaceIds;
-      const availabilities = req.query.availabilities;
+      const { spaceIds, availabilities } = req.query;
 
       if (!isString(spaceIds) || !isString(availabilities)) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

- This PR improves the performances of the `/mcp/views` endpoint, which is used in the Agent Builder and in the Capabilities Picker.
- Instead of feching in a loop each space + all MCP server views on the space it batches both call. Will improve performances for users that have many spaces.

## Tests

- Tested locally.

## Risk

- Low. Blast radius: list of MCP server views on Agent Builder and Capabiltiies Picker.

## Deploy Plan

- Deploy front.
