### PR TITLE
[Connector] perf(oauth): clear oauth cache expired entries to avoid memory overflow

### DIFF
--- a/connectors/src/types/oauth/client/access_token.ts
+++ b/connectors/src/types/oauth/client/access_token.ts
@@ -1,11 +1,12 @@
 import type { LoggerInterface, Result } from "@dust-tt/client";
 import { Ok } from "@dust-tt/client";
-
+import throttle from "lodash/throttle";
 import type { OAuthConnectionType, OAuthProvider } from "../../oauth/lib";
 import type { OAuthAPIError } from "../../oauth/oauth_api";
 import { OAuthAPI } from "../../oauth/oauth_api";
 
 const OAUTH_ACCESS_TOKEN_CACHE_TTL = 1000 * 60 * 5;
+const CACHE_CLEAR_INTERVAL = 1000 * 60;
 
 const CACHE = new Map<
   string,
@@ -39,7 +40,7 @@ export async function getOAuthConnectionAccessToken({
     OAuthAPIError
   >
 > {
-  clearExpiredEntries();
+  throttle(clearExpiredEntries, CACHE_CLEAR_INTERVAL);
 
   const cached = CACHE.get(connectionId);
 

--- a/connectors/src/types/oauth/client/access_token.ts
+++ b/connectors/src/types/oauth/client/access_token.ts
@@ -39,6 +39,8 @@ export async function getOAuthConnectionAccessToken({
     OAuthAPIError
   >
 > {
+  clearExpiredEntries();
+
   const cached = CACHE.get(connectionId);
 
   if (cached && cached.local_expiry > Date.now()) {
@@ -60,4 +62,13 @@ export async function getOAuthConnectionAccessToken({
   });
 
   return res;
+}
+
+function clearExpiredEntries() {
+  const nowMs = Date.now();
+  for (const [key, entry] of CACHE.entries()) {
+    if (entry.local_expiry < nowMs) {
+      CACHE.delete(key);
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
     },
     "cli/dust-cli": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.2.6",


### PR DESCRIPTION
## Description

Fixes memory leak introduced in : https://github.com/dust-tt/dust/pull/23253

The connectors access token retrieval is cached in-memory with a map that grows unbound and causes pod restarts.
It's only the case for microsoft connector for now as it's requesting the token for every graphql call to avoid token expiration on big sharepoint sync (see https://github.com/dust-tt/dust/pull/23253).

This PR clears expired entries from the map whenever a new access token is requested, keeping the cache map at a reasonable size.

![Uploading image.png…]()


## Deploy Plan

Connectors