### PR TITLE
Add a batch_llm.ts to store the conversation when using batch LLM calls

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -27,6 +27,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 
 export interface LlmConversationOptions
@@ -50,7 +51,7 @@ export interface LlmConversationOptions
  *
  * Returns the conversation resource.
  */
-export async function createLlmConversation(
+export async function writeBatchUserMessages(
   auth: Authenticator,
   {
     newMessages,
@@ -218,7 +219,7 @@ export async function storeLlmResult(
     // Create step content entries from LLM events.
     let index = 0;
     for (const event of events) {
-      const stepContent = eventToStepContent(event);
+      const stepContent = eventToStoredStepContent(event);
       if (stepContent) {
         await AgentStepContentResource.createNewVersion(
           {
@@ -258,7 +259,7 @@ export async function sendBatchCallToLlm(
 
   for (const input of conversations) {
     // Store new messages in DB.
-    const conversationResource = await createLlmConversation(auth, input);
+    const conversationResource = await writeBatchUserMessages(auth, input);
     conversationIds.push(conversationResource.sId);
 
     // Reconstruct the full conversation from DB.
@@ -323,12 +324,12 @@ export async function downloadBatchResultFromLlm(
     auth,
     conversationIds
   );
-  const conversationBySId = new Map(
+  const conversationById = new Map(
     conversationResources.map((c) => [c.sId, c])
   );
 
   for (const [conversationId, events] of results) {
-    const conversation = conversationBySId.get(conversationId);
+    const conversation = conversationById.get(conversationId);
     if (!conversation) {
       continue;
     }
@@ -342,7 +343,9 @@ export async function downloadBatchResultFromLlm(
  * Convert an LLM event to an AgentStepContent value.
  * Returns null for events that don't map to stored content (deltas, token usage, etc.).
  */
-function eventToStepContent(event: LLMEvent): AgentContentItemType | null {
+function eventToStoredStepContent(
+  event: LLMEvent
+): AgentContentItemType | null {
   if (event instanceof EventError) {
     return {
       type: "error",
@@ -386,8 +389,14 @@ function eventToStepContent(event: LLMEvent): AgentContentItemType | null {
           provider: event.metadata.clientId,
         },
       };
-
-    default:
+    case "interaction_id":
+    case "reasoning_delta":
+    case "success":
+    case "text_delta":
+    case "token_usage":
+    case "tool_call_delta":
       return null;
+    default:
+      assertNever(event.type);
   }
 }

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -38,7 +38,7 @@ export interface LlmConversationOptions
   visibility?: ConversationVisibility;
   metadata?: ConversationMetadata;
   userContextUsername?: string;
-  userContextOrigin?: UserMessageOrigin;
+  userContextOrigin: UserMessageOrigin;
 }
 
 /**
@@ -60,7 +60,7 @@ export async function writeBatchUserMessages(
     visibility = "unlisted",
     metadata = {},
     userContextUsername = "system",
-    userContextOrigin = "api",
+    userContextOrigin,
   }: LlmConversationOptions
 ): Promise<ConversationResource> {
   const workspace = auth.getNonNullableWorkspace();

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -155,7 +155,7 @@ export async function storeLlmResult(
 ): Promise<void> {
   const workspace = auth.getNonNullableWorkspace();
 
-  await withTransaction(async (t: Transaction) => {
+  const agentMessage = await withTransaction(async (t: Transaction) => {
     // Find the last user message in this conversation to use as parent.
     const parentMessage = await MessageModel.findOne({
       where: {
@@ -190,7 +190,7 @@ export async function storeLlmResult(
       (e): e is EventError => e instanceof EventError
     );
 
-    const agentMessage = await AgentMessageModel.create(
+    const msg = await AgentMessageModel.create(
       {
         status,
         agentConfigurationId,
@@ -210,32 +210,31 @@ export async function storeLlmResult(
         rank: nextRank,
         conversationId: conversation.id,
         parentId: parentMessage?.id ?? null,
-        agentMessageId: agentMessage.id,
+        agentMessageId: msg.id,
         workspaceId: workspace.id,
       },
       { transaction: t }
     );
 
-    // Create step content entries from LLM events.
-    let index = 0;
-    for (const event of events) {
-      const stepContent = eventToStoredStepContent(event);
-      if (stepContent) {
-        await AgentStepContentResource.createNewVersion(
-          {
-            agentMessageId: agentMessage.id,
-            workspaceId: workspace.id,
-            step: 0,
-            index,
-            type: stepContent.type,
-            value: stepContent,
-          },
-          t
-        );
-        index++;
-      }
-    }
+    return msg;
   });
+
+  // Create step content entries from LLM events.
+  let index = 0;
+  for (const event of events) {
+    const stepContent = eventToStoredStepContent(event);
+    if (stepContent) {
+      await AgentStepContentResource.createNewVersion({
+        agentMessageId: agentMessage.id,
+        workspaceId: workspace.id,
+        step: 0,
+        index,
+        type: stepContent.type,
+        value: stepContent,
+      });
+      index++;
+    }
+  }
 }
 
 /**

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -1,0 +1,393 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import type { LLM } from "@app/lib/api/llm/llm";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { EventError } from "@app/lib/api/llm/types/events";
+import type {
+  LLMParametersWithoutConversation,
+  LLMStreamParameters,
+} from "@app/lib/api/llm/types/options";
+import { systemPromptToText } from "@app/lib/api/llm/types/options";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import type {
+  AgentMessageStatus,
+  ConversationMetadata,
+  ConversationVisibility,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import { isTextContent } from "@app/types/assistant/generation";
+import type { Transaction } from "sequelize";
+
+export interface LlmConversationOptions
+  extends LLMParametersWithoutConversation {
+  newMessages: ModelMessageTypeMultiActionsWithoutContentFragment[];
+  existingConversationId?: string;
+  title?: string;
+  visibility?: ConversationVisibility;
+  metadata?: ConversationMetadata;
+  userContextUsername?: string;
+  userContextOrigin?: UserMessageOrigin;
+}
+
+/**
+ * Create (or reuse) a conversation and store the new user messages.
+ *
+ * - If no `existingConversationId`: creates a new conversation.
+ * - If `existingConversationId`: reuses that conversation.
+ * - Creates one `UserMessageModel` + `MessageModel` per user-role message in
+ *   `newMessages`, preserving the multi-turn structure.
+ *
+ * Returns the conversation resource.
+ */
+export async function createLlmConversation(
+  auth: Authenticator,
+  {
+    newMessages,
+    existingConversationId,
+    title,
+    visibility = "unlisted",
+    metadata = {},
+    userContextUsername = "system",
+    userContextOrigin = "api",
+  }: LlmConversationOptions
+): Promise<ConversationResource> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  let conversationResource: ConversationResource;
+
+  if (existingConversationId) {
+    const existing = await ConversationResource.fetchById(
+      auth,
+      existingConversationId
+    );
+    if (!existing) {
+      throw new Error(`Conversation not found: ${existingConversationId}`);
+    }
+    conversationResource = existing;
+  } else {
+    conversationResource = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: title ?? null,
+        visibility,
+        requestedSpaceIds: [],
+        metadata,
+      },
+      null
+    );
+  }
+
+  const userMessages = newMessages.filter((msg) => msg.role === "user");
+
+  await withTransaction(async (t: Transaction) => {
+    const maxRank = await MessageModel.max<number, MessageModel>("rank", {
+      where: {
+        conversationId: conversationResource.id,
+        workspaceId: workspace.id,
+      },
+      transaction: t,
+    });
+    let nextRank = typeof maxRank === "number" ? maxRank + 1 : 0;
+
+    for (const msg of userMessages) {
+      const textParts = msg.content.filter(isTextContent).map((p) => p.text);
+      const content = textParts.join("\n");
+
+      const userMessage = await UserMessageModel.create(
+        {
+          workspaceId: workspace.id,
+          userId: null,
+          content,
+          userContextUsername,
+          userContextTimezone: "UTC",
+          userContextFullName: null,
+          userContextEmail: null,
+          userContextProfilePictureUrl: null,
+          userContextOrigin,
+          clientSideMCPServerIds: [],
+        },
+        { transaction: t }
+      );
+
+      await MessageModel.create(
+        {
+          sId: generateRandomModelSId(),
+          rank: nextRank,
+          conversationId: conversationResource.id,
+          parentId: null,
+          userMessageId: userMessage.id,
+          workspaceId: workspace.id,
+        },
+        { transaction: t }
+      );
+      nextRank++;
+    }
+  });
+
+  return conversationResource;
+}
+
+/**
+ * Store LLM result events as an agent message in a conversation.
+ *
+ * - Creates an `AgentMessageModel` (status "succeeded" or "failed").
+ * - Creates a `MessageModel` at the next rank, parented to the last user message.
+ * - Creates `AgentStepContentModel` entries for text, tool calls, reasoning, errors.
+ */
+export async function storeLlmResult(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  events: LLMEvent[],
+  agentConfigurationId: string
+): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  await withTransaction(async (t: Transaction) => {
+    // Find the last user message in this conversation to use as parent.
+    const parentMessage = await MessageModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: true,
+        },
+      ],
+      order: [["rank", "DESC"]],
+      transaction: t,
+    });
+
+    const maxRank = await MessageModel.max<number, MessageModel>("rank", {
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+      },
+      transaction: t,
+    });
+    const nextRank = typeof maxRank === "number" ? maxRank + 1 : 0;
+
+    // Determine status from events.
+    const hasError = events.some((e) => e instanceof EventError);
+    const status: AgentMessageStatus = hasError ? "failed" : "succeeded";
+
+    const firstError = events.find(
+      (e): e is EventError => e instanceof EventError
+    );
+
+    const agentMessage = await AgentMessageModel.create(
+      {
+        status,
+        agentConfigurationId,
+        agentConfigurationVersion: 0,
+        workspaceId: workspace.id,
+        skipToolsValidation: false,
+        errorCode: firstError ? firstError.content.type : null,
+        errorMessage: firstError ? firstError.content.message : null,
+        completedAt: new Date(),
+      },
+      { transaction: t }
+    );
+
+    await MessageModel.create(
+      {
+        sId: generateRandomModelSId(),
+        rank: nextRank,
+        conversationId: conversation.id,
+        parentId: parentMessage?.id ?? null,
+        agentMessageId: agentMessage.id,
+        workspaceId: workspace.id,
+      },
+      { transaction: t }
+    );
+
+    // Create step content entries from LLM events.
+    let index = 0;
+    for (const event of events) {
+      const stepContent = eventToStepContent(event);
+      if (stepContent) {
+        await AgentStepContentResource.createNewVersion(
+          {
+            agentMessageId: agentMessage.id,
+            workspaceId: workspace.id,
+            step: 0,
+            index,
+            type: stepContent.type,
+            value: stepContent,
+          },
+          t
+        );
+        index++;
+      }
+    }
+  });
+}
+
+/**
+ * Create (or reuse) conversations, store the new user messages, reconstruct the
+ * full conversation from DB, and submit a batch to the LLM.
+ *
+ * Returns the batch ID and the conversation sIds in the same order as the input array.
+ */
+export async function sendBatchCallToLlm(
+  auth: Authenticator,
+  llm: LLM,
+  conversations: LlmConversationOptions[]
+): Promise<{
+  batchId: string;
+  conversationIds: string[];
+}> {
+  const conversationIds: string[] = [];
+  const batchMap = new Map<string, LLMStreamParameters>();
+
+  const modelConfig = llm.getModelConfig();
+
+  for (const input of conversations) {
+    // Store new messages in DB.
+    const conversationResource = await createLlmConversation(auth, input);
+    conversationIds.push(conversationResource.sId);
+
+    // Reconstruct the full conversation from DB.
+    const conversationRes = await getConversation(
+      auth,
+      conversationResource.sId
+    );
+    if (conversationRes.isErr()) {
+      throw new Error(
+        `Failed to load conversation ${conversationResource.sId}: ${conversationRes.error.message}`
+      );
+    }
+
+    const promptText = systemPromptToText(input.prompt);
+    const tools = JSON.stringify(
+      input.specifications.map((s) => ({
+        name: s.name,
+        description: s.description,
+        inputSchema: s.inputSchema,
+      }))
+    );
+
+    const modelConversationRes = await renderConversationForModel(auth, {
+      conversation: conversationRes.value,
+      model: modelConfig,
+      prompt: promptText,
+      tools,
+      allowedTokenCount:
+        modelConfig.contextSize - modelConfig.generationTokensCount,
+    });
+
+    if (modelConversationRes.isErr()) {
+      throw new Error(
+        `Failed to render conversation ${conversationResource.sId}: ${modelConversationRes.error.message}`
+      );
+    }
+
+    batchMap.set(conversationResource.sId, {
+      conversation: modelConversationRes.value.modelConversation,
+      ...input,
+    });
+  }
+
+  const batchId = await llm.sendBatchProcessing(batchMap);
+  return { batchId, conversationIds };
+}
+
+/**
+ * Download batch results from the LLM and store them as agent messages in the
+ * corresponding conversations.
+ */
+export async function downloadBatchResultFromLlm(
+  auth: Authenticator,
+  llm: LLM,
+  batchId: string,
+  conversationIds: string[],
+  agentConfigurationId: string
+): Promise<Map<string, LLMEvent[]>> {
+  const results = await llm.getBatchResult(batchId);
+
+  const conversationResources = await ConversationResource.fetchByIds(
+    auth,
+    conversationIds
+  );
+  const conversationBySId = new Map(
+    conversationResources.map((c) => [c.sId, c])
+  );
+
+  for (const [conversationId, events] of results) {
+    const conversation = conversationBySId.get(conversationId);
+    if (!conversation) {
+      continue;
+    }
+    await storeLlmResult(auth, conversation, events, agentConfigurationId);
+  }
+
+  return results;
+}
+
+/**
+ * Convert an LLM event to an AgentStepContent value.
+ * Returns null for events that don't map to stored content (deltas, token usage, etc.).
+ */
+function eventToStepContent(event: LLMEvent): AgentContentItemType | null {
+  if (event instanceof EventError) {
+    return {
+      type: "error",
+      value: {
+        code: event.content.type,
+        message: event.content.message,
+        metadata: null,
+      },
+    };
+  }
+
+  switch (event.type) {
+    case "text_generated":
+      return {
+        type: "text_content",
+        value: event.content.text,
+      };
+
+    case "tool_call":
+      return {
+        type: "function_call",
+        value: {
+          id: event.content.id,
+          name: event.content.name,
+          arguments: JSON.stringify(event.content.arguments),
+          ...(event.metadata.thoughtSignature
+            ? {
+                metadata: { thoughtSignature: event.metadata.thoughtSignature },
+              }
+            : {}),
+        },
+      };
+
+    case "reasoning_generated":
+      return {
+        type: "reasoning",
+        value: {
+          reasoning: event.content.text,
+          metadata: event.metadata.encrypted_content ?? "",
+          tokens: 0,
+          provider: event.metadata.clientId,
+        },
+      };
+
+    default:
+      return null;
+  }
+}

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -172,15 +172,7 @@ export async function storeLlmResult(
       order: [["rank", "DESC"]],
       transaction: t,
     });
-
-    const maxRank = await MessageModel.max<number, MessageModel>("rank", {
-      where: {
-        conversationId: conversation.id,
-        workspaceId: workspace.id,
-      },
-      transaction: t,
-    });
-    const nextRank = typeof maxRank === "number" ? maxRank + 1 : 0;
+    const nextRank = parentMessage ? parentMessage.rank + 1 : 0;
 
     // Determine status from events.
     const hasError = events.some((e) => e instanceof EventError);
@@ -396,6 +388,6 @@ function eventToStoredStepContent(
     case "tool_call_delta":
       return null;
     default:
-      assertNever(event.type);
+      assertNever(event);
   }
 }

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -19,14 +19,16 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
-import type {
-  AgentMessageStatus,
-  ConversationMetadata,
-  ConversationVisibility,
-  UserMessageOrigin,
+import {
+  type AgentMessageStatus,
+  ConversationError,
+  type ConversationMetadata,
+  type ConversationVisibility,
+  type UserMessageOrigin,
 } from "@app/types/assistant/conversation";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 
@@ -62,7 +64,7 @@ export async function writeBatchUserMessages(
     userContextUsername = "system",
     userContextOrigin,
   }: LlmConversationOptions
-): Promise<ConversationResource> {
+): Promise<Result<ConversationResource, ConversationError>> {
   const workspace = auth.getNonNullableWorkspace();
 
   let conversationResource: ConversationResource;
@@ -73,7 +75,7 @@ export async function writeBatchUserMessages(
       existingConversationId
     );
     if (!existing) {
-      throw new Error(`Conversation not found: ${existingConversationId}`);
+      return new Err(new ConversationError("conversation_not_found"));
     }
     conversationResource = existing;
   } else {
@@ -137,7 +139,7 @@ export async function writeBatchUserMessages(
     }
   });
 
-  return conversationResource;
+  return new Ok(conversationResource);
 }
 
 /**
@@ -239,10 +241,15 @@ export async function sendBatchCallToLlm(
   auth: Authenticator,
   llm: LLM,
   conversations: LlmConversationOptions[]
-): Promise<{
-  batchId: string;
-  conversationIds: string[];
-}> {
+): Promise<
+  Result<
+    {
+      batchId: string;
+      conversationIds: string[];
+    },
+    Error
+  >
+> {
   const conversationIds: string[] = [];
   const batchMap = new Map<string, LLMStreamParameters>();
 
@@ -250,7 +257,11 @@ export async function sendBatchCallToLlm(
 
   for (const input of conversations) {
     // Store new messages in DB.
-    const conversationResource = await writeBatchUserMessages(auth, input);
+    const writeBatchResult = await writeBatchUserMessages(auth, input);
+    if (writeBatchResult.isErr()) {
+      return writeBatchResult;
+    }
+    const conversationResource = writeBatchResult.value;
     conversationIds.push(conversationResource.sId);
 
     // Reconstruct the full conversation from DB.
@@ -259,9 +270,7 @@ export async function sendBatchCallToLlm(
       conversationResource.sId
     );
     if (conversationRes.isErr()) {
-      throw new Error(
-        `Failed to load conversation ${conversationResource.sId}: ${conversationRes.error.message}`
-      );
+      return conversationRes;
     }
 
     const promptText = systemPromptToText(input.prompt);
@@ -283,9 +292,7 @@ export async function sendBatchCallToLlm(
     });
 
     if (modelConversationRes.isErr()) {
-      throw new Error(
-        `Failed to render conversation ${conversationResource.sId}: ${modelConversationRes.error.message}`
-      );
+      return modelConversationRes;
     }
 
     batchMap.set(conversationResource.sId, {
@@ -295,7 +302,7 @@ export async function sendBatchCallToLlm(
   }
 
   const batchId = await llm.sendBatchProcessing(batchMap);
-  return { batchId, conversationIds };
+  return new Ok({ batchId, conversationIds });
 }
 
 /**

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -349,6 +349,10 @@ export abstract class LLM<TPayload = unknown> {
     return this.metadata;
   }
 
+  getModelConfig(): ModelConfigurationType {
+    return this.modelConfig;
+  }
+
   async *stream(
     streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -124,16 +124,15 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
           await setupTest();
 
         // --- Step 1: Send a batch with a single conversation ---
-        const { batchId, conversationIds } = await sendBatchCallToLlm(
-          authenticator,
-          llm,
-          [
-            makeConversationOptions(
-              "What is 1+1? Reply with just the number.",
-              { title: "Batch Store Test" }
-            ),
-          ]
-        );
+        const sendBatchResult = await sendBatchCallToLlm(authenticator, llm, [
+          makeConversationOptions("What is 1+1? Reply with just the number.", {
+            title: "Batch Store Test",
+          }),
+        ]);
+        if (sendBatchResult.isErr()) {
+          throw sendBatchResult.error;
+        }
+        const { batchId, conversationIds } = sendBatchResult.value;
 
         expect(batchId).toBeTruthy();
         expect(conversationIds).toHaveLength(1);
@@ -241,12 +240,16 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
           await setupTest();
 
         // Create conversation and user message.
-        const conversation = await writeBatchUserMessages(
+        const writeResult = await writeBatchUserMessages(
           authenticator,
           makeConversationOptions("What is 2+2? Reply with just the number.", {
             title: "Stream Store Test",
           })
         );
+        if (writeResult.isErr()) {
+          throw writeResult.error;
+        }
+        const conversation = writeResult.value;
 
         // Build LLMStreamParameters for the streaming call.
         const streamParams: LLMStreamParameters = {
@@ -319,13 +322,21 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         const { authenticator, llm, agentConfigurationId } = await setupTest();
 
         // --- Turn 1: Send a first batch ---
-        const { batchId: batchId1, conversationIds: conversationIds1 } =
-          await sendBatchCallToLlm(authenticator, llm, [
+        const sendBatchCallResult1 = await sendBatchCallToLlm(
+          authenticator,
+          llm,
+          [
             makeConversationOptions(
               "Remember this number: 42. Just confirm you noted it.",
               { title: "Multi-turn Test" }
             ),
-          ]);
+          ]
+        );
+        if (sendBatchCallResult1.isErr()) {
+          throw sendBatchCallResult1.error;
+        }
+        const { batchId: batchId1, conversationIds: conversationIds1 } =
+          sendBatchCallResult1.value;
 
         const conversationId = conversationIds1[0];
 
@@ -341,13 +352,21 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         );
 
         // --- Turn 2: Send a follow-up on the same conversation ---
-        const { batchId: batchId2, conversationIds: conversationIds2 } =
-          await sendBatchCallToLlm(authenticator, llm, [
+        const sendBatchCallResult2 = await sendBatchCallToLlm(
+          authenticator,
+          llm,
+          [
             makeConversationOptions(
               "What was the number I told you to remember? Reply with just the number.",
               { existingConversationId: conversationId }
             ),
-          ]);
+          ]
+        );
+        if (sendBatchCallResult2.isErr()) {
+          throw sendBatchCallResult2.error;
+        }
+        const { batchId: batchId2, conversationIds: conversationIds2 } =
+          sendBatchCallResult2.value;
 
         // The returned conversationId should be the same.
         expect(conversationIds2[0]).toBe(conversationId);

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -53,6 +53,7 @@ function makeConversationOptions(
   return {
     newMessages: [makeUserMessage(question)],
     prompt: "You are a helpful assistant. Be concise.",
+    userContextOrigin: "api",
     specifications: [],
     ...overrides,
   };

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -1,10 +1,10 @@
 import { getLLM } from "@app/lib/api/llm";
 import type { LlmConversationOptions } from "@app/lib/api/llm/batch_llm";
 import {
-  createLlmConversation,
   downloadBatchResultFromLlm,
   sendBatchCallToLlm,
   storeLlmResult,
+  writeBatchUserMessages,
 } from "@app/lib/api/llm/batch_llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
@@ -17,6 +17,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
@@ -94,7 +95,7 @@ async function setupTest(): Promise<{
 async function awaitBatch(llm: LLM, batchId: string): Promise<void> {
   let status = await llm.getBatchStatus(batchId);
   while (status === "computing") {
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    await setTimeoutAsync(POLL_INTERVAL_MS);
     status = await llm.getBatchStatus(batchId);
   }
   expect(status).toBe("ready");
@@ -233,13 +234,13 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
     );
 
     it(
-      "createLlmConversation + storeLlmResult stores data for a streamed call",
+      "writeBatchUserMessages + storeLlmResult stores data for a streamed call",
       async () => {
         const { authenticator, workspace, llm, agentConfigurationId } =
           await setupTest();
 
         // Create conversation and user message.
-        const conversation = await createLlmConversation(
+        const conversation = await writeBatchUserMessages(
           authenticator,
           makeConversationOptions("What is 2+2? Reply with just the number.", {
             title: "Stream Store Test",

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -1,0 +1,376 @@
+import { getLLM } from "@app/lib/api/llm";
+import type { LlmConversationOptions } from "@app/lib/api/llm/batch_llm";
+import {
+  createLlmConversation,
+  downloadBatchResultFromLlm,
+  sendBatchCallToLlm,
+  storeLlmResult,
+} from "@app/lib/api/llm/batch_llm";
+import type { LLM } from "@app/lib/api/llm/llm";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the tokenizer to avoid CoreAPI dependency in tests.
+vi.mock("@app/lib/tokenization", () => ({
+  tokenCountForTexts: vi.fn(async (texts: string[]) => {
+    return new Ok(texts.map((t) => t.length));
+  }),
+}));
+
+const POLL_INTERVAL_MS = 5000;
+const TEST_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour — batches can take a while
+
+function makeUserMessage(
+  text: string
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return {
+    role: "user",
+    name: "User",
+    content: [{ type: "text", text }],
+  };
+}
+
+function makeConversationOptions(
+  question: string,
+  overrides?: Partial<LlmConversationOptions>
+): LlmConversationOptions {
+  return {
+    newMessages: [makeUserMessage(question)],
+    prompt: "You are a helpful assistant. Be concise.",
+    specifications: [],
+    ...overrides,
+  };
+}
+
+async function setupTest(): Promise<{
+  authenticator: Authenticator;
+  workspace: LightWorkspaceType;
+  llm: LLM;
+  agentConfigurationId: string;
+}> {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+
+  const credentials = await getLlmCredentials(authenticator, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+
+  const llm = await getLLM(authenticator, {
+    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    bypassFeatureFlag: true,
+    credentials,
+  });
+  if (!llm) {
+    throw new Error("Failed to create LLM");
+  }
+
+  const agentConfig =
+    await AgentConfigurationFactory.createTestAgent(authenticator);
+
+  return {
+    authenticator,
+    workspace,
+    llm,
+    agentConfigurationId: agentConfig.sId,
+  };
+}
+
+async function awaitBatch(llm: LLM, batchId: string): Promise<void> {
+  let status = await llm.getBatchStatus(batchId);
+  while (status === "computing") {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    status = await llm.getBatchStatus(batchId);
+  }
+  expect(status).toBe("ready");
+}
+
+/**
+ * Batch LLM Storage Integration Tests
+ *
+ * These tests verify that sendBatchCallToLlm and downloadBatchResultFromLlm
+ * correctly store conversations, messages, and step contents in the database.
+ *
+ * To run from the front directory:
+ *
+ *   NODE_ENV=test FRONT_DATABASE_URI="$FRONT_DATABASE_URI"_test \
+ *     RUN_LLM_TEST=true RUN_LLM_TEST_WITH_DB=true \
+ *     npx vitest --config lib/api/llm/tests/vite.config.js --run lib/api/llm/tests/batch_llm_store.test.ts
+ */
+describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
+  "Batch LLM Storage Integration Tests",
+  () => {
+    it(
+      "sendBatchCallToLlm + downloadBatchResultFromLlm stores conversations, messages, and step contents",
+      async () => {
+        const { authenticator, workspace, llm, agentConfigurationId } =
+          await setupTest();
+
+        // --- Step 1: Send a batch with a single conversation ---
+        const { batchId, conversationIds } = await sendBatchCallToLlm(
+          authenticator,
+          llm,
+          [
+            makeConversationOptions(
+              "What is 1+1? Reply with just the number.",
+              { title: "Batch Store Test" }
+            ),
+          ]
+        );
+
+        expect(batchId).toBeTruthy();
+        expect(conversationIds).toHaveLength(1);
+        const conversationId = conversationIds[0];
+
+        // Verify conversation was created.
+        const conversation = await ConversationResource.fetchById(
+          authenticator,
+          conversationId
+        );
+        expect(conversation).not.toBeNull();
+        if (!conversation) {
+          return;
+        }
+        expect(conversation.title).toBe("Batch Store Test");
+
+        // Verify user message was stored.
+        const userMessages = await MessageModel.findAll({
+          where: {
+            conversationId: conversation.id,
+            workspaceId: workspace.id,
+          },
+          include: [
+            {
+              model: UserMessageModel,
+              as: "userMessage",
+              required: true,
+            },
+          ],
+        });
+        expect(userMessages).toHaveLength(1);
+        expect(userMessages[0].userMessage?.content).toContain("1+1");
+        expect(userMessages[0].rank).toBe(0);
+
+        // --- Step 2: Poll until batch completes ---
+        await awaitBatch(llm, batchId);
+
+        // --- Step 3: Download results and store them ---
+        const results = await downloadBatchResultFromLlm(
+          authenticator,
+          llm,
+          batchId,
+          conversationIds,
+          agentConfigurationId
+        );
+
+        expect(results.size).toBe(1);
+        const events = results.get(conversationId);
+        expect(events).toBeDefined();
+
+        // Verify the response contains "2".
+        const textEvent = events?.find((e) => e.type === "text_generated");
+        expect(textEvent).toBeDefined();
+        if (textEvent?.type === "text_generated") {
+          expect(textEvent.content.text.toLowerCase()).toContain("2");
+        }
+
+        // --- Step 4: Verify agent message was stored in DB ---
+        const agentMessages = await MessageModel.findAll({
+          where: {
+            conversationId: conversation.id,
+            workspaceId: workspace.id,
+          },
+          include: [
+            {
+              model: AgentMessageModel,
+              as: "agentMessage",
+              required: true,
+            },
+          ],
+        });
+        expect(agentMessages).toHaveLength(1);
+        const agentMessageRow = agentMessages[0].agentMessage;
+        expect(agentMessageRow).not.toBeNull();
+        expect(agentMessageRow?.status).toBe("succeeded");
+        expect(agentMessageRow?.agentConfigurationId).toBe(
+          agentConfigurationId
+        );
+        // Agent message rank should be after the user message.
+        expect(agentMessages[0].rank).toBe(1);
+        // Parent should be the user message.
+        expect(agentMessages[0].parentId).toBe(userMessages[0].id);
+
+        // --- Step 5: Verify step contents were stored ---
+        const stepContents =
+          await AgentStepContentResource.fetchByAgentMessages(authenticator, {
+            agentMessageIds: agentMessageRow ? [agentMessageRow.id] : [],
+          });
+
+        // Should have at least one text_content entry.
+        const textContent = stepContents.find(
+          (sc) => sc.type === "text_content"
+        );
+        expect(textContent).toBeDefined();
+        expect(textContent?.step).toBe(0);
+        expect(textContent?.version).toBe(0);
+      },
+      TEST_TIMEOUT_MS
+    );
+
+    it(
+      "createLlmConversation + storeLlmResult stores data for a streamed call",
+      async () => {
+        const { authenticator, workspace, llm, agentConfigurationId } =
+          await setupTest();
+
+        // Create conversation and user message.
+        const conversation = await createLlmConversation(
+          authenticator,
+          makeConversationOptions("What is 2+2? Reply with just the number.", {
+            title: "Stream Store Test",
+          })
+        );
+
+        // Build LLMStreamParameters for the streaming call.
+        const streamParams: LLMStreamParameters = {
+          conversation: {
+            messages: [
+              makeUserMessage("What is 2+2? Reply with just the number."),
+            ],
+          },
+          prompt: "You are a helpful assistant. Be concise.",
+          specifications: [],
+        };
+
+        // Stream the LLM call and collect events.
+        const events = [];
+        for await (const event of llm.stream(streamParams)) {
+          events.push(event);
+        }
+
+        // Store the result.
+        await storeLlmResult(
+          authenticator,
+          conversation,
+          events,
+          agentConfigurationId
+        );
+
+        // Verify conversation.
+        expect(conversation.title).toBe("Stream Store Test");
+
+        // Verify all messages in the conversation (1 user + 1 agent).
+        const allMessages = await MessageModel.findAll({
+          where: {
+            conversationId: conversation.id,
+            workspaceId: workspace.id,
+          },
+          order: [["rank", "ASC"]],
+        });
+        expect(allMessages).toHaveLength(2);
+        expect(allMessages[0].userMessageId).not.toBeNull();
+        expect(allMessages[1].agentMessageId).not.toBeNull();
+
+        // Verify agent message status.
+        const agentMessage = await AgentMessageModel.findOne({
+          where: {
+            id: allMessages[1].agentMessageId!,
+            workspaceId: workspace.id,
+          },
+        });
+        expect(agentMessage?.status).toBe("succeeded");
+
+        // Verify step contents exist.
+        const stepContents =
+          await AgentStepContentResource.fetchByAgentMessages(authenticator, {
+            agentMessageIds: agentMessage ? [agentMessage.id] : [],
+          });
+
+        expect(stepContents.length).toBeGreaterThan(0);
+
+        const textContent = stepContents.find(
+          (sc) => sc.type === "text_content"
+        );
+        expect(textContent).toBeDefined();
+      },
+      TEST_TIMEOUT_MS
+    );
+
+    it(
+      "multi-turn: sendBatchCallToLlm reuses an existing conversation",
+      async () => {
+        const { authenticator, llm, agentConfigurationId } = await setupTest();
+
+        // --- Turn 1: Send a first batch ---
+        const { batchId: batchId1, conversationIds: conversationIds1 } =
+          await sendBatchCallToLlm(authenticator, llm, [
+            makeConversationOptions(
+              "Remember this number: 42. Just confirm you noted it.",
+              { title: "Multi-turn Test" }
+            ),
+          ]);
+
+        const conversationId = conversationIds1[0];
+
+        await awaitBatch(llm, batchId1);
+
+        // Download and store turn 1 results.
+        await downloadBatchResultFromLlm(
+          authenticator,
+          llm,
+          batchId1,
+          conversationIds1,
+          agentConfigurationId
+        );
+
+        // --- Turn 2: Send a follow-up on the same conversation ---
+        const { batchId: batchId2, conversationIds: conversationIds2 } =
+          await sendBatchCallToLlm(authenticator, llm, [
+            makeConversationOptions(
+              "What was the number I told you to remember? Reply with just the number.",
+              { existingConversationId: conversationId }
+            ),
+          ]);
+
+        // The returned conversationId should be the same.
+        expect(conversationIds2[0]).toBe(conversationId);
+
+        await awaitBatch(llm, batchId2);
+
+        // Download and store turn 2 results.
+        const results2 = await downloadBatchResultFromLlm(
+          authenticator,
+          llm,
+          batchId2,
+          conversationIds2,
+          agentConfigurationId
+        );
+
+        // The model should recall "42" from the previous turn.
+        const events2 = results2.get(conversationId);
+        expect(events2).toBeDefined();
+        const textEvent2 = events2?.find((e) => e.type === "text_generated");
+        expect(textEvent2).toBeDefined();
+        if (textEvent2?.type === "text_generated") {
+          expect(textEvent2.content.text).toContain("42");
+        }
+      },
+      TEST_TIMEOUT_MS
+    );
+  }
+);

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -8,9 +8,9 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";
-import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { describe, expect, it, vi } from "vitest";
 

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -10,6 +10,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { describe, expect, it, vi } from "vitest";
 
@@ -288,9 +289,7 @@ describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
           // Poll until the batch is done (up to the test timeout).
           let status = await llm.getBatchStatus(batchId);
           while (status === "computing") {
-            await new Promise((resolve) =>
-              setTimeout(resolve, POLL_INTERVAL_MS)
-            );
+            await setTimeoutAsync(POLL_INTERVAL_MS);
             status = await llm.getBatchStatus(batchId);
           }
 

--- a/front/lib/api/llm/tests/vite.config.js
+++ b/front/lib/api/llm/tests/vite.config.js
@@ -38,7 +38,11 @@ export default defineConfig(() => {
 
   // Merge with the base config and explicitly override globalSetup
   const merged = mergeConfig(baseConfig, testConfig);
-  merged.test.globalSetup = []; // Force override the globalSetup
+  // By default, skip DB setup (globalSetup/setupFiles). Set RUN_LLM_TEST_WITH_DB=true
+  // to keep them (needed for tests that store LLM results in the database).
+  if (process.env.RUN_LLM_TEST_WITH_DB !== "true") {
+    merged.test.globalSetup = [];
+  }
   merged.test.environment = "node"; // LLM tests need Node.js env for stream uploads
   return merged;
 });

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -131,3 +131,8 @@ export interface LLMStreamParameters {
   forceToolCall?: ForceToolCall;
   omittedThinking?: boolean;
 }
+
+export type LLMParametersWithoutConversation = Omit<
+  LLMStreamParameters,
+  "conversation"
+>;

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -11,6 +11,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -397,29 +398,35 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     CreationAttributes<AgentStepContentModel>,
     "version"
   >): Promise<AgentStepContentResource> {
-    const existingContent = await this.model.findAll({
-      where: {
-        agentMessageId,
-        step,
-        index,
-        workspaceId,
-      },
-      order: [["version", "DESC"]],
-      attributes: ["version"],
-      limit: 1,
-    });
+    return withTransaction(async (transaction: Transaction) => {
+      const existingContent = await this.model.findAll({
+        where: {
+          agentMessageId,
+          step,
+          index,
+          workspaceId,
+        },
+        order: [["version", "DESC"]],
+        attributes: ["version"],
+        limit: 1,
+        transaction,
+      });
 
-    const currentMaxVersion =
-      existingContent.length > 0 ? existingContent[0].version + 1 : 0;
+      const currentMaxVersion =
+        existingContent.length > 0 ? existingContent[0].version + 1 : 0;
 
-    return this.makeNew({
-      agentMessageId,
-      workspaceId,
-      step,
-      index,
-      version: currentMaxVersion,
-      type,
-      value,
+      return this.makeNew(
+        {
+          agentMessageId,
+          workspaceId,
+          step,
+          index,
+          version: currentMaxVersion,
+          type,
+          value,
+        },
+        transaction
+      );
     });
   }
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -387,18 +387,18 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     };
   }
 
-  static async createNewVersion({
-    agentMessageId,
-    workspaceId,
-    step,
-    index,
-    type,
-    value,
-  }: Omit<
-    CreationAttributes<AgentStepContentModel>,
-    "version"
-  >): Promise<AgentStepContentResource> {
-    return withTransaction(async (transaction: Transaction) => {
+  static async createNewVersion(
+    {
+      agentMessageId,
+      workspaceId,
+      step,
+      index,
+      type,
+      value,
+    }: Omit<CreationAttributes<AgentStepContentModel>, "version">,
+    transaction?: Transaction
+  ): Promise<AgentStepContentResource> {
+    return withTransaction(async (t: Transaction) => {
       const existingContent = await this.model.findAll({
         where: {
           agentMessageId,
@@ -409,7 +409,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         order: [["version", "DESC"]],
         attributes: ["version"],
         limit: 1,
-        transaction,
+        transaction: t,
       });
 
       const currentMaxVersion =
@@ -425,9 +425,9 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           type,
           value,
         },
-        transaction
+        t
       );
-    });
+    }, transaction);
   }
 
   get sId(): string {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -11,7 +11,6 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -387,47 +386,41 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     };
   }
 
-  static async createNewVersion(
-    {
+  static async createNewVersion({
+    agentMessageId,
+    workspaceId,
+    step,
+    index,
+    type,
+    value,
+  }: Omit<
+    CreationAttributes<AgentStepContentModel>,
+    "version"
+  >): Promise<AgentStepContentResource> {
+    const existingContent = await this.model.findAll({
+      where: {
+        agentMessageId,
+        step,
+        index,
+        workspaceId,
+      },
+      order: [["version", "DESC"]],
+      attributes: ["version"],
+      limit: 1,
+    });
+
+    const currentMaxVersion =
+      existingContent.length > 0 ? existingContent[0].version + 1 : 0;
+
+    return this.makeNew({
       agentMessageId,
       workspaceId,
       step,
       index,
+      version: currentMaxVersion,
       type,
       value,
-    }: Omit<CreationAttributes<AgentStepContentModel>, "version">,
-    transaction?: Transaction
-  ): Promise<AgentStepContentResource> {
-    return withTransaction(async (t: Transaction) => {
-      const existingContent = await this.model.findAll({
-        where: {
-          agentMessageId,
-          step,
-          index,
-          workspaceId,
-        },
-        order: [["version", "DESC"]],
-        attributes: ["version"],
-        limit: 1,
-        transaction: t,
-      });
-
-      const currentMaxVersion =
-        existingContent.length > 0 ? existingContent[0].version + 1 : 0;
-
-      return this.makeNew(
-        {
-          agentMessageId,
-          workspaceId,
-          step,
-          index,
-          version: currentMaxVersion,
-          type,
-          value,
-        },
-        t
-      );
-    }, transaction);
+    });
   }
 
   get sId(): string {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/7201

We already have API to do batch llm calls, this wraps the calls to store the conversations in the DB in the following tables:
 - conversations
 - user_messages
 - messages
 - agent_messages
 - agent_step_contents

This will be used in Reinforced Agent is https://github.com/dust-tt/dust/pull/23312

## Tests

Added 3 units tests
```
 ✓ lib/api/llm/tests/batch_llm_store.test.ts (3 tests) 382798ms
   ✓ Batch LLM Storage Integration Tests (3)
     ✓ sendBatchCallToLlm + downloadBatchResultFromLlm stores conversations, messages, and step contents  105916ms
     ✓ createLlmConversation + storeLlmResult stores data for a streamed call  1803ms
     ✓ multi-turn: sendBatchCallToLlm reuses an existing conversation  275078ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  17:37:22
   Duration  390.40s (transform 1.34s, setup 263ms, import 3.83s, tests 382.80s, environment 0ms)

```

## Risk

low
These conversations are now stored as workspace conversations and messages, they may be counted as normal conversation somewhere they should not.
Esay to revert if necessary

## Deploy Plan

deploy front
