### PR TITLE
Add send_mail functionality to Outlook integration

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -416,6 +416,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_contacts": "never_ask",
     "get_drafts": "never_ask",
     "get_messages": "never_ask",
+    "send_mail": "high",
     "update_contact": "high",
   },
   "outlook_calendar": {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -486,6 +486,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_arguments_requiring_approval: {
       create_draft: ["to"],
+      send_mail: ["to"],
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -147,6 +147,38 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       done: "Create reply draft",
     },
   },
+  send_mail: {
+    description: `Send an email directly via Outlook.
+- The email will be sent immediately without creating a draft.
+- Use this when all required email information is already available.
+- The email will include proper recipients, body formatting, and optional importance.`,
+    schema: {
+      to: z
+        .array(z.string())
+        .min(1)
+        .describe("The email addresses of the recipients"),
+      cc: z.array(z.string()).optional().describe("The email addresses to CC"),
+      bcc: z
+        .array(z.string())
+        .optional()
+        .describe("The email addresses to BCC"),
+      subject: z.string().describe("The subject line of the email"),
+      contentType: z
+        .string()
+        .default("text")
+        .describe("The content type of the email (text or html)."),
+      body: z.string().describe("The body of the email"),
+      importance: z
+        .string()
+        .optional()
+        .describe("The importance level of the email"),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Sending email",
+      done: "Send email",
+    },
+  },
   get_contacts: {
     description:
       "Get contacts from Outlook. Supports search queries to filter contacts.",
@@ -255,9 +287,9 @@ export const OUTLOOK_MAIL_SERVER = {
     description: "Read emails, manage drafts and contacts.",
     authorization: {
       provider: "microsoft_tools",
-      supported_use_cases: ["personal_actions"],
+      supported_use_cases: ["personal_actions", "platform_actions"],
       scope:
-        "Mail.ReadWrite Mail.ReadWrite.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
+        "Mail.ReadWrite Mail.ReadWrite.Shared Mail.Send Mail.Send.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -338,6 +338,70 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     ]);
   },
 
+  send_mail: async (
+    { to, cc, bcc, subject, contentType, body, importance = "normal" },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const message: Record<string, unknown> = {
+      subject,
+      importance,
+      body: {
+        contentType,
+        content: body,
+      },
+      toRecipients: to.map((email) => ({
+        emailAddress: { address: email },
+      })),
+    };
+
+    if (cc && cc.length > 0) {
+      message.ccRecipients = cc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    if (bcc && bcc.length > 0) {
+      message.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    const response = await fetchFromOutlook("/me/sendMail", accessToken, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(new MCPError(`Failed to send email: ${errorText}`));
+    }
+
+    return new Ok([
+      { type: "text" as const, text: "Email sent successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            subject,
+            to,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+
   delete_draft: async ({ messageId, subject, to }, { authInfo }) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {

--- a/front/lib/api/oauth/providers/microsoft_tools.ts
+++ b/front/lib/api/oauth/providers/microsoft_tools.ts
@@ -160,7 +160,12 @@ export class MicrosoftToolsOAuthProvider implements BaseOAuthStrategyProvider {
     }
   ): Promise<ExtraConfigType> {
     if (useCase === "personal_actions") {
-      const { mcp_server_id, ...restConfig } = extraConfig;
+      const {
+        mcp_server_id,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we always remove client_secret from persisted extra config.
+        client_secret,
+        ...restConfig
+      } = extraConfig;
 
       if (mcp_server_id) {
         const oauthConnectionIdRes =

--- a/front/lib/api/oauth/providers/microsoft_tools.ts
+++ b/front/lib/api/oauth/providers/microsoft_tools.ts
@@ -1,18 +1,30 @@
 import config from "@app/lib/api/config";
-import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import type { OAuthError } from "@app/lib/api/oauth";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
+import type {
+  BaseOAuthStrategyProvider,
+  RelatedCredential,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
 export class MicrosoftToolsOAuthProvider implements BaseOAuthStrategyProvider {
+  requiresWorkspaceConnectionForPersonalAuth = true;
+
   setupUri({
     connection,
     useCase,
@@ -55,10 +67,129 @@ export class MicrosoftToolsOAuthProvider implements BaseOAuthStrategyProvider {
   }
 
   isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
-    if (useCase === "personal_actions" || useCase === "platform_actions") {
+    if (useCase === "personal_actions") {
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+      return !!extraConfig.scope;
+    }
+
+    if (useCase === "platform_actions") {
       // Require scope to be specified for Microsoft Tools
       return !!extraConfig.scope;
     }
     return Object.keys(extraConfig).length === 0;
+  }
+
+  async getRelatedCredential(
+    auth: Authenticator,
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<Result<RelatedCredential, OAuthError> | undefined> {
+    if (useCase === "personal_actions") {
+      const { mcp_server_id } = extraConfig;
+
+      if (mcp_server_id) {
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getAccessToken({
+          connectionId: oauthConnectionIdRes.value,
+        });
+        if (connectionRes.isErr()) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to get connection metadata: " +
+              connectionRes.error.message,
+            oAuthAPIError: connectionRes.error,
+          });
+        }
+        const connection = connectionRes.value.connection;
+        const connectionId = connection.connection_id;
+
+        return new Ok({
+          content: {
+            from_connection_id: connectionId,
+          },
+          metadata: { workspace_id: workspaceId, user_id: userId },
+        });
+      }
+    }
+
+    const { client_id, client_secret } = extraConfig;
+
+    // No explicit workspace credential to create (default app credentials path).
+    if (!client_id || !client_secret) {
+      return undefined;
+    }
+
+    return new Ok({
+      content: {
+        client_secret,
+        client_id,
+      },
+      metadata: { workspace_id: workspaceId, user_id: userId },
+    });
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase === "personal_actions") {
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getAccessToken({
+          connectionId: oauthConnectionIdRes.value,
+        });
+        if (connectionRes.isErr()) {
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+        const connection = connectionRes.value.connection;
+
+        return {
+          client_id: connection.metadata.client_id,
+          ...restConfig,
+        };
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we filter out the client_secret from the extraConfig.
+    const { client_secret, ...restConfig } = extraConfig;
+
+    return restConfig;
   }
 }


### PR DESCRIPTION
## Description

- Introduced a new action `send_mail` to send emails directly via Outlook without creating drafts.
- Updated `OUTLOOK_TOOLS_METADATA` to include detailed schema and description for the `send_mail` action.
- Enhanced `OUTLOOK_MAIL_SERVER` to support the new action by adding necessary permissions.
- Implemented the `send_mail` handler to manage email sending, including handling recipients and error responses.
- Updated constants to require approval for the new action.

## Tests

Manual test
- Sent HTML encoded emails using both a personal credential and a shared credential configuration to my Dust address.

## Risk

N/A

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
