### PR TITLE
[Email] Add confirmation to workspace email agents toggle

### DIFF
--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   ActionMailAiIcon,
   BookOpenIcon,
+  Button,
   Chip,
   ContextItem,
   Dialog,
@@ -99,16 +100,20 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
               disabled: isChanging,
               variant: "outline",
             }}
-            rightButtonProps={{
-              label: confirmButtonLabel,
-              disabled: isChanging,
-              variant: nextIsEnabled ? "primary" : "warning",
-              onClick: async () => {
-                await doToggleEmailAgents();
-                setIsConfirmOpen(false);
-              },
-            }}
-          />
+          >
+            <Button
+              label={confirmButtonLabel}
+              disabled={isChanging}
+              variant={nextIsEnabled ? "primary" : "warning"}
+              onClick={async () => {
+                const isSuccess = await doToggleEmailAgents();
+
+                if (isSuccess) {
+                  setIsConfirmOpen(false);
+                }
+              }}
+            />
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -4,9 +4,23 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   ActionMailAiIcon,
   BookOpenIcon,
+  Chip,
   ContextItem,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   SliderToggle,
 } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE =
+  "All users in your company will be able to forward emails to their agents. " +
+  "As a general rule, caution is advised when forwarding emails or attachments " +
+  "from untrusted sources, since those are exposed to security risks such as " +
+  "prompt injection.";
 
 interface EmailAgentsToggleProps {
   owner: WorkspaceType;
@@ -16,35 +30,87 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
   const { isEnabled, isChanging, doToggleEmailAgents } = useEmailAgentsToggle({
     owner,
   });
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const nextIsEnabled = !isEnabled;
+  const confirmDialogTitle = nextIsEnabled
+    ? "Enable email agents"
+    : "Disable email agents";
+  const confirmDialogDescription = nextIsEnabled
+    ? ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE
+    : `All users in your company will no longer be able to forward emails to their agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}.`;
+  const confirmButtonLabel = nextIsEnabled
+    ? "Enable email agents"
+    : "Disable email agents";
 
   return (
-    <ContextItem
-      title="Email agents"
-      subElement={
-        <div className="flex flex-row items-center gap-2">
-          <span>
-            Allow workspace members to email agents at{" "}
-            <code>AGENT_NAME@{ASSISTANT_EMAIL_SUBDOMAIN}</code>
-          </span>
-          <a
-            href="https://dust-tt.notion.site/Email-Agents-32028599d94181209594fbf1402b720d"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-action-400 hover:text-action-500 text-sm"
-          >
-            <BookOpenIcon className="h-4 w-4" />
-          </a>
-        </div>
-      }
-      visual={<ActionMailAiIcon className="h-6 w-6" />}
-      hasSeparatorIfLast={true}
-      action={
-        <SliderToggle
-          selected={isEnabled}
-          disabled={isChanging}
-          onClick={doToggleEmailAgents}
-        />
-      }
-    />
+    <>
+      <ContextItem
+        title={
+          <div className="flex items-center gap-2">
+            <span>Email agents</span>
+            <Chip size="xs" color="golden" label="Beta" />
+          </div>
+        }
+        subElement={
+          <div className="flex flex-row items-center gap-2">
+            <span>
+              Allow workspace members to email agents at{" "}
+              <code>AGENT_NAME@{ASSISTANT_EMAIL_SUBDOMAIN}</code>
+            </span>
+            <a
+              href="https://dust-tt.notion.site/Email-Agents-32028599d94181209594fbf1402b720d"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-action-400 hover:text-action-500 text-sm"
+            >
+              <BookOpenIcon className="h-4 w-4" />
+            </a>
+          </div>
+        }
+        visual={<ActionMailAiIcon className="h-6 w-6" />}
+        hasSeparatorIfLast={true}
+        action={
+          <SliderToggle
+            selected={isEnabled}
+            disabled={isChanging}
+            onClick={() => {
+              setIsConfirmOpen(true);
+            }}
+          />
+        }
+      />
+      <Dialog
+        open={isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsConfirmOpen(false);
+          }
+        }}
+      >
+        <DialogContent size="md" isAlertDialog>
+          <DialogHeader hideButton>
+            <DialogTitle>{confirmDialogTitle}</DialogTitle>
+            <DialogDescription>{confirmDialogDescription}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              disabled: isChanging,
+              variant: "outline",
+            }}
+            rightButtonProps={{
+              label: confirmButtonLabel,
+              disabled: isChanging,
+              variant: nextIsEnabled ? "primary" : "warning",
+              onClick: async () => {
+                await doToggleEmailAgents();
+                setIsConfirmOpen(false);
+              },
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/front/hooks/useEmailAgentsToggle.ts
+++ b/front/hooks/useEmailAgentsToggle.ts
@@ -32,14 +32,17 @@ export function useEmailAgentsToggle({ owner }: UseEmailAgentsToggleProps) {
         throw new Error("Failed to update Email agents setting");
       }
       setIsEnabled(!isEnabled);
+      return true;
     } catch (error) {
       sendNotification({
         type: "error",
         title: "Failed to update Email agents setting",
         description: normalizeError(error).message,
       });
+      return false;
+    } finally {
+      setIsChanging(false);
     }
-    setIsChanging(false);
   };
 
   return {


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/22897.

Adds a `Beta` chip to the workspace email agents setting and routes toggle changes through a confirmation dialog.
When enabling the feature, the dialog shows the prompt injection warning for forwarded emails and attachments.

<img width="891" height="160" alt="image" src="https://github.com/user-attachments/assets/6762ed0a-1704-4f09-85a4-51bf934b35f7" />


#### Confirmation:

<img width="892" height="196" alt="image" src="https://github.com/user-attachments/assets/3e1c1098-bdee-4452-96ca-e835c97a7e63" />


## Risks
Blast radius: admin workspace settings for the email agents capability in front.
Risk: low

## Deploy Plan
- pmrr
- deploy front
