### PR TITLE
Bump Slack channel list limit

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -29,7 +29,7 @@ interface CanvasCreateResult extends WebAPICallResult {
 export const MAX_CHANNEL_SEARCH_RESULTS = 20;
 export const MAX_THREAD_MESSAGES = 200;
 export const SLACK_API_PAGE_SIZE = 200; // Slack recommendation 100 to 200 and max 1000 per request.
-export const MAX_PUBLIC_CHANNELS_LIMIT = 1000; // conversations.list is Tier 2 (20 req/min) => max 5 request plus cache TTL.
+export const MAX_PUBLIC_CHANNELS_LIMIT = 4000; // conversations.list is Tier 2 (20 req/min) => max 20 request plus cache TTL.
 export const DEFAULT_THREAD_MESSAGES = 20;
 export const SLACK_THREAD_LISTING_LIMIT = 100;
 export const CHANNEL_CACHE_TTL_MS = 60 * 10 * 1000;


### PR DESCRIPTION
## Description

* Customer channels are never being found due to limits
* Increasing limit to be closer to the Tier 2 slack limit

## Tests

* N/a

## Risk

* Low

## Deploy Plan

* Deploy front