### PR TITLE
Show error message when failing to stream agent message events, automatically try resuming on focus.

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -26,6 +26,7 @@ import {
   isHandoverUserMessage,
   isMessageTemporayState,
   isUserMessage,
+  makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
 import { ConfirmContext } from "@app/components/Confirm";
 import {
@@ -53,15 +54,18 @@ import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isInlineActivityEnabled as isDevInlineActivityEnabled } from "@app/lib/development";
+import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
+import type { FetchConversationMessageResponseLight } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import {
   canShowAgentConversationActions,
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
+import { isUserMessageType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
@@ -189,6 +193,7 @@ export function AgentMessage({
   additionalMarkdownPlugins,
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
+  const [streamId, setStreamId] = useState<string>(`message-${sId}`);
   const { hasFeature } = useFeatureFlags();
   const isCollapsibleEnabled = hasFeature("collapsible_messages");
 
@@ -232,7 +237,7 @@ export function AgentMessage({
     [triggeringUser, user.sId]
   );
 
-  const { shouldStream } = useAgentMessageStream({
+  const { shouldStream, streamError } = useAgentMessageStream({
     agentMessage: agentMessage,
     conversationId,
     owner,
@@ -355,7 +360,7 @@ export function AgentMessage({
         mutateSandboxFiles,
       ]
     ),
-    streamId: `message-${sId}`,
+    streamId,
     useFullChainOfThought: false,
   });
 
@@ -622,6 +627,48 @@ export function AgentMessage({
     [retryMessage]
   );
 
+  const reloadMessage = useCallback(
+    async ({
+      conversationId,
+      messageId,
+    }: {
+      conversationId: string;
+      messageId: string;
+    }) => {
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}?viewType=light`
+      );
+      if (response.ok) {
+        const msg: FetchConversationMessageResponseLight =
+          await response.json();
+        // Update the message state from the backend
+        methods.data.map((m) => {
+          if (m.sId === msg.message.sId && !isUserMessageType(msg.message)) {
+            return makeInitialMessageStreamState(msg.message);
+          }
+          return m;
+        });
+        // Force the stream to be re-created if needed
+        setStreamId(`message-${msg.message.sId}-${Date.now()}`);
+      }
+    },
+    [owner.sId, methods.data]
+  );
+
+  useEffect(() => {
+    if (!!streamError) {
+      // Hook to the focus event of the document to try reloading the message automatically
+      const handleFocus = () => {
+        void reloadMessage({ conversationId, messageId: agentMessage.sId });
+        window.removeEventListener("focus", handleFocus);
+      };
+      window.addEventListener("focus", handleFocus);
+      return () => {
+        window.removeEventListener("focus", handleFocus);
+      };
+    }
+  }, [streamError, reloadMessage, conversationId, agentMessage.sId]);
+
   // Add feedback buttons (always visible)
   if (shouldShowFeedback) {
     alwaysVisibleButtons.push(
@@ -830,11 +877,13 @@ export function AgentMessage({
           owner={owner}
           conversationId={conversationId}
           retryHandler={retryHandler}
+          reloadMessage={reloadMessage}
           isRetryHandlerProcessing={isRetryHandlerProcessing}
           isLastMessage={isLastMessage}
           agentMessage={agentMessage}
           references={references}
           streaming={shouldStream}
+          streamError={streamError}
           lastTokenClassification={
             agentMessage.streaming.agentState === "thinking" ? "tokens" : null
           }
@@ -945,12 +994,14 @@ function AgentMessageContent({
   agentMessage,
   references,
   streaming,
+  streamError,
   lastTokenClassification,
   owner,
   conversationId,
   activeReferences,
   setActiveReferences,
   retryHandler,
+  reloadMessage,
   isRetryHandlerProcessing,
   onQuickReplySend,
   additionalMarkdownComponents: propsAdditionalMarkdownComponents,
@@ -965,10 +1016,15 @@ function AgentMessageContent({
     messageId: string;
     blockedOnly?: boolean;
   }) => Promise<void>;
+  reloadMessage: (params: {
+    conversationId: string;
+    messageId: string;
+  }) => Promise<void>;
   isRetryHandlerProcessing: boolean;
   agentMessage: MessageTemporaryState;
   references: { [key: string]: MCPReferenceCitation };
   streaming: boolean;
+  streamError: Error | null;
   lastTokenClassification: null | "tokens" | "chain_of_thought";
   activeReferences: { index: number; document: MCPReferenceCitation }[];
   setActiveReferences: (
@@ -1142,6 +1198,22 @@ function AgentMessageContent({
           />
         );
     }
+  }
+
+  if (agentMessage.status === "created" && !!streamError) {
+    return (
+      <ErrorMessage
+        error={{
+          message:
+            "Connection lost while generating message. Please try again.",
+          code: "stream_error",
+          metadata: {},
+        }}
+        retryHandler={() =>
+          reloadMessage({ conversationId, messageId: agentMessage.sId })
+        }
+      />
+    );
   }
 
   if (agentMessage.status === "failed") {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -14,6 +14,7 @@ import type {
 } from "@app/components/assistant/conversation/types";
 import {
   areSameRankAndBranch,
+  convertLightMessageTypeToVirtuosoMessages,
   getPredicateForRankAndBranch,
   isMessageTemporayState,
   isUserMessage,
@@ -41,14 +42,8 @@ import type { DustError } from "@app/lib/error";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
-import type {
-  ConversationWithoutContentType,
-  LightMessageType,
-} from "@app/types/assistant/conversation";
-import {
-  isUserMessageType,
-  isUserMessageTypeWithContentFragments,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import {
   isRichAgentMention,
@@ -983,12 +978,3 @@ export const ConversationViewer = ({
     </>
   );
 };
-
-const convertLightMessageTypeToVirtuosoMessages = (
-  messages: LightMessageType[]
-) =>
-  messages.map((message) =>
-    isUserMessageTypeWithContentFragments(message)
-      ? message
-      : makeInitialMessageStreamState(message)
-  );

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -13,10 +13,14 @@ import type {
   ConversationWithoutContentType,
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
+  LightMessageType,
   UserMessageOrigin,
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
-import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
+import {
+  isLightAgentMessageWithActionsType,
+  isUserMessageTypeWithContentFragments,
+} from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { ButlerSuggestionPublicType } from "@app/types/conversation_butler_suggestion";
@@ -177,3 +181,12 @@ export const isSidekickBootstrapMessage = (
 ): boolean => {
   return message.context.origin === "agent_sidekick" && message.rank === 0;
 };
+
+export const convertLightMessageTypeToVirtuosoMessages = (
+  messages: LightMessageType[]
+) =>
+  messages.map((message) =>
+    isUserMessageTypeWithContentFragments(message)
+      ? message
+      : makeInitialMessageStreamState(message)
+  );

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -471,11 +471,17 @@ export function useAgentMessageStream({
     [customOnEventCallback, methods, sId]
   );
 
-  useEventSource(buildEventSourceURL, onEventCallback, streamId, {
-    isReadyToConsumeStream: shouldStream,
-  });
+  const { isError } = useEventSource(
+    buildEventSourceURL,
+    onEventCallback,
+    streamId,
+    {
+      isReadyToConsumeStream: shouldStream,
+    }
+  );
 
   return {
+    streamError: isError,
     shouldStream,
     isFreshMountWithContent,
   };

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -95,12 +95,16 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { MessageType } from "@app/types/assistant/conversation";
+import type {
+  LightMessageType,
+  MessageType,
+} from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -108,11 +112,17 @@ export type FetchConversationMessageResponse = {
   message: MessageType;
 };
 
+export type FetchConversationMessageResponseLight = {
+  message: LightMessageType;
+};
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      FetchConversationMessageResponse | { success: boolean }
+      | FetchConversationMessageResponse
+      | FetchConversationMessageResponseLight
+      | { success: boolean }
     >
   >,
   auth: Authenticator
@@ -169,11 +179,13 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
+      const viewType = req.query.viewType === "light" ? "light" : "full";
+
       const renderedMessages = await batchRenderMessages(
         auth,
         conversation,
         [message],
-        "full"
+        viewType
       );
 
       if (renderedMessages.isErr()) {
@@ -186,7 +198,23 @@ async function handler(
         });
       }
 
-      res.status(200).json({ message: renderedMessages.value[0] });
+      switch (viewType) {
+        case "light": {
+          res
+            .status(200)
+            .json({ message: renderedMessages.value[0] as LightMessageType });
+          return;
+        }
+        case "full": {
+          res
+            .status(200)
+            .json({ message: renderedMessages.value[0] as MessageType });
+          return;
+        }
+        default:
+          assertNever(viewType);
+      }
+
       return;
     }
 


### PR DESCRIPTION
## Description

Surface error to user when failing to stream events while generating a message.
Also try to automatically resume when window goes back in focus.

## Tests

Locally, blocking the events endpoint.

## Risk

Low

## Deploy Plan

Deploy front-spa