### PR TITLE
Skip snippets if the list attachments command output is > 256ko

### DIFF
--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -1,0 +1,143 @@
+import type { FileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { describe, expect, it } from "vitest";
+
+import { contentFromAttachments } from "./index";
+
+function makeFileAttachment(
+  partial: Partial<FileAttachmentType> &
+    Pick<FileAttachmentType, "fileId" | "title" | "isInProjectContext">
+): FileAttachmentType {
+  return {
+    contentType: "text/plain",
+    contentFragmentVersion: "latest",
+    snippet: null,
+    generatedTables: [],
+    isIncludable: true,
+    isSearchable: true,
+    isQueryable: false,
+    creator: null,
+    source: null,
+    ...partial,
+  };
+}
+
+describe("contentFromAttachments", () => {
+  it("returns an empty string when there are no attachments", () => {
+    expect(contentFromAttachments([])).toBe("");
+  });
+
+  it("lists direct attachments under the direct header", () => {
+    const attachments = [
+      makeFileAttachment({
+        fileId: "file-direct",
+        title: "Notes.txt",
+        isInProjectContext: false,
+        snippet: "preview",
+      }),
+    ];
+
+    const out = contentFromAttachments(attachments);
+
+    expect(out).toContain(
+      "The following files are currently attached to the conversation directly:"
+    );
+    expect(out).toContain('id="file-direct"');
+    expect(out).toContain('title="Notes.txt"');
+    expect(out).toContain(">preview\n</attachment>");
+    expect(out).not.toContain("via the project context");
+  });
+
+  it("lists project-context attachments under the project header", () => {
+    const attachments = [
+      makeFileAttachment({
+        fileId: "file-proj",
+        title: "Spec.md",
+        isInProjectContext: true,
+        snippet: null,
+      }),
+    ];
+
+    const out = contentFromAttachments(attachments);
+
+    expect(out).toContain(
+      "The following files are currently attached to the conversation via the project context:"
+    );
+    expect(out).toContain('id="file-proj"');
+    expect(out).toContain('isInProjectContext="true"');
+    expect(out).toMatch(/<attachment[\s\S]*?\/>/);
+    expect(out).not.toContain("</attachment>");
+    expect(out).not.toContain("attached to the conversation directly");
+  });
+
+  it("places all direct attachments before all project-context attachments", () => {
+    const attachments = [
+      makeFileAttachment({
+        fileId: "proj-first",
+        title: "A",
+        isInProjectContext: true,
+      }),
+      makeFileAttachment({
+        fileId: "direct-mid",
+        title: "B",
+        isInProjectContext: false,
+      }),
+      makeFileAttachment({
+        fileId: "proj-last",
+        title: "C",
+        isInProjectContext: true,
+      }),
+    ];
+
+    const out = contentFromAttachments(attachments);
+
+    const idxDirectHeader = out.indexOf("conversation directly:");
+    const idxProjectHeader = out.indexOf("via the project context:");
+    const idxDirectFile = out.indexOf('id="direct-mid"');
+    const idxProjFirst = out.indexOf('id="proj-first"');
+    const idxProjLast = out.indexOf('id="proj-last"');
+
+    expect(idxDirectHeader).toBeLessThan(idxProjectHeader);
+    expect(idxDirectHeader).toBeLessThan(idxDirectFile);
+    expect(idxDirectFile).toBeLessThan(idxProjectHeader);
+    expect(idxProjectHeader).toBeLessThan(idxProjFirst);
+    expect(idxProjFirst).toBeLessThan(idxProjLast);
+  });
+
+  it("separates multiple attachments in the same section with a newline", () => {
+    const attachments = [
+      makeFileAttachment({
+        fileId: "a",
+        title: "A",
+        isInProjectContext: false,
+      }),
+      makeFileAttachment({
+        fileId: "b",
+        title: "B",
+        isInProjectContext: false,
+      }),
+    ];
+
+    const out = contentFromAttachments(attachments);
+
+    expect(out).toContain("/>\n<attachment");
+  });
+
+  it("uses snippetContent for every attachment when provided", () => {
+    const attachments = [
+      makeFileAttachment({
+        fileId: "x",
+        title: "X",
+        isInProjectContext: false,
+        snippet: "original snippet",
+      }),
+    ];
+
+    const out = contentFromAttachments(
+      attachments,
+      "Snippet content too large."
+    );
+
+    expect(out).toContain(">Snippet content too large.\n</attachment>");
+    expect(out).not.toContain("original snippet");
+  });
+});

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -17,6 +17,7 @@ import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import {
   type ContentNodeAttachmentType,
+  type ConversationAttachmentType,
   conversationAttachmentId,
   isContentNodeAttachmentType,
   renderAttachmentXml,
@@ -50,6 +51,41 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 const MAX_FILE_SIZE_FOR_GREP = 20 * 1024 * 1024; // 20MB.
+const MAX_CONTENT_SIZE_FOR_LIST_FILES = 1024 * 256; // 256KB.
+
+export const contentFromAttachments = (
+  attachments: ConversationAttachmentType[],
+  snippetContent?: string
+) => {
+  let content = "";
+
+  // Directly attached files.
+  attachments
+    .filter((a) => !a.isInProjectContext)
+    .forEach((attachment, i) => {
+      if (i === 0) {
+        content +=
+          "The following files are currently attached to the conversation directly:\n";
+      } else {
+        content += "\n";
+      }
+      content += renderAttachmentXml({ attachment, content: snippetContent });
+    });
+
+  // Project context attached files.
+  attachments
+    .filter((a) => a.isInProjectContext)
+    .forEach((attachment, i) => {
+      if (i === 0) {
+        content +=
+          "The following files are currently attached to the conversation via the project context:\n";
+      } else {
+        content += "\n";
+      }
+      content += renderAttachmentXml({ attachment, content: snippetContent });
+    });
+  return content;
+};
 
 const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
   [CONVERSATION_LIST_FILES_ACTION_NAME]: async (
@@ -72,33 +108,14 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
       ]);
     }
 
-    let content = "";
+    let content = contentFromAttachments(attachments);
 
-    // Directly attached files.
-    attachments
-      .filter((a) => !a.isInProjectContext)
-      .forEach((attachment, i) => {
-        if (i === 0) {
-          content +=
-            "The following files are currently attached to the conversation directly:\n";
-        } else {
-          content += "\n";
-        }
-        content += renderAttachmentXml({ attachment });
-      });
-
-    // Project context attached files.
-    attachments
-      .filter((a) => a.isInProjectContext)
-      .forEach((attachment, i) => {
-        if (i === 0) {
-          content +=
-            "The following files are currently attached to the conversation via the project context:\n";
-        } else {
-          content += "\n";
-        }
-        content += renderAttachmentXml({ attachment });
-      });
+    if (content.length > MAX_CONTENT_SIZE_FOR_LIST_FILES) {
+      content = contentFromAttachments(
+        attachments,
+        "Snippet content too large."
+      );
+    }
 
     return new Ok([
       {


### PR DESCRIPTION
## Description

Trim so that listAttachments's output never grows too big.

## Tests

Added

## Risk

Low

## Deploy Plan

Deploy front