### PR TITLE
Remove html format from webbrowse tool, disable spider except when global kill switch for firecrawl

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -31,6 +31,11 @@ const killSwitchMap: Record<
     title: "Global Blacklist OpenAI",
     description: "Disable OpenAI models in global agents",
   },
+  global_disable_firecrawl: {
+    title: "Global Disable Firecrawl",
+    description:
+      "Disable Firecrawl for webbrowse tool, use Spider.cloud instead",
+  },
 };
 
 export function KillPage() {

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -118,13 +118,6 @@ export const WebbrowseInputSchema = z.object({
     .array()
     .max(MAX_BROWSE_URLS)
     .describe(`List of urls to browse (max: ${MAX_BROWSE_URLS})`),
-  format: z
-    .enum(["markdown", "html"])
-    .optional()
-    .describe(
-      "Format to return content: 'markdown' (default) or 'html'. " +
-        "Markdown is the default choice and should be used unless there's a specific reason for using HTML."
-    ),
   screenshotMode: z
     .enum(["none", "viewport", "fullPage"])
     .optional()

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -19,6 +19,7 @@ import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/gu
 import { WEB_SEARCH_BROWSE_TOOLS_METADATA } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
@@ -93,12 +94,10 @@ async function handleWebsearch(
 async function handleWebbrowser(
   {
     urls,
-    format = "markdown",
     screenshotMode = "none",
     links,
   }: {
     urls: string[];
-    format?: "markdown" | "html";
     screenshotMode?: "none" | "viewport" | "fullPage";
     links?: boolean;
   },
@@ -116,9 +115,13 @@ async function handleWebbrowser(
     isLightServerSideMCPToolConfiguration(toolConfiguration) &&
     toolConfiguration.additionalConfiguration[USE_SUMMARY_SWITCH] === true;
 
-  const browsingProvider = Math.random() < 0.8 ? "firecrawl" : "spider";
+  const isFirecrawlDisabled =
+    await KillSwitchResource.isKillSwitchEnabledCached(
+      "global_disable_firecrawl"
+    );
+  const browsingProvider = isFirecrawlDisabled ? "spider" : "firecrawl";
 
-  const results = await browseUrls(urls, 8, format, {
+  const results = await browseUrls(urls, 8, "markdown", {
     screenshotMode,
     links,
     provider: browsingProvider,
@@ -263,14 +266,12 @@ async function handleWebbrowser(
     }
 
     const {
-      markdown,
-      html,
+      markdown: contentText,
       title,
       description,
       screenshots: allScreenshots,
       links: outLinks,
     } = result;
-    const contentText = format === "html" ? html : markdown;
 
     const tokensRes = await tokenCountForTexts(
       [contentText ?? ""],
@@ -319,11 +320,6 @@ async function handleWebbrowser(
       description: description,
       responseCode: result.status.toString(),
     };
-
-    // Include HTML content when format is HTML
-    if (format === "html" && html) {
-      browseResult.html = html.slice(0, maxCharacters);
-    }
 
     toolContent.push({
       type: "resource" as const,

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -3,6 +3,7 @@ export const KILL_SWITCH_TYPES = [
   "save_data_source_views",
   "global_blacklist_anthropic",
   "global_blacklist_openai",
+  "global_disable_firecrawl",
 ] as const;
 export type KillSwitchType = (typeof KILL_SWITCH_TYPES)[number];
 export function isKillSwitchType(type: string): type is KillSwitchType {


### PR DESCRIPTION
## Description

Remove spider.cloud for webcrawl, except when firecrawl is disabled.
Remove "format" option.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front