### PR TITLE
Fix cross region user creation on login

### DIFF
--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -518,8 +518,9 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       const targetRegionInfo = multiRegionsConfig.getOtherRegionInfo();
       const params = new URLSearchParams();
 
-      // Use sanitizedReturnTo if available, otherwise default to "/"
-      const returnTo = sanitizedReturnTo ?? "/";
+      // Use sanitizedReturnTo if available, otherwise default to "/api/login"
+      // so that the target region creates the user in its database.
+      const returnTo = sanitizedReturnTo ?? "/api/login";
 
       params.set("returnTo", returnTo);
       if (organizationId) {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7219

When a user logs in for the first time via `app.dust.tt` and their workspace is in the EU region, the cross-region redirect sets `returnTo="/"` instead of `returnTo="/api/login"`. This means the user never hits `/api/login` on the EU side, so their account is never created in the EU database — causing the page to load indefinitely.

The normal (same-region) flow correctly defaults to `/api/login` (line 581), but the cross-region redirect path was defaulting to `/` when no explicit `returnTo` was provided.

**Flow before fix:**
1. US callback authenticates user, sees region=EU
2. Redirects to `eu.dust.tt/api/workos/login?returnTo=/`
3. EU callback completes, redirects to `/` → user never created → infinite load

**Flow after fix:**
1. US callback authenticates user, sees region=EU
2. Redirects to `eu.dust.tt/api/workos/login?returnTo=/api/login`
3. EU callback completes, redirects to `/api/login` → user created → works

## Tests

Manual verification of the redirect flow logic. The change is a single default value (`"/"` → `"/api/login"`), matching the existing same-region default at line 581.

## Risk

Low. This only changes the default `returnTo` for cross-region redirects when no explicit `returnTo` is provided. Same-region logins are unaffected.

## Deploy Plan

Standard deploy — no migration or multi-step rollout needed.