### PR TITLE
[front] enh: Add sandbox APM spans

### DIFF
--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -12,6 +12,7 @@ import type {
   SandboxImageId,
   SandboxResources,
 } from "@app/lib/api/sandbox/image/types";
+import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
 
 // ---------------------------------------------------------------------------
@@ -97,28 +98,76 @@ export class SandboxNotFoundError extends Error {
  * signal recoverable failures — callers never need try/catch.
  */
 export interface SandboxProvider {
-  create(config: SandboxCreateConfig): Promise<Result<SandboxHandle, Error>>;
-  wake(providerId: string): Promise<Result<SandboxHandle, Error>>;
-  sleep(providerId: string): Promise<Result<void, Error>>;
-  destroy(providerId: string): Promise<Result<void, Error>>;
+  create(
+    tracingOpts: { workspaceSId: string },
+    config: SandboxCreateConfig
+  ): Promise<Result<SandboxHandle, Error>>;
+  wake(
+    tracingOpts: { workspaceSId: string },
+    providerId: string
+  ): Promise<Result<SandboxHandle, Error>>;
+  sleep(
+    tracingOpts: { workspaceSId: string },
+    providerId: string
+  ): Promise<Result<void, Error>>;
+  destroy(
+    tracingOpts: { workspaceSId: string },
+    providerId: string
+  ): Promise<Result<void, Error>>;
 
   exec(
+    tracingOpts: { workspaceSId: string },
     providerId: string,
     command: string,
     opts?: ExecOptions
   ): Promise<Result<ExecResult, Error>>;
 
   writeFile(
+    tracingOpts: { workspaceSId: string },
     providerId: string,
     path: string,
     data: ArrayBuffer
   ): Promise<Result<void, Error>>;
 
-  readFile(providerId: string, path: string): Promise<Buffer>;
+  readFile(
+    tracingOpts: { workspaceSId: string },
+    providerId: string,
+    path: string
+  ): Promise<Buffer>;
 
   listFiles(
+    tracingOpts: { workspaceSId: string },
     providerId: string,
     path: string,
     opts?: { recursive?: boolean }
   ): Promise<FileEntry[]>;
+}
+
+// ---------------------------------------------------------------------------
+// APM instrumentation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps provider operations with APM spans for tracing.
+ *
+ * This helper is provider-agnostic and can be used by any SandboxProvider
+ * implementation to add lightweight APM instrumentation.
+ */
+export function traceSandboxOperation<T>(
+  operation: string,
+  fn: () => Promise<T>,
+  tags?: Record<string, string>
+): Promise<T> {
+  return tracer.trace(
+    `sandbox.provider.${operation}`,
+    { resource: operation },
+    async (span) => {
+      if (tags) {
+        Object.entries(tags).forEach(([key, value]) => {
+          span?.setTag(key, value);
+        });
+      }
+      return fn();
+    }
+  );
 }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -10,7 +10,10 @@ import type {
   SandboxHandle,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
-import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
+import {
+  SandboxNotFoundError,
+  traceSandboxOperation,
+} from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -73,6 +76,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   async create(
+    tracingOpts: { workspaceSId: string },
     config: SandboxCreateConfig
   ): Promise<Result<SandboxHandle, Error>> {
     if (!config.imageId) {
@@ -80,206 +84,287 @@ export class E2BSandboxProvider implements SandboxProvider {
         "imageId is required in SandboxCreateConfig. Use getSandboxImage().toCreateConfig() to get the config."
       );
     }
-    const templateId = formatSandboxImageId(config.imageId);
+    const imageId = formatSandboxImageId(config.imageId);
 
-    logger.info(
-      { templateId, imageId: config.imageId },
-      "Creating E2B sandbox"
+    return traceSandboxOperation(
+      "create",
+      async () => {
+        const templateId = imageId;
+
+        logger.info(
+          { templateId, imageId: config.imageId },
+          "Creating E2B sandbox"
+        );
+
+        let sandbox: Sandbox;
+        try {
+          const envVars = config.envVars ?? {};
+          const hasEnvVars = Object.keys(envVars).length > 0;
+          sandbox = await Sandbox.create(templateId, {
+            ...this.connectionOpts(),
+            envs: hasEnvVars ? envVars : undefined,
+            timeoutMs: SANDBOX_LIFETIME_MS,
+            requestTimeoutMs: REQUEST_TIMEOUT_MS,
+            network: {
+              ...(config.network ? toE2BNetworkOpts(config.network) : {}),
+              allowPublicTraffic: false,
+            },
+          });
+        } catch (err) {
+          return new Err(normalizeError(err));
+        }
+
+        logger.info(
+          { sandboxId: sandbox.sandboxId, templateId },
+          "E2B sandbox created"
+        );
+
+        return new Ok({ providerId: sandbox.sandboxId });
+      },
+      {
+        image_id: imageId,
+        workspace_id: tracingOpts.workspaceSId,
+      }
     );
+  }
 
-    let sandbox: Sandbox;
-    try {
-      const envVars = config.envVars ?? {};
-      const hasEnvVars = Object.keys(envVars).length > 0;
-      sandbox = await Sandbox.create(templateId, {
-        ...this.connectionOpts(),
-        envs: hasEnvVars ? envVars : undefined,
-        timeoutMs: SANDBOX_LIFETIME_MS,
-        requestTimeoutMs: REQUEST_TIMEOUT_MS,
-        network: {
-          ...(config.network ? toE2BNetworkOpts(config.network) : {}),
-          allowPublicTraffic: false,
-        },
-      });
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
+  async wake(
+    tracingOpts: { workspaceSId: string },
+    providerId: string
+  ): Promise<Result<SandboxHandle, Error>> {
+    return traceSandboxOperation(
+      "wake",
+      async () => {
+        logger.info({ providerId }, "Waking E2B sandbox");
 
-    logger.info(
-      { sandboxId: sandbox.sandboxId, templateId },
-      "E2B sandbox created"
+        // Sandbox.connect auto-resumes paused sandboxes.
+        try {
+          await Sandbox.connect(providerId, {
+            ...this.connectionOpts(),
+            timeoutMs: SANDBOX_LIFETIME_MS,
+          });
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
+
+        logger.info({ providerId }, "E2B sandbox woken");
+
+        return new Ok({ providerId });
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceSId,
+      }
     );
-
-    return new Ok({ providerId: sandbox.sandboxId });
   }
 
-  async wake(providerId: string): Promise<Result<SandboxHandle, Error>> {
-    logger.info({ providerId }, "Waking E2B sandbox");
+  async sleep(
+    tracingOpts: { workspaceSId: string },
+    providerId: string
+  ): Promise<Result<void, Error>> {
+    return traceSandboxOperation(
+      "sleep",
+      async () => {
+        logger.info({ providerId }, "Pausing E2B sandbox");
 
-    // Sandbox.connect auto-resumes paused sandboxes.
-    try {
-      await Sandbox.connect(providerId, {
-        ...this.connectionOpts(),
-        timeoutMs: SANDBOX_LIFETIME_MS,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return new Err(new SandboxNotFoundError(providerId));
+        let sandbox: Sandbox;
+        try {
+          sandbox = await Sandbox.connect(providerId, this.connectionOpts());
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
+
+        try {
+          await sandbox.betaPause();
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
+
+        logger.info({ providerId }, "E2B sandbox paused");
+
+        return new Ok(undefined);
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceSId,
       }
-      return new Err(normalizeError(err));
-    }
-
-    logger.info({ providerId }, "E2B sandbox woken");
-
-    return new Ok({ providerId });
+    );
   }
 
-  async sleep(providerId: string): Promise<Result<void, Error>> {
-    logger.info({ providerId }, "Pausing E2B sandbox");
+  async destroy(
+    tracingOpts: { workspaceSId: string },
+    providerId: string
+  ): Promise<Result<void, Error>> {
+    return traceSandboxOperation(
+      "destroy",
+      async () => {
+        logger.info({ providerId }, "Killing E2B sandbox");
 
-    let sandbox: Sandbox;
-    try {
-      sandbox = await Sandbox.connect(providerId, this.connectionOpts());
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return new Err(new SandboxNotFoundError(providerId));
+        try {
+          await Sandbox.kill(providerId, this.connectionOpts());
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
+
+        logger.info({ providerId }, "E2B sandbox killed");
+
+        return new Ok(undefined);
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceSId,
       }
-      return new Err(normalizeError(err));
-    }
-
-    try {
-      await sandbox.betaPause();
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return new Err(new SandboxNotFoundError(providerId));
-      }
-      return new Err(normalizeError(err));
-    }
-
-    logger.info({ providerId }, "E2B sandbox paused");
-
-    return new Ok(undefined);
-  }
-
-  async destroy(providerId: string): Promise<Result<void, Error>> {
-    logger.info({ providerId }, "Killing E2B sandbox");
-
-    try {
-      await Sandbox.kill(providerId, this.connectionOpts());
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return new Err(new SandboxNotFoundError(providerId));
-      }
-      return new Err(normalizeError(err));
-    }
-
-    logger.info({ providerId }, "E2B sandbox killed");
-
-    return new Ok(undefined);
+    );
   }
 
   async exec(
+    tracingOpts: { workspaceSId: string },
     providerId: string,
     command: string,
     opts?: ExecOptions
   ): Promise<Result<ExecResult, Error>> {
-    let sandbox: Sandbox;
-    try {
-      sandbox = await Sandbox.connect(providerId, {
-        ...this.connectionOpts(),
-        timeoutMs: SANDBOX_LIFETIME_MS,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return new Err(new SandboxNotFoundError(providerId));
-      }
-      return new Err(normalizeError(err));
-    }
+    return traceSandboxOperation(
+      "exec",
+      async () => {
+        let sandbox: Sandbox;
+        try {
+          sandbox = await Sandbox.connect(providerId, {
+            ...this.connectionOpts(),
+            timeoutMs: SANDBOX_LIFETIME_MS,
+          });
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
 
-    try {
-      const result = await sandbox.commands.run(command, {
-        cwd: opts?.workingDirectory,
-        envs: opts?.envVars,
-        timeoutMs: opts?.timeoutMs,
-      });
+        try {
+          const result = await sandbox.commands.run(command, {
+            cwd: opts?.workingDirectory,
+            envs: opts?.envVars,
+            timeoutMs: opts?.timeoutMs,
+          });
 
-      return new Ok({
-        exitCode: result.exitCode,
-        stdout: result.stdout,
-        stderr: result.stderr,
-      });
-    } catch (err) {
-      // The E2B SDK throws CommandExitError on non-zero exit codes.
-      // Normalize into a regular ExecResult so callers never see E2B types.
-      if (err instanceof CommandExitError) {
-        return new Ok({
-          exitCode: err.exitCode,
-          stdout: err.stdout,
-          stderr: err.stderr,
-        });
+          return new Ok({
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          });
+        } catch (err) {
+          // The E2B SDK throws CommandExitError on non-zero exit codes.
+          // Normalize into a regular ExecResult so callers never see E2B types.
+          if (err instanceof CommandExitError) {
+            return new Ok({
+              exitCode: err.exitCode,
+              stdout: err.stdout,
+              stderr: err.stderr,
+            });
+          }
+          return new Err(normalizeError(err));
+        }
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceSId,
       }
-      return new Err(normalizeError(err));
-    }
+    );
   }
 
   async writeFile(
+    tracingOpts: { workspaceSId: string },
     providerId: string,
     path: string,
     data: ArrayBuffer
   ): Promise<Result<void, Error>> {
-    let sandbox: Sandbox;
-    try {
-      sandbox = await Sandbox.connect(providerId, {
-        ...this.connectionOpts(),
-        timeoutMs: SANDBOX_LIFETIME_MS,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return new Err(new SandboxNotFoundError(providerId));
+    return traceSandboxOperation(
+      "writeFile",
+      async () => {
+        let sandbox: Sandbox;
+        try {
+          sandbox = await Sandbox.connect(providerId, {
+            ...this.connectionOpts(),
+            timeoutMs: SANDBOX_LIFETIME_MS,
+          });
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
+
+        try {
+          // Note: this creates the necessary directories if missing.
+          await sandbox.files.write(path, data);
+        } catch (err) {
+          return new Err(normalizeError(err));
+        }
+
+        return new Ok(undefined);
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceSId,
       }
-      return new Err(normalizeError(err));
-    }
-
-    try {
-      // Note: this creates the necessary directories if missing.
-      await sandbox.files.write(path, data);
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
-
-    return new Ok(undefined);
+    );
   }
 
-  async readFile(_providerId: string, _path: string): Promise<Buffer> {
+  async readFile(
+    _tracingOpts: { workspaceSId: string },
+    _providerId: string,
+    _path: string
+  ): Promise<Buffer> {
     throw new Error("readFile is not implemented yet.");
   }
 
   async listFiles(
+    tracingOpts: { workspaceSId: string },
     providerId: string,
     path: string,
     opts?: { recursive?: boolean }
   ): Promise<FileEntry[]> {
-    let sandbox: Sandbox;
-    try {
-      sandbox = await Sandbox.connect(providerId, {
-        ...this.connectionOpts(),
-        timeoutMs: SANDBOX_LIFETIME_MS,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new SandboxNotFoundError(providerId);
+    return traceSandboxOperation(
+      "listFiles",
+      async () => {
+        let sandbox: Sandbox;
+        try {
+          sandbox = await Sandbox.connect(providerId, {
+            ...this.connectionOpts(),
+            timeoutMs: SANDBOX_LIFETIME_MS,
+          });
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            throw new SandboxNotFoundError(providerId);
+          }
+          throw normalizeError(err);
+        }
+
+        const entries = await sandbox.files.list(path, {
+          depth: opts?.recursive ? 10 : 1,
+        });
+
+        return entries.map((e) => ({
+          path: e.path,
+          size: e.size,
+          isDirectory: e.type === "dir",
+        }));
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceSId,
       }
-      throw normalizeError(err);
-    }
-
-    const entries = await sandbox.files.list(path, {
-      depth: opts?.recursive ? 10 : 1,
-    });
-
-    return entries.map((e) => ({
-      path: e.path,
-      size: e.size,
-      isDirectory: e.type === "dir",
-    }));
+    );
   }
 }

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -22,7 +22,6 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -115,7 +114,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
-   * Return conversation sIds that have a sandbox with the given `status` and
+   * Return conversation sIds and workspace ModelIds for sandboxes with the given `status`
    * whose `lastActivityAt` is older than `olderThanMs`. Used by the reaper
    * workflow to identify candidates for sleep/destroy.
    *
@@ -125,7 +124,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     status: SandboxStatus;
     olderThanMs: number;
     limit: number;
-  }): Promise<string[]> {
+  }): Promise<Array<{ conversationId: string; workspaceModelId: ModelId }>> {
     const rows = await this.model.findAll({
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
@@ -138,7 +137,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       include: [
         {
           model: ConversationModel,
-          attributes: ["sId"],
+          attributes: ["sId", "workspaceId"],
           required: true,
         },
       ],
@@ -146,7 +145,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       limit: opts.limit,
     });
 
-    return rows.map((r) => r.conversation.sId);
+    return rows.map((r) => ({
+      conversationId: r.conversation.sId,
+      workspaceModelId: r.conversation.workspaceId,
+    }));
   }
 
   /**
@@ -261,7 +263,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       }
 
       if (sandbox.status !== "deleted") {
-        const result = await provider.destroy(sandbox.providerId);
+        const tracingOpts = {
+          workspaceSId: auth.getNonNullableWorkspace().sId,
+        };
+        const result = await provider.destroy(tracingOpts, sandbox.providerId);
         if (result.isErr() && !(result.error instanceof SandboxNotFoundError)) {
           logger.error(
             { sandbox: sandbox.toLogJSON(), error: result.error.message },
@@ -314,6 +319,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
 
     return this.withLifecycleLock(conversation.sId, async (provider) => {
+      const ctx = { workspaceSId: auth.getNonNullableWorkspace().sId };
+      const tracingOpts = { workspaceSId: auth.getNonNullableWorkspace().sId };
       const existing = await SandboxResource.fetchByConversationId(
         auth,
         conversation.sId
@@ -325,6 +332,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           return imageResult;
         }
         const createResult = await provider.create(
+          tracingOpts,
           imageResult.value.toCreateConfig()
         );
         if (createResult.isErr()) {
@@ -354,7 +362,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           break;
 
         case "sleeping": {
-          const wakeResult = await provider.wake(existing.providerId);
+          const wakeResult = await provider.wake(
+            tracingOpts,
+            existing.providerId
+          );
           if (wakeResult.isErr()) {
             // The sandbox may have been killed by the provider (e.g. lifetime
             // expired). Fall through to recreation instead of propagating the
@@ -380,6 +391,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             return imageResult;
           }
           const createResult = await provider.create(
+            tracingOpts,
             imageResult.value.toCreateConfig()
           );
           if (createResult.isErr()) {
@@ -401,7 +413,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           assertNever(status);
       }
 
-      const ctx = { workspaceSId: auth.getNonNullableWorkspace().sId };
       await existing.updateStatus("running", { ctx });
       await existing.updateLastActivityAt();
 
@@ -423,6 +434,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslySleepIfRunning(
+    auth: Authenticator,
     conversationId: string
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(conversationId, async (provider) => {
@@ -432,12 +444,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const [workspace] = await WorkspaceResource.fetchByModelIds([
-        sandbox.workspaceId,
-      ]);
-      const ctx = { workspaceSId: workspace?.sId ?? "unknown" };
+      const ctx = { workspaceSId: auth.getNonNullableWorkspace().sId };
+      const tracingOpts = { workspaceSId: auth.getNonNullableWorkspace().sId };
 
-      const result = await provider.sleep(sandbox.providerId);
+      const result = await provider.sleep(tracingOpts, sandbox.providerId);
       if (result.isErr()) {
         if (result.error instanceof SandboxNotFoundError) {
           logger.info(
@@ -466,6 +476,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslyDestroyIfSleeping(
+    auth: Authenticator,
     conversationId: string
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(conversationId, async (provider) => {
@@ -475,12 +486,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const [workspace] = await WorkspaceResource.fetchByModelIds([
-        sandbox.workspaceId,
-      ]);
-      const ctx = { workspaceSId: workspace?.sId ?? "unknown" };
+      const ctx = { workspaceSId: auth.getNonNullableWorkspace().sId };
+      const tracingOpts = { workspaceSId: auth.getNonNullableWorkspace().sId };
 
-      const result = await provider.destroy(sandbox.providerId);
+      const result = await provider.destroy(tracingOpts, sandbox.providerId);
       if (result.isErr()) {
         if (result.error instanceof SandboxNotFoundError) {
           logger.info(
@@ -513,7 +522,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       return new Err(new Error("Sandbox provider not configured."));
     }
 
-    const result = await provider.exec(this.providerId, command, opts);
+    const tracingOpts = { workspaceSId: auth.getNonNullableWorkspace().sId };
+    const result = await provider.exec(
+      tracingOpts,
+      this.providerId,
+      command,
+      opts
+    );
 
     if (result.isErr() && result.error instanceof SandboxNotFoundError) {
       logger.error(
@@ -530,6 +545,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * List files in a directory on this sandbox.
    */
   async listFiles(
+    auth: Authenticator,
     path: string,
     opts?: { recursive?: boolean }
   ): Promise<Result<FileEntry[], Error>> {
@@ -539,7 +555,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     try {
-      const entries = await provider.listFiles(this.providerId, path, opts);
+      const tracingOpts = { workspaceSId: auth.getNonNullableWorkspace().sId };
+      const entries = await provider.listFiles(
+        tracingOpts,
+        this.providerId,
+        path,
+        opts
+      );
       return new Ok(entries);
     } catch (err) {
       if (err instanceof SandboxNotFoundError) {
@@ -557,6 +579,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Write a file to the sandbox filesystem.
    */
   private async writeFile(
+    auth: Authenticator,
     path: string,
     data: ArrayBuffer
   ): Promise<Result<void, Error>> {
@@ -565,7 +588,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       return new Err(new Error("Sandbox provider not configured."));
     }
 
-    const result = await provider.writeFile(this.providerId, path, data);
+    const tracingOpts = { workspaceSId: auth.getNonNullableWorkspace().sId };
+    const result = await provider.writeFile(
+      tracingOpts,
+      this.providerId,
+      path,
+      data
+    );
 
     if (result.isErr() && result.error instanceof SandboxNotFoundError) {
       logger.error(
@@ -599,7 +628,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       const readStream = file.getReadStream({ auth, version: "original" });
       const data = await streamConsumers.arrayBuffer(readStream);
 
-      const writeResult = await this.writeFile(targetPath, data);
+      const writeResult = await this.writeFile(auth, targetPath, data);
       if (writeResult.isErr()) {
         return writeResult;
       }

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -1,6 +1,9 @@
+import { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
 import { heartbeat } from "@temporalio/activity";
 
 import { BATCH_SIZE, DESTROY_THRESHOLD_MS, SLEEP_THRESHOLD_MS } from "./config";
@@ -8,29 +11,73 @@ import { BATCH_SIZE, DESTROY_THRESHOLD_MS, SLEEP_THRESHOLD_MS } from "./config";
 const REAPER_CONCURRENCY = 16;
 
 /**
+ * Batch-fetch workspaces for a list of conversations to avoid N+1 queries.
+ * Returns a Map for O(1) lookup during concurrent processing.
+ */
+async function fetchWorkspaceMap(
+  conversations: Array<{ conversationId: string; workspaceModelId: ModelId }>
+): Promise<Map<ModelId, WorkspaceResource>> {
+  const uniqueWorkspaceModelIds = [
+    ...new Set(conversations.map((c) => c.workspaceModelId)),
+  ];
+
+  const workspaces = await WorkspaceResource.fetchByModelIds(
+    uniqueWorkspaceModelIds
+  );
+
+  return new Map(workspaces.map((w) => [w.id, w]));
+}
+
+/**
  * Process one batch of stale sandboxes. Returns `true` when either query
  * returned a full batch, signalling the workflow to loop for more.
  */
 export async function reapStaleSandboxesActivity(): Promise<boolean> {
   // Phase 1: Sleep running sandboxes that have been idle > SLEEP_THRESHOLD_MS.
-  const runningConversationIds =
+  const runningConversations =
     await SandboxResource.dangerouslyGetStaleConversationIds({
       status: "running",
       olderThanMs: SLEEP_THRESHOLD_MS,
       limit: BATCH_SIZE,
     });
 
-  if (runningConversationIds.length > 0) {
+  if (runningConversations.length > 0) {
     logger.info(
-      { count: runningConversationIds.length },
+      { count: runningConversations.length },
       "Reaper: stale running sandboxes found."
     );
 
+    // Batch-fetch all workspaces to avoid N queries inside the concurrent loop
+    const workspaceMap = await fetchWorkspaceMap(runningConversations);
+
+    logger.info(
+      {
+        conversationCount: runningConversations.length,
+        uniqueWorkspaceCount: workspaceMap.size,
+      },
+      "Batch-fetched workspaces for running sandboxes"
+    );
+
     await concurrentExecutor(
-      runningConversationIds,
-      async (conversationId) => {
-        const result =
-          await SandboxResource.dangerouslySleepIfRunning(conversationId);
+      runningConversations,
+      async ({ conversationId, workspaceModelId }) => {
+        const workspace = workspaceMap.get(workspaceModelId);
+
+        if (!workspace) {
+          logger.warn(
+            { conversationId, workspaceModelId },
+            "Workspace not found, skipping"
+          );
+          return;
+        }
+
+        const auth = await Authenticator.internalBuilderForWorkspace(
+          workspace.sId
+        );
+        const result = await SandboxResource.dangerouslySleepIfRunning(
+          auth,
+          conversationId
+        );
         if (result.isErr()) {
           logger.error(
             { conversationId, error: result.error.message },
@@ -44,24 +91,50 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
   }
 
   // Phase 2: Destroy sleeping sandboxes that have been idle > DESTROY_THRESHOLD_MS.
-  const sleepingConversationIds =
+  const sleepingConversations =
     await SandboxResource.dangerouslyGetStaleConversationIds({
       status: "sleeping",
       olderThanMs: DESTROY_THRESHOLD_MS,
       limit: BATCH_SIZE,
     });
 
-  if (sleepingConversationIds.length > 0) {
+  if (sleepingConversations.length > 0) {
     logger.info(
-      { count: sleepingConversationIds.length },
+      { count: sleepingConversations.length },
       "Reaper: stale sleeping sandboxes found."
     );
 
+    // Batch-fetch all workspaces to avoid N queries inside the concurrent loop
+    const workspaceMap = await fetchWorkspaceMap(sleepingConversations);
+
+    logger.info(
+      {
+        conversationCount: sleepingConversations.length,
+        uniqueWorkspaceCount: workspaceMap.size,
+      },
+      "Batch-fetched workspaces for sleeping sandboxes"
+    );
+
     await concurrentExecutor(
-      sleepingConversationIds,
-      async (conversationId) => {
-        const result =
-          await SandboxResource.dangerouslyDestroyIfSleeping(conversationId);
+      sleepingConversations,
+      async ({ conversationId, workspaceModelId }) => {
+        const workspace = workspaceMap.get(workspaceModelId);
+
+        if (!workspace) {
+          logger.warn(
+            { conversationId, workspaceModelId },
+            "Workspace not found, skipping"
+          );
+          return;
+        }
+
+        const auth = await Authenticator.internalBuilderForWorkspace(
+          workspace.sId
+        );
+        const result = await SandboxResource.dangerouslyDestroyIfSleeping(
+          auth,
+          conversationId
+        );
         if (result.isErr()) {
           logger.error(
             { conversationId, error: result.error.message },
@@ -75,7 +148,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
   }
 
   return (
-    runningConversationIds.length >= BATCH_SIZE ||
-    sleepingConversationIds.length >= BATCH_SIZE
+    runningConversations.length >= BATCH_SIZE ||
+    sleepingConversations.length >= BATCH_SIZE
   );
 }


### PR DESCRIPTION
## Description

We want to emit spans each time a provider operation is called, essentially one of `create | wake | sleep | destroy | exec | writeFile | readFile | listFiles`, with two tags for now: providerId (sandbox id) and workspaceId (sId).

The later proved to be much more involved than anticipated initially, as a side effect we now pass auth to every provider method, same for the resource (but that's more aligned with what we do otherwise so ok to me).

The piece I'm the least fan of is the batch fetch of workspaces to get actual sId inside the reaper, because of legacy 😞 .
 
## Tests

- Tested locally


## Risk

Low

## Deploy Plan

- [ ] Deploy front