### PR TITLE
Conversation files: route rename to remove sandbox references

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -14,7 +14,7 @@ import { useConversationSandboxStatus } from "@app/hooks/conversations/useConver
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { downloadSandboxFile } from "@app/lib/swr/files";
-import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isInteractiveContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -8,7 +8,7 @@ import { useConversationSandboxFiles } from "@app/hooks/conversations/useConvers
 import { useDebounce } from "@app/hooks/useDebounce";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { downloadSandboxFile, getFileProcessedUrl } from "@app/lib/swr/files";
-import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Card,

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -6,7 +6,7 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
-import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import {
   frameSlideshowContentType,
   isInteractiveContentType,

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -1,8 +1,8 @@
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GCSMountFileEntry,
-  GetConversationSandboxFilesResponseBody,
-} from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files";
+  GetConversationFilesResponseBody,
+} from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 
@@ -16,12 +16,12 @@ export function useConversationSandboxFiles({
   options?: { disabled?: boolean };
 }) {
   const { fetcher } = useFetcher();
-  const sandboxFilesFetcher: Fetcher<GetConversationSandboxFilesResponseBody> =
+  const sandboxFilesFetcher: Fetcher<GetConversationFilesResponseBody> =
     fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     conversationId
-      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/sandbox/files`
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/files`
       : null,
     sandboxFilesFetcher,
     options

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -48,7 +48,7 @@ export async function downloadSandboxFile(
   conversationId: string,
   filePath: string
 ): Promise<Response> {
-  const url = `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/sandbox/files/download`;
+  const url = `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/download`;
   const res = await clientFetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
@@ -1,4 +1,4 @@
-import handler from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download";
+import handler from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files/download";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import type { RequestMethod } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -50,7 +50,7 @@ async function setupTest(method: RequestMethod = "POST") {
   return { req, res };
 }
 
-describe("POST /api/w/[wId]/assistant/conversations/[cId]/sandbox/files/download", () => {
+describe("POST /api/w/[wId]/assistant/conversations/[cId]/files/download", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -95,7 +95,7 @@ async function handler(
   readStream.on("error", (err) => {
     logger.error(
       { err, filePath: normalizedPath },
-      "Error streaming sandbox file"
+      "Error streaming conversation file"
     );
     readStream.destroy();
     res.end();

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/index.ts
@@ -14,15 +14,13 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export type { GCSMountFileEntry };
 
-export type GetConversationSandboxFilesResponseBody = {
+export type GetConversationFilesResponseBody = {
   files: GCSMountFileEntry[];
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<GetConversationSandboxFilesResponseBody>
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<GetConversationFilesResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
   if (req.method !== "GET") {


### PR DESCRIPTION
## Description

Remove `sandbox` from route to conversation files endpoints + other minor renames.

## Tests

Covered by updated tests
Tested locally

## Risk

Low (gated feature)

## Deploy Plan

- deploy `front`