### PR TITLE
[front] feat: add support for mentions in messages posted using the Teams tools

### DIFF
--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -177,12 +177,12 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
               .number()
               .int()
               .describe(
-                "Zero-based index matching the id attribute in the corresponding <at id=\"N\"> tag in messageContent."
+                'Zero-based index matching the id attribute in the corresponding <at id="N"> tag in messageContent.'
               ),
             mentionText: z
               .string()
               .describe(
-                "Display name used inside the <at> tag (e.g. <at id=\"0\">Display Name</at>)."
+                'Display name used inside the <at> tag (e.g. <at id="0">Display Name</at>).'
               ),
             userAadId: z
               .string()
@@ -191,7 +191,7 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         )
         .optional()
         .describe(
-          "List of @mentions. Each entry must have a corresponding <at id=\"N\">Name</at> tag in messageContent."
+          'List of @mentions. Each entry must have a corresponding <at id="N">Name</at> tag in messageContent.'
         ),
     },
     stake: "medium",

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -170,6 +170,29 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .describe(
           "The ID of the parent message to reply to (optional, creates a threaded reply). Only supported for channels."
         ),
+      mentions: z
+        .array(
+          z.object({
+            id: z
+              .number()
+              .int()
+              .describe(
+                "Zero-based index matching the id attribute in the corresponding <at id=\"N\"> tag in messageContent."
+              ),
+            mentionText: z
+              .string()
+              .describe(
+                "Display name used inside the <at> tag (e.g. <at id=\"0\">Display Name</at>)."
+              ),
+            userAadId: z
+              .string()
+              .describe("AAD object ID of the user to mention."),
+          })
+        )
+        .optional()
+        .describe(
+          "List of @mentions. Each entry must have a corresponding <at id=\"N\">Name</at> tag in messageContent."
+        ),
     },
     stake: "medium",
     displayLabels: {

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -286,6 +286,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       chatId,
       userIds,
       parentMessageId,
+      mentions,
     },
     { auth, authInfo, agentLoopContext }
   ) => {
@@ -434,12 +435,35 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         finalContent = `${messageContent}<br/><br/>${footerMessage}`;
       }
 
-      const requestBody = {
+      // Allow <at id="N"> tags so Teams @mentions are preserved after sanitization.
+      const sanitizedContent = sanitizeHtml(finalContent, {
+        allowedTags: [...sanitizeHtml.defaults.allowedTags, "at"],
+        allowedAttributes: {
+          ...sanitizeHtml.defaults.allowedAttributes,
+          at: ["id"],
+        },
+      });
+
+      const requestBody: Record<string, unknown> = {
         body: {
           contentType: "html",
-          content: sanitizeHtml(finalContent),
+          content: sanitizedContent,
         },
       };
+
+      if (mentions && mentions.length > 0) {
+        requestBody.mentions = mentions.map(({ id, mentionText, userAadId }) => ({
+          id,
+          mentionText,
+          mentioned: {
+            user: {
+              id: userAadId,
+              displayName: mentionText,
+              userIdentityType: "aadUser",
+            },
+          },
+        }));
+      }
 
       const response = await client.api(endpoint).post(requestBody);
 

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -452,17 +452,19 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       };
 
       if (mentions && mentions.length > 0) {
-        requestBody.mentions = mentions.map(({ id, mentionText, userAadId }) => ({
-          id,
-          mentionText,
-          mentioned: {
-            user: {
-              id: userAadId,
-              displayName: mentionText,
-              userIdentityType: "aadUser",
+        requestBody.mentions = mentions.map(
+          ({ id, mentionText, userAadId }) => ({
+            id,
+            mentionText,
+            mentioned: {
+              user: {
+                id: userAadId,
+                displayName: mentionText,
+                userIdentityType: "aadUser",
+              },
             },
-          },
-        }));
+          })
+        );
       }
 
       const response = await client.api(endpoint).post(requestBody);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/23327
- This PR adds support for `@mentions` in the `post_message` tool for Microsoft Teams.

<img width="956" height="207" alt="Screenshot 2026-03-26 at 11 10 59 AM" src="https://github.com/user-attachments/assets/ee320ab0-bbcb-4f76-bd26-685a928ea6f1" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
