### PR TITLE
[front] fix: prevent extra keyboard pops on conversation open on mobile

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -645,7 +645,9 @@ const InputBarContainer = ({
       (editorService.isEmpty() || editorContainsOnlyStickyMentions)
     ) {
       // Schedule content restoration to avoid flushing during render lifecycle.
-      queueMicrotask(() => editorService.setContent(draft.text));
+      queueMicrotask(() =>
+        editorService.setContent(draft.text, { focus: !disableAutoFocus })
+      );
     }
   }, [
     conversation,

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -72,7 +72,10 @@ const useEditorService = (editor: Editor | null) => {
           .insertContent(" ") // Add an extra space after the mention.
           .run();
       },
-      setContent: (content: string, { focus = true }: { focus?: boolean } = {}) => {
+      setContent: (
+        content: string,
+        { focus = true }: { focus?: boolean } = {}
+      ) => {
         const chain = editor
           ?.chain()
           .setContent(content, { contentType: "markdown" });

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -72,14 +72,14 @@ const useEditorService = (editor: Editor | null) => {
           .insertContent(" ") // Add an extra space after the mention.
           .run();
       },
-      setContent: (content: string) => {
-        editor
+      setContent: (content: string, { focus = true }: { focus?: boolean }) => {
+        const chain = editor
           ?.chain()
-          .setContent(content, {
-            contentType: "markdown",
-          })
-          .focus()
-          .run();
+          .setContent(content, { contentType: "markdown" });
+        if (focus) {
+          chain?.focus();
+        }
+        chain?.run();
       },
       resetWithMentions: (
         mentions: RichMention[],

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -72,7 +72,7 @@ const useEditorService = (editor: Editor | null) => {
           .insertContent(" ") // Add an extra space after the mention.
           .run();
       },
-      setContent: (content: string, { focus = true }: { focus?: boolean }) => {
+      setContent: (content: string, { focus = true }: { focus?: boolean } = {}) => {
         const chain = editor
           ?.chain()
           .setContent(content, { contentType: "markdown" });

--- a/front/lib/swr/useIsMobile.ts
+++ b/front/lib/swr/useIsMobile.ts
@@ -5,7 +5,10 @@ const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
   const clientType = useClientType();
-  const [isMobile, setIsMobile] = useState<boolean | undefined>();
+  // Read from window immediately so the initial value is correct to avoid keyboard pop up on mobile.
+  const [isMobile, setIsMobile] = useState<boolean>(
+    () => !!window && window.innerWidth < MOBILE_BREAKPOINT
+  );
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -22,5 +25,5 @@ export function useIsMobile() {
     return false;
   }
 
-  return !!isMobile;
+  return isMobile;
 }


### PR DESCRIPTION
## Description

- On mobile, opening a conversation while having content from local storage causes two extra keyboard pops.
- This PR fixes that.

https://github.com/user-attachments/assets/5f07adae-6853-4af9-b2ea-f16c6dfd2bf7


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
