### PR TITLE
Fix SSO/SCIM lifecycle: block usage when plan disallows it, delay cleanup to scrub workflow

### DIFF
--- a/front/components/pages/onboarding/LoginErrorPage.tsx
+++ b/front/components/pages/onboarding/LoginErrorPage.tsx
@@ -142,6 +142,18 @@ function getErrorMessage(domain: string | null, reason: string | null) {
         </>
       );
 
+    case "sso-not-allowed":
+      return (
+        <>
+          {headerNode}
+          <p className={defaultErrorMessageClassName}>
+            SSO login is not available for this workspace.
+            <br />
+            Please contact your workspace administrator for assistance.
+          </p>
+        </>
+      );
+
     default:
       return (
         <>

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -51,6 +51,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   cacheWithRedis,
   invalidateCacheAfterCommit,
@@ -262,7 +263,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   static async invalidateSubscriptionCacheForPlan(
     planId: number
   ): Promise<void> {
-    const subscriptions = await SubscriptionModel.findAll({
+    const subscriptions = await SubscriptionResource.model.findAll({
       attributes: ["workspaceId"],
       where: { planId, status: "active" },
       // WORKSPACE_ISOLATION_BYPASS: We need to invalidate caches across all workspaces on this plan.
@@ -270,9 +271,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
-    for (const sub of subscriptions) {
-      await SubscriptionResource.invalidateSubscriptionCache(sub.workspaceId);
-    }
+    await concurrentExecutor(
+      subscriptions,
+      (sub) =>
+        SubscriptionResource.invalidateSubscriptionCache(sub.workspaceId),
+      { concurrency: 8 }
+    );
   }
 
   private static fromCachedData(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1,9 +1,6 @@
 import assert from "node:assert";
 import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
-import {
-  disableWorkOSSSOAndSCIM,
-  getOrCreateWorkOSOrganization,
-} from "@app/lib/api/workos/organization";
+import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -257,6 +254,26 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     SubscriptionResource._fetchActiveByWorkspaceModelIdUncached,
     SubscriptionResource.subscriptionCacheKeyResolver
   );
+
+  /**
+   * Invalidate subscription caches for all workspaces on a given plan.
+   * Should be called when plan attributes are updated (e.g., via Poke).
+   */
+  static async invalidateSubscriptionCacheForPlan(
+    planId: number
+  ): Promise<void> {
+    const subscriptions = await SubscriptionModel.findAll({
+      attributes: ["workspaceId"],
+      where: { planId, status: "active" },
+      // WORKSPACE_ISOLATION_BYPASS: We need to invalidate caches across all workspaces on this plan.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    for (const sub of subscriptions) {
+      await SubscriptionResource.invalidateSubscriptionCache(sub.workspaceId);
+    }
+  }
 
   private static fromCachedData(
     workspaceModelId: ModelId,
@@ -589,12 +606,6 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
     await this.endActiveSubscription(workspace);
 
-    // FREE_NO_PLAN never allows SSO/SCIM, clean up any existing WorkOS config.
-    await disableWorkOSSSOAndSCIM(workspace, {
-      disableSSO: true,
-      disableSCIM: true,
-    });
-
     await SubscriptionResource.invalidateSubscriptionCache(workspace.id);
 
     return new SubscriptionResource(
@@ -700,14 +711,6 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       if (result.isErr() && !activeSubscription.isMetronomeShadowBilled) {
         throw result.error;
       }
-    }
-
-    // Clean up WorkOS config for features the new plan doesn't allow.
-    if (!newPlan.isSSOAllowed || !newPlan.isSCIMAllowed) {
-      await disableWorkOSSSOAndSCIM(workspace, {
-        disableSSO: !newPlan.isSSOAllowed,
-        disableSCIM: !newPlan.isSCIMAllowed,
-      });
     }
 
     await SubscriptionResource.invalidateSubscriptionCache(workspace.id);

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -4,6 +4,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { apiError } from "@app/logger/withlogging";
 import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -128,8 +129,7 @@ async function handler(
         });
       }
 
-      await PlanModel.upsert({
-        code: body.code,
+      const planFields = {
         name: body.name,
         isSlackbotAllowed: body.limits.assistant.isSlackBotAllowed,
         maxImagesPerWeek: body.limits.capabilities.images.maxImagesPerWeek,
@@ -156,7 +156,19 @@ async function handler(
         trialPeriodDays: body.trialPeriodDays,
         canUseProduct: body.limits.canUseProduct,
         isByok: body.isByok,
-      });
+      };
+
+      let plan = await PlanModel.findOne({ where: { code: body.code } });
+      if (plan) {
+        await plan.update(planFields);
+      } else {
+        plan = await PlanModel.create({ code: body.code, ...planFields });
+      }
+
+      // Invalidate subscription caches for all workspaces on this plan,
+      // since the cached subscription includes a snapshot of plan data.
+      await SubscriptionResource.invalidateSubscriptionCacheForPlan(plan.id);
+
       res.status(200).json({
         plan: body,
       });

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -128,6 +128,7 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { DUST_HAS_SESSION } from "@app/lib/cookies";
 import { fetchUserFromSession } from "@app/lib/iam/users";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getClientIp } from "@app/lib/utils/request";
@@ -418,6 +419,25 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 
     if (!sealedSession) {
       throw new Error("Sealed session not found");
+    }
+
+    // If login was via SSO, verify the workspace's plan still allows SSO.
+    if (authenticationMethod?.toLowerCase() === "sso" && organizationId) {
+      const workspace =
+        await WorkspaceResource.fetchByWorkOSOrganizationId(organizationId);
+      if (workspace) {
+        const subscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspace.id
+          );
+        if (!subscription?.getPlan().limits.users.isSSOAllowed) {
+          logger.warn(
+            { workspaceId: workspace.sId, organizationId },
+            "SSO login blocked: workspace plan does not allow SSO"
+          );
+          return redirectTo(res, "/login-error?reason=sso-not-allowed");
+        }
+      }
     }
 
     // Decode and inspect JWT content

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/api/data_sources";
 import { sendAdminDataDeletionEmail } from "@app/lib/api/email";
 import { softDeleteSpaceAndLaunchScrubWorkflow } from "@app/lib/api/spaces";
+import { disableWorkOSSSOAndSCIM } from "@app/lib/api/workos/organization";
 import {
   getMembers,
   getWorkspaceInfos,
@@ -135,6 +136,10 @@ export async function scrubWorkspaceData({
   await deleteDatasources(auth);
   await deleteSpaces(auth);
   await cleanupCustomerio(auth);
+  await disableWorkOSSSOAndSCIM(renderLightWorkspaceType({ workspace }), {
+    disableSSO: true,
+    disableSCIM: true,
+  });
 }
 
 export async function pauseAllConnectors({

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -33,6 +33,7 @@ import {
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
@@ -98,9 +99,19 @@ async function verifyWorkOSWorkspace<E extends object, R>(
     }
   }
 
-  // For dsync events, verify the directoryId matches the current organization's
-  // active directory. Events from disconnected directories should be ignored.
+  // For dsync events, verify the plan allows SCIM and the directoryId matches
+  // the current organization's active directory.
   if (isRecord(event) && typeof event.directoryId === "string") {
+    const subscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    if (!subscription?.getPlan().limits.users.isSCIMAllowed) {
+      logger.warn(
+        { workspaceId: workspace.sId, organizationId },
+        "SCIM event received but workspace plan does not allow SCIM, skipping"
+      );
+      return;
+    }
+
     const directoriesResult = await getWorkOSOrganizationDSyncDirectories({
       workspace,
     });


### PR DESCRIPTION
## Description

Fixes a bug where SSO connections and SCIM directories were being deleted when a workspace was upgraded to a plan that allows SSO/SCIM, due to a stale Redis subscription cache.

### Root cause

When a plan's `isSSOAllowed`/`isSCIMAllowed` flags were edited in Poke, the subscription cache was never invalidated. The cache stored a snapshot of the plan at write time, so workspaces would see the old (incorrect) plan limits until their cache expired. During an upgrade, the downgrade code path was reading the stale cached values (`false`) and deleting the WorkOS connections.

### Fixes

- **Plan cache invalidation** (`subscription_resource.ts`, `poke/plans.ts`): Invalidate subscription caches for all workspaces on a plan whenever that plan is saved in Poke. Also fixed `PlanModel.upsert` not updating `updatedAt` by switching to explicit `findOne` + `update`/`create`.

- **Removed immediate SSO/SCIM deletion on plan change** (`subscription_resource.ts`): Removed the `disableWorkOSSSOAndSCIM` calls from `internalSubscribeWorkspaceToFreeNoPlan` and `internalSubscribeWorkspaceToFreePlan`. Deleting connections immediately on downgrade was too aggressive.

- **Delayed SSO/SCIM cleanup via scrub workflow** (`scrub_workspace/activities.ts`): Added `disableWorkOSSSOAndSCIM` to `scrubWorkspaceData`, so connections are cleaned up as part of the existing 30-day delayed scrub when a workspace is fully decommissioned.

- **Block SSO login when plan disallows it** (`workos/[action].ts`): In the WorkOS callback, if the login used SSO and the workspace's plan does not allow SSO, the login is rejected and redirected to an error page.

- **Block SCIM events when plan disallows it** (`workos_events_queue/activities.ts`): Before processing any `dsync.*` webhook event, check that the workspace's plan allows SCIM. If not, log a warning and skip the event.

## Risk

Low. The changes are defensive — they block operations that should not happen rather than enabling new ones. The scrub workflow change adds a cleanup step that was previously missing (no connections were ever deleted on scrub).