### PR TITLE
Bump webhook router forwarder timeout from 10 seconds to 20 seconds

### DIFF
--- a/firebase-functions/webhook-router/src/config.ts
+++ b/firebase-functions/webhook-router/src/config.ts
@@ -6,7 +6,7 @@ const gcpUsProjectId = defineString("GCP_US_PROJECT_ID");
 const gcpEuProjectId = defineString("GCP_EU_PROJECT_ID");
 
 export const CONFIG = {
-  FETCH_TIMEOUT_MS: 10000,
+  FETCH_TIMEOUT_MS: 20_000,
 
   // Environment secrets.
   DUST_CONNECTORS_WEBHOOKS_SECRET: process.env.DUST_CONNECTORS_WEBHOOKS_SECRET,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While debugging a Slack data sync issue, I noticed that we had a lot of timeout errors when forwarding to Dust. This ultimately lead to sometimes missing sync.

This PR:
- bumps the timeout to 20 seconds (previously was 10 seconds). `/slack` endpoint in connectors does a bunch of heavy thing before responding (things like fetching spaces, ...).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
