### PR TITLE
[Email Agents] Harden inbound header mailbox parsing

### DIFF
--- a/front/lib/api/assistant/email/header_parsing.test.ts
+++ b/front/lib/api/assistant/email/header_parsing.test.ts
@@ -36,6 +36,20 @@ describe("extractSingleEmailAddressFromHeader", () => {
     expect(result.value).toBe("sender@dust.tt");
   });
 
+  it("accepts punycode domains inside angle brackets", () => {
+    const result = extractSingleEmailAddressFromHeader(
+      "From",
+      "Sender Name <sender@xn--e1afmkfd.xn--p1ai>"
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value).toBe("sender@xn--e1afmkfd.xn--p1ai");
+  });
+
   it("rejects a From header with multiple mailboxes", () => {
     const result = extractSingleEmailAddressFromHeader(
       "From",

--- a/front/lib/api/assistant/email/header_parsing.test.ts
+++ b/front/lib/api/assistant/email/header_parsing.test.ts
@@ -13,6 +13,12 @@ describe("extractEmailAddressesFromHeader", () => {
       )
     ).toEqual(["sender@dust.tt"]);
   });
+
+  it("does not recover a mailbox from an unmatched opening angle bracket", () => {
+    expect(extractEmailAddressesFromHeader("Sender <sender@dust.tt")).toEqual(
+      []
+    );
+  });
 });
 
 describe("extractSingleEmailAddressFromHeader", () => {

--- a/front/lib/api/assistant/email/header_parsing.test.ts
+++ b/front/lib/api/assistant/email/header_parsing.test.ts
@@ -1,8 +1,19 @@
 import {
+  extractEmailAddressesFromHeader,
   extractSingleEmailAddressFromHeader,
   parseHeaderValue,
 } from "@app/lib/api/assistant/email/header_parsing";
 import { describe, expect, it } from "vitest";
+
+describe("extractEmailAddressesFromHeader", () => {
+  it("ignores malformed angle-bracket content that only partially looks like an email", () => {
+    expect(
+      extractEmailAddressesFromHeader(
+        "Sender <mailto:sender@dust.tt>, sender@dust.tt"
+      )
+    ).toEqual(["sender@dust.tt"]);
+  });
+});
 
 describe("extractSingleEmailAddressFromHeader", () => {
   it("extracts the single mailbox from a From header", () => {

--- a/front/lib/api/assistant/email/header_parsing.ts
+++ b/front/lib/api/assistant/email/header_parsing.ts
@@ -1,6 +1,16 @@
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+const EMAIL_ADDRESS_PATTERN_SOURCE =
+  "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}";
+const FULL_EMAIL_ADDRESS_PATTERN = new RegExp(
+  `^${EMAIL_ADDRESS_PATTERN_SOURCE}$`
+);
+const GLOBAL_EMAIL_ADDRESS_PATTERN = new RegExp(
+  EMAIL_ADDRESS_PATTERN_SOURCE,
+  "g"
+);
+
 export function extractEmailAddressesFromHeader(
   headerValue: string | null
 ): string[] {
@@ -25,16 +35,14 @@ export function extractEmailAddressesFromHeader(
   let match;
   while ((match = anglePattern.exec(headerValue)) !== null) {
     const content = match[1].trim();
-    // Basic validation: must contain exactly one "@" and no spaces.
-    if (content.includes("@") && !content.includes(" ")) {
+    if (FULL_EMAIL_ADDRESS_PATTERN.test(content)) {
       addEmail(content);
     }
   }
 
   // Second pass: extract bare email addresses from parts without angle brackets.
   const remaining = headerValue.replace(/<[^>]*>/g, " ");
-  const barePattern = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
-  while ((match = barePattern.exec(remaining)) !== null) {
+  while ((match = GLOBAL_EMAIL_ADDRESS_PATTERN.exec(remaining)) !== null) {
     addEmail(match[0]);
   }
 

--- a/front/lib/api/assistant/email/header_parsing.ts
+++ b/front/lib/api/assistant/email/header_parsing.ts
@@ -11,6 +11,31 @@ const GLOBAL_EMAIL_ADDRESS_PATTERN = new RegExp(
   "g"
 );
 
+function getTextOutsideAngleBrackets(headerValue: string): string {
+  let textOutsideAngleBrackets = "";
+  let isInsideAngleBrackets = false;
+
+  for (const character of headerValue) {
+    if (character === "<") {
+      isInsideAngleBrackets = true;
+      textOutsideAngleBrackets += " ";
+      continue;
+    }
+
+    if (character === ">") {
+      isInsideAngleBrackets = false;
+      textOutsideAngleBrackets += " ";
+      continue;
+    }
+
+    if (!isInsideAngleBrackets) {
+      textOutsideAngleBrackets += character;
+    }
+  }
+
+  return textOutsideAngleBrackets;
+}
+
 export function extractEmailAddressesFromHeader(
   headerValue: string | null
 ): string[] {
@@ -41,7 +66,7 @@ export function extractEmailAddressesFromHeader(
   }
 
   // Second pass: extract bare email addresses from parts without angle brackets.
-  const remaining = headerValue.replace(/<[^>]*>/g, " ");
+  const remaining = getTextOutsideAngleBrackets(headerValue);
   while ((match = GLOBAL_EMAIL_ADDRESS_PATTERN.exec(remaining)) !== null) {
     addEmail(match[0]);
   }

--- a/front/lib/api/assistant/email/header_parsing.ts
+++ b/front/lib/api/assistant/email/header_parsing.ts
@@ -1,8 +1,11 @@
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-const EMAIL_ADDRESS_PATTERN_SOURCE =
-  "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}";
+const DOMAIN_LABEL_PATTERN_SOURCE =
+  "[a-zA-Z0-9](?:[a-zA-Z0-9\\-]*[a-zA-Z0-9])?";
+const TOP_LEVEL_LABEL_PATTERN_SOURCE =
+  "(?:[a-zA-Z]{2,}|xn--[a-zA-Z0-9\\-]{2,})";
+const EMAIL_ADDRESS_PATTERN_SOURCE = `[a-zA-Z0-9._%+\\-]+@(?:${DOMAIN_LABEL_PATTERN_SOURCE}\\.)+${TOP_LEVEL_LABEL_PATTERN_SOURCE}`;
 const FULL_EMAIL_ADDRESS_PATTERN = new RegExp(
   `^${EMAIL_ADDRESS_PATTERN_SOURCE}$`
 );
@@ -67,6 +70,7 @@ export function extractEmailAddressesFromHeader(
 
   // Second pass: extract bare email addresses from parts without angle brackets.
   const remaining = getTextOutsideAngleBrackets(headerValue);
+  GLOBAL_EMAIL_ADDRESS_PATTERN.lastIndex = 0;
   while ((match = GLOBAL_EMAIL_ADDRESS_PATTERN.exec(remaining)) !== null) {
     addEmail(match[0]);
   }


### PR DESCRIPTION
## Description
Follows comment from @zmarouf in https://github.com/dust-tt/dust/pull/23313.

Tighten inbound header mailbox parsing in `header_parsing.ts` by sharing one mailbox matcher across angle-bracket and bare-address paths, failing closed on unmatched `<` fragments in the bare-address fallback, and keeping punycode domains accepted.

## Risks
Blast radius: inbound email header parsing for email agents.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `cd front && NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/api/assistant/email/header_parsing.test.ts`