### PR TITLE
[Email] Log malformed SendGrid DKIM parse failures

### DIFF
--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -4,14 +4,7 @@ import {
   evaluateInboundAuth,
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
-import logger from "@app/logger/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@app/logger/logger", () => ({
-  default: {
-    warn: vi.fn(),
-  },
-}));
+import { describe, expect, it } from "vitest";
 
 function makeEmail(
   overrides: Partial<{
@@ -41,15 +34,10 @@ function makeEmail(
 }
 
 describe("parseSendgridDkimResults", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("parses a single passing signature", () => {
     expect(parseSendgridDkimResults("{@company.com : pass}")).toEqual([
       { domain: "company.com", result: "pass" },
     ]);
-    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("parses multiple signatures in a single SendGrid hash", () => {
@@ -78,41 +66,10 @@ describe("parseSendgridDkimResults", () => {
     expect(parseSendgridDkimResults("{@company.com : pass, broken}")).toEqual(
       []
     );
-    expect(logger.warn).toHaveBeenCalledWith(
-      {
-        rawDkim: "{@company.com : pass, broken}",
-        reason: "malformed_dkim_entry",
-        entry: "broken",
-        parsedEntryCount: 1,
-      },
-      "[email] Failed to parse SendGrid DKIM results"
-    );
   });
 
   it("returns an empty list for non-SendGrid input", () => {
     expect(parseSendgridDkimResults("pass")).toEqual([]);
-    expect(logger.warn).toHaveBeenCalledWith(
-      {
-        rawDkim: "pass",
-        reason: "missing_enclosing_braces",
-        entry: undefined,
-        parsedEntryCount: undefined,
-      },
-      "[email] Failed to parse SendGrid DKIM results"
-    );
-  });
-
-  it("returns an empty list and logs when the DKIM payload is empty", () => {
-    expect(parseSendgridDkimResults("{}")).toEqual([]);
-    expect(logger.warn).toHaveBeenCalledWith(
-      {
-        rawDkim: "{}",
-        reason: "empty_dkim_results",
-        entry: undefined,
-        parsedEntryCount: undefined,
-      },
-      "[email] Failed to parse SendGrid DKIM results"
-    );
   });
 });
 

--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -4,7 +4,14 @@ import {
   evaluateInboundAuth,
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
-import { describe, expect, it } from "vitest";
+import logger from "@app/logger/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    warn: vi.fn(),
+  },
+}));
 
 function makeEmail(
   overrides: Partial<{
@@ -34,10 +41,15 @@ function makeEmail(
 }
 
 describe("parseSendgridDkimResults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("parses a single passing signature", () => {
     expect(parseSendgridDkimResults("{@company.com : pass}")).toEqual([
       { domain: "company.com", result: "pass" },
     ]);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("parses multiple signatures in a single SendGrid hash", () => {
@@ -66,10 +78,41 @@ describe("parseSendgridDkimResults", () => {
     expect(parseSendgridDkimResults("{@company.com : pass, broken}")).toEqual(
       []
     );
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        rawDkim: "{@company.com : pass, broken}",
+        reason: "malformed_dkim_entry",
+        entry: "broken",
+        parsedEntryCount: 1,
+      },
+      "[email] Failed to parse SendGrid DKIM results"
+    );
   });
 
   it("returns an empty list for non-SendGrid input", () => {
     expect(parseSendgridDkimResults("pass")).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        rawDkim: "pass",
+        reason: "missing_enclosing_braces",
+        entry: undefined,
+        parsedEntryCount: undefined,
+      },
+      "[email] Failed to parse SendGrid DKIM results"
+    );
+  });
+
+  it("returns an empty list and logs when the DKIM payload is empty", () => {
+    expect(parseSendgridDkimResults("{}")).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        rawDkim: "{}",
+        reason: "empty_dkim_results",
+        entry: undefined,
+        parsedEntryCount: undefined,
+      },
+      "[email] Failed to parse SendGrid DKIM results"
+    );
   });
 });
 

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -1,7 +1,10 @@
 import type { InboundEmail } from "@app/lib/api/assistant/email/email_trigger";
+import logger from "@app/logger/logger";
 
 const REPEATED_DKIM_ENTRY_SEPARATOR_PATTERN = /\}\s*,?\s*\{/g;
 const SENDGRID_DKIM_ENTRY_PATTERN = /^@([^:\s]+)\s*:\s*([^,\s}]+)$/;
+const DKIM_PARSE_FAILURE_LOG_MESSAGE =
+  "[email] Failed to parse SendGrid DKIM results";
 
 export type InboundEmailDkimResult = {
   domain: string;
@@ -18,6 +21,26 @@ export type InboundAuthDecision = {
   dkimEntries: InboundEmailDkimResult[];
 };
 
+function logDkimParseIssue({
+  rawDkim,
+  reason,
+  entry,
+  parsedEntryCount,
+}: {
+  rawDkim: string;
+  reason:
+    | "missing_enclosing_braces"
+    | "empty_dkim_results"
+    | "malformed_dkim_entry";
+  entry?: string;
+  parsedEntryCount?: number;
+}) {
+  logger.warn(
+    { rawDkim, reason, entry, parsedEntryCount },
+    DKIM_PARSE_FAILURE_LOG_MESSAGE
+  );
+}
+
 export function parseSendgridDkimResults(
   rawDkim: string | null
 ): InboundEmailDkimResult[] {
@@ -27,6 +50,10 @@ export function parseSendgridDkimResults(
 
   const trimmedDkim = rawDkim.trim();
   if (!trimmedDkim.startsWith("{") || !trimmedDkim.endsWith("}")) {
+    logDkimParseIssue({
+      rawDkim,
+      reason: "missing_enclosing_braces",
+    });
     return [];
   }
 
@@ -34,6 +61,10 @@ export function parseSendgridDkimResults(
     .replace(REPEATED_DKIM_ENTRY_SEPARATOR_PATTERN, ",")
     .slice(1, -1);
   if (normalizedDkim.length === 0) {
+    logDkimParseIssue({
+      rawDkim,
+      reason: "empty_dkim_results",
+    });
     return [];
   }
 
@@ -41,6 +72,12 @@ export function parseSendgridDkimResults(
   for (const entry of normalizedDkim.split(",")) {
     const match = entry.trim().match(SENDGRID_DKIM_ENTRY_PATTERN);
     if (!match) {
+      logDkimParseIssue({
+        rawDkim,
+        reason: "malformed_dkim_entry",
+        entry: entry.trim(),
+        parsedEntryCount: dkimResults.length,
+      });
       return [];
     }
 

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -28,19 +28,10 @@ export function parseSendgridDkimResults(
     return [];
   }
 
-  let parseFailureReason:
-    | "missing_enclosing_braces"
-    | "empty_dkim_results"
-    | "malformed_dkim_entry"
-    | null = null;
   const trimmedDkim = rawDkim.trim();
   if (!trimmedDkim.startsWith("{") || !trimmedDkim.endsWith("}")) {
-    parseFailureReason = "missing_enclosing_braces";
-  }
-
-  if (parseFailureReason !== null) {
     logger.warn(
-      { rawDkim, reason: parseFailureReason },
+      { rawDkim, reason: "missing_enclosing_braces" },
       DKIM_PARSE_FAILURE_LOG_MESSAGE
     );
     return [];
@@ -50,32 +41,29 @@ export function parseSendgridDkimResults(
     .replace(REPEATED_DKIM_ENTRY_SEPARATOR_PATTERN, ",")
     .slice(1, -1);
   if (normalizedDkim.length === 0) {
-    parseFailureReason = "empty_dkim_results";
-  }
-
-  const dkimResults: InboundEmailDkimResult[] = [];
-  if (parseFailureReason === null) {
-    for (const entry of normalizedDkim.split(",")) {
-      const match = entry.trim().match(SENDGRID_DKIM_ENTRY_PATTERN);
-      if (!match) {
-        parseFailureReason = "malformed_dkim_entry";
-        break;
-      }
-
-      const [, domain, result] = match;
-      dkimResults.push({
-        domain: domain.toLowerCase(),
-        result: result.toLowerCase(),
-      });
-    }
-  }
-
-  if (parseFailureReason !== null) {
     logger.warn(
-      { rawDkim, reason: parseFailureReason },
+      { rawDkim, reason: "empty_dkim_results" },
       DKIM_PARSE_FAILURE_LOG_MESSAGE
     );
     return [];
+  }
+
+  const dkimResults: InboundEmailDkimResult[] = [];
+  for (const entry of normalizedDkim.split(",")) {
+    const match = entry.trim().match(SENDGRID_DKIM_ENTRY_PATTERN);
+    if (!match) {
+      logger.warn(
+        { rawDkim, entry, reason: "malformed_dkim_entry" },
+        DKIM_PARSE_FAILURE_LOG_MESSAGE
+      );
+      return [];
+    }
+
+    const [, domain, result] = match;
+    dkimResults.push({
+      domain: domain.toLowerCase(),
+      result: result.toLowerCase(),
+    });
   }
 
   return dkimResults;

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -21,26 +21,6 @@ export type InboundAuthDecision = {
   dkimEntries: InboundEmailDkimResult[];
 };
 
-function logDkimParseIssue({
-  rawDkim,
-  reason,
-  entry,
-  parsedEntryCount,
-}: {
-  rawDkim: string;
-  reason:
-    | "missing_enclosing_braces"
-    | "empty_dkim_results"
-    | "malformed_dkim_entry";
-  entry?: string;
-  parsedEntryCount?: number;
-}) {
-  logger.warn(
-    { rawDkim, reason, entry, parsedEntryCount },
-    DKIM_PARSE_FAILURE_LOG_MESSAGE
-  );
-}
-
 export function parseSendgridDkimResults(
   rawDkim: string | null
 ): InboundEmailDkimResult[] {
@@ -48,12 +28,21 @@ export function parseSendgridDkimResults(
     return [];
   }
 
+  let parseFailureReason:
+    | "missing_enclosing_braces"
+    | "empty_dkim_results"
+    | "malformed_dkim_entry"
+    | null = null;
   const trimmedDkim = rawDkim.trim();
   if (!trimmedDkim.startsWith("{") || !trimmedDkim.endsWith("}")) {
-    logDkimParseIssue({
-      rawDkim,
-      reason: "missing_enclosing_braces",
-    });
+    parseFailureReason = "missing_enclosing_braces";
+  }
+
+  if (parseFailureReason !== null) {
+    logger.warn(
+      { rawDkim, reason: parseFailureReason },
+      DKIM_PARSE_FAILURE_LOG_MESSAGE
+    );
     return [];
   }
 
@@ -61,31 +50,32 @@ export function parseSendgridDkimResults(
     .replace(REPEATED_DKIM_ENTRY_SEPARATOR_PATTERN, ",")
     .slice(1, -1);
   if (normalizedDkim.length === 0) {
-    logDkimParseIssue({
-      rawDkim,
-      reason: "empty_dkim_results",
-    });
-    return [];
+    parseFailureReason = "empty_dkim_results";
   }
 
   const dkimResults: InboundEmailDkimResult[] = [];
-  for (const entry of normalizedDkim.split(",")) {
-    const match = entry.trim().match(SENDGRID_DKIM_ENTRY_PATTERN);
-    if (!match) {
-      logDkimParseIssue({
-        rawDkim,
-        reason: "malformed_dkim_entry",
-        entry: entry.trim(),
-        parsedEntryCount: dkimResults.length,
-      });
-      return [];
-    }
+  if (parseFailureReason === null) {
+    for (const entry of normalizedDkim.split(",")) {
+      const match = entry.trim().match(SENDGRID_DKIM_ENTRY_PATTERN);
+      if (!match) {
+        parseFailureReason = "malformed_dkim_entry";
+        break;
+      }
 
-    const [, domain, result] = match;
-    dkimResults.push({
-      domain: domain.toLowerCase(),
-      result: result.toLowerCase(),
-    });
+      const [, domain, result] = match;
+      dkimResults.push({
+        domain: domain.toLowerCase(),
+        result: result.toLowerCase(),
+      });
+    }
+  }
+
+  if (parseFailureReason !== null) {
+    logger.warn(
+      { rawDkim, reason: parseFailureReason },
+      DKIM_PARSE_FAILURE_LOG_MESSAGE
+    );
+    return [];
   }
 
   return dkimResults;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23318
Context: https://github.com/dust-tt/dust/pull/23318#discussion_r2974278171

Log malformed SendGrid `dkim` payloads in each fail-closed parser path so unexpected input leaves a trace instead of silently rejecting inbound mail.

## Risks
Blast radius: inbound email auth logging for malformed SendGrid DKIM payloads.
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/api/assistant/email/inbound_auth.test.ts`