### PR TITLE
[Email Agents] Case-insensitive SPF comparison and PSL TODO

### DIFF
--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -125,6 +125,20 @@ describe("evaluateInboundAuth", () => {
     expect(decision.reason).toBe("aligned_spf");
   });
 
+  it("accepts SPF regardless of case", () => {
+    const decision = evaluateInboundAuth(
+      makeEmail({
+        senderEmail: "alice@company.com",
+        envelopeFrom: "bounce@company.com",
+        SPF: "Pass",
+        dkim: [],
+      })
+    );
+
+    expect(decision.authenticated).toBe(true);
+    expect(decision.reason).toBe("aligned_spf");
+  });
+
   it("rejects when DKIM passes for a non-aligned domain", () => {
     const decision = evaluateInboundAuth(
       makeEmail({

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -71,7 +71,7 @@ function getEmailDomain(email: string): string {
  *
  * Limitation: this is suffix-based, not PSL-aware — domains under public
  * suffixes like co.uk could incorrectly align (e.g. a.co.uk / b.co.uk).
- * A PSL-aware check should replace this if false positives arise.
+ * TODO: replace with PSL-aware organizational-domain extraction.
  */
 export function domainsAlign(a: string, b: string): boolean {
   const la = a.toLowerCase();
@@ -115,7 +115,7 @@ export function evaluateInboundAuth(
   }
 
   // Path 2: SPF pass with aligned envelope domain.
-  const spfPasses = email.auth.SPF === "pass";
+  const spfPasses = email.auth.SPF.toLowerCase() === "pass";
   const spfDomainAligns = domainsAlign(envelopeDomain, headerFromDomain);
 
   if (spfPasses && spfDomainAligns) {


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/23317

Addresses review comments from @zmarouf:
- Lowercase SPF result before comparing to `"pass"`, for consistency with DKIM parsing which already normalizes to lowercase
- Update `domainsAlign` comment to a TODO for PSL-aware organizational-domain extraction in a follow-up PR

## Risks

Blast radius: inbound email authentication for email agents
Risk: none

## Deploy Plan

- deploy front