### PR TITLE
Fix slack message splitting thread id

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -899,10 +899,9 @@ async function postThreadFollowUpMessages(
   followUpMessages: string[],
   conversationData: StreamConversationToSlackParams
 ): Promise<void> {
-  const { slack, connector, conversation, mainMessage, streamHandler } =
-    conversationData;
-  const { slackChannelId, slackClient } = slack;
-  const threadTs = mainMessage?.ts ?? streamHandler?.messageTs;
+  const { slack, connector, conversation, mainMessage } = conversationData;
+  const { slackChannelId, slackClient, slackMessageTs } = slack;
+  const threadTs = mainMessage?.message?.thread_ts ?? slackMessageTs;
 
   for (let i = 0; i < followUpMessages.length; i++) {
     const threadResponse = await slackClient.chat.postMessage({


### PR DESCRIPTION
## Description

Fix postThreadFollowUpMessages to use slackMessageTs (the original user trigger message) as thread_ts instead of the bot's own reply timestamp, which could cause Slack to create a sub-thread or post at the top level. Aligns with the same pattern used in deleteAndRepostMessageWithFiles.

## Risk

* Low (only applies if you have message splitting FF enabled)

## Deploy Plan

* Deploy connectors