### PR TITLE
Increase maximum attempts before skipping GitHub extraction to GCS

### DIFF
--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -199,7 +199,7 @@ export async function githubExtractToGcsActivity({
 
   logger.info("Extracting GitHub repository tarball to GCS");
 
-  const MAX_ATTEMPTS_BEFORE_SKIP = 10;
+  const MAX_ATTEMPTS_BEFORE_SKIP = 20;
 
   let extractResult;
   try {


### PR DESCRIPTION
## Description

Continuation of https://github.com/dust-tt/dust/pull/20859, but bump up retry limit from 10 to 20.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front