### PR TITLE
fix(logs): add missing modelId to llm trace log when langfuse is enabled

### DIFF
--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -393,7 +393,7 @@ export class LLMTraceBuffer {
           workspaceId: this.workspaceId,
           operationType: this.context.operationType,
           userId: this.context.userId,
-          modelId: this.input?.modelId,
+          modelId: this.input?.modelId ?? this.modelId,
           gcsPath: this.filePath,
           durationMs,
           hasError: !!this.endingError,


### PR DESCRIPTION
## Description

Following https://github.com/dust-tt/dust/pull/23036, input is no longer populated when langfuse is enabled, meaning `LLM trace written to GCS` log no longer contains `modelId`.

This PR adds it back in order to add a visualization of latency per provider, by aggregating the durationMs of those logs per modelId.


## Tests

None
## Risk

None
## Deploy Plan

Front