### PR TITLE
feat: filter out non-usable sandbox tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -299,6 +299,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
+    availableInDirectExecution: false,
     metadata: INCLUDE_DATA_SERVER,
   },
   run_dust_app: {
@@ -878,6 +879,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
+    availableInDirectExecution: false,
     metadata: SEARCH_SERVER,
   },
   run_agent: {
@@ -900,6 +902,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
+    availableInDirectExecution: false,
     metadata: QUERY_TABLES_V2_SERVER,
   },
   data_sources_file_system: {
@@ -937,6 +940,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
+    availableInDirectExecution: false,
     metadata: DATA_WAREHOUSES_SERVER,
   },
   toolsets: {
@@ -1007,6 +1011,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
+    availableInDirectExecution: false,
     metadata: SKILL_MANAGEMENT_SERVER,
   },
   schedules_management: {
@@ -1018,6 +1023,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
+    availableInDirectExecution: false,
     metadata: SCHEDULES_MANAGEMENT_SERVER,
   },
   project_manager: {
@@ -1067,6 +1073,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: 120000, // 2 minutes for command execution
+    availableInDirectExecution: false,
   },
   project_conversation: {
     id: 1025,
@@ -1127,6 +1134,9 @@ type InternalMCPServerEntryCommon = {
   tools_retry_policies: Record<string, MCPToolRetryPolicyType> | undefined;
   timeoutMs: number | undefined;
   requiresBearerToken?: boolean;
+  // When false, the server is hidden from direct execution contexts (e.g. sandbox CLI).
+  // Defaults to true.
+  availableInDirectExecution?: boolean;
 };
 
 type InternalMCPServerEntryWithMetadata<K extends InternalMCPServerNameType> =
@@ -1355,4 +1365,11 @@ export function getInternalMCPServerMetadata(
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
 
   return server.metadata;
+}
+
+export function isInternalMCPServerAvailableInDirectExecution(
+  name: InternalMCPServerNameType
+): boolean {
+  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  return server.availableInDirectExecution !== false;
 }

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -117,10 +117,12 @@ export function createNotionTools(
         const citationsOffset =
           agentLoopContext?.runContext?.stepContext.citationsOffset ?? 0;
 
-        const refs = getRefs().slice(
-          citationsOffset,
-          citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
-        );
+        const refs = agentLoopContext?.runContext?.stepContext.citationsOffset
+          ? getRefs().slice(
+              citationsOffset,
+              citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
+            )
+          : [];
 
         const resultResources = results.map((result) => {
           if (isFullPage(result)) {

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -74,10 +74,6 @@ export function createNotionTools(
       { query, type, relativeTimeFrame },
       { authInfo }: ToolHandlerExtra
     ) => {
-      if (!agentLoopContext?.runContext) {
-        return new Err(new MCPError("Agent loop run context is required"));
-      }
-
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Ok(makePersonalAuthenticationError("notion").content);
@@ -118,7 +114,8 @@ export function createNotionTools(
           },
         ]);
       } else {
-        const { citationsOffset } = agentLoopContext.runContext.stepContext;
+        const citationsOffset =
+          agentLoopContext?.runContext?.stepContext.citationsOffset ?? 0;
 
         const refs = getRefs().slice(
           citationsOffset,

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -1,3 +1,7 @@
+import {
+  isInternalMCPServerAvailableInDirectExecution,
+  isInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
@@ -111,7 +115,16 @@ async function handler(
 
       const { server, light } = req.query;
 
-      let serverViews = views.map((view) => view.toJSON());
+      let serverViews = views
+        .map((view) => view.toJSON())
+        // Filter out internal servers not available in direct execution.
+        .filter((sv) => {
+          const name = sv.server.name;
+          if (isInternalMCPServerName(name)) {
+            return isInternalMCPServerAvailableInDirectExecution(name);
+          }
+          return true;
+        });
 
       // Filter by server name if requested.
       if (isString(server)) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

The sandbox CLI (dsbx tools) lists all MCP servers available to the agent, but some of them hard-fail when called because they require an agentLoopRunContext that doesn't exist in direct execution. This means the sandbox shows tools that can never work.

Some tools will be fixed to work in the sandbox. Some tools just does not make sense in the sandbox. This PR filters out tools that are not made to be used in the sandbox (`sandbox`, `search`, `include_data`, `query_tables_v2`, `data_warehouses`, `schedules_management`, `skill_management`).

It also quick-fixes the notion tool to gracefully handle missing context instead of hard failing. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front