### PR TITLE
Remove useless include when fetching messages.

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,7 +1,5 @@
-import { getMaximalVersionAgentStepContent } from "@app/lib/api/assistant/configuration/steps";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageModel,
   MessageModel,
@@ -143,13 +141,6 @@ async function _getConversation<V extends "light" | "full">(
         model: AgentMessageModel,
         as: "agentMessage",
         required: false,
-        include: [
-          {
-            model: AgentStepContentModel,
-            as: "agentStepContents",
-            required: false,
-          },
-        ],
       },
       // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
       // along with messages in one query). Only once we move to a MessageResource will we be able
@@ -161,16 +152,6 @@ async function _getConversation<V extends "light" | "full">(
       },
     ],
   });
-
-  // Filter to only keep the step content with the maximum version for each step and index combination.
-  for (const message of messages) {
-    if (message.agentMessage && message.agentMessage.agentStepContents) {
-      message.agentMessage.agentStepContents =
-        getMaximalVersionAgentStepContent(
-          message.agentMessage.agentStepContents
-        );
-    }
-  }
 
   const renderRes = await batchRenderMessages(
     auth,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1,7 +1,5 @@
-import { getMaximalVersionAgentStepContent } from "@app/lib/api/assistant/configuration/steps";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -1668,13 +1666,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: AgentMessageModel,
           as: "agentMessage",
           required: false,
-          include: [
-            {
-              model: AgentStepContentModel,
-              as: "agentStepContents",
-              required: false,
-            },
-          ],
         },
         // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
         // along with messages in one query). Only once we move to a MessageResource will we be able
@@ -1686,16 +1677,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         },
       ],
     });
-
-    // Filter to only keep the step content with the maximum version for each step and index combination.
-    for (const message of messages) {
-      if (message.agentMessage && message.agentMessage.agentStepContents) {
-        message.agentMessage.agentStepContents =
-          getMaximalVersionAgentStepContent(
-            message.agentMessage.agentStepContents
-          );
-      }
-    }
 
     return {
       hasMore,


### PR DESCRIPTION
## Description

Useless include of step contents (we do it again in `batchRenderMessages` > `batchRenderAgentMessages`).

## Tests

Local + Green

## Risk

Medium but I'm pretty sure of myself.

## Deploy Plan

Deploy front