### PR TITLE
feat: support full output types in dsbx

### DIFF
--- a/cli/dust-sandbox/src/api/mod.rs
+++ b/cli/dust-sandbox/src/api/mod.rs
@@ -2,3 +2,4 @@ mod client;
 mod types;
 
 pub use client::DustApiClient;
+pub use types::ContentBlock;

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -53,6 +53,39 @@ pub struct CallToolResult {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ContentBlock {
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image {
+        #[allow(dead_code)]
+        data: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+    },
+    #[serde(rename = "audio")]
+    Audio {
+        #[allow(dead_code)]
+        data: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+    },
+    #[serde(rename = "resource")]
+    Resource { resource: ResourceContent },
+    #[serde(rename = "resource_link")]
+    ResourceLink { uri: String, name: Option<String> },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResourceContent {
+    pub uri: String,
+    #[serde(rename = "mimeType")]
+    #[allow(dead_code)]
+    pub mime_type: Option<String>,
     pub text: Option<String>,
+    #[allow(dead_code)]
+    pub blob: Option<String>,
 }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -53,36 +53,40 @@ pub struct CallToolResult {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum ContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "image")]
+    Text {
+        text: String,
+    },
     Image {
         #[allow(dead_code)]
         data: String,
-        #[serde(rename = "mimeType")]
         mime_type: String,
     },
-    #[serde(rename = "audio")]
     Audio {
         #[allow(dead_code)]
         data: String,
-        #[serde(rename = "mimeType")]
         mime_type: String,
     },
-    #[serde(rename = "resource")]
-    Resource { resource: ResourceContent },
-    #[serde(rename = "resource_link")]
-    ResourceLink { uri: String, name: Option<String> },
+    Resource {
+        resource: ResourceContent,
+    },
+    ResourceLink {
+        uri: String,
+        name: Option<String>,
+    },
     #[serde(other)]
     Unknown,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourceContent {
     pub uri: String,
-    #[serde(rename = "mimeType")]
     #[allow(dead_code)]
     pub mime_type: Option<String>,
     pub text: Option<String>,

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 
-use crate::api::DustApiClient;
+use crate::api::{ContentBlock, DustApiClient};
 
 pub async fn cmd_exec(
     client: &DustApiClient,
@@ -33,8 +33,33 @@ pub async fn cmd_exec(
         .await?;
 
     for block in &resp.result.content {
-        if let Some(text) = &block.text {
-            println!("{text}");
+        match block {
+            ContentBlock::Text { text } => {
+                println!("{text}");
+            }
+            ContentBlock::Image { mime_type, .. } => {
+                eprintln!("[image: {mime_type}]");
+            }
+            ContentBlock::Audio { mime_type, .. } => {
+                eprintln!("[audio: {mime_type}]");
+            }
+            ContentBlock::Resource { resource } => {
+                if let Some(text) = &resource.text {
+                    println!("{text}");
+                } else if resource.blob.is_some() {
+                    eprintln!("[binary resource: {}]", resource.uri);
+                } else {
+                    eprintln!("[resource: {}]", resource.uri);
+                }
+            }
+            ContentBlock::ResourceLink { uri, name } => {
+                if let Some(name) = name {
+                    eprintln!("[resource link: {name} — {uri}]");
+                } else {
+                    eprintln!("[resource link: {uri}]");
+                }
+            }
+            ContentBlock::Unknown => {}
         }
     }
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -122,11 +122,7 @@ async function handler(
           });
         }
 
-        const content: CallMCPToolResponseType["result"]["content"] =
-          result.content.map((block: { type: string; text?: string }) => ({
-            type: block.type,
-            ...("text" in block ? { text: block.text } : {}),
-          }));
+        const content = result.content;
 
         return res.status(200).json({
           success: true,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -10,7 +10,7 @@ import {
   NotificationInteractiveContentFileContentSchema,
   OAuthProviderSchema,
 } from "./output_schemas";
-import { CallToolResultSchema } from "./raw_mcp_types";
+import { CallToolResultSchema, ContentBlockSchema } from "./raw_mcp_types";
 import { TIMEZONE_NAMES } from "./timezone_names";
 
 const ModelProviderIdSchema = FlexibleEnumSchema<
@@ -3295,15 +3295,10 @@ export type CallMCPToolRequestBodyType = z.infer<
   typeof CallMCPToolRequestBodySchema
 >;
 
-const CallMCPToolContentBlockSchema = z.object({
-  type: z.string(),
-  text: z.string().optional(),
-});
-
 export const CallMCPToolResponseSchema = z.object({
   success: z.literal(true),
   result: z.object({
-    content: z.array(CallMCPToolContentBlockSchema),
+    content: z.array(ContentBlockSchema),
     isError: z.boolean(),
   }),
 });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

The dsbx tools command and the call_tool API endpoint were only handling text content blocks from MCP tool responses, silently discarding images, audio, embedded resources, and resource links. This meant that tools returning rich content (like image-generating tools or tools that return structured resources) would appear to produce no output at all.

The root cause was threefold: the SDK's CallMCPToolContentBlockSchema only defined {type, text?}, the API endpoint manually stripped all fields except type and text from the MCP server's response, and the Rust CLI only deserialized a text field.

The fix replaces the custom SDK schema with the canonical ContentBlockSchema from raw_mcp_types.ts that already covers all five MCP content block types. With this, the API endpoint can simply forward `result.content` from the MCP SDK as-is, eliminating 60 lines of manual field extraction. The CLI renders text content to `stdout` (keeping it pipeable) and prints descriptive placeholders for non-renderable content like images and audio to `stderr`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Publish new dsbx cli and add it to sandbox image