### PR TITLE
Tracking: enhance signup flow handling in PostHog

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -13,7 +13,11 @@ import {
   getOrCreateAnonymousId,
   getPostHogCookieDomain,
 } from "@app/lib/utils/anonymous_id";
-import { getStoredUTMParams, MARKETING_PARAMS } from "@app/lib/utils/utm";
+import {
+  getStoredReferrer,
+  getStoredUTMParams,
+  MARKETING_PARAMS,
+} from "@app/lib/utils/utm";
 import { isString } from "@app/types/shared/utils/general";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
@@ -250,6 +254,20 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
           firstTouchProps[`first_${param}`] = value;
         }
       }
+
+      // Include the original external referrer (from the _dust_referrer cookie).
+      const storedReferrer = getStoredReferrer();
+      if (storedReferrer) {
+        firstTouchProps["first_referrer"] = storedReferrer;
+        try {
+          firstTouchProps["first_referring_domain"] = new URL(
+            storedReferrer
+          ).hostname;
+        } catch {
+          // Ignore malformed referrer URLs.
+        }
+      }
+
       if (Object.keys(firstTouchProps).length > 0) {
         posthog.setPersonProperties({}, firstTouchProps);
       }

--- a/front/hooks/useStripUtmParams.ts
+++ b/front/hooks/useStripUtmParams.ts
@@ -6,6 +6,7 @@ import {
   MARKETING_PARAMS,
   persistClickIdCookies,
   persistDustAidFromURL,
+  persistReferrerCookie,
   persistUTMCookies,
 } from "@app/lib/utils/utm";
 import { useEffect } from "react";
@@ -34,6 +35,9 @@ export function useStripUtmParams() {
     try {
       // Re-establish anonymous device ID from email CTA links (?dust_aid=...).
       persistDustAidFromURL();
+
+      // Capture the original external referrer in a cross-subdomain cookie.
+      persistReferrerCookie();
 
       const params = Object.fromEntries(
         new URLSearchParams(window.location.search)

--- a/front/lib/utils/anonymous_id.ts
+++ b/front/lib/utils/anonymous_id.ts
@@ -9,7 +9,7 @@ const ANONYMOUS_ID_MAX_AGE_SECONDS = 31536000; // 1 year
  * On production (any *.dust.tt host) returns `.dust.tt`;
  * on localhost/dev returns null (no domain attribute needed).
  */
-function getRootCookieDomain(): string | null {
+export function getRootCookieDomain(): string | null {
   if (typeof window === "undefined") {
     return null;
   }

--- a/front/lib/utils/utm.ts
+++ b/front/lib/utils/utm.ts
@@ -1,4 +1,7 @@
-import { buildDustAidCookieString } from "@app/lib/utils/anonymous_id";
+import {
+  buildDustAidCookieString,
+  getRootCookieDomain,
+} from "@app/lib/utils/anonymous_id";
 import { posthog } from "posthog-js";
 
 // Marketing and UTM parameter keys to track across the application.
@@ -67,6 +70,9 @@ export function persistClickIdCookies(params: UTMParams): void {
     return;
   }
 
+  const domain = getRootCookieDomain();
+  const domainPart = domain ? `; domain=${domain}` : "";
+
   for (const key of CLICK_ID_KEYS) {
     const value = params[key];
     if (value) {
@@ -74,7 +80,7 @@ export function persistClickIdCookies(params: UTMParams): void {
       const expires = new Date(
         Date.now() + expiryDays * 24 * 60 * 60 * 1000
       ).toUTCString();
-      document.cookie = `_dust_${key}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
+      document.cookie = `_dust_${key}=${encodeURIComponent(value)}; expires=${expires}; path=/${domainPart}; SameSite=Lax; Secure`;
     }
   }
 }
@@ -101,13 +107,16 @@ export function persistUTMCookies(params: UTMParams): void {
     return;
   }
 
+  const domain = getRootCookieDomain();
+  const domainPart = domain ? `; domain=${domain}` : "";
+
   for (const key of UTM_KEYS) {
     const value = params[key];
     if (value) {
       const expires = new Date(
         Date.now() + UTM_COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
       ).toUTCString();
-      document.cookie = `_dust_${key}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
+      document.cookie = `_dust_${key}=${encodeURIComponent(value)}; expires=${expires}; path=/${domainPart}; SameSite=Lax; Secure`;
     }
   }
 }
@@ -170,6 +179,57 @@ export const getStoredUTMParams = (): UTMParams => {
     return {};
   }
 };
+
+const REFERRER_COOKIE = "_dust_referrer";
+const REFERRER_COOKIE_EXPIRY_DAYS = 30;
+
+// Persist `document.referrer` in a cross-subdomain cookie (first-touch only).
+// Only written when the referrer is external (not *.dust.tt) and the cookie
+// does not already exist, so the original traffic source survives the
+// dust.tt → signin → app.dust.tt auth flow.
+export function persistReferrerCookie(): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  if (getStoredReferrer()) {
+    return;
+  }
+
+  const referrer = document.referrer;
+  if (!referrer) {
+    return;
+  }
+
+  try {
+    const host = new URL(referrer).hostname;
+    if (host === "localhost" || host.endsWith(".dust.tt")) {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  const domain = getRootCookieDomain();
+  const domainPart = domain ? `; domain=${domain}` : "";
+  const expires = new Date(
+    Date.now() + REFERRER_COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+  ).toUTCString();
+
+  document.cookie = `${REFERRER_COOKIE}=${encodeURIComponent(referrer)}; expires=${expires}; path=/${domainPart}; SameSite=Lax; Secure`;
+}
+
+// Read the stored referrer from the cross-subdomain `_dust_referrer` cookie.
+export function getStoredReferrer(): string | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const prefix = `${REFERRER_COOKIE}=`;
+  const cookie = document.cookie.split("; ").find((c) => c.startsWith(prefix));
+
+  return cookie ? decodeURIComponent(cookie.slice(prefix.length)) : null;
+}
 
 // Append UTM parameters to URLs.
 export const appendUTMParams = (url: string, utmParams?: UTMParams): string => {


### PR DESCRIPTION
## Description
 
Fix PostHog marketing attribution data (UTMs, referrer) being lost during the dust.tt -> signin.dust.tt -> app.dust.tt auth flow.

The root cause: UTM and click-ID cookies were set without domain=.dust.tt, making them origin-specific. When posthog.identify() fires on app.dust.tt, the UTM data captured on dust.tt wasn't accessible. Similarly, $initial_referrer was always signin.dust.tt because that's the referrer at the time the person profile gets created. 
  
Changes: 
 - Add domain=.dust.tt to all UTM (`_dust_utm_*`) and click-ID (`_dust_gclid`, etc.) cookies so they're readable across subdomains
 - Add a new `_dust_referrer` cross-subdomain cookie that captures the first external referrer on landing (first-touch only, skips internal *.dust.tt referrers)  
 - On identify(), read the referrer cookie and set first_referrer / first_referring_domain as $set_once person properties
 
## Tests

 - Manual: visit dust.tt with UTM params (e.g. ?utm_source=google), go through the auth flow, verify the UTM cookies are readable on app.dust.tt and the person profile in PostHog shows correct first_utm_source and first_referrer values visits)
 - Verify internal navigation (between dust.tt subdomains) doesn't set the referrer cookie

## Risk
 
 Low: cookie domain changes are additive; the referrer cookie is new and only read in one place.
 
## Deploy Plan

 Standard deploy, no migration needed. Existing users won't retroactively get marketing data — this fixes attribution for new signups going forward.
