### PR TITLE
Do not gate agent edition behind FF

### DIFF
--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -1,6 +1,6 @@
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
@@ -13,7 +13,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { canShowAgentConversationActions } from "@app/types/assistant/assistant";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
-import { isAdmin, isBuilder } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   BracesIcon,
   Button,

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -46,12 +46,6 @@ export function AgentDetailsButtonBar({
 }: AgentDetailsButtonBarProps) {
   const { user } = useAuth();
 
-  const { featureFlags } = useFeatureFlags();
-
-  const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") &&
-    !isBuilder(owner);
-
   const { updateUserFavorite, isUpdatingFavorite } = useUpdateUserFavorite({
     owner,
     agentConfigurationId: agentConfiguration.sId,
@@ -120,21 +114,20 @@ export function AgentDetailsButtonBar({
         />
       )}
 
-      {agentConfiguration.scope !== "global" &&
-        !isRestrictedFromAgentCreation && (
-          <Button
-            size="sm"
-            tooltip="Edit agent"
-            href={
-              canEditAgent
-                ? getAgentBuilderRoute(owner.sId, agentConfiguration.sId)
-                : undefined
-            }
-            disabled={!canEditAgent}
-            variant="outline"
-            icon={PencilSquareIcon}
-          />
-        )}
+      {agentConfiguration.scope !== "global" && (
+        <Button
+          size="sm"
+          tooltip="Edit agent"
+          href={
+            canEditAgent
+              ? getAgentBuilderRoute(owner.sId, agentConfiguration.sId)
+              : undefined
+          }
+          disabled={!canEditAgent}
+          variant="outline"
+          icon={PencilSquareIcon}
+        />
+      )}
 
       {agentConfiguration.scope !== "global" && (
         <AgentDetailsDropdownMenu


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/7251.

Implementation of the `disallow_agent_creation_to_users` FF was hidding the "edit agent" where as we surface it to customers are block agent creation, not edition.

This PR ensures that we don't get the edit agent CTA behind the FF + builder requirements and uses the default `canEdit` permissions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
