### PR TITLE
Add logic to handle when suggestion increases number of blocks

### DIFF
--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -78,6 +78,7 @@ import {
   isSubAgentSuggestion,
   isToolsSuggestion,
 } from "@app/types/suggestions/agent_suggestion";
+import { JSDOM } from "jsdom";
 
 const SIDEKICK_KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
   "managed",
@@ -189,6 +190,14 @@ async function markDuplicateSuggestionsAsOutdated(
 type InstructionSuggestionInput = z.infer<typeof InstructionsSuggestionSchema>;
 
 /**
+ * Returns the number of top-level HTML elements in the given HTML string
+ */
+function countTopLevelBlocks(html: string): number {
+  const dom = new JSDOM(`<body>${html}</body>`);
+  return dom.window.document.body.children.length;
+}
+
+/**
  * Shared logic for creating instruction suggestions. Used by both the
  * suggest_prompt_edits MCP handler and reinforced agent analysis.
  */
@@ -243,6 +252,19 @@ export async function createInstructionSuggestions({
 
   if (!agentConfiguration) {
     return new Err(`Agent configuration not found: ${agentConfigurationId}`);
+  }
+
+  // Reject non-root suggestions that contain multiple top-level blocks.
+  for (const suggestion of suggestions) {
+    if (suggestion.targetBlockId !== INSTRUCTIONS_ROOT_TARGET_BLOCK_ID) {
+      const blockCount = countTopLevelBlocks(suggestion.content);
+      if (blockCount > 1) {
+        return new Err(
+          `Suggestion for block "${suggestion.targetBlockId}" contains ${blockCount} top-level elements but replace only supports 1. ` +
+            `Keep it within a single tag, or use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' if the change requires multiple blocks.`
+        );
+      }
+    }
   }
 
   const createdSuggestions: {

--- a/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
@@ -14,10 +14,6 @@ Use imperatives for critical rules:
 - "NEVER invent features that don't exist"
 - "DO NOT output text between tool calls"
 
-Include negative constraints (what NOT to do):
-- More effective than positive instructions alone
-- Prevents common failure modes
-
 <generalization_over_examples>
 When users provide examples, extract the INTENT, not the literal pattern:
 - Examples are illustrations, not the full scope
@@ -62,26 +58,32 @@ When you detect a conflict: flag it BEFORE suggesting.
 `,
 
   instructionSuggestionFormatting: `<block_aware_editing>
-The following information is for you to understand how to edit agent instructions. NEVER mention anything about these details in your response.
+The following information is for you to understand how to edit agent instructions. NEVER mention anything about these details or decisions in your response.
 
-Agent instructions are organized into "blocks", logical containers that group related instructions.
+Agent instructions are organized into a hierarchy of "blocks", logical containers that group related instructions.
+Blocks are the unit of user review: users accept or reject each suggestion independently, so block granularity defines how precisely they can review your edits.
 Each block has a unique \`data-block-id\` attribute, an 8-character random identifier (e.g., "7f3a2b1c").
 These IDs are persisted and stable across editing sessions.
 
 When you receive the agent instructions via \`get_agent_config\`, they will be in HTML format with block IDs:
 \`\`\`html
 <p data-block-id="7f3a2b1c">You are a helpful assistant.</p>
-<p data-block-id="e9d8c7b6">Always respond in JSON format.</p>
 \`\`\`
 
 <block_editing_principles>
 1. Think in blocks, not documents. Identify which block(s) your change affects before suggesting.
-2. One block per suggestion. Users accept/reject each independently.
-3. One suggestion per block. Never send multiple suggestions targeting the same block ID.
-4. Copy block IDs exactly. They are random identifiers, never construct them yourself.
-5. Always include the HTML tag. Content must include the wrapping tag (e.g., \`<p>...</p>\`).
-6. Diffs are computed automatically. Just provide the full new content.
-7. For full rewrites, target the root. Use \`targetBlockId: "${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"\` with content wrapped in \`<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}">...</div>\` to replace all instructions at once.
+2. Classify your edit before acting:
+   - (a) Modifying or expanding content within an existing concern → target that block directly
+   - (b) Adding a genuinely new independent concern → root rewrite to introduce a new block
+   - (c) Restructuring across multiple existing blocks → root rewrite
+   Never reach for a root rewrite if the change fits case (a).
+3. One block per suggestion. Users accept/reject each independently.
+4. One suggestion per block. Never send multiple suggestions targeting the same block ID.
+5. Copy block IDs exactly. They are random identifiers, never construct them yourself.
+6. Always include the HTML tag. Content must include the wrapping tag (e.g., \`<p>...</p>\`).
+7. A root rewrite invalidates all other pending suggestions and shows the user a larger, harder-to-review diff. Only use it for cases (b) or (c) above.
+8. A single-block replace must produce exactly one top-level HTML element. Never output multiple sibling elements for a non-root target — the system will reject it.
+9. For full rewrites, target the root. Use \`targetBlockId: "${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"\` with content wrapped in \`<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}">...</div>\` to replace all instructions at once.
 </block_editing_principles>
 
 <block_examples>
@@ -128,10 +130,9 @@ Allowed block structures: \`<ul><li>\`, \`<ol><li>\`, \`<pre><code>\`.
 
 <suggestion_conflict_rules>
 When you create a new instruction suggestion, the system automatically marks existing suggestions as outdated based on hierarchy:
-
-- **Same block**: If you suggest changes to block "abc123" and there's already a pending suggestion for "abc123", the old one becomes outdated
-- **Parent-child**: If you suggest changes to a parent block that contains child blocks, any suggestions targeting those children become outdated (because the parent replacement would overwrite them)
-- **Full rewrite**: If you target \`${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}\` (full rewrite), ALL other instruction suggestions become outdated
+- Same block: If you suggest changes to block "abc123" and there's already a pending suggestion for "abc123", the old one becomes outdated
+- Parent-child: If you suggest changes to a parent block that contains child blocks, any suggestions targeting those children become outdated (because the parent replacement would overwrite them)
+- Full rewrite: If you target \`${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}\` (full rewrite), ALL other instruction suggestions become outdated
 
 This happens automatically. You do NOT need to call \`update_suggestions_state\` to mark suggestions as outdated.
 </suggestion_conflict_rules>
@@ -140,35 +141,6 @@ This happens automatically. You do NOT need to call \`update_suggestions_state\`
 <newline_discipline>
 Be conservative with newlines. Only add them when they genuinely improve readability.
 </newline_discipline>`,
-
-  skillsToolsDecisionLogic: `- Tools = specific integrations (Jira, Gmail, Slack)
-- Skills = packaged expertise (instructions + methodology + tools) that can be reused across agents
-
-**Decision Logic:**
-Use a skill when the task overlaps with that skill's domain expertise and specialized instructions.
-
-**When to use tools directly:**
-- Task maps directly to a tool's function without needing specialized methodology
-- Examples: "Create Jira ticket", "Search Slack for X", "Send email"
-
-**When to enable skills:**
-- Task benefits from the skill's specialized instructions and approach
-- The skill's packaged expertise adds value beyond just using tools
-
-**Key Points:**
-- Skills aren't about complexity alone—they're about leveraging specialized expertise
-- Ask: "Would this task benefit from the specific instructions this skill provides?"
-- Don't enable a skill if you can handle it well without its specialized approach
-- Skills compose with tools—they can use tools as part of their methodology
-
-**Skill vs Tool Example Scenario**
-Should use the Jira tool directly given it is a straightforward action with no methodology needed:
-- "Search Jira for bugs assigned to me"
-- "Create a ticket for this bug"
-
-Should use a hypothetical "Sprint Planning" skill given it has specific expertise on how to use the Jira tool, including on sprint methodology, story sizing, capacity planning:
-- "Help me plan next sprint"
-- "Prioritize the backlog"`,
 
   skillsToolsGuidance: `
 - Tools = specific integrations (Jira, Gmail, Slack)


### PR DESCRIPTION
## Description

* Prevent replace action to be taken across multiple nodes
* Removed some dead / redundant prompts

## Tests

This did not work previously:

<img width="1371" height="598" alt="Screenshot 2026-03-27 at 9 16 40 AM" src="https://github.com/user-attachments/assets/995d2081-a170-4b8b-a9ea-a53bac9d6deb" />


## Risk

* Low

## Deploy Plan

* Deploy front