### PR TITLE
Add cache on /extension/config calls

### DIFF
--- a/front/lib/swr/extension.ts
+++ b/front/lib/swr/extension.ts
@@ -13,7 +13,12 @@ export function useExtensionConfig(
   const { data, error } = useSWRWithDefaults(
     `/api/w/${owner.sId}/extension/config`,
     configFetcher,
-    { disabled }
+    {
+      disabled,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 5 * 60 * 1000, // 5 minutes.
+    }
   );
 
   return {


### PR DESCRIPTION
## Description

Add SWR cache configuration to the `/extension/config` API call to prevent unnecessary revalidation. The extension config (blacklisted domains) rarely changes and doesn't need to be refetched on every tab focus or network reconnect. The hook now disables `revalidateOnFocus` and `revalidateOnReconnect`, and sets a 5-minute deduping interval to reduce redundant API calls.

## Tests

Manually tested in the extension: verified config is cached and not refetched on focus/reconnect events.

## Risk

None. Standard SWR caching configuration change that only affects extension config fetching.

## Deploy Plan

Deploy front.