### PR TITLE
feat: extension attach page shortcut

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -562,7 +562,7 @@ const InputBarContainer = ({
     return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
   }, []);
 
-  const pageShortcut = isMac ? "⇧⌘P" : "Ctrl+Maj+P";
+  const pageShortcut = isMac ? "⇧⌘Y" : "Ctrl+Maj+Y";
   const screenshotShortcut = isMac ? "⇧⌘S" : "Ctrl+Maj+S";
 
   useEffect(() => {
@@ -578,7 +578,7 @@ const InputBarContainer = ({
       if (captureActions.isCapturing || fileUploaderService.isProcessingFiles) {
         return;
       }
-      if (e.key === "p" || e.key === "P") {
+      if (e.key === "y" || e.key === "Y") {
         e.preventDefault();
         captureActions.onCapture("text");
       } else if (e.key === "s" || e.key === "S") {


### PR DESCRIPTION
<html><head></head><body><h2>Description</h2>
<p>This PR changes the keyboard shortcut for attaching pages in the extension from Shift+Cmd+P to Shift+Cmd+Y on Mac (Ctrl+Shift+P to Ctrl+Shift+Y on other platforms).</p>
<p>Other more mnemonic alternatives were considered, but discarded because of conflicts:</p>

Shortcut | Reason discarded
-- | --
⇧⌘P | Firefox opens private window
⇧⌘A | Chrome opens "Search tabs"; Firefox opens Add-ons Manager
⇧⌘E | Already used by Dust extension to open the panel
⇧⌘I | Ctrl+Shift+I opens DevTools on Windows (Chrome + Firefox)
⇧⌘C | Opens DevTools inspector in Chrome and Firefox
⇧⌘S | Already used for screenshot
⌥⇧P | Option+Shift+P produces ∏ on Mac, intercepts typing
Ctrl+Shift+P | macOS system shortcut: extends text selection upward in inputs


<h2>Tests</h2>
<p>Manually.</p>
<h2>Risks</h2>
<p>Low risk - keyboard shortcut change only.</p>
<h2>Deploy Plan</h2>
<p>Standard deployment. Update documentation once released</p>
</body></html>