### PR TITLE
Add a 'reinforcement' agent to not re-use sidekick

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/reinforcement.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/reinforcement.ts
@@ -1,0 +1,39 @@
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
+
+// This agent is never called directly. It is only used as a placeholder when
+// building reinforcement conversations so they can be rendered in poke.
+export function _getReinforcementGlobalAgent(): AgentConfigurationType {
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.REINFORCEMENT,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: "Reinforcement",
+    description:
+      "Internal agent used as a placeholder for reinforcement conversations.",
+    instructions: "",
+    instructionsHtml: null,
+    pictureUrl: DUST_AVATAR_URL,
+    status: "active",
+    scope: "global",
+    userFavorite: false,
+    model: {
+      providerId: NOOP_MODEL_CONFIG.providerId,
+      modelId: NOOP_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
+    actions: [],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -511,6 +511,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "An agent that suggests improvements for another agent.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.REINFORCEMENT:
+      return {
+        sId: GLOBAL_AGENTS_SID.REINFORCEMENT,
+        name: "Reinforcement",
+        description:
+          "Internal agent used as a placeholder for reinforcement conversations.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.NOOP:
       return {
         sId: GLOBAL_AGENTS_SID.NOOP,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -47,6 +47,7 @@ import {
   _getDustQuickMediumGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
+import { _getReinforcementGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/reinforcement";
 import { _getSidekickGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/sidekick";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import { _getGeminiProGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/google";
@@ -327,6 +328,12 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsToolsets: false,
     injectsUserContext: true,
     injectsWorkspaceContext: true,
+  },
+  [GLOBAL_AGENTS_SID.REINFORCEMENT]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.SLACK]: {
     injectsMemory: false,
@@ -1015,6 +1022,9 @@ function getGlobalAgent({
         globalAgentContext,
       });
       break;
+    case GLOBAL_AGENTS_SID.REINFORCEMENT:
+      agentConfiguration = _getReinforcementGlobalAgent();
+      break;
     case GLOBAL_AGENTS_SID.NOOP:
       // we want only to have it in development
       if (isDevelopment()) {
@@ -1100,7 +1110,10 @@ export async function getGlobalAgents(
     Object.values(GLOBAL_AGENTS_SID)
       .filter((sId) => !RETIRED_GLOBAL_AGENTS_SID.includes(sId))
       // We only want to fetch sidekick global agents if explicitly requested.
-      .filter((sId) => sId !== GLOBAL_AGENTS_SID.SIDEKICK);
+      .filter((sId) => sId !== GLOBAL_AGENTS_SID.SIDEKICK)
+      // The reinforcement agent is never called directly, it is only used as a
+      // placeholder when building reinforcement conversations.
+      .filter((sId) => sId !== GLOBAL_AGENTS_SID.REINFORCEMENT);
 
   const flags = await getFeatureFlags(auth);
 

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -58,9 +58,7 @@ type ReinforcedOperationType =
   | "reinforced_agent_analyze_conversation"
   | "reinforced_agent_aggregate_suggestions";
 
-// TODO(reinforced agent) create a hidden static agent for reinforcement
-// We need a real agent to redner the conversation in poke
-export const REINFORCEMENT_AGENT_ID = "sidekick";
+export const REINFORCEMENT_AGENT_ID = "reinforcement";
 
 export function getReinforcementDefaultOptions(
   reinforcedOperationType: ReinforcedOperationType

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -86,6 +86,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
   DUST_PLANNING = "dust-planning",
   SIDEKICK = "sidekick",
+  REINFORCEMENT = "reinforcement",
   SLACK = "slack",
   GOOGLE_DRIVE = "google_drive",
   NOTION = "notion",


### PR DESCRIPTION
## Description

The agent is never actually used, only used to have one real agent to display in poke when redering the conversation.

<img width="1644" height="1698" alt="image" src="https://github.com/user-attachments/assets/c3da322d-90f5-4760-9b8c-3cfbd544f1f2" />


## Tests

manual tests locally

## Risk

low

## Deploy Plan

deploy front
