### PR TITLE
feat(project): add conversation TODO model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -72,6 +72,7 @@ import {
 } from "@app/lib/resources/storage/models/apps";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { ConversationButlerSuggestionModel } from "@app/lib/resources/storage/models/conversation_butler_suggestion";
+import { ConversationTodoVersionedModel } from "@app/lib/resources/storage/models/conversation_todo_versioned";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -219,6 +220,7 @@ export function loadAllModels() {
     AcademyChapterVisitModel,
     SandboxModel,
     ConversationButlerSuggestionModel,
+    ConversationTodoVersionedModel,
     ConversationBranchModel,
     ProjectTodoModel,
     ProjectTodoConversationModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -21,6 +21,7 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { ConversationButlerSuggestionModel } from "@app/lib/resources/storage/models/conversation_butler_suggestion";
+import { ConversationTodoVersionedModel } from "@app/lib/resources/storage/models/conversation_todo_versioned";
 import {
   ProjectTodoConversationModel,
   ProjectTodoSourceModel,
@@ -282,6 +283,13 @@ export async function destroyConversation(
   });
 
   await ConversationButlerSuggestionModel.destroy({
+    where: {
+      workspaceId: owner.id,
+      conversationId: conversation.id,
+    },
+  });
+
+  await ConversationTodoVersionedModel.destroy({
     where: {
       workspaceId: owner.id,
       conversationId: conversation.id,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1335,7 +1335,9 @@ describe("getOptions", () => {
       const { frontSequelize } = await import("@app/lib/resources/storage");
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: threeDaysAgo.toISOString(),
@@ -1345,7 +1347,9 @@ describe("getOptions", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: fiveDaysAgo.toISOString(),
@@ -1384,7 +1388,9 @@ describe("getOptions", () => {
       const { frontSequelize } = await import("@app/lib/resources/storage");
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: threeDaysAgo.toISOString(),
@@ -1427,7 +1433,9 @@ describe("getOptions", () => {
       const { frontSequelize } = await import("@app/lib/resources/storage");
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: threeDaysAgo.toISOString(),
@@ -1437,7 +1445,9 @@ describe("getOptions", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: fiveDaysAgo.toISOString(),
@@ -1496,7 +1506,9 @@ describe("getOptions", () => {
       const { frontSequelize } = await import("@app/lib/resources/storage");
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: threeDaysAgo.toISOString(),
@@ -1506,7 +1518,9 @@ describe("getOptions", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: fiveDaysAgo.toISOString(),
@@ -1573,7 +1587,9 @@ describe("getOptions", () => {
       const { frontSequelize } = await import("@app/lib/resources/storage");
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: threeDaysAgo.toISOString(),
@@ -1583,7 +1599,9 @@ describe("getOptions", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: fiveDaysAgo.toISOString(),
@@ -1593,7 +1611,9 @@ describe("getOptions", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: fiveDaysAgo.toISOString(),
@@ -4315,7 +4335,9 @@ describe("markAsActionRequired", () => {
       const { frontSequelize } = await import("@app/lib/resources/storage");
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: sixDaysAgo.toISOString(),
@@ -4325,7 +4347,9 @@ describe("markAsActionRequired", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: fourDaysAgo.toISOString(),
@@ -4335,7 +4359,9 @@ describe("markAsActionRequired", () => {
       );
 
       await frontSequelize.query(
-        `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+        `UPDATE conversations
+         SET "updatedAt" = :updatedAt
+         WHERE id = :id`,
         {
           replacements: {
             updatedAt: twoDaysAgo.toISOString(),
@@ -4684,7 +4710,9 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     });
     const { frontSequelize } = await import("@app/lib/resources/storage");
     await frontSequelize.query(
-      `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+      `UPDATE conversations
+       SET "updatedAt" = :updatedAt
+       WHERE id = :id`,
       {
         replacements: {
           updatedAt: dateFromDaysAgo(daysAgo).toISOString(),
@@ -4984,6 +5012,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "user_conversation_reads",
   "user_project_digest",
   "conversation_butler_suggestion",
+  "conversation_todo_versioned",
 ];
 
 const KNOWN_MESSAGE_RELATED_MODELS = [
@@ -5092,7 +5121,7 @@ describe("ConversationResource cleanup on delete", () => {
       modelsWithMessageFK.sort();
       const knownModels = [...KNOWN_MESSAGE_RELATED_MODELS].sort();
 
-      if (modelsWithMessageFK.length !== knownModels.length) {
+      if (modelsWithMessageFK.length != knownModels.length) {
         const missing = modelsWithMessageFK.filter(
           (m) => !knownModels.includes(m)
         );

--- a/front/lib/resources/conversation_todo_versioned_resource.ts
+++ b/front/lib/resources/conversation_todo_versioned_resource.ts
@@ -1,0 +1,183 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { ConversationTodoVersionedModel } from "@app/lib/resources/storage/models/conversation_todo_versioned";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Ok, type Result } from "@app/types/shared/result";
+import { md5 } from "@app/types/shared/utils/encryption";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+import { col, fn } from "sequelize";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ConversationTodoVersionedResource
+  extends ReadonlyAttributesType<ConversationTodoVersionedModel> {}
+
+const MAX_JSONB_SIZE_BYTES = 4_096;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ConversationTodoVersionedResource extends BaseResource<ConversationTodoVersionedModel> {
+  static model: ModelStaticWorkspaceAware<ConversationTodoVersionedModel> =
+    ConversationTodoVersionedModel;
+
+  constructor(
+    model: ModelStatic<ConversationTodoVersionedModel>,
+    blob: Attributes<ConversationTodoVersionedModel>
+  ) {
+    super(ConversationTodoVersionedModel, blob);
+  }
+
+  // Creates a new versioned snapshot for the conversation. The version is
+  // determined by incrementing the current maximum version for that
+  // conversation. An advisory lock scoped to the conversation is acquired
+  // first to serialise concurrent butler runs, matching the same pattern used
+  // for message version increments.
+  static async makeNew(
+    auth: Authenticator,
+    blob: Omit<
+      CreationAttributes<ConversationTodoVersionedModel>,
+      "workspaceId" | "version"
+    >,
+    transaction?: Transaction
+  ): Promise<ConversationTodoVersionedResource> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const jsonbSizeBytes =
+      Buffer.byteLength(JSON.stringify(blob.actionItems)) +
+      Buffer.byteLength(JSON.stringify(blob.notableFacts)) +
+      Buffer.byteLength(JSON.stringify(blob.keyDecisions)) +
+      Buffer.byteLength(JSON.stringify(blob.agentSuggestions));
+
+    if (jsonbSizeBytes > MAX_JSONB_SIZE_BYTES) {
+      throw new Error(
+        `ConversationTodoVersionedResource.makeNew: JSONB payload exceeds 4 KB (${jsonbSizeBytes} bytes).`
+      );
+    }
+
+    return withTransaction(async (t) => {
+      // Advisory lock scoped to this conversation to prevent concurrent
+      // version bumps from racing each other (same pattern as
+      // getConversationRankVersionLock in conversation.ts).
+      const hash = md5(`conversation_todo_version_${blob.conversationId}`);
+      const lockKey = parseInt(hash, 16) % 9999999999;
+      // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
+      await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
+        transaction: t,
+        replacements: { key: lockKey },
+      });
+
+      const maxVersionResult = await ConversationTodoVersionedModel.findOne({
+        where: { workspaceId, conversationId: blob.conversationId },
+        attributes: [[fn("MAX", col("version")), "maxVersion"]],
+        raw: true,
+        transaction: t,
+      });
+
+      const nextVersion =
+        ((maxVersionResult as { maxVersion: number | null } | null)
+          ?.maxVersion ?? 0) + 1;
+
+      const row = await ConversationTodoVersionedModel.create(
+        { ...blob, workspaceId, version: nextVersion },
+        { transaction: t }
+      );
+
+      return new this(ConversationTodoVersionedModel, row.get());
+    }, transaction);
+  }
+
+  // Returns the most recent snapshot for a conversation, or null if none exists.
+  static async fetchLatestByConversation(
+    auth: Authenticator,
+    { conversationId }: { conversationId: ModelId },
+    transaction?: Transaction
+  ): Promise<ConversationTodoVersionedResource | null> {
+    const row = await ConversationTodoVersionedModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId,
+      },
+      order: [["version", "DESC"]],
+      transaction,
+    });
+
+    return row ? new this(ConversationTodoVersionedModel, row.get()) : null;
+  }
+
+  // Returns all versioned snapshots for a conversation, oldest first.
+  static async fetchAllByConversation(
+    auth: Authenticator,
+    { conversationId }: { conversationId: ModelId },
+    transaction?: Transaction
+  ): Promise<ConversationTodoVersionedResource[]> {
+    const rows = await ConversationTodoVersionedModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId,
+      },
+      order: [["version", "ASC"]],
+      transaction,
+    });
+
+    return rows.map((r) => new this(ConversationTodoVersionedModel, r.get()));
+  }
+
+  // Returns a specific version for a conversation, or null if it does not exist.
+  static async fetchByConversationAndVersion(
+    auth: Authenticator,
+    { conversationId, version }: { conversationId: ModelId; version: number },
+    transaction?: Transaction
+  ): Promise<ConversationTodoVersionedResource | null> {
+    const row = await ConversationTodoVersionedModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId,
+        version,
+      },
+      transaction,
+    });
+
+    return row ? new this(ConversationTodoVersionedModel, row.get()) : null;
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  get sId(): string {
+    return ConversationTodoVersionedResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("conversation_todo_versioned", { id, workspaceId });
+  }
+}

--- a/front/lib/resources/storage/models/conversation_todo_versioned.ts
+++ b/front/lib/resources/storage/models/conversation_todo_versioned.ts
@@ -1,0 +1,137 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  TodoVersionedActionItem,
+  TodoVersionedAgentSuggestion,
+  TodoVersionedKeyDecision,
+  TodoVersionedNotableFact,
+} from "@app/types/conversation_todo_versioned";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class ConversationTodoVersionedModel extends WorkspaceAwareModel<ConversationTodoVersionedModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]>;
+
+  // Versioning: each butler run appends a new row. Version is monotonically
+  // increasing per conversation, starting at 1.
+  declare version: number;
+
+  // UUID identifying the butler run that produced this version, for log
+  // correlation.
+  declare runId: string;
+
+  // Rolling state — full replacement on each run.
+  declare topic: string | null;
+  declare actionItems: TodoVersionedActionItem[];
+  declare notableFacts: TodoVersionedNotableFact[];
+  declare keyDecisions: TodoVersionedKeyDecision[];
+  declare agentSuggestions: TodoVersionedAgentSuggestion[];
+
+  // Run tracking.
+  declare lastRunAt: Date;
+  declare lastProcessedMessageRank: number;
+
+  declare conversation: NonAttribute<ConversationModel>;
+}
+
+ConversationTodoVersionedModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+      comment:
+        "Monotonically increasing per conversation. Each butler run inserts a new row rather than overwriting.",
+    },
+    runId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      comment:
+        "UUID of the butler run that produced this version, for log correlation.",
+    },
+    topic: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      comment:
+        "One-line summary of the conversation topic, e.g. 'Debugging the embed timeout issue'.",
+    },
+    actionItems: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      comment:
+        "Detected action items with assignee, status, and source message rank.",
+    },
+    notableFacts: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      comment: "Notable facts extracted from the conversation.",
+    },
+    keyDecisions: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      comment: "Key decisions made during the conversation.",
+    },
+    agentSuggestions: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      comment: "Agents suggested to invoke based on conversation content.",
+    },
+    lastRunAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      comment: "Timestamp of when this butler run was executed.",
+    },
+    lastProcessedMessageRank: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment:
+        "Rank of the last message processed in this run. Used to skip already-seen messages on the next run.",
+    },
+  },
+  {
+    modelName: "conversation_todo_versioned",
+    tableName: "conversation_todo_versioned",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "conversation_todo_versioned_ws_conv_version_unique_idx",
+        fields: ["workspaceId", "conversationId", "version"],
+        unique: true,
+        concurrently: true,
+      },
+      {
+        name: "conversation_todo_versioned_conversationId_idx",
+        fields: ["conversationId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ConversationTodoVersionedModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "conversation",
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -80,6 +80,7 @@ export const RESOURCES_PREFIX = {
 
   // Butler
   user_project_digest: "pje",
+  conversation_todo_versioned: "ctv",
   conversation_butler_suggestion: "cbs",
 
   // Conversation branches.

--- a/front/migrations/db/migration_553.sql
+++ b/front/migrations/db/migration_553.sql
@@ -1,0 +1,22 @@
+-- Migration created on Mar 27, 2026
+CREATE TABLE IF NOT EXISTS "conversation_todo_versioned"
+(
+    "createdAt"                TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt"                TIMESTAMP WITH TIME ZONE NOT NULL,
+    "conversationId"           BIGINT                   NOT NULL REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "version"                  INTEGER                  NOT NULL DEFAULT 1,
+    "runId"                    UUID                     NOT NULL,
+    "topic"                    TEXT,
+    "actionItems"              JSONB                    NOT NULL DEFAULT '[]',
+    "notableFacts"             JSONB                    NOT NULL DEFAULT '[]',
+    "keyDecisions"             JSONB                    NOT NULL DEFAULT '[]',
+    "agentSuggestions"         JSONB                    NOT NULL DEFAULT '[]',
+    "lastRunAt"                TIMESTAMP WITH TIME ZONE NOT NULL,
+    "lastProcessedMessageRank" INTEGER                  NOT NULL,
+    "workspaceId"              BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "id"                       BIGSERIAL,
+    PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "conversation_todo_versioned_ws_conv_version_unique_idx" ON "conversation_todo_versioned" ("workspaceId", "conversationId", "version");
+CREATE INDEX CONCURRENTLY "conversation_todo_versioned_conversationId_idx" ON "conversation_todo_versioned" ("conversationId");

--- a/front/types/conversation_todo_versioned.ts
+++ b/front/types/conversation_todo_versioned.ts
@@ -1,0 +1,34 @@
+export type TodoVersionedActionItemStatus = "open" | "done";
+
+export type TodoVersionedActionItem = {
+  key: string;
+  text: string;
+  assigneeUserId: string | null;
+  assigneeName: string | null;
+  sourceMessageRank: number;
+  status: TodoVersionedActionItemStatus;
+  detectedDoneAt: string | null;
+  detectedDoneRationale: string | null;
+};
+
+export type TodoVersionedNotableFact = {
+  key: string;
+  text: string;
+  relevantUserIds: string[];
+  sourceMessageRank: number;
+};
+
+export type TodoVersionedKeyDecisionStatus = "decided" | "open";
+
+export type TodoVersionedKeyDecision = {
+  key: string;
+  text: string;
+  relevantUserIds: string[];
+  sourceMessageRank: number;
+  status: TodoVersionedKeyDecisionStatus;
+};
+
+export type TodoVersionedAgentSuggestion = {
+  agentId: string;
+  rationale: string;
+};


### PR DESCRIPTION
# Description

Adds the `ConversationTodoSnapshot` model — the per-conversation analysis state used by the project butler to extract actionable data from conversations.

The design doc mentioned `conversation_butler_state`, but as we named the other model `todo` I went to align both

It's an append model, a new version is adedd for each run, preserving the full history of what was extracted. Each snapshot contains:

* topic — one-line summary of the conversation
* actionItems — detected tasks with assignee, status, and source message rank
* notableFacts — facts worth remembering from the conversation
* keyDecisions — decisions made during the conversation
* agentSuggestions — agents recommended based on conversation content
* lastProcessedMessageRank — allows the next run to skip already-seen messages
* runId — UUID for log correlation across runs (from temporal)
* version — monotonically increasing per conversation (append-only)

This is a data model PR only — no business logic yet. It follows the same patterns as ProjectTodo (#548) and ConversationButlerSuggestion.

Related to the project butler feature.

# Tests

# Risk


# Deploy Plan

1. Run migration migration_549.sql to create the conversation_todo_snapshots table
2. Deploy front 