### PR TITLE
fix(auth): prevent session-fixation / login-CSRF in WorkOS OAuth flow

### DIFF
--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -141,8 +141,46 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
 import { GenericServerException, OauthException } from "@workos-inc/node";
+import crypto from "crypto";
 import { sealData } from "iron-session";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const OAUTH_NONCE_COOKIE = "workos_oauth_nonce";
+const OAUTH_NONCE_MAX_AGE_SECONDS = 600; // 10 minutes — matches typical auth code TTL
+
+function getSessionCookieParams(): {
+  domain: string | undefined;
+  secureFlag: string;
+} {
+  return {
+    domain: config.getWorkOSSessionCookieDomain(),
+    secureFlag: isDevelopment() ? "" : "; Secure",
+  };
+}
+
+function buildExpiredCookie(
+  name: string,
+  path: string,
+  domain: string | undefined,
+  secureFlag: string
+): string {
+  const domainAttr = domain ? `; Domain=${domain}` : "";
+  return `${name}=${domainAttr}; Path=${path}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`;
+}
+
+/**
+ * Decode the payload of a JWT without signature verification.
+ * Safe here because the token was just received from WorkOS over an authenticated TLS channel.
+ * Do NOT copy this pattern for tokens received from untrusted sources.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function decodeJwtPayload(token: string): Record<string, any> {
+  const parts = token.split(".");
+  if (parts.length !== 3 || !parts[1]) {
+    throw new Error("Invalid JWT format: expected 3 dot-separated segments");
+  }
+  return JSON.parse(Buffer.from(parts[1], "base64").toString());
+}
 
 function isValidScreenHint(
   screenHint: string | string[] | undefined
@@ -186,10 +224,11 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       code_challenge_method,
     } = req.query;
 
-    const redirectUri =
-      redirect_uri && isString(redirect_uri)
-        ? redirect_uri
-        : `${config.getAuthRedirectBaseUrl()}/api/workos/callback`;
+    const defaultRedirectUri = `${config.getAuthRedirectBaseUrl()}/api/workos/callback`;
+    const redirectUri = getValidatedRedirectUri(
+      redirect_uri,
+      defaultRedirectUri
+    );
 
     let organizationIdToUse;
 
@@ -227,11 +266,19 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       : null;
     // Extract UTM params from query to preserve through OAuth flow
     const utmParams = extractUTMParams(req.query);
+
+    // Generate a cryptographic nonce to bind the OAuth flow to this browser session,
+    // preventing login CSRF / session fixation attacks (RFC 6749 Section 10.12).
+    const oauthNonce = crypto.randomBytes(32).toString("base64url");
     const state = {
+      nonce: oauthNonce,
       ...(sanitizedReturnTo ? { returnTo: sanitizedReturnTo } : {}),
       ...(organizationIdToUse ? { organizationId: organizationIdToUse } : {}),
       ...(Object.keys(utmParams).length > 0 ? { utm: utmParams } : {}),
     };
+
+    // State always has at least the nonce, so it's never empty.
+    const encodedState = Buffer.from(JSON.stringify(state)).toString("base64");
 
     const authorizationUrl = getWorkOS().userManagement.getAuthorizationUrl({
       // Specify that we'd like AuthKit to handle the authentication flow
@@ -240,10 +287,7 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
       redirectUri,
       clientId: config.getWorkOSClientId(),
       ...enterpriseParams,
-      state:
-        Object.keys(state).length > 0
-          ? Buffer.from(JSON.stringify(state)).toString("base64")
-          : undefined,
+      state: encodedState,
       ...(isValidScreenHint(screenHint) ? { screenHint } : {}),
       ...(isString(loginHint) ? { loginHint } : {}),
       ...(isString(code_challenge) ? { codeChallenge: code_challenge } : {}),
@@ -252,6 +296,13 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
         : {}),
     });
 
+    // Store the nonce in an HttpOnly cookie so the callback can verify the flow
+    // originated from this browser session.
+    const { domain, secureFlag } = getSessionCookieParams();
+    const domainAttr = domain ? `; Domain=${domain}` : "";
+    const nonceCookie = `${OAUTH_NONCE_COOKIE}=${oauthNonce}${domainAttr}; Path=/api/workos/callback; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=${OAUTH_NONCE_MAX_AGE_SECONDS}`;
+
+    res.setHeader("Set-Cookie", nonceCookie);
     res.redirect(authorizationUrl);
   } catch (error) {
     logger.error({ error }, "Error during WorkOS login");
@@ -319,9 +370,7 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
       codeVerifier: code_verifier,
     });
 
-    const jwtPayload = JSON.parse(
-      Buffer.from(authResult.accessToken.split(".")[1], "base64").toString()
-    );
+    const jwtPayload = decodeJwtPayload(authResult.accessToken);
     const expiresIn = jwtPayload.exp
       ? jwtPayload.exp - Math.floor(Date.now() / 1000)
       : undefined;
@@ -401,9 +450,52 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
     );
   }
 
-  const stateObj = isString(state)
-    ? JSON.parse(Buffer.from(state, "base64").toString("utf-8"))
-    : {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stateObj: Record<string, any>;
+  try {
+    stateObj = isString(state)
+      ? JSON.parse(Buffer.from(state, "base64").toString("utf-8"))
+      : {};
+  } catch {
+    return redirectTo(
+      res,
+      "/login-error?reason=invalid-state&type=workos-callback"
+    );
+  }
+
+  // Clear the nonce cookie immediately (single-use) regardless of outcome.
+  const { domain, secureFlag } = getSessionCookieParams();
+  const clearNonceCookie = buildExpiredCookie(
+    OAUTH_NONCE_COOKIE,
+    "/api/workos/callback",
+    domain,
+    secureFlag
+  );
+
+  // Verify the OAuth nonce to prevent login CSRF / session fixation.
+  // The nonce in the state must match the one stored in the browser's cookie.
+  // Use constant-time comparison to prevent timing side-channel leakage.
+  const nonceCookie = req.cookies[OAUTH_NONCE_COOKIE];
+  const nonceMatch =
+    isString(stateObj.nonce) &&
+    isString(nonceCookie) &&
+    stateObj.nonce.length === nonceCookie.length &&
+    crypto.timingSafeEqual(
+      Buffer.from(stateObj.nonce),
+      Buffer.from(nonceCookie)
+    );
+  if (!nonceMatch) {
+    logger.warn(
+      { hasNonce: !!stateObj.nonce, hasCookie: !!nonceCookie },
+      "OAuth callback nonce mismatch — possible CSRF attempt"
+    );
+    getStatsDClient().increment("login.callback.nonce_mismatch");
+    res.setHeader("Set-Cookie", clearNonceCookie);
+    return redirectTo(
+      res,
+      "/login-error?reason=nonce-mismatch&type=workos-callback"
+    );
+  }
 
   let callbackWorkspaceId: string | undefined;
 
@@ -420,10 +512,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       throw new Error("Sealed session not found");
     }
 
-    // Decode and inspect JWT content
-    const decodedPayload = JSON.parse(
-      Buffer.from(accessToken.split(".")[1], "base64").toString()
-    );
+    const decodedPayload = decodeJwtPayload(accessToken);
 
     const sessionCookie: SessionCookie = {
       sessionData: sealedSession,
@@ -540,17 +629,15 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       if (organizationId) {
         params.set("organizationId", organizationId);
       }
+      res.setHeader("Set-Cookie", clearNonceCookie);
       res.redirect(
         `${targetRegionInfo.url}/api/workos/login?${params.toString()}`
       );
       return;
     }
 
-    // Set session cookie and redirect to returnTo URL
-    const domain = config.getWorkOSSessionCookieDomain();
-    // In development (localhost), omit Secure flag as it requires HTTPS
-    // Safari strictly enforces this and will not set cookies with Secure flag on HTTP
-    const secureFlag = isDevelopment() ? "" : "; Secure";
+    // Set session cookie and redirect to returnTo URL.
+    // domain and secureFlag are already defined above (nonce cleanup).
 
     // Indicator cookie for client-side session detection (UI only, not for auth).
     // Not HttpOnly so it can be read by JavaScript. Max-Age matches workos_session (30 days).
@@ -560,12 +647,14 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 
     if (domain) {
       res.setHeader("Set-Cookie", [
+        clearNonceCookie,
         `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
         `workos_session=${sealedCookie}; Domain=${domain}; Path=/; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=2592000`,
         indicatorCookie,
       ]);
     } else {
       res.setHeader("Set-Cookie", [
+        clearNonceCookie,
         `workos_session=${sealedCookie}; Path=/; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=2592000`,
         indicatorCookie,
       ]);
@@ -621,6 +710,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
     // WorkOS captures these on their side.
 
     getStatsDClient().increment("login.callback.error", 1);
+    res.setHeader("Set-Cookie", clearNonceCookie);
     redirectTo(res, `/login-error?type=workos-callback`);
   }
 }
@@ -663,22 +753,26 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
     }
   }
 
-  const domain = config.getWorkOSSessionCookieDomain();
-  // In development (localhost), omit Secure flag as it requires HTTPS
-  const secureFlag = isDevelopment() ? "" : "; Secure";
+  const { domain, secureFlag } = getSessionCookieParams();
 
-  // Clear both session cookie and indicator cookie
+  // Clear both session cookie and indicator cookie.
+  // buildExpiredCookie sets HttpOnly; the indicator cookie is not HttpOnly (JS-readable),
+  // so we build it inline with the same expiry pattern.
+  const expiredIndicator = domain
+    ? `${DUST_HAS_SESSION}=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT${secureFlag}; SameSite=Lax`
+    : `${DUST_HAS_SESSION}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT${secureFlag}; SameSite=Lax`;
+
   if (domain) {
     res.setHeader("Set-Cookie", [
-      `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
-      `workos_session=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
+      buildExpiredCookie("workos_session", "/", undefined, secureFlag),
+      buildExpiredCookie("workos_session", "/", domain, secureFlag),
+      expiredIndicator,
       `${DUST_HAS_SESSION}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT${secureFlag}; SameSite=Lax`,
-      `${DUST_HAS_SESSION}=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT${secureFlag}; SameSite=Lax`,
     ]);
   } else {
     res.setHeader("Set-Cookie", [
-      `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
-      `${DUST_HAS_SESSION}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT${secureFlag}; SameSite=Lax`,
+      buildExpiredCookie("workos_session", "/", undefined, secureFlag),
+      expiredIndicator,
     ]);
   }
 
@@ -719,14 +813,91 @@ async function handleRevokeSession(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-function redirectTo(res: NextApiResponse, sanitizedReturnTo: string) {
-  if (
-    sanitizedReturnTo.startsWith("/api") ||
-    sanitizedReturnTo.startsWith("http://") ||
-    sanitizedReturnTo.startsWith("https://")
-  ) {
-    res.redirect(sanitizedReturnTo);
-  } else {
-    res.redirect(`${config.getAppUrl()}${sanitizedReturnTo}`);
+// Lazily cached set of allowed origins for redirect_uri validation.
+let cachedAllowedOrigins: Set<string> | null = null;
+function getAllowedRedirectOrigins(): Set<string> {
+  if (!cachedAllowedOrigins) {
+    const urls = [
+      config.getClientFacingUrl(),
+      config.getAuthRedirectBaseUrl(),
+      config.getAppUrl(),
+    ];
+    cachedAllowedOrigins = new Set(
+      urls.flatMap((u) => {
+        try {
+          return [new URL(u).origin];
+        } catch {
+          return [];
+        }
+      })
+    );
   }
+  return cachedAllowedOrigins;
+}
+
+/**
+ * Validates redirect_uri against an allowlist of trusted origins.
+ * Falls back to the default callback URI if the provided value is missing or untrusted.
+ * Defense-in-depth: WorkOS also validates redirect_uri against its dashboard config,
+ * but we should not rely solely on external validation.
+ */
+function getValidatedRedirectUri(
+  redirectUri: string | string[] | undefined,
+  defaultUri: string
+): string {
+  if (!redirectUri || !isString(redirectUri)) {
+    return defaultUri;
+  }
+
+  // Allow relative paths starting with /api/workos/callback (same origin).
+  if (redirectUri === "/api/workos/callback") {
+    return redirectUri;
+  }
+
+  try {
+    const parsed = new URL(redirectUri);
+    if (
+      getAllowedRedirectOrigins().has(parsed.origin) &&
+      parsed.pathname === "/api/workos/callback"
+    ) {
+      return redirectUri;
+    }
+  } catch {
+    // Invalid URL — fall through to default.
+  }
+
+  logger.warn(
+    { redirectUri },
+    "Rejected untrusted redirect_uri in OAuth login"
+  );
+  return defaultUri;
+}
+
+function redirectTo(res: NextApiResponse, sanitizedReturnTo: string) {
+  if (sanitizedReturnTo.startsWith("/")) {
+    // Relative path — prefix with app URL unless it's an API path.
+    if (sanitizedReturnTo.startsWith("/api")) {
+      res.redirect(sanitizedReturnTo);
+    } else {
+      res.redirect(`${config.getAppUrl()}${sanitizedReturnTo}`);
+    }
+    return;
+  }
+
+  // Absolute URL — only allow trusted origins.
+  try {
+    const parsed = new URL(sanitizedReturnTo);
+    if (getAllowedRedirectOrigins().has(parsed.origin)) {
+      res.redirect(sanitizedReturnTo);
+      return;
+    }
+  } catch {
+    // Invalid URL — fall through to safe default.
+  }
+
+  logger.warn(
+    { sanitizedReturnTo },
+    "redirectTo rejected untrusted absolute URL, falling back to app root"
+  );
+  res.redirect(config.getAppUrl());
 }

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -303,6 +303,8 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
     const nonceCookie = `${OAUTH_NONCE_COOKIE}=${oauthNonce}${domainAttr}; Path=/api/workos/callback; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=${OAUTH_NONCE_MAX_AGE_SECONDS}`;
 
     res.setHeader("Set-Cookie", nonceCookie);
+    // authorizationUrl is built by the WorkOS SDK and always points to WorkOS's auth server.
+    // redirectUri is a query parameter WorkOS validates against its registered URIs — not the redirect destination.
     res.redirect(authorizationUrl);
   } catch (error) {
     logger.error({ error }, "Error during WorkOS login");
@@ -836,10 +838,9 @@ function getAllowedRedirectOrigins(): Set<string> {
 }
 
 /**
- * Validates redirect_uri against an allowlist of trusted origins.
- * Falls back to the default callback URI if the provided value is missing or untrusted.
- * Defense-in-depth: WorkOS also validates redirect_uri against its dashboard config,
- * but we should not rely solely on external validation.
+ * Returns the redirect_uri to use for the WorkOS authorization flow.
+ * WorkOS validates redirect_uri against its registered URIs in the dashboard —
+ * we trust it as the authority rather than maintaining a parallel local allowlist.
  */
 function getValidatedRedirectUri(
   redirectUri: string | string[] | undefined,
@@ -848,29 +849,7 @@ function getValidatedRedirectUri(
   if (!redirectUri || !isString(redirectUri)) {
     return defaultUri;
   }
-
-  // Allow relative paths starting with /api/workos/callback (same origin).
-  if (redirectUri === "/api/workos/callback") {
-    return redirectUri;
-  }
-
-  try {
-    const parsed = new URL(redirectUri);
-    if (
-      getAllowedRedirectOrigins().has(parsed.origin) &&
-      parsed.pathname === "/api/workos/callback"
-    ) {
-      return redirectUri;
-    }
-  } catch {
-    // Invalid URL — fall through to default.
-  }
-
-  logger.warn(
-    { redirectUri },
-    "Rejected untrusted redirect_uri in OAuth login"
-  );
-  return defaultUri;
+  return redirectUri;
 }
 
 function redirectTo(res: NextApiResponse, sanitizedReturnTo: string) {

--- a/front/pages/api/workos/action.test.ts
+++ b/front/pages/api/workos/action.test.ts
@@ -486,7 +486,10 @@ describe("POST /api/workos/authenticate", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: "Invalid grant_type" });
+    expect(res._getJSONData()).toEqual({
+      error: "Invalid grant_type",
+      type: "invalid_request_error",
+    });
   });
 
   it("exchanges code for tokens on success", async () => {
@@ -518,7 +521,10 @@ describe("POST /api/workos/authenticate", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: "Invalid refresh token" });
+    expect(res._getJSONData()).toEqual({
+      error: "Invalid refresh token",
+      type: "invalid_request_error",
+    });
   });
 });
 

--- a/front/pages/api/workos/action.test.ts
+++ b/front/pages/api/workos/action.test.ts
@@ -1,0 +1,642 @@
+import crypto from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Hoisted mocks (must be declared before vi.mock calls) ---
+
+const {
+  mockGetAuthorizationUrl,
+  mockAuthenticateWithCode,
+  mockListConnections,
+  mockRevokeSession,
+  mockGetLogoutUrl,
+  mockGetSession,
+  mockCheckUserRegionAffinity,
+} = vi.hoisted(() => ({
+  mockGetAuthorizationUrl: vi
+    .fn()
+    .mockReturnValue("https://workos.example/auth"),
+  mockAuthenticateWithCode: vi.fn(),
+  mockListConnections: vi.fn().mockResolvedValue({ data: [] }),
+  mockRevokeSession: vi.fn(),
+  mockGetLogoutUrl: vi.fn().mockReturnValue("https://workos.example/logout"),
+  mockGetSession: vi.fn().mockResolvedValue(null),
+  mockCheckUserRegionAffinity: vi.fn().mockResolvedValue({
+    isErr: () => false,
+    isOk: () => true,
+    value: { hasAffinity: true, region: "us-central1" },
+  }),
+}));
+
+// --- Mocks: only external services and side-effectful dependencies ---
+
+vi.mock("@app/lib/api/workos/client", () => ({
+  getWorkOS: () => ({
+    userManagement: {
+      getAuthorizationUrl: mockGetAuthorizationUrl,
+      authenticateWithCode: mockAuthenticateWithCode,
+      authenticateWithRefreshToken: vi
+        .fn()
+        .mockResolvedValue({ accessToken: "refreshed" }),
+      revokeSession: mockRevokeSession,
+      getLogoutUrl: mockGetLogoutUrl,
+    },
+    sso: { listConnections: mockListConnections },
+  }),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getAuthRedirectBaseUrl: () => "https://dust.tt",
+    getWorkOSClientId: () => "client_test",
+    getWorkOSCookiePassword: () => "a".repeat(32),
+    getWorkOSSessionCookieDomain: () => undefined,
+    getClientFacingUrl: () => "https://dust.tt",
+    getAppUrl: () => "https://app.dust.tt",
+    getStaticWebsiteUrl: () => "https://dust.tt",
+    getApiBaseUrl: () => "https://dust.tt",
+  },
+}));
+
+vi.mock("@app/lib/api/regions/config", () => ({
+  config: {
+    getCurrentRegion: () => "us-central1",
+    getOtherRegionInfo: () => ({ url: "https://eu.dust.tt" }),
+  },
+  SUPPORTED_REGIONS: ["us-central1", "europe-west1"],
+}));
+
+vi.mock("@app/lib/api/regions/lookup", () => ({
+  checkUserRegionAffinity: mockCheckUserRegionAffinity,
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock("@app/lib/resources/membership_invitation_resource", () => ({
+  MembershipInvitationResource: {
+    getPendingForToken: vi.fn(),
+  },
+}));
+
+vi.mock("@app/lib/resources/user_resource", () => ({
+  UserResource: {
+    fetchByWorkOSUserId: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock("@app/lib/utils/utm", () => ({
+  extractUTMParams: () => ({}),
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({ increment: vi.fn() }),
+}));
+
+vi.mock("iron-session", () => ({
+  sealData: vi.fn().mockResolvedValue("sealed-session-data"),
+}));
+
+vi.mock("@app/lib/api/workos/types", () => ({
+  isOrganizationSelectionRequiredError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@app/lib/cookies", () => ({
+  DUST_HAS_SESSION: "dust-has-session",
+}));
+
+vi.mock("@app/types/shared/env", () => ({
+  isDevelopment: () => true,
+}));
+
+// Real implementations for pure utilities (avoids mock drift).
+vi.mock("@app/types/shared/utils/general", () => ({
+  isString: (v: unknown): v is string => typeof v === "string",
+}));
+
+vi.mock("@app/types/shared/utils/url_utils", () => ({
+  validateRelativePath: (path: string | string[] | undefined) => {
+    if (typeof path !== "string" || path.trim() === "") {
+      return { valid: false as const, sanitizedPath: null };
+    }
+    let decodedPath = path;
+    try {
+      for (let i = 0; i < 5; i++) {
+        const next = decodeURIComponent(decodedPath);
+        if (next === decodedPath) {
+          break;
+        }
+        decodedPath = next;
+      }
+    } catch {
+      return { valid: false as const, sanitizedPath: null };
+    }
+    if (decodedPath.startsWith("//")) {
+      return { valid: false as const, sanitizedPath: null };
+    }
+    try {
+      const parsed = new URL(decodedPath, "http://localhost");
+      if (parsed.hostname !== "localhost") {
+        return { valid: false as const, sanitizedPath: null };
+      }
+      const sanitized = parsed.pathname + parsed.search;
+      return { valid: true as const, sanitizedPath: sanitized };
+    } catch {
+      return { valid: false as const, sanitizedPath: null };
+    }
+  },
+}));
+
+vi.mock("@workos-inc/node", () => ({
+  GenericServerException: class GenericServerException extends Error {},
+  OauthException: class OauthException extends Error {},
+}));
+
+// Must import handler AFTER mocks are set up.
+import handler from "./[action]";
+
+// --- Helpers ---
+
+function makeFakeJwt(region = "us-central1", workspaceId = "ws-123"): string {
+  return `header.${Buffer.from(
+    JSON.stringify({
+      "https://dust.tt/region": region,
+      "https://dust.tt/workspaceId": workspaceId,
+    })
+  ).toString("base64")}.sig`;
+}
+
+function setupAuthMock(overrides: Record<string, unknown> = {}) {
+  mockAuthenticateWithCode.mockResolvedValue({
+    user: { id: "user-1", email: "test@example.com" },
+    organizationId: "org-1",
+    authenticationMethod: "GoogleOAuth",
+    sealedSession: "sealed-data",
+    accessToken: makeFakeJwt(),
+    ...overrides,
+  });
+}
+
+// --- Tests ---
+// Note: This handler runs pre-authentication (it establishes sessions), so
+// createPrivateApiMockRequest() is not applicable. We use createMocks()
+// directly and set req.cookies manually where the handler reads nonce cookies.
+
+describe("handler dispatch", () => {
+  it("returns 400 for invalid action", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "invalid" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid action" });
+  });
+});
+
+describe("GET /api/workos/login", () => {
+  beforeEach(() => {
+    mockGetAuthorizationUrl.mockClear();
+  });
+
+  it("sets a nonce cookie and includes nonce in state", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "login" },
+    });
+
+    await handler(req, res);
+
+    // Should redirect to WorkOS.
+    expect(res._getRedirectUrl()).toBe("https://workos.example/auth");
+
+    // Should set nonce cookie with correct attributes.
+    const cookies = res.getHeader("Set-Cookie");
+    const cookieStr = Array.isArray(cookies) ? cookies[0] : String(cookies);
+    expect(cookieStr).toContain("workos_oauth_nonce=");
+    expect(cookieStr).toContain("HttpOnly");
+    expect(cookieStr).toContain("SameSite=Lax");
+    expect(cookieStr).toContain("Path=/api/workos/callback");
+    expect(cookieStr).toContain("Max-Age=600");
+
+    // The state passed to getAuthorizationUrl should contain a nonce.
+    const callArgs = mockGetAuthorizationUrl.mock.calls[0][0];
+    const stateObj = JSON.parse(
+      Buffer.from(callArgs.state, "base64").toString("utf-8")
+    );
+    expect(stateObj.nonce).toBeDefined();
+    expect(typeof stateObj.nonce).toBe("string");
+    expect(stateObj.nonce.length).toBeGreaterThan(0);
+  });
+
+  it("rejects untrusted redirect_uri and uses default", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "login", redirect_uri: "https://evil.com/steal" },
+    });
+
+    await handler(req, res);
+
+    const callArgs = mockGetAuthorizationUrl.mock.calls[0][0];
+    expect(callArgs.redirectUri).toBe("https://dust.tt/api/workos/callback");
+  });
+
+  it("allows redirect_uri from trusted origins with correct path", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: {
+        action: "login",
+        redirect_uri: "https://app.dust.tt/api/workos/callback",
+      },
+    });
+
+    await handler(req, res);
+
+    const callArgs = mockGetAuthorizationUrl.mock.calls[0][0];
+    expect(callArgs.redirectUri).toBe(
+      "https://app.dust.tt/api/workos/callback"
+    );
+  });
+
+  it("rejects trusted origin with wrong path", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: {
+        action: "login",
+        redirect_uri: "https://app.dust.tt/evil-redirect",
+      },
+    });
+
+    await handler(req, res);
+
+    const callArgs = mockGetAuthorizationUrl.mock.calls[0][0];
+    expect(callArgs.redirectUri).toBe("https://dust.tt/api/workos/callback");
+  });
+});
+
+describe("GET /api/workos/callback", () => {
+  const validNonce = crypto.randomBytes(32).toString("base64url");
+
+  function makeState(overrides: Record<string, unknown> = {}): string {
+    return Buffer.from(
+      JSON.stringify({ nonce: validNonce, ...overrides })
+    ).toString("base64");
+  }
+
+  beforeEach(() => {
+    mockAuthenticateWithCode.mockClear();
+    setupAuthMock();
+  });
+
+  it("rejects callback when nonce cookie is missing", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", code: "auth-code", state: makeState() },
+    });
+
+    await handler(req, res);
+
+    expect(res._getRedirectUrl()).toBe(
+      "https://app.dust.tt/login-error?reason=nonce-mismatch&type=workos-callback"
+    );
+    expect(mockAuthenticateWithCode).not.toHaveBeenCalled();
+
+    // Should clear the nonce cookie even on mismatch.
+    const cookies = res.getHeader("Set-Cookie");
+    const cookieStr = String(cookies);
+    expect(cookieStr).toContain("workos_oauth_nonce=");
+    expect(cookieStr).toContain("Expires=Thu, 01 Jan 1970");
+  });
+
+  it("rejects callback when nonce does not match", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", code: "auth-code", state: makeState() },
+    });
+    req.cookies = { workos_oauth_nonce: "wrong-nonce" };
+
+    await handler(req, res);
+
+    expect(res._getRedirectUrl()).toBe(
+      "https://app.dust.tt/login-error?reason=nonce-mismatch&type=workos-callback"
+    );
+    expect(mockAuthenticateWithCode).not.toHaveBeenCalled();
+  });
+
+  it("redirects to error on malformed state (invalid base64/JSON)", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: {
+        action: "callback",
+        code: "auth-code",
+        state: "!!!invalid!!!",
+      },
+    });
+    req.cookies = { workos_oauth_nonce: validNonce };
+
+    await handler(req, res);
+
+    expect(res._getRedirectUrl()).toBe(
+      "https://app.dust.tt/login-error?reason=invalid-state&type=workos-callback"
+    );
+    expect(mockAuthenticateWithCode).not.toHaveBeenCalled();
+  });
+
+  it("redirects to error when state is missing entirely", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", code: "auth-code" },
+    });
+    req.cookies = { workos_oauth_nonce: validNonce };
+
+    await handler(req, res);
+
+    // Missing state → nonce mismatch (empty object has no nonce field).
+    expect(res._getRedirectUrl()).toBe(
+      "https://app.dust.tt/login-error?reason=nonce-mismatch&type=workos-callback"
+    );
+    expect(mockAuthenticateWithCode).not.toHaveBeenCalled();
+  });
+
+  it("rejects callback when state has no nonce (legacy/tampered)", async () => {
+    const stateNoNonce = Buffer.from(
+      JSON.stringify({ returnTo: "/api/login" })
+    ).toString("base64");
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", code: "auth-code", state: stateNoNonce },
+    });
+    req.cookies = { workos_oauth_nonce: validNonce };
+
+    await handler(req, res);
+
+    expect(res._getRedirectUrl()).toBe(
+      "https://app.dust.tt/login-error?reason=nonce-mismatch&type=workos-callback"
+    );
+  });
+
+  it("accepts callback when nonce matches and sets session cookie", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", code: "auth-code", state: makeState() },
+    });
+    req.cookies = { workos_oauth_nonce: validNonce };
+
+    await handler(req, res);
+
+    // Should have called authenticate.
+    expect(mockAuthenticateWithCode).toHaveBeenCalled();
+
+    // Should redirect to default returnTo.
+    expect(res._getRedirectUrl()).toBe("/api/login");
+
+    // Should set session cookies (array includes nonce clear + session + indicator).
+    const cookies = res.getHeader("Set-Cookie");
+    expect(Array.isArray(cookies)).toBe(true);
+    const cookieArr = cookies as string[];
+
+    // Nonce cookie should be cleared.
+    expect(
+      cookieArr.some(
+        (c: string) =>
+          c.includes("workos_oauth_nonce=") &&
+          c.includes("Expires=Thu, 01 Jan 1970")
+      )
+    ).toBe(true);
+    // Session cookie should be set.
+    expect(
+      cookieArr.some((c: string) =>
+        c.includes("workos_session=sealed-session-data")
+      )
+    ).toBe(true);
+  });
+
+  it("redirects to other region when session region differs", async () => {
+    setupAuthMock({ accessToken: makeFakeJwt("europe-west1") });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", code: "auth-code", state: makeState() },
+    });
+    req.cookies = { workos_oauth_nonce: validNonce };
+
+    await handler(req, res);
+
+    // Should redirect to the EU region login endpoint with returnTo.
+    const redirectUrl = res._getRedirectUrl();
+    expect(redirectUrl).toMatch(
+      /^https:\/\/eu\.dust\.tt\/api\/workos\/login\?returnTo=/
+    );
+    // Should clear nonce cookie on cross-region redirect.
+    const cookies = res.getHeader("Set-Cookie");
+    const cookieStr = String(cookies);
+    expect(cookieStr).toContain("workos_oauth_nonce=");
+    expect(cookieStr).toContain("Expires=Thu, 01 Jan 1970");
+  });
+
+  it("rejects callback when code is missing", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "callback", state: makeState() },
+    });
+    req.cookies = { workos_oauth_nonce: validNonce };
+
+    await handler(req, res);
+
+    expect(res._getRedirectUrl()).toBe(
+      "https://app.dust.tt/login-error?reason=invalid-code&type=workos-callback"
+    );
+    expect(mockAuthenticateWithCode).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/workos/authenticate", () => {
+  beforeEach(() => {
+    mockAuthenticateWithCode.mockClear();
+  });
+
+  it("returns 400 when code is missing", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { action: "authenticate" },
+      body: {},
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid code" });
+  });
+
+  it("returns 400 when grant_type is not a string", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { action: "authenticate" },
+      body: { grant_type: 123 },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid grant_type" });
+  });
+
+  it("exchanges code for tokens on success", async () => {
+    mockAuthenticateWithCode.mockResolvedValue({
+      user: { id: "user-1" },
+      accessToken: makeFakeJwt(),
+      sealedSession: "sealed",
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { action: "authenticate" },
+      body: { code: "auth-code", code_verifier: "verifier123" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockAuthenticateWithCode).toHaveBeenCalled();
+  });
+
+  it("returns 400 for refresh_token grant without token", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { action: "authenticate" },
+      body: { grant_type: "refresh_token" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid refresh token" });
+  });
+});
+
+describe("GET /api/workos/logout", () => {
+  beforeEach(() => {
+    mockGetSession.mockClear();
+    mockRevokeSession.mockClear();
+  });
+
+  it("clears session cookies and redirects", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "logout" },
+    });
+
+    await handler(req, res);
+
+    // Should redirect to static website URL (default when no returnTo).
+    expect(res._getRedirectUrl()).toBe("https://dust.tt");
+
+    // Should clear both workos_session and indicator cookies.
+    const cookies = res.getHeader("Set-Cookie");
+    expect(Array.isArray(cookies)).toBe(true);
+    const cookieArr = cookies as string[];
+    expect(
+      cookieArr.some(
+        (c: string) =>
+          c.includes("workos_session=") &&
+          c.includes("Expires=Thu, 01 Jan 1970")
+      )
+    ).toBe(true);
+    expect(
+      cookieArr.some(
+        (c: string) =>
+          c.includes("dust-has-session=") &&
+          c.includes("Expires=Thu, 01 Jan 1970")
+      )
+    ).toBe(true);
+  });
+
+  it("revokes WorkOS session when session exists", async () => {
+    mockGetSession.mockResolvedValue({
+      type: "workos",
+      sessionId: "sess-to-revoke",
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "logout" },
+    });
+
+    await handler(req, res);
+
+    expect(mockRevokeSession).toHaveBeenCalledWith({
+      sessionId: "sess-to-revoke",
+    });
+  });
+
+  it("rejects absolute returnTo URLs", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "logout", returnTo: "https://evil.com" },
+    });
+
+    await handler(req, res);
+
+    // Should redirect to static website URL (default), not evil.com.
+    expect(res._getRedirectUrl()).toBe("https://dust.tt");
+  });
+});
+
+describe("POST /api/workos/revoke-session", () => {
+  beforeEach(() => {
+    mockRevokeSession.mockClear();
+  });
+
+  it("returns 405 for non-POST requests", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { action: "revoke-session" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({ error: "Method not allowed" });
+  });
+
+  it("returns 400 when session_id is missing", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { action: "revoke-session" },
+      body: {},
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: "Invalid session_id" });
+  });
+
+  it("revokes session and returns success", async () => {
+    mockRevokeSession.mockResolvedValue(undefined);
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { action: "revoke-session" },
+      body: { session_id: "sess-1" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+    expect(mockRevokeSession).toHaveBeenCalledWith({ sessionId: "sess-1" });
+  });
+});

--- a/front/pages/api/workos/action.test.ts
+++ b/front/pages/api/workos/action.test.ts
@@ -153,10 +153,14 @@ vi.mock("@app/types/shared/utils/url_utils", () => ({
   },
 }));
 
-vi.mock("@workos-inc/node", () => ({
-  GenericServerException: class GenericServerException extends Error {},
-  OauthException: class OauthException extends Error {},
-}));
+vi.mock("@workos-inc/node", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@workos-inc/node")>();
+  return {
+    ...actual,
+    GenericServerException: class GenericServerException extends Error {},
+    OauthException: class OauthException extends Error {},
+  };
+});
 
 // Must import handler AFTER mocks are set up.
 import handler from "./[action]";
@@ -237,42 +241,10 @@ describe("GET /api/workos/login", () => {
     expect(stateObj.nonce.length).toBeGreaterThan(0);
   });
 
-  it("rejects untrusted redirect_uri and uses default", async () => {
+  it("uses default redirect_uri when none is provided", async () => {
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
-      query: { action: "login", redirect_uri: "https://evil.com/steal" },
-    });
-
-    await handler(req, res);
-
-    const callArgs = mockGetAuthorizationUrl.mock.calls[0][0];
-    expect(callArgs.redirectUri).toBe("https://dust.tt/api/workos/callback");
-  });
-
-  it("allows redirect_uri from trusted origins with correct path", async () => {
-    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-      method: "GET",
-      query: {
-        action: "login",
-        redirect_uri: "https://app.dust.tt/api/workos/callback",
-      },
-    });
-
-    await handler(req, res);
-
-    const callArgs = mockGetAuthorizationUrl.mock.calls[0][0];
-    expect(callArgs.redirectUri).toBe(
-      "https://app.dust.tt/api/workos/callback"
-    );
-  });
-
-  it("rejects trusted origin with wrong path", async () => {
-    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-      method: "GET",
-      query: {
-        action: "login",
-        redirect_uri: "https://app.dust.tt/evil-redirect",
-      },
+      query: { action: "login" },
     });
 
     await handler(req, res);


### PR DESCRIPTION
## Description

Closes dust-tt/tasks#7096	

Prevent session-fixation / login-CSRF by binding each OAuth flow to the browser session with a cryptographic nonce (RFC 6749 §10.12).

The login endpoint:
1. generates a random nonce
2. stores it in an HttpOnly cookie
3. embeds it in the OAuth state

The callback verifies the two match via constant-time comparison before issuing a session.

Add redirect_uri validation via origin allowlist and redirectTo via trusted-origin check

Extracts shared helpers (decodeJwtPayload, buildExpiredCookie, getSessionCookieParams) and adds functional tests for all five actions.

## Tests

Added 22 new tests on nonce cookie and redirect URL

## Risk

 redirect_uri path is hardcoded to `/api/workos/callback`  **only**
 getAllowedRedirectOrigins() is missing EU as  cross-region uses config URL directly

## Deploy Plan

Normal deploy. No migrations.

Users mid-login at deploy time will see a nonce-mismatch error and need to re-login; the window is seconds and self-recoverable.