### PR TITLE
Put agents before humans when not participant

### DIFF
--- a/front/lib/api/assistant/conversation/mention_suggestions.test.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.test.ts
@@ -97,7 +97,27 @@ describe("interleaveMentionsPreservingAgentOrder", () => {
   });
 
   describe("query-based prioritization", () => {
-    it("should prioritize users whose label starts with query", () => {
+    it("should prioritize users whose label starts with query when in a conversation", () => {
+      const agents = [buildAgent(1, "AgentJo", false)];
+      const users = [
+        buildUser(1, "John Doe", false),
+        buildUser(2, "Joan Smith", false),
+      ];
+
+      const result = interleaveMentionsPreservingAgentOrder(
+        agents,
+        users,
+        "jo",
+        null,
+        "conv-1"
+      );
+
+      expect(result[0].label).toBe("John Doe");
+      expect(result[1].label).toBe("Joan Smith");
+      expect(result[2].label).toBe("AgentJo");
+    });
+
+    it("should prioritize agents whose label starts with query when new message", () => {
       const agents = [buildAgent(1, "AgentJo", false)];
       const users = [
         buildUser(1, "John Doe", false),
@@ -110,9 +130,9 @@ describe("interleaveMentionsPreservingAgentOrder", () => {
         "jo"
       );
 
-      expect(result[0].label).toBe("John Doe");
-      expect(result[1].label).toBe("Joan Smith");
-      expect(result[2].label).toBe("AgentJo");
+      expect(result[0].label).toBe("AgentJo");
+      expect(result[1].label).toBe("John Doe");
+      expect(result[2].label).toBe("Joan Smith");
     });
 
     it("should prioritize agents whose label starts with query", () => {

--- a/front/lib/api/assistant/conversation/mention_suggestions.test.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.test.ts
@@ -118,7 +118,7 @@ describe("interleaveMentionsPreservingAgentOrder", () => {
     });
 
     it("should prioritize agents whose label starts with query when new message", () => {
-      const agents = [buildAgent(1, "AgentJo", false)];
+      const agents = [buildAgent(1, "John MyAgent", false)];
       const users = [
         buildUser(1, "John Doe", false),
         buildUser(2, "Joan Smith", false),
@@ -130,7 +130,7 @@ describe("interleaveMentionsPreservingAgentOrder", () => {
         "jo"
       );
 
-      expect(result[0].label).toBe("AgentJo");
+      expect(result[0].label).toBe("John MyAgent");
       expect(result[1].label).toBe("John Doe");
       expect(result[2].label).toBe("Joan Smith");
     });

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -26,7 +26,8 @@ export function interleaveMentionsPreservingAgentOrder(
   agents: RichAgentMentionInConversation[],
   users: RichUserMentionInConversation[],
   lowerCaseQuery: string = "",
-  lastMentionedId: string | null = null
+  lastMentionedId: string | null = null,
+  conversationId: string | null = null
 ): RichMention[] {
   if (users.length === 0) {
     return [...agents];
@@ -72,7 +73,7 @@ export function interleaveMentionsPreservingAgentOrder(
       lowerCaseQuery &&
       nextAgent?.label?.toLowerCase().startsWith(lowerCaseQuery);
 
-    // Our high priority agents first, then users, then other agents
+    // Our high priority agents first, then other agents, then users
     if (
       nextAgentStartsWithQuery &&
       SUGGESTION_PRIORITY[nextAgent.id] !== undefined
@@ -81,15 +82,30 @@ export function interleaveMentionsPreservingAgentOrder(
       agentIndex += 1;
       continue;
     }
-    if (nextUserStartsWithQuery) {
-      result.push(nextUser);
-      userIndex += 1;
-      continue;
-    }
-    if (nextAgentStartsWithQuery) {
-      result.push(nextAgent);
-      agentIndex += 1;
-      continue;
+    if (conversationId) {
+      // In a conversation, prioritize users over agents.
+      if (nextUserStartsWithQuery) {
+        result.push(nextUser);
+        userIndex += 1;
+        continue;
+      }
+      if (nextAgentStartsWithQuery) {
+        result.push(nextAgent);
+        agentIndex += 1;
+        continue;
+      }
+    } else {
+      // Outside a conversation, prioritize agents over users.
+      if (nextAgentStartsWithQuery) {
+        result.push(nextAgent);
+        agentIndex += 1;
+        continue;
+      }
+      if (nextUserStartsWithQuery) {
+        result.push(nextUser);
+        userIndex += 1;
+        continue;
+      }
     }
 
     // Then interleave agents and users
@@ -321,6 +337,7 @@ export const suggestionsOfMentions = async (
     selectedAgents,
     userSuggestions,
     normalizedQuery,
-    lastMentionedId
+    lastMentionedId,
+    conversationId
   );
 };

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -73,7 +73,7 @@ export function interleaveMentionsPreservingAgentOrder(
       lowerCaseQuery &&
       nextAgent?.label?.toLowerCase().startsWith(lowerCaseQuery);
 
-    // Our high priority agents first, then other agents, then users
+    // Our high priority agents first
     if (
       nextAgentStartsWithQuery &&
       SUGGESTION_PRIORITY[nextAgent.id] !== undefined


### PR DESCRIPTION
## Description

Adjusts mention suggestion ordering based on context: when starting a new message (no `conversationId`), agents are prioritized over users in query-based suggestions. When already in a conversation, users are prioritized over agents. This provides a more natural mention suggestion flow depending on whether the user is initiating a conversation or continuing an existing one.

## Tests

- Updated existing test to verify user priority when in a conversation
- Added new test to verify agent priority when creating a new message

## Risk

Low - only affects the ordering of mention suggestions, doesn't change the underlying data or logic.

## Deploy Plan

Deploy front