### PR TITLE
feat: add firefox extension to package worflows

### DIFF
--- a/.github/workflows/package-extension-preview.yaml
+++ b/.github/workflows/package-extension-preview.yaml
@@ -11,8 +11,8 @@ permissions:
 jobs:
   package-chrome:
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'package-extension-preview')
-      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'package-extension-preview'))
+      (github.event.action == 'labeled' && github.event.label.name == 'package-chrome-extension-preview')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'package-chrome-extension-preview'))
     uses: ./.github/workflows/package-extension.yaml
     with:
       target: "chrome:production"
@@ -29,9 +29,54 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const marker = '<!-- package-extension-preview -->';
+            const marker = '<!-- package-extension-preview-chrome -->';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = `${marker}\n📦 **Extension packaged (chrome:production)**\n\nDownload the artifact from the [workflow run](${runUrl}).`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  package-firefox:
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'package-firefox-extension-preview')
+      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'package-firefox-extension-preview'))
+    uses: ./.github/workflows/package-extension.yaml
+    with:
+      target: "firefox:production"
+    secrets: inherit
+
+  comment-package-firefox:
+    needs: [package-firefox]
+    if: ${{ !failure() && !cancelled() && needs.package-firefox.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment artifact link on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- package-extension-preview-firefox -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `${marker}\n📦 **Extension packaged (firefox:production)**\n\nDownload the artifact from the [workflow run](${runUrl}).`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/package-extension.yaml
+++ b/.github/workflows/package-extension.yaml
@@ -9,6 +9,8 @@ on:
         options:
           - chrome:production
           - chrome:release
+          - firefox:production
+          - firefox:release
           - front:production
         required: true
   workflow_call:
@@ -66,4 +68,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.name }}
-          path: extension/platforms/${{ contains(inputs.target, 'chrome') && 'chrome' || 'front' }}/build/
+          path: extension/platforms/${{ contains(inputs.target, 'chrome') && 'chrome' || contains(inputs.target, 'firefox') && 'firefox' || 'front' }}/build/

--- a/extension/package.json
+++ b/extension/package.json
@@ -11,6 +11,7 @@
     "dev:firefox": "tsx run/watch.ts --platform=firefox --mode=development",
     "package:firefox:production": "tsx run/build.ts --platform=firefox",
     "package:chrome:release": "tsx run/build.ts --platform=chrome --release",
+    "package:firefox:release": "tsx run/build.ts --platform=firefox --release",
     "analyze:chrome": "tsx run/build.ts --platform=chrome --analyze",
     "tsgo": "tsgo"
   },


### PR DESCRIPTION
## Description

This PR adds Firefox extension support to the existing package workflows.

- Updates the Chrome workflow to use a more specific label (`package-chrome-extension-preview`) to differentiate from Firefox and adds a specific label for firefox preview
- Extends the reusable package workflow to support `firefox:production` and `firefox:release` targets

## Tests

Manually

## Risks

Low risk.

## Deploy Plan

Standard deploy - no special considerations needed.