### PR TITLE
Fix file download names from mounted files

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -116,7 +116,13 @@ export function ConversationFilesPanel({
         }
         const url = URL.createObjectURL(blob);
         blobUrlRef.current = url;
-        window.open(url, "_blank", "noopener,noreferrer");
+
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = entry.fileName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
       } catch {
         sendNotification({
           type: "error",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -80,6 +80,12 @@ async function handler(
     if (contentType) {
       res.setHeader("Content-Type", contentType);
     }
+
+    const fileName = path.posix.basename(normalizedPath);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${encodeURIComponent(fileName)}"`
+    );
   } catch {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Downloaded files from the sandbox "Mounted Files" tab were getting random blob UUIDs as filenames. Now they download with their actual name.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
