### PR TITLE
Use ConversationResource.fetchById instead of getLightConversation in files endpoints

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
@@ -23,8 +23,10 @@ vi.mock("@app/lib/api/auth_wrappers", async () => {
   };
 });
 
-vi.mock("@app/lib/api/assistant/conversation/fetch", () => ({
-  getLightConversation: vi.fn().mockResolvedValue({ isErr: () => false }),
+vi.mock("@app/lib/resources/conversation_resource", () => ({
+  ConversationResource: {
+    fetchById: vi.fn().mockResolvedValue({}),
+  },
 }));
 
 vi.mock("@app/lib/file_storage", () => ({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -1,10 +1,9 @@
 /** @ignoreswagger */
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -50,9 +49,15 @@ async function handler(
   }
 
   // Validate the conversation exists and user has access.
-  const conversationRes = await getLightConversation(auth, cId);
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
   }
 
   // Validate the requested path is within this conversation's files directory.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/index.ts
@@ -1,12 +1,11 @@
 /** @ignoreswagger */
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   type GCSMountFileEntry,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -44,9 +43,15 @@ async function handler(
     });
   }
 
-  const conversationRes = await getLightConversation(auth, cId);
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
   }
 
   const files = await listGCSMountFiles(auth, {


### PR DESCRIPTION
## Description

Replace getLightConversation with ConversationResource.fetchById() in the conversation files endpoints (download and index). These endpoints only need to check for conversation existence and permissions, so fetchById is the idiomatic and most efficient approach — it avoids fetching messages entirely.

Follow-up to #23298 per review feedback.

## Tests

Covered by tests

## Risk

Low

## Deploy Plan

- deploy `front`