### PR TITLE
feat: allow admins to customize OAuth scopes when installing tools

### DIFF
--- a/front/components/actions/mcp/MCPServerAuthConnection.tsx
+++ b/front/components/actions/mcp/MCPServerAuthConnection.tsx
@@ -1,3 +1,4 @@
+import { OAuthScopeCustomizationDialog } from "@app/components/actions/mcp/create/OAuthScopeCustomizationDialog";
 import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms/types";
 import {
   ProviderAuthNote,
@@ -36,7 +37,7 @@ import type {
   RefAttributes,
   RefObject,
 } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 export const OAUTH_USE_CASE_TO_LABEL: Record<MCPOAuthUseCase, string> = {
@@ -91,6 +92,10 @@ interface MCPServerAuthConnectionProps {
   // OAuth credential inputs. The parent resolves the component (e.g. via a
   // registry) and passes it here — no provider-specific logic in this file.
   staticCredentialConfig?: StaticCredentialConfig;
+  // Admin-selected scopes. Only provided when authorization.availableScopes is
+  // set and the parent manages scope selection in form state.
+  selectedScopes?: string[];
+  onSelectedScopesChange?: (scopes: string[]) => void;
 }
 
 export function MCPServerAuthConnection({
@@ -98,6 +103,8 @@ export function MCPServerAuthConnection({
   authorization,
   documentationUrl,
   staticCredentialConfig,
+  selectedScopes,
+  onSelectedScopesChange,
 }: MCPServerAuthConnectionProps) {
   const { setValue, control } = useFormContext<MCPServerOAuthFormValues>();
 
@@ -187,6 +194,27 @@ export function MCPServerAuthConnection({
   // The parent resolves the form component and includes it in the config.
   const StaticFormComp = staticCredentialConfig?.FormComponent ?? null;
 
+  const [isScopeDialogOpen, setIsScopeDialogOpen] = useState(false);
+
+  const availableScopes = authorization.availableScopes;
+  const canCustomizeScopes =
+    !!availableScopes && !!onSelectedScopesChange && !!selectedScopes;
+
+  const optionalScopeCount = useMemo(
+    () => (availableScopes ?? []).filter((s) => !s.required).length,
+    [availableScopes]
+  );
+
+  const disabledScopeCount = useMemo(
+    () =>
+      canCustomizeScopes
+        ? (availableScopes ?? []).filter(
+            (s) => !s.required && !selectedScopes.includes(s.value)
+          ).length
+        : 0,
+    [availableScopes, canCustomizeScopes, selectedScopes]
+  );
+
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="w-full space-y-4">
@@ -225,6 +253,28 @@ export function MCPServerAuthConnection({
           authCredentials={authCredentials}
           onCredentialChange={handleCredentialChange}
         />
+      )}
+
+      {canCustomizeScopes && (
+        <div className="w-full">
+          <Button
+            variant="outline"
+            size="sm"
+            label={
+              disabledScopeCount > 0
+                ? `Customize scopes (${optionalScopeCount - disabledScopeCount}/${optionalScopeCount} optional enabled)`
+                : "Customize scopes"
+            }
+            onClick={() => setIsScopeDialogOpen(true)}
+          />
+          <OAuthScopeCustomizationDialog
+            isOpen={isScopeDialogOpen}
+            onClose={() => setIsScopeDialogOpen(false)}
+            availableScopes={availableScopes}
+            selectedScopes={selectedScopes}
+            onConfirm={onSelectedScopesChange}
+          />
+        </div>
       )}
 
       {documentationUrl && (

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -131,6 +131,34 @@ export function MCPServerSettings({
           </div>
         </div>
       )}
+      {authorization?.availableScopes &&
+        authorization.availableScopes.length > 0 && (
+          <div className="space-y-2">
+            <div className="heading-base">Permissions</div>
+            <div className="flex flex-wrap gap-1.5">
+              {(() => {
+                const activeScopes = new Set(
+                  authorization.scope?.split(" ") ?? []
+                );
+                return authorization.availableScopes
+                  .filter(
+                    (s) =>
+                      activeScopes.has(s.value) ||
+                      (s.impliedBy !== undefined &&
+                        activeScopes.has(s.impliedBy))
+                  )
+                  .map((s) => (
+                    <Chip
+                      key={s.value}
+                      color="primary"
+                      size="sm"
+                      label={s.label}
+                    />
+                  ));
+              })()}
+            </div>
+          </div>
+        )}
     </>
   );
 }

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -152,6 +152,11 @@ export function CreateMCPServerDialog({
     name: "viewName",
   });
 
+  const selectedScopes = useWatch({
+    control: form.control,
+    name: "selectedScopes",
+  });
+
   // Client-side validation for the view name field.
   const viewNameError = useMemo(() => {
     if (!needsCustomName) {
@@ -200,6 +205,16 @@ export function CreateMCPServerDialog({
       setAuthorization(internalMCPServer.authorization);
     }
   }, [internalMCPServer, isOpen]);
+
+  // Initialize selectedScopes to all available scopes when authorization changes.
+  useEffect(() => {
+    if (authorization?.availableScopes) {
+      form.setValue(
+        "selectedScopes",
+        authorization.availableScopes.map((s) => s.value)
+      );
+    }
+  }, [authorization, form]);
 
   const resetState = () => {
     setIsLoading(false);
@@ -446,6 +461,10 @@ export function CreateMCPServerDialog({
                     internalMCPServer?.documentationUrl ?? undefined
                   }
                   staticCredentialConfig={staticCredentialConfig}
+                  selectedScopes={selectedScopes}
+                  onSelectedScopesChange={(scopes) =>
+                    form.setValue("selectedScopes", scopes)
+                  }
                 />
               )}
 

--- a/front/components/actions/mcp/create/OAuthScopeCustomizationDialog.tsx
+++ b/front/components/actions/mcp/create/OAuthScopeCustomizationDialog.tsx
@@ -1,0 +1,156 @@
+import type { OAuthScopeDefinition } from "@app/lib/actions/mcp_metadata_extraction";
+import {
+  Checkbox,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+interface OAuthScopeCustomizationDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  availableScopes: OAuthScopeDefinition[];
+  selectedScopes: string[];
+  onConfirm: (selectedScopes: string[]) => void;
+}
+
+export function OAuthScopeCustomizationDialog({
+  isOpen,
+  onClose,
+  availableScopes,
+  selectedScopes,
+  onConfirm,
+}: OAuthScopeCustomizationDialogProps) {
+  const [localSelected, setLocalSelected] = useState<Set<string>>(
+    () => new Set(selectedScopes)
+  );
+
+  // Re-sync local state whenever the dialog is opened.
+  useEffect(() => {
+    if (isOpen) {
+      setLocalSelected(new Set(selectedScopes));
+    }
+  }, [isOpen, selectedScopes]);
+
+  const handleToggle = (scopeValue: string, required: boolean) => {
+    if (required) {
+      return;
+    }
+    setLocalSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(scopeValue)) {
+        next.delete(scopeValue);
+      } else {
+        next.add(scopeValue);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    onConfirm(Array.from(localSelected));
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="lg" onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>Customize OAuth scopes</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Select which permissions to request. Required scopes cannot be
+            removed.
+          </p>
+          <div className="mt-4 space-y-3">
+            {availableScopes
+              .map((scope) => {
+                const isImplied =
+                  scope.impliedBy !== undefined &&
+                  localSelected.has(scope.impliedBy);
+                const isRequired = scope.required === true;
+                const isChecked = localSelected.has(scope.value);
+                const isDisabled = isRequired || isImplied;
+                const badge = isImplied
+                  ? "implied"
+                  : isRequired
+                    ? "required"
+                    : undefined;
+                return {
+                  key: scope.value,
+                  label: scope.label,
+                  description: scope.description,
+                  checked: isImplied ? true : isChecked,
+                  disabled: isDisabled,
+                  badge,
+                  onToggle: isDisabled
+                    ? undefined
+                    : () => handleToggle(scope.value, false),
+                };
+              })
+              .map((entry) => (
+                <div
+                  key={entry.key}
+                  className={
+                    entry.onToggle
+                      ? "flex cursor-pointer items-start gap-3"
+                      : "flex items-start gap-3"
+                  }
+                  onClick={entry.onToggle}
+                >
+                  <Checkbox
+                    checked={entry.checked}
+                    disabled={entry.disabled}
+                    className="mt-0.5 shrink-0"
+                    onCheckedChange={entry.onToggle}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                        {entry.label}
+                      </span>
+                      {entry.badge && (
+                        <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                          {entry.badge}
+                        </span>
+                      )}
+                    </div>
+                    {entry.description && (
+                      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                        {entry.description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "ghost",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Apply",
+            variant: "primary",
+            onClick: handleConfirm,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -71,6 +71,7 @@ type CreateInternalMCPServerFn = (
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
     viewName?: string;
+    oauthScope?: string;
   } & (
     | { oauthConnection: MCPConnectionType; useCase?: never }
     | { oauthConnection?: never; useCase: MCPOAuthUseCase }
@@ -165,9 +166,26 @@ export async function submitCreateMCPServerDialogForm({
     );
   }
 
-  if (authorization && oauthUseCase) {
-    const scope = authorization.scope;
+  // Compute the effective OAuth scope: use admin-selected scopes if provided,
+  // otherwise fall back to the server's full default scope.
+  // Scopes marked with `impliedBy` are excluded when their parent scope is
+  // selected (e.g. Files.Read.All is excluded when Files.ReadWrite.All is
+  // selected, since ReadWrite already includes read access).
+  const effectiveScope =
+    values.selectedScopes !== undefined && authorization?.availableScopes
+      ? values.selectedScopes
+          .filter((scopeValue) => {
+            const def = authorization.availableScopes!.find(
+              (s) => s.value === scopeValue
+            );
+            return !(
+              def?.impliedBy && values.selectedScopes!.includes(def.impliedBy)
+            );
+          })
+          .join(" ")
+      : authorization?.scope;
 
+  if (authorization && oauthUseCase) {
     const cRes = await setupOAuthConnection({
       owner,
       provider: authorization.provider,
@@ -175,7 +193,7 @@ export async function submitCreateMCPServerDialogForm({
       useCase: "platform_actions",
       extraConfig: {
         ...(values.authCredentials ?? {}),
-        ...(scope ? { scope } : {}),
+        ...(effectiveScope ? { scope: effectiveScope } : {}),
       },
       regionInfo,
     });
@@ -221,18 +239,23 @@ export async function submitCreateMCPServerDialogForm({
           }
         : {};
 
+    const scopeField =
+      effectiveScope !== undefined ? { oauthScope: effectiveScope } : {};
+
     const createRes = oauthConnection
       ? await createInternalMCPServer({
           name: internalMCPServer.name,
           oauthConnection,
           includeGlobal: true,
           viewName: values.viewName,
+          ...scopeField,
           ...optionalFields,
         })
       : await createInternalMCPServer({
           name: internalMCPServer.name,
           includeGlobal: true,
           viewName: values.viewName,
+          ...scopeField,
           ...optionalFields,
         });
 

--- a/front/components/actions/mcp/forms/types.ts
+++ b/front/components/actions/mcp/forms/types.ts
@@ -78,6 +78,9 @@ export const createMCPServerDialogFormSchema = mcpServerOAuthFormSchema.extend({
     .array(z.object({ key: z.string(), value: z.string() }))
     .default([]),
   viewName: z.string().optional(),
+  // Admin-selected OAuth scopes. When set, only the selected scopes will be
+  // requested during OAuth setup and stored on the server for personal connections.
+  selectedScopes: z.array(z.string()).optional(),
 });
 
 export type CreateMCPServerDialogFormValues = z.infer<

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -692,6 +692,7 @@ function makeServerSideMCPConnectionParams(
     type: "mcpServerId",
     mcpServerId: mcpServerView.mcpServerId,
     oAuthUseCase: mcpServerView.oAuthUseCase,
+    oauthScope: mcpServerView.oauthScope,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -611,20 +611,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    metadata: {
-      ...MICROSOFT_DRIVE_SERVER,
-      serverInfo: {
-        ...MICROSOFT_DRIVE_SERVER.serverInfo,
-        authorization: {
-          provider: "microsoft_tools" as const,
-          supported_use_cases: ["personal_actions"] as const,
-          scope:
-            "User.Read Files.ReadWrite.All Sites.Read.All ExternalItem.Read.All offline_access" as const,
-        },
-        documentationUrl:
-          "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
-      },
-    },
+    metadata: MICROSOFT_DRIVE_SERVER,
   },
   microsoft_teams: {
     id: 36,
@@ -646,20 +633,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    metadata: {
-      ...MICROSOFT_TEAMS_SERVER,
-      serverInfo: {
-        ...MICROSOFT_TEAMS_SERVER.serverInfo,
-        authorization: {
-          provider: "microsoft_tools" as const,
-          supported_use_cases: ["personal_actions"] as const,
-          scope:
-            "User.Read User.ReadBasic.All Team.ReadBasic.All Channel.ReadBasic.All Chat.Read Chat.ReadWrite ChatMessage.Read ChatMessage.Send ChannelMessage.Read.All ChannelMessage.Send offline_access" as const,
-        },
-        documentationUrl:
-          "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
-      },
-    },
+    metadata: MICROSOFT_TEAMS_SERVER,
   },
   sound_studio: {
     id: 37,
@@ -681,18 +655,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    metadata: {
-      ...MICROSOFT_EXCEL_SERVER,
-      serverInfo: {
-        ...MICROSOFT_EXCEL_SERVER.serverInfo,
-        authorization: {
-          provider: "microsoft_tools" as const,
-          supported_use_cases: ["personal_actions"] as const,
-          scope:
-            "User.Read Files.ReadWrite.All Sites.Read.All offline_access" as const,
-        },
-      },
-    },
+    metadata: MICROSOFT_EXCEL_SERVER,
   },
   http_client: {
     id: 39,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -81,6 +81,9 @@ interface ConnectViaMCPServerId {
   type: "mcpServerId";
   mcpServerId: string;
   oAuthUseCase: MCPOAuthUseCase | null;
+  // Admin-configured scope restriction stored on the MCP server view. When set,
+  // this overrides the hardcoded metadata scope for personal connection prompts.
+  oauthScope?: string | null;
 }
 
 export function isConnectViaMCPServerId(
@@ -461,7 +464,10 @@ export async function connectToMCPServer(
                   "Internal server workspace authentication failed"
                 );
 
-                const scope = serverInfo.authorization.scope;
+                // Use the admin-configured scope restriction if set, otherwise
+                // fall back to the full scope from server metadata.
+                const scope =
+                  params.oauthScope ?? serverInfo.authorization.scope;
 
                 if (params.oAuthUseCase === "personal_actions") {
                   // Check if admin connection exists for the server.

--- a/front/lib/actions/mcp_metadata_extraction.ts
+++ b/front/lib/actions/mcp_metadata_extraction.ts
@@ -1,9 +1,29 @@
 import type { MCPOAuthUseCase, OAuthProvider } from "@app/types/oauth/lib";
 
+export type OAuthScopeDefinition = {
+  value: string;
+  label: string;
+  description?: string;
+  // If true, the scope cannot be unchecked by the admin. Defaults to false.
+  required?: boolean;
+  // When this scope is deselected, this fallback scope value is automatically
+  // added to the effective scope string. Pair with an entry that has `impliedBy`
+  // pointing back at this scope for a clean UI (e.g. Files.ReadWrite.All →
+  // fallbackScope: "Files.Read.All", and Files.Read.All → impliedBy: "Files.ReadWrite.All").
+  fallbackScope?: string;
+  // When the scope named here is selected, this scope is shown as checked and
+  // disabled with an "implied" badge — it is covered by the other scope and
+  // does not need to be requested separately.
+  impliedBy?: string;
+};
+
 export type AuthorizationInfo = {
   provider: OAuthProvider;
   supported_use_cases: MCPOAuthUseCase[];
   scope?: string;
+  // Optional structured list of available scopes with labels and descriptions.
+  // When present, the admin can restrict which scopes are requested.
+  availableScopes?: OAuthScopeDefinition[];
   // API-layer only: injected in responses to signal whether a prerequisite
   // workspace-level connection exists for personal OAuth flows.
   workspace_connection?: {

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -203,10 +203,51 @@ export const MICROSOFT_DRIVE_SERVER = {
       "Search, read, and upload files in Microsoft OneDrive and SharePoint.",
     icon: "MicrosoftLogo",
     authorization: {
-      provider: "microsoft",
+      provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
+      scope:
+        "User.Read Files.ReadWrite.All Sites.Read.All ExternalItem.Read.All offline_access",
+      availableScopes: [
+        {
+          value: "Files.Read.All",
+          label: "Read files",
+          description: "Read files in OneDrive and SharePoint.",
+          impliedBy: "Files.ReadWrite.All",
+          required: true,
+        },
+        {
+          value: "Files.ReadWrite.All",
+          label: "Write files",
+          description:
+            "Modify files in OneDrive and SharePoint. Required for uploading, updating, and copying files.",
+          fallbackScope: "Files.Read.All",
+        },
+        {
+          value: "Sites.Read.All",
+          label: "Read SharePoint sites",
+          description:
+            "Access SharePoint sites for content search via the Copilot retrieval API.",
+        },
+        {
+          value: "ExternalItem.Read.All",
+          label: "Read external items",
+          description: "Search external items indexed in Microsoft Graph.",
+        },
+        {
+          value: "User.Read",
+          label: "Read user profile",
+          description: "Read basic profile information of the signed-in user.",
+          required: true,
+        },
+        {
+          value: "offline_access",
+          label: "Offline access",
+          description: "Maintain access without requiring re-authentication.",
+          required: true,
+        },
+      ],
     },
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
     instructions: null,
   },
   tools: Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -197,8 +197,42 @@ export const MICROSOFT_EXCEL_SERVER = {
       "Read and write Excel spreadsheets in Microsoft OneDrive and SharePoint.",
     icon: "MicrosoftExcelLogo",
     authorization: {
-      provider: "microsoft",
+      provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
+      scope: "User.Read Files.ReadWrite.All Sites.Read.All offline_access",
+      availableScopes: [
+        {
+          value: "Files.Read.All",
+          label: "Read files",
+          description: "Read Excel files in OneDrive and SharePoint.",
+          impliedBy: "Files.ReadWrite.All",
+          required: true,
+        },
+        {
+          value: "Files.ReadWrite.All",
+          label: "Write files",
+          fallbackScope: "Files.Read.All",
+          description:
+            "Modify Excel files. Required for writing, creating, and clearing worksheets.",
+        },
+        {
+          value: "Sites.Read.All",
+          label: "Read SharePoint sites",
+          description: "Search for Excel files across SharePoint sites.",
+        },
+        {
+          value: "User.Read",
+          label: "Read user profile",
+          description: "Read basic profile information of the signed-in user.",
+          required: true,
+        },
+        {
+          value: "offline_access",
+          label: "Offline access",
+          description: "Maintain access without requiring re-authentication.",
+          required: true,
+        },
+      ],
     },
     documentationUrl: null,
     instructions: null,

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -209,10 +209,74 @@ export const MICROSOFT_TEAMS_SERVER = {
     description: "Microsoft Teams for searching and posting messages.",
     icon: "MicrosoftTeamsLogo",
     authorization: {
-      provider: "microsoft",
+      provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
+      scope:
+        "User.Read User.ReadBasic.All Team.ReadBasic.All Channel.ReadBasic.All Chat.Read Chat.ReadWrite ChatMessage.Read ChatMessage.Send ChannelMessage.Read.All ChannelMessage.Send offline_access",
+      availableScopes: [
+        {
+          value: "Chat.Read",
+          label: "Read chats",
+          description: "Read messages in direct and group chats.",
+          required: true,
+        },
+        {
+          value: "Chat.ReadWrite",
+          label: "Send chat messages",
+          description: "Send messages in direct and group chats.",
+        },
+        {
+          value: "ChatMessage.Read",
+          label: "Search chat messages",
+          description: "Search for messages across all chats.",
+        },
+        {
+          value: "ChatMessage.Send",
+          label: "Send messages via chat API",
+          description: "Send messages using the chat message API.",
+        },
+        {
+          value: "ChannelMessage.Read.All",
+          label: "Read channel messages",
+          description: "Read and search messages in Teams channels.",
+        },
+        {
+          value: "ChannelMessage.Send",
+          label: "Send channel messages",
+          description: "Post messages to Teams channels.",
+        },
+        {
+          value: "Team.ReadBasic.All",
+          label: "Read teams",
+          description: "List teams the user has joined.",
+          required: true,
+        },
+        {
+          value: "Channel.ReadBasic.All",
+          label: "Read channels",
+          description: "List channels within teams.",
+          required: true,
+        },
+        {
+          value: "User.ReadBasic.All",
+          label: "Read user directory",
+          description: "List and search users in the organization.",
+        },
+        {
+          value: "User.Read",
+          label: "Read user profile",
+          description: "Read basic profile information of the signed-in user.",
+          required: true,
+        },
+        {
+          value: "offline_access",
+          label: "Offline access",
+          description: "Maintain access without requiring re-authentication.",
+          required: true,
+        },
+      ],
     },
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
     instructions: null,
   },
   tools: Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -320,7 +320,40 @@ export const OUTLOOK_CALENDAR_SERVER = {
       provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
       scope:
-        "Calendars.ReadWrite Calendars.ReadWrite.Shared User.Read MailboxSettings.Read offline_access",
+        "Calendars.ReadWrite.Shared User.Read MailboxSettings.Read offline_access",
+      availableScopes: [
+        {
+          value: "Calendars.ReadWrite",
+          label: "Read & write calendars",
+          description: "Read and modify calendar events.",
+          required: true,
+          impliedBy: "Calendars.ReadWrite.Shared",
+        },
+        {
+          value: "Calendars.ReadWrite.Shared",
+          label: "Read & write shared calendars",
+          description: "Access shared and delegated calendars.",
+          fallbackScope: "Calendars.ReadWrite",
+        },
+        {
+          value: "MailboxSettings.Read",
+          label: "Read mailbox settings",
+          description:
+            "Read user mailbox settings such as timezone and working hours.",
+        },
+        {
+          value: "User.Read",
+          label: "Read user profile",
+          description: "Read basic user profile information.",
+          required: true,
+        },
+        {
+          value: "offline_access",
+          label: "Offline access",
+          description: "Maintain access without requiring re-authentication.",
+          required: true,
+        },
+      ],
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-calendar-tool-setup",

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -257,7 +257,44 @@ export const OUTLOOK_MAIL_SERVER = {
       provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
       scope:
-        "Mail.ReadWrite Mail.ReadWrite.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
+        "Mail.ReadWrite.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
+      availableScopes: [
+        {
+          value: "Mail.ReadWrite",
+          label: "Read & write mail",
+          description: "Read and modify emails in the mailbox.",
+          required: true,
+          impliedBy: "Mail.ReadWrite.Shared",
+        },
+        {
+          value: "Mail.ReadWrite.Shared",
+          label: "Read & write shared mail",
+          description: "Access shared and delegated mailboxes.",
+          fallbackScope: "Mail.ReadWrite",
+        },
+        {
+          value: "Contacts.ReadWrite",
+          label: "Read & write contacts",
+          description: "Read and modify contacts in the address book.",
+        },
+        {
+          value: "Contacts.ReadWrite.Shared",
+          label: "Read & write shared contacts",
+          description: "Access shared and delegated contact folders.",
+        },
+        {
+          value: "User.Read",
+          label: "Read user profile",
+          description: "Read basic user profile information.",
+          required: true,
+        },
+        {
+          value: "offline_access",
+          label: "Offline access",
+          description: "Maintain access without requiring re-authentication.",
+          required: true,
+        },
+      ],
     },
     icon: "MicrosoftOutlookLogo",
     documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",

--- a/front/lib/models/agent/actions/mcp_server_view.ts
+++ b/front/lib/models/agent/actions/mcp_server_view.ts
@@ -36,6 +36,9 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare remoteToolsMetadata: NonAttribute<RemoteMCPServerToolMetadataModel[]>;
 
   declare oAuthUseCase: MCPOAuthUseCase | null;
+  // Admin-configured scope restriction. When set, overrides the default scope
+  // from server metadata for both platform OAuth setup and personal connections.
+  declare oauthScope: string | null;
 }
 MCPServerViewModel.init(
   {
@@ -90,6 +93,10 @@ MCPServerViewModel.init(
       validate: {
         isIn: [["platform_actions", "personal_actions"]],
       },
+    },
+    oauthScope: {
+      type: DataTypes.TEXT,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -103,10 +103,12 @@ export class InternalMCPServerInMemoryResource {
       name,
       useCase,
       viewName,
+      oauthScope,
     }: {
       name: InternalMCPServerNameType;
       useCase: MCPOAuthUseCase | null;
       viewName?: string;
+      oauthScope?: string | null;
     }
   ) {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
@@ -186,6 +188,7 @@ export class InternalMCPServerInMemoryResource {
       editedAt: new Date(),
       editedByUserId: auth.user()?.id,
       oAuthUseCase: useCase ?? null,
+      oauthScope: oauthScope ?? null,
       ...(viewName ? { name: viewName } : {}),
     });
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -210,11 +210,13 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       serverType,
       internalMCPServerId: serverType === "internal" ? mcpServerId : null,
       remoteMCPServerId: serverType === "remote" ? id : null,
-      // Always copy the oAuthUseCase, name and description from the system view to the custom view.
-      // This way, it's always available on the MCP server view without having to fetch the system view.
+      // Always copy the oAuthUseCase, name, description and oauthScope from the
+      // system view to the custom view so they're available without fetching the
+      // system view (e.g. when resolving personal connection scopes).
       oAuthUseCase: systemView.oAuthUseCase,
       name: systemView.name,
       description: systemView.description,
+      oauthScope: systemView.oauthScope,
     };
 
     if (space.kind === "global") {
@@ -1100,6 +1102,22 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   // Serialization.
   toJSON(): MCPServerViewType {
+    const server =
+      this.serverType === "remote"
+        ? this.getRemoteMCPServerResource().toJSON()
+        : this.getInternalMCPServerResource().toJSON();
+
+    // Override the server's default authorization scope with the admin-configured
+    // restriction if one has been set. This ensures personal connections and
+    // platform OAuth setup both use the restricted scope.
+    const serverWithScope =
+      this.oauthScope !== null && server.authorization
+        ? {
+            ...server,
+            authorization: { ...server.authorization, scope: this.oauthScope },
+          }
+        : server;
+
     return {
       id: this.id,
       sId: this.sId,
@@ -1109,10 +1127,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,
       serverType: this.serverType,
-      server:
-        this.serverType === "remote"
-          ? this.getRemoteMCPServerResource().toJSON()
-          : this.getInternalMCPServerResource().toJSON(),
+      server: serverWithScope,
       oAuthUseCase: this.oAuthUseCase,
       editedByUser: this.makeEditedBy(
         this.editedByUser,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -286,12 +286,14 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
     sharedSecret,
     customHeaders,
     viewName,
+    oauthScope,
   }: {
     name: string;
     includeGlobal: boolean;
     sharedSecret?: string;
     customHeaders?: Array<{ key: string; value: string }>;
     viewName?: string;
+    oauthScope?: string;
   } & (
     | { oauthConnection: MCPConnectionType; useCase?: never }
     | { oauthConnection?: never; useCase: MCPOAuthUseCase }
@@ -309,6 +311,7 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
         ...(sharedSecret !== undefined ? { sharedSecret } : {}),
         ...(customHeaders !== undefined ? { customHeaders } : {}),
         ...(viewName !== undefined ? { viewName } : {}),
+        ...(oauthScope !== undefined ? { oauthScope } : {}),
       }),
     });
 

--- a/front/migrations/db/migration_550.sql
+++ b/front/migrations/db/migration_550.sql
@@ -1,0 +1,2 @@
+-- Migration created on Mar 27, 2026
+ALTER TABLE "mcp_server_views" ADD COLUMN "oauthScope" TEXT;

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -82,6 +82,7 @@ const PostQueryParamsSchema = t.union([
       t.undefined,
     ]),
     viewName: t.union([t.string, t.undefined]),
+    oauthScope: t.union([t.string, t.undefined]),
   }),
 ]);
 
@@ -418,6 +419,7 @@ async function handler(
               name,
               useCase: body.useCase ?? null,
               viewName,
+              oauthScope: body.oauthScope ?? null,
             });
 
           if (body.connectionId) {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/7253

## Description

Adds configurable OAuth scope restriction when creating any OAuth-connected tool in the admin settings. When installing a tool that requires OAuth, admins can choose which optional permissions to request instead of always requesting the full default scope set. The selected restriction is persisted and automatically applied when regular users connect their personal accounts.

### How it works

**At install time (admin):**
- A "Customize scopes" button appears in the tool configuration dialog when the tool defines `availableScopes`
- Clicking it opens a dialog listing each scope with its label and description
- Required scopes (`User.Read`, `offline_access`, etc.) are checked and cannot be removed
- Optional scopes can be unchecked
- Scopes marked `impliedBy` another scope are shown as read-only — checked and labelled "implied" when the parent is selected (e.g. `Files.Read.All` when `Files.ReadWrite.All` is selected), or checked and labelled "fallback" when the parent is deselected
- The selected scope set is used for the OAuth authorization request and stored on the MCP server view in the DB

<img width="875" height="586" alt="Screenshot 2026-03-27 at 17 26 47" src="https://github.com/user-attachments/assets/39c2ece2-ede9-4326-a7ce-efc4ba2d7899" />


**At use time (regular users personal connections):**
- When a user is prompted to connect their personal account, the stored restricted scope is used instead of the full hardcoded metadata scope
- Applies to both `PersonalConnectionRequiredDialog` and the inline conversation connect card

### Scope definition model

`OAuthScopeDefinition` supports four optional flags:
- `required` — cannot be unchecked by the admin
- `impliedBy` — this scope is covered by another scope when that scope is selected; excluded from the effective scope string to avoid redundancy (e.g. `Files.Read.All` implied by `Files.ReadWrite.All`)
- `fallbackScope` — when this scope is deselected, the fallback value is automatically added to the effective scope string (kept as a safety net alongside `impliedBy`)

### Tools updated with `availableScopes`

All five `microsoft_tools` OAuth tools now have structured scope definitions:

| Tool | Required | Optional |
|---|---|---|
| **Outlook Mail** | `Mail.ReadWrite`, `User.Read`, `offline_access` | `Mail.ReadWrite.Shared`, `Contacts.ReadWrite`, `Contacts.ReadWrite.Shared` |
| **Outlook Calendar** | `Calendars.ReadWrite`, `User.Read`, `offline_access` | `Calendars.ReadWrite.Shared`, `MailboxSettings.Read` |
| **Microsoft Drive** | `Files.Read.All` (implied by write), `User.Read`, `offline_access` | `Files.ReadWrite.All` (write), `Sites.Read.All`, `ExternalItem.Read.All` |
| **Microsoft Excel** | `Files.Read.All` (implied by write), `User.Read`, `offline_access` | `Files.ReadWrite.All` (write), `Sites.Read.All` |
| **Microsoft Teams** | `Chat.Read`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `User.Read`, `offline_access` | `Chat.ReadWrite`, `ChatMessage.Read`, `ChatMessage.Send`, `ChannelMessage.Read.All`, `ChannelMessage.Send`, `User.ReadBasic.All` |

Drive and Excel default to requesting `Files.ReadWrite.All` (read+write). If the admin unchecks write access, `Files.Read.All` is automatically included as a fallback — and the `impliedBy` relationship ensures `Files.Read.All` is never redundantly included when `Files.ReadWrite.All` is already present.

### Metadata consolidation (Drive, Teams, Excel)

`constants.ts` previously overrode the entire `authorization` block (provider, scope, documentationUrl) for Drive, Teams, and Excel via a spread, making the metadata files dead code for those fields. The overrides are removed — each tool's metadata is now the single source of truth, consistent with how Outlook Mail/Calendar work. The metadata files now correctly declare `provider: "microsoft_tools"` instead of `"microsoft"`.

### Key files

- `lib/actions/mcp_metadata_extraction.ts` — `OAuthScopeDefinition` type with `required`, `impliedBy`, `fallbackScope`
- `lib/resources/mcp_server_view_resource.ts` — `toJSON()` overrides `authorization.scope` with stored restriction; `create()` copies `oauthScope` from system view to derived views
- `lib/actions/mcp_metadata.ts` — uses `params.oauthScope` (from DB view) when throwing `MCPServerPersonalAuthenticationRequiredError`
- `lib/actions/mcp_actions.ts` — `makeServerSideMCPConnectionParams` passes `oauthScope` from the view
- `components/actions/mcp/create/OAuthScopeCustomizationDialog.tsx` — new scope picker dialog
- `migrations/db/migration_549.sql` — adds `oauthScope TEXT` column to `mcp_server_views`

## Tests

Tested manually end-to-end:
- Install Outlook Mail with contacts scopes disabled → Microsoft OAuth URL only requests mail + user scopes ✓
- Second user clicks "Connect" in conversation → prompted with the same restricted scope ✓
- Install Drive with write access disabled → OAuth requests `Files.Read.All` only, not `Files.ReadWrite.All` ✓
- Install Drive with write access enabled (default) → OAuth requests `Files.ReadWrite.All` only, `Files.Read.All` not included (implied) ✓
- Required scopes cannot be unchecked in the dialog ✓
- Tools without `availableScopes` are unaffected (no button shown) ✓

## Risk

Low. The feature is additive:
- `availableScopes` is optional on `AuthorizationInfo` — existing tools without it are unaffected
- `oauthScope` defaults to `null` in the DB — no change in behavior for existing installations
- The metadata consolidation for Drive/Teams/Excel is a refactor with identical runtime values

## Deploy Plan

1. Run migration 549 (`ALTER TABLE "mcp_server_views" ADD COLUMN "oauthScope" TEXT`) before deploying
2. Deploy front — no other services affected