### PR TITLE
Add poke table view to list reinforcement conversations

### DIFF
--- a/front/components/poke/conversation/reinforcement_table.tsx
+++ b/front/components/poke/conversation/reinforcement_table.tsx
@@ -1,0 +1,147 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
+import { usePokeConversations } from "@app/poke/swr/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { ColumnDef } from "@tanstack/react-table";
+
+interface ReinforcementConversationDataTableProps {
+  owner: LightWorkspaceType;
+  agentId: string;
+}
+
+function getOperationTypeLabel(metadata: Record<string, unknown>): string {
+  const operationType =
+    metadata[REINFORCEMENT_METADATA_KEYS.reinforcedOperationType];
+
+  switch (operationType) {
+    case "reinforced_agent_analyze_conversation":
+      return "Analysis";
+    case "reinforced_agent_aggregate_suggestions":
+      return "Aggregation";
+    default:
+      return "Unknown";
+  }
+}
+
+const makeColumnsForReinforcementConversations = (
+  owner: LightWorkspaceType
+): ColumnDef<ConversationWithoutContentType>[] => {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Id</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        const conversation = row.original;
+        return (
+          <LinkWrapper
+            href={`/poke/${owner.sId}/conversation/${conversation.sId}`}
+          >
+            {conversation.sId}
+          </LinkWrapper>
+        );
+      },
+    },
+    {
+      accessorKey: "created",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Created at</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        return formatTimestampToFriendlyDate(row.original.created);
+      },
+    },
+    {
+      accessorKey: "title",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Title</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      id: "operationType",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Type</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      accessorFn: (row) => getOperationTypeLabel(row.metadata),
+    },
+  ];
+};
+
+export function ReinforcementConversationDataTable({
+  owner,
+  agentId,
+}: ReinforcementConversationDataTableProps) {
+  const useReinforcementConversations = (props: PokeConversationsFetchProps) =>
+    usePokeConversations({ ...props, reinforcedAgentId: agentId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      header="Reinforcement conversations"
+      owner={owner}
+      showSensitiveDataWarning={true}
+      useSWRHook={useReinforcementConversations}
+    >
+      {(conversations) => {
+        const columns = makeColumnsForReinforcementConversations(owner);
+
+        return (
+          <PokeDataTable<ConversationWithoutContentType, unknown>
+            columns={columns}
+            data={conversations}
+          />
+        );
+      }}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { AgentOverviewTable } from "@app/components/poke/assistants/AgentOverviewTable";
 import { ConversationAgentDataTable } from "@app/components/poke/conversation/agent_table";
+import { ReinforcementConversationDataTable } from "@app/components/poke/conversation/reinforcement_table";
 import { DatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { SuggestionDataTable } from "@app/components/poke/suggestions/table";
@@ -139,6 +140,13 @@ export function AssistantDetailsPage() {
 
           <div className="mt-4">
             <ConversationAgentDataTable
+              owner={owner}
+              agentId={agentConfigurations[0].sId}
+            />
+          </div>
+
+          <div className="mt-4">
+            <ReinforcementConversationDataTable
               owner={owner}
               agentId={agentConfigurations[0].sId}
             />

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -16,6 +16,8 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import type { ReinforcedOperationType } from "@app/lib/reinforced_agent/types";
+import { getReinforcementMetadata } from "@app/lib/reinforced_agent/types";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -54,21 +56,18 @@ function buildSpecifications(): AgentActionSpecification[] {
   }));
 }
 
-type ReinforcedOperationType =
-  | "reinforced_agent_analyze_conversation"
-  | "reinforced_agent_aggregate_suggestions";
-
 export const REINFORCEMENT_AGENT_ID = "reinforcement";
 
 export function getReinforcementDefaultOptions(
-  reinforcedOperationType: ReinforcedOperationType
+  reinforcedOperationType: ReinforcedOperationType,
+  reinforcedAgentConfigurationId: string
 ) {
   return {
     visibility: "test" as const,
-    metadata: {
-      reinforcedAgentBatch: true,
+    metadata: getReinforcementMetadata(
       reinforcedOperationType,
-    },
+      reinforcedAgentConfigurationId
+    ),
     userContextUsername: "reinforced_agent",
     userContextOrigin: "reinforcement" as const,
     agentConfigurationId: REINFORCEMENT_AGENT_ID,
@@ -382,7 +381,7 @@ export async function runReinforcedAnalysis({
     newMessages: llmConversation.messages,
     title: reinforcementConversationTitle(operationType, contextId),
     ...llmParamsWithoutConversation,
-    ...getReinforcementDefaultOptions(operationType),
+    ...getReinforcementDefaultOptions(operationType, agentConfig.sId),
   });
   if (writeResult.isErr()) {
     throw writeResult.error;

--- a/front/lib/reinforced_agent/types.ts
+++ b/front/lib/reinforced_agent/types.ts
@@ -1,0 +1,22 @@
+export type ReinforcedOperationType =
+  | "reinforced_agent_analyze_conversation"
+  | "reinforced_agent_aggregate_suggestions";
+
+export const REINFORCEMENT_METADATA_KEYS = {
+  reinforcedAgent: "reinforcedAgent",
+  reinforcedOperationType: "reinforcedOperationType",
+  reinforcedAgentConfigurationId: "reinforcedAgentConfigurationId",
+} as const;
+
+export function getReinforcementMetadata(
+  reinforcedOperationType: ReinforcedOperationType,
+  reinforcedAgentConfigurationId: string
+) {
+  return {
+    [REINFORCEMENT_METADATA_KEYS.reinforcedAgent]: true,
+    [REINFORCEMENT_METADATA_KEYS.reinforcedOperationType]:
+      reinforcedOperationType,
+    [REINFORCEMENT_METADATA_KEYS.reinforcedAgentConfigurationId]:
+      reinforcedAgentConfigurationId,
+  };
+}

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -8,6 +8,10 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+import {
+  getReinforcementMetadata,
+  REINFORCEMENT_METADATA_KEYS,
+} from "@app/lib/reinforced_agent/types";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -208,6 +212,107 @@ describe("ConversationResource", () => {
         }
       );
       expect(oldConversations.length).toBe(4);
+    });
+  });
+});
+
+describe("listReinforcementConversations", () => {
+  let auth: Authenticator;
+  let anotherAuth: Authenticator;
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const anotherWorkspace = await WorkspaceFactory.basic();
+    const anotherUser = await UserFactory.basic();
+    await MembershipFactory.associate(anotherWorkspace, anotherUser, {
+      role: "admin",
+    });
+    anotherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      anotherUser.sId,
+      anotherWorkspace.sId
+    );
+  });
+
+  it("should return only conversations with reinforcedAgent metadata for the given agent", async () => {
+    // Create reinforcement conversation for agent-1.
+    const reinforcedConvo1 = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Reinforcement for agent-1",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcementMetadata(
+          "reinforced_agent_analyze_conversation",
+          "agent-1"
+        ),
+      },
+      null
+    );
+
+    // Create reinforcement conversation for agent-2 (should be excluded).
+    await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Reinforcement for agent-2",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcementMetadata(
+          "reinforced_agent_aggregate_suggestions",
+          "agent-2"
+        ),
+      },
+      null
+    );
+
+    // Create a regular (non-reinforcement) conversation (should be excluded).
+    await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Regular conversation",
+        visibility: "unlisted",
+        requestedSpaceIds: [],
+        metadata: {},
+      },
+      null
+    );
+
+    // Create reinforcement conversation in another workspace (should be excluded).
+    await ConversationResource.makeNew(
+      anotherAuth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Other workspace reinforcement",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcementMetadata(
+          "reinforced_agent_analyze_conversation",
+          "agent-1"
+        ),
+      },
+      null
+    );
+
+    const results = await ConversationResource.listReinforcementConversations(
+      auth,
+      "agent-1"
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].sId).toBe(reinforcedConvo1.sId);
+    expect(results[0].title).toBe("Reinforcement for agent-1");
+    expect(results[0].metadata).toMatchObject({
+      [REINFORCEMENT_METADATA_KEYS.reinforcedAgent]: true,
+      [REINFORCEMENT_METADATA_KEYS.reinforcedAgentConfigurationId]: "agent-1",
     });
   });
 });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -9,6 +9,7 @@ import {
   UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1199,6 +1200,55 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         };
       })
     );
+  }
+
+  static async listReinforcementConversations(
+    auth: Authenticator,
+    agentConfigurationId: string
+  ): Promise<ConversationWithoutContentType[]> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const conversations = await ConversationModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        [Op.and]: [
+          where(
+            fn(
+              "jsonb_extract_path_text",
+              col("metadata"),
+              REINFORCEMENT_METADATA_KEYS.reinforcedAgent
+            ),
+            "true"
+          ),
+          where(
+            fn(
+              "jsonb_extract_path_text",
+              col("metadata"),
+              REINFORCEMENT_METADATA_KEYS.reinforcedAgentConfigurationId
+            ),
+            agentConfigurationId
+          ),
+        ],
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return conversations.map((c) => ({
+      id: c.id,
+      created: c.createdAt.getTime(),
+      updated: c.updatedAt.getTime(),
+      sId: c.sId,
+      title: c.title,
+      triggerId: ConversationResource.triggerIdToSId(c.triggerId, workspace.id),
+      actionRequired: false,
+      unread: false,
+      lastReadMs: Date.now(),
+      hasError: c.hasError,
+      requestedSpaceIds: c.requestedSpaceIds.map(String),
+      spaceId: null,
+      depth: c.depth,
+      metadata: c.metadata,
+    }));
   }
 
   static async markAsActionRequired(

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -23,7 +23,7 @@ async function handler(
     req.query.wId as string
   );
 
-  const { agentId, triggerId } = req.query;
+  const { agentId, triggerId, reinforcedAgentId } = req.query;
 
   if (!auth.isDustSuperUser()) {
     return apiError(req, res, {
@@ -45,6 +45,12 @@ async function handler(
           auth,
           triggerId
         );
+      } else if (isString(reinforcedAgentId)) {
+        conversations =
+          await ConversationResource.listReinforcementConversations(
+            auth,
+            reinforcedAgentId
+          );
       } else if (isString(agentId)) {
         // Get conversation IDs for this agent
         const conversationIds =
@@ -90,7 +96,8 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Either agent ID or trigger ID is required.",
+            message:
+              "Either agent ID, reinforcedAgent ID or trigger ID is required.",
           },
         });
       }

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -6,6 +6,7 @@ import type { Fetcher } from "swr";
 export interface PokeConversationsFetchProps extends PokeConditionalFetchProps {
   agentId?: string;
   triggerId?: string;
+  reinforcedAgentId?: string;
 }
 
 export function usePokeConversations({
@@ -13,12 +14,15 @@ export function usePokeConversations({
   owner,
   agentId,
   triggerId,
+  reinforcedAgentId,
 }: PokeConversationsFetchProps) {
   const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
 
   let url: string | null = null;
-  if (agentId) {
+  if (reinforcedAgentId) {
+    url = `/api/poke/workspaces/${owner.sId}/conversations?reinforcedAgentId=${reinforcedAgentId}`;
+  } else if (agentId) {
     url = `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}`;
   } else if (triggerId) {
     url = `/api/poke/workspaces/${owner.sId}/conversations?triggerId=${triggerId}`;

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -206,7 +206,8 @@ export async function startConversationAnalysisBatchActivity({
       ),
       ...llmParamsWithoutConversation,
       ...getReinforcementDefaultOptions(
-        "reinforced_agent_analyze_conversation"
+        "reinforced_agent_analyze_conversation",
+        agentConfigurationId
       ),
     });
     orderedAnalysedConversationIds.push(conversationId);
@@ -393,7 +394,8 @@ export async function startAggregationBatchActivity({
       ),
       ...llmParamsWithoutConversation,
       ...getReinforcementDefaultOptions(
-        "reinforced_agent_aggregate_suggestions"
+        "reinforced_agent_aggregate_suggestions",
+        agentConfigurationId
       ),
     });
   }


### PR DESCRIPTION
## Description
 
 - requires to add the analysed agent SID as metadata so we can filter on it
 - add a new resource method to get retrieve the reinforced agent conversation specifically
 
<img width="3376" height="688" alt="image" src="https://github.com/user-attachments/assets/49c9bd62-be44-4b98-88db-f0dd13e1162d" />

Note: this will only work for new convos with the new metadata

## Tests

 - Added unit test
 - tested locally

## Risk

low, this is poke

## Deploy Plan

deploy front
