### PR TITLE
Separate remote MCP size limits from file offload thresholds

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -1,13 +1,19 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-// Size limits for MCP tool outputs
+// Thresholds for offloading MCP tool output items to files.
+// When a single content block exceeds these sizes, it gets stored as a file and replaced with a
+// snippet + file reference.
+export const FILE_OFFLOAD_TEXT_SIZE_BYTES = 20 * 1024; // 20KB.
+export const FILE_OFFLOAD_IMAGE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
+export const FILE_OFFLOAD_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
 
-// Max bytes for a single text block in a tool result before it gets offloaded to a file.
-export const MAX_TEXT_CONTENT_SIZE_BYTES = 20 * 1024; // 20KB.
-export const MAX_IMAGE_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB.
-export const MAX_RESOURCE_CONTENT_SIZE = 20 * 1024 * 1024; // 20MB.
+export const FILE_OFFLOAD_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 
-export const MAXED_OUTPUT_FILE_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
+// Hard limits for remote MCP server tool results.
+// When any content block exceeds these sizes, the entire tool result is rejected.
+export const REMOTE_MAX_TEXT_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
+export const REMOTE_MAX_IMAGE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
+export const REMOTE_MAX_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
 
 export function computeTextByteSize(text: string): number {
   return Buffer.byteLength(text, "utf8");
@@ -17,16 +23,18 @@ export function computeBase64ByteSize(base64: string): number {
   return Math.ceil((base64.length * 3) / 4);
 }
 
-export function getMaxSize(item: CallToolResult["content"][number]) {
+export function getRemoteContentMaxSize(
+  item: CallToolResult["content"][number]
+) {
   switch (item.type) {
     case "text":
-      return MAX_TEXT_CONTENT_SIZE_BYTES;
+      return REMOTE_MAX_TEXT_SIZE_BYTES;
 
     case "image":
-      return MAX_IMAGE_CONTENT_SIZE;
+      return REMOTE_MAX_IMAGE_SIZE_BYTES;
 
     case "resource":
-      return MAX_RESOURCE_CONTENT_SIZE;
+      return REMOTE_MAX_RESOURCE_SIZE_BYTES;
 
     default:
       return 1 * 1024 * 1024; // 1MB default
@@ -64,8 +72,10 @@ export function calculateContentSize(
   }
 }
 
-export function isValidContentSize(
+export function isWithinRemoteContentLimit(
   content: CallToolResult["content"]
 ): boolean {
-  return !content.some((item) => calculateContentSize(item) > getMaxSize(item));
+  return !content.some(
+    (item) => calculateContentSize(item) > getRemoteContentMaxSize(item)
+  );
 }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -2,8 +2,8 @@
 
 import {
   calculateContentSize,
-  getMaxSize,
-  isValidContentSize,
+  getRemoteContentMaxSize,
+  isWithinRemoteContentLimit,
 } from "@app/lib/actions/action_output_limits";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
@@ -268,7 +268,7 @@ function generateContentMetadata(content: CallToolResult["content"]): {
   const result = [];
   for (const item of content) {
     const byteSize = calculateContentSize(item);
-    const maxSize = getMaxSize(item);
+    const maxSize = getRemoteContentMaxSize(item);
 
     result.push({ type: item.type, byteSize, maxSize });
 
@@ -552,8 +552,7 @@ export async function* tryCallMCPTool(
     }
 
     if (serverType === "remote") {
-      const isValid = isValidContentSize(content);
-
+      const isValid = isWithinRemoteContentLimit(content);
       if (!isValid) {
         const contentMetadata = generateContentMetadata(content);
         logger.info(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -260,7 +260,7 @@ function makeClientSideMCPToolConfigurations(
   }));
 }
 
-function generateContentMetadata(content: CallToolResult["content"]): {
+function generateRemoteContentMetadata(content: CallToolResult["content"]): {
   type: "text" | "image" | "resource" | "audio" | "resource_link";
   byteSize: number;
   maxSize: number;
@@ -554,7 +554,7 @@ export async function* tryCallMCPTool(
     if (serverType === "remote") {
       const isValid = isWithinRemoteContentLimit(content);
       if (!isValid) {
-        const contentMetadata = generateContentMetadata(content);
+        const contentMetadata = generateRemoteContentMetadata(content);
         logger.info(
           { contentMetadata, isValid },
           "Information on MCP tool result"

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -1,7 +1,7 @@
 import {
-  MAX_RESOURCE_CONTENT_SIZE,
-  MAX_TEXT_CONTENT_SIZE_BYTES,
-  MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
+  FILE_OFFLOAD_RESOURCE_SIZE_BYTES,
+  FILE_OFFLOAD_SNIPPET_LENGTH,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
 } from "@app/lib/actions/action_output_limits";
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { processToolResults } from "@app/lib/actions/mcp_execution";
@@ -83,11 +83,11 @@ async function setupTest() {
 }
 
 describe("processToolResults", () => {
-  it("should store snippet in DB when text exceeds MAX_TEXT_CONTENT_SIZE_BYTES", async () => {
+  it("should store snippet in DB when text exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
-    // Generate text that exceeds MAX_TEXT_CONTENT_SIZE_BYTES (20KB).
-    const largeText = "x".repeat(MAX_TEXT_CONTENT_SIZE_BYTES + 1);
+    // Generate text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
+    const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
     const { outputItems } = await processToolResults(auth, {
       action,
@@ -104,7 +104,7 @@ describe("processToolResults", () => {
     expect(stored.type).toBe("resource");
     if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text.length).toBeLessThanOrEqual(
-        MAXED_OUTPUT_FILE_SNIPPET_LENGTH + 50
+        FILE_OFFLOAD_SNIPPET_LENGTH + 50
       );
       expect(stored.resource.text).toContain("... (truncated)");
     }
@@ -113,8 +113,8 @@ describe("processToolResults", () => {
   it("should store snippet for large resource text", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
-    // Generate resource text that exceeds MAX_RESOURCE_CONTENT_SIZE (20MB).
-    const largeResourceText = "y".repeat(MAX_RESOURCE_CONTENT_SIZE + 1);
+    // Generate resource text that exceeds FILE_OFFLOAD_RESOURCE_SIZE_BYTES (20MB).
+    const largeResourceText = "y".repeat(FILE_OFFLOAD_RESOURCE_SIZE_BYTES + 1);
 
     const { outputItems } = await processToolResults(auth, {
       action,
@@ -135,7 +135,7 @@ describe("processToolResults", () => {
     expect(stored.type).toBe("resource");
     if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text.length).toBeLessThanOrEqual(
-        MAXED_OUTPUT_FILE_SNIPPET_LENGTH + 50
+        FILE_OFFLOAD_SNIPPET_LENGTH + 50
       );
       expect(stored.resource.text).toContain("... (truncated)");
     }

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -325,7 +325,10 @@ export async function processToolResults(
             const sanitizedResource = sanitizeStringsDeep(block.resource);
 
             // If the resource text is too large, we create a file and return a resource block that references the file.
-            if (text && computeTextByteSize(text) > FILE_OFFLOAD_RESOURCE_SIZE_BYTES) {
+            if (
+              text &&
+              computeTextByteSize(text) > FILE_OFFLOAD_RESOURCE_SIZE_BYTES
+            ) {
               const fileName =
                 block.resource.uri?.split("/").pop() ??
                 `resource_${Date.now()}.txt`;

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -4,9 +4,9 @@ import {
 } from "@app/lib/actions/action_file_helpers";
 import {
   computeTextByteSize,
-  MAX_RESOURCE_CONTENT_SIZE,
-  MAX_TEXT_CONTENT_SIZE_BYTES,
-  MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
+  FILE_OFFLOAD_RESOURCE_SIZE_BYTES,
+  FILE_OFFLOAD_SNIPPET_LENGTH,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
 } from "@app/lib/actions/action_output_limits";
 import type {
   LightMCPToolConfigurationType,
@@ -170,12 +170,12 @@ export async function processToolResults(
         case "text": {
           // If the text is too large we create a file and return a resource block that references the file.
           if (
-            computeTextByteSize(block.text) > MAX_TEXT_CONTENT_SIZE_BYTES &&
+            computeTextByteSize(block.text) > FILE_OFFLOAD_TEXT_SIZE_BYTES &&
             toolConfiguration.mcpServerName !== "conversation_files"
           ) {
             const fileName = `${toolConfiguration.mcpServerName}_${timestamp}_${idx}.txt`;
             const snippet =
-              block.text.substring(0, MAXED_OUTPUT_FILE_SNIPPET_LENGTH) +
+              block.text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
               "... (truncated)";
 
             const file = await generatePlainTextFile(auth, {
@@ -325,12 +325,12 @@ export async function processToolResults(
             const sanitizedResource = sanitizeStringsDeep(block.resource);
 
             // If the resource text is too large, we create a file and return a resource block that references the file.
-            if (text && computeTextByteSize(text) > MAX_RESOURCE_CONTENT_SIZE) {
+            if (text && computeTextByteSize(text) > FILE_OFFLOAD_RESOURCE_SIZE_BYTES) {
               const fileName =
                 block.resource.uri?.split("/").pop() ??
                 `resource_${Date.now()}.txt`;
               const snippet =
-                text.substring(0, MAXED_OUTPUT_FILE_SNIPPET_LENGTH) +
+                text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
                 "... (truncated)";
 
               const file = await generatePlainTextFile(auth, {

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -1,6 +1,6 @@
 // All mime types are okay to use from the public API.
 
-import { MAX_RESOURCE_CONTENT_SIZE } from "@app/lib/actions/action_output_limits";
+import { FILE_OFFLOAD_RESOURCE_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import {
   isBlobResource,
   isRunAgentQueryResourceType,
@@ -175,7 +175,7 @@ export async function handleBase64Upload(
     };
   }
 
-  if (base64Data.length > MAX_RESOURCE_CONTENT_SIZE) {
+  if (base64Data.length > FILE_OFFLOAD_RESOURCE_SIZE_BYTES) {
     return {
       content: {
         type: "text",

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -1,6 +1,6 @@
 import {
   computeTextByteSize,
-  MAX_TEXT_CONTENT_SIZE_BYTES,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
 } from "@app/lib/actions/action_output_limits";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -201,9 +201,9 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
       );
     }
 
-    // Cap to MAX_TEXT_CONTENT_SIZE_BYTES to avoid storing oversized content in the DB.
-    // For ASCII-dominant text, 1 char ≈ 1 byte, so we use MAX_TEXT_CONTENT_SIZE_BYTES directly.
-    const maxCharacters = MAX_TEXT_CONTENT_SIZE_BYTES;
+    // Cap to FILE_OFFLOAD_TEXT_SIZE_BYTES to avoid storing oversized content in the DB.
+    // For ASCII-dominant text, 1 char ≈ 1 byte, so we use FILE_OFFLOAD_TEXT_SIZE_BYTES directly.
+    const maxCharacters = FILE_OFFLOAD_TEXT_SIZE_BYTES;
     const effectiveLimit =
       limit !== undefined ? Math.min(limit, maxCharacters) : maxCharacters;
     const end = start + effectiveLimit;

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -190,10 +190,7 @@ async function handleWebbrowser(
           "Summarized content"
         );
 
-        const snippet = snippetRes.value.slice(
-          0,
-          FILE_OFFLOAD_SNIPPET_LENGTH
-        );
+        const snippet = snippetRes.value.slice(0, FILE_OFFLOAD_SNIPPET_LENGTH);
 
         const baseTitle = title ?? result.url;
         const fileTitle = `${baseTitle}`;

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -2,7 +2,7 @@ import {
   generatePlainTextFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import { MAXED_OUTPUT_FILE_SNIPPET_LENGTH } from "@app/lib/actions/action_output_limits";
+import { FILE_OFFLOAD_SNIPPET_LENGTH } from "@app/lib/actions/action_output_limits";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { USE_SUMMARY_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
@@ -192,7 +192,7 @@ async function handleWebbrowser(
 
         const snippet = snippetRes.value.slice(
           0,
-          MAXED_OUTPUT_FILE_SNIPPET_LENGTH
+          FILE_OFFLOAD_SNIPPET_LENGTH
         );
 
         const baseTitle = title ?? result.url;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR renames content size constants and functions to distinguish between remote MCP server hard limits (reject the result) and file offload thresholds (store oversized output as a file). Values are currently identical but can now be tuned independently. When we recently reduced the offload size, many remote MCP servers were impacted. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
