### PR TITLE
Change MCP client logo to be Dust hosted

### DIFF
--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -29,7 +29,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       redirect_uris: [finalizeUriForProvider("mcp")],
       client_name: "Dust",
       client_uri: config.getStaticWebsiteUrl(),
-      logo_uri: "https://avatars.githubusercontent.com/u/116068963?s=200&v=4",
+      logo_uri: config.getStaticWebsiteUrl() + "/static/AppIcon.png",
       contacts: ["support@dust.com"],
       tos_uri: config.getStaticWebsiteUrl() + "/terms",
       policy_uri: config.getStaticWebsiteUrl() + "/privacy",


### PR DESCRIPTION
## Description

* Context: https://github.com/dust-tt/tasks/issues/7257

## Tests

<img width="645" height="663" alt="Screenshot 2026-03-27 at 11 13 30 AM" src="https://github.com/user-attachments/assets/1b579a37-978a-4f4d-acd2-40890fef8c6f" />


## Risk

* Low

## Deploy Plan

* Deploy front