### PR TITLE
[oauth] fix: bump timeout on Jira OAuth token refresh, add instrumentation

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -38,8 +38,8 @@ use super::{credential::Credential, providers::utils::ProviderHttpRequestError};
 // To ensure we don't write without holding the lock providers must comply to this timeout when
 // operating on tokens.
 pub static PROVIDER_TIMEOUT_SECONDS: u64 = 10;
-pub static ATLASSIAN_PROVIDER_TIMEOUT_SECONDS: u64 = 15;
-pub static JIRA_PROVIDER_TIMEOUT_SECONDS: u64 = 30;
+pub static ATLASSIAN_PROVIDER_TIMEOUT_SECONDS: u64 = 75;
+pub static JIRA_PROVIDER_TIMEOUT_SECONDS: u64 = 75;
 // We hold the lock long enough for the slowest provider timeout plus secret persistence.
 static REDIS_LOCK_TTL_BUFFER_SECONDS: u64 = 10;
 static REDIS_LOCK_TTL_SECONDS: u64 = JIRA_PROVIDER_TIMEOUT_SECONDS + REDIS_LOCK_TTL_BUFFER_SECONDS;

--- a/core/src/oauth/providers/utils.rs
+++ b/core/src/oauth/providers/utils.rs
@@ -8,7 +8,7 @@ use reqwest::RequestBuilder;
 use std::io::prelude::*;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::error;
+use tracing::{error, info};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderHttpRequestError {
@@ -30,6 +30,7 @@ pub async fn execute_request(
     provider: ConnectionProvider,
     req: RequestBuilder,
 ) -> Result<serde_json::Value, ProviderHttpRequestError> {
+    let start = std::time::Instant::now();
     let now = utils::now_secs();
 
     let timeout_secs = provider_timeout_seconds(provider);
@@ -84,6 +85,12 @@ pub async fn execute_request(
             anyhow::anyhow!("Empty response body").into(),
         ));
     }
+
+    info!(
+        provider = ?provider,
+        elapsed_ms = start.elapsed().as_millis(),
+        "OAuth provider token request succeeded"
+    );
 
     // Check content_type to determine parsing strategy
     // OAuth 2.0 spec allows token endpoints to return either JSON or form-encoded

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -33,58 +33,20 @@ export async function getConnectionForMCPServer(
     DustError<"mcp_access_token_error" | "connection_not_found">
   >
 > {
+  const localLogger = logger.child({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    mcpServerId,
+    connectionType,
+  });
+
   const connection = await MCPServerConnectionResource.findByMCPServer(auth, {
     mcpServerId,
     connectionType,
   });
-  if (connection.isOk()) {
-    if (!connection.value.connectionId) {
-      logger.info(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          mcpServerId,
-          connectionType,
-          connectionId: connection.value.connectionId,
-          credentialId: connection.value.credentialId,
-        },
-        "MCP server connection is not configured for OAuth"
-      );
-      return new Err(
-        new DustError("connection_not_found", "Connection not found")
-      );
-    }
-    const token = await getOAuthConnectionAccessToken({
-      config: apiConfig.getOAuthAPIConfig(),
-      logger,
-      connectionId: connection.value.connectionId,
-    });
-    if (token.isOk()) {
-      return new Ok(token.value);
-    } else {
-      logger.warn(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          mcpServerId,
-          connectionType,
-          error: token.error,
-        },
-        "Failed to get access token for MCP server"
-      );
-      return new Err(
-        new DustError(
-          "mcp_access_token_error",
-          "Failed to get access token for MCP server"
-        )
-      );
-    }
-  } else {
-    logger.info(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        mcpServerId,
-        connectionType,
-        error: connection.error,
-      },
+
+  if (connection.isErr()) {
+    localLogger.info(
+      { error: connection.error },
       "No connection found for MCP server"
     );
     return new Err(
@@ -94,6 +56,37 @@ export async function getConnectionForMCPServer(
       )
     );
   }
+
+  if (!connection.value.connectionId) {
+    localLogger.info(
+      { credentialId: connection.value.credentialId },
+      "MCP server connection is not configured for OAuth"
+    );
+    return new Err(
+      new DustError("connection_not_found", "Connection not found")
+    );
+  }
+
+  const tokenResult = await getOAuthConnectionAccessToken({
+    config: apiConfig.getOAuthAPIConfig(),
+    logger,
+    connectionId: connection.value.connectionId,
+  });
+
+  if (tokenResult.isErr()) {
+    localLogger.warn(
+      { error: tokenResult.error },
+      "Failed to get access token for MCP server"
+    );
+    return new Err(
+      new DustError(
+        "mcp_access_token_error",
+        "Failed to get access token for MCP server"
+      )
+    );
+  }
+
+  return new Ok(tokenResult.value);
 }
 
 const MCPServerRequiresPersonalAuthenticationErrorName =


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7241
- We see requests to refresh OAuth tokens hitting the timeout on a regular basis (example [trace](https://app.datadoghq.eu/apm/trace/69c52e16000000004aeda09b49112b05?graphType=waterfall&shouldShowLegend=true&spanID=9932089355692350034&spanViewType=logs&timeHint=1774530070566.0005&traceQuery=)).
- This PR bumps the timeout to 75s (seems to be a magical value as used in both the package `atlassian-python-api` and `mcp-atlassian`).
- Also adds some telemetry here so that we can analyze the distribution and fine tune the timeout.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy oauth.
