### PR TITLE
fix: firefox extension validation

### DIFF
--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -9,4 +9,15 @@ declare global {
   }
 }
 
+// Augment webextension-polyfill to include `data_collection`, a Firefox-specific
+// field for built-in data consent permissions not yet in @types/webextension-polyfill.
+// See: https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/
+declare module "webextension-polyfill" {
+  namespace Permissions {
+    interface AnyPermissions {
+      data_collection?: string[];
+    }
+  }
+}
+
 export {};

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/firefox/main.tsx
+++ b/extension/platforms/firefox/main.tsx
@@ -10,19 +10,24 @@ import { initDatadogLogs } from "@app/logger/datadogLogger";
 import { datadogLogs } from "@datadog/browser-logs";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import browser from "webextension-polyfill";
 import { FirefoxApp } from "./FirefoxApp";
 
 if (process.env.DATADOG_CLIENT_TOKEN) {
-  initDatadogLogs({
-    clientToken: process.env.DATADOG_CLIENT_TOKEN,
-    service: "dust-firefox-extension",
-    env: process.env.DATADOG_ENV,
-    version: process.env.DUST_EXTENSION_VERSION,
-    forwardConsoleLogs: ["error"],
-  });
-  datadogLogs.setGlobalContext({
-    extensionVersion: process.env.DUST_EXTENSION_VERSION,
-    commitHash: process.env.COMMIT_HASH,
+  void browser.permissions.getAll().then((permissions) => {
+    if (permissions?.data_collection && process.env.DATADOG_CLIENT_TOKEN) {
+      initDatadogLogs({
+        clientToken: process.env.DATADOG_CLIENT_TOKEN,
+        service: "dust-firefox-extension",
+        env: process.env.DATADOG_ENV,
+        version: process.env.DUST_EXTENSION_VERSION,
+        forwardConsoleLogs: ["error"],
+      });
+      datadogLogs.setGlobalContext({
+        extensionVersion: process.env.DUST_EXTENSION_VERSION,
+        commitHash: process.env.COMMIT_HASH,
+      });
+    }
   });
 }
 

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.development.json
+++ b/extension/platforms/firefox/manifests/manifest.development.json
@@ -8,7 +8,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "dust-dev@dust.tt",
-      "strict_min_version": "109.0"
+      "strict_min_version": "140.0"
     }
   },
   "sidebar_action": {

--- a/extension/platforms/firefox/manifests/manifest.production.json
+++ b/extension/platforms/firefox/manifests/manifest.production.json
@@ -2,7 +2,15 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "dust-dev@dust.tt",
-      "strict_min_version": "109.0"
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": [
+          "authenticationInfo"
+        ],
+        "optional": [
+          "technicalAndInteraction"
+        ]
+      }
     }
   },
   "content_security_policy": {

--- a/extension/platforms/firefox/manifests/manifest.production.json
+++ b/extension/platforms/firefox/manifests/manifest.production.json
@@ -5,6 +5,7 @@
       "strict_min_version": "140.0",
       "data_collection_permissions": {
         "required": [
+          "personallyIdentifyingInfo",
           "authenticationInfo"
         ],
         "optional": [

--- a/extension/platforms/firefox/manifests/manifest.release.json
+++ b/extension/platforms/firefox/manifests/manifest.release.json
@@ -2,7 +2,15 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "dust@dust.tt",
-      "strict_min_version": "109.0"
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": [
+          "authenticationInfo"
+        ],
+        "optional": [
+          "technicalAndInteraction"
+        ]
+      }
     }
   },
   "content_security_policy": {

--- a/extension/platforms/firefox/manifests/manifest.release.json
+++ b/extension/platforms/firefox/manifests/manifest.release.json
@@ -5,6 +5,7 @@
       "strict_min_version": "140.0",
       "data_collection_permissions": {
         "required": [
+          "personallyIdentifyingInfo",
           "authenticationInfo"
         ],
         "optional": [

--- a/extension/platforms/firefox/webpack.config.ts
+++ b/extension/platforms/firefox/webpack.config.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import CopyPlugin from "copy-webpack-plugin";
 import Dotenv from "dotenv-webpack";
 import fs from "fs";
+import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import TerserPlugin from "terser-webpack-plugin";
 import { promisify } from "util";
@@ -219,10 +220,6 @@ export const getConfig = async ({
             to: path.join(buildDirPath, "manifest.json"),
           },
           {
-            from: resolvePath("../../ui/main.html"),
-            to: path.join(buildDirPath, "main.html"),
-          },
-          {
             from: resolvePath("../../ui/request-mic.html"),
             to: path.join(buildDirPath, "request-mic.html"),
           },
@@ -236,6 +233,13 @@ export const getConfig = async ({
             to: path.resolve(buildDirPath, "images"),
           },
         ],
+      }),
+      new HtmlWebpackPlugin({
+        template: resolvePath("../../ui/main.html"),
+        filename: "main.html",
+        chunks: ["main"],
+        inject: "body",
+        scriptLoading: "blocking",
       }),
       new webpack.BannerPlugin({
         banner: "\ufeff", // UTF-8 BOM

--- a/extension/platforms/firefox/webpack.config.ts
+++ b/extension/platforms/firefox/webpack.config.ts
@@ -87,6 +87,19 @@ export const getConfig = async ({
         }),
       ],
       concatenateModules: shouldBuild !== "analyze",
+      splitChunks: {
+        chunks: (chunk) => chunk.name === "main",
+        maxSize: 5 * 1024 * 1024, // 5MB — Firefox's 5MB limit
+        minSize: 50 * 1024,
+        cacheGroups: {
+          vendors: {
+            test: /[\\/]node_modules[\\/]/,
+            name: "vendors",
+            chunks: (chunk) => chunk.name === "main",
+            priority: 10,
+          },
+        },
+      },
     },
     performance: false,
     devtool: isDevelopment ? "inline-source-map" : undefined,

--- a/extension/ui/main.html
+++ b/extension/ui/main.html
@@ -5,6 +5,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="main.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,7 +233,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,7 +233,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
@@ -4209,9 +4209,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -4229,9 +4226,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -4249,9 +4243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -4269,9 +4260,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -7210,9 +7198,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7230,9 +7215,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7250,9 +7232,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7270,9 +7249,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7290,9 +7266,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7310,9 +7283,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7330,9 +7300,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7350,9 +7317,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -7370,9 +7334,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7396,9 +7357,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7422,9 +7380,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7448,9 +7403,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7474,9 +7426,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7500,9 +7449,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7526,9 +7472,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7552,9 +7495,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9160,9 +9100,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9178,9 +9115,6 @@
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9198,9 +9132,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9216,9 +9147,6 @@
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -12845,9 +12773,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12862,9 +12787,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12879,9 +12801,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12896,9 +12815,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12913,9 +12829,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12930,9 +12843,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12947,9 +12857,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12964,9 +12871,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13195,9 +13099,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13217,9 +13118,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -13241,9 +13139,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13263,9 +13158,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -13287,9 +13179,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13309,9 +13198,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -15898,9 +15784,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15915,9 +15798,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15932,9 +15812,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15949,9 +15826,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15966,9 +15840,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15983,9 +15854,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16000,9 +15868,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16017,9 +15882,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16034,9 +15896,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16051,9 +15910,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16068,9 +15924,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16083,9 +15936,6 @@
       "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -16101,9 +15951,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16252,9 +16099,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16270,9 +16114,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16288,9 +16129,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16306,9 +16144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20721,9 +20556,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -20739,9 +20571,6 @@
       "integrity": "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -20759,9 +20588,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -20777,9 +20603,6 @@
       "integrity": "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,


### PR DESCRIPTION
## Description

This PR addresses Firefox extension validation requirements to ensure the extension can be published.

**Manifest (`manifest.json`)**
- Add `data_collection_permissions` under `browser_specific_settings.gecko` (required for all new Firefox extensions since November 2025). Double check that all needed permissions have been added https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/
- Bump `strict_min_version` from `109.0` to `140.0` to match the minimum version that supports `background.type` and `permissions.request`

**Webpack config (`webpack.config.ts`)**
- Add `splitChunks` to the `optimization` block to split `main.js` into smaller chunks, keeping each file under Firefox's 5MB per-file limit

### Why

The extension was failing AMO validation with:
- `data_collection_permissions` missing (hard blocker for submission)
- **2 warnings**: manifest keys requiring a higher minimum Firefox version than declared
- `main.js` exceeding the 5MB file size limit enforced by the Firefox addons linter

## Tests

Manually

## Risks

Low. Changes are specific to the Firefox platform and don't affect the Chrome extension. 

## Deploy Plan

Standard deployment. The Firefox extension will need to be submitted to the Firefox Add-ons store after this PR is merged.
