### PR TITLE
Fix reinforced agent workflows not awaiting child completion

### DIFF
--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -7,11 +7,11 @@ import {
 import type { WorkflowInterceptorsFactory } from "@temporalio/workflow";
 import {
   ApplicationFailure,
+  executeChild,
   ParentClosePolicy,
   proxyActivities,
   setHandler,
   sleep,
-  startChild,
 } from "@temporalio/workflow";
 import { concurrentExecutor } from "../utils";
 
@@ -98,7 +98,7 @@ export async function reinforcedAgentWorkflow(): Promise<void> {
   await concurrentExecutor(
     workspaceIds,
     (workspaceId) =>
-      startChild(reinforcedAgentWorkspaceWorkflow, {
+      executeChild(reinforcedAgentWorkspaceWorkflow, {
         workflowId: `reinforced-agent-workspace-${workspaceId}`,
         args: [{ workspaceId, useBatchMode: true }],
         parentClosePolicy: ParentClosePolicy.ABANDON,
@@ -122,7 +122,7 @@ export async function reinforcedAgentWorkspaceWorkflow({
   await concurrentExecutor(
     agentIds,
     (agentConfigurationId) =>
-      startChild(reinforcedAgentForAgentWorkflow, {
+      executeChild(reinforcedAgentForAgentWorkflow, {
         workflowId: `reinforced-agent-${workspaceId}-${agentConfigurationId}`,
         args: [{ workspaceId, agentConfigurationId, useBatchMode }],
         parentClosePolicy: ParentClosePolicy.ABANDON,


### PR DESCRIPTION
## Description

Use executeChild instead of startChild so parent workflows wait for their children to finish before proceeding.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front