### PR TITLE
Inline citations on AgentMCPActionOutputItemModel.

### DIFF
--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -13,6 +13,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 let REFS: string[] | null = null;
 const getRand = rand("chawarma");
@@ -58,12 +59,38 @@ export function getCitationsFromActions(
     "internalMCPServerName" | "toolName" | "status" | "displayLabels"
   >[]
 ): Record<string, CitationType> {
-  const searchResultsWithDocs = removeNulls(
-    actions.flatMap((action) =>
-      action.output?.filter(isSearchResultResourceType).map((o) => o.resource)
-    )
-  );
+  // Prefer persisted citations when present (backfilled/new rows).
+  const persistedRefs: Record<string, CitationType> = {};
+  let hasAnyPersisted = false;
+  for (const action of actions) {
+    if (action.citations !== undefined && action.citations !== null) {
+      hasAnyPersisted = true;
+      Object.assign(persistedRefs, action.citations);
+    }
+  }
+  if (hasAnyPersisted) {
+    return persistedRefs;
+  }
 
+  // Legacy fallback: compute citations from the tool output.
+  return actions.reduce<Record<string, CitationType>>((acc, action) => {
+    return {
+      ...acc,
+      ...getCitationsFromToolOutput(action.output ?? null),
+    };
+  }, {});
+}
+
+export function getCitationsFromToolOutput(
+  output: CallToolResult["content"] | null
+): Record<string, CitationType> {
+  if (!output || output.length === 0) {
+    return {};
+  }
+
+  const searchResultsWithDocs = removeNulls(
+    output.filter(isSearchResultResourceType).map((o) => o.resource)
+  );
   const searchRefs: Record<string, CitationType> = {};
   searchResultsWithDocs.forEach((d) => {
     searchRefs[d.ref] = {
@@ -75,11 +102,8 @@ export function getCitationsFromActions(
   });
 
   const websearchResultsWithDocs = removeNulls(
-    actions.flatMap((action) =>
-      action.output?.filter(isWebsearchResultResourceType)
-    )
+    output.filter(isWebsearchResultResourceType)
   );
-
   const websearchRefs: Record<string, CitationType> = {};
   websearchResultsWithDocs.forEach((d) => {
     websearchRefs[d.resource.reference] = {
@@ -91,11 +115,8 @@ export function getCitationsFromActions(
   });
 
   const runAgentResultsWithRefs = removeNulls(
-    actions.flatMap((action) =>
-      action.output?.filter(isRunAgentResultResourceType)
-    )
+    output.filter(isRunAgentResultResourceType)
   );
-
   const runAgentRefs: Record<string, CitationType> = {};
   runAgentResultsWithRefs.forEach((result) => {
     if (result.resource.refs) {
@@ -111,11 +132,8 @@ export function getCitationsFromActions(
   });
 
   const dataSourceNodeContentResults = removeNulls(
-    actions.flatMap((action) =>
-      action.output?.filter(isDataSourceNodeContentType).map((o) => o.resource)
-    )
+    output.filter(isDataSourceNodeContentType).map((o) => o.resource)
   );
-
   const dataSourceNodeContentRefs: Record<string, CitationType> = {};
   dataSourceNodeContentResults.forEach((d) => {
     if (!d.ref) {

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -9,6 +9,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
+import type { CitationType } from "@app/types/assistant/conversation";
 import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -336,6 +337,7 @@ export class AgentMCPActionOutputItemModel extends WorkspaceAwareModel<AgentMCPA
   declare content: CallToolResult["content"][number];
   declare contentGcsPath: string | null;
   declare fileId: ForeignKey<FileModel["id"]> | null;
+  declare citations: Record<string, CitationType> | null;
 
   declare file: NonAttribute<FileModel>;
 }
@@ -370,6 +372,21 @@ AgentMCPActionOutputItemModel.init(
     contentGcsPath: {
       type: DataTypes.TEXT,
       allowNull: true,
+    },
+    citations: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+      validate: {
+        isValidCitations(value: unknown) {
+          if (value === null) {
+            return;
+          }
+          if (!value || typeof value !== "object") {
+            throw new Error("Citations must be an object or null");
+          }
+        },
+      },
     },
   },
   {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -19,6 +19,7 @@ import {
   isLightClientSideMCPToolConfiguration,
   isLightServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
+import { getCitationsFromToolOutput } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -647,6 +648,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         agentMCPActionId: this.id,
         // Write content to DB (kept during migration period to ease rollback).
         content: c.content,
+        citations: getCitationsFromToolOutput([c.content]),
         fileId: c.fileId,
         workspaceId: this.workspaceId,
       }))
@@ -903,6 +905,17 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           return {
             ...action.toJSON(),
             output: removeNulls(outputItems.map(hideFileFromActionOutput)),
+            citations: outputItems.some(
+              (o) => o.citations !== null && o.citations !== undefined
+            )
+              ? outputItems.reduce(
+                  (acc, o) => ({
+                    ...acc,
+                    ...(o.citations ?? {}),
+                  }),
+                  {}
+                )
+              : null,
             generatedFiles: removeNulls(
               outputItems.map((o) => {
                 const file = o.file;

--- a/front/migrations/db/migration_549.sql
+++ b/front/migrations/db/migration_549.sql
@@ -1,0 +1,6 @@
+-- Migration created on Mar 27, 2026
+-- Add persisted citations to MCP actions and output items (nullable for backfill).
+
+ALTER TABLE "agent_mcp_action_output_items"
+ADD COLUMN IF NOT EXISTS "citations" JSONB;
+

--- a/front/scripts/backfill_mcp_action_output_item_citations.ts
+++ b/front/scripts/backfill_mcp_action_output_item_citations.ts
@@ -1,0 +1,201 @@
+import { getCitationsFromToolOutput } from "@app/lib/api/assistant/citations";
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMCPActionModel,
+  AgentMCPActionOutputItemModel,
+} from "@app/lib/models/agent/actions/mcp";
+import { batchFetchContentsFromGcs } from "@app/lib/resources/agent_mcp_action/output_storage";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
+import { Op } from "sequelize";
+
+import { makeScript } from "./helpers";
+
+const BATCH_SIZE_DEFAULT = 500;
+const ACTION_IDS_CHUNK_SIZE = 5_000;
+
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) {
+    throw new Error("chunkArray size must be > 0");
+  }
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+makeScript(
+  {
+    batchSize: {
+      type: "number",
+      default: BATCH_SIZE_DEFAULT,
+      describe: "Number of output items to process per batch per workspace",
+    },
+    concurrency: {
+      type: "number",
+      default: 2,
+      describe: "Concurrent item updates per batch",
+    },
+  },
+  async ({ execute, batchSize, concurrency }, logger) => {
+    const workspaces = await WorkspaceResource.listAll();
+
+    logger.info(
+      { candidateWorkspaceCount: workspaces.length },
+      "[Backfill MCP output citations] Found workspaces with citationsAllocated > 0"
+    );
+
+    for (const workspace of workspaces) {
+      const workspaceSId = workspace.sId;
+      const workspaceId = workspace.id;
+
+      logger.info(
+        { workspaceId: workspaceSId, batchSize, execute },
+        "[Backfill MCP output citations] Starting workspace"
+      );
+
+      const auth =
+        await Authenticator.internalBuilderForWorkspace(workspaceSId);
+
+      const actionRows = await AgentMCPActionModel.findAll({
+        attributes: ["id"],
+        where: {
+          workspaceId,
+          citationsAllocated: { [Op.gt]: 0 },
+        },
+        raw: true,
+      });
+
+      const actionIds = actionRows.map((r) => r.id);
+      if (actionIds.length === 0) {
+        logger.info(
+          { workspaceId: workspaceSId },
+          "[Backfill MCP output citations] No actions with citationsAllocated > 0; skipping workspace"
+        );
+        continue;
+      }
+
+      const actionIdChunks = chunkArray(actionIds, ACTION_IDS_CHUNK_SIZE);
+      logger.info(
+        {
+          workspaceId: workspaceSId,
+          actionCount: actionIds.length,
+          chunkCount: actionIdChunks.length,
+        },
+        "[Backfill MCP output citations] Found actions with citationsAllocated > 0"
+      );
+
+      for (const [chunkIdx, chunkActionIds] of actionIdChunks.entries()) {
+        let lastId: ModelId | null = null;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const whereBase: Record<string, unknown> = {
+            workspaceId,
+            citations: null,
+            agentMCPActionId: {
+              [Op.in]: chunkActionIds,
+            },
+          };
+          if (lastId !== null) {
+            whereBase.id = { [Op.gt]: lastId };
+          }
+
+          // Split query to avoid fetching large JSONB `content` for GCS-backed rows.
+          const [gcsItems, legacyItems] = await Promise.all([
+            AgentMCPActionOutputItemModel.findAll({
+              attributes: { exclude: ["content"] },
+              where: { ...whereBase, contentGcsPath: { [Op.ne]: null } },
+              order: [["id", "ASC"]],
+              limit: batchSize,
+            }),
+            AgentMCPActionOutputItemModel.findAll({
+              where: { ...whereBase, contentGcsPath: null },
+              order: [["id", "ASC"]],
+              limit: batchSize,
+            }),
+          ]);
+
+          const items = [...gcsItems, ...legacyItems].sort(
+            (a, b) => a.id - b.id
+          );
+
+          if (items.length === 0) {
+            break;
+          }
+
+          lastId = items[items.length - 1].id;
+
+          const gcsToHydrate = removeNulls(
+            items
+              .filter((i) => i.contentGcsPath)
+              .map((i) => ({
+                itemId: i.id,
+                gcsPath: i.contentGcsPath!,
+              }))
+          );
+
+          if (gcsToHydrate.length > 0) {
+            const contentResult = await batchFetchContentsFromGcs(
+              auth,
+              gcsToHydrate
+            );
+            if (contentResult.isOk()) {
+              for (const item of items) {
+                if (item.contentGcsPath) {
+                  const hydrated = contentResult.value.get(item.id);
+                  if (hydrated) {
+                    item.content = hydrated;
+                  }
+                }
+              }
+            } else {
+              logger.error(
+                {
+                  workspaceId: workspaceSId,
+                  chunkIdx,
+                  error: contentResult.error.message,
+                },
+                "[Backfill MCP output citations] Failed to hydrate GCS-backed output items; skipping batch"
+              );
+              continue;
+            }
+          }
+
+          let updated = 0;
+          await concurrentExecutor(
+            items,
+            async (item) => {
+              const citations = getCitationsFromToolOutput([item.content]);
+
+              if (execute) {
+                await AgentMCPActionOutputItemModel.update(
+                  { citations },
+                  { where: { id: item.id, workspaceId } }
+                );
+              }
+              updated += 1;
+            },
+            { concurrency }
+          );
+
+          logger.info(
+            { workspaceId: workspaceSId, chunkIdx, lastId, updated, execute },
+            execute
+              ? "[Backfill MCP output citations] Updated batch"
+              : "[Backfill MCP output citations] [DRY RUN] Would update batch"
+          );
+        }
+      }
+
+      logger.info(
+        { workspaceId: workspaceSId, execute },
+        "[Backfill MCP output citations] Completed workspace"
+      );
+    }
+
+    logger.info("[Backfill MCP output citations] Done.");
+  }
+);

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -1,6 +1,7 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
+import type { CitationType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -31,4 +32,5 @@ export type AgentMCPActionType = {
 export type AgentMCPActionWithOutputType = AgentMCPActionType & {
   generatedFiles: ActionGeneratedFileType[];
   output: CallToolResult["content"] | null;
+  citations?: Record<string, CitationType> | null;
 };


### PR DESCRIPTION
## Description

Inline citations directly on `AgentMCPActionOutputItemModel` to avoid the need to fetch the content (could be very large and on GCS) just to compute the citations.
+ backfill script.

## Tests

Locally

## Risk

Low, we can always go back to the old way.

## Deploy Plan

Migration, then deploy front, then run backfill script, then do another PR to remove fallback.