### PR TITLE
Remove Microsoft tools metadata overriding

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -611,20 +611,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    metadata: {
-      ...MICROSOFT_DRIVE_SERVER,
-      serverInfo: {
-        ...MICROSOFT_DRIVE_SERVER.serverInfo,
-        authorization: {
-          provider: "microsoft_tools" as const,
-          supported_use_cases: ["personal_actions"] as const,
-          scope:
-            "User.Read Files.ReadWrite.All Sites.Read.All ExternalItem.Read.All offline_access" as const,
-        },
-        documentationUrl:
-          "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
-      },
-    },
+    metadata: MICROSOFT_DRIVE_SERVER,
   },
   microsoft_teams: {
     id: 36,
@@ -646,20 +633,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    metadata: {
-      ...MICROSOFT_TEAMS_SERVER,
-      serverInfo: {
-        ...MICROSOFT_TEAMS_SERVER.serverInfo,
-        authorization: {
-          provider: "microsoft_tools" as const,
-          supported_use_cases: ["personal_actions"] as const,
-          scope:
-            "User.Read User.ReadBasic.All Team.ReadBasic.All Channel.ReadBasic.All Chat.Read Chat.ReadWrite ChatMessage.Read ChatMessage.Send ChannelMessage.Read.All ChannelMessage.Send offline_access" as const,
-        },
-        documentationUrl:
-          "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
-      },
-    },
+    metadata: MICROSOFT_TEAMS_SERVER,
   },
   sound_studio: {
     id: 37,
@@ -681,18 +655,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    metadata: {
-      ...MICROSOFT_EXCEL_SERVER,
-      serverInfo: {
-        ...MICROSOFT_EXCEL_SERVER.serverInfo,
-        authorization: {
-          provider: "microsoft_tools" as const,
-          supported_use_cases: ["personal_actions"] as const,
-          scope:
-            "User.Read Files.ReadWrite.All Sites.Read.All offline_access" as const,
-        },
-      },
-    },
+    metadata: MICROSOFT_EXCEL_SERVER,
   },
   http_client: {
     id: 39,

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -203,10 +203,12 @@ export const MICROSOFT_DRIVE_SERVER = {
       "Search, read, and upload files in Microsoft OneDrive and SharePoint.",
     icon: "MicrosoftLogo",
     authorization: {
-      provider: "microsoft",
+      provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
+      scope:
+        "User.Read Files.ReadWrite.All Sites.Read.All ExternalItem.Read.All offline_access",
     },
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
     instructions: null,
   },
   tools: Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -197,8 +197,9 @@ export const MICROSOFT_EXCEL_SERVER = {
       "Read and write Excel spreadsheets in Microsoft OneDrive and SharePoint.",
     icon: "MicrosoftExcelLogo",
     authorization: {
-      provider: "microsoft",
+      provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
+      scope: "User.Read Files.ReadWrite.All Sites.Read.All offline_access",
     },
     documentationUrl: null,
     instructions: null,

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -209,10 +209,12 @@ export const MICROSOFT_TEAMS_SERVER = {
     description: "Microsoft Teams for searching and posting messages.",
     icon: "MicrosoftTeamsLogo",
     authorization: {
-      provider: "microsoft",
+      provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
+      scope:
+        "User.Read User.ReadBasic.All Team.ReadBasic.All Channel.ReadBasic.All Chat.Read Chat.ReadWrite ChatMessage.Read ChatMessage.Send ChannelMessage.Read.All ChannelMessage.Send offline_access",
     },
-    documentationUrl: null,
+    documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
     instructions: null,
   },
   tools: Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => ({


### PR DESCRIPTION
## Description

Removes redundant metadata overriding for Microsoft tools (Drive, Teams, Excel) in `constants.ts`. The authorization configuration (provider, scope, documentationUrl) was previously hardcoded in `INTERNAL_MCP_SERVERS` but is now properly defined in each tool's metadata file (`microsoft_drive/metadata.ts`, `microsoft_teams/metadata.ts`, `microsoft_excel/metadata.ts`). This PR eliminates the duplication by directly referencing the metadata objects instead of spreading and overriding them.

## Tests

Verified that Microsoft tools still work correctly with personal authentication flow. The authorization metadata (provider: `microsoft_tools`, scopes, documentation URLs) is now read from the source metadata files.

## Risk

Low. This is a refactoring that removes code duplication without changing behavior - the same values are now sourced from the metadata files instead of being hardcoded in constants.

## Deploy Plan

Deploy front.