### PR TITLE
[Salesforce] Add create_object tool to Salesforce MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -473,6 +473,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "run_dust_app": "never_ask",
   },
   "salesforce": {
+    "create_object": "medium",
     "describe_object": "never_ask",
     "execute_read_query": "never_ask",
     "list_attachments": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -359,6 +359,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: false,
     tools_arguments_requiring_approval: {
+      create_object: ["objectName"],
       update_object: ["objectName"],
     },
     tools_retry_policies: undefined,

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -45,6 +45,30 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       done: "Describe Salesforce object",
     },
   },
+  create_object: {
+    description: "Create one or more records in Salesforce",
+    schema: {
+      objectName: z
+        .string()
+        .describe("The name of the Salesforce object (e.g., Account, Contact)"),
+      records: z
+        .array(z.object({}).passthrough())
+        .min(1)
+        .describe(
+          "Record(s) to create. Must include all required fields for the object"
+        ),
+      allOrNone: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("If true, all creates must succeed or all fail"),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Creating Salesforce records",
+      done: "Create Salesforce records",
+    },
+  },
   update_object: {
     description: "Update one or more records in Salesforce",
     schema: {

--- a/front/lib/api/actions/servers/salesforce/tools/index.ts
+++ b/front/lib/api/actions/servers/salesforce/tools/index.ts
@@ -200,6 +200,34 @@ export function createSalesforceTools(auth: Authenticator): ToolDefinition[] {
       });
     },
 
+    create_object: async ({ objectName, records, allOrNone }, extra) => {
+      return withAuth(extra, async (conn) => {
+        try {
+          const result = await conn.sobject(objectName).create(records, {
+            allOrNone,
+          });
+
+          const results = Array.isArray(result) ? result : [result];
+          const successCount = results.filter((r) => r.success).length;
+          const failureCount = results.length - successCount;
+
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `Create completed: ${successCount} successful, ${failureCount} failed`,
+            },
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ]);
+        } catch (error) {
+          return logAndReturnError({
+            error,
+            params: { objectName, recordCount: records.length, allOrNone },
+            message: "Error creating Salesforce records",
+          });
+        }
+      });
+    },
+
     update_object: async ({ objectName, records, allOrNone }, extra) => {
       return withAuth(extra, async (conn) => {
         try {

--- a/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
+++ b/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
@@ -18,113 +18,68 @@ async function disableCreateObjectForWorkspace(
   execute: boolean,
   logger: Logger,
   cutoffDate: Date
-): Promise<{ processedCount: number }> {
-  // Finding all internal MCP server connections created before the cutoff date.
+): Promise<number> {
   const connections = await MCPServerConnectionModel.findAll({
     where: {
       workspaceId: workspace.id,
       serverType: "internal",
-      internalMCPServerId: {
-        [Op.ne]: null,
-      },
-      createdAt: {
-        [Op.lt]: cutoffDate,
-      },
+      internalMCPServerId: { [Op.ne]: null },
+      createdAt: { [Op.lt]: cutoffDate },
     },
   });
 
-  // Filter to keep only Salesforce instances by decoding the internalMCPServerId.
-  // Group by internalMCPServerId to avoid duplicates (personal + workspace connections).
-  const uniqueInstancesMap = new Map<
-    string,
-    {
-      connectionId: number;
-      workspaceId: number;
-      internalMCPServerId: string;
-      createdAt: Date;
-    }
-  >();
-
+  // Deduplicate by internalMCPServerId, keeping only Salesforce instances.
+  const salesforceServerIds = new Set<string>();
   for (const conn of connections) {
     if (!conn.internalMCPServerId) continue;
-
     const parsed = getInternalMCPServerNameAndWorkspaceId(
       conn.internalMCPServerId
     );
-
     if (parsed.isOk() && parsed.value.name === INTERNAL_MCP_SERVER_NAME) {
-      if (!uniqueInstancesMap.has(conn.internalMCPServerId)) {
-        uniqueInstancesMap.set(conn.internalMCPServerId, {
-          connectionId: conn.id,
-          workspaceId: conn.workspaceId,
-          internalMCPServerId: conn.internalMCPServerId,
-          createdAt: conn.createdAt,
-        });
-      }
+      salesforceServerIds.add(conn.internalMCPServerId);
     }
   }
-
-  const existingInstances = Array.from(uniqueInstancesMap.values());
-
-  if (existingInstances.length === 0) {
-    return { processedCount: 0 };
-  }
-
-  logger.info(
-    {
-      workspaceId: workspace.id,
-      instancesCount: existingInstances.length,
-    },
-    "Found Salesforce instances to disable create_object in workspace."
-  );
 
   let processedCount = 0;
 
-  for (const instance of existingInstances) {
+  for (const serverId of salesforceServerIds) {
     const instanceLogger = logger.child({
-      workspaceId: instance.workspaceId,
-      connectionId: instance.connectionId,
-      internalMCPServerId: instance.internalMCPServerId,
+      workspaceId: workspace.id,
+      internalMCPServerId: serverId,
       toolName: TOOL_NAME,
-      permission: PERMISSION_LEVEL,
     });
 
     if (execute) {
-      const existing = await RemoteMCPServerToolMetadataModel.findOne({
-        where: {
-          workspaceId: instance.workspaceId,
-          internalMCPServerId: instance.internalMCPServerId,
-          toolName: TOOL_NAME,
-        },
-      });
-
-      if (!existing) {
-        await RemoteMCPServerToolMetadataModel.create({
-          workspaceId: instance.workspaceId,
-          internalMCPServerId: instance.internalMCPServerId,
-          toolName: TOOL_NAME,
-          permission: PERMISSION_LEVEL,
-          enabled: false,
+      const [record, created] =
+        await RemoteMCPServerToolMetadataModel.findOrCreate({
+          where: {
+            workspaceId: workspace.id,
+            internalMCPServerId: serverId,
+            toolName: TOOL_NAME,
+          },
+          defaults: {
+            workspaceId: workspace.id,
+            internalMCPServerId: serverId,
+            toolName: TOOL_NAME,
+            permission: PERMISSION_LEVEL,
+            enabled: false,
+          },
         });
+
+      if (!created && record.enabled) {
+        await record.update({ enabled: false });
       }
-
-      processedCount++;
-
-      instanceLogger.info(
-        { instanceCreatedAt: instance.createdAt.toISOString() },
-        "Forced create_object disabled for existing Salesforce instance."
-      );
-    } else {
-      processedCount++;
-
-      instanceLogger.info(
-        { instanceCreatedAt: instance.createdAt.toISOString() },
-        "Would force create_object disabled for existing Salesforce instance."
-      );
     }
+
+    processedCount++;
+    instanceLogger.info(
+      execute
+        ? "Disabled create_object for Salesforce instance."
+        : "Would disable create_object for Salesforce instance."
+    );
   }
 
-  return { processedCount };
+  return processedCount;
 }
 
 makeScript(
@@ -146,33 +101,26 @@ makeScript(
     }
 
     logger.info(
-      {
-        cutoffDate: cutoffDate.toISOString(),
-        toolName: TOOL_NAME,
-        serverName: INTERNAL_MCP_SERVER_NAME,
-      },
-      "Starting create_object disabling migration for existing Salesforce instances."
+      { cutoffDate: cutoffDate.toISOString() },
+      "Starting create_object disabling migration."
     );
 
     let totalProcessed = 0;
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        const result = await disableCreateObjectForWorkspace(
+        totalProcessed += await disableCreateObjectForWorkspace(
           workspace,
           execute,
           logger,
           cutoffDate
         );
-        totalProcessed += result.processedCount;
       },
       { concurrency: 8 }
     );
 
     logger.info(
-      {
-        processedCount: totalProcessed,
-      },
+      { processedCount: totalProcessed },
       execute
         ? "Migration completed successfully."
         : "Dry-run completed. Use --execute to apply changes."

--- a/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
+++ b/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
@@ -1,0 +1,181 @@
+import { Op } from "sequelize";
+
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Logger } from "@app/logger/logger";
+
+const DEFAULT_CUTOFF_DATE = new Date("2026-03-27T00:00:00Z");
+const TOOL_NAME = "create_object";
+const INTERNAL_MCP_SERVER_NAME = "salesforce";
+const PERMISSION_LEVEL = "medium";
+
+async function disableCreateObjectForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger,
+  cutoffDate: Date
+): Promise<{ processedCount: number }> {
+  // Finding all internal MCP server connections created before the cutoff date.
+  const connections = await MCPServerConnectionModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      serverType: "internal",
+      internalMCPServerId: {
+        [Op.ne]: null,
+      },
+      createdAt: {
+        [Op.lt]: cutoffDate,
+      },
+    },
+  });
+
+  // Filter to keep only Salesforce instances by decoding the internalMCPServerId.
+  // Group by internalMCPServerId to avoid duplicates (personal + workspace connections).
+  const uniqueInstancesMap = new Map<
+    string,
+    {
+      connectionId: number;
+      workspaceId: number;
+      internalMCPServerId: string;
+      createdAt: Date;
+    }
+  >();
+
+  for (const conn of connections) {
+    if (!conn.internalMCPServerId) continue;
+
+    const parsed = getInternalMCPServerNameAndWorkspaceId(
+      conn.internalMCPServerId
+    );
+
+    if (parsed.isOk() && parsed.value.name === INTERNAL_MCP_SERVER_NAME) {
+      if (!uniqueInstancesMap.has(conn.internalMCPServerId)) {
+        uniqueInstancesMap.set(conn.internalMCPServerId, {
+          connectionId: conn.id,
+          workspaceId: conn.workspaceId,
+          internalMCPServerId: conn.internalMCPServerId,
+          createdAt: conn.createdAt,
+        });
+      }
+    }
+  }
+
+  const existingInstances = Array.from(uniqueInstancesMap.values());
+
+  if (existingInstances.length === 0) {
+    return { processedCount: 0 };
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.id,
+      instancesCount: existingInstances.length,
+    },
+    "Found Salesforce instances to disable create_object in workspace."
+  );
+
+  let processedCount = 0;
+
+  for (const instance of existingInstances) {
+    const instanceLogger = logger.child({
+      workspaceId: instance.workspaceId,
+      connectionId: instance.connectionId,
+      internalMCPServerId: instance.internalMCPServerId,
+      toolName: TOOL_NAME,
+      permission: PERMISSION_LEVEL,
+    });
+
+    if (execute) {
+      const existing = await RemoteMCPServerToolMetadataModel.findOne({
+        where: {
+          workspaceId: instance.workspaceId,
+          internalMCPServerId: instance.internalMCPServerId,
+          toolName: TOOL_NAME,
+        },
+      });
+
+      if (!existing) {
+        await RemoteMCPServerToolMetadataModel.create({
+          workspaceId: instance.workspaceId,
+          internalMCPServerId: instance.internalMCPServerId,
+          toolName: TOOL_NAME,
+          permission: PERMISSION_LEVEL,
+          enabled: false,
+        });
+      }
+
+      processedCount++;
+
+      instanceLogger.info(
+        { instanceCreatedAt: instance.createdAt.toISOString() },
+        "Forced create_object disabled for existing Salesforce instance."
+      );
+    } else {
+      processedCount++;
+
+      instanceLogger.info(
+        { instanceCreatedAt: instance.createdAt.toISOString() },
+        "Would force create_object disabled for existing Salesforce instance."
+      );
+    }
+  }
+
+  return { processedCount };
+}
+
+makeScript(
+  {
+    cutoffDate: {
+      type: "string",
+      description:
+        "ISO date string for the cutoff date (connections created before this date are affected)",
+      required: false,
+    },
+  },
+  async ({ cutoffDate: cutoffDateStr, execute }, logger) => {
+    const cutoffDate = cutoffDateStr
+      ? new Date(cutoffDateStr)
+      : DEFAULT_CUTOFF_DATE;
+
+    if (isNaN(cutoffDate.getTime())) {
+      throw new Error(`Invalid cutoff date: ${cutoffDateStr}`);
+    }
+
+    logger.info(
+      {
+        cutoffDate: cutoffDate.toISOString(),
+        toolName: TOOL_NAME,
+        serverName: INTERNAL_MCP_SERVER_NAME,
+      },
+      "Starting create_object disabling migration for existing Salesforce instances."
+    );
+
+    let totalProcessed = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const result = await disableCreateObjectForWorkspace(
+          workspace,
+          execute,
+          logger,
+          cutoffDate
+        );
+        totalProcessed += result.processedCount;
+      },
+      { concurrency: 8 }
+    );
+
+    logger.info(
+      {
+        processedCount: totalProcessed,
+      },
+      execute
+        ? "Migration completed successfully."
+        : "Dry-run completed. Use --execute to apply changes."
+    );
+  }
+);

--- a/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
+++ b/front/migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
@@ -1,17 +1,24 @@
 import { Op } from "sequelize";
 
-import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import {
+  getInternalMCPServerNameAndWorkspaceId,
+  type InternalMCPServerNameType,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import { SALESFORCE_TOOLS_METADATA } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Logger } from "@app/logger/logger";
 
 const DEFAULT_CUTOFF_DATE = new Date("2026-03-27T00:00:00Z");
-const TOOL_NAME = "create_object";
-const INTERNAL_MCP_SERVER_NAME = "salesforce";
-const PERMISSION_LEVEL = "medium";
+const TOOL_NAME: keyof typeof SALESFORCE_TOOLS_METADATA = "create_object";
+const INTERNAL_MCP_SERVER_NAME: InternalMCPServerNameType = "salesforce";
+const PERMISSION_LEVEL: MCPToolStakeLevelType = "medium";
 
 async function disableCreateObjectForWorkspace(
   workspace: LightWorkspaceType,
@@ -40,43 +47,62 @@ async function disableCreateObjectForWorkspace(
     }
   }
 
+  if (salesforceServerIds.size > 0) {
+    logger.info(
+      { workspaceId: workspace.sId, count: salesforceServerIds.size },
+      "Salesforce instances to process."
+    );
+  }
+
   let processedCount = 0;
 
   for (const serverId of salesforceServerIds) {
     const instanceLogger = logger.child({
-      workspaceId: workspace.id,
+      workspaceId: workspace.sId,
       internalMCPServerId: serverId,
       toolName: TOOL_NAME,
     });
 
     if (execute) {
-      const [record, created] =
-        await RemoteMCPServerToolMetadataModel.findOrCreate({
-          where: {
-            workspaceId: workspace.id,
-            internalMCPServerId: serverId,
-            toolName: TOOL_NAME,
-          },
-          defaults: {
-            workspaceId: workspace.id,
-            internalMCPServerId: serverId,
-            toolName: TOOL_NAME,
-            permission: PERMISSION_LEVEL,
-            enabled: false,
-          },
-        });
+      const existing = await RemoteMCPServerToolMetadataModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          internalMCPServerId: serverId,
+          toolName: TOOL_NAME,
+        },
+      });
 
-      if (!created && record.enabled) {
-        await record.update({ enabled: false });
+      if (!existing) {
+        const created = await RemoteMCPServerToolMetadataModel.create({
+          workspaceId: workspace.id,
+          internalMCPServerId: serverId,
+          toolName: TOOL_NAME,
+          permission: PERMISSION_LEVEL,
+          enabled: false,
+        });
+        instanceLogger.info(
+          { metadataId: created.id, action: "created" },
+          "Disabled create_object for Salesforce instance."
+        );
+      } else if (existing.enabled) {
+        await existing.update({ enabled: false });
+        instanceLogger.info(
+          { metadataId: existing.id, action: "updated" },
+          "Disabled create_object for Salesforce instance."
+        );
+      } else {
+        instanceLogger.info(
+          { metadataId: existing.id, action: "skipped" },
+          "Already disabled, skipping."
+        );
       }
+    } else {
+      instanceLogger.info(
+        "Would disable create_object for Salesforce instance."
+      );
     }
 
     processedCount++;
-    instanceLogger.info(
-      execute
-        ? "Disabled create_object for Salesforce instance."
-        : "Would disable create_object for Salesforce instance."
-    );
   }
 
   return processedCount;
@@ -84,6 +110,12 @@ async function disableCreateObjectForWorkspace(
 
 makeScript(
   {
+    workspaceId: {
+      type: "string",
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
     cutoffDate: {
       type: "string",
       description:
@@ -91,7 +123,7 @@ makeScript(
       required: false,
     },
   },
-  async ({ cutoffDate: cutoffDateStr, execute }, logger) => {
+  async ({ workspaceId, cutoffDate: cutoffDateStr, execute }, logger) => {
     const cutoffDate = cutoffDateStr
       ? new Date(cutoffDateStr)
       : DEFAULT_CUTOFF_DATE;
@@ -107,17 +139,33 @@ makeScript(
 
     let totalProcessed = 0;
 
-    await runOnAllWorkspaces(
-      async (workspace) => {
-        totalProcessed += await disableCreateObjectForWorkspace(
-          workspace,
-          execute,
-          logger,
-          cutoffDate
-        );
-      },
-      { concurrency: 8 }
-    );
+    if (workspaceId) {
+      const workspaceResource = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspaceResource) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      const workspace = renderLightWorkspaceType({
+        workspace: workspaceResource,
+      });
+      totalProcessed += await disableCreateObjectForWorkspace(
+        workspace,
+        execute,
+        logger,
+        cutoffDate
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          totalProcessed += await disableCreateObjectForWorkspace(
+            workspace,
+            execute,
+            logger,
+            cutoffDate
+          );
+        },
+        { concurrency: 8 }
+      );
+    }
 
     logger.info(
       { processedCount: totalProcessed },


### PR DESCRIPTION
## Description

  Adds a new create_object tool to the Salesforce MCP server, allowing agents to create one or more records in Salesforce. The tool mirrors the existing update_object tool:
  - Medium stake level (requires user approval)
  - objectName argument requires approval display
  - Supports allOrNone for atomic batch creates

  Includes a migration script (20260327_disable_create_object_for_existing_salesforce_instances.ts) to disable the tool for all Salesforce instances created before the cutoff date (2026-03-27), so only newly
  connected instances get it enabled by default.

## Tests

Manual testing. No functional tests added — the tool follows the same pattern as update_object which is also untested at the endpoint level.

## Risk

  Low. The tool is disabled by default for existing instances via the migration. New instances will have it enabled but it's gated behind medium stake (user approval required). Rollback is safe — removing the tool definition will simply make it unavailable.

## Deploy Plan

  1. Merge and deploy
  2. Run the migration in dry-run mode: npx tsx ./migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts
  3. Run with --execute to disable for existing instances: npx tsx ./migrations/20260327_disable_create_object_for_existing_salesforce_instances.ts --execute