### PR TITLE
Tracking: explicitly set set_once properties

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -189,11 +189,22 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
         // UTM params across page loads, and URLs may have been stripped by
         // useStripUtmParams.
         const storedParams = getStoredUTMParams();
+        const setOnceProps: Record<string, string> = {};
         for (const param of MARKETING_PARAMS) {
           const storedValue = storedParams[param];
           if (storedValue) {
             event.properties[param] = storedValue;
+            // Also populate PostHog's built-in "Initial UTM" person properties.
+            // The SDK normally reads these from the URL, but since we strip UTMs
+            // before PostHog sees them, we inject them via $set_once.
+            setOnceProps[`$initial_${param}`] = storedValue;
           }
+        }
+        if (Object.keys(setOnceProps).length > 0) {
+          event.properties["$set_once"] = {
+            ...event.properties["$set_once"],
+            ...setOnceProps,
+          };
         }
 
         // Inject the persistent anonymous device ID from the _dust_aid cookie


### PR DESCRIPTION
## Description
Follow-up from https://github.com/dust-tt/dust/pull/23371 and https://github.com/dust-tt/dust/pull/23402. We hijack PostHog's initial properties and set them ourselves. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
