### PR TITLE
Add script to generate an audit log schema for workOS registration

### DIFF
--- a/front/admin/register_audit_log_schemas.ts
+++ b/front/admin/register_audit_log_schemas.ts
@@ -8,6 +8,8 @@
  *   npx tsx front/admin/register_audit_log_schemas.ts                # register all
  *   npx tsx front/admin/register_audit_log_schemas.ts --changed      # only new/modified schemas (vs origin/main)
  *   npx tsx front/admin/register_audit_log_schemas.ts user.login     # register specific actions
+ *   npx tsx front/admin/register_audit_log_schemas.ts --dry-run      # preview all schemas without registering
+ *   npx tsx front/admin/register_audit_log_schemas.ts --dry-run --changed  # preview only new/modified schemas
  */
 
 import { getWorkOS } from "@app/lib/api/workos/client";
@@ -38,7 +40,7 @@ function getChangedSchemaFiles(): Set<string> {
 
 function loadSchemas(args: string[]): CreateAuditLogSchemaOptions[] {
   const isChanged = args.includes("--changed");
-  const actions = args.filter((a) => a !== "--changed");
+  const actions = args.filter((a) => a !== "--changed" && a !== "--dry-run");
 
   const changedFiles = isChanged ? getChangedSchemaFiles() : null;
 
@@ -72,13 +74,26 @@ function loadSchemas(args: string[]): CreateAuditLogSchemaOptions[] {
 
 async function main() {
   const args = process.argv.slice(2);
+  const isDryRun = args.includes("--dry-run");
   const schemas = loadSchemas(args);
-  const workos = getWorkOS();
 
   if (schemas.length === 0) {
     console.log("No schemas to register.");
     return;
   }
+
+  if (isDryRun) {
+    for (const schema of schemas) {
+      const file = `admin/audit_log_schemas/${schema.action}.json`;
+      console.log(
+        `[dry-run] Would register schema: ${schema.action} (${file})`
+      );
+    }
+    console.log(`[dry-run] ${schemas.length} schemas would be registered`);
+    return;
+  }
+
+  const workos = getWorkOS();
 
   console.log(`Registering ${schemas.length} schema(s)\n`);
   let success = 0;

--- a/front/admin/register_audit_log_schemas.ts
+++ b/front/admin/register_audit_log_schemas.ts
@@ -1,0 +1,111 @@
+/**
+ * Register audit log event schemas with WorkOS.
+ *
+ * WorkOS requires event schemas to be pre-registered before events can be emitted.
+ * Schemas are loaded from JSON files in front/admin/audit_log_schemas/.
+ *
+ * Usage:
+ *   npx tsx front/admin/register_audit_log_schemas.ts                # register all
+ *   npx tsx front/admin/register_audit_log_schemas.ts --changed      # only new/modified schemas (vs origin/main)
+ *   npx tsx front/admin/register_audit_log_schemas.ts user.login     # register specific actions
+ */
+
+import { getWorkOS } from "@app/lib/api/workos/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { WorkOS } from "@workos-inc/node";
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+type CreateAuditLogSchemaOptions = Parameters<
+  WorkOS["auditLogs"]["createSchema"]
+>[0];
+
+const SCHEMAS_DIR = path.join(__dirname, "audit_log_schemas");
+
+function getChangedSchemaFiles(): Set<string> {
+  const diff = execSync(
+    `git diff --name-only --diff-filter=AM origin/main -- "${SCHEMAS_DIR}"`,
+    { encoding: "utf-8" }
+  ).trim();
+
+  if (!diff) {
+    return new Set();
+  }
+
+  return new Set(diff.split("\n").map((f) => path.basename(f)));
+}
+
+function loadSchemas(args: string[]): CreateAuditLogSchemaOptions[] {
+  const isChanged = args.includes("--changed");
+  const actions = args.filter((a) => a !== "--changed");
+
+  const changedFiles = isChanged ? getChangedSchemaFiles() : null;
+
+  let files = fs
+    .readdirSync(SCHEMAS_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+
+  if (changedFiles) {
+    files = files.filter((f) => changedFiles.has(f));
+  }
+
+  // JSON.parse returns `any`, which is assignable to CreateAuditLogSchemaOptions.
+  const schemas: CreateAuditLogSchemaOptions[] = files.map((file) => {
+    const content = fs.readFileSync(path.join(SCHEMAS_DIR, file), "utf-8");
+    return JSON.parse(content);
+  });
+
+  if (actions.length > 0) {
+    const filtered = schemas.filter((s) => actions.includes(s.action));
+    const found = new Set(filtered.map((s) => s.action));
+    const missing = actions.filter((a) => !found.has(a));
+    if (missing.length > 0) {
+      throw new Error(`No schema files found for: ${missing.join(", ")}`);
+    }
+    return filtered;
+  }
+
+  return schemas;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const schemas = loadSchemas(args);
+  const workos = getWorkOS();
+
+  if (schemas.length === 0) {
+    console.log("No schemas to register.");
+    return;
+  }
+
+  console.log(`Registering ${schemas.length} schema(s)\n`);
+  let success = 0;
+  let failed = 0;
+
+  for (const schema of schemas) {
+    const { action } = schema;
+    try {
+      const result = await workos.auditLogs.createSchema(schema);
+      console.log(`  OK  ${action} (v${result.version})`);
+      success++;
+    } catch (error: unknown) {
+      console.error(`  FAIL  ${action}: ${normalizeError(error).message}`);
+      failed++;
+    }
+  }
+
+  console.log(
+    `\nDone: ${success} registered, ${failed} failed, ${schemas.length} total`
+  );
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", normalizeError(error).message);
+  process.exit(1);
+});

--- a/front/admin/register_audit_log_schemas.ts
+++ b/front/admin/register_audit_log_schemas.ts
@@ -5,19 +5,22 @@
  * Schemas are loaded from JSON files in front/admin/audit_log_schemas/.
  *
  * Usage:
- *   npx tsx front/admin/register_audit_log_schemas.ts                # register all
- *   npx tsx front/admin/register_audit_log_schemas.ts --changed      # only new/modified schemas (vs origin/main)
- *   npx tsx front/admin/register_audit_log_schemas.ts user.login     # register specific actions
- *   npx tsx front/admin/register_audit_log_schemas.ts --dry-run      # preview all schemas without registering
- *   npx tsx front/admin/register_audit_log_schemas.ts --dry-run --changed  # preview only new/modified schemas
+ *   npx tsx front/admin/register_audit_log_schemas.ts                          # preview all (dry-run)
+ *   npx tsx front/admin/register_audit_log_schemas.ts --execute                # register all
+ *   npx tsx front/admin/register_audit_log_schemas.ts --changed                # preview only new/modified schemas
+ *   npx tsx front/admin/register_audit_log_schemas.ts --execute --changed      # register only new/modified schemas
+ *   npx tsx front/admin/register_audit_log_schemas.ts user.login               # preview specific actions
+ *   npx tsx front/admin/register_audit_log_schemas.ts --execute user.login     # register specific actions
  */
 
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkOS } from "@workos-inc/node";
-import { execSync } from "child_process";
-import * as fs from "fs";
+import { execFileSync } from "child_process";
+import * as fs from "fs/promises";
+import minimist from "minimist";
 import * as path from "path";
+import { z } from "zod";
 
 type CreateAuditLogSchemaOptions = Parameters<
   WorkOS["auditLogs"]["createSchema"]
@@ -25,9 +28,40 @@ type CreateAuditLogSchemaOptions = Parameters<
 
 const SCHEMAS_DIR = path.join(__dirname, "audit_log_schemas");
 
+const metadataSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.boolean(), z.number()])
+);
+
+const auditLogSchemaValidator = z.object({
+  action: z.string().min(1, "action must be a non-empty string"),
+  targets: z
+    .array(
+      z.object({
+        type: z.string().min(1, "target type must be a non-empty string"),
+        metadata: metadataSchema.optional(),
+      })
+    )
+    .min(1, "targets must be a non-empty array"),
+  actor: z
+    .object({
+      metadata: metadataSchema,
+    })
+    .optional(),
+  metadata: metadataSchema.optional(),
+});
+
 function getChangedSchemaFiles(): Set<string> {
-  const diff = execSync(
-    `git diff --name-only --diff-filter=AM origin/main -- "${SCHEMAS_DIR}"`,
+  const diff = execFileSync(
+    "git",
+    [
+      "diff",
+      "--name-only",
+      "--diff-filter=AM",
+      "origin/main",
+      "--",
+      SCHEMAS_DIR,
+    ],
     { encoding: "utf-8" }
   ).trim();
 
@@ -38,14 +72,15 @@ function getChangedSchemaFiles(): Set<string> {
   return new Set(diff.split("\n").map((f) => path.basename(f)));
 }
 
-function loadSchemas(args: string[]): CreateAuditLogSchemaOptions[] {
-  const isChanged = args.includes("--changed");
-  const actions = args.filter((a) => a !== "--changed" && a !== "--dry-run");
+async function loadSchemas(
+  args: minimist.ParsedArgs
+): Promise<CreateAuditLogSchemaOptions[]> {
+  const isChanged = !!args.changed;
+  const actions = args._.map(String);
 
   const changedFiles = isChanged ? getChangedSchemaFiles() : null;
 
-  let files = fs
-    .readdirSync(SCHEMAS_DIR)
+  let files = (await fs.readdir(SCHEMAS_DIR))
     .filter((f) => f.endsWith(".json"))
     .sort();
 
@@ -53,11 +88,20 @@ function loadSchemas(args: string[]): CreateAuditLogSchemaOptions[] {
     files = files.filter((f) => changedFiles.has(f));
   }
 
-  // JSON.parse returns `any`, which is assignable to CreateAuditLogSchemaOptions.
-  const schemas: CreateAuditLogSchemaOptions[] = files.map((file) => {
-    const content = fs.readFileSync(path.join(SCHEMAS_DIR, file), "utf-8");
-    return JSON.parse(content);
-  });
+  const schemas: CreateAuditLogSchemaOptions[] = [];
+  for (const file of files) {
+    const content = await fs.readFile(path.join(SCHEMAS_DIR, file), "utf-8");
+    const parsed: unknown = JSON.parse(content);
+
+    const result = auditLogSchemaValidator.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(
+        `Invalid schema in ${file}: ${result.error.issues.map((i) => i.message).join(", ")}`
+      );
+    }
+
+    schemas.push(result.data);
+  }
 
   if (actions.length > 0) {
     const filtered = schemas.filter((s) => actions.includes(s.action));
@@ -73,23 +117,23 @@ function loadSchemas(args: string[]): CreateAuditLogSchemaOptions[] {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
-  const isDryRun = args.includes("--dry-run");
-  const schemas = loadSchemas(args);
+  const args = minimist(process.argv.slice(2));
+  const execute = !!args.execute;
+  const schemas = await loadSchemas(args);
 
   if (schemas.length === 0) {
     console.log("No schemas to register.");
     return;
   }
 
-  if (isDryRun) {
+  if (!execute) {
     for (const schema of schemas) {
       const file = `admin/audit_log_schemas/${schema.action}.json`;
-      console.log(
-        `[dry-run] Would register schema: ${schema.action} (${file})`
-      );
+      console.log(`Would register schema: ${schema.action} (${file})`);
     }
-    console.log(`[dry-run] ${schemas.length} schemas would be registered`);
+    console.log(
+      `\n${schemas.length} schema(s) would be registered. Pass --execute to register.`
+    );
     return;
   }
 
@@ -118,6 +162,8 @@ async function main() {
   if (failed > 0) {
     process.exit(1);
   }
+
+  process.exit(0);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/7212
## Description
Adds an admin script to register audit log event schemas with WorkOS. WorkOS requires schemas to be pre-registered before events of that type can be emitted — if an event fires without a registered schema, WorkOS silently rejects it.
Isolating this into a single PR for easy review. Next PR's will include the schemas and events themselves. Runbook for this and new coding rules also incoming 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
- `npx ts-node front/admin/register_audit_log_schemas.ts` with no schema files present → logs "no schemas found", exits 0
- Add a test schema file, run with `--changed` → registers only that file
- Run with an invalid schema file → exits non-zero with error logged
- Run with a named action that doesn't have a file → exits non-zero with clear error message

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
None, just an admin script
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
No deploy needed. Script will need to be run manually after merging new events, before deploy. All will be documented in a runbook
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
