### PR TITLE
[Email Agents] Reply only to sender

### DIFF
--- a/front/lib/api/assistant/email/email_reply.test.ts
+++ b/front/lib/api/assistant/email/email_reply.test.ts
@@ -1,0 +1,133 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import {
+  deleteEmailReplyContext,
+  getEmailReplyContext,
+  replyToEmail,
+  sendToolValidationEmail,
+  storeEmailReplyContext,
+} from "@app/lib/api/assistant/email/email_trigger";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/assistant/configuration/agent", () => ({
+  getAgentConfiguration: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/email/email_trigger", () => ({
+  deleteEmailReplyContext: vi.fn(),
+  getEmailReplyContext: vi.fn(),
+  replyToEmail: vi.fn(),
+  sendToolValidationEmail: vi.fn(),
+  storeEmailReplyContext: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getAppUrl: vi.fn(() => "https://app.dust.tt"),
+  },
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  Authenticator: {
+    fromJSON: vi.fn(),
+  },
+  getFeatureFlags: vi.fn(),
+}));
+
+vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
+  AgentMCPActionResource: {
+    listBlockedActionsForConversation: vi.fn(),
+  },
+}));
+
+vi.mock("@app/lib/resources/conversation_resource", () => ({
+  ConversationResource: {
+    fetchById: vi.fn(),
+  },
+}));
+
+vi.mock("@app/lib/utils/router", () => ({
+  getConversationRoute: vi.fn(() => "https://app.dust.tt/conv"),
+}));
+
+vi.mock("@app/types/assistant/agent_run", () => ({
+  getAgentLoopData: vi.fn(),
+}));
+
+import { sendEmailReplyOnCompletion } from "@app/lib/api/assistant/email/email_reply";
+
+describe("sendEmailReplyOnCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(Authenticator.fromJSON).mockResolvedValue({
+      isErr: () => false,
+      value: {
+        getNonNullableWorkspace: () => ({
+          metadata: { allowEmailAgents: true },
+        }),
+      },
+    } as never);
+    vi.mocked(getFeatureFlags).mockResolvedValue(["email_agents"]);
+    vi.mocked(ConversationResource.fetchById).mockResolvedValue({} as never);
+    vi.mocked(
+      AgentMCPActionResource.listBlockedActionsForConversation
+    ).mockResolvedValue([]);
+    vi.mocked(getAgentConfiguration).mockResolvedValue(null);
+  });
+
+  it("replies only to the sender even when the stored context contains legacy reply-all fields", async () => {
+    vi.mocked(getEmailReplyContext).mockResolvedValue({
+      subject: "Test",
+      originalText: "Hello",
+      fromEmail: "sender@dust.tt",
+      fromFull: "Sender <sender@dust.tt>",
+      threadingMessageId: "<incoming-message-id@dust.tt>",
+      threadingInReplyTo: null,
+      threadingReferences: null,
+      agentConfigurationId: "agent-config-1",
+      workspaceId: "workspace-1",
+      conversationId: "conversation-1",
+      replyTo: ["sender@dust.tt", "observer@dust.tt"],
+      replyCc: ["security@dust.tt"],
+    } as never);
+
+    vi.mocked(getAgentLoopData).mockResolvedValue({
+      isErr: () => false,
+      value: {
+        auth: {},
+        agentMessage: {
+          sId: "agent-message-1",
+          content: "Done",
+        },
+        conversation: {
+          sId: "conversation-1",
+        },
+      },
+    } as never);
+
+    await sendEmailReplyOnCompletion(
+      { workspaceId: "workspace-1" } as never,
+      {
+        agentMessageId: "agent-message-1",
+        userMessageOrigin: "email",
+      } as never
+    );
+
+    expect(deleteEmailReplyContext).toHaveBeenCalledWith(
+      "workspace-1",
+      "agent-message-1"
+    );
+    expect(replyToEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: "sender@dust.tt",
+      })
+    );
+    expect(replyToEmail).toHaveBeenCalledTimes(1);
+    expect(sendToolValidationEmail).not.toHaveBeenCalled();
+    expect(storeEmailReplyContext).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -265,18 +265,14 @@ export async function sendEmailReplyOnCompletion(
       email,
       agentConfiguration: agentConfiguration ?? undefined,
       htmlContent: fullHtmlContent,
-      recipients: {
-        to: context.replyTo,
-        cc: context.replyCc,
-      },
+      recipient: context.fromEmail,
     });
 
     logger.info(
       {
         agentMessageId: agentLoopArgs.agentMessageId,
         conversationId: conversation.sId,
-        to: context.replyTo,
-        cc: context.replyCc,
+        to: context.fromEmail,
       },
       "[email] Sent email reply on agent completion"
     );
@@ -334,10 +330,7 @@ export async function sendEmailReplyOnError(
     await replyToEmail({
       email,
       htmlContent,
-      recipients: {
-        to: [context.fromEmail],
-        cc: [],
-      },
+      recipient: context.fromEmail,
     });
 
     logger.info(

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -81,6 +81,8 @@ describe("parseEmailReplyContext", () => {
       workspaceId: "workspace-1",
       conversationId: "conversation-1",
     });
+    expect(parsed).not.toHaveProperty("replyTo");
+    expect(parsed).not.toHaveProperty("replyCc");
   });
 });
 

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -1,133 +1,86 @@
 import {
   ASSISTANT_EMAIL_SUBDOMAIN,
+  buildEmailUserMessage,
   buildReplyThreadingHeaders,
-  buildSuccessReplyRecipients,
-  MAX_REPLY_RECIPIENTS,
+  parseEmailReplyContext,
 } from "@app/lib/api/assistant/email/email_trigger";
 import { describe, expect, it } from "vitest";
 
 const TEST_EMAIL_AUTH = { SPF: "pass", dkim: [], dkimRaw: "" };
 
-describe("buildSuccessReplyRecipients", () => {
-  it("returns sender-only recipients when no human to/cc recipients exist", () => {
-    const recipients = buildSuccessReplyRecipients({
-      subject: "Test",
-      text: "Hello",
-      auth: TEST_EMAIL_AUTH,
-      threadingHeaders: {
-        messageId: null,
-        inReplyTo: null,
-        references: null,
+describe("buildEmailUserMessage", () => {
+  it("keeps thread context but replies only to the sender", () => {
+    const message = buildEmailUserMessage({
+      email: {
+        subject: "Test",
+        text: "Hello",
+        auth: TEST_EMAIL_AUTH,
+        threadingHeaders: {
+          messageId: null,
+          inReplyTo: null,
+          references: null,
+        },
+        sender: {
+          email: "sender@dust.tt",
+          full: "Sender <sender@dust.tt>",
+        },
+        envelope: {
+          from: "bounce@mailer.dust.tt",
+          to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "teammate@dust.tt"],
+          cc: [`other-agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "observer@dust.tt"],
+          bcc: ["hidden@dust.tt"],
+        },
+        attachments: [],
       },
-      sender: {
-        email: "sender@dust.tt",
-        full: "Sender <sender@dust.tt>",
-      },
-      envelope: {
-        from: "bounce@mailer.dust.tt",
-        to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`],
-        cc: [],
-        bcc: ["hidden@dust.tt"],
-      },
-      attachments: [],
+      userMessage: "Can you summarize this thread?",
+      hasThreadHistory: false,
+      attachmentCount: 0,
     });
 
-    expect(recipients).toEqual({
-      to: ["sender@dust.tt"],
-      cc: [],
-    });
-  });
-
-  it("includes original human to/cc recipients and excludes assistant recipients", () => {
-    const recipients = buildSuccessReplyRecipients({
-      subject: "Test",
-      text: "Hello",
-      auth: TEST_EMAIL_AUTH,
-      threadingHeaders: {
-        messageId: null,
-        inReplyTo: null,
-        references: null,
-      },
-      sender: {
-        email: "sender@dust.tt",
-        full: "Sender <sender@dust.tt>",
-      },
-      envelope: {
-        from: "bounce@mailer.dust.tt",
-        to: [`agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "teammate@dust.tt"],
-        cc: [`other-agent@${ASSISTANT_EMAIL_SUBDOMAIN}`, "observer@dust.tt"],
-        bcc: ["hidden@dust.tt"],
-      },
-      attachments: [],
-    });
-
-    expect(recipients).toEqual({
-      to: ["sender@dust.tt", "teammate@dust.tt"],
-      cc: ["observer@dust.tt"],
-    });
-  });
-
-  it("deduplicates recipients across to and cc", () => {
-    const recipients = buildSuccessReplyRecipients({
-      subject: "Test",
-      text: "Hello",
-      auth: TEST_EMAIL_AUTH,
-      threadingHeaders: {
-        messageId: null,
-        inReplyTo: null,
-        references: null,
-      },
-      sender: {
-        email: "sender@dust.tt",
-        full: "Sender <sender@dust.tt>",
-      },
-      envelope: {
-        from: "bounce@mailer.dust.tt",
-        to: ["Sender@dust.tt", "teammate@dust.tt", "teammate@dust.tt"],
-        cc: ["teammate@dust.tt", "observer@dust.tt", "observer@dust.tt"],
-        bcc: [],
-      },
-      attachments: [],
-    });
-
-    expect(recipients).toEqual({
-      to: ["sender@dust.tt", "teammate@dust.tt"],
-      cc: ["observer@dust.tt"],
-    });
-  });
-
-  it("caps total recipients at MAX_REPLY_RECIPIENTS, dropping cc first", () => {
-    const manyCC = Array.from(
-      { length: MAX_REPLY_RECIPIENTS },
-      (_, i) => `cc${i}@dust.tt`
+    expect(message).toContain(
+      `<email_to>agent@${ASSISTANT_EMAIL_SUBDOMAIN}, teammate@dust.tt</email_to>`
     );
-    const recipients = buildSuccessReplyRecipients({
-      subject: "Test",
-      text: "Hello",
-      auth: TEST_EMAIL_AUTH,
-      threadingHeaders: {
-        messageId: null,
-        inReplyTo: null,
-        references: null,
-      },
-      sender: {
-        email: "sender@dust.tt",
-        full: "Sender <sender@dust.tt>",
-      },
-      envelope: {
-        from: "bounce@mailer.dust.tt",
-        to: ["teammate@dust.tt"],
-        cc: manyCC,
-        bcc: [],
-      },
-      attachments: [],
-    });
-
-    expect(recipients.to).toEqual(["sender@dust.tt", "teammate@dust.tt"]);
-    expect(recipients.to.length + recipients.cc.length).toBe(
-      MAX_REPLY_RECIPIENTS
+    expect(message).toContain(
+      `<email_cc>other-agent@${ASSISTANT_EMAIL_SUBDOMAIN}, observer@dust.tt</email_cc>`
     );
-    expect(recipients.cc).toEqual(manyCC.slice(0, MAX_REPLY_RECIPIENTS - 2));
+    expect(message).toContain(
+      `<dust_agent_recipients>agent@${ASSISTANT_EMAIL_SUBDOMAIN}, other-agent@${ASSISTANT_EMAIL_SUBDOMAIN}</dust_agent_recipients>`
+    );
+    expect(message).toContain(
+      "<email_response_to>sender@dust.tt</email_response_to>"
+    );
+    expect(message).not.toContain("<email_response_cc>");
+    expect(message).toContain("only to me, the sender above.");
+  });
+});
+
+describe("parseEmailReplyContext", () => {
+  it("accepts legacy Redis payloads that still contain reply-all fields", () => {
+    const parsed = parseEmailReplyContext(
+      JSON.stringify({
+        subject: "Test",
+        originalText: "Hello",
+        fromEmail: "sender@dust.tt",
+        fromFull: "Sender <sender@dust.tt>",
+        replyTo: ["sender@dust.tt", "observer@dust.tt"],
+        replyCc: ["security@dust.tt"],
+        threadingMessageId: "<incoming-message-id@dust.tt>",
+        threadingInReplyTo: null,
+        threadingReferences: null,
+        agentConfigurationId: "agent-config-1",
+        workspaceId: "workspace-1",
+        conversationId: "conversation-1",
+      }),
+      "agent-message-1",
+      "email-reply-context:workspace-1:agent-message-1"
+    );
+
+    expect(parsed).toMatchObject({
+      fromEmail: "sender@dust.tt",
+      agentConfigurationId: "agent-config-1",
+      workspaceId: "workspace-1",
+      conversationId: "conversation-1",
+    });
   });
 });
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -30,7 +30,7 @@ import type { ConversationType } from "@app/types/assistant/conversation";
 import type { SupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { isString, isStringArray } from "@app/types/shared/utils/general";
+import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import fs from "fs";
 import sanitizeHtml from "sanitize-html";
@@ -53,8 +53,6 @@ export type EmailReplyContext = {
   originalText: string;
   fromEmail: string;
   fromFull: string;
-  replyTo: string[];
-  replyCc: string[];
   threadingMessageId: string | null;
   threadingInReplyTo: string | null;
   threadingReferences: string | null;
@@ -80,10 +78,6 @@ function isEmailReplyContext(value: unknown): value is EmailReplyContext {
     isString(value.fromEmail) &&
     "fromFull" in value &&
     isString(value.fromFull) &&
-    "replyTo" in value &&
-    isStringArray(value.replyTo) &&
-    "replyCc" in value &&
-    isStringArray(value.replyCc) &&
     "threadingMessageId" in value &&
     isNullableString(value.threadingMessageId) &&
     "threadingInReplyTo" in value &&
@@ -129,7 +123,7 @@ export async function storeEmailReplyContext(
 /**
  * Parse and validate a raw Redis value into an EmailReplyContext.
  */
-function parseEmailReplyContext(
+export function parseEmailReplyContext(
   value: string,
   agentMessageId: string,
   key: string
@@ -153,6 +147,7 @@ function parseEmailReplyContext(
     return null;
   }
 
+  // Legacy contexts may still contain replyTo/replyCc during the Redis TTL window.
   return parsed;
 }
 
@@ -261,11 +256,6 @@ function isAssistantRecipient(email: string): boolean {
   return normalizeEmailAddress(email).endsWith(`@${ASSISTANT_EMAIL_SUBDOMAIN}`);
 }
 
-// Cap on total reply recipients (to + cc combined). To/Cc are sourced from raw email headers,
-// which a sender can freely forge to list arbitrary addresses. The cap prevents using the agent
-// as a bulk relay while leaving no impact on legitimate threads (nobody CCs 15+ people normally).
-export const MAX_REPLY_RECIPIENTS = 15;
-
 function formatEmailRecipients(recipients: string[]): string {
   return recipients.length > 0 ? recipients.join(", ") : "(none)";
 }
@@ -359,53 +349,14 @@ function buildSendgridThreadingHeaders(
   };
 }
 
-export function buildSuccessReplyRecipients(email: InboundEmail): {
-  to: string[];
-  cc: string[];
-} {
-  const to = deduplicateEmailAddresses(
-    [email.sender.email, ...email.envelope.to].filter(
-      (recipient) => !isAssistantRecipient(recipient)
-    )
-  );
-
-  const toSet = new Set(to.map(normalizeEmailAddress));
-  const cc = deduplicateEmailAddresses(
-    email.envelope.cc.filter((recipient) => {
-      const normalizedRecipient = normalizeEmailAddress(recipient);
-      return (
-        !isAssistantRecipient(recipient) && !toSet.has(normalizedRecipient)
-      );
-    })
-  );
-
-  // Enforce recipient cap: the authenticated sender is always kept, extras are dropped from cc
-  // first.
-  const total = to.length + cc.length;
-  if (total <= MAX_REPLY_RECIPIENTS) {
-    return { to, cc };
-  }
-  const cappedCc = cc.slice(0, Math.max(0, MAX_REPLY_RECIPIENTS - to.length));
-  logger.warn(
-    { totalRecipients: total, cappedTo: to.length, cappedCc: cappedCc.length },
-    "[email] Reply recipient list truncated to MAX_REPLY_RECIPIENTS."
-  );
-  return { to, cc: cappedCc };
-}
-
 export function buildEmailUserMessage({
   email,
   userMessage,
-  replyRecipients,
   hasThreadHistory,
   attachmentCount,
 }: {
   email: InboundEmail;
   userMessage: string;
-  replyRecipients: {
-    to: string[];
-    cc: string[];
-  };
   hasThreadHistory: boolean;
   attachmentCount: number;
 }): string {
@@ -448,19 +399,10 @@ export function buildEmailUserMessage({
     escapeTagContent(userMessage),
     "  </email_body>",
     ...additionalContext.map((line) => `  ${line}`),
-    `  <email_response_to>${escapeTagContent(
-      formatEmailRecipients(replyRecipients.to)
-    )}</email_response_to>`,
-    ...(replyRecipients.cc.length > 0
-      ? [
-          `  <email_response_cc>${escapeTagContent(
-            formatEmailRecipients(replyRecipients.cc)
-          )}</email_response_cc>`,
-        ]
-      : []),
+    `  <email_response_to>${escapeTagContent(email.sender.email)}</email_response_to>`,
     "</email_message>",
     "",
-    "You are in the recipients. Answer appropriately. Your full response will be emailed automatically as-is to the recipients listed above (and me).",
+    "You are in the recipients. Answer appropriately. Your full response will be emailed automatically as-is only to me, the sender above.",
   ].join("\n");
 }
 export async function userAndWorkspaceFromEmail({
@@ -829,7 +771,6 @@ export async function triggerFromEmail({
     }
   }
 
-  const successReplyRecipients = buildSuccessReplyRecipients(email);
   const content =
     agentConfigurations
       .map((agent) => {
@@ -840,7 +781,6 @@ export async function triggerFromEmail({
     buildEmailUserMessage({
       email,
       userMessage,
-      replyRecipients: successReplyRecipients,
       hasThreadHistory: restOfThread.length > 0,
       attachmentCount: attachedContentCount,
     });
@@ -890,8 +830,6 @@ export async function triggerFromEmail({
         originalText: email.text,
         fromEmail: email.sender.email,
         fromFull: email.sender.full,
-        replyTo: successReplyRecipients.to,
-        replyCc: successReplyRecipients.cc,
         threadingMessageId: email.threadingHeaders.messageId,
         threadingInReplyTo: email.threadingHeaders.inReplyTo,
         threadingReferences: email.threadingHeaders.references,
@@ -1045,15 +983,12 @@ export async function replyToEmail({
   email,
   agentConfiguration,
   htmlContent,
-  recipients,
+  recipient,
 }: {
   email: InboundEmail;
   agentConfiguration?: LightAgentConfigurationType;
   htmlContent: string;
-  recipients: {
-    to: string[];
-    cc: string[];
-  };
+  recipient: string;
 }) {
   const name = agentConfiguration
     ? `Dust Agent (${agentConfiguration.name})`
@@ -1100,8 +1035,8 @@ export async function replyToEmail({
   };
 
   await sendEmailToRecipients({
-    to: recipients.to,
-    cc: recipients.cc,
+    to: [recipient],
+    cc: [],
     message: msg,
   });
 }

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -147,8 +147,18 @@ export function parseEmailReplyContext(
     return null;
   }
 
-  // Legacy contexts may still contain replyTo/replyCc during the Redis TTL window.
-  return parsed;
+  return {
+    subject: parsed.subject,
+    originalText: parsed.originalText,
+    fromEmail: parsed.fromEmail,
+    fromFull: parsed.fromFull,
+    threadingMessageId: parsed.threadingMessageId,
+    threadingInReplyTo: parsed.threadingInReplyTo,
+    threadingReferences: parsed.threadingReferences,
+    agentConfigurationId: parsed.agentConfigurationId,
+    workspaceId: parsed.workspaceId,
+    conversationId: parsed.conversationId,
+  };
 }
 
 /**

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -177,10 +177,7 @@ const replyToError = async (
   await replyToEmail({
     email,
     htmlContent,
-    recipients: {
-      to: [email.sender.email],
-      cc: [],
-    },
+    recipient: email.sender.email,
   });
 };
 


### PR DESCRIPTION
## Description
Reply to email-agent threads only to the authenticated sender.

Keep the original To/Cc thread context in the injected prompt so agents still see the participants, but remove reply-all response metadata and stored reply recipient lists.

Tolerate legacy Redis contexts that still contain `replyTo` / `replyCc` during the TTL window.

## Risks
Blast radius: email-agent reply behavior in front
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `cd front && NODE_ENV=test npm test -- email_trigger.test.ts email_reply.test.ts --reporter verbose`
