### PR TITLE
[Email Agents] Align email copy with web app and Slack bot

### DIFF
--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -257,7 +257,19 @@ export async function sendEmailReplyOnCompletion(
       undefined,
       config.getAppUrl()
     );
-    const fullHtmlContent = `<div><div>${htmlContent}</div><br/><a href="${conversationLink}">Open in Dust</a></div>`;
+    const agentName = agentConfiguration
+      ? sanitizeHtml(agentConfiguration.name, {
+          allowedTags: [],
+          allowedAttributes: {},
+        })
+      : null;
+    const attribution = agentName
+      ? `Answered by <strong>${agentName}</strong>`
+      : "Answered";
+    const fullHtmlContent =
+      `<div><div>${htmlContent}</div>` +
+      `<p style="color: #666; font-size: 13px; margin-top: 16px;">${attribution} · <a href="${conversationLink}" style="color: #2563eb;">View full conversation</a></p>` +
+      `</div>`;
 
     // Reconstruct the email and send reply.
     const email = reconstructEmailFromContext(context);

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -31,6 +31,7 @@ import type { SupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import fs from "fs";
 import sanitizeHtml from "sanitize-html";
@@ -914,14 +915,14 @@ export async function sendToolValidationEmail({
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;");
 
-    const toolName = sanitizeHtml(action.metadata.toolName, {
+    const toolName = sanitizeHtml(asDisplayName(action.metadata.toolName), {
       allowedTags: [],
       allowedAttributes: {},
     });
-    const serverName = sanitizeHtml(action.metadata.mcpServerName, {
-      allowedTags: [],
-      allowedAttributes: {},
-    });
+    const serverName = sanitizeHtml(
+      asDisplayName(action.metadata.mcpServerName),
+      { allowedTags: [], allowedAttributes: {} }
+    );
 
     return `
       <div style="border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin: 12px 0; background-color: #f9f9f9;">

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -884,7 +884,7 @@ export async function sendToolValidationEmail({
     agentName: agentConfiguration.name,
   });
 
-  const name = `Dust Agent (${agentConfiguration.name})`;
+  const name = `${agentConfiguration.name} (Dust agent)`;
   const sender = `${agentConfiguration.name}@${ASSISTANT_EMAIL_SUBDOMAIN}`;
 
   const subject = email.subject
@@ -925,12 +925,11 @@ export async function sendToolValidationEmail({
 
     return `
       <div style="border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin: 12px 0; background-color: #f9f9f9;">
-        <h3 style="margin: 0 0 8px 0; color: #333;">${toolName}</h3>
-        <p style="margin: 0 0 8px 0; color: #666;">Server: ${serverName}</p>
+        <h3 style="margin: 0 0 8px 0; color: #333;">Allow ${serverName} to ${toolName}?</h3>
         <pre style="background-color: #fff; padding: 12px; border-radius: 4px; overflow-x: auto; font-size: 12px; border: 1px solid #eee;">${inputsJson}</pre>
         <div style="margin-top: 12px;">
-          <a href="${approveUrl}" style="display: inline-block; padding: 10px 20px; background-color: #22c55e; color: white; text-decoration: none; border-radius: 4px; margin-right: 8px; font-weight: 500;">Approve</a>
-          <a href="${rejectUrl}" style="display: inline-block; padding: 10px 20px; background-color: #ef4444; color: white; text-decoration: none; border-radius: 4px; font-weight: 500;">Reject</a>
+          <a href="${approveUrl}" style="display: inline-block; padding: 10px 20px; background-color: #22c55e; color: white; text-decoration: none; border-radius: 4px; margin-right: 8px; font-weight: 500;">Allow</a>
+          <a href="${rejectUrl}" style="display: inline-block; padding: 10px 20px; background-color: #ef4444; color: white; text-decoration: none; border-radius: 4px; font-weight: 500;">Decline</a>
         </div>
       </div>
     `;
@@ -938,8 +937,7 @@ export async function sendToolValidationEmail({
 
   const htmlContent = `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
-      <h2 style="color: #333;">Tool Approval Required</h2>
-      <p>The agent <strong>@${sanitizeHtml(agentConfiguration.name, { allowedTags: [], allowedAttributes: {} })}</strong> needs your approval to execute the following tool(s):</p>
+      <p><strong>@${sanitizeHtml(agentConfiguration.name, { allowedTags: [], allowedAttributes: {} })}</strong> needs permission to use the following tool(s):</p>
       ${actionBlocks.join("")}
       <p style="color: #666; margin-top: 16px;">Links expire in 24 hours.</p>
       <p><a href="${conversationUrl}" style="color: #2563eb;">View conversation in Dust</a></p>
@@ -1001,8 +999,8 @@ export async function replyToEmail({
   recipient: string;
 }) {
   const name = agentConfiguration
-    ? `Dust Agent (${agentConfiguration.name})`
-    : "Dust Agent";
+    ? `${agentConfiguration.name} (Dust agent)`
+    : "Dust agent";
   const sender = agentConfiguration
     ? `${agentConfiguration.name}@${ASSISTANT_EMAIL_SUBDOMAIN}`
     : `assistants@${ASSISTANT_EMAIL_SUBDOMAIN}`;


### PR DESCRIPTION
## Description

Aligns email agent copy with existing patterns in the web app and Slack bot:

- **Sender name**: Dust Agent (name) -> name (Dust agent) -- puts the agent name first for better readability in email clients
- **Reply footer**: Replaces plain Open in Dust link with Answered by agentName - View full conversation, matching the Slack bot attribution style (see connectors/src/connectors/slack/chat/blocks.ts)
- **Tool validation email**: Matches web app MCPToolValidationRequired component -- Allow ServerName to ToolName? title with Allow/Decline buttons instead of Approve/Reject

## Risks

Blast radius: email agent replies and tool validation emails
Risk: low

## Deploy Plan
- pmrr (can wait monday)
- deploy front