### PR TITLE
feat: add firefox extension to allowed origins

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -7,6 +7,8 @@ const STATIC_ALLOWED_ORIGINS = [
   // Chrome extension.
   "chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg",
   "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
+  // Firefox extension.
+  "moz-extension://8513c13e-1050-4fe6-a548-34448bfa51af",
   // Documentation website.
   "https://docs.dust.tt",
   // Microsoft Power Automate.

--- a/viz/next.config.mjs
+++ b/viz/next.config.mjs
@@ -2,7 +2,7 @@
 const isDev = process.env.NODE_ENV === "development";
 
 const CONTENT_SECURITY_POLICIES = `connect-src 'self'; media-src 'self'; frame-ancestors 'self' ${
-  isDev ? "http://localhost:3000 http://localhost:3011 chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg" : "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt https://*.preview.dust.tt chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn"
+  isDev ? "http://localhost:3000 http://localhost:3011 chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg moz-extension:" : "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt https://*.preview.dust.tt chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn moz-extension://8513c13e-1050-4fe6-a548-34448bfa51af"
 };`;
 
 const nextConfig = {


### PR DESCRIPTION
## Description

This PR adds the Firefox extension to the list of allowed origins for CORS and Content Security Policy configurations.

- Added `moz-extension://8513c13e-1050-4fe6-a548-34448bfa51af` to the static allowed origins in `front/config/cors.ts`
- Updated the Content Security Policy in `viz/next.config.mjs` to include the Firefox extension origin

## Tests

Manually

## Risks

Low risk. This change only adds new origins to the allowlist without modifying existing behavior.

## Deploy Plan

Standard deployment - no special steps required.
