### PR TITLE
Do not fech content for agent messages in agent loop, except the last X.

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,3 +1,4 @@
+import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -26,6 +27,7 @@ import {
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isArrayOf } from "@app/types/shared/typescipt_utils";
@@ -43,8 +45,17 @@ export const getConversation = async (
   auth: Authenticator,
   conversationId: string,
   includeDeleted: boolean = false,
-  branchId: string | null = null
-) => _getConversation(auth, conversationId, includeDeleted, branchId, "full");
+  branchId: string | null = null,
+  lastInteractionsToFetchContentFor: number | null = null
+) =>
+  _getConversation(
+    auth,
+    conversationId,
+    includeDeleted,
+    branchId,
+    "full",
+    lastInteractionsToFetchContentFor
+  );
 
 export const getLightConversation = async (
   auth: Authenticator,
@@ -58,7 +69,8 @@ async function _getConversation<V extends "light" | "full">(
   conversationId: string,
   includeDeleted: boolean = false,
   branchId: string | null = null,
-  viewType: V = "full" as V
+  viewType: V = "full" as V,
+  lastInteractionsToFetchContentFor: number | null = null
 ): Promise<
   Result<
     V extends "light"
@@ -153,11 +165,52 @@ async function _getConversation<V extends "light" | "full">(
     ],
   });
 
+  let outputItemContentOnlyForAgentMessageIds: Set<ModelId> | null = null;
+
+  // In the case of the agentic loop, to save memory and latency, we only want to fetch content for the last N interactions.
+  if (lastInteractionsToFetchContentFor !== null) {
+    if (lastInteractionsToFetchContentFor <= 0) {
+      outputItemContentOnlyForAgentMessageIds = new Set();
+    } else {
+      const interactions = groupMessagesIntoInteractions(
+        removeNulls(
+          messages.map((m) => {
+            if (m.userMessageId) {
+              return {
+                id: m.userMessageId,
+                role: "user",
+              };
+            } else if (m.agentMessageId) {
+              return {
+                id: m.agentMessageId,
+                role: "agent",
+              };
+            }
+            // We don't care about the other messages.
+          })
+        )
+      );
+
+      // Keep the last N interactions with the highest ranks (order is correct because of the sort above).
+      const interactionsToKeep = interactions.slice(
+        -lastInteractionsToFetchContentFor
+      );
+
+      // We only need to fetch content for the actions of the last N interactions.
+      outputItemContentOnlyForAgentMessageIds = new Set(
+        interactionsToKeep.flatMap((i) =>
+          i.messages.filter((m) => m.role === "agent").map((m) => m.id)
+        )
+      );
+    }
+  }
+
   const renderRes = await batchRenderMessages(
     auth,
     conversation,
     messages,
-    viewType
+    viewType,
+    outputItemContentOnlyForAgentMessageIds
   );
 
   if (renderRes.isErr()) {

--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -1,0 +1,86 @@
+import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
+import { describe, expect, it } from "vitest";
+
+describe("groupMessagesIntoInteractions", () => {
+  type Tagged = { role: string; tag: string };
+
+  const msg = (role: string, tag: string): Tagged => ({ role, tag });
+
+  it("returns an empty array when there are no messages", () => {
+    expect(groupMessagesIntoInteractions([])).toEqual([]);
+  });
+
+  it("puts a lone user message in a single interaction", () => {
+    const interactions = groupMessagesIntoInteractions([msg("user", "u1")]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1"]);
+  });
+
+  it("keeps consecutive user and content_fragment messages in the same user turn", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("content_fragment", "cf1"),
+      msg("user", "u1"),
+      msg("content_fragment", "cf2"),
+      msg("user", "u2"),
+      msg("assistant", "a1"),
+      msg("function", "f1"),
+      msg("function", "f2"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "cf1",
+      "u1",
+      "cf2",
+      "u2",
+      "a1",
+      "f1",
+      "f2",
+    ]);
+  });
+
+  it("starts a new interaction when a user turn follows an agent turn", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+    ]);
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
+  });
+
+  it("keeps multiple consecutive agent messages in one interaction", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("function", "f1"),
+      msg("assistant", "a2"),
+      msg("function", "f2"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "u1",
+      "a1",
+      "f1",
+      "a2",
+      "f2",
+    ]);
+  });
+
+  it("closes the interaction after the last agent message when the next message is a user turn", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("function", "f1"),
+      msg("user", "u2"),
+    ]);
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "u1",
+      "a1",
+      "f1",
+    ]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u2"]);
+  });
+});

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -1,0 +1,58 @@
+import type {
+  InteractionWithTokens,
+  MinimalMessageType,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
+
+/**
+ * Group messages into interactions (user turn + agent responses),
+ * using turn type (user/content_fragment vs assistant/function) as the delimiter.
+ *
+ * Example: [content_fragment, user, content_fragment, user, assistant, function, function]
+ * results in a single interaction.
+ */
+export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
+  messages: T[]
+): InteractionWithTokens<T>[] {
+  const interactions: InteractionWithTokens<T>[] = [];
+  let currentInteraction: T[] = [];
+
+  // Determine the high-level turn type for a message.
+  // - "user": user messages and content fragments
+  // - "agent": assistant messages and tool/function results
+  const turnTypeForMessage = (message: T): "user" | "agent" => {
+    if (message.role === "user" || message.role === "content_fragment") {
+      return "user";
+    }
+    // Includes "assistant" and "function" roles
+    return "agent";
+  };
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    currentInteraction.push(message);
+
+    const isLastMessage = i === messages.length - 1;
+
+    // Decide if we should close the current interaction.
+    // We close when:
+    // - it's the last message, or
+    // - the next message is a "user" turn while the current message is an "agent" turn.
+    // This ensures that all consecutive user/content_fragment messages remain in the same
+    // user turn, followed by all agent/tool messages for that interaction.
+    const shouldClose = (() => {
+      if (isLastMessage) {
+        return true;
+      }
+      const currentTurn = turnTypeForMessage(message);
+      const nextTurn = turnTypeForMessage(messages[i + 1]);
+      return currentTurn === "agent" && nextTurn === "user";
+    })();
+
+    if (shouldClose) {
+      interactions.push({ messages: currentInteraction });
+      currentInteraction = [];
+    }
+  }
+
+  return interactions;
+}

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -1,3 +1,4 @@
+import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
 import { renderAllMessages } from "@app/lib/api/assistant/conversation_rendering/message_rendering";
 import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -21,7 +22,7 @@ import type { CredentialsType } from "@app/types/provider";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { InteractionWithTokens, MessageWithTokens } from "./pruning";
+import type { MessageWithTokens } from "./pruning";
 import {
   getInteractionTokenCount,
   progressivelyPruneInteraction,
@@ -29,7 +30,7 @@ import {
 } from "./pruning";
 
 // When previous interactions pruning is enabled, we'll attempt to fully preserve this number of interactions.
-const PREVIOUS_INTERACTIONS_TO_PRESERVE = 1;
+export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 1;
 
 // Fixed number of tokens assumed for image contents
 const IMAGE_CONTENT_TOKEN_COUNT = 3100;
@@ -284,62 +285,6 @@ export async function renderConversationForModel(
     tokensUsed,
     prunedContext,
   });
-}
-
-/**
- * Group messages into interactions (user turn + agent responses),
- * using turn type (user/content_fragment vs assistant/function) as the delimiter.
- *
- * Example: [content_fragment, user, content_fragment, user, assistant, function, function]
- * results in a single interaction.
- */
-function groupMessagesIntoInteractions(
-  messages: MessageWithTokens[]
-): InteractionWithTokens[] {
-  const interactions: InteractionWithTokens[] = [];
-  let currentInteraction: MessageWithTokens[] = [];
-
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i];
-    currentInteraction.push(message);
-
-    //Determine the high-level turn type for a message.
-    // - "user": user messages and content fragments
-    // - "agent": assistant messages and tool/function results*/
-    const turnTypeForMessage = (
-      message: MessageWithTokens
-    ): "user" | "agent" => {
-      if (message.role === "user" || message.role === "content_fragment") {
-        return "user";
-      }
-      // Includes "assistant" and "function" roles
-      return "agent";
-    };
-
-    const isLastMessage = i === messages.length - 1;
-
-    // Decide if we should close the current interaction.
-    // We close when:
-    // - it's the last message, or
-    // - the next message is a "user" turn while the current message is an "agent" turn.
-    // This ensures that all consecutive user/content_fragment messages remain in the same
-    // user turn, followed by all agent/tool messages for that interaction.
-    const shouldClose = (() => {
-      if (isLastMessage) {
-        return true;
-      }
-      const currentTurn = turnTypeForMessage(message);
-      const nextTurn = turnTypeForMessage(messages[i + 1]);
-      return currentTurn === "agent" && nextTurn === "user";
-    })();
-
-    if (shouldClose) {
-      interactions.push({ messages: currentInteraction });
-      currentInteraction = [];
-    }
-  }
-
-  return interactions;
 }
 
 async function countTokensForMessages(

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -13,8 +13,12 @@ export type MessageWithTokens = ModelMessageTypeMultiActions & {
   tokenCount: number;
 };
 
-export type InteractionWithTokens = {
-  messages: MessageWithTokens[];
+export type MinimalMessageType = {
+  role: string;
+};
+
+export type InteractionWithTokens<T extends MinimalMessageType> = {
+  messages: T[];
   prunedContext?: boolean;
 };
 
@@ -22,9 +26,9 @@ export type InteractionWithTokens = {
  * Prunes all tool results in an interaction.
  * Returns a new interaction with all tool results replaced by placeholders.
  */
-export function pruneAllToolResults(
-  interaction: InteractionWithTokens
-): InteractionWithTokens {
+export function pruneAllToolResults<T extends MinimalMessageType>(
+  interaction: InteractionWithTokens<T>
+): InteractionWithTokens<T> {
   const prunedMessages = interaction.messages.map((msg) => {
     if (msg.role === "function") {
       return {
@@ -45,7 +49,7 @@ export function pruneAllToolResults(
  * Calculate total tokens for an interaction.
  */
 export function getInteractionTokenCount(
-  interaction: InteractionWithTokens
+  interaction: InteractionWithTokens<MessageWithTokens>
 ): number {
   return interaction.messages.reduce((sum, msg) => sum + msg.tokenCount, 0);
 }
@@ -55,9 +59,9 @@ export function getInteractionTokenCount(
  * Prunes from oldest to newest tool results until the interaction fits.
  */
 export function progressivelyPruneInteraction(
-  interaction: InteractionWithTokens,
+  interaction: InteractionWithTokens<MessageWithTokens>,
   maxTokens: number
-): InteractionWithTokens {
+): InteractionWithTokens<MessageWithTokens> {
   const currentTokens = getInteractionTokenCount(interaction);
   if (currentTokens <= maxTokens) {
     return interaction;
@@ -113,10 +117,10 @@ export function progressivelyPruneInteraction(
  * we'll fully prune the remaining interactions.
  */
 export function prunePreviousInteractions(
-  inputInteractions: InteractionWithTokens[],
+  inputInteractions: InteractionWithTokens<MessageWithTokens>[],
   maxTokens: number,
   interactionsToPreserve: number
-): InteractionWithTokens[] {
+): InteractionWithTokens<MessageWithTokens>[] {
   const interactions = [...inputInteractions];
 
   let shouldPrune = false;

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -304,7 +304,8 @@ async function batchRenderUserMessages(
 async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
   messages: MessageModel[],
-  viewType: V
+  viewType: V,
+  outputItemContentOnlyForAgentMessageIds: Set<ModelId> | null = null
 ): Promise<
   Result<
     V extends "full" ? AgentMessageType[] : LightAgentMessageType[],
@@ -369,18 +370,55 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     );
   }
 
-  const agentMCPActions = await AgentMCPActionResource.fetchByStepContents(
+  const allAgentMCPActions = await AgentMCPActionResource.fetchByStepContents(
     auth,
     {
       stepContents,
       latestVersionsOnly: true,
     }
   );
-  const actionsWithOutputs =
-    await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
-      actions: agentMCPActions,
-      ignoreContent: viewType === "light",
-    });
+
+  let agentMCPActionsWithContent: AgentMCPActionResource[] = [];
+  let agentMCPActionsWithoutContent: AgentMCPActionResource[] = [];
+
+  for (const action of allAgentMCPActions) {
+    // Light messages always exclude content for all actions.
+    // Otherwise, for full messages, we only include content for the actions that are in the optional outputItemContentOnlyForMessageIds.
+    if (
+      viewType === "light" ||
+      (outputItemContentOnlyForAgentMessageIds &&
+        !outputItemContentOnlyForAgentMessageIds.has(action.agentMessageId))
+    ) {
+      agentMCPActionsWithoutContent.push(action);
+    } else {
+      agentMCPActionsWithContent.push(action);
+    }
+  }
+
+  const [actionsWithOutputs, actionsWithoutOutputs] = await Promise.all([
+    AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+      actions: agentMCPActionsWithContent,
+      ignoreContent: false,
+    }),
+    AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+      actions: agentMCPActionsWithoutContent,
+      ignoreContent: true,
+    }),
+  ]);
+
+  const actionsByAgentMessageId: Record<
+    number,
+    AgentMCPActionWithOutputType[]
+  > = [...actionsWithOutputs, ...actionsWithoutOutputs].reduce(
+    (acc, a) => {
+      if (!acc[a.agentMessageId]) {
+        acc[a.agentMessageId] = [];
+      }
+      acc[a.agentMessageId].push(a);
+      return acc;
+    },
+    {} as Record<number, AgentMCPActionWithOutputType[]>
+  );
 
   const stepContentsByMessageId: Record<string, AgentStepContentResource[]> =
     stepContents.reduce(
@@ -413,9 +451,9 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       }
       const agentMessage = message.agentMessage;
 
-      const actions = actionsWithOutputs
-        .filter((a) => a.agentMessageId === agentMessage.id)
-        .sort((a, b) => a.step - b.step);
+      const actions = (actionsByAgentMessageId[agentMessage.id] ?? []).sort(
+        (a, b) => a.step - b.step
+      );
 
       const agentConfiguration = agentConfigurationsById.get(
         agentMessage.agentConfigurationId
@@ -643,7 +681,8 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
   conversation: ConversationResource,
   messages: MessageModel[],
-  viewType: V
+  viewType: V,
+  outputItemContentOnlyForAgentMessageIds: Set<ModelId> | null = null
 ): Promise<
   Result<
     V extends "full"
@@ -658,7 +697,12 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
 > {
   const [userMessages, agentMessagesRes, contentFragments] = await Promise.all([
     batchRenderUserMessages(auth, messages),
-    batchRenderAgentMessages(auth, messages, viewType),
+    batchRenderAgentMessages(
+      auth,
+      messages,
+      viewType,
+      outputItemContentOnlyForAgentMessageIds
+    ),
     batchRenderContentFragment(auth, conversation.sId, messages),
   ]);
 

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -512,7 +512,10 @@ describe("Output items with GCS storage", () => {
     // action2's items should still be fetchable.
     const remaining = await AgentMCPActionResource.fetchOutputItemsByActionIds(
       auth,
-      { actionIds: [action2.id], ignoreContent: false }
+      {
+        actionIds: [action2.id],
+        ignoreContent: false,
+      }
     );
     const items = remaining.get(action2.id);
     expect(items).toHaveLength(1);
@@ -522,7 +525,7 @@ describe("Output items with GCS storage", () => {
     });
   });
 
-  it("fetchOutputItemsByActionIds returns an empty map for empty actionIds", async () => {
+  it("fetchOutputItemsByActionIds returns an empty map when both id lists are empty", async () => {
     const map = await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
       actionIds: [],
       ignoreContent: false,
@@ -531,7 +534,7 @@ describe("Output items with GCS storage", () => {
     expect(map.size).toBe(0);
   });
 
-  it("fetchOutputItemsByActionIds with ignoreContent true does not load content or GCS path", async () => {
+  it("fetchOutputItemsByActionIds with actionIdsWithoutContent does not load content or GCS path", async () => {
     const { action, outputItems } = await createActionWithOutputItems([
       { type: "text", text: "not loaded" },
     ]);
@@ -546,6 +549,50 @@ describe("Output items with GCS storage", () => {
     expect(items![0].id).toBe(outputItems[0].id);
     expect(items![0].content).toBeUndefined();
     expect(items![0].contentGcsPath).toBeUndefined();
+  });
+
+  it("fetchOutputItemsByActionIds mixes metadata-only and full-content actions in one call", async () => {
+    const { action: actionMetadataOnly } = await createActionWithOutputItems([
+      { type: "text", text: "should not appear on row" },
+    ]);
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    const { action: actionWithContent } = await createActionWithOutputItems([
+      { type: "text", text: "loaded from GCS" },
+    ]);
+
+    const [a, b] = await Promise.all([
+      AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+        actionIds: [actionWithContent.id],
+        ignoreContent: false,
+      }),
+      AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+        actionIds: [actionMetadataOnly.id],
+        ignoreContent: true,
+      }),
+    ]);
+
+    const map = new Map<number, AgentMCPActionOutputItemModel[]>(
+      [...a, ...b].map(([actionId, items]) => [actionId, items])
+    );
+
+    const metaItems = map.get(actionMetadataOnly.id);
+    expect(metaItems).toHaveLength(1);
+    expect(metaItems![0].content).toBeUndefined();
+    expect(metaItems![0].contentGcsPath).toBeUndefined();
+
+    const fullItems = map.get(actionWithContent.id);
+    expect(fullItems).toHaveLength(1);
+    expect(fullItems![0].content).toEqual({
+      type: "text",
+      text: "loaded from GCS",
+    });
+    expect(fullItems![0].contentGcsPath).toBeTruthy();
   });
 
   it("fetchOutputItemsByActionIds loads legacy rows (no GCS path) from DB content", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -699,6 +699,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     let outputItems: AgentMCPActionOutputItemModel[] = [];
+
     if (ignoreContent) {
       outputItems = await AgentMCPActionOutputItemModel.findAll({
         attributes: { exclude: ["content", "contentGcsPath"] },
@@ -806,7 +807,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         { concurrency: FETCH_OUTPUT_ITEMS_CONCURRENCY }
       );
 
-      outputItems = batchResults.flat();
+      outputItems.push(...batchResults.flat());
     }
 
     const outputItemsByActionId = new Map<
@@ -869,7 +870,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     {
       actions,
       ignoreContent,
-    }: { actions: AgentMCPActionResource[]; ignoreContent: boolean }
+    }: {
+      actions: AgentMCPActionResource[];
+      ignoreContent: boolean;
+    }
   ): Promise<AgentMCPActionWithOutputType[]> {
     return tracer.trace(
       "agent_mcp_action.enrich_with_output_items",

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -3,6 +3,7 @@
  */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -22,7 +23,6 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-
 import type { Result } from "../shared/result";
 import { Err, Ok } from "../shared/result";
 import { isGlobalAgentId } from "./assistant";
@@ -94,7 +94,8 @@ async function getConversationForAgentLoop(
     auth,
     conversationId,
     false,
-    conversationBranchId
+    conversationBranchId,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE + 1 // X previous + the last one
   );
   if (res.isErr()) {
     throw res.error;
@@ -242,7 +243,8 @@ export async function getAgentLoopDataWithAuth(
       auth,
       conversationId,
       false,
-      conversationBranchId
+      conversationBranchId,
+      PREVIOUS_INTERACTIONS_TO_PRESERVE + 1 // X previous + the last one
     );
     if (conversationRes.isErr()) {
       if (conversationRes.error.type === "conversation_not_found") {


### PR DESCRIPTION
## Description

As we prune the last X interactions from their action's output "content" in renderConversationForModel, we do not need to fetch more than what's needed. It should reduce significantly the memory and cpu usage of the agentic loop for conversation with a lot of messages (as it did for the conversations/[id]/messages endpoint).

- Add support for specifying an optional list of messageIds for which we want to fetch the content, otherwise, fallback to the current behavior.
- In the getConversation() used in the agentic loop, pass the number of interactions to keep and then compute the messagesIds to get content for.

NEXT:
From my exploration to do this, I realize that we usually do NOT need the action's output in most (if not all) the places we use `getConversation()`.
My plan is to update them to use `getLightConversation()` (which do NOT fetch action's content at all) and then see what's left that requires `getConversation()`. I'll then probably invert the logic of the optional parameter.

## Tests

Local + updated and added.

## Risk

High as we touch what we send to the wire but I compared LLM traces before / after.

## Deploy Plan

Deploy front