### PR TITLE
Reinforced agent: per-workspace cron workflows instead of global workflow

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -18,6 +18,7 @@ export * from "./manage_authorized_domains";
 export * from "./manage_conversation_kill_switch";
 export * from "./manage_programmatic_usage_configuration";
 export * from "./manage_workspace_kill_switch";
+export * from "./reinforced_agent_workflow";
 export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";
 export * from "./reset_provisioned_members_not_in_directory";

--- a/front/lib/api/poke/plugins/workspaces/reinforced_agent_workflow.ts
+++ b/front/lib/api/poke/plugins/workspaces/reinforced_agent_workflow.ts
@@ -1,0 +1,59 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import {
+  launchReinforcedAgentWorkspaceCron,
+  stopReinforcedAgentWorkspaceCron,
+} from "@app/temporal/reinforced_agent/client";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const reinforcedAgentWorkflowPlugin = createPlugin({
+  manifest: {
+    id: "reinforced-agent-workflow",
+    name: "Reinforced Agent Workflow",
+    description:
+      "Start or stop the nightly reinforced agent cron workflow for this workspace.",
+    resourceTypes: ["workspaces"],
+    args: {
+      action: {
+        type: "enum",
+        label: "Action",
+        description: "Whether to start or stop the cron workflow.",
+        values: [
+          { label: "Start", value: "start" },
+          { label: "Stop", value: "stop" },
+        ],
+        multiple: false,
+      },
+    },
+  },
+  execute: async (auth, _, args) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const action = args.action[0];
+
+    switch (action) {
+      case "start": {
+        const result = await launchReinforcedAgentWorkspaceCron({
+          workspaceId: workspace.sId,
+        });
+        if (result.isErr()) {
+          return new Err(result.error);
+        }
+        return new Ok({
+          display: "text",
+          value: `Reinforced agent cron workflow started for workspace ${workspace.sId}.`,
+        });
+      }
+      case "stop": {
+        await stopReinforcedAgentWorkspaceCron({
+          workspaceId: workspace.sId,
+          stopReason: "Stopped via poke plugin",
+        });
+        return new Ok({
+          display: "text",
+          value: `Reinforced agent cron workflow stopped for workspace ${workspace.sId}.`,
+        });
+      }
+      default:
+        return new Err(new Error(`Unknown action: ${action}`));
+    }
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/reinforced_agent_workflow.ts
+++ b/front/lib/api/poke/plugins/workspaces/reinforced_agent_workflow.ts
@@ -1,6 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import {
   launchReinforcedAgentWorkspaceCron,
+  startReinforcedAgentWorkspaceWorkflow,
   stopReinforcedAgentWorkspaceCron,
 } from "@app/temporal/reinforced_agent/client";
 import { Err, Ok } from "@app/types/shared/result";
@@ -10,16 +11,19 @@ export const reinforcedAgentWorkflowPlugin = createPlugin({
     id: "reinforced-agent-workflow",
     name: "Reinforced Agent Workflow",
     description:
-      "Start or stop the nightly reinforced agent cron workflow for this workspace.",
+      "Run, start cron, or stop the reinforced agent workflow for this workspace.",
     resourceTypes: ["workspaces"],
     args: {
       action: {
         type: "enum",
         label: "Action",
-        description: "Whether to start or stop the cron workflow.",
+        description:
+          "Run now (one-off, no delay), Start cron (nightly schedule), or Stop cron.",
         values: [
-          { label: "Start", value: "start" },
-          { label: "Stop", value: "stop" },
+          { label: "Run now (batch)", value: "run-now-batch" },
+          { label: "Run now (no batching)", value: "run-now-no-batching" },
+          { label: "Start cron", value: "start-cron" },
+          { label: "Stop cron", value: "stop-cron" },
         ],
         multiple: false,
       },
@@ -30,7 +34,22 @@ export const reinforcedAgentWorkflowPlugin = createPlugin({
     const action = args.action[0];
 
     switch (action) {
-      case "start": {
+      case "run-now-batch":
+      case "run-now-no-batching": {
+        const useBatchMode = action === "run-now-batch";
+        const result = await startReinforcedAgentWorkspaceWorkflow({
+          workspaceId: workspace.sId,
+          useBatchMode,
+        });
+        if (result.isErr()) {
+          return new Err(result.error);
+        }
+        return new Ok({
+          display: "text",
+          value: `Reinforced agent workflow started in ${useBatchMode ? "batch" : "no batching"} mode (workflowId: ${result.value}).`,
+        });
+      }
+      case "start-cron": {
         const result = await launchReinforcedAgentWorkspaceCron({
           workspaceId: workspace.sId,
         });
@@ -42,7 +61,7 @@ export const reinforcedAgentWorkflowPlugin = createPlugin({
           value: `Reinforced agent cron workflow started for workspace ${workspace.sId}.`,
         });
       }
-      case "stop": {
+      case "stop-cron": {
         await stopReinforcedAgentWorkspaceCron({
           workspaceId: workspace.sId,
           stopReason: "Stopped via poke plugin",

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -6,7 +6,7 @@ import {
   sendBatchCallToLlm,
 } from "@app/lib/api/llm/batch_llm";
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import {
   aggregateSyntheticSuggestions,
@@ -40,24 +40,6 @@ async function getAuthForWorkspace(
     );
   }
   return Authenticator.internalAdminForWorkspace(workspaceId);
-}
-
-/**
- * List workspace sIds that have the reinforced_agents feature flag.
- */
-export async function getFlaggedWorkspacesActivity(): Promise<string[]> {
-  const allWorkspaces = await WorkspaceResource.listAll();
-  const flaggedIds: string[] = [];
-
-  for (const workspace of allWorkspaces) {
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    const featureFlags = await getFeatureFlags(auth);
-    if (featureFlags.includes("reinforced_agents")) {
-      flaggedIds.push(workspace.sId);
-    }
-  }
-
-  return flaggedIds;
 }
 
 /**

--- a/front/temporal/reinforced_agent/admin/cli.ts
+++ b/front/temporal/reinforced_agent/admin/cli.ts
@@ -1,21 +1,20 @@
-import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import {
-  launchReinforcedAgentWorkflow,
+  launchAllReinforcedAgentWorkspaceCrons,
+  launchReinforcedAgentWorkspaceCron,
   startReinforcedAgentForAgentWorkflow,
   startReinforcedAgentWorkspaceWorkflow,
-  stopReinforcedAgentWorkflow,
+  stopAllReinforcedAgentWorkspaceCrons,
+  stopReinforcedAgentWorkspaceCron,
 } from "@app/temporal/reinforced_agent/client";
-import { QUEUE_NAME } from "@app/temporal/reinforced_agent/config";
-import { runSignal } from "@app/temporal/reinforced_agent/signals";
-import { reinforcedAgentWorkflow } from "@app/temporal/reinforced_agent/workflows";
 import parseArgs from "minimist";
 
 function usage() {
   console.error(`Usage:
-  start                                                                          Start the cron workflow
-  stop                                                                           Stop the cron workflow
-  run-now                                                                        Trigger the top-level workflow immediately
-  run-workspace --workspace-id <sId> [--batch]                                  Run for a specific workspace (--batch defaults to false)
+  start                                                                          Start cron workflows for all flagged workspaces
+  stop                                                                           Stop cron workflows for all flagged workspaces
+  start-workspace --workspace-id <sId>                                          Start the cron workflow for a specific workspace
+  stop-workspace --workspace-id <sId>                                           Stop the cron workflow for a specific workspace
+  run-workspace --workspace-id <sId> [--batch]                                  Run once for a specific workspace (--batch defaults to false)
   run-agent --workspace-id <sId> --agent-id <sId> [--batch] [--days <n>]       Run for a specific agent (--batch defaults to false, --days defaults to 1)`);
 }
 
@@ -30,18 +29,31 @@ const main = async () => {
 
   switch (command) {
     case "start":
-      await launchReinforcedAgentWorkflow();
+      await launchAllReinforcedAgentWorkspaceCrons();
       return;
     case "stop":
-      await stopReinforcedAgentWorkflow({ stopReason: "Stopped via CLI" });
+      await stopAllReinforcedAgentWorkspaceCrons();
       return;
-    case "run-now": {
-      const client = await getTemporalClientForFrontNamespace();
-      await client.workflow.signalWithStart(reinforcedAgentWorkflow, {
-        workflowId: "reinforced-agent-workflow",
-        taskQueue: QUEUE_NAME,
-        signal: runSignal,
-        signalArgs: undefined,
+    case "start-workspace": {
+      const workspaceId = argv["workspace-id"];
+      if (!workspaceId) {
+        console.error("Error: --workspace-id is required");
+        usage();
+        process.exit(1);
+      }
+      await launchReinforcedAgentWorkspaceCron({ workspaceId });
+      return;
+    }
+    case "stop-workspace": {
+      const workspaceId = argv["workspace-id"];
+      if (!workspaceId) {
+        console.error("Error: --workspace-id is required");
+        usage();
+        process.exit(1);
+      }
+      await stopReinforcedAgentWorkspaceCron({
+        workspaceId,
+        stopReason: "Stopped via CLI",
       });
       return;
     }

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -65,7 +65,7 @@ export async function launchReinforcedAgentWorkspaceCron({
   const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
 
   await client.workflow.start(reinforcedAgentWorkspaceWorkflow, {
-    args: [{ workspaceId, useBatchMode: true }],
+    args: [{ workspaceId, useBatchMode: true, skipDelay: false }],
     taskQueue: QUEUE_NAME,
     workflowId,
     cronSchedule: `0 ${utcHour} * * *`,

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -2,12 +2,12 @@ import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { WorkflowHandle } from "@temporalio/client";
 import moment from "moment-timezone";
-
 import { QUEUE_NAME } from "./config";
 import {
   reinforcedAgentForAgentWorkflow,
@@ -113,9 +113,11 @@ export async function launchAllReinforcedAgentWorkspaceCrons(): Promise<
 > {
   const workspaceIds = await getFlaggedWorkspaceIds();
 
-  for (const workspaceId of workspaceIds) {
-    await launchReinforcedAgentWorkspaceCron({ workspaceId });
-  }
+  await concurrentExecutor(
+    workspaceIds,
+    (workspaceId) => launchReinforcedAgentWorkspaceCron({ workspaceId }),
+    { concurrency: 8 }
+  );
 
   logger.info(
     { workspaceCount: workspaceIds.length },
@@ -128,12 +130,15 @@ export async function launchAllReinforcedAgentWorkspaceCrons(): Promise<
 export async function stopAllReinforcedAgentWorkspaceCrons(): Promise<void> {
   const workspaceIds = await getFlaggedWorkspaceIds();
 
-  for (const workspaceId of workspaceIds) {
-    await stopReinforcedAgentWorkspaceCron({
-      workspaceId,
-      stopReason: "Stopped all via CLI",
-    });
-  }
+  await concurrentExecutor(
+    workspaceIds,
+    (workspaceId) =>
+      stopReinforcedAgentWorkspaceCron({
+        workspaceId,
+        stopReason: "Stopped all via CLI",
+      }),
+    { concurrency: 8 }
+  );
 
   logger.info(
     { workspaceCount: workspaceIds.length },

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -9,7 +9,6 @@ import type { WorkflowHandle } from "@temporalio/client";
 import moment from "moment-timezone";
 
 import { QUEUE_NAME } from "./config";
-import { runSignal } from "./signals";
 import {
   reinforcedAgentForAgentWorkflow,
   reinforcedAgentWorkspaceWorkflow,
@@ -65,12 +64,10 @@ export async function launchReinforcedAgentWorkspaceCron({
   const utcHour = getMidnightUtcHour(timezone);
   const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
 
-  await client.workflow.signalWithStart(reinforcedAgentWorkspaceWorkflow, {
+  await client.workflow.start(reinforcedAgentWorkspaceWorkflow, {
     args: [{ workspaceId, useBatchMode: true }],
     taskQueue: QUEUE_NAME,
     workflowId,
-    signal: runSignal,
-    signalArgs: undefined,
     cronSchedule: `0 ${utcHour} * * *`,
   });
 
@@ -159,7 +156,7 @@ export async function startReinforcedAgentWorkspaceWorkflow({
   const workflowId = `reinforced-agent-workspace-${workspaceId}-manual-${Date.now()}`;
 
   await client.workflow.start(reinforcedAgentWorkspaceWorkflow, {
-    args: [{ workspaceId, useBatchMode }],
+    args: [{ workspaceId, useBatchMode, skipDelay: true }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -1,4 +1,6 @@
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -10,7 +12,6 @@ import { QUEUE_NAME } from "./config";
 import { runSignal } from "./signals";
 import {
   reinforcedAgentForAgentWorkflow,
-  reinforcedAgentWorkflow,
   reinforcedAgentWorkspaceWorkflow,
 } from "./workflows";
 
@@ -22,46 +23,130 @@ function getMidnightUtcHour(timezone: string): number {
   return midnightInTz.utc().hour();
 }
 
-export async function launchReinforcedAgentWorkflow(): Promise<
-  Result<undefined, Error>
-> {
+function makeWorkspaceCronWorkflowId(workspaceId: string): string {
+  return `reinforced-agent-workspace-${workspaceId}`;
+}
+
+/**
+ * List workspace sIds that have the reinforced_agents feature flag.
+ */
+async function getFlaggedWorkspaceIds(): Promise<string[]> {
+  const allWorkspaces = await WorkspaceResource.listAll();
+  const flaggedIds: string[] = [];
+
+  for (const workspace of allWorkspaces) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const featureFlags = await getFeatureFlags(auth);
+    if (featureFlags.includes("reinforced_agents")) {
+      flaggedIds.push(workspace.sId);
+    }
+  }
+
+  return flaggedIds;
+}
+
+// ---------------------------------------------------------------------------
+// Per-workspace cron lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Launch a cron-scheduled workflow for a single workspace.
+ * The cron fires at regional midnight; the workflow itself spreads execution
+ * over a 0–2 hour window using a deterministic delay.
+ */
+export async function launchReinforcedAgentWorkspaceCron({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const region = config.getCurrentRegion();
   const timezone = REGION_TIMEZONES[region];
   const utcHour = getMidnightUtcHour(timezone);
+  const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
 
-  await client.workflow.signalWithStart(reinforcedAgentWorkflow, {
-    args: [],
+  await client.workflow.signalWithStart(reinforcedAgentWorkspaceWorkflow, {
+    args: [{ workspaceId, useBatchMode: true }],
     taskQueue: QUEUE_NAME,
-    workflowId: "reinforced-agent-workflow",
+    workflowId,
     signal: runSignal,
     signalArgs: undefined,
     cronSchedule: `0 ${utcHour} * * *`,
   });
 
   logger.info(
-    { region, timezone, utcHour },
-    "[ReinforcedAgent] Launched workflow."
+    { region, timezone, utcHour, workflowId, workspaceId },
+    "[ReinforcedAgent] Launched workspace cron workflow."
   );
 
   return new Ok(undefined);
 }
 
-export async function stopReinforcedAgentWorkflow({
+/**
+ * Stop the cron-scheduled workflow for a single workspace.
+ */
+export async function stopReinforcedAgentWorkspaceCron({
+  workspaceId,
   stopReason,
 }: {
+  workspaceId: string;
   stopReason: string;
 }) {
   const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
 
   try {
-    const handle: WorkflowHandle<typeof reinforcedAgentWorkflow> =
-      client.workflow.getHandle("reinforced-agent-workflow");
+    const handle: WorkflowHandle<typeof reinforcedAgentWorkspaceWorkflow> =
+      client.workflow.getHandle(workflowId);
     await handle.terminate(stopReason);
   } catch (e) {
-    logger.error({ error: e }, "[ReinforcedAgent] Failed stopping workflow.");
+    logger.error(
+      { error: e, workflowId, workspaceId },
+      "[ReinforcedAgent] Failed stopping workspace cron workflow."
+    );
   }
 }
+
+// ---------------------------------------------------------------------------
+// Bulk operations (all flagged workspaces)
+// ---------------------------------------------------------------------------
+
+export async function launchAllReinforcedAgentWorkspaceCrons(): Promise<
+  Result<undefined, Error>
+> {
+  const workspaceIds = await getFlaggedWorkspaceIds();
+
+  for (const workspaceId of workspaceIds) {
+    await launchReinforcedAgentWorkspaceCron({ workspaceId });
+  }
+
+  logger.info(
+    { workspaceCount: workspaceIds.length },
+    "[ReinforcedAgent] Launched cron workflows for all flagged workspaces."
+  );
+
+  return new Ok(undefined);
+}
+
+export async function stopAllReinforcedAgentWorkspaceCrons(): Promise<void> {
+  const workspaceIds = await getFlaggedWorkspaceIds();
+
+  for (const workspaceId of workspaceIds) {
+    await stopReinforcedAgentWorkspaceCron({
+      workspaceId,
+      stopReason: "Stopped all via CLI",
+    });
+  }
+
+  logger.info(
+    { workspaceCount: workspaceIds.length },
+    "[ReinforcedAgent] Stopped cron workflows for all flagged workspaces."
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Manual one-off runs
+// ---------------------------------------------------------------------------
 
 export async function startReinforcedAgentWorkspaceWorkflow({
   workspaceId,

--- a/front/temporal/reinforced_agent/signals.ts
+++ b/front/temporal/reinforced_agent/signals.ts
@@ -1,3 +1,0 @@
-import { defineSignal } from "@temporalio/workflow";
-
-export const runSignal = defineSignal<[void]>("run_signal");

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -10,12 +10,9 @@ import {
   executeChild,
   ParentClosePolicy,
   proxyActivities,
-  setHandler,
   sleep,
 } from "@temporalio/workflow";
 import { concurrentExecutor } from "../utils";
-
-import { runSignal } from "./signals";
 
 // Export an interceptors variable to add OpenTelemetry interceptors to the workflow.
 export const interceptors: WorkflowInterceptorsFactory = () => ({
@@ -93,23 +90,19 @@ function computeWorkspaceDelayMs(workspaceId: string): number {
 
 /**
  * Workspace-level workflow (one per workspace, cron-scheduled).
- * When triggered by cron, sleeps a deterministic delay derived from the
- * workspace ID to spread load across the midnight–2am window, then lists
- * active agents and starts a child workflow for each.
+ * When `skipDelay` is false (cron runs), sleeps a deterministic delay derived
+ * from the workspace ID to spread load across the midnight–2am window.
+ * When `skipDelay` is true (manual runs), starts immediately.
  */
 export async function reinforcedAgentWorkspaceWorkflow({
   workspaceId,
   useBatchMode,
+  skipDelay = false,
 }: {
   workspaceId: string;
   useBatchMode: boolean;
+  skipDelay?: boolean;
 }): Promise<void> {
-  let skipDelay = false;
-  setHandler(runSignal, () => {
-    skipDelay = true;
-  });
-
-  // When run via cron (no signal), spread start times across 0–2 hours.
   if (!skipDelay) {
     const delayMs = computeWorkspaceDelayMs(workspaceId);
     if (delayMs > 0) {

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -24,10 +24,6 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
   internals: [new OpenTelemetryInternalsInterceptor()],
 });
 
-const { getFlaggedWorkspacesActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
-});
-
 const { getAgentConfigurationsActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
@@ -72,11 +68,6 @@ const { processAggregationBatchResultActivity } = proxyActivities<
   startToCloseTimeout: "30 minutes",
 });
 
-// Note on concurrency: we can reach (WORKSPACE_CONCURRENCY x AGENT_CONCURRENCY) simulateneous workflows
-// and it may be way higher than the worker's maxConcurrentActivityTaskExecutions but this is OK
-// as a lot of the time will be spent waiting for the batch to finish so many workflows should not
-// have any activity running.
-const WORKSPACE_CONCURRENCY = 8;
 const AGENT_CONCURRENCY = 8;
 const CONVERSATION_ANALYSIS_CONCURRENCY = 4;
 
@@ -85,30 +76,26 @@ const BATCH_POLL_INTERVAL_MAX_MS = 5 * 60_000; // 5 minutes (linear backoff cap)
 const BATCH_POLL_INTERVAL_STEP_MS = 10_000; // 10 seconds (linear backoff step).
 const BATCH_TIMEOUT_MS = 6 * 60 * 60_000; // 6 hours.
 
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+
 /**
- * Top-level workflow: find flagged workspaces and start a child workflow for each.
+ * Compute a deterministic delay (0 to 2 hours) from a workspace ID string.
+ * This spreads cron-triggered executions across the midnight–2am window
+ * without using non-deterministic APIs (safe for Temporal replay).
  */
-export async function reinforcedAgentWorkflow(): Promise<void> {
-  setHandler(runSignal, () => {
-    // Empty handler — receiving the signal triggers a workflow execution.
-  });
-
-  const workspaceIds = await getFlaggedWorkspacesActivity();
-
-  await concurrentExecutor(
-    workspaceIds,
-    (workspaceId) =>
-      executeChild(reinforcedAgentWorkspaceWorkflow, {
-        workflowId: `reinforced-agent-workspace-${workspaceId}`,
-        args: [{ workspaceId, useBatchMode: true }],
-        parentClosePolicy: ParentClosePolicy.ABANDON,
-      }),
-    { concurrency: WORKSPACE_CONCURRENCY }
-  );
+function computeWorkspaceDelayMs(workspaceId: string): number {
+  let hash = 0;
+  for (const ch of workspaceId) {
+    hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0;
+  }
+  return Math.abs(hash) % TWO_HOURS_MS;
 }
 
 /**
- * Workspace-level workflow: list active agents and start a child workflow for each.
+ * Workspace-level workflow (one per workspace, cron-scheduled).
+ * When triggered by cron, sleeps a deterministic delay derived from the
+ * workspace ID to spread load across the midnight–2am window, then lists
+ * active agents and starts a child workflow for each.
  */
 export async function reinforcedAgentWorkspaceWorkflow({
   workspaceId,
@@ -117,6 +104,19 @@ export async function reinforcedAgentWorkspaceWorkflow({
   workspaceId: string;
   useBatchMode: boolean;
 }): Promise<void> {
+  let skipDelay = false;
+  setHandler(runSignal, () => {
+    skipDelay = true;
+  });
+
+  // When run via cron (no signal), spread start times across 0–2 hours.
+  if (!skipDelay) {
+    const delayMs = computeWorkspaceDelayMs(workspaceId);
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
   const agentIds = await getAgentConfigurationsActivity({ workspaceId });
 
   await concurrentExecutor(


### PR DESCRIPTION
## Description

- Replace the single global reinforced agent workflow with one cron workflow per workspace, each running nightly
- Each workspace's workflow sleeps a deterministic delay (0–2 hours, derived from workspace ID hash) to spread load across the midnight–2am window
- CLI updated: start/stop manage all flagged workspaces, start-workspace/stop-workspace manage a single workspace
- New workspace-level poke plugin with 4 actions: Run now (batch), Run now (no batching), Start cron, Stop cron
 
## Tests

Manual

## Risk

Low

## Deploy Plan

Front