### PR TITLE
[Email Agents] PSL-aware domain alignment for DMARC auth

### DIFF
--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -33,16 +33,15 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
   });
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
-  const nextIsEnabled = !isEnabled;
-  const confirmDialogTitle = nextIsEnabled
-    ? "Enable email agents"
-    : "Disable email agents";
-  const confirmDialogDescription = nextIsEnabled
-    ? ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE
-    : `All users in your company will no longer be able to forward emails to their agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}.`;
-  const confirmButtonLabel = nextIsEnabled
-    ? "Enable email agents"
-    : "Disable email agents";
+  const confirmDialogTitle = isEnabled
+    ? "Disable email agents"
+    : "Enable email agents";
+  const confirmDialogDescription = isEnabled
+    ? `All users in your company will no longer be able to forward emails to their agents at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}.`
+    : ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE;
+  const confirmButtonLabel = isEnabled
+    ? "Disable email agents"
+    : "Enable email agents";
 
   return (
     <>
@@ -104,7 +103,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
             <Button
               label={confirmButtonLabel}
               disabled={isChanging}
-              variant={nextIsEnabled ? "primary" : "warning"}
+              variant={isEnabled ? "warning" : "primary"}
               onClick={async () => {
                 const isSuccess = await doToggleEmailAgents();
 

--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -92,8 +92,25 @@ describe("domainsAlign", () => {
   });
 
   it("does not align on partial suffix matches", () => {
-    // "evilcompany.com" should not align with "company.com".
     expect(domainsAlign("evilcompany.com", "company.com")).toBe(false);
+  });
+
+  it("aligns sibling subdomains sharing the same registered domain", () => {
+    expect(domainsAlign("alerts.company.com", "mailer.company.com")).toBe(true);
+  });
+
+  it("does not align domains under a public suffix (PSL-aware)", () => {
+    expect(domainsAlign("a.co.uk", "b.co.uk")).toBe(false);
+    expect(domainsAlign("a.com.au", "b.com.au")).toBe(false);
+  });
+
+  it("aligns subdomains under a ccTLD registered domain", () => {
+    expect(domainsAlign("mail.company.co.uk", "company.co.uk")).toBe(true);
+  });
+
+  it("returns false for bare public suffixes", () => {
+    expect(domainsAlign("co.uk", "co.uk")).toBe(false);
+    expect(domainsAlign("com", "com")).toBe(false);
   });
 });
 

--- a/front/lib/api/assistant/email/inbound_auth.test.ts
+++ b/front/lib/api/assistant/email/inbound_auth.test.ts
@@ -112,6 +112,12 @@ describe("domainsAlign", () => {
     expect(domainsAlign("co.uk", "co.uk")).toBe(false);
     expect(domainsAlign("com", "com")).toBe(false);
   });
+
+  it("does not align different registrations under a private suffix", () => {
+    // github.io is a private PSL entry; foo.github.io and bar.github.io
+    // are separate registrations and must not align.
+    expect(domainsAlign("foo.github.io", "bar.github.io")).toBe(false);
+  });
 });
 
 describe("evaluateInboundAuth", () => {

--- a/front/lib/api/assistant/email/inbound_auth.ts
+++ b/front/lib/api/assistant/email/inbound_auth.ts
@@ -1,5 +1,6 @@
 import type { InboundEmail } from "@app/lib/api/assistant/email/email_trigger";
 import logger from "@app/logger/logger";
+import { getDomain } from "tldts";
 
 const REPEATED_DKIM_ENTRY_SEPARATOR_PATTERN = /\}\s*,?\s*\{/g;
 const SENDGRID_DKIM_ENTRY_PATTERN = /^@([^:\s]+)\s*:\s*([^,\s}]+)$/;
@@ -81,23 +82,20 @@ function getEmailDomain(email: string): string {
 
 /**
  * Relaxed domain alignment per DMARC RFC 7489 §3.1.
- * Two domains are aligned when they share the same organizational domain,
- * i.e. one is a subdomain of the other or they are equal.
- *
- * Limitation: this is suffix-based, not PSL-aware — domains under public
- * suffixes like co.uk could incorrectly align (e.g. a.co.uk / b.co.uk).
- * TODO: replace with PSL-aware organizational-domain extraction.
+ * Two domains are aligned when they share the same organizational domain
+ * (registered domain under the Public Suffix List).
+ * Uses `tldts` for PSL-aware extraction, e.g. `a.co.uk` and `b.co.uk`
+ * correctly do NOT align.
  */
 export function domainsAlign(a: string, b: string): boolean {
-  const la = a.toLowerCase();
-  const lb = b.toLowerCase();
+  const orgA = getDomain(a, { allowPrivateDomains: true });
+  const orgB = getDomain(b, { allowPrivateDomains: true });
 
-  if (la === lb) {
-    return true;
+  if (!orgA || !orgB) {
+    return false;
   }
 
-  // One is a subdomain of the other: "mail.example.com" aligns with "example.com".
-  return la.endsWith(`.${lb}`) || lb.endsWith(`.${la}`);
+  return orgA.toLowerCase() === orgB.toLowerCase();
 }
 
 /**

--- a/front/package.json
+++ b/front/package.json
@@ -207,6 +207,7 @@
     "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
+    "tldts": "^7.0.27",
     "tmp": "^0.2.5",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "turndown": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -485,6 +485,7 @@
         "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
+        "tldts": "^7.0.27",
         "tmp": "^0.2.5",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "turndown": "^7.2.2",
@@ -622,6 +623,15 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "front/node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -54138,21 +54148,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.24.tgz",
-      "integrity": "sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==",
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.24"
+        "tldts-core": "^7.0.27"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.24.tgz",
-      "integrity": "sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==",
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "license": "MIT"
     },
     "node_modules/tmp": {


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/23317 and https://github.com/dust-tt/dust/pull/23356

Replaces the suffix-based `domainsAlign` heuristic with PSL-aware organizational domain extraction using `tldts`. This fixes two issues:

- **False positives**: `a.co.uk` / `b.co.uk` no longer incorrectly align (they have different registered domains under the `.co.uk` public suffix)
- **Sibling subdomains**: `alerts.company.com` / `mailer.company.com` now correctly align (they share the `company.com` registered domain)

Uses `allowPrivateDomains: true` so private-use suffixes (e.g. hosted platforms) are also handled.

Also includes a small readability refactor in `EmailAgentsToggle`: removes the `nextIsEnabled` indirection per [review comment](https://github.com/dust-tt/dust/pull/23331#discussion_r2999648304).

## Risks

Blast radius: inbound email authentication for email agents
Risk: low — strictly improves correctness of domain alignment; same auth paths, just better domain comparison

## Deploy Plan

- deploy front