### PR TITLE
[Stripe Webhook] Fix initial free-credit grant race

### DIFF
--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -14,6 +14,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
+import { UniqueConstraintError } from "sequelize";
 import type Stripe from "stripe";
 
 const BRACKET_1_USERS = 10;
@@ -254,13 +255,29 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
   const periodStart = new Date(stripeSubscription.current_period_start * 1000);
   const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
-  const credit = await CreditResource.makeNew(auth, {
-    type: "free",
-    initialAmountMicroUsd: creditAmountMicroUsd,
-    consumedAmountMicroUsd: 0,
-    discount: null,
-    invoiceOrLineItemId: idempotencyKey,
-  });
+  let credit: CreditResource;
+  try {
+    credit = await CreditResource.makeNew(auth, {
+      type: "free",
+      initialAmountMicroUsd: creditAmountMicroUsd,
+      consumedAmountMicroUsd: 0,
+      discount: null,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+  } catch (error) {
+    if (error instanceof UniqueConstraintError) {
+      logger.info(
+        {
+          workspaceId: workspaceSId,
+          subscriptionId: stripeSubscription.id,
+          idempotencyKey,
+        },
+        "[Free Credits] Credit already exists for this billing cycle, skipping"
+      );
+      return new Ok(undefined);
+    }
+    throw error;
+  }
 
   logger.info(
     {
@@ -413,13 +430,29 @@ export async function grantFreeCreditFromSubscriptionStateChangeYearly({
   const periodStart = new Date(stripeSubscription.current_period_start * 1000);
   const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
-  const credit = await CreditResource.makeNew(auth, {
-    type: "free",
-    initialAmountMicroUsd: creditAmountMicroUsd,
-    consumedAmountMicroUsd: 0,
-    discount: null,
-    invoiceOrLineItemId: idempotencyKey,
-  });
+  let credit: CreditResource;
+  try {
+    credit = await CreditResource.makeNew(auth, {
+      type: "free",
+      initialAmountMicroUsd: creditAmountMicroUsd,
+      consumedAmountMicroUsd: 0,
+      discount: null,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+  } catch (error) {
+    if (error instanceof UniqueConstraintError) {
+      logger.info(
+        {
+          workspaceId: workspaceSId,
+          subscriptionId: stripeSubscription.id,
+          idempotencyKey,
+        },
+        "[Free Credits Yearly] Credit already exists for this billing cycle, skipping"
+      );
+      return new Ok(undefined);
+    }
+    throw error;
+  }
 
   logger.info(
     {

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -14,7 +14,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
-import { UniqueConstraintError } from "sequelize";
 import type Stripe from "stripe";
 
 const BRACKET_1_USERS = 10;
@@ -255,28 +254,25 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
   const periodStart = new Date(stripeSubscription.current_period_start * 1000);
   const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
-  let credit: CreditResource;
-  try {
-    credit = await CreditResource.makeNew(auth, {
+  const { credit, created } =
+    await CreditResource.makeNewOrFetchByInvoiceOrLineItemId(auth, {
       type: "free",
       initialAmountMicroUsd: creditAmountMicroUsd,
       consumedAmountMicroUsd: 0,
       discount: null,
       invoiceOrLineItemId: idempotencyKey,
     });
-  } catch (error) {
-    if (error instanceof UniqueConstraintError) {
-      logger.info(
-        {
-          workspaceId: workspaceSId,
-          subscriptionId: stripeSubscription.id,
-          idempotencyKey,
-        },
-        "[Free Credits] Credit already exists for this billing cycle, skipping"
-      );
-      return new Ok(undefined);
-    }
-    throw error;
+
+  if (!created) {
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        creditId: credit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
   }
 
   logger.info(
@@ -430,28 +426,25 @@ export async function grantFreeCreditFromSubscriptionStateChangeYearly({
   const periodStart = new Date(stripeSubscription.current_period_start * 1000);
   const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
-  let credit: CreditResource;
-  try {
-    credit = await CreditResource.makeNew(auth, {
+  const { credit, created } =
+    await CreditResource.makeNewOrFetchByInvoiceOrLineItemId(auth, {
       type: "free",
       initialAmountMicroUsd: creditAmountMicroUsd,
       consumedAmountMicroUsd: 0,
       discount: null,
       invoiceOrLineItemId: idempotencyKey,
     });
-  } catch (error) {
-    if (error instanceof UniqueConstraintError) {
-      logger.info(
-        {
-          workspaceId: workspaceSId,
-          subscriptionId: stripeSubscription.id,
-          idempotencyKey,
-        },
-        "[Free Credits Yearly] Credit already exists for this billing cycle, skipping"
-      );
-      return new Ok(undefined);
-    }
-    throw error;
+
+  if (!created) {
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        creditId: credit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits Yearly] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
   }
 
   logger.info(

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -75,6 +75,33 @@ export class CreditResource extends BaseResource<CreditModel> {
     return new this(this.model, credit.get());
   }
 
+  static async makeNewOrFetchByInvoiceOrLineItemId(
+    auth: Authenticator,
+    blob: Omit<CreationAttributes<CreditModel>, "boughtByUserId"> & {
+      boughtByUserId?: number | null;
+      invoiceOrLineItemId: string;
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<{ credit: CreditResource; created: boolean }> {
+    try {
+      const credit = await this.makeNew(auth, blob, { transaction });
+      return { credit, created: true };
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        const existingCredit = await this.fetchByInvoiceOrLineItemId(
+          auth,
+          blob.invoiceOrLineItemId
+        );
+        assert(
+          existingCredit,
+          "Credit not found after duplicate invoiceOrLineItemId create attempt"
+        );
+        return { credit: existingCredit, created: false };
+      }
+      throw error;
+    }
+  }
+
   private static async baseFetch(
     auth: Authenticator,
     options?: ResourceFindOptions<CreditModel>

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -222,6 +222,8 @@ async function handler(
                 `Cannot subscribe to plan ${planCode}: not found.`
               );
             }
+            const checkoutStripeSubscription =
+              await stripe.subscriptions.retrieve(stripeSubscriptionId);
 
             await withTransaction(async (t) => {
               const activeSubscription =
@@ -274,8 +276,6 @@ async function handler(
               if (activeSubscription) {
                 await activeSubscription.markAsEnded("ended", t);
               }
-              const stripeSubscription =
-                await stripe.subscriptions.retrieve(stripeSubscriptionId);
 
               await SubscriptionResource.makeNew(
                 {
@@ -283,7 +283,7 @@ async function handler(
                   workspaceId: workspace.id,
                   planId: plan.id,
                   status: "active",
-                  trialing: stripeSubscription.status === "trialing",
+                  trialing: checkoutStripeSubscription.status === "trialing",
                   startDate: now,
                   stripeSubscriptionId: stripeSubscriptionId,
                 },
@@ -291,6 +291,31 @@ async function handler(
                 t
               );
             });
+            const auth = await Authenticator.internalAdminForWorkspace(
+              workspace.sId
+            );
+            const shouldGrantFreeCreditsOnCheckoutCompletion =
+              checkoutStripeSubscription.status === "active" ||
+              checkoutStripeSubscription.status === "trialing";
+
+            if (shouldGrantFreeCreditsOnCheckoutCompletion) {
+              const freeCreditsResult = await grantFreeCreditsForSubscription({
+                auth,
+                stripeSubscription: checkoutStripeSubscription,
+              });
+
+              if (freeCreditsResult.isErr()) {
+                logger.error(
+                  {
+                    error: freeCreditsResult.error,
+                    subscriptionId: checkoutStripeSubscription.id,
+                    workspaceId: workspace.sId,
+                  },
+                  "[Stripe Webhook] Error granting free credits on checkout.session.completed"
+                );
+              }
+            }
+
             if (userId) {
               const workspaceSeats =
                 await MembershipResource.countActiveSeatsInWorkspace(
@@ -304,9 +329,7 @@ async function handler(
                 subscriptionStartAt: now,
               });
             }
-            await restoreWorkspaceAfterSubscription(
-              await Authenticator.internalAdminForWorkspace(workspace.sId)
-            );
+            await restoreWorkspaceAfterSubscription(auth);
 
             await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({
               workspaceId,


### PR DESCRIPTION
## Description
This grants the initial free credits from `checkout.session.completed` immediately after creating the local subscription row in the region that owns the workspace.

This closes the race where `customer.subscription.created` or `customer.subscription.updated` can arrive before `fetchByStripeId()` sees the new subscription, which skips the first billing cycle credit grant.

The existing free-credit idempotency key keeps later subscription events safe.

## Risks
Blast radius: Stripe paid-plan activation in `front`, specifically the initial free-credit grant path.
Risk: low

## Deploy Plan
- deploy front