### PR TITLE
[Agent Email] Remove email_agents feature flag

### DIFF
--- a/front/components/pages/workspace/WorkspaceSettingsPage.tsx
+++ b/front/components/pages/workspace/WorkspaceSettingsPage.tsx
@@ -43,7 +43,6 @@ export function WorkspaceSettingsPage() {
         publishingRestrictionMessage={getPublishingRestrictionMessage(
           featureFlags
         )}
-        isEmailAgentsAvailable={featureFlags.includes("email_agents")}
       />
       <IntegrationsSection
         owner={owner}

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -8,13 +8,11 @@ import { ContextItem, Page } from "@dust-tt/sparkle";
 interface CapabilitiesSectionProps {
   owner: WorkspaceType;
   publishingRestrictionMessage: string | null;
-  isEmailAgentsAvailable: boolean;
 }
 
 export function CapabilitiesSection({
   owner,
   publishingRestrictionMessage,
-  isEmailAgentsAvailable,
 }: CapabilitiesSectionProps) {
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -23,7 +21,7 @@ export function CapabilitiesSection({
         <div className="h-full border-b border-border dark:border-border-night" />
         <InteractiveContentSharingToggle owner={owner} />
         <VoiceTranscriptionToggle owner={owner} />
-        {isEmailAgentsAvailable && <EmailAgentsToggle owner={owner} />}
+        <EmailAgentsToggle owner={owner} />
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability
             subElement={publishingRestrictionMessage}

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -60,7 +60,7 @@ export function EmailAgentsToggle({ owner }: EmailAgentsToggleProps) {
               <code>AGENT_NAME@{ASSISTANT_EMAIL_SUBDOMAIN}</code>
             </span>
             <a
-              href="https://dust-tt.notion.site/Email-Agents-32028599d94181209594fbf1402b720d"
+              href="https://docs.dust.tt/docs/email-agents"
               target="_blank"
               rel="noopener noreferrer"
               className="text-action-400 hover:text-action-500 text-sm"

--- a/front/lib/api/assistant/email/email_reply.test.ts
+++ b/front/lib/api/assistant/email/email_reply.test.ts
@@ -6,7 +6,7 @@ import {
   sendToolValidationEmail,
   storeEmailReplyContext,
 } from "@app/lib/api/assistant/email/email_trigger";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
@@ -34,7 +34,6 @@ vi.mock("@app/lib/auth", () => ({
   Authenticator: {
     fromJSON: vi.fn(),
   },
-  getFeatureFlags: vi.fn(),
 }));
 
 vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
@@ -71,7 +70,6 @@ describe("sendEmailReplyOnCompletion", () => {
         }),
       },
     } as never);
-    vi.mocked(getFeatureFlags).mockResolvedValue(["email_agents"]);
     vi.mocked(ConversationResource.fetchById).mockResolvedValue({} as never);
     vi.mocked(
       AgentMCPActionResource.listBlockedActionsForConversation
@@ -129,5 +127,56 @@ describe("sendEmailReplyOnCompletion", () => {
     expect(replyToEmail).toHaveBeenCalledTimes(1);
     expect(sendToolValidationEmail).not.toHaveBeenCalled();
     expect(storeEmailReplyContext).not.toHaveBeenCalled();
+  });
+
+  it("skips the reply when email agents are disabled in workspace metadata", async () => {
+    vi.mocked(Authenticator.fromJSON).mockResolvedValue({
+      isErr: () => false,
+      value: {
+        getNonNullableWorkspace: () => ({
+          metadata: { allowEmailAgents: false },
+        }),
+      },
+    } as never);
+    vi.mocked(getEmailReplyContext).mockResolvedValue({
+      subject: "Test",
+      originalText: "Hello",
+      fromEmail: "sender@dust.tt",
+      fromFull: "Sender <sender@dust.tt>",
+      threadingMessageId: "<incoming-message-id@dust.tt>",
+      threadingInReplyTo: null,
+      threadingReferences: null,
+      agentConfigurationId: "agent-config-1",
+      workspaceId: "workspace-1",
+      conversationId: "conversation-1",
+    } as never);
+    vi.mocked(getAgentLoopData).mockResolvedValue({
+      isErr: () => false,
+      value: {
+        auth: {},
+        agentMessage: {
+          sId: "agent-message-1",
+          content: "Done",
+        },
+        conversation: {
+          sId: "conversation-1",
+        },
+      },
+    } as never);
+
+    await sendEmailReplyOnCompletion(
+      { workspaceId: "workspace-1" } as never,
+      {
+        agentMessageId: "agent-message-1",
+        userMessageOrigin: "email",
+      } as never
+    );
+
+    expect(deleteEmailReplyContext).toHaveBeenCalledWith(
+      "workspace-1",
+      "agent-message-1"
+    );
+    expect(replyToEmail).not.toHaveBeenCalled();
+    expect(sendToolValidationEmail).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -11,11 +11,7 @@ import {
   storeEmailReplyContext,
 } from "@app/lib/api/assistant/email/email_trigger";
 import config from "@app/lib/api/config";
-import {
-  Authenticator,
-  type AuthenticatorType,
-  getFeatureFlags,
-} from "@app/lib/auth";
+import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -54,30 +50,19 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
 }
 
 /**
- * Defense-in-depth: check feature flag before sending email replies.
- * Duplicates the webhook handler check in case Redis data is manipulated
- * or context is stored incorrectly.
+ * Defense-in-depth: check the workspace toggle before sending email replies.
+ * Duplicates the webhook handler check in case Redis data is manipulated or
+ * context is stored incorrectly.
  */
 async function isEmailAgentsEnabled(
   authType: AuthenticatorType
 ): Promise<boolean> {
   const authResult = await Authenticator.fromJSON(authType);
   if (authResult.isErr()) {
-    logger.warn(
-      "[email] Failed to create authenticator for feature flag check"
-    );
+    logger.warn("[email] Failed to create authenticator for email reply check");
     return false;
   }
-  const auth = authResult.value;
-  const workspace = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("email_agents")) {
-    logger.info(
-      { workspaceId: authType.workspaceId },
-      "[email] email_agents feature flag not enabled, skipping reply"
-    );
-    return false;
-  }
+  const workspace = authResult.value.getNonNullableWorkspace();
   if (workspace.metadata?.allowEmailAgents !== true) {
     logger.info(
       { workspaceId: authType.workspaceId },

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -13,7 +13,7 @@ import { generateValidationToken } from "@app/lib/api/email/validation_token";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisStreamClient } from "@app/lib/api/redis";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -463,22 +463,11 @@ export async function userAndWorkspaceFromEmail({
     });
   }
 
-  // Filter to workspaces with the email_agents feature flag enabled.
-  const eligibleWorkspaceModels: typeof workspaceModels = [];
-  for (const w of workspaceModels) {
-    const lightWorkspace = renderLightWorkspaceType({ workspace: w });
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      lightWorkspace.sId
-    );
-    const flags = await getFeatureFlags(auth);
-    if (
-      flags.includes("email_agents") &&
-      lightWorkspace.metadata?.allowEmailAgents === true
-    ) {
-      eligibleWorkspaceModels.push(w);
-    }
-  }
+  const eligibleWorkspaceModels = workspaceModels.filter(
+    (workspaceModel) =>
+      renderLightWorkspaceType({ workspace: workspaceModel }).metadata
+        ?.allowEmailAgents === true
+  );
 
   if (eligibleWorkspaceModels.length === 0) {
     return new Err({

--- a/front/lib/resources/feature_flag_resource.ts
+++ b/front/lib/resources/feature_flag_resource.ts
@@ -3,7 +3,10 @@ import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import {
+  isWhitelistableFeature,
+  type WhitelistableFeature,
+} from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
@@ -32,7 +35,9 @@ export class FeatureFlagResource extends BaseResource<FeatureFlagModel> {
       where: { workspaceId: workspace.id },
     });
 
-    return flags.map((f) => new FeatureFlagResource(FeatureFlagModel, f.get()));
+    return flags
+      .map((f) => new FeatureFlagResource(FeatureFlagModel, f.get()))
+      .filter((flag) => isWhitelistableFeature(flag.name));
   }
 
   static async isEnabledForWorkspace(

--- a/front/migrations/20260329_delete_email_agents_feature_flag.ts
+++ b/front/migrations/20260329_delete_email_agents_feature_flag.ts
@@ -1,0 +1,62 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const FEATURE_FLAG_NAME = "email_agents";
+
+makeScript({}, async ({ execute }, logger) => {
+  const [{ count }] = await frontSequelize.query<{ count: number }>(
+    `
+      SELECT COUNT(*)::int AS count
+      FROM feature_flags
+      WHERE name = :featureFlag
+    `,
+    {
+      replacements: { featureFlag: FEATURE_FLAG_NAME },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  logger.info(
+    {
+      execute,
+      featureFlag: FEATURE_FLAG_NAME,
+      workspaceCount: count,
+    },
+    "Found legacy email_agents feature flags."
+  );
+
+  if (count === 0) {
+    return;
+  }
+
+  if (!execute) {
+    logger.info(
+      {
+        featureFlag: FEATURE_FLAG_NAME,
+        workspaceCount: count,
+      },
+      "Would delete legacy email_agents feature flags."
+    );
+    return;
+  }
+
+  await frontSequelize.query(
+    `
+      DELETE FROM feature_flags
+      WHERE name = :featureFlag
+    `,
+    {
+      replacements: { featureFlag: FEATURE_FLAG_NAME },
+    }
+  );
+
+  logger.info(
+    {
+      featureFlag: FEATURE_FLAG_NAME,
+      workspaceCount: count,
+    },
+    "Deleted legacy email_agents feature flags."
+  );
+});

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -21,7 +21,7 @@ import {
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
 import apiConfig from "@app/lib/api/config";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -304,16 +304,6 @@ async function handler(
         user.sId,
         workspace.sId
       );
-
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("email_agents")) {
-        await replyToError(email, {
-          type: "invalid_email_error",
-          message:
-            "Email interactions with agents are not enabled for your workspace.",
-        });
-        return;
-      }
 
       if (workspace.metadata?.allowEmailAgents !== true) {
         await replyToError(email, {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -203,10 +203,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
   },
-  email_agents: {
-    description: "Enable triggering and interacting with agents via email",
-    stage: "dust_only",
-  },
   project_butler: {
     description: "Enable user project digest generation in project spaces",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -693,7 +693,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disallow_agent_creation_to_users"
   | "discord_bot"
   | "discover_skills"
-  | "email_agents"
   | "dust_academy"
   | "dust_internal_global_agents"
   | "dust_no_spa"


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/22751

Removes `email_agents` gating from inbound email handling, reply sending, and workspace settings so `allowEmailAgents` is the only runtime control. Also removes the shared flag definition and adds a cleanup migration for legacy `feature_flags` rows.

## Risks
Blast radius: Email agent enablement, workspace feature flag listings, and legacy feature flag cleanup.
Risk: low

## Deploy Plan
- deploy front
- after the new front build is fully rolled out, run `front/migrations/20260329_delete_email_agents_feature_flag.ts`

## Test
- [x] `NODE_ENV=test npm test -- lib/api/assistant/email/email_reply.test.ts`