### PR TITLE
[front] feat: add public endpoint for uploading skill

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -20,43 +20,6 @@ type ImportSkillsResult = {
   errored: { name: string; message: string }[];
 };
 
-function isSkillFromFileImportSource(
-  skill: SkillResource,
-  {
-    source,
-    repoUrl,
-  }: {
-    source: FileImportSource;
-    repoUrl?: string;
-  }
-): boolean {
-  if (skill.source !== source) {
-    return false;
-  }
-
-  if (source !== "api" || !repoUrl) {
-    return true;
-  }
-
-  return skill.sourceMetadata?.repoUrl === repoUrl;
-}
-
-function buildSourceMetadata({
-  filePath,
-  repoUrl,
-  source,
-}: {
-  filePath: string;
-  repoUrl?: string;
-  source: FileImportSource;
-}) {
-  if (source === "api" && repoUrl) {
-    return { filePath, repoUrl };
-  }
-
-  return { filePath };
-}
-
 /**
  * Imports skills from uploaded files. Detects skills from the files,
  * then creates or updates SkillResource objects.
@@ -67,12 +30,10 @@ export async function importSkillsFromFiles(
     uploadedFiles,
     names,
     source = "local_file",
-    repoUrl,
   }: {
     uploadedFiles: formidable.File[];
     names?: string[];
     source?: FileImportSource;
-    repoUrl?: string;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const detectResult = await detectSkillsFromUploadedFiles(uploadedFiles);
@@ -106,10 +67,7 @@ export async function importSkillsFromFiles(
     async (skill) => {
       const existing = await SkillResource.fetchActiveByName(auth, skill.name);
 
-      if (
-        existing &&
-        !isSkillFromFileImportSource(existing, { source, repoUrl })
-      ) {
+      if (existing && existing.source !== source) {
         errored.push({
           name: skill.name,
           message: `A different skill named "${skill.name}" already exists.`,
@@ -130,11 +88,7 @@ export async function importSkillsFromFiles(
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
           source,
-          sourceMetadata: buildSourceMetadata({
-            filePath: skill.skillMdPath,
-            repoUrl,
-            source,
-          }),
+          sourceMetadata: { filePath: skill.skillMdPath },
         });
 
         updated.push(existing);
@@ -167,11 +121,7 @@ export async function importSkillsFromFiles(
             extendedSkillId: null,
             icon,
             source,
-            sourceMetadata: buildSourceMetadata({
-              filePath: skill.skillMdPath,
-              repoUrl,
-              source,
-            }),
+            sourceMetadata: { filePath: skill.skillMdPath },
             isDefault: false,
           },
           { mcpServerViews: [] }

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -41,7 +41,11 @@ export async function importSkillsFromFiles(
 
   const detectedSkills = detectResult.value;
   if (detectedSkills.length === 0) {
-    return new Err(new Error("No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification)."));
+    return new Err(
+      new Error(
+        "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification)."
+      )
+    );
   }
 
   const requestedNames = names ? new Set(names) : null;
@@ -55,7 +59,7 @@ export async function importSkillsFromFiles(
     return new Err(new Error("No matching importable skills found."));
   }
 
-  const user = auth.getNonNullableUser();
+  const user = auth.user();
   const imported: SkillResource[] = [];
   const updated: SkillResource[] = [];
   const errored: { name: string; message: string }[] = [];
@@ -114,7 +118,7 @@ export async function importSkillsFromFiles(
             agentFacingDescription: skill.description,
             userFacingDescription: skill.description,
             instructions: skill.instructions,
-            editedBy: user.id,
+            editedBy: user?.id ?? null,
             requestedSpaceIds: [],
             extendedSkillId: null,
             icon,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -5,16 +5,57 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type formidable from "formidable";
 
 const IMPORT_CONCURRENCY = 4;
+const NO_DETECTED_SKILLS_ERROR_MESSAGE =
+  "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).";
+
+type FileImportSource = "github_action" | "local_file";
 
 type ImportSkillsResult = {
   imported: SkillResource[];
   updated: SkillResource[];
   errored: { name: string; message: string }[];
 };
+
+function isSkillFromFileImportSource(
+  skill: SkillResource,
+  {
+    source,
+    repoUrl,
+  }: {
+    source: FileImportSource;
+    repoUrl?: string;
+  }
+): boolean {
+  if (skill.source !== source) {
+    return false;
+  }
+
+  if (source !== "github_action" || !repoUrl) {
+    return true;
+  }
+
+  return skill.sourceMetadata?.repoUrl === repoUrl;
+}
+
+function buildSourceMetadata({
+  filePath,
+  repoUrl,
+  source,
+}: {
+  filePath: string;
+  repoUrl?: string;
+  source: FileImportSource;
+}) {
+  if (source === "github_action" && repoUrl) {
+    return { filePath, repoUrl };
+  }
+
+  return { filePath };
+}
 
 /**
  * Imports skills from uploaded files. Detects skills from the files,
@@ -25,9 +66,13 @@ export async function importSkillsFromFiles(
   {
     uploadedFiles,
     names,
+    source = "local_file",
+    repoUrl,
   }: {
     uploadedFiles: formidable.File[];
-    names: string[];
+    names?: string[];
+    source?: FileImportSource;
+    repoUrl?: string;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const detectResult = await detectSkillsFromUploadedFiles(uploadedFiles);
@@ -36,12 +81,20 @@ export async function importSkillsFromFiles(
   }
 
   const detectedSkills = detectResult.value;
+  if (detectedSkills.length === 0) {
+    return new Err(new Error(NO_DETECTED_SKILLS_ERROR_MESSAGE));
+  }
 
-  const requestedNames = new Set(names);
+  const requestedNames = names ? new Set(names) : null;
   const selectedSkills = detectedSkills.filter(
     (skill) =>
-      skill.name && skill.instructions.trim() && requestedNames.has(skill.name)
+      skill.name &&
+      skill.instructions.trim() &&
+      (!requestedNames || requestedNames.has(skill.name))
   );
+  if (selectedSkills.length === 0) {
+    return new Err(new Error("No matching importable skills found."));
+  }
 
   const user = auth.getNonNullableUser();
   const imported: SkillResource[] = [];
@@ -53,7 +106,10 @@ export async function importSkillsFromFiles(
     async (skill) => {
       const existing = await SkillResource.fetchActiveByName(auth, skill.name);
 
-      if (existing && existing.source !== "local_file") {
+      if (
+        existing &&
+        !isSkillFromFileImportSource(existing, { source, repoUrl })
+      ) {
         errored.push({
           name: skill.name,
           message: `A different skill named "${skill.name}" already exists.`,
@@ -73,8 +129,12 @@ export async function importSkillsFromFiles(
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
-          source: "local_file",
-          sourceMetadata: { filePath: skill.skillMdPath },
+          source,
+          sourceMetadata: buildSourceMetadata({
+            filePath: skill.skillMdPath,
+            repoUrl,
+            source,
+          }),
         });
 
         updated.push(existing);
@@ -106,8 +166,12 @@ export async function importSkillsFromFiles(
             requestedSpaceIds: [],
             extendedSkillId: null,
             icon,
-            source: "local_file",
-            sourceMetadata: { filePath: skill.skillMdPath },
+            source,
+            sourceMetadata: buildSourceMetadata({
+              filePath: skill.skillMdPath,
+              repoUrl,
+              source,
+            }),
             isDefault: false,
           },
           { mcpServerViews: [] }

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -4,13 +4,14 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type formidable from "formidable";
 
 const IMPORT_CONCURRENCY = 4;
 
-type FileImportSource = "api" | "local_file";
+type FileImportSource = Extract<SkillSourceType, "api" | "local_file">;
 
 type ImportSkillsResult = {
   imported: SkillResource[];

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -12,7 +12,7 @@ const IMPORT_CONCURRENCY = 4;
 const NO_DETECTED_SKILLS_ERROR_MESSAGE =
   "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).";
 
-type FileImportSource = "github_action" | "local_file";
+type FileImportSource = "api" | "local_file";
 
 type ImportSkillsResult = {
   imported: SkillResource[];
@@ -34,7 +34,7 @@ function isSkillFromFileImportSource(
     return false;
   }
 
-  if (source !== "github_action" || !repoUrl) {
+  if (source !== "api" || !repoUrl) {
     return true;
   }
 
@@ -50,7 +50,7 @@ function buildSourceMetadata({
   repoUrl?: string;
   source: FileImportSource;
 }) {
-  if (source === "github_action" && repoUrl) {
+  if (source === "api" && repoUrl) {
     return { filePath, repoUrl };
   }
 

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -9,8 +9,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import type formidable from "formidable";
 
 const IMPORT_CONCURRENCY = 4;
-const NO_DETECTED_SKILLS_ERROR_MESSAGE =
-  "No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification).";
 
 type FileImportSource = "api" | "local_file";
 
@@ -43,7 +41,7 @@ export async function importSkillsFromFiles(
 
   const detectedSkills = detectResult.value;
   if (detectedSkills.length === 0) {
-    return new Err(new Error(NO_DETECTED_SKILLS_ERROR_MESSAGE));
+    return new Err(new Error("No skills found. Skills must contain a SKILL.md file with valid YAML frontmatter (see https://agentskills.io/specification)."));
   }
 
   const requestedNames = names ? new Set(names) : null;

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -1,16 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
-import { KeyResource } from "@app/lib/resources/key_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
-import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
 } from "@app/tests/utils/generic_public_api_tests";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { Ok } from "@app/types/shared/result";
-import type { NextApiRequest, NextApiResponse } from "next";
-import { createMocks } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
@@ -24,7 +19,7 @@ const serializedSkill: SkillType = {
   sId: "skill_new",
   createdAt: null,
   updatedAt: null,
-  editedBy: 1,
+  editedBy: null,
   status: "active",
   name: "Release Notes",
   agentFacingDescription: "Summarize releases",
@@ -64,31 +59,6 @@ describe(
   "public api authentication tests",
   createPublicApiAuthenticationTests(handler)
 );
-
-async function createNonBuilderPublicApiMockRequest() {
-  const workspace = await WorkspaceFactory.basic();
-  const { globalGroup } = await GroupFactory.defaults(workspace);
-  const key = await KeyResource.makeNew(
-    {
-      name: "non-builder-key",
-      workspaceId: workspace.id,
-      isSystem: false,
-      status: "active",
-      role: "user",
-    },
-    globalGroup
-  );
-
-  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-    method: "POST",
-    query: { wId: workspace.sId },
-    headers: {
-      authorization: `Bearer ${key.secret}`,
-    },
-  });
-
-  return { req, res };
-}
 
 describe("POST /api/v1/w/[wId]/skills", () => {
   beforeEach(() => {
@@ -143,20 +113,6 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       imported: [serializedSkill],
       updated: [],
       errored: [],
-    });
-  });
-
-  it("returns 403 when the caller is not a builder", async () => {
-    const { req, res } = await createNonBuilderPublicApiMockRequest();
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "app_auth_error",
-        message: "User is not a builder.",
-      },
     });
   });
 

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -66,56 +66,6 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     mockFormidable.mockReturnValue({ parse: mockParse });
   });
 
-  it("imports all uploaded skills through the api source", async () => {
-    const { req, res, auth } = await createPublicApiMockRequest({
-      method: "POST",
-    });
-
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
-
-    mockParse.mockResolvedValue([
-      {},
-      {
-        files: [
-          { filepath: "/tmp/skills.zip", originalFilename: "skills.zip" },
-        ],
-      },
-    ]);
-
-    const importedSkill: MockSkillResource = {
-      toJSON: vi.fn((_auth: Authenticator) => serializedSkill),
-    };
-
-    mockImportSkillsFromFiles.mockResolvedValue(
-      new Ok({
-        imported: [importedSkill],
-        updated: [],
-        errored: [],
-      })
-    );
-
-    await handler(req, res);
-
-    expect(mockImportSkillsFromFiles).toHaveBeenCalledTimes(1);
-    expect(mockImportSkillsFromFiles).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspaceId: auth.getNonNullableWorkspace().id,
-      }),
-      {
-        uploadedFiles: [
-          { filepath: "/tmp/skills.zip", originalFilename: "skills.zip" },
-        ],
-        source: "api",
-      }
-    );
-    expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual({
-      imported: [serializedSkill],
-      updated: [],
-      errored: [],
-    });
-  });
-
   it("returns 400 when no files are uploaded", async () => {
     const { req, res, auth } = await createPublicApiMockRequest({
       method: "POST",

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -85,7 +85,7 @@ function makeSerializedSkill(): SkillType {
     userFacingDescription: "Summarize releases",
     instructions: "Use the changelog.",
     icon: null,
-    source: "github_action",
+    source: "api",
     sourceMetadata: {
       repoUrl: "https://github.com/dust-tt/dust",
       filePath: "skills/release-notes/SKILL.md",
@@ -134,7 +134,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     mockGetFeatureFlags.mockResolvedValue(["sandbox_tools"]);
   });
 
-  it("imports all uploaded skills through the github_action source", async () => {
+  it("imports all uploaded skills through the api source", async () => {
     const { req, res } = makeRequest();
 
     mockParse.mockResolvedValue([
@@ -162,7 +162,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     expect(mockImportSkillsFromFiles).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        source: "github_action",
+        source: "api",
         repoUrl: "https://github.com/dust-tt/dust",
       })
     );

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -1,0 +1,242 @@
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { Ok } from "@app/types/shared/result";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./index";
+
+type TestAuth = {
+  isBuilder: () => boolean;
+};
+
+type AuthedRequest = NextApiRequest & {
+  auth: TestAuth;
+};
+
+type MockSkillResource = {
+  toJSON: (auth: TestAuth) => SkillType;
+};
+
+type ApiErrorPayload = {
+  status_code: number;
+  api_error: {
+    type: string;
+    message: string;
+  };
+};
+
+type PublicHandler = (
+  req: AuthedRequest,
+  res: NextApiResponse,
+  auth: TestAuth,
+  _session: null
+) => Promise<void> | void;
+
+const {
+  mockFormidable,
+  mockGetFeatureFlags,
+  mockImportSkillsFromFiles,
+  mockParse,
+} = vi.hoisted(() => ({
+  mockFormidable: vi.fn(),
+  mockGetFeatureFlags: vi.fn(),
+  mockImportSkillsFromFiles: vi.fn(),
+  mockParse: vi.fn(),
+}));
+
+vi.mock("formidable", () => ({
+  default: mockFormidable,
+}));
+
+vi.mock("@app/lib/api/skills/detection/files/import_skills", () => ({
+  importSkillsFromFiles: mockImportSkillsFromFiles,
+}));
+
+vi.mock("@app/lib/api/auth_wrappers", () => ({
+  withPublicAPIAuthentication: (handler: PublicHandler) => {
+    return async (req: AuthedRequest, res: NextApiResponse) =>
+      handler(req, res, req.auth, null);
+  },
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  getFeatureFlags: mockGetFeatureFlags,
+}));
+
+vi.mock("@app/logger/withlogging", () => ({
+  apiError: vi.fn(
+    (_req: NextApiRequest, res: NextApiResponse, error: ApiErrorPayload) => {
+      res.status(error.status_code).json({ error: error.api_error });
+    }
+  ),
+}));
+
+function makeSerializedSkill(): SkillType {
+  return {
+    id: 1,
+    sId: "skill_new",
+    createdAt: null,
+    updatedAt: null,
+    editedBy: 1,
+    status: "active",
+    name: "Release Notes",
+    agentFacingDescription: "Summarize releases",
+    userFacingDescription: "Summarize releases",
+    instructions: "Use the changelog.",
+    icon: null,
+    source: "github_action",
+    sourceMetadata: {
+      repoUrl: "https://github.com/dust-tt/dust",
+      filePath: "skills/release-notes/SKILL.md",
+    },
+    requestedSpaceIds: [],
+    tools: [],
+    fileAttachments: [],
+    canWrite: true,
+    isExtendable: true,
+    isDefault: false,
+    extendedSkillId: null,
+  };
+}
+
+function makeImportedSkill(): MockSkillResource {
+  return {
+    toJSON: vi.fn((_auth: TestAuth) => makeSerializedSkill()),
+  };
+}
+
+function makeRequest({
+  method = "POST",
+  isBuilder = true,
+}: {
+  method?: "GET" | "POST";
+  isBuilder?: boolean;
+} = {}) {
+  const { req: baseReq, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method,
+    query: { wId: "w_123" },
+  });
+
+  const req = Object.assign(baseReq, {
+    auth: {
+      isBuilder: vi.fn().mockReturnValue(isBuilder),
+    },
+  });
+
+  return { req, res };
+}
+
+describe("POST /api/v1/w/[wId]/skills", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFormidable.mockReturnValue({ parse: mockParse });
+    mockGetFeatureFlags.mockResolvedValue(["sandbox_tools"]);
+  });
+
+  it("imports all uploaded skills through the github_action source", async () => {
+    const { req, res } = makeRequest();
+
+    mockParse.mockResolvedValue([
+      {
+        repoUrl: ["https://github.com/dust-tt/dust"],
+      },
+      {
+        files: [
+          { filepath: "/tmp/skills.zip", originalFilename: "skills.zip" },
+        ],
+      },
+    ]);
+
+    mockImportSkillsFromFiles.mockResolvedValue(
+      new Ok({
+        imported: [makeImportedSkill()],
+        updated: [],
+        errored: [],
+      })
+    );
+
+    await handler(req, res);
+
+    expect(mockImportSkillsFromFiles).toHaveBeenCalledTimes(1);
+    expect(mockImportSkillsFromFiles).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source: "github_action",
+        repoUrl: "https://github.com/dust-tt/dust",
+      })
+    );
+    expect(mockImportSkillsFromFiles.mock.calls[0]?.[1]).not.toHaveProperty(
+      "names"
+    );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      imported: [makeSerializedSkill()],
+      updated: [],
+      errored: [],
+    });
+  });
+
+  it("returns 403 when the caller is not a builder", async () => {
+    const { req, res } = makeRequest({ isBuilder: false });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "User is not a builder.",
+      },
+    });
+  });
+
+  it("returns 400 when no files are uploaded", async () => {
+    const { req, res } = makeRequest();
+
+    mockParse.mockResolvedValue([
+      { repoUrl: ["https://github.com/dust-tt/dust"] },
+      {},
+    ]);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "No files uploaded.",
+      },
+    });
+  });
+
+  it("returns 403 when the workspace does not support skill import", async () => {
+    const { req, res } = makeRequest();
+
+    mockGetFeatureFlags.mockResolvedValue([]);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Skill import is not supported.",
+      },
+    });
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const { req, res } = makeRequest({ method: "GET" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  });
+});

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -1,43 +1,11 @@
-import type { Authenticator } from "@app/lib/auth";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
 } from "@app/tests/utils/generic_public_api_tests";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
-
-type MockSkillResource = {
-  toJSON: (auth: Authenticator) => SkillType;
-};
-
-const serializedSkill: SkillType = {
-  id: 1,
-  sId: "skill_new",
-  createdAt: null,
-  updatedAt: null,
-  editedBy: null,
-  status: "active",
-  name: "Release Notes",
-  agentFacingDescription: "Summarize releases",
-  userFacingDescription: "Summarize releases",
-  instructions: "Use the changelog.",
-  icon: null,
-  source: "api",
-  sourceMetadata: {
-    filePath: "skills/release-notes/SKILL.md",
-  },
-  requestedSpaceIds: [],
-  tools: [],
-  fileAttachments: [],
-  canWrite: true,
-  isExtendable: true,
-  isDefault: false,
-  extendedSkillId: null,
-};
 
 const { mockFormidable, mockImportSkillsFromFiles, mockParse } = vi.hoisted(
   () => ({

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -87,7 +87,6 @@ function makeSerializedSkill(): SkillType {
     icon: null,
     source: "api",
     sourceMetadata: {
-      repoUrl: "https://github.com/dust-tt/dust",
       filePath: "skills/release-notes/SKILL.md",
     },
     requestedSpaceIds: [],
@@ -138,9 +137,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     const { req, res } = makeRequest();
 
     mockParse.mockResolvedValue([
-      {
-        repoUrl: ["https://github.com/dust-tt/dust"],
-      },
+      {},
       {
         files: [
           { filepath: "/tmp/skills.zip", originalFilename: "skills.zip" },
@@ -163,11 +160,13 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       expect.anything(),
       expect.objectContaining({
         source: "api",
-        repoUrl: "https://github.com/dust-tt/dust",
       })
     );
     expect(mockImportSkillsFromFiles.mock.calls[0]?.[1]).not.toHaveProperty(
       "names"
+    );
+    expect(mockImportSkillsFromFiles.mock.calls[0]?.[1]).not.toHaveProperty(
+      "repoUrl"
     );
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({
@@ -194,10 +193,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   it("returns 400 when no files are uploaded", async () => {
     const { req, res } = makeRequest();
 
-    mockParse.mockResolvedValue([
-      { repoUrl: ["https://github.com/dust-tt/dust"] },
-      {},
-    ]);
+    mockParse.mockResolvedValue([{}, {}]);
 
     await handler(req, res);
 

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -1,3 +1,12 @@
+import type { Authenticator } from "@app/lib/auth";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import {
+  createPublicApiAuthenticationTests,
+  createPublicApiMockRequest,
+} from "@app/tests/utils/generic_public_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { Ok } from "@app/types/shared/result";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -6,44 +15,42 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
-type TestAuth = {
-  isBuilder: () => boolean;
-};
-
-type AuthedRequest = NextApiRequest & {
-  auth: TestAuth;
-};
-
 type MockSkillResource = {
-  toJSON: (auth: TestAuth) => SkillType;
+  toJSON: (auth: Authenticator) => SkillType;
 };
 
-type ApiErrorPayload = {
-  status_code: number;
-  api_error: {
-    type: string;
-    message: string;
-  };
+const serializedSkill: SkillType = {
+  id: 1,
+  sId: "skill_new",
+  createdAt: null,
+  updatedAt: null,
+  editedBy: 1,
+  status: "active",
+  name: "Release Notes",
+  agentFacingDescription: "Summarize releases",
+  userFacingDescription: "Summarize releases",
+  instructions: "Use the changelog.",
+  icon: null,
+  source: "api",
+  sourceMetadata: {
+    filePath: "skills/release-notes/SKILL.md",
+  },
+  requestedSpaceIds: [],
+  tools: [],
+  fileAttachments: [],
+  canWrite: true,
+  isExtendable: true,
+  isDefault: false,
+  extendedSkillId: null,
 };
 
-type PublicHandler = (
-  req: AuthedRequest,
-  res: NextApiResponse,
-  auth: TestAuth,
-  _session: null
-) => Promise<void> | void;
-
-const {
-  mockFormidable,
-  mockGetFeatureFlags,
-  mockImportSkillsFromFiles,
-  mockParse,
-} = vi.hoisted(() => ({
-  mockFormidable: vi.fn(),
-  mockGetFeatureFlags: vi.fn(),
-  mockImportSkillsFromFiles: vi.fn(),
-  mockParse: vi.fn(),
-}));
+const { mockFormidable, mockImportSkillsFromFiles, mockParse } = vi.hoisted(
+  () => ({
+    mockFormidable: vi.fn(),
+    mockImportSkillsFromFiles: vi.fn(),
+    mockParse: vi.fn(),
+  })
+);
 
 vi.mock("formidable", () => ({
   default: mockFormidable,
@@ -53,73 +60,30 @@ vi.mock("@app/lib/api/skills/detection/files/import_skills", () => ({
   importSkillsFromFiles: mockImportSkillsFromFiles,
 }));
 
-vi.mock("@app/lib/api/auth_wrappers", () => ({
-  withPublicAPIAuthentication: (handler: PublicHandler) => {
-    return async (req: AuthedRequest, res: NextApiResponse) =>
-      handler(req, res, req.auth, null);
-  },
-}));
+describe(
+  "public api authentication tests",
+  createPublicApiAuthenticationTests(handler)
+);
 
-vi.mock("@app/lib/auth", () => ({
-  getFeatureFlags: mockGetFeatureFlags,
-}));
-
-vi.mock("@app/logger/withlogging", () => ({
-  apiError: vi.fn(
-    (_req: NextApiRequest, res: NextApiResponse, error: ApiErrorPayload) => {
-      res.status(error.status_code).json({ error: error.api_error });
-    }
-  ),
-}));
-
-function makeSerializedSkill(): SkillType {
-  return {
-    id: 1,
-    sId: "skill_new",
-    createdAt: null,
-    updatedAt: null,
-    editedBy: 1,
-    status: "active",
-    name: "Release Notes",
-    agentFacingDescription: "Summarize releases",
-    userFacingDescription: "Summarize releases",
-    instructions: "Use the changelog.",
-    icon: null,
-    source: "api",
-    sourceMetadata: {
-      filePath: "skills/release-notes/SKILL.md",
+async function createNonBuilderPublicApiMockRequest() {
+  const workspace = await WorkspaceFactory.basic();
+  const { globalGroup } = await GroupFactory.defaults(workspace);
+  const key = await KeyResource.makeNew(
+    {
+      name: "non-builder-key",
+      workspaceId: workspace.id,
+      isSystem: false,
+      status: "active",
+      role: "user",
     },
-    requestedSpaceIds: [],
-    tools: [],
-    fileAttachments: [],
-    canWrite: true,
-    isExtendable: true,
-    isDefault: false,
-    extendedSkillId: null,
-  };
-}
+    globalGroup
+  );
 
-function makeImportedSkill(): MockSkillResource {
-  return {
-    toJSON: vi.fn((_auth: TestAuth) => makeSerializedSkill()),
-  };
-}
-
-function makeRequest({
-  method = "POST",
-  isBuilder = true,
-}: {
-  method?: "GET" | "POST";
-  isBuilder?: boolean;
-} = {}) {
-  const { req: baseReq, res } = createMocks<NextApiRequest, NextApiResponse>({
-    method,
-    query: { wId: "w_123" },
-  });
-
-  const req = Object.assign(baseReq, {
-    auth: {
-      isBuilder: vi.fn().mockReturnValue(isBuilder),
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method: "POST",
+    query: { wId: workspace.sId },
+    headers: {
+      authorization: `Bearer ${key.secret}`,
     },
   });
 
@@ -130,11 +94,14 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFormidable.mockReturnValue({ parse: mockParse });
-    mockGetFeatureFlags.mockResolvedValue(["sandbox_tools"]);
   });
 
   it("imports all uploaded skills through the api source", async () => {
-    const { req, res } = makeRequest();
+    const { req, res, auth } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     mockParse.mockResolvedValue([
       {},
@@ -145,9 +112,13 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       },
     ]);
 
+    const importedSkill: MockSkillResource = {
+      toJSON: vi.fn((_auth: Authenticator) => serializedSkill),
+    };
+
     mockImportSkillsFromFiles.mockResolvedValue(
       new Ok({
-        imported: [makeImportedSkill()],
+        imported: [importedSkill],
         updated: [],
         errored: [],
       })
@@ -157,27 +128,26 @@ describe("POST /api/v1/w/[wId]/skills", () => {
 
     expect(mockImportSkillsFromFiles).toHaveBeenCalledTimes(1);
     expect(mockImportSkillsFromFiles).toHaveBeenCalledWith(
-      expect.anything(),
       expect.objectContaining({
+        workspaceId: auth.getNonNullableWorkspace().id,
+      }),
+      {
+        uploadedFiles: [
+          { filepath: "/tmp/skills.zip", originalFilename: "skills.zip" },
+        ],
         source: "api",
-      })
-    );
-    expect(mockImportSkillsFromFiles.mock.calls[0]?.[1]).not.toHaveProperty(
-      "names"
-    );
-    expect(mockImportSkillsFromFiles.mock.calls[0]?.[1]).not.toHaveProperty(
-      "repoUrl"
+      }
     );
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({
-      imported: [makeSerializedSkill()],
+      imported: [serializedSkill],
       updated: [],
       errored: [],
     });
   });
 
   it("returns 403 when the caller is not a builder", async () => {
-    const { req, res } = makeRequest({ isBuilder: false });
+    const { req, res } = await createNonBuilderPublicApiMockRequest();
 
     await handler(req, res);
 
@@ -191,7 +161,11 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   });
 
   it("returns 400 when no files are uploaded", async () => {
-    const { req, res } = makeRequest();
+    const { req, res, auth } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     mockParse.mockResolvedValue([{}, {}]);
 
@@ -207,9 +181,9 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   });
 
   it("returns 403 when the workspace does not support skill import", async () => {
-    const { req, res } = makeRequest();
-
-    mockGetFeatureFlags.mockResolvedValue([]);
+    const { req, res } = await createPublicApiMockRequest({
+      method: "POST",
+    });
 
     await handler(req, res);
 
@@ -223,7 +197,9 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   });
 
   it("returns 405 for unsupported methods", async () => {
-    const { req, res } = makeRequest({ method: "GET" });
+    const { req, res } = await createPublicApiMockRequest({
+      method: "GET",
+    });
 
     await handler(req, res);
 

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -31,16 +31,6 @@ async function handler(
     });
   }
 
-  if (!auth.isBuilder()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "User is not a builder.",
-      },
-    });
-  }
-
   const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("sandbox_tools")) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -1,0 +1,110 @@
+/** @ignoreswagger */
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
+import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import formidable from "formidable";
+import type { NextApiRequest, NextApiResponse } from "next";
+import {isString} from "@app/types/shared/utils/general";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ImportSkillsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "User is not a builder.",
+      },
+    });
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("sandbox_tools")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Skill import is not supported.",
+      },
+    });
+  }
+
+  let fields: formidable.Fields;
+  let files: formidable.Files;
+  try {
+    const form = formidable({
+      multiples: true,
+      maxFileSize: MAX_ZIP_SIZE_BYTES,
+    });
+    [fields, files] = await form.parse(req);
+  } catch (err) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `File upload failed: ${normalizeError(err).message}`,
+      },
+    });
+  }
+
+  const uploadedFiles = files.files;
+  if (!uploadedFiles || uploadedFiles.length === 0) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "No files uploaded.",
+      },
+    });
+  }
+
+  const repoUrl =
+    isString(fields.repoUrl) ? fields.repoUrl : fields.repoUrl?.[0];
+
+  const result = await importSkillsFromFiles(auth, {
+    uploadedFiles,
+    source: "github_action",
+    repoUrl,
+  });
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: result.error.message,
+      },
+    });
+  }
+
+  return res.status(200).json({
+    imported: result.value.imported.map((skill) => skill.toJSON(auth)),
+    updated: result.value.updated.map((skill) => skill.toJSON(auth)),
+    errored: result.value.errored,
+  });
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -7,9 +7,9 @@ import { apiError } from "@app/logger/withlogging";
 import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import formidable from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
-import {isString} from "@app/types/shared/utils/general";
 
 export const config = {
   api: {
@@ -82,12 +82,13 @@ async function handler(
     });
   }
 
-  const repoUrl =
-    isString(fields.repoUrl) ? fields.repoUrl : fields.repoUrl?.[0];
+  const repoUrl = isString(fields.repoUrl)
+    ? fields.repoUrl
+    : fields.repoUrl?.[0];
 
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
-    source: "github_action",
+    source: "api",
     repoUrl,
   });
   if (result.isErr()) {

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -7,7 +7,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isString } from "@app/types/shared/utils/general";
 import formidable from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -53,14 +52,13 @@ async function handler(
     });
   }
 
-  let fields: formidable.Fields;
   let files: formidable.Files;
   try {
     const form = formidable({
       multiples: true,
       maxFileSize: MAX_ZIP_SIZE_BYTES,
     });
-    [fields, files] = await form.parse(req);
+    [, files] = await form.parse(req);
   } catch (err) {
     return apiError(req, res, {
       status_code: 400,
@@ -82,14 +80,9 @@ async function handler(
     });
   }
 
-  const repoUrl = isString(fields.repoUrl)
-    ? fields.repoUrl
-    : fields.repoUrl?.[0];
-
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
     source: "api",
-    repoUrl,
   });
   if (result.isErr()) {
     return apiError(req, res, {

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -4,7 +4,12 @@ import type { UserType } from "@app/types/user";
 
 export type SkillStatus = "active" | "archived" | "suggested";
 
-export const SKILL_SOURCES = ["web_app", "github", "local_file"] as const;
+export const SKILL_SOURCES = [
+  "web_app",
+  "github",
+  "github_action",
+  "local_file",
+] as const;
 
 export type SkillSourceType = (typeof SKILL_SOURCES)[number];
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -7,7 +7,7 @@ export type SkillStatus = "active" | "archived" | "suggested";
 export const SKILL_SOURCES = [
   "web_app",
   "github",
-  "github_action",
+  "api",
   "local_file",
 ] as const;
 


### PR DESCRIPTION
## Description

- This PR adds an `api/v1` endpoint for uploading a skill.
- A follow up PR will provide a GitHub action that bundles it to allow syncing skills to Dust as part of a CI/CD pipeline.
- Will refine the semantics of the endpoint in a follow up PR (both this endpoint and the private one) to prevent partial successes and either fully succeed or error.

## Tests

- Tested locally.

## Risk

- Low. Behind FF.

## Deploy Plan

- Deploy front.
