### PR TITLE
Skip message rate limiting for system-initiated messages

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1855,6 +1855,11 @@ async function checkMessagesLimit(
     context: UserMessageContext;
   }
 ): Promise<Result<void, APIErrorWithStatusCode>> {
+  // Skip rate limiting for system-initiated messages (e.g. reinforced agent workflows).
+  if (!auth.user() && !auth.key()) {
+    return new Ok(undefined);
+  }
+
   const messageLimit = await isMessagesLimitReached(auth, {
     mentions,
     context,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1856,7 +1856,7 @@ async function checkMessagesLimit(
   }
 ): Promise<Result<void, APIErrorWithStatusCode>> {
   // Skip rate limiting for system-initiated messages (e.g. reinforced agent workflows).
-  if (auth.authMethod() === "internal") {
+  if (!auth.user() && !auth.key() && auth.authMethod() === "internal") {
     return new Ok(undefined);
   }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1856,7 +1856,7 @@ async function checkMessagesLimit(
   }
 ): Promise<Result<void, APIErrorWithStatusCode>> {
   // Skip rate limiting for system-initiated messages (e.g. reinforced agent workflows).
-  if (!auth.user() && !auth.key()) {
+  if (auth.authMethod() === "internal") {
     return new Ok(undefined);
   }
 


### PR DESCRIPTION
## Description

- Internal admin authenticators (used by system workflows like the reinforced agent) have neither a user nor an API key, causing getMessageRateLimitActor to throw when postUserMessage is called
- Fix: skip checkMessagesLimit entirely when the authenticator has no user and no key, since system-initiated messages should not be rate-limited or counted against workspace message quotas. e.g. this is needed for the reinforced agent workflow scenario.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front