### PR TITLE
[Front] feat(image-gen): add OpenAI image generation for BYOK workspaces

### DIFF
--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -13,6 +13,7 @@ import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import {
   fileSizeToHumanReadable,
   isSupportedImageContentType,
@@ -21,23 +22,16 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { Part } from "@google/genai";
-import { createPartFromUri } from "@google/genai";
 import { z } from "zod";
 
-const GEMINI_SUPPORTED_IMAGE_TYPES = [
-  "image/bmp",
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-] as const;
+export class ImageGenerationError extends Error {
+  readonly data?: Record<string, unknown>;
 
-type GeminiSupportedImageType = (typeof GEMINI_SUPPORTED_IMAGE_TYPES)[number];
-
-function isGeminiSupportedImageType(
-  contentType: string
-): contentType is GeminiSupportedImageType {
-  return GEMINI_SUPPORTED_IMAGE_TYPES.some((type) => type === contentType);
+  constructor(message: string, data?: Record<string, unknown>) {
+    super(message);
+    this.name = "ImageGenerationError";
+    this.data = data;
+  }
 }
 
 export const IMAGE_GENERATION_RATE_LIMITER_KEY = "image_generation";
@@ -85,8 +79,8 @@ export function geminiPartsToBase64Images(
 }
 
 export function computeImageGenerationCostDetails(usageMetadata: {
-  promptTokenCount?: number;
-  candidatesTokenCount?: number;
+  inputTokens: number;
+  outputTokens: number;
 }): {
   inputTokens: number;
   outputTokens: number;
@@ -98,8 +92,8 @@ export function computeImageGenerationCostDetails(usageMetadata: {
     total: number;
   };
 } {
-  const inputTokens = usageMetadata.promptTokenCount ?? 0;
-  const outputTokens = usageMetadata.candidatesTokenCount ?? 0;
+  const inputTokens = usageMetadata.inputTokens;
+  const outputTokens = usageMetadata.outputTokens;
   const totalTokens = inputTokens + outputTokens;
 
   const totalCostMicroUsd = computeTokensCostForUsageInMicroUsd({
@@ -242,21 +236,24 @@ export function validateGeminiImageResponse(
   return new Ok(imageParts);
 }
 
-export function trackGeminiTokenUsage(response: {
-  usageMetadata?: {
-    promptTokenCount?: number;
-    candidatesTokenCount?: number;
-  };
+export function trackTokenUsage({
+  inputTokens,
+  outputTokens,
+  providerId,
+}: {
+  inputTokens: number;
+  outputTokens: number;
+  providerId: ModelProviderIdType;
 }): void {
   getStatsDClient().increment(
     "tools.image_generation.usage.input_tokens",
-    response.usageMetadata?.promptTokenCount ?? 0,
-    ["provider:gemini"]
+    inputTokens,
+    [`provider:${providerId}`]
   );
   getStatsDClient().increment(
     "tools.image_generation.usage.output_tokens",
-    response.usageMetadata?.candidatesTokenCount ?? 0,
-    ["provider:gemini"]
+    outputTokens,
+    [`provider:${providerId}`]
   );
 }
 
@@ -338,12 +335,14 @@ async function processSingleImageFile(
     imageFileId,
     conversationId,
     maxImageSize,
+    supportedContentTypes,
   }: {
     imageFileId: string;
     conversationId: string;
     maxImageSize: number;
+    supportedContentTypes: string[];
   }
-): Promise<Ok<Part> | Err<MCPError>> {
+): Promise<Ok<FileResource> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
   const fileResource = await FileResource.fetchById(auth, imageFileId);
   if (!fileResource) {
@@ -391,10 +390,12 @@ async function processSingleImageFile(
     );
   }
 
-  if (!isGeminiSupportedImageType(fileResource.contentType)) {
+  if (!supportedContentTypes.includes(fileResource.contentType)) {
     return new Err(
       new MCPError(
-        `File ${imageFileId} is not a supported image type for editing. Got: ${fileResource.contentType}. Supported types: ${GEMINI_SUPPORTED_IMAGE_TYPES.map((t) => t.replace("image/", "").toUpperCase()).join(", ")}.`,
+        `File ${imageFileId} is not a supported image type. Got: ${fileResource.contentType}. Supported types: ${supportedContentTypes
+          .map((t) => t.replace("image/", "").toUpperCase())
+          .join(", ")}.`,
         {
           tracked: false,
         }
@@ -402,12 +403,7 @@ async function processSingleImageFile(
     );
   }
 
-  const signedUrl = await fileResource.getSignedUrlForDownload(
-    auth,
-    "original"
-  );
-
-  return new Ok(createPartFromUri(signedUrl, fileResource.contentType));
+  return new Ok(fileResource);
 }
 
 export async function processImageFileIds(
@@ -415,11 +411,13 @@ export async function processImageFileIds(
   {
     imageFileIds,
     agentLoopContext,
+    supportedContentTypes,
   }: {
     imageFileIds: string[];
     agentLoopContext: AgentLoopContextType | undefined;
+    supportedContentTypes: string[];
   }
-): Promise<Ok<Part[]> | Err<MCPError>> {
+): Promise<Ok<FileResource[]> | Err<MCPError>> {
   if (!agentLoopContext?.runContext) {
     return new Err(
       new MCPError("No conversation context available for file access", {
@@ -438,6 +436,7 @@ export async function processImageFileIds(
         imageFileId,
         conversationId,
         maxImageSize,
+        supportedContentTypes,
       }),
     { concurrency: 8 }
   );
@@ -447,9 +446,9 @@ export async function processImageFileIds(
     return firstError;
   }
 
-  const parts = results
-    .filter((r): r is Ok<Part> => r.isOk())
+  const fileResources = results
+    .filter((r): r is Ok<FileResource> => r.isOk())
     .map((r) => r.value);
 
-  return new Ok(parts);
+  return new Ok(fileResources);
 }

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -12,7 +12,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
+import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import {
   fileSizeToHumanReadable,
@@ -21,16 +21,22 @@ import {
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { z } from "zod";
+
+export type ImageGenerationErrorCode =
+  | "api_error"
+  | "safety_blocked"
+  | "empty_response";
 
 export class ImageGenerationError extends Error {
-  readonly data?: Record<string, unknown>;
-
-  constructor(message: string, data?: Record<string, unknown>) {
-    super(message);
+  constructor(
+    public readonly code: ImageGenerationErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, { cause: options?.cause });
     this.name = "ImageGenerationError";
-    this.data = data;
   }
 }
 
@@ -49,39 +55,18 @@ export const QUALITY_TO_IMAGE_SIZE: Record<string, string> = {
   high: "4K",
 };
 
-const GeminiInlineDataPartSchema = z.object({
-  inlineData: z.object({
-    data: z.string(),
-    mimeType: z.string().optional(),
-  }),
-});
-
-export type GeminiInlineDataPart = z.infer<typeof GeminiInlineDataPartSchema>;
-
-export function isValidGeminiInlineDataPart(
-  part: unknown
-): part is GeminiInlineDataPart {
-  return GeminiInlineDataPartSchema.safeParse(part).success;
-}
-
 export type Base64ImageData = {
   base64: string;
   mimeType?: string;
 };
 
-export function geminiPartsToBase64Images(
-  parts: GeminiInlineDataPart[]
-): Base64ImageData[] {
-  return parts.map((part) => ({
-    base64: part.inlineData.data,
-    mimeType: part.inlineData.mimeType,
-  }));
-}
-
-export function computeImageGenerationCostDetails(usageMetadata: {
-  inputTokens: number;
-  outputTokens: number;
-}): {
+export function computeImageGenerationCostDetails(
+  usageMetadata: {
+    inputTokens: number;
+    outputTokens: number;
+  },
+  modelId: ImageModelIdType
+): {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -97,7 +82,7 @@ export function computeImageGenerationCostDetails(usageMetadata: {
   const totalTokens = inputTokens + outputTokens;
 
   const totalCostMicroUsd = computeTokensCostForUsageInMicroUsd({
-    modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
+    modelId,
     promptTokens: inputTokens,
     completionTokens: outputTokens,
     cachedTokens: null,
@@ -158,7 +143,8 @@ export async function sendImageProgressNotification(
 
 export async function checkImageGenerationRateLimit(
   auth: Authenticator,
-  workspace: { sId: string }
+  workspace: WorkspaceType,
+  providerId: ModelProviderIdType
 ): Promise<Ok<void> | Err<MCPError>> {
   const { limits } = auth.getNonNullablePlan();
   const { maxImagesPerWeek } = limits.capabilities.images;
@@ -172,7 +158,7 @@ export async function checkImageGenerationRateLimit(
 
   if (remaining <= 0) {
     getStatsDClient().increment("tools.image_generation.rate_limit_hit", 1, [
-      "provider:gemini",
+      `provider:${providerId}`,
     ]);
 
     return new Err(
@@ -187,53 +173,6 @@ export async function checkImageGenerationRateLimit(
   }
 
   return new Ok(undefined);
-}
-
-export function validateGeminiImageResponse(
-  response: {
-    candidates?: Array<{
-      content?: {
-        parts?: unknown[];
-      };
-    }>;
-    promptFeedback?: {
-      blockReason?: string;
-      safetyRatings?: unknown;
-    };
-  },
-  operationType: "generation" | "editing",
-  promptText: string
-): Ok<GeminiInlineDataPart[]> | Err<MCPError> {
-  if (!response.candidates || response.candidates.length === 0) {
-    if (response.promptFeedback?.blockReason) {
-      logger.error(
-        {
-          blockReason: response.promptFeedback.blockReason,
-          safetyRatings: response.promptFeedback.safetyRatings,
-          prompt: promptText,
-        },
-        `Gemini image ${operationType}: Prompt blocked by safety filters`
-      );
-      return new Err(
-        new MCPError(
-          `Image ${operationType} blocked by safety filters: ${response.promptFeedback.blockReason}`
-        )
-      );
-    }
-    return new Err(new MCPError("No image generated."));
-  }
-
-  const content = response.candidates[0].content;
-  if (!content || !content.parts) {
-    return new Err(new MCPError("No image data in response"));
-  }
-
-  const imageParts = content.parts.filter(isValidGeminiInlineDataPart);
-  if (imageParts.length === 0) {
-    return new Err(new MCPError("No image data in response."));
-  }
-
-  return new Ok(imageParts);
 }
 
 export function trackTokenUsage({
@@ -336,11 +275,13 @@ async function processSingleImageFile(
     conversationId,
     maxImageSize,
     supportedContentTypes,
+    providerId,
   }: {
     imageFileId: string;
     conversationId: string;
     maxImageSize: number;
     supportedContentTypes: string[];
+    providerId: ModelProviderIdType;
   }
 ): Promise<Ok<FileResource> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -377,7 +318,7 @@ async function processSingleImageFile(
     getStatsDClient().increment(
       "tools.image_generation.file_size_limit_exceeded",
       1,
-      ["provider:gemini"]
+      [`provider:${providerId}`]
     );
 
     return new Err(
@@ -412,10 +353,12 @@ export async function processImageFileIds(
     imageFileIds,
     agentLoopContext,
     supportedContentTypes,
+    providerId,
   }: {
     imageFileIds: string[];
     agentLoopContext: AgentLoopContextType | undefined;
     supportedContentTypes: string[];
+    providerId: ModelProviderIdType;
   }
 ): Promise<Ok<FileResource[]> | Err<MCPError>> {
   if (!agentLoopContext?.runContext) {
@@ -437,6 +380,7 @@ export async function processImageFileIds(
         conversationId,
         maxImageSize,
         supportedContentTypes,
+        providerId,
       }),
     { concurrency: 8 }
   );

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -75,10 +75,8 @@ const IMAGE_GENERATION_SERVER_INSTRUCTIONS =
   "- Be very specific about style, composition, colors, lighting, and mood\n" +
   "- In most usecases, medium quality is enough\n\n" +
   "REFERENCE IMAGES:\n" +
-  "- For object inclusion: up to 6 images to reproduce objects with high fidelity\n" +
-  "- For human consistency: up to 5 images to maintain character appearance\n" +
-  "- Maximum 14 total reference images can be combined\n" +
-  "- Supported formats: PNG, JPEG, WebP, HEIC, HEIF\n\n" +
+  "- Up to 14 reference images can be combined\n" +
+  "- Supported formats: PNG, JPEG, WebP\n\n" +
   "IMAGE EDITING:\n" +
   "- Provide the source image as reference and describe the desired changes\n" +
   "- Example: 'Remove the background and replace it with a sunset beach scene'\n\n" +
@@ -89,7 +87,7 @@ const IMAGE_GENERATION_SERVER_INSTRUCTIONS =
   "- Images from previous tool calls can be used as reference for subsequent generations\n" +
   "- Example: generate a character portrait, then use it as reference for different poses\n\n" +
   "OUTPUT OPTIONS:\n" +
-  "- Quality: 'low' (1K), 'medium' (2K), or 'high' (4K)\n" +
+  "- Quality: 'low', 'medium', or 'high'\n" +
   "- Aspect ratios: 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9";
 
 export const IMAGE_GENERATION_SERVER = {

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -6,54 +6,60 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const IMAGE_GENERATION_SERVER_NAME = "image_generation" as const;
 
+export const imageGenerationToolInputSchema = z.object({
+  prompt: z
+    .string()
+    .max(4000)
+    .describe("A text description of the desired image."),
+  outputName: z
+    .string()
+    .max(64)
+    .describe(
+      "The filename that will be used to save the generated image. Must be 64 characters or less."
+    ),
+  referenceImages: z
+    .array(z.string())
+    .max(14)
+    .optional()
+    .describe(
+      "Optional file IDs of reference images from conversation attachments. Up to 14 reference images."
+    ),
+  aspectRatio: z
+    .enum([
+      "1:1",
+      "3:2",
+      "2:3",
+      "3:4",
+      "4:3",
+      "4:5",
+      "5:4",
+      "9:16",
+      "16:9",
+      "21:9",
+    ])
+    .optional()
+    .default("1:1")
+    .describe(
+      "The aspect ratio of the generated image. Must be one of 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9."
+    ),
+  quality: z
+    .enum(["low", "medium", "high"])
+    .optional()
+    .default("low")
+    .describe(
+      "Output resolution: low (1K/1024px), medium (2K/2048px), or high (4K/4096px)."
+    ),
+});
+
+export type ImageGenerationToolInput = z.infer<
+  typeof imageGenerationToolInputSchema
+>;
+
 export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
   generate_image: {
     description:
       "Generate or edit images from text descriptions and reference images.",
-    schema: {
-      prompt: z
-        .string()
-        .max(4000)
-        .describe("A text description of the desired image."),
-      outputName: z
-        .string()
-        .max(64)
-        .describe(
-          "The filename that will be used to save the generated image. Must be 64 characters or less."
-        ),
-      referenceImages: z
-        .array(z.string())
-        .max(14)
-        .optional()
-        .describe(
-          "Optional file IDs of reference images from conversation attachments. Up to 14 reference images."
-        ),
-      aspectRatio: z
-        .enum([
-          "1:1",
-          "3:2",
-          "2:3",
-          "3:4",
-          "4:3",
-          "4:5",
-          "5:4",
-          "9:16",
-          "16:9",
-          "21:9",
-        ])
-        .optional()
-        .default("1:1")
-        .describe(
-          "The aspect ratio of the generated image. Must be one of 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9."
-        ),
-      quality: z
-        .enum(["low", "medium", "high"])
-        .optional()
-        .default("low")
-        .describe(
-          "Output resolution: low (1K/1024px), medium (2K/2048px), or high (4K/4096px)."
-        ),
-    },
+    schema: imageGenerationToolInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
       running: "Generating image",

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -8,23 +8,22 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   checkImageGenerationRateLimit,
   computeImageGenerationCostDetails,
-  geminiPartsToBase64Images,
   processImageFileIds,
   QUALITY_TO_IMAGE_SIZE,
   sendImageProgressNotification,
-  trackGeminiTokenUsage,
+  trackTokenUsage,
   uploadAndFormatImageResponse,
-  validateGeminiImageResponse,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
+import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { Err } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { GoogleGenAI, type Part } from "@google/genai";
 import { startObservation } from "@langfuse/tracing";
 
 export function createImageGenerationTools(
@@ -62,24 +61,27 @@ export function createImageGenerationTools(
       const credentials = await getLlmCredentials(auth, {
         skipEmbeddingApiKeyRequirement: true,
       });
-      const gemini = new GoogleGenAI({
-        apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
+
+      const generationImageModel = new ImageGenerationGoogleLLM(auth, {
+        modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
+        credentials,
       });
 
-      let referenceImageParts: Part[] = [];
+      let referenceFileResources: FileResource[] = [];
 
       if (referenceImages && referenceImages.length > 0) {
         const processResult = await processImageFileIds(auth, {
           imageFileIds: referenceImages,
           agentLoopContext,
+          supportedContentTypes: generationImageModel.supportedContentTypes,
         });
         if (processResult.isErr()) {
           return processResult;
         }
-        referenceImageParts = processResult.value;
+        referenceFileResources = processResult.value;
       }
 
-      const imageSize = QUALITY_TO_IMAGE_SIZE[quality ?? "low"];
+      const imageSize = QUALITY_TO_IMAGE_SIZE[quality];
 
       const generation = startObservation(
         "image-generation",
@@ -109,34 +111,17 @@ export function createImageGenerationTools(
         userId: workspace.sId,
       });
 
-      const contents =
-        referenceImageParts.length > 0
-          ? [
-              {
-                parts: [...referenceImageParts, { text: prompt }],
-              },
-            ]
-          : prompt;
+      const generationResult = await generationImageModel.generateImage({
+        prompt,
+        aspectRatio,
+        fileResources: referenceFileResources,
+        quality,
+      });
 
-      let response;
-      try {
-        response = await gemini.models.generateContent({
-          model: GEMINI_3_PRO_IMAGE_MODEL_ID,
-          contents,
-          config: {
-            temperature: 0.7,
-            responseModalities: ["IMAGE"],
-            candidateCount: 1,
-            imageConfig: {
-              aspectRatio,
-              imageSize,
-            },
-          },
-        });
-      } catch (error) {
+      if (generationResult.isErr()) {
         logger.error(
           {
-            error,
+            error: generationResult.error,
           },
           "Error generating image."
         );
@@ -144,55 +129,39 @@ export function createImageGenerationTools(
           level: "ERROR",
           statusMessage: "Error generating image",
           metadata: {
-            error: normalizeError(error),
+            error: normalizeError(generationResult.error),
           },
         });
         generation.end();
+
         return new Err(new MCPError("Error generating image."));
       }
 
-      const validationResult = validateGeminiImageResponse(
-        response,
-        "generation",
-        prompt
-      );
-      if (validationResult.isErr()) {
-        logger.error(
-          {
-            error: validationResult.error,
-          },
-          "Error generating image."
-        );
-        generation.update({
-          level: "ERROR",
-          statusMessage: validationResult.error.message,
-        });
-        generation.end();
-        return validationResult;
-      }
+      const { images, usageMetadata } = generationResult.value;
 
-      const imageParts = validationResult.value;
+      trackTokenUsage({
+        ...usageMetadata,
+        providerId: generationImageModel.providerId,
+      });
 
-      trackGeminiTokenUsage(response);
+      const { inputTokens, outputTokens, totalTokens, costDetails } =
+        computeImageGenerationCostDetails(usageMetadata);
 
-      if (response.usageMetadata) {
-        const { inputTokens, outputTokens, totalTokens, costDetails } =
-          computeImageGenerationCostDetails(response.usageMetadata);
+      generation.update({
+        usageDetails: {
+          input: inputTokens,
+          output: outputTokens,
+          total: totalTokens,
+        },
+        costDetails,
+      });
 
-        generation.update({
-          usageDetails: {
-            input: inputTokens,
-            output: outputTokens,
-            total: totalTokens,
-          },
-          costDetails,
-        });
-      }
       generation.end();
+
       return uploadAndFormatImageResponse(
         auth,
         agentLoopContext,
-        geminiPartsToBase64Images(imageParts),
+        images,
         outputName
       );
     },

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -15,8 +15,7 @@ import {
   uploadAndFormatImageResponse,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
-import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { getImageGenerationLLM } from "@app/lib/api/llm/getImageGenerationLLM";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -58,14 +57,21 @@ export function createImageGenerationTools(
         return rateLimitResult;
       }
 
-      const credentials = await getLlmCredentials(auth, {
-        skipEmbeddingApiKeyRequirement: true,
-      });
+      const imageGenerationModel = await getImageGenerationLLM(auth);
 
-      const generationImageModel = new ImageGenerationGoogleLLM(auth, {
-        modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
-        credentials,
-      });
+      if (!imageGenerationModel) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+          },
+          "No image generation model available for this workspace."
+        );
+        return new Err(
+          new MCPError(
+            "No image generation model available for this workspace."
+          )
+        );
+      }
 
       let referenceFileResources: FileResource[] = [];
 
@@ -73,7 +79,7 @@ export function createImageGenerationTools(
         const processResult = await processImageFileIds(auth, {
           imageFileIds: referenceImages,
           agentLoopContext,
-          supportedContentTypes: generationImageModel.supportedContentTypes,
+          supportedContentTypes: imageGenerationModel.supportedContentTypes,
         });
         if (processResult.isErr()) {
           return processResult;
@@ -111,7 +117,7 @@ export function createImageGenerationTools(
         userId: workspace.sId,
       });
 
-      const generationResult = await generationImageModel.generateImage({
+      const generationResult = await imageGenerationModel.generateImage({
         prompt,
         aspectRatio,
         fileResources: referenceFileResources,
@@ -141,7 +147,7 @@ export function createImageGenerationTools(
 
       trackTokenUsage({
         ...usageMetadata,
-        providerId: generationImageModel.providerId,
+        providerId: imageGenerationModel.providerId,
       });
 
       const { inputTokens, outputTokens, totalTokens, costDetails } =

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -102,7 +102,7 @@ export function createImageGenerationTools(
           },
           model: imageGenerationModel.modelId,
           modelParameters:
-            imageGenerationModel.getModelParameters?.(generationInput),
+            imageGenerationModel.getModelParameters(generationInput),
         },
         { asType: "generation" }
       );

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -9,18 +9,17 @@ import {
   checkImageGenerationRateLimit,
   computeImageGenerationCostDetails,
   processImageFileIds,
-  QUALITY_TO_IMAGE_SIZE,
   sendImageProgressNotification,
   trackTokenUsage,
   uploadAndFormatImageResponse,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { getImageGenerationLLM } from "@app/lib/api/llm/getImageGenerationLLM";
+import type { ImageGenerationInput } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { Err } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { startObservation } from "@langfuse/tracing";
@@ -42,35 +41,31 @@ export function createImageGenerationTools(
         "Generating image..."
       );
 
+      const imageGenerationModel = await getImageGenerationLLM(auth);
+
+      if (!imageGenerationModel) {
+        const errorMessage =
+          "No image generation model available for this workspace.";
+        logger.error({ workspaceId: workspace.sId }, errorMessage);
+        return new Err(new MCPError(errorMessage, { tracked: false }));
+      }
+
+      const { providerId } = imageGenerationModel;
+
       getStatsDClient().increment("tools.image_generation.generated", 1, [
         `aspect_ratio:${aspectRatio}`,
         `image_count:${referenceImages?.length ?? 0}`,
         `quality:${quality}`,
-        "provider:gemini",
+        `provider:${providerId}`,
       ]);
 
       const rateLimitResult = await checkImageGenerationRateLimit(
         auth,
-        workspace
+        workspace,
+        providerId
       );
       if (rateLimitResult.isErr()) {
         return rateLimitResult;
-      }
-
-      const imageGenerationModel = await getImageGenerationLLM(auth);
-
-      if (!imageGenerationModel) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-          },
-          "No image generation model available for this workspace."
-        );
-        return new Err(
-          new MCPError(
-            "No image generation model available for this workspace."
-          )
-        );
       }
 
       let referenceFileResources: FileResource[] = [];
@@ -80,6 +75,7 @@ export function createImageGenerationTools(
           imageFileIds: referenceImages,
           agentLoopContext,
           supportedContentTypes: imageGenerationModel.supportedContentTypes,
+          providerId,
         });
         if (processResult.isErr()) {
           return processResult;
@@ -87,7 +83,12 @@ export function createImageGenerationTools(
         referenceFileResources = processResult.value;
       }
 
-      const imageSize = QUALITY_TO_IMAGE_SIZE[quality];
+      const generationInput = {
+        prompt,
+        aspectRatio,
+        fileResources: referenceFileResources,
+        quality,
+      } satisfies ImageGenerationInput;
 
       const generation = startObservation(
         "image-generation",
@@ -99,8 +100,9 @@ export function createImageGenerationTools(
             imageFileIds: referenceImages,
             quality,
           },
-          model: GEMINI_3_PRO_IMAGE_MODEL_ID,
-          modelParameters: { aspectRatio, imageSize, temperature: 0.7 },
+          model: imageGenerationModel.modelId,
+          modelParameters:
+            imageGenerationModel.getModelParameters(generationInput),
         },
         { asType: "generation" }
       );
@@ -117,17 +119,16 @@ export function createImageGenerationTools(
         userId: workspace.sId,
       });
 
-      const generationResult = await imageGenerationModel.generateImage({
-        prompt,
-        aspectRatio,
-        fileResources: referenceFileResources,
-        quality,
-      });
+      const generationResult =
+        await imageGenerationModel.generateImage(generationInput);
 
       if (generationResult.isErr()) {
+        const genError = generationResult.error;
+        const tracked = genError.code !== "safety_blocked";
+
         logger.error(
           {
-            error: generationResult.error,
+            error: genError,
           },
           "Error generating image."
         );
@@ -135,12 +136,14 @@ export function createImageGenerationTools(
           level: "ERROR",
           statusMessage: "Error generating image",
           metadata: {
-            error: normalizeError(generationResult.error),
+            error: normalizeError(genError),
           },
         });
         generation.end();
 
-        return new Err(new MCPError("Error generating image."));
+        return new Err(
+          new MCPError(genError.message, { tracked, cause: genError })
+        );
       }
 
       const { images, usageMetadata } = generationResult.value;
@@ -151,7 +154,10 @@ export function createImageGenerationTools(
       });
 
       const { inputTokens, outputTokens, totalTokens, costDetails } =
-        computeImageGenerationCostDetails(usageMetadata);
+        computeImageGenerationCostDetails(
+          usageMetadata,
+          imageGenerationModel.modelId
+        );
 
       generation.update({
         usageDetails: {

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -102,7 +102,7 @@ export function createImageGenerationTools(
           },
           model: imageGenerationModel.modelId,
           modelParameters:
-            imageGenerationModel.getModelParameters(generationInput),
+            imageGenerationModel.getModelParameters?.(generationInput),
         },
         { asType: "generation" }
       );

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -343,6 +343,11 @@ const IMAGE_MODEL_PRICING: Record<string, PricingEntry> = {
     input: 0.25,
     output: 60.0,
   },
+  // https://platform.openai.com/docs/pricing
+  "gpt-image-1.5": {
+    input: 8.0,
+    output: 32.0,
+  },
 };
 
 // Pricing for legacy/deprecated models that are no longer in BaseModelIdType.

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -111,12 +111,9 @@ export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
       });
     } catch (error) {
       return new Err(
-        new ImageGenerationError(
-          "Failed to generate image",
-          error instanceof Error
-            ? { message: error.message, stack: error.stack }
-            : undefined
-        )
+        new ImageGenerationError("api_error", "Failed to generate image", {
+          cause: error,
+        })
       );
     }
 
@@ -161,26 +158,28 @@ export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
       if (response.promptFeedback?.blockReason) {
         return new Err(
           new ImageGenerationError(
-            `Image ${operationType} blocked by safety filters: ${response.promptFeedback.blockReason}`,
-            {
-              blockReason: response.promptFeedback.blockReason,
-              safetyRatings: response.promptFeedback.safetyRatings,
-              prompt: promptText,
-            }
+            "safety_blocked",
+            `Image ${operationType} blocked by safety filters: ${response.promptFeedback.blockReason}`
           )
         );
       }
-      return new Err(new ImageGenerationError("No image generated."));
+      return new Err(
+        new ImageGenerationError("empty_response", "No image generated.")
+      );
     }
 
     const content = response.candidates[0].content;
     if (!content || !content.parts) {
-      return new Err(new ImageGenerationError("No image data in response"));
+      return new Err(
+        new ImageGenerationError("empty_response", "No image data in response.")
+      );
     }
 
     const imageParts = content.parts.filter(this.isValidInlineDataPart);
     if (imageParts.length === 0) {
-      return new Err(new ImageGenerationError("No image data in response."));
+      return new Err(
+        new ImageGenerationError("empty_response", "No image data in response.")
+      );
     }
 
     return new Ok(imageParts);
@@ -193,6 +192,16 @@ export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
       base64: part.inlineData.data,
       mimeType: part.inlineData.mimeType,
     }));
+  }
+
+  getModelParameters(
+    params: ImageGenerationInput
+  ): Record<string, string | number> {
+    return {
+      aspectRatio: params.aspectRatio,
+      imageSize: QUALITY_TO_IMAGE_SIZE[params.quality],
+      temperature: 0.7,
+    };
   }
 
   private isValidInlineDataPart(part: unknown): part is GeminiInlineDataPart {

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -208,9 +208,7 @@ export class ImageGenerationGoogleLLM {
     }));
   }
 
-  private isValidInlineDataPart(
-    part: unknown
-  ): part is GeminiInlineDataPart {
+  private isValidInlineDataPart(part: unknown): part is GeminiInlineDataPart {
     return geminiInlineDataPartSchema.safeParse(part).success;
   }
 }

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -1,0 +1,216 @@
+import {
+  type Base64ImageData,
+  ImageGenerationError,
+  QUALITY_TO_IMAGE_SIZE,
+} from "@app/lib/api/actions/servers/image_generation/helpers";
+import type { ImageGenerationToolInput } from "@app/lib/api/actions/servers/image_generation/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/temporal/utils";
+import type { ImageModelIdType } from "@app/types/assistant/models/models";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import {
+  createPartFromUri,
+  type GenerateContentResponse,
+  GoogleGenAI,
+  type Part,
+} from "@google/genai";
+import assert from "assert";
+import z from "zod";
+import { GOOGLE_AI_STUDIO_PROVIDER_ID } from "./types";
+
+const geminiInlineDataPartSchema = z.object({
+  inlineData: z.object({
+    data: z.string(),
+    mimeType: z.string().optional(),
+  }),
+});
+
+type GeminiInlineDataPart = z.infer<typeof geminiInlineDataPartSchema>;
+
+type TokenCountDetails = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+};
+
+type ImageGenerationInput = Omit<
+  ImageGenerationToolInput,
+  "referenceImages" | "outputName"
+> & {
+  fileResources?: FileResource[];
+};
+
+type ImageGenerationOutput = {
+  images: Base64ImageData[];
+  usageMetadata: TokenCountDetails;
+};
+
+export class ImageGenerationGoogleLLM {
+  get supportedContentTypes(): string[] {
+    return ["image/bmp", "image/jpeg", "image/png", "image/webp"];
+  }
+  protected readonly auth: Authenticator;
+  protected readonly modelId: ImageModelIdType;
+  readonly providerId: ModelProviderIdType;
+
+  private readonly client: GoogleGenAI;
+
+  constructor(
+    auth: Authenticator,
+    {
+      modelId,
+      credentials,
+    }: {
+      modelId: ImageModelIdType;
+      credentials: { GOOGLE_AI_STUDIO_API_KEY?: string };
+    }
+  ) {
+    this.auth = auth;
+    this.modelId = modelId;
+    this.providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
+    assert(
+      credentials.GOOGLE_AI_STUDIO_API_KEY,
+      "GOOGLE_AI_STUDIO_API_KEY credential is required"
+    );
+    this.client = new GoogleGenAI({
+      apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
+    });
+  }
+
+  async generateImage(
+    params: ImageGenerationInput
+  ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
+    const { prompt, aspectRatio, fileResources, quality } = params;
+
+    let imageParts: Part[] = [];
+
+    if (fileResources && fileResources.length > 0) {
+      imageParts = await concurrentExecutor(
+        fileResources,
+        async (fileResource) => {
+          const signedUrl = await fileResource.getSignedUrlForDownload(
+            this.auth,
+            "original"
+          );
+          return createPartFromUri(signedUrl, fileResource.contentType);
+        },
+        { concurrency: 8 }
+      );
+    }
+
+    const imageSize = QUALITY_TO_IMAGE_SIZE[quality];
+
+    const contents =
+      imageParts.length > 0
+        ? [{ parts: [...imageParts, { text: prompt }] }]
+        : prompt;
+
+    let response: GenerateContentResponse;
+    try {
+      response = await this.client.models.generateContent({
+        model: this.modelId,
+        contents,
+        config: {
+          temperature: 0.7,
+          responseModalities: ["IMAGE"],
+          candidateCount: 1,
+          imageConfig: {
+            aspectRatio,
+            imageSize,
+          },
+        },
+      });
+    } catch (error) {
+      return new Err(
+        new ImageGenerationError(
+          "Failed to generate image",
+          error instanceof Error
+            ? { message: error.message, stack: error.stack }
+            : undefined
+        )
+      );
+    }
+
+    const validationResult = this.validateGeminiImageResponse(
+      response,
+      "generation",
+      prompt
+    );
+
+    if (validationResult.isErr()) {
+      return validationResult;
+    }
+
+    const responseImageParts = validationResult.value;
+
+    return new Ok({
+      images: this.geminiPartsToBase64Images(responseImageParts),
+      usageMetadata: {
+        inputTokens: response.usageMetadata?.promptTokenCount ?? 0,
+        outputTokens: response.usageMetadata?.candidatesTokenCount ?? 0,
+        totalTokens: response.usageMetadata?.totalTokenCount ?? 0,
+      },
+    });
+  }
+
+  private validateGeminiImageResponse(
+    response: {
+      candidates?: Array<{
+        content?: {
+          parts?: unknown[];
+        };
+      }>;
+      promptFeedback?: {
+        blockReason?: string;
+        safetyRatings?: unknown;
+      };
+    },
+    operationType: "generation" | "editing",
+    promptText: string
+  ): Ok<GeminiInlineDataPart[]> | Err<ImageGenerationError> {
+    if (!response.candidates || response.candidates.length === 0) {
+      if (response.promptFeedback?.blockReason) {
+        return new Err(
+          new ImageGenerationError(
+            `Image ${operationType} blocked by safety filters: ${response.promptFeedback.blockReason}`,
+            {
+              blockReason: response.promptFeedback.blockReason,
+              safetyRatings: response.promptFeedback.safetyRatings,
+              prompt: promptText,
+            }
+          )
+        );
+      }
+      return new Err(new ImageGenerationError("No image generated."));
+    }
+
+    const content = response.candidates[0].content;
+    if (!content || !content.parts) {
+      return new Err(new ImageGenerationError("No image data in response"));
+    }
+
+    const imageParts = content.parts.filter(this.isValidGeminiInlineDataPart);
+    if (imageParts.length === 0) {
+      return new Err(new ImageGenerationError("No image data in response."));
+    }
+
+    return new Ok(imageParts);
+  }
+
+  private geminiPartsToBase64Images(
+    parts: GeminiInlineDataPart[]
+  ): Base64ImageData[] {
+    return parts.map((part) => ({
+      base64: part.inlineData.data,
+      mimeType: part.inlineData.mimeType,
+    }));
+  }
+
+  private isValidGeminiInlineDataPart(
+    part: unknown
+  ): part is GeminiInlineDataPart {
+    return geminiInlineDataPartSchema.safeParse(part).success;
+  }
+}

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -4,6 +4,7 @@ import {
   QUALITY_TO_IMAGE_SIZE,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import type { ImageGenerationToolInput } from "@app/lib/api/actions/servers/image_generation/metadata";
+import { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/temporal/utils";
@@ -47,12 +48,8 @@ type ImageGenerationOutput = {
   usageMetadata: TokenCountDetails;
 };
 
-export class ImageGenerationGoogleLLM {
-  get supportedContentTypes(): string[] {
-    return ["image/bmp", "image/jpeg", "image/png", "image/webp"];
-  }
-  protected readonly auth: Authenticator;
-  protected readonly modelId: ImageModelIdType;
+export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
+  readonly supportedContentTypes: string[];
   readonly providerId: ModelProviderIdType;
 
   private readonly client: GoogleGenAI;
@@ -67,9 +64,15 @@ export class ImageGenerationGoogleLLM {
       credentials: { GOOGLE_AI_STUDIO_API_KEY?: string };
     }
   ) {
-    this.auth = auth;
-    this.modelId = modelId;
+    super(auth, { modelId, credentials });
     this.providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
+    this.supportedContentTypes = [
+      "image/bmp",
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+    ];
+
     assert(
       credentials.GOOGLE_AI_STUDIO_API_KEY,
       "GOOGLE_AI_STUDIO_API_KEY credential is required"

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -133,7 +133,7 @@ export class ImageGenerationGoogleLLM {
       );
     }
 
-    const validationResult = this.validateGeminiImageResponse(
+    const validationResult = this.validateImageResponse(
       response,
       "generation",
       prompt
@@ -146,7 +146,7 @@ export class ImageGenerationGoogleLLM {
     const responseImageParts = validationResult.value;
 
     return new Ok({
-      images: this.geminiPartsToBase64Images(responseImageParts),
+      images: this.partsToBase64Images(responseImageParts),
       usageMetadata: {
         inputTokens: response.usageMetadata?.promptTokenCount ?? 0,
         outputTokens: response.usageMetadata?.candidatesTokenCount ?? 0,
@@ -155,7 +155,7 @@ export class ImageGenerationGoogleLLM {
     });
   }
 
-  private validateGeminiImageResponse(
+  private validateImageResponse(
     response: {
       candidates?: Array<{
         content?: {
@@ -191,7 +191,7 @@ export class ImageGenerationGoogleLLM {
       return new Err(new ImageGenerationError("No image data in response"));
     }
 
-    const imageParts = content.parts.filter(this.isValidGeminiInlineDataPart);
+    const imageParts = content.parts.filter(this.isValidInlineDataPart);
     if (imageParts.length === 0) {
       return new Err(new ImageGenerationError("No image data in response."));
     }
@@ -199,7 +199,7 @@ export class ImageGenerationGoogleLLM {
     return new Ok(imageParts);
   }
 
-  private geminiPartsToBase64Images(
+  private partsToBase64Images(
     parts: GeminiInlineDataPart[]
   ): Base64ImageData[] {
     return parts.map((part) => ({
@@ -208,7 +208,7 @@ export class ImageGenerationGoogleLLM {
     }));
   }
 
-  private isValidGeminiInlineDataPart(
+  private isValidInlineDataPart(
     part: unknown
   ): part is GeminiInlineDataPart {
     return geminiInlineDataPartSchema.safeParse(part).success;

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -100,7 +100,7 @@ export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
         model: this.modelId,
         contents,
         config: {
-          temperature: 0.7,
+          temperature: this.TEMPERATURE,
           responseModalities: ["IMAGE"],
           candidateCount: 1,
           imageConfig: {
@@ -194,13 +194,15 @@ export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
     }));
   }
 
-  getModelParameters(
-    params: ImageGenerationInput
-  ): Record<string, string | number> {
+  getModelParameters({
+    aspectRatio,
+    quality,
+  }: ImageGenerationInput): Record<string, string | number> {
     return {
-      aspectRatio: params.aspectRatio,
-      imageSize: QUALITY_TO_IMAGE_SIZE[params.quality],
-      temperature: 0.7,
+      aspectRatio,
+      imageSize: QUALITY_TO_IMAGE_SIZE[quality],
+      quality,
+      temperature: this.TEMPERATURE,
     };
   }
 

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -3,10 +3,12 @@ import {
   ImageGenerationError,
   QUALITY_TO_IMAGE_SIZE,
 } from "@app/lib/api/actions/servers/image_generation/helpers";
-import type { ImageGenerationToolInput } from "@app/lib/api/actions/servers/image_generation/metadata";
-import { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
+import {
+  type ImageGenerationInput,
+  ImageGenerationLLM,
+  type ImageGenerationOutput,
+} from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/temporal/utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
@@ -29,24 +31,6 @@ const geminiInlineDataPartSchema = z.object({
 });
 
 type GeminiInlineDataPart = z.infer<typeof geminiInlineDataPartSchema>;
-
-type TokenCountDetails = {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-};
-
-type ImageGenerationInput = Omit<
-  ImageGenerationToolInput,
-  "referenceImages" | "outputName"
-> & {
-  fileResources?: FileResource[];
-};
-
-type ImageGenerationOutput = {
-  images: Base64ImageData[];
-  usageMetadata: TokenCountDetails;
-};
 
 export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
   readonly supportedContentTypes: string[];

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -26,6 +26,7 @@ export const GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS = [
   GEMINI_3_1_PRO_MODEL_ID,
   GEMINI_3_FLASH_MODEL_ID,
 ] as const;
+
 export type GoogleAIStudioWhitelistedModelId =
   (typeof GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS)[number];
 

--- a/front/lib/api/llm/clients/openai/imageGeneration.ts
+++ b/front/lib/api/llm/clients/openai/imageGeneration.ts
@@ -1,0 +1,138 @@
+import {
+  type Base64ImageData,
+  ImageGenerationError,
+} from "@app/lib/api/actions/servers/image_generation/helpers";
+import {
+  type ImageGenerationInput,
+  ImageGenerationLLM,
+  type ImageGenerationOutput,
+} from "@app/lib/api/llm/imageGeneration";
+import type { Authenticator } from "@app/lib/auth";
+import { concurrentExecutor } from "@app/temporal/utils";
+import type { ImageModelIdType } from "@app/types/assistant/models/models";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import assert from "assert";
+import { OpenAI, toFile } from "openai";
+import type { ImagesResponse } from "openai/resources/images";
+import { OPENAI_PROVIDER_ID } from "./types";
+
+const ASPECT_RATIO_TO_SIZE: Record<
+  string,
+  "1024x1024" | "1536x1024" | "1024x1536"
+> = {
+  "1:1": "1024x1024",
+  "3:2": "1536x1024",
+  "4:3": "1536x1024",
+  "5:4": "1536x1024",
+  "16:9": "1536x1024",
+  "21:9": "1536x1024",
+  "2:3": "1024x1536",
+  "3:4": "1024x1536",
+  "4:5": "1024x1536",
+  "9:16": "1024x1536",
+};
+
+export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
+  readonly supportedContentTypes: string[];
+  readonly providerId: ModelProviderIdType;
+
+  private readonly client: OpenAI;
+
+  constructor(
+    auth: Authenticator,
+    {
+      modelId,
+      credentials,
+    }: {
+      modelId: ImageModelIdType;
+      credentials: { OPENAI_API_KEY?: string };
+    }
+  ) {
+    super(auth, { modelId, credentials });
+    this.providerId = OPENAI_PROVIDER_ID;
+    this.supportedContentTypes = ["image/jpeg", "image/png", "image/webp"];
+
+    assert(credentials.OPENAI_API_KEY, "OPENAI_API_KEY credential is required");
+    this.client = new OpenAI({ apiKey: credentials.OPENAI_API_KEY });
+  }
+
+  async generateImage(
+    params: ImageGenerationInput
+  ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
+    const { prompt, aspectRatio, fileResources, quality } = params;
+
+    const size = ASPECT_RATIO_TO_SIZE[aspectRatio] ?? "1024x1024";
+
+    let response: ImagesResponse;
+    try {
+      if (fileResources && fileResources.length > 0) {
+        const uploadables = await concurrentExecutor(
+          fileResources,
+          async (fileResource) => {
+            const signedUrl = await fileResource.getSignedUrlForDownload(
+              this.auth,
+              "original"
+            );
+            const res = await fetch(signedUrl);
+            const buffer = Buffer.from(await res.arrayBuffer());
+            return toFile(buffer, fileResource.fileName ?? "image.png", {
+              type: fileResource.contentType,
+            });
+          },
+          { concurrency: 8 }
+        );
+
+        response = await this.client.images.edit({
+          model: this.modelId,
+          image: uploadables,
+          prompt,
+          size,
+          quality,
+          output_format: "png",
+        });
+      } else {
+        response = await this.client.images.generate({
+          model: this.modelId,
+          prompt,
+          size,
+          quality,
+          output_format: "png",
+        });
+      }
+    } catch (error) {
+      return new Err(
+        new ImageGenerationError(
+          "Failed to generate image",
+          error instanceof Error
+            ? { message: error.message, stack: error.stack }
+            : undefined
+        )
+      );
+    }
+
+    if (!response.data || response.data.length === 0) {
+      return new Err(new ImageGenerationError("No image generated."));
+    }
+
+    const images: Base64ImageData[] = response.data
+      .filter((img) => img.b64_json)
+      .map((img) => ({
+        base64: img.b64_json as string,
+        mimeType: "image/png",
+      }));
+
+    if (images.length === 0) {
+      return new Err(new ImageGenerationError("No image data in response."));
+    }
+
+    return new Ok({
+      images,
+      usageMetadata: {
+        inputTokens: response.usage?.input_tokens ?? 0,
+        outputTokens: response.usage?.output_tokens ?? 0,
+        totalTokens: response.usage?.total_tokens ?? 0,
+      },
+    });
+  }
+}

--- a/front/lib/api/llm/clients/openai/imageGeneration.ts
+++ b/front/lib/api/llm/clients/openai/imageGeneration.ts
@@ -24,25 +24,29 @@ import type {
 } from "openai/resources/images";
 import { OPENAI_PROVIDER_ID } from "./types";
 
+const SQUARE = "1024x1024";
+const LANDSCAPE = "1536x1024";
+const PORTRAIT = "1024x1536";
+
 type SupportedImageSize = Extract<
   ImageGenerateParamsBase["size"],
-  "1024x1024" | "1536x1024" | "1024x1536"
+  typeof SQUARE | typeof LANDSCAPE | typeof PORTRAIT
 >;
 
-const ASPECT_RATIO_TO_SIZE: Record<
+const ASPECT_RATIO_TO_IMAGE_SIZE: Record<
   GenerateImageInputType["aspectRatio"],
   SupportedImageSize
 > = {
-  "1:1": "1024x1024",
-  "3:2": "1536x1024",
-  "4:3": "1536x1024",
-  "5:4": "1536x1024",
-  "16:9": "1536x1024",
-  "21:9": "1536x1024",
-  "2:3": "1024x1536",
-  "3:4": "1024x1536",
-  "4:5": "1024x1536",
-  "9:16": "1024x1536",
+  "1:1": SQUARE,
+  "3:2": LANDSCAPE,
+  "4:3": LANDSCAPE,
+  "5:4": LANDSCAPE,
+  "16:9": LANDSCAPE,
+  "21:9": LANDSCAPE,
+  "2:3": PORTRAIT,
+  "3:4": PORTRAIT,
+  "4:5": PORTRAIT,
+  "9:16": PORTRAIT,
 };
 
 function isSafetyBlockError(
@@ -84,7 +88,7 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
     const { prompt, aspectRatio, fileResources, quality } = params;
 
-    const size = ASPECT_RATIO_TO_SIZE[aspectRatio];
+    const size = ASPECT_RATIO_TO_IMAGE_SIZE[aspectRatio];
 
     let response: ImagesResponse;
     try {
@@ -165,12 +169,14 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
     return new Ok(images);
   }
 
-  getModelParameters(
-    params: ImageGenerationInput
-  ): Record<string, string | number> {
+  getModelParameters({
+    aspectRatio,
+    quality,
+  }: ImageGenerationInput): Record<string, string | number> {
     return {
-      size: ASPECT_RATIO_TO_SIZE[params.aspectRatio],
-      quality: params.quality,
+      aspectRatio,
+      imageSize: ASPECT_RATIO_TO_IMAGE_SIZE[aspectRatio],
+      quality,
     };
   }
 

--- a/front/lib/api/llm/clients/openai/imageGeneration.ts
+++ b/front/lib/api/llm/clients/openai/imageGeneration.ts
@@ -1,3 +1,4 @@
+import type { GenerateImageInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import {
   type Base64ImageData,
   ImageGenerationError,
@@ -8,18 +9,29 @@ import {
   type ImageGenerationOutput,
 } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
+import { trustedFetch } from "@app/lib/egress/server";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/temporal/utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
 import { OpenAI, toFile } from "openai";
-import type { ImagesResponse } from "openai/resources/images";
+import type {
+  ImageGenerateParamsBase,
+  ImagesResponse,
+} from "openai/resources/images";
 import { OPENAI_PROVIDER_ID } from "./types";
 
-const ASPECT_RATIO_TO_SIZE: Record<
-  string,
+type SupportedImageSize = Extract<
+  ImageGenerateParamsBase["size"],
   "1024x1024" | "1536x1024" | "1024x1536"
+>;
+
+const ASPECT_RATIO_TO_SIZE: Record<
+  GenerateImageInputType["aspectRatio"],
+  SupportedImageSize
 > = {
   "1:1": "1024x1024",
   "3:2": "1536x1024",
@@ -32,6 +44,16 @@ const ASPECT_RATIO_TO_SIZE: Record<
   "4:5": "1024x1536",
   "9:16": "1024x1536",
 };
+
+function isSafetyBlockError(
+  error: unknown
+): error is InstanceType<typeof OpenAI.BadRequestError> {
+  return (
+    error instanceof OpenAI.BadRequestError &&
+    (error.code === "content_policy_violation" ||
+      error.code === "contentFilter")
+  );
+}
 
 export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
   readonly supportedContentTypes: string[];
@@ -62,26 +84,12 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
     const { prompt, aspectRatio, fileResources, quality } = params;
 
-    const size = ASPECT_RATIO_TO_SIZE[aspectRatio] ?? "1024x1024";
+    const size = ASPECT_RATIO_TO_SIZE[aspectRatio];
 
     let response: ImagesResponse;
     try {
       if (fileResources && fileResources.length > 0) {
-        const uploadables = await concurrentExecutor(
-          fileResources,
-          async (fileResource) => {
-            const signedUrl = await fileResource.getSignedUrlForDownload(
-              this.auth,
-              "original"
-            );
-            const res = await fetch(signedUrl);
-            const buffer = Buffer.from(await res.arrayBuffer());
-            return toFile(buffer, fileResource.fileName ?? "image.png", {
-              type: fileResource.contentType,
-            });
-          },
-          { concurrency: 8 }
-        );
+        const uploadables = await this.toUploadableFiles(fileResources);
 
         response = await this.client.images.edit({
           model: this.modelId,
@@ -90,6 +98,7 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
           size,
           quality,
           output_format: "png",
+          n: 1,
         });
       } else {
         response = await this.client.images.generate({
@@ -98,41 +107,88 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
           size,
           quality,
           output_format: "png",
+          n: 1,
         });
       }
     } catch (error) {
+      if (isSafetyBlockError(error)) {
+        return new Err(
+          new ImageGenerationError("safety_blocked", error.message, {
+            cause: error,
+          })
+        );
+      }
+
       return new Err(
-        new ImageGenerationError(
-          "Failed to generate image",
-          error instanceof Error
-            ? { message: error.message, stack: error.stack }
-            : undefined
-        )
+        new ImageGenerationError("api_error", "Failed to generate image", {
+          cause: error,
+        })
       );
     }
 
-    if (!response.data || response.data.length === 0) {
-      return new Err(new ImageGenerationError("No image generated."));
-    }
-
-    const images: Base64ImageData[] = response.data
-      .filter((img) => img.b64_json)
-      .map((img) => ({
-        base64: img.b64_json as string,
-        mimeType: "image/png",
-      }));
-
-    if (images.length === 0) {
-      return new Err(new ImageGenerationError("No image data in response."));
+    const validationResult = this.validateImageResponse(response);
+    if (validationResult.isErr()) {
+      return validationResult;
     }
 
     return new Ok({
-      images,
+      images: validationResult.value,
       usageMetadata: {
         inputTokens: response.usage?.input_tokens ?? 0,
         outputTokens: response.usage?.output_tokens ?? 0,
         totalTokens: response.usage?.total_tokens ?? 0,
       },
     });
+  }
+
+  private validateImageResponse(
+    response: ImagesResponse
+  ): Result<Base64ImageData[], ImageGenerationError> {
+    if (!response.data || response.data.length === 0) {
+      return new Err(
+        new ImageGenerationError("empty_response", "No image generated.")
+      );
+    }
+
+    const images: Base64ImageData[] = response.data.flatMap((img) =>
+      isString(img.b64_json)
+        ? [{ base64: img.b64_json, mimeType: "image/png" }]
+        : []
+    );
+
+    if (images.length === 0) {
+      return new Err(
+        new ImageGenerationError("empty_response", "No image data in response.")
+      );
+    }
+
+    return new Ok(images);
+  }
+
+  getModelParameters(
+    params: ImageGenerationInput
+  ): Record<string, string | number> {
+    return {
+      size: ASPECT_RATIO_TO_SIZE[params.aspectRatio],
+      quality: params.quality,
+    };
+  }
+
+  private async toUploadableFiles(fileResources: FileResource[]) {
+    return concurrentExecutor(
+      fileResources,
+      async (fileResource) => {
+        const signedUrl = await fileResource.getSignedUrlForDownload(
+          this.auth,
+          "original"
+        );
+        const res = await trustedFetch(signedUrl);
+        const arrayBuffer = await res.arrayBuffer();
+        return toFile(Buffer.from(arrayBuffer), fileResource.fileName, {
+          type: fileResource.contentType,
+        });
+      },
+      { concurrency: 8 }
+    );
   }
 }

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -1,11 +1,12 @@
 import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
+import type { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 
 export async function getImageGenerationLLM(
   auth: Authenticator
-): Promise<ImageGenerationGoogleLLM | null> {
+): Promise<ImageGenerationLLM | null> {
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -1,8 +1,11 @@
 import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
+import { ImageGenerationOpenAILLM } from "@app/lib/api/llm/clients/openai/imageGeneration";
 import type { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
+import { GPT_IMAGE_1_5_MODEL_ID } from "@app/types/assistant/models/openai";
 
 export async function getImageGenerationLLM(
   auth: Authenticator
@@ -10,11 +13,17 @@ export async function getImageGenerationLLM(
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  const plan = auth.getNonNullablePlan();
 
-  if (!plan.isByok) {
+  if (isProviderWhitelisted(auth, "google_ai_studio")) {
     return new ImageGenerationGoogleLLM(auth, {
       modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
+      credentials,
+    });
+  }
+
+  if (isProviderWhitelisted(auth, "openai")) {
+    return new ImageGenerationOpenAILLM(auth, {
+      modelId: GPT_IMAGE_1_5_MODEL_ID,
       credentials,
     });
   }

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -1,0 +1,22 @@
+import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
+
+export async function getImageGenerationLLM(
+  auth: Authenticator
+): Promise<ImageGenerationGoogleLLM | null> {
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+  const plan = auth.getNonNullablePlan();
+
+  if (!plan.isByok) {
+    return new ImageGenerationGoogleLLM(auth, {
+      modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
+      credentials,
+    });
+  }
+
+  return null;
+}

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -14,7 +14,9 @@ export async function getImageGenerationLLM(
     skipEmbeddingApiKeyRequirement: true,
   });
 
-  if (isProviderWhitelisted(auth, "google_ai_studio")) {
+  const plan = auth.getNonNullablePlan();
+
+  if (!plan.isByok || isProviderWhitelisted(auth, "google_ai_studio")) {
     return new ImageGenerationGoogleLLM(auth, {
       modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
       credentials,

--- a/front/lib/api/llm/imageGeneration.ts
+++ b/front/lib/api/llm/imageGeneration.ts
@@ -31,7 +31,7 @@ export type ImageGenerationOutput = {
 export abstract class ImageGenerationLLM {
   abstract readonly supportedContentTypes: string[];
   protected readonly auth: Authenticator;
-  protected readonly modelId: ImageModelIdType;
+  readonly modelId: ImageModelIdType;
   abstract readonly providerId: ModelProviderIdType;
 
   constructor(
@@ -51,4 +51,8 @@ export abstract class ImageGenerationLLM {
   abstract generateImage(
     params: ImageGenerationInput
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>>;
+
+  abstract getModelParameters(
+    params: ImageGenerationInput
+  ): Record<string, string | number>;
 }

--- a/front/lib/api/llm/imageGeneration.ts
+++ b/front/lib/api/llm/imageGeneration.ts
@@ -1,0 +1,54 @@
+import type {
+  Base64ImageData,
+  ImageGenerationError,
+} from "@app/lib/api/actions/servers/image_generation/helpers";
+import type { ImageGenerationToolInput } from "@app/lib/api/actions/servers/image_generation/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { ImageModelIdType } from "@app/types/assistant/models/models";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
+import type { Result } from "@app/types/shared/result";
+
+type TokenCountDetails = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+};
+
+type ImageGenerationInput = Omit<
+  ImageGenerationToolInput,
+  "referenceImages" | "outputName"
+> & {
+  fileResources?: FileResource[];
+};
+
+type ImageGenerationOutput = {
+  images: Base64ImageData[];
+  usageMetadata: TokenCountDetails;
+};
+
+export abstract class ImageGenerationLLM {
+  abstract readonly supportedContentTypes: string[];
+  protected readonly auth: Authenticator;
+  protected readonly modelId: ImageModelIdType;
+  abstract readonly providerId: ModelProviderIdType;
+
+  constructor(
+    auth: Authenticator,
+    {
+      modelId,
+      credentials: _credentials,
+    }: {
+      modelId: ImageModelIdType;
+      credentials: LLMCredentialsType;
+    }
+  ) {
+    this.auth = auth;
+    this.modelId = modelId;
+  }
+
+  abstract generateImage(
+    params: ImageGenerationInput
+  ): Promise<Result<ImageGenerationOutput, ImageGenerationError>>;
+}

--- a/front/lib/api/llm/imageGeneration.ts
+++ b/front/lib/api/llm/imageGeneration.ts
@@ -34,6 +34,8 @@ export abstract class ImageGenerationLLM {
   readonly modelId: ImageModelIdType;
   abstract readonly providerId: ModelProviderIdType;
 
+  protected readonly TEMPERATURE = 0.7;
+
   constructor(
     auth: Authenticator,
     {
@@ -52,7 +54,7 @@ export abstract class ImageGenerationLLM {
     params: ImageGenerationInput
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>>;
 
-  abstract getModelParameters(
+  abstract getModelParameters?(
     params: ImageGenerationInput
   ): Record<string, string | number>;
 }

--- a/front/lib/api/llm/imageGeneration.ts
+++ b/front/lib/api/llm/imageGeneration.ts
@@ -10,20 +10,20 @@ import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
 import type { Result } from "@app/types/shared/result";
 
-type TokenCountDetails = {
+export type TokenCountDetails = {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
 };
 
-type ImageGenerationInput = Omit<
+export type ImageGenerationInput = Omit<
   ImageGenerationToolInput,
   "referenceImages" | "outputName"
 > & {
   fileResources?: FileResource[];
 };
 
-type ImageGenerationOutput = {
+export type ImageGenerationOutput = {
   images: Base64ImageData[];
   usageMetadata: TokenCountDetails;
 };

--- a/front/lib/api/llm/imageGeneration.ts
+++ b/front/lib/api/llm/imageGeneration.ts
@@ -54,7 +54,7 @@ export abstract class ImageGenerationLLM {
     params: ImageGenerationInput
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>>;
 
-  abstract getModelParameters?(
+  abstract getModelParameters(
     params: ImageGenerationInput
   ): Record<string, string | number>;
 }

--- a/front/lib/dev/byok_seed.sql
+++ b/front/lib/dev/byok_seed.sql
@@ -175,8 +175,8 @@ inserted_subscription AS (
 
 -- Step 8a: Create membership (user → workspace as admin)
 inserted_membership AS (
-  INSERT INTO memberships ("workspaceId", "userId", role, origin, "startAt", "endAt", "createdAt", "updatedAt")
-  SELECT w.id, u.id, 'admin', 'invited', NOW(), NULL, NOW(), NOW()
+  INSERT INTO memberships ("workspaceId", "userId", role, origin, "startAt", "endAt", "firstUsedAt", "createdAt", "updatedAt")
+  SELECT w.id, u.id, 'admin', 'invited', NOW(), NULL, NOW(), NOW(), NOW()
   FROM inserted_workspace w
   CROSS JOIN existing_user u
   RETURNING id

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -109,6 +109,7 @@ import {
   GPT_5_MODEL_ID,
   GPT_5_NANO_MODEL_CONFIG,
   GPT_5_NANO_MODEL_ID,
+  GPT_IMAGE_1_5_MODEL_ID,
   O1_MINI_MODEL_CONFIG,
   O1_MINI_MODEL_ID,
   O1_MODEL_CONFIG,
@@ -240,6 +241,7 @@ export const ModelIdSchema = z.custom<ModelIdType>(
 export const IMAGE_MODEL_IDS = [
   GEMINI_3_PRO_IMAGE_MODEL_ID,
   GEMINI_3_1_FLASH_IMAGE_MODEL_ID,
+  GPT_IMAGE_1_5_MODEL_ID,
 ] as const;
 
 export type ImageModelIdType = (typeof IMAGE_MODEL_IDS)[number];

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -4,6 +4,8 @@
 import type { ModelConfigurationType } from "./types";
 
 export const GPT_3_5_TURBO_MODEL_ID = "gpt-3.5-turbo" as const;
+// Image generation model IDs (internal-only, not user-selectable)
+export const GPT_IMAGE_1_5_MODEL_ID = "gpt-image-1.5" as const;
 export const GPT_4_TURBO_MODEL_ID = "gpt-4-turbo" as const;
 export const GPT_4O_MODEL_ID = "gpt-4o" as const;
 export const GPT_4_1_MODEL_ID = "gpt-4.1-2025-04-14" as const;


### PR DESCRIPTION
## Description

BYOK workspaces may not have a Google AI Studio key configured. This PR adds OpenAI as a fallback image generation provider so these workspaces can still generate images using their own OpenAI key.

**What changed:**
- Added `ImageGenerationOpenAILLM` client wrapping OpenAI's `gpt-image-1.5` Images API (generate + edit)
- Introduced `ImageGenerationLLM` base class and `getImageGenerationLLM` factory — selects Google when available, falls back to OpenAI
- Made the tool handler and shared helpers fully provider-agnostic (no more hardcoded Gemini model IDs, provider tags, or dead Gemini-specific code)


Closes https://github.com/dust-tt/tasks/issues/6968

## Tests

Tested manually via the `generate_image` tool with both Google and OpenAI credentials.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`