### PR TITLE
Remove InMemorySpanExporter

### DIFF
--- a/front/lib/api/instrumentation/noop_span_exporter.ts
+++ b/front/lib/api/instrumentation/noop_span_exporter.ts
@@ -1,0 +1,27 @@
+import type { ExportResult } from "@opentelemetry/core";
+import { ExportResultCode } from "@opentelemetry/core";
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+/**
+ * A SpanExporter that discards all spans immediately.
+ *
+ * Used as the Temporal workflow sink exporter: workflow-level spans from the V8
+ * isolate need a sink but we don't consume them (Langfuse gets its spans
+ * through the separate FilteredLangfuseSpanProcessor pipeline).
+ */
+export class NoopSpanExporter implements SpanExporter {
+  export(
+    _spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -2,6 +2,7 @@ import {
   initializeOpenTelemetryInstrumentation,
   resource,
 } from "@app/lib/api/instrumentation/init";
+import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
@@ -17,7 +18,6 @@ import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { instrumentationSinks } from "@app/temporal/agent_loop/sinks";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
-import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import { isDevelopment } from "@app/types/shared/env";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Context } from "@temporalio/activity";

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -17,9 +17,9 @@ import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { instrumentationSinks } from "@app/temporal/agent_loop/sinks";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import { isDevelopment } from "@app/types/shared/env";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { Context } from "@temporalio/activity";
 import {
   makeWorkflowExporter,
@@ -38,7 +38,7 @@ export async function runAgentLoopWorker() {
   // Initialize LLMs instrumentation for the worker.
   initializeOpenTelemetryInstrumentation({ serviceName: "dust-agent-loop" });
 
-  const spanExporter = new InMemorySpanExporter();
+  const spanExporter = new NoopSpanExporter();
 
   const worker = await Worker.create({
     ...getWorkflowConfig({
@@ -98,27 +98,6 @@ export async function runAgentLoopWorker() {
       ignoreModules: ["child_process", "crypto", "stream"],
     },
   });
-
-  // Monitor InMemorySpanExporter growth to detect potential memory leaks.
-  // TODO(fabien): remove when we have enough data
-  const SPAN_SAMPLE_SIZE = 100;
-  const MONITOR_INTERVAL_MS = 60_000;
-  setInterval(() => {
-    const spans = spanExporter.getFinishedSpans();
-    const spanCount = spans.length;
-    const sampleSize = Math.min(SPAN_SAMPLE_SIZE, spanCount);
-    const sampleBytes =
-      sampleSize > 0
-        ? Buffer.byteLength(JSON.stringify(spans.slice(0, sampleSize)), "utf8")
-        : 0;
-    const estimatedTotalBytes =
-      spanCount > 0 ? Math.round((sampleBytes / sampleSize) * spanCount) : 0;
-
-    logger.info(
-      { spanCount, estimatedTotalBytes },
-      "InMemorySpanExporter span count for agent loop worker"
-    );
-  }, MONITOR_INTERVAL_MS).unref();
 
   // TODO(2025-11-12 INSTRUMENTATION): Drain Langfuse data before shutdown.
   process.on("SIGTERM", () => worker.shutdown());

--- a/front/temporal/reinforced_agent/worker.ts
+++ b/front/temporal/reinforced_agent/worker.ts
@@ -2,6 +2,7 @@ import {
   initializeOpenTelemetryInstrumentation,
   resource,
 } from "@app/lib/api/instrumentation/init";
+import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
@@ -10,7 +11,6 @@ import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/reinforced_agent/activities";
-import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import { isDevelopment } from "@app/types/shared/env";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Context } from "@temporalio/activity";

--- a/front/temporal/reinforced_agent/worker.ts
+++ b/front/temporal/reinforced_agent/worker.ts
@@ -10,9 +10,9 @@ import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/reinforced_agent/activities";
+import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import { isDevelopment } from "@app/types/shared/env";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { Context } from "@temporalio/activity";
 import {
   makeWorkflowExporter,
@@ -30,7 +30,7 @@ export async function runReinforcedAgentWorker() {
     serviceName: "dust-reinforced-agent",
   });
 
-  const spanExporter = new InMemorySpanExporter();
+  const spanExporter = new NoopSpanExporter();
 
   const worker = await Worker.create({
     ...getWorkflowConfig({


### PR DESCRIPTION
## Description

We don't actually need the `InMemorySpanExporter`
It is a memory leak where we accumulate the span until the pod is restarted
Over the weekend we have accumulated a estimated 1GB of spans

<img width="2504" height="888" alt="image" src="https://github.com/user-attachments/assets/b92c58e1-5503-42bc-927c-e3baee6bbce2" />



## Tests

Tested locally, we still have the langfuse spans

## Risk

may break spans somewhere, but easy to revert 

## Deploy Plan

deploy front
