### PR TITLE
Add workspace id to LLM timeout logs

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -36,7 +36,12 @@ class LLMStreamTimeoutError extends Error {
 // even when the source is slow to yield values.
 async function* withPeriodicHeartbeat<T>(
   stream: AsyncIterator<T>,
-  logContext?: { conversationId: string; step: number; modelId: ModelIdType }
+  logContext?: {
+    workspaceId: string;
+    conversationId: string;
+    step: number;
+    modelId: ModelIdType;
+  }
 ): AsyncGenerator<T> {
   let nextPromise = stream.next();
   let streamExhausted = false;
@@ -167,6 +172,7 @@ export async function getOutputFromLLMStream(
   let nativeChainOfThought = "";
 
   const logContext = {
+    workspaceId: conversation.owner.sId,
     conversationId: conversation.sId,
     step,
     modelId: model.modelId,


### PR DESCRIPTION
## Description

Allow to go to the conversation directy on Poke without checking the workspace in DB first

## Tests

no

## Risk

low

## Deploy Plan

deploy front
