### PR TITLE
[Workspace Scrub] Avoid redundant deletes and tolerate ES conflicts

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -6,6 +6,7 @@ use base64::{engine::general_purpose::URL_SAFE, Engine};
 use elasticsearch::{
     auth::Credentials,
     http::transport::{SingleNodeConnectionPool, TransportBuilder},
+    params::Conflicts,
     DeleteByQueryParts, DeleteParts, Elasticsearch, IndexParts, SearchParts,
 };
 use elasticsearch_dsl::{
@@ -557,6 +558,7 @@ impl SearchStore for ElasticsearchSearchStore {
         let response = self
             .client
             .delete_by_query(DeleteByQueryParts::Index(&[DATA_SOURCE_NODE_INDEX_NAME]))
+            .conflicts(Conflicts::Proceed)
             .body(json!({
                 "query": {
                     "term": { "data_source_id": data_source.data_source_id() }
@@ -565,13 +567,31 @@ impl SearchStore for ElasticsearchSearchStore {
             .send()
             .await?;
 
-        if !response.status_code().is_success() {
-            let error = response.json::<serde_json::Value>().await?;
+        let status_code = response.status_code();
+        let body = response.json::<serde_json::Value>().await?;
+
+        if !status_code.is_success() {
             return Err(anyhow::anyhow!(
                 "Failed to delete data source nodes {}",
-                error
+                body
             ));
         }
+
+        if let Some(failures) = body["failures"].as_array() {
+            if !failures.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Failed to delete data source nodes {}",
+                    body
+                ));
+            }
+        }
+
+        info!(
+            data_source_internal_id = data_source.internal_id(),
+            deleted_node_count = body["deleted"].as_i64().unwrap_or(0),
+            version_conflicts = body["version_conflicts"].as_i64().unwrap_or(0),
+            "[ElasticsearchSearchStore] Deleted data source nodes"
+        );
 
         // Then, delete the data source document.
         self.delete_document(data_source).await

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -231,10 +231,14 @@ export async function destroyConversation(
   const messagesChunks = chunk(messages, DESTROY_MESSAGE_BATCH);
   for (const messagesChunk of messagesChunks) {
     const messageIds = messagesChunk.map((m) => m.id);
-    const userMessageIds = removeNulls(messages.map((m) => m.userMessageId));
-    const agentMessageIds = removeNulls(messages.map((m) => m.agentMessageId));
+    const userMessageIds = removeNulls(
+      messagesChunk.map((m) => m.userMessageId)
+    );
+    const agentMessageIds = removeNulls(
+      messagesChunk.map((m) => m.agentMessageId)
+    );
     const messageAndContentFragmentIds = removeNulls(
-      messages.map((m) => {
+      messagesChunk.map((m) => {
         if (m.contentFragmentId) {
           return { contentFragmentId: m.contentFragmentId, messageId: m.sId };
         }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3,6 +3,7 @@ import { loadAllModels } from "@app/admin/db";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
 import {
+  AgentMessageModel,
   ConversationModel,
   MessageModel,
   UserMessageModel,
@@ -213,6 +214,79 @@ describe("ConversationResource", () => {
       );
       expect(oldConversations.length).toBe(4);
     });
+  });
+});
+
+describe("destroyConversation", () => {
+  let auth: Authenticator;
+  let agentConfigurationId: string;
+  let conversationId: string | null = null;
+
+  const getDestroyIdCounts = (calls: unknown[][]) => {
+    return calls.map((call) => {
+      const options = call[0] as { where?: { id?: unknown } };
+      const ids = options.where?.id;
+
+      if (Array.isArray(ids)) {
+        return ids.length;
+      }
+
+      return ids === undefined ? 0 : 1;
+    });
+  };
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agents = await setupTestAgents(workspace, user);
+    agentConfigurationId = agents[0].sId;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+
+    if (conversationId) {
+      await destroyConversation(auth, { conversationId });
+    }
+  });
+
+  it("should delete batched message resources chunk by chunk", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId,
+      messagesCreatedAt: Array.from({ length: 30 }, () => new Date()),
+    });
+    conversationId = conversation.sId;
+
+    const userMessageDestroySpy = vi.spyOn(UserMessageModel, "destroy");
+    const agentMessageDestroySpy = vi.spyOn(AgentMessageModel, "destroy");
+
+    const result = await destroyConversation(auth, { conversationId });
+
+    expect(result.isOk()).toBe(true);
+    conversationId = null;
+
+    const userMessageDestroyCounts = getDestroyIdCounts(
+      userMessageDestroySpy.mock.calls as unknown[][]
+    );
+    expect(userMessageDestroyCounts).toHaveLength(2);
+    expect(userMessageDestroyCounts.reduce((sum, count) => sum + count, 0)).toBe(
+      30
+    );
+    expect(Math.max(...userMessageDestroyCounts)).toBeLessThan(30);
+
+    const agentMessageDestroyCounts = getDestroyIdCounts(
+      agentMessageDestroySpy.mock.calls as unknown[][]
+    );
+    expect(agentMessageDestroyCounts).toHaveLength(2);
+    expect(
+      agentMessageDestroyCounts.reduce((sum, count) => sum + count, 0)
+    ).toBe(30);
+    expect(Math.max(...agentMessageDestroyCounts)).toBeLessThan(30);
   });
 });
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -274,9 +274,9 @@ describe("destroyConversation", () => {
       userMessageDestroySpy.mock.calls as unknown[][]
     );
     expect(userMessageDestroyCounts).toHaveLength(2);
-    expect(userMessageDestroyCounts.reduce((sum, count) => sum + count, 0)).toBe(
-      30
-    );
+    expect(
+      userMessageDestroyCounts.reduce((sum, count) => sum + count, 0)
+    ).toBe(30);
     expect(Math.max(...userMessageDestroyCounts)).toBeLessThan(30);
 
     const agentMessageDestroyCounts = getDestroyIdCounts(


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1774734483595339)
- Fix workspace conversation scrub so each batch only deletes message resources for the current chunk instead of reissuing full-conversation deletes on every batch. This addresses a likely cause of the EU DB CPU spike seen during scrub.
- Let core data source deletion continue through Elasticsearch version conflicts while still failing on real delete-by-query failures, so datasource scrubs do not get stuck when node docs are already gone by delete time.

## Risks
Blast radius: workspace scrub and data source scrub flows in front and core
Risk: low

## Deploy Plan
- deploy core
- deploy front

## Test
- [x] `cd front && NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/resources/conversation_resource.test.ts`