### PR TITLE
test: add tests on blake3 

### DIFF
--- a/connectors/src/connectors/github/lib/utils.test.ts
+++ b/connectors/src/connectors/github/lib/utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { getCodeDirInternalId, getCodeFileInternalId } from "./utils";
+
+describe("getCodeDirInternalId", () => {
+  // These expected values are computed with blake3 and serve as regression
+  // tests. If blake3 is replaced with a different hash function, these tests
+  // will fail, signaling that all persisted directory IDs would become
+  // inconsistent with the data stored in the database.
+
+  it("generates a stable id for a nested directory path", () => {
+    expect(getCodeDirInternalId(12345678, "src/lib")).toBe(
+      "github-code-12345678-dir-6437271cdac5c663"
+    );
+  });
+
+  it("generates a stable id for a top-level directory", () => {
+    expect(getCodeDirInternalId(12345678, "src")).toBe(
+      "github-code-12345678-dir-ae9f2331f8d32459"
+    );
+  });
+
+  it("includes the repo id in the result", () => {
+    const id = getCodeDirInternalId(99999, "src");
+    expect(id.startsWith("github-code-99999-dir-")).toBe(true);
+  });
+
+  it("returns different ids for different repo ids", () => {
+    const id1 = getCodeDirInternalId(111, "src");
+    const id2 = getCodeDirInternalId(222, "src");
+    expect(id1).not.toBe(id2);
+  });
+
+  it("returns different ids for different paths", () => {
+    const id1 = getCodeDirInternalId(12345678, "src/a");
+    const id2 = getCodeDirInternalId(12345678, "src/b");
+    expect(id1).not.toBe(id2);
+  });
+
+  it("returns the same id for the same input on repeated calls", () => {
+    const id1 = getCodeDirInternalId(12345678, "src/lib");
+    const id2 = getCodeDirInternalId(12345678, "src/lib");
+    expect(id1).toBe(id2);
+  });
+});
+
+describe("getCodeFileInternalId", () => {
+  // These expected values are computed with blake3 and serve as regression
+  // tests. If blake3 is replaced with a different hash function, these tests
+  // will fail, signaling that all persisted file IDs would become inconsistent
+  // with the data stored in the database.
+
+  it("generates a stable id for a nested file path", () => {
+    expect(getCodeFileInternalId(12345678, "src/index.ts")).toBe(
+      "github-code-12345678-file-034fa4d252023108"
+    );
+  });
+
+  it("generates a stable id for a root-level file", () => {
+    expect(getCodeFileInternalId(12345678, "README.md")).toBe(
+      "github-code-12345678-file-d104b37c5e461a47"
+    );
+  });
+
+  it("includes the repo id in the result", () => {
+    const id = getCodeFileInternalId(99999, "src/index.ts");
+    expect(id.startsWith("github-code-99999-file-")).toBe(true);
+  });
+
+  it("returns different ids for different file paths", () => {
+    const id1 = getCodeFileInternalId(12345678, "src/a.ts");
+    const id2 = getCodeFileInternalId(12345678, "src/b.ts");
+    expect(id1).not.toBe(id2);
+  });
+
+  it("returns different ids for different repo ids", () => {
+    const id1 = getCodeFileInternalId(111, "src/index.ts");
+    const id2 = getCodeFileInternalId(222, "src/index.ts");
+    expect(id1).not.toBe(id2);
+  });
+
+  it("returns the same id for the same input on repeated calls", () => {
+    const id1 = getCodeFileInternalId(12345678, "src/index.ts");
+    const id2 = getCodeFileInternalId(12345678, "src/index.ts");
+    expect(id1).toBe(id2);
+  });
+});

--- a/connectors/src/connectors/webcrawler/lib/utils.test.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.test.ts
@@ -1,7 +1,7 @@
 import { WebCrawlerConfigurationResourceFactory } from "@connectors/tests/utils/WebCrawlerConfigurationFactory";
 import { describe, expect, test } from "vitest";
 
-import { shouldCrawlLink } from "./utils";
+import { shouldCrawlLink, stableIdForUrl } from "./utils";
 
 describe("shouldCrawlLink", () => {
   const baseConfig = WebCrawlerConfigurationResourceFactory.createMock();
@@ -145,5 +145,77 @@ describe("shouldCrawlLink", () => {
       const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
+  });
+});
+
+describe("stableIdForUrl", () => {
+  // These expected values are computed with blake3 and serve as regression tests.
+  // If blake3 is replaced with a different hash function, these tests will fail,
+  // signaling that all persisted document IDs would become inconsistent.
+
+  test("generates a stable hex id for a document URL", () => {
+    const id = stableIdForUrl({
+      url: "https://example.com/page",
+      ressourceType: "document",
+    });
+    expect(id).toBe(
+      "37c116c576407985ebab61057ebbe2bef272d763a7fd24615323d2db80aeb2c3"
+    );
+  });
+
+  test("generates a stable hex id for a folder URL", () => {
+    const id = stableIdForUrl({
+      url: "https://example.com",
+      ressourceType: "folder",
+    });
+    expect(id).toBe(
+      "5c52da5148ba2a5de7d048f860e055ad719ac6e38c03fdf3abccb6701c84e527"
+    );
+  });
+
+  test("generates a stable hex id for a table URL", () => {
+    const id = stableIdForUrl({
+      url: "https://example.com/data",
+      ressourceType: "table",
+    });
+    expect(id).toBe(
+      "a5a24193f2893d414e7db5ab19dbad21f897c62c40b233cb25ec3ee4b996afc9"
+    );
+  });
+
+  test("returns the same id for the same input on repeated calls", () => {
+    const id1 = stableIdForUrl({
+      url: "https://example.com/foo",
+      ressourceType: "document",
+    });
+    const id2 = stableIdForUrl({
+      url: "https://example.com/foo",
+      ressourceType: "document",
+    });
+    expect(id1).toBe(id2);
+  });
+
+  test("returns different ids for different URLs", () => {
+    const id1 = stableIdForUrl({
+      url: "https://example.com/foo",
+      ressourceType: "document",
+    });
+    const id2 = stableIdForUrl({
+      url: "https://example.com/bar",
+      ressourceType: "document",
+    });
+    expect(id1).not.toBe(id2);
+  });
+
+  test("returns different ids for different resource types with the same URL", () => {
+    const id1 = stableIdForUrl({
+      url: "https://example.com",
+      ressourceType: "document",
+    });
+    const id2 = stableIdForUrl({
+      url: "https://example.com",
+      ressourceType: "folder",
+    });
+    expect(id1).not.toBe(id2);
   });
 });

--- a/front/lib/misc.test.ts
+++ b/front/lib/misc.test.ts
@@ -1,0 +1,42 @@
+import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
+import type { LightWorkspaceType } from "@app/types/user";
+import { hash as blake3 } from "blake3";
+import { describe, expect, it } from "vitest";
+
+// The function only accesses workspace.sId, so only that field matters here.
+function makeWorkspace(sId: string): LightWorkspaceType {
+  return {
+    id: 1,
+    sId,
+    name: "Test Workspace",
+    role: "admin",
+    segmentation: null,
+    whiteListedProviders: null,
+    defaultEmbeddingProvider: null,
+    sharingPolicy: "emails_only",
+  };
+}
+
+describe("isWorkspaceUsingStaticIP", () => {
+  it("returns false for an arbitrary workspace sId", () => {
+    expect(isWorkspaceUsingStaticIP(makeWorkspace("test-workspace-sid"))).toBe(
+      false
+    );
+  });
+
+  it("returns false for another arbitrary sId", () => {
+    expect(
+      isWorkspaceUsingStaticIP(makeWorkspace("some-other-workspace"))
+    ).toBe(false);
+  });
+
+  // Regression test: verifies that blake3 produces the expected deterministic
+  // output for a known input. If blake3 is replaced with a different hash
+  // function, this test will fail, signaling that the hardcoded hash in the
+  // source file must be recomputed with the new algorithm.
+  it("blake3 produces a known deterministic output for a test sId", () => {
+    expect(blake3("test-workspace-sid").toString("hex")).toBe(
+      "cef767c5f6c06be34a6bc6abcded9d1a8dd23985bba73f31143cb2b76ac871ba"
+    );
+  });
+});

--- a/front/lib/resources/string_ids.test.ts
+++ b/front/lib/resources/string_ids.test.ts
@@ -1,4 +1,7 @@
-import { generateSecureSecret } from "@app/lib/resources/string_ids";
+import {
+  generateRandomModelSId,
+  generateSecureSecret,
+} from "@app/lib/resources/string_ids";
 import { describe, expect, it } from "vitest";
 
 describe("generateSecureSecret", () => {
@@ -12,5 +15,27 @@ describe("generateSecureSecret", () => {
     const secret = generateSecureSecret(100);
     expect(secret).toHaveLength(100);
     expect(/^[A-Za-z0-9]+$/.test(secret)).toBe(true);
+  });
+});
+
+describe("generateRandomModelSId", () => {
+  it("generates a 10-char alphanumeric string without prefix", () => {
+    const sId = generateRandomModelSId();
+    expect(sId).toHaveLength(10);
+    expect(/^[A-Za-z0-9]+$/.test(sId)).toBe(true);
+  });
+
+  it("generates a string with the correct prefix when provided", () => {
+    const sId = generateRandomModelSId("conv");
+    expect(sId.startsWith("conv_")).toBe(true);
+    const suffix = sId.slice("conv_".length);
+    expect(suffix).toHaveLength(10);
+    expect(/^[A-Za-z0-9]+$/.test(suffix)).toBe(true);
+  });
+
+  it("generates different values on each call", () => {
+    const sId1 = generateRandomModelSId();
+    const sId2 = generateRandomModelSId();
+    expect(sId1).not.toBe(sId2);
   });
 });


### PR DESCRIPTION
## Description

blake3 is outdated (2021) and is probably not compatible with node24, so I would like to remove it (and use the built in node runtime for it).

So first thing: add tests to not break anything

## Tests


## Risk

