### PR TITLE
fix: firefox extension datadog init and manifest

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/main.tsx
+++ b/extension/platforms/firefox/main.tsx
@@ -14,21 +14,23 @@ import browser from "webextension-polyfill";
 import { FirefoxApp } from "./FirefoxApp";
 
 if (process.env.DATADOG_CLIENT_TOKEN) {
-  void browser.permissions.getAll().then((permissions) => {
-    if (permissions?.data_collection && process.env.DATADOG_CLIENT_TOKEN) {
-      initDatadogLogs({
-        clientToken: process.env.DATADOG_CLIENT_TOKEN,
-        service: "dust-firefox-extension",
-        env: process.env.DATADOG_ENV,
-        version: process.env.DUST_EXTENSION_VERSION,
-        forwardConsoleLogs: ["error"],
-      });
-      datadogLogs.setGlobalContext({
-        extensionVersion: process.env.DUST_EXTENSION_VERSION,
-        commitHash: process.env.COMMIT_HASH,
-      });
-    }
-  });
+  void browser.permissions
+    .contains({ data_collection: ["technicalAndInteraction"] })
+    .then((granted) => {
+      if (granted && process.env.DATADOG_CLIENT_TOKEN) {
+        initDatadogLogs({
+          clientToken: process.env.DATADOG_CLIENT_TOKEN,
+          service: "dust-firefox-extension",
+          env: process.env.DATADOG_ENV,
+          version: process.env.DUST_EXTENSION_VERSION,
+          forwardConsoleLogs: ["error"],
+        });
+        datadogLogs.setGlobalContext({
+          extensionVersion: process.env.DUST_EXTENSION_VERSION,
+          commitHash: process.env.COMMIT_HASH,
+        });
+      }
+    });
 }
 
 const rootElement = document.getElementById("root");

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.production.json
+++ b/extension/platforms/firefox/manifests/manifest.production.json
@@ -14,7 +14,7 @@
       }
     }
   },
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ data:"
+ "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
   }
 }

--- a/extension/platforms/firefox/manifests/manifest.release.json
+++ b/extension/platforms/firefox/manifests/manifest.release.json
@@ -15,6 +15,6 @@
     }
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ data:"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
   }
 }

--- a/extension/shared/AuthenticatedImage.tsx
+++ b/extension/shared/AuthenticatedImage.tsx
@@ -15,7 +15,10 @@ function isDustApiUrl(url: string): boolean {
   }
 
   const baseUrl = getBaseUrl();
-  if (baseUrl && url.startsWith(`${baseUrl}/api/`)) {
+  const normalizedBase = baseUrl?.endsWith("/")
+    ? baseUrl.slice(0, -1)
+    : baseUrl;
+  if (normalizedBase && url.startsWith(`${normalizedBase}/api/`)) {
     return true;
   }
 
@@ -90,7 +93,7 @@ export const AuthenticatedImage: SparkleContextImageType = forwardRef<
     const baseUrl = getBaseUrl();
     const resolvedSrc =
       baseUrl && isString(src) && src?.startsWith("/")
-        ? `${baseUrl}${src}`
+        ? `${baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl}${src}`
         : src;
     return <img ref={ref} src={resolvedSrc} {...props} />;
   }

--- a/extension/shared/AuthenticatedImage.tsx
+++ b/extension/shared/AuthenticatedImage.tsx
@@ -1,5 +1,6 @@
 import { getBaseUrl } from "@app/lib/api/config";
 import { clientFetch } from "@app/lib/egress/client";
+import { isString } from "@app/types/shared/utils/general";
 import type { SparkleContextImageType } from "@dust-tt/sparkle";
 import { forwardRef, type ImgHTMLAttributes, useEffect, useState } from "react";
 
@@ -14,7 +15,7 @@ function isDustApiUrl(url: string): boolean {
   }
 
   const baseUrl = getBaseUrl();
-  if (baseUrl && url.startsWith(baseUrl)) {
+  if (baseUrl && url.startsWith(`${baseUrl}/api/`)) {
     return true;
   }
 
@@ -86,7 +87,12 @@ export const AuthenticatedImage: SparkleContextImageType = forwardRef<
 
   // For non-API URLs (external images, data:, blob:), render a plain img.
   if (!needsAuth) {
-    return <img ref={ref} src={src} {...props} />;
+    const baseUrl = getBaseUrl();
+    const resolvedSrc =
+      baseUrl && isString(src) && src?.startsWith("/")
+        ? `${baseUrl}${src}`
+        : src;
+    return <img ref={ref} src={resolvedSrc} {...props} />;
   }
 
   // While fetching or on error, render an img without src so the layout is preserved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,7 +233,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",


### PR DESCRIPTION
## Description

This PR fixes Datadog initialization in the Firefox extension to respect user data collection consent and updates the extension manifest.

- Gates Datadog initialization behind Firefox's data collection permission check using `browser.permissions.contains()` API
- Updates Content Security Policy in Firefox manifests to match the Chrome ones.
- Refines Dust API URL detection to specifically check for `/api/` prefix to visualize images.

## Tests

Manually

## Risks

Low risk.

## Deploy Plan

Standard deployment. No special considerations needed.
