### PR TITLE
[front] fix scroll glitches

### DIFF
--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -2,7 +2,7 @@ import { Button } from "@sparkle/components/Button";
 import { ChevronDownIcon, ChevronUpIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 const contentVariants = cva("s-relative", {
   variants: {
@@ -43,10 +43,10 @@ export function TruncatedContent({
   buttonClassName,
 }: TruncatedContentProps) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const [exceedsThreshold, setExceedsThreshold] = useState(false);
+  const [exceedsThreshold, setExceedsThreshold] = useState(defaultCollapsed);
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const el = contentRef.current;
     if (el) {
       setExceedsThreshold(el.scrollHeight > thresholdPx);

--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -2,7 +2,7 @@ import { Button } from "@sparkle/components/Button";
 import { ChevronDownIcon, ChevronUpIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 const contentVariants = cva("s-relative", {
   variants: {

--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -46,7 +46,7 @@ export function TruncatedContent({
   const [exceedsThreshold, setExceedsThreshold] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = contentRef.current;
     if (el) {
       setExceedsThreshold(el.scrollHeight > thresholdPx);


### PR DESCRIPTION
## Description
This PR is to fix the scroll glitches. Instead of starting the expanded state, we start with collapsed state, because most likely agent messages are longer than the threshold. From my testing it seems to be working and I don't see any glitches, maybe because it's less expensive to go from collapsed => expanded when actually a message is shorter than threshold 🤔 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
