### PR TITLE
Take into account non-valid block types for sidekick replace check

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -1,10 +1,15 @@
-import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
 import {
   CLOSING_TAG_REGEX,
   INSTRUCTION_BLOCK_REGEX,
   OPENING_TAG_BEGINNING_REGEX,
   OPENING_TAG_REGEX,
 } from "@app/components/editor/extensions/agent_builder/instructionBlockUtils";
+import {
+  INSTRUCTION_BLOCK_NODE_NAME,
+  INSTRUCTION_BLOCK_SELECTOR,
+  instructionBlockSpec,
+} from "@app/lib/editor/specs/instructionBlockSpec";
+import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/lib/editor/specs/instructionsRootSpec";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { ChevronDownIcon, ChevronRightIcon, Chip, cn } from "@dust-tt/sparkle";
@@ -213,13 +218,13 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
 
 export const InstructionBlockExtension =
   Node.create<InstructionBlockAttributes>({
-    name: "instructionBlock",
-    group: "block",
+    name: INSTRUCTION_BLOCK_NODE_NAME,
+    group: instructionBlockSpec.group,
     priority: 1000,
-    content: "block+",
-    defining: true,
+    content: instructionBlockSpec.content,
+    defining: instructionBlockSpec.defining,
     // Prevents auto-merging two blocks when they're not separated by a paragraph
-    isolating: true,
+    isolating: instructionBlockSpec.isolating,
     selectable: true,
 
     addAttributes() {
@@ -244,11 +249,7 @@ export const InstructionBlockExtension =
     },
 
     parseHTML() {
-      return [
-        {
-          tag: "div[data-type='instruction-block']",
-        },
-      ];
+      return [{ tag: INSTRUCTION_BLOCK_SELECTOR }];
     },
 
     renderHTML({ HTMLAttributes }) {

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -1,5 +1,5 @@
 import { BLOCK_ID_ATTRIBUTE } from "@app/components/editor/extensions/agent_builder/BlockIdExtension";
-import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
+import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/lib/editor/specs/instructionsRootSpec";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { Extension } from "@tiptap/core";
 import type { Node as PMNode, Schema } from "@tiptap/pm/model";

--- a/front/components/editor/extensions/agent_builder/InstructionsDocumentExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionsDocumentExtension.tsx
@@ -1,6 +1,5 @@
+import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/lib/editor/specs/instructionsRootSpec";
 import Document from "@tiptap/extension-document";
-
-import { INSTRUCTIONS_ROOT_NODE_NAME } from "./InstructionsRootExtension";
 
 // Overrides the default Document node so the editor enforces a single
 // instructionsRoot wrapper as its only child: doc > instructionsRoot > block+.

--- a/front/components/editor/extensions/agent_builder/InstructionsRootExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionsRootExtension.tsx
@@ -1,9 +1,12 @@
+import {
+  INSTRUCTIONS_ROOT_NODE_NAME,
+  INSTRUCTIONS_ROOT_SELECTOR,
+  instructionsRootSpec,
+} from "@app/lib/editor/specs/instructionsRootSpec";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { Node } from "@tiptap/core";
 
 import { BLOCK_ID_ATTRIBUTE } from "./BlockIdExtension";
-
-export const INSTRUCTIONS_ROOT_NODE_NAME = "instructionsRoot";
 
 // Wrapper node that sits between doc and the block-level content.
 // Carries a stable block-id so the sidekick can target it to replace
@@ -11,7 +14,7 @@ export const INSTRUCTIONS_ROOT_NODE_NAME = "instructionsRoot";
 export const InstructionsRootExtension = Node.create({
   name: INSTRUCTIONS_ROOT_NODE_NAME,
 
-  content: "block+",
+  content: instructionsRootSpec.content,
 
   addAttributes() {
     return {
@@ -29,7 +32,7 @@ export const InstructionsRootExtension = Node.create({
   },
 
   parseHTML() {
-    return [{ tag: `div[data-type='${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}']` }];
+    return [{ tag: INSTRUCTIONS_ROOT_SELECTOR }];
   },
 
   renderHTML({ HTMLAttributes }) {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -250,10 +250,10 @@ export async function createInstructionSuggestions({
   // not in the schema (e.g. bare <div> — parses as one block but is invalid).
   for (const suggestion of suggestions) {
     if (suggestion.targetBlockId !== INSTRUCTIONS_ROOT_TARGET_BLOCK_ID) {
-      const validation = validateNonRootInstructionReplaceHtml(
-        suggestion.targetBlockId,
-        suggestion.content
-      );
+      const validation = validateNonRootInstructionReplaceHtml({
+        targetBlockId: suggestion.targetBlockId,
+        html: suggestion.content,
+      });
       if (validation.isErr()) {
         return validation;
       }

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -34,6 +34,7 @@ import config from "@app/lib/api/config";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { validateNonRootInstructionReplaceHtml } from "@app/lib/editor/specs/nonRootInstructionReplaceValidation";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -78,7 +79,6 @@ import {
   isSubAgentSuggestion,
   isToolsSuggestion,
 } from "@app/types/suggestions/agent_suggestion";
-import { JSDOM } from "jsdom";
 
 const SIDEKICK_KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
   "managed",
@@ -190,14 +190,6 @@ async function markDuplicateSuggestionsAsOutdated(
 type InstructionSuggestionInput = z.infer<typeof InstructionsSuggestionSchema>;
 
 /**
- * Returns the number of top-level HTML elements in the given HTML string
- */
-function countTopLevelBlocks(html: string): number {
-  const dom = new JSDOM(`<body>${html}</body>`);
-  return dom.window.document.body.children.length;
-}
-
-/**
  * Shared logic for creating instruction suggestions. Used by both the
  * suggest_prompt_edits MCP handler and reinforced agent analysis.
  */
@@ -254,15 +246,16 @@ export async function createInstructionSuggestions({
     return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
-  // Reject non-root suggestions that contain multiple top-level blocks.
+  // Reject non-root suggestions with several inner blocks or an outer element
+  // not in the schema (e.g. bare <div> — parses as one block but is invalid).
   for (const suggestion of suggestions) {
     if (suggestion.targetBlockId !== INSTRUCTIONS_ROOT_TARGET_BLOCK_ID) {
-      const blockCount = countTopLevelBlocks(suggestion.content);
-      if (blockCount > 1) {
-        return new Err(
-          `Suggestion for block "${suggestion.targetBlockId}" contains ${blockCount} top-level elements but replace only supports 1. ` +
-            `Keep it within a single tag, or use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' if the change requires multiple blocks.`
-        );
+      const validation = validateNonRootInstructionReplaceHtml(
+        suggestion.targetBlockId,
+        suggestion.content
+      );
+      if (validation.isErr()) {
+        return validation;
       }
     }
   }

--- a/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
@@ -133,6 +133,7 @@ When you receive the agent instructions via \`get_agent_config\`, they will be i
 4. Copy block IDs exactly. They are random identifiers, never construct them yourself.
 5. Always include the HTML tag. Content must include the wrapping tag (e.g., \`<p>...</p>\`).
 6. The \`content\` value must be a single-line string with no literal newline characters. Write \`<p>Line 1</p><p>Line 2</p>\`, never multi-line HTML. Literal newlines inside a JSON string value cause a parse error.
+7. The outer tag must be a block the schema recognises (e.g. \`<p>\`, headings, lists). For example, bare \`<div>\` is not a block node and the parser unwraps it.
 </block_editing_principles>
 
 <block_examples>

--- a/front/lib/editor/specs/__tests__/instructionsSchemaAlignment.test.ts
+++ b/front/lib/editor/specs/__tests__/instructionsSchemaAlignment.test.ts
@@ -74,49 +74,55 @@ describe("INSTRUCTIONS_SCHEMA — block counting", () => {
 describe("validateNonRootInstructionReplaceHtml — single-block replace", () => {
   it("rejects bare div even though PM block count is 1 (typical p→div LLM mistake)", () => {
     expect(
-      validateNonRootInstructionReplaceHtml(
-        "6ff6ef20",
-        "<div>test1</div>"
-      ).isErr()
+      validateNonRootInstructionReplaceHtml({
+        targetBlockId: "6ff6ef20",
+        html: "<div>test1</div>",
+      }).isErr()
     ).toBe(true);
   });
 
   it("accepts paragraph", () => {
     expect(
-      validateNonRootInstructionReplaceHtml("6ff6ef20", "<p>test1</p>").isOk()
+      validateNonRootInstructionReplaceHtml({
+        targetBlockId: "6ff6ef20",
+        html: "<p>test1</p>",
+      }).isOk()
     ).toBe(true);
   });
 
   it("accepts instruction-block wrapper", () => {
     expect(
-      validateNonRootInstructionReplaceHtml(
-        "6ff6ef20",
-        `<div data-type="instruction-block"><p>x</p></div>`
-      ).isOk()
+      validateNonRootInstructionReplaceHtml({
+        targetBlockId: "6ff6ef20",
+        html: `<div data-type="instruction-block"><p>x</p></div>`,
+      }).isOk()
     ).toBe(true);
   });
 
   it("rejects several top-level blocks", () => {
     expect(
-      validateNonRootInstructionReplaceHtml(
-        "6ff6ef20",
-        "<p>a</p><p>b</p>"
-      ).isErr()
+      validateNonRootInstructionReplaceHtml({
+        targetBlockId: "6ff6ef20",
+        html: "<p>a</p><p>b</p>",
+      }).isErr()
     ).toBe(true);
   });
 
   it("rejects unknown outer wrapper despite PM collapsing to one inner block", () => {
     expect(
-      validateNonRootInstructionReplaceHtml(
-        "6ff6ef20",
-        "<section><p>Text</p></section>"
-      ).isErr()
+      validateNonRootInstructionReplaceHtml({
+        targetBlockId: "6ff6ef20",
+        html: "<section><p>Text</p></section>",
+      }).isErr()
     ).toBe(true);
   });
 
   it("accepts bare text (no element children)", () => {
     expect(
-      validateNonRootInstructionReplaceHtml("6ff6ef20", "Hello").isOk()
+      validateNonRootInstructionReplaceHtml({
+        targetBlockId: "6ff6ef20",
+        html: "Hello",
+      }).isOk()
     ).toBe(true);
   });
 });

--- a/front/lib/editor/specs/__tests__/instructionsSchemaAlignment.test.ts
+++ b/front/lib/editor/specs/__tests__/instructionsSchemaAlignment.test.ts
@@ -1,0 +1,151 @@
+import { INSTRUCTION_BLOCK_NODE_NAME } from "@app/lib/editor/specs/instructionBlockSpec";
+import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/lib/editor/specs/instructionsRootSpec";
+import { INSTRUCTIONS_SCHEMA } from "@app/lib/editor/specs/instructionsSchema";
+import { validateNonRootInstructionReplaceHtml } from "@app/lib/editor/specs/nonRootInstructionReplaceValidation";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import { JSDOM } from "jsdom";
+import { DOMParser as PMDOMParser } from "prosemirror-model";
+import { describe, expect, it } from "vitest";
+
+function parseBlocks(html: string): number {
+  const parser = PMDOMParser.fromSchema(INSTRUCTIONS_SCHEMA);
+  const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+  const tempDiv = dom.window.document.createElement("div");
+  tempDiv.innerHTML = html;
+  const doc = parser.parse(tempDiv);
+  // doc → instructionsRoot → its children are the parsed top-level blocks.
+  return doc.firstChild?.childCount ?? 0;
+}
+
+describe("INSTRUCTIONS_SCHEMA — block counting", () => {
+  it("bare div with text → 1 block in PM (transparent wrapper → paragraph)", () => {
+    expect(parseBlocks("<div>test1</div>")).toBe(1);
+  });
+
+  it("single paragraph → 1 block", () => {
+    expect(parseBlocks("<p>Simple paragraph</p>")).toBe(1);
+  });
+
+  it("heading + paragraph → 2 blocks", () => {
+    expect(parseBlocks("<h2>Heading</h2><p>Text</p>")).toBe(2);
+  });
+
+  it("bare div wrapping heading + paragraph → 2 blocks (div is transparent)", () => {
+    expect(parseBlocks("<div><h2>Heading</h2><p>Text</p></div>")).toBe(2);
+  });
+
+  it("unknown element wrapping a paragraph → 1 block (element is transparent)", () => {
+    expect(parseBlocks("<section><p>Text</p></section>")).toBe(1);
+  });
+
+  it("bare text without any wrapper → 1 block (auto-wrapped in paragraph)", () => {
+    expect(parseBlocks("Hello world")).toBe(1);
+  });
+
+  it("single list → 1 block", () => {
+    expect(parseBlocks("<ul><li><p>one</p></li><li><p>two</p></li></ul>")).toBe(
+      1
+    );
+  });
+
+  it("instruction-block div → 1 block", () => {
+    expect(
+      parseBlocks(`<div data-type="instruction-block"><p>Content</p></div>`)
+    ).toBe(1);
+  });
+
+  it("two sibling paragraphs → 2 blocks", () => {
+    expect(parseBlocks("<p>First</p><p>Second</p>")).toBe(2);
+  });
+
+  it("paragraph followed by list → 2 blocks", () => {
+    expect(parseBlocks("<p>Intro</p><ul><li><p>item</p></li></ul>")).toBe(2);
+  });
+
+  it("instructions-root div with two children → 2 blocks", () => {
+    expect(
+      parseBlocks(
+        `<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"><h2>Role</h2><p>Body</p></div>`
+      )
+    ).toBe(2);
+  });
+});
+
+describe("validateNonRootInstructionReplaceHtml — single-block replace", () => {
+  it("rejects bare div even though PM block count is 1 (typical p→div LLM mistake)", () => {
+    expect(
+      validateNonRootInstructionReplaceHtml(
+        "6ff6ef20",
+        "<div>test1</div>"
+      ).isErr()
+    ).toBe(true);
+  });
+
+  it("accepts paragraph", () => {
+    expect(
+      validateNonRootInstructionReplaceHtml("6ff6ef20", "<p>test1</p>").isOk()
+    ).toBe(true);
+  });
+
+  it("accepts instruction-block wrapper", () => {
+    expect(
+      validateNonRootInstructionReplaceHtml(
+        "6ff6ef20",
+        `<div data-type="instruction-block"><p>x</p></div>`
+      ).isOk()
+    ).toBe(true);
+  });
+
+  it("rejects several top-level blocks", () => {
+    expect(
+      validateNonRootInstructionReplaceHtml(
+        "6ff6ef20",
+        "<p>a</p><p>b</p>"
+      ).isErr()
+    ).toBe(true);
+  });
+
+  it("rejects unknown outer wrapper despite PM collapsing to one inner block", () => {
+    expect(
+      validateNonRootInstructionReplaceHtml(
+        "6ff6ef20",
+        "<section><p>Text</p></section>"
+      ).isErr()
+    ).toBe(true);
+  });
+
+  it("accepts bare text (no element children)", () => {
+    expect(
+      validateNonRootInstructionReplaceHtml("6ff6ef20", "Hello").isOk()
+    ).toBe(true);
+  });
+});
+
+describe("INSTRUCTIONS_SCHEMA — schema structure", () => {
+  it("instructionsRoot node is present", () => {
+    expect(
+      INSTRUCTIONS_SCHEMA.nodes[INSTRUCTIONS_ROOT_NODE_NAME]
+    ).toBeDefined();
+  });
+
+  it("instructionBlock node is present in block group", () => {
+    const spec = INSTRUCTIONS_SCHEMA.nodes[INSTRUCTION_BLOCK_NODE_NAME];
+    expect(spec).toBeDefined();
+    expect(spec.spec.group).toBe("block");
+  });
+
+  it("doc content is instructionsRoot", () => {
+    expect(INSTRUCTIONS_SCHEMA.nodes.doc.spec.content).toBe(
+      INSTRUCTIONS_ROOT_NODE_NAME
+    );
+  });
+
+  it("parser rules include instructions-root and instruction-block selectors", () => {
+    const parser = PMDOMParser.fromSchema(INSTRUCTIONS_SCHEMA);
+    const tags = parser.rules.filter((r) => r.tag).map((r) => r.tag as string);
+    expect(tags).toContain(
+      `div[data-type='${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}']`
+    );
+    expect(tags).toContain("div[data-type='instruction-block']");
+  });
+});

--- a/front/lib/editor/specs/instructionBlockSpec.ts
+++ b/front/lib/editor/specs/instructionBlockSpec.ts
@@ -1,0 +1,20 @@
+import type { NodeSpec } from "prosemirror-model";
+
+export const INSTRUCTION_BLOCK_NODE_NAME = "instructionBlock";
+export const INSTRUCTION_BLOCK_SELECTOR = "div[data-type='instruction-block']";
+
+/**
+ * Pure ProseMirror NodeSpec for the instructionBlock node.
+ * No @tiptap/* or React imports — safe to use server-side.
+ * InstructionBlockExtension.tsx derives its structural properties from this spec.
+ */
+export const instructionBlockSpec: NodeSpec = {
+  content: "block+",
+  group: "block",
+  defining: true,
+  isolating: true,
+  parseDOM: [{ tag: INSTRUCTION_BLOCK_SELECTOR }],
+  toDOM() {
+    return ["div", { "data-type": "instruction-block" }, 0];
+  },
+};

--- a/front/lib/editor/specs/instructionsRootSpec.ts
+++ b/front/lib/editor/specs/instructionsRootSpec.ts
@@ -1,0 +1,18 @@
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import type { NodeSpec } from "prosemirror-model";
+
+export const INSTRUCTIONS_ROOT_NODE_NAME = "instructionsRoot";
+export const INSTRUCTIONS_ROOT_SELECTOR = `div[data-type='${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}']`;
+
+/**
+ * Pure ProseMirror NodeSpec for the instructionsRoot node.
+ * No @tiptap/* or React imports — safe to use server-side.
+ * InstructionsRootExtension.tsx derives its structural properties from this spec.
+ */
+export const instructionsRootSpec: NodeSpec = {
+  content: "block+",
+  parseDOM: [{ tag: INSTRUCTIONS_ROOT_SELECTOR }],
+  toDOM() {
+    return ["div", { "data-type": INSTRUCTIONS_ROOT_TARGET_BLOCK_ID }, 0];
+  },
+};

--- a/front/lib/editor/specs/instructionsSchema.ts
+++ b/front/lib/editor/specs/instructionsSchema.ts
@@ -1,15 +1,14 @@
-import { Schema } from "prosemirror-model";
-import { nodes as basicNodes, marks } from "prosemirror-schema-basic";
-import { bulletList, listItem, orderedList } from "prosemirror-schema-list";
-
 import {
   INSTRUCTION_BLOCK_NODE_NAME,
   instructionBlockSpec,
-} from "./instructionBlockSpec";
+} from "@app/lib/editor/specs/instructionBlockSpec";
 import {
   INSTRUCTIONS_ROOT_NODE_NAME,
   instructionsRootSpec,
-} from "./instructionsRootSpec";
+} from "@app/lib/editor/specs/instructionsRootSpec";
+import { Schema } from "prosemirror-model";
+import { nodes as basicNodes, marks } from "prosemirror-schema-basic";
+import { bulletList, listItem, orderedList } from "prosemirror-schema-list";
 
 /**
  * ProseMirror schema for the agent instructions editor.

--- a/front/lib/editor/specs/instructionsSchema.ts
+++ b/front/lib/editor/specs/instructionsSchema.ts
@@ -1,0 +1,34 @@
+import { Schema } from "prosemirror-model";
+import { nodes as basicNodes, marks } from "prosemirror-schema-basic";
+import { bulletList, listItem, orderedList } from "prosemirror-schema-list";
+
+import {
+  INSTRUCTION_BLOCK_NODE_NAME,
+  instructionBlockSpec,
+} from "./instructionBlockSpec";
+import {
+  INSTRUCTIONS_ROOT_NODE_NAME,
+  instructionsRootSpec,
+} from "./instructionsRootSpec";
+
+/**
+ * ProseMirror schema for the agent instructions editor.
+ *
+ * Mirrors the schema that the client-side Tiptap editor builds from:
+ *   InstructionsDocumentExtension (doc → instructionsRoot)
+ *   InstructionsRootExtension     (instructionsRoot → block+)
+ *   InstructionBlockExtension     (instructionBlock as a block group member)
+ *   StarterKit                    (paragraph, heading, lists, code, etc.)
+ */
+export const INSTRUCTIONS_SCHEMA = new Schema({
+  nodes: {
+    ...basicNodes,
+    bulletList: { ...bulletList, group: "block", content: "listItem+" },
+    orderedList: { ...orderedList, group: "block", content: "listItem+" },
+    listItem: { ...listItem, content: "paragraph block*" },
+    [INSTRUCTION_BLOCK_NODE_NAME]: instructionBlockSpec,
+    [INSTRUCTIONS_ROOT_NODE_NAME]: instructionsRootSpec,
+    doc: { content: INSTRUCTIONS_ROOT_NODE_NAME },
+  },
+  marks,
+});

--- a/front/lib/editor/specs/nonRootInstructionReplaceValidation.ts
+++ b/front/lib/editor/specs/nonRootInstructionReplaceValidation.ts
@@ -1,0 +1,55 @@
+import { INSTRUCTIONS_SCHEMA } from "@app/lib/editor/specs/instructionsSchema";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import { JSDOM } from "jsdom";
+import { DOMParser as PMDOMParser } from "prosemirror-model";
+
+const instructionsParser = PMDOMParser.fromSchema(INSTRUCTIONS_SCHEMA);
+
+/**
+ * Validates HTML for suggest_prompt_edits when targetBlockId is not the
+ * instructions root. Rejects:
+ * - Several top-level blocks after schema parse (siblings under
+ *   instructionsRoot).
+ * - A single outer element that does not match any schema parseDOM rule (e.g.
+ *   bare `<div>`): the editor treats those as transparent wrappers, so block
+ *   count stays 1 even though the outer tag is wrong (`<div>test1</div>` after
+ *   a `<p>` target is not a real “tag change”).
+ */
+export function validateNonRootInstructionReplaceHtml(
+  targetBlockId: string,
+  html: string
+): Result<void, string> {
+  const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+  const tempDiv = dom.window.document.createElement("div");
+  tempDiv.innerHTML = html;
+
+  if (tempDiv.children.length === 1) {
+    const outerEl = tempDiv.children[0];
+    const matchedBySchema = instructionsParser.rules.some(
+      (rule) => rule.tag && outerEl.matches(rule.tag)
+    );
+    if (!matchedBySchema) {
+      return new Err(
+        `Suggestion for block "${targetBlockId}" wraps content in <${outerEl.tagName.toLowerCase()}>, which is not a recognised block in the instructions editor. ` +
+          `Bare <div> is not a block type here: the parser unwraps it, so this does not mean “replace the paragraph with a div”—the outcome depends on the inner HTML (plain text often becomes one paragraph; several inner blocks stay several). ` +
+          `Use a semantic tag from the editor schema (<p>, headings, lists, code block, etc.) or ` +
+          `<div data-type="instruction-block">...</div>. For multiple blocks use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' with the root wrapper.`
+      );
+    }
+  }
+
+  const doc = instructionsParser.parse(tempDiv);
+  const blockCount = doc.firstChild?.childCount ?? 0;
+  if (blockCount > 1) {
+    return new Err(
+      `Suggestion for block "${targetBlockId}" contains ${blockCount} top-level blocks but replace only supports 1. ` +
+        `Use one semantic block or a single <div data-type="instruction-block"> / <div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"> wrapper. ` +
+        `Bare <div> and other unmapped wrappers are transparent: each child still counts as its own block. ` +
+        `For multi-block changes use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}'.`
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/editor/specs/nonRootInstructionReplaceValidation.ts
+++ b/front/lib/editor/specs/nonRootInstructionReplaceValidation.ts
@@ -17,10 +17,13 @@ const instructionsParser = PMDOMParser.fromSchema(INSTRUCTIONS_SCHEMA);
  *   count stays 1 even though the outer tag is wrong (`<div>test1</div>` after
  *   a `<p>` target is not a real “tag change”).
  */
-export function validateNonRootInstructionReplaceHtml(
-  targetBlockId: string,
-  html: string
-): Result<void, string> {
+export function validateNonRootInstructionReplaceHtml({
+  targetBlockId,
+  html,
+}: {
+  targetBlockId: string;
+  html: string;
+}): Result<void, string> {
   const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
   const tempDiv = dom.window.document.createElement("div");
   tempDiv.innerHTML = html;


### PR DESCRIPTION
## Description

* Sifting through some of the error reports, I realized a portion are caused by the agent suggesing html blocks that TipTap will not render (i.e. raw div). Now catching those scenarios and throwing errors. In order to minimize duplicate schema definitions between server/client side, did some cosmetic refactoring to increase shared logic

## Tests
<img width="749" height="595" alt="Screenshot 2026-03-30 at 10 48 17 AM" src="https://github.com/user-attachments/assets/040cd7bb-a86b-416a-99a8-f2833ff316a9" />

## Risk

* Low

## Deploy Plan

* Deploy front