### PR TITLE
fix: run next-sitemap in same Docker RUN as next build

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -126,9 +126,8 @@ RUN --mount=type=cache,id=next-cache,target=/app/front/.next/cache \
   --service=${svc} || exit 1; \
   done && \
   find .next -type f -name "*.map" -print -delete; \
-  fi
-
-RUN npm run sitemap
+  fi && \
+  npm run sitemap
 
 # Workers-specific build stage
 FROM base-deps AS workers-build


### PR DESCRIPTION
## Description

Moves `npm run sitemap` (`next-sitemap`) into the same Docker `RUN` command as `npm run build` (`next build`) in the front Dockerfile.

Previously, `next-sitemap` ran as a separate `RUN` step (2/2) after the build step (1/2). The build step uses `--mount=type=cache,target=/app/front/.next/cache`, and the `.next` directory created during the build was not reliably available in the subsequent layer — causing `next-sitemap` to fail with "Unable to find build-manifest."

By running both in the same `RUN`, `next-sitemap` executes while `.next` is still fully materialized in the same filesystem context.

## Tests

CI build should now pass the sitemap generation step.

## Risk

None — same commands, same order, just combined into one Docker layer.

## Deploy Plan

Deploy front.