### PR TITLE
Add a cache on /extension/config calls

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.5",
+  "version": "0.1.3",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.5",
+  "version": "0.1.3",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.5",
+  "version": "0.1.3",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -45,7 +45,7 @@ const EXTENSION_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000;
 let extensionConfigCache: {
   key: string;
   blacklistedDomains: string[];
-  timestamp: number;
+  timestampMs: number;
 } | null = null;
 
 function withTimeout<T>(
@@ -107,7 +107,7 @@ const shouldDisableContextMenuForDomain = async (
     if (
       extensionConfigCache &&
       extensionConfigCache.key === cacheKey &&
-      Date.now() - extensionConfigCache.timestamp <
+      Date.now() - extensionConfigCache.timestampMs <
         EXTENSION_CONFIG_CACHE_TTL_MS
     ) {
       blacklistedDomains = extensionConfigCache.blacklistedDomains;
@@ -127,7 +127,7 @@ const shouldDisableContextMenuForDomain = async (
       extensionConfigCache = {
         key: cacheKey,
         blacklistedDomains,
-        timestamp: Date.now(),
+        timestampMs: Date.now(),
       };
     }
 

--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -40,6 +40,14 @@ import { jwtDecode } from "jwt-decode";
 
 const log = console.error;
 
+// Cache for /extension/config responses (5-minute TTL, matching front's SWR config).
+const EXTENSION_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000;
+let extensionConfigCache: {
+  key: string;
+  blacklistedDomains: string[];
+  timestamp: number;
+} | null = null;
+
 function withTimeout<T>(
   promise: Promise<T>,
   ms: number,
@@ -93,18 +101,36 @@ const shouldDisableContextMenuForDomain = async (
   }
 
   try {
-    const res = await fetch(
-      `${regionInfo.url}/api/w/${selectedWorkspace}/extension/config`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-        credentials: "omit",
+    const cacheKey = `${regionInfo.url}:${selectedWorkspace}`;
+    let blacklistedDomains: string[];
+
+    if (
+      extensionConfigCache &&
+      extensionConfigCache.key === cacheKey &&
+      Date.now() - extensionConfigCache.timestamp <
+        EXTENSION_CONFIG_CACHE_TTL_MS
+    ) {
+      blacklistedDomains = extensionConfigCache.blacklistedDomains;
+    } else {
+      const res = await fetch(
+        `${regionInfo.url}/api/w/${selectedWorkspace}/extension/config`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          credentials: "omit",
+        }
+      );
+      if (!res.ok) {
+        return false;
       }
-    );
-    if (!res.ok) {
-      return false;
+      const data = await res.json();
+      blacklistedDomains = data.blacklistedDomains ?? [];
+      extensionConfigCache = {
+        key: cacheKey,
+        blacklistedDomains,
+        timestamp: Date.now(),
+      };
     }
-    const data = await res.json();
-    const blacklistedDomains: string[] = data.blacklistedDomains ?? [];
+
     const hostname = new URL(url).hostname;
     return blacklistedDomains.some((d) =>
       d.startsWith("http://") || d.startsWith("https://")

--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -42,11 +42,12 @@ const log = console.error;
 
 // Cache for /extension/config responses (5-minute TTL, matching front's SWR config).
 const EXTENSION_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000;
-let extensionConfigCache: {
-  key: string;
+const EXTENSION_CONFIG_CACHE_PREFIX = "extensionConfigCache:";
+
+type ExtensionConfigCache = {
   blacklistedDomains: string[];
   timestampMs: number;
-} | null = null;
+};
 
 function withTimeout<T>(
   promise: Promise<T>,
@@ -101,16 +102,16 @@ const shouldDisableContextMenuForDomain = async (
   }
 
   try {
-    const cacheKey = `${regionInfo.url}:${selectedWorkspace}`;
+    const storageKey = `${EXTENSION_CONFIG_CACHE_PREFIX}${regionInfo.url}:${selectedWorkspace}`;
     let blacklistedDomains: string[];
 
+    const cached = await platform.storage.get<ExtensionConfigCache>(storageKey);
+
     if (
-      extensionConfigCache &&
-      extensionConfigCache.key === cacheKey &&
-      Date.now() - extensionConfigCache.timestampMs <
-        EXTENSION_CONFIG_CACHE_TTL_MS
+      cached &&
+      Date.now() - cached.timestampMs < EXTENSION_CONFIG_CACHE_TTL_MS
     ) {
-      blacklistedDomains = extensionConfigCache.blacklistedDomains;
+      blacklistedDomains = cached.blacklistedDomains;
     } else {
       const res = await fetch(
         `${regionInfo.url}/api/w/${selectedWorkspace}/extension/config`,
@@ -124,11 +125,10 @@ const shouldDisableContextMenuForDomain = async (
       }
       const data = await res.json();
       blacklistedDomains = data.blacklistedDomains ?? [];
-      extensionConfigCache = {
-        key: cacheKey,
+      await platform.storage.set<ExtensionConfigCache>(storageKey, {
         blacklistedDomains,
         timestampMs: Date.now(),
-      };
+      });
     }
 
     const hostname = new URL(url).hostname;

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,7 +231,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.5",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",


### PR DESCRIPTION
## Description

Adds a 5-minute in-memory cache to `/extension/config` API calls in the extension background script. The cache reduces redundant fetches to retrieve blacklisted domains when `shouldDisableContextMenuForDomain` is called (triggered on every tab change or activation). This mirrors the SWR caching configuration already applied to the front-end in PR #23375.

## Tests

Manually tested in the extension: verified that config is cached and not refetched for 5 minutes across tab changes and activations.

## Risk

None. Standard caching optimization that only affects the extension background script.

## Deploy Plan

Deploy extension.