### PR TITLE
Support tool calls in reinforced agent

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -28,6 +28,7 @@ import {
 } from "@app/types/assistant/conversation";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
@@ -149,69 +150,89 @@ export async function writeBatchUserMessages(
  * - Creates a `MessageModel` at the next rank, parented to the last user message.
  * - Creates `AgentStepContentModel` entries for text, tool calls, reasoning, errors.
  */
+export interface StoreLlmResultInfo {
+  agentMessageModelId: ModelId;
+  agentMessageSId: string;
+  userMessageSId: string;
+}
+
 export async function storeLlmResult(
   auth: Authenticator,
   conversation: ConversationResource,
   events: LLMEvent[],
   agentConfigurationId: string
-): Promise<void> {
+): Promise<StoreLlmResultInfo> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const agentMessage = await withTransaction(async (t: Transaction) => {
-    // Find the last user message in this conversation to use as parent.
-    const parentMessage = await MessageModel.findOne({
-      where: {
-        conversationId: conversation.id,
-        workspaceId: workspace.id,
-      },
-      include: [
-        {
-          model: UserMessageModel,
-          as: "userMessage",
-          required: true,
+  const { agentMessageModel, agentMessageSId, userMessageSId } =
+    await withTransaction(async (t: Transaction) => {
+      // Find the last user message in this conversation to use as parent.
+      const parentMessage = await MessageModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
         },
-      ],
-      order: [["rank", "DESC"]],
-      transaction: t,
+        include: [
+          {
+            model: UserMessageModel,
+            as: "userMessage",
+            required: true,
+          },
+        ],
+        order: [["rank", "DESC"]],
+        transaction: t,
+      });
+
+      const maxRank = await MessageModel.max<number, MessageModel>("rank", {
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+        },
+        transaction: t,
+      });
+      const nextRank = typeof maxRank === "number" ? maxRank + 1 : 0;
+
+      // Determine status from events.
+      const hasError = events.some((e) => e instanceof EventError);
+      const status: AgentMessageStatus = hasError ? "failed" : "succeeded";
+
+      const firstError = events.find(
+        (e): e is EventError => e instanceof EventError
+      );
+
+      const msg = await AgentMessageModel.create(
+        {
+          status,
+          agentConfigurationId,
+          agentConfigurationVersion: 0,
+          workspaceId: workspace.id,
+          skipToolsValidation: false,
+          errorCode: firstError ? firstError.content.type : null,
+          errorMessage: firstError ? firstError.content.message : null,
+          completedAt: new Date(),
+        },
+        { transaction: t }
+      );
+
+      const messageSId = generateRandomModelSId();
+      await MessageModel.create(
+        {
+          sId: messageSId,
+          rank: nextRank,
+          conversationId: conversation.id,
+          parentId: parentMessage?.id ?? null,
+          agentMessageId: msg.id,
+          workspaceId: workspace.id,
+        },
+        { transaction: t }
+      );
+
+      return {
+        agentMessageModel: msg,
+        agentMessageSId: messageSId,
+        userMessageSId: parentMessage?.sId ?? "",
+      };
     });
-    const nextRank = parentMessage ? parentMessage.rank + 1 : 0;
-
-    // Determine status from events.
-    const hasError = events.some((e) => e instanceof EventError);
-    const status: AgentMessageStatus = hasError ? "failed" : "succeeded";
-
-    const firstError = events.find(
-      (e): e is EventError => e instanceof EventError
-    );
-
-    const msg = await AgentMessageModel.create(
-      {
-        status,
-        agentConfigurationId,
-        agentConfigurationVersion: 0,
-        workspaceId: workspace.id,
-        skipToolsValidation: false,
-        errorCode: firstError ? firstError.content.type : null,
-        errorMessage: firstError ? firstError.content.message : null,
-        completedAt: new Date(),
-      },
-      { transaction: t }
-    );
-
-    await MessageModel.create(
-      {
-        sId: generateRandomModelSId(),
-        rank: nextRank,
-        conversationId: conversation.id,
-        parentId: parentMessage?.id ?? null,
-        agentMessageId: msg.id,
-        workspaceId: workspace.id,
-      },
-      { transaction: t }
-    );
-
-    return msg;
-  });
 
   // Create step content entries from LLM events.
   let index = 0;
@@ -219,7 +240,7 @@ export async function storeLlmResult(
     const stepContent = eventToStoredStepContent(event);
     if (stepContent) {
       await AgentStepContentResource.createNewVersion({
-        agentMessageId: agentMessage.id,
+        agentMessageId: agentMessageModel.id,
         workspaceId: workspace.id,
         step: 0,
         index,
@@ -229,6 +250,12 @@ export async function storeLlmResult(
       index++;
     }
   }
+
+  return {
+    agentMessageModelId: agentMessageModel.id,
+    agentMessageSId,
+    userMessageSId,
+  };
 }
 
 /**
@@ -305,6 +332,11 @@ export async function sendBatchCallToLlm(
   return new Ok({ batchId, conversationIds });
 }
 
+export interface BatchDownloadResult {
+  events: Map<string, LLMEvent[]>;
+  storedResultInfo: Map<string, StoreLlmResultInfo>;
+}
+
 /**
  * Download batch results from the LLM and store them as agent messages in the
  * corresponding conversations.
@@ -315,8 +347,8 @@ export async function downloadBatchResultFromLlm(
   batchId: string,
   conversationIds: string[],
   agentConfigurationId: string
-): Promise<Map<string, LLMEvent[]>> {
-  const results = await llm.getBatchResult(batchId);
+): Promise<BatchDownloadResult> {
+  const events = await llm.getBatchResult(batchId);
 
   const conversationResources = await ConversationResource.fetchByIds(
     auth,
@@ -326,15 +358,22 @@ export async function downloadBatchResultFromLlm(
     conversationResources.map((c) => [c.sId, c])
   );
 
-  for (const [conversationId, events] of results) {
+  const storedResultInfo = new Map<string, StoreLlmResultInfo>();
+  for (const [conversationId, convEvents] of events) {
     const conversation = conversationById.get(conversationId);
     if (!conversation) {
       continue;
     }
-    await storeLlmResult(auth, conversation, events, agentConfigurationId);
+    const info = await storeLlmResult(
+      auth,
+      conversation,
+      convEvents,
+      agentConfigurationId
+    );
+    storedResultInfo.set(conversationId, info);
   }
 
-  return results;
+  return { events, storedResultInfo };
 }
 
 /**

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -183,6 +183,8 @@ export async function storeLlmResult(
         transaction: t,
       });
 
+      // Note: max rank cannot be inferred from parent message's rank:
+      // There can be several agent messages in a row without user message when doing tool calls.
       const maxRank = await MessageModel.max<number, MessageModel>("rank", {
         where: {
           conversationId: conversation.id,

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -179,8 +179,8 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
           agentConfigurationId
         );
 
-        expect(results.size).toBe(1);
-        const events = results.get(conversationId);
+        expect(results.events.size).toBe(1);
+        const events = results.events.get(conversationId);
         expect(events).toBeDefined();
 
         // Verify the response contains "2".
@@ -383,7 +383,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         );
 
         // The model should recall "42" from the previous turn.
-        const events2 = results2.get(conversationId);
+        const events2 = results2.events.get(conversationId);
         expect(events2).toBeDefined();
         const textEvent2 = events2?.find((e) => e.type === "text_generated");
         expect(textEvent2).toBeDefined();

--- a/front/lib/reinforced_agent/analyze_conversation.test.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.test.ts
@@ -64,36 +64,21 @@ function makeAction(
 describe("buildAnalysisPrompt", () => {
   it("includes agent name in user message", () => {
     const agent = makeAgentConfig({ name: "SalesBot" });
-    const { userMessage } = buildAnalysisPrompt(
-      agent,
-      "User: hello",
-      "No tools.",
-      []
-    );
+    const { userMessage } = buildAnalysisPrompt(agent, "User: hello", []);
 
     expect(userMessage).toContain("Name: SalesBot");
   });
 
   it("includes description when present", () => {
     const agent = makeAgentConfig({ description: "Handles sales queries" });
-    const { userMessage } = buildAnalysisPrompt(
-      agent,
-      "User: hello",
-      "No tools.",
-      []
-    );
+    const { userMessage } = buildAnalysisPrompt(agent, "User: hello", []);
 
     expect(userMessage).toContain("Description: Handles sales queries");
   });
 
   it("omits description section when empty", () => {
     const agent = makeAgentConfig({ description: "" });
-    const { userMessage } = buildAnalysisPrompt(
-      agent,
-      "User: hello",
-      "No tools.",
-      []
-    );
+    const { userMessage } = buildAnalysisPrompt(agent, "User: hello", []);
 
     expect(userMessage).not.toContain("Description:");
   });
@@ -102,12 +87,7 @@ describe("buildAnalysisPrompt", () => {
     const agent = makeAgentConfig({
       instructionsHtml: "<p>Be polite</p>",
     });
-    const { userMessage } = buildAnalysisPrompt(
-      agent,
-      "User: hello",
-      "No tools.",
-      []
-    );
+    const { userMessage } = buildAnalysisPrompt(agent, "User: hello", []);
 
     expect(userMessage).toContain("### Current instructions");
     expect(userMessage).toContain("<p>Be polite</p>");
@@ -115,12 +95,7 @@ describe("buildAnalysisPrompt", () => {
 
   it("omits instructions section when null", () => {
     const agent = makeAgentConfig({ instructionsHtml: null });
-    const { userMessage } = buildAnalysisPrompt(
-      agent,
-      "User: hello",
-      "No tools.",
-      []
-    );
+    const { userMessage } = buildAnalysisPrompt(agent, "User: hello", []);
 
     expect(userMessage).not.toContain("### Current instructions");
   });
@@ -130,7 +105,6 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig(),
       conversationText,
-      "No tools.",
       []
     );
 
@@ -139,29 +113,18 @@ describe("buildAnalysisPrompt", () => {
     expect(userMessage).toContain("</conversation>");
   });
 
-  it("includes tools and skills context in user message", () => {
-    const toolsContext = "## Available tools\n- search\n- browse";
-    const { userMessage } = buildAnalysisPrompt(
-      makeAgentConfig(),
-      "User: hello",
-      toolsContext,
-      []
-    );
-
-    expect(userMessage).toContain(toolsContext);
-  });
-
-  it("system prompt mentions the three available tools", () => {
+  it("system prompt mentions exploratory and suggestion tools", () => {
     const { systemPrompt } = buildAnalysisPrompt(
       makeAgentConfig(),
       "User: hello",
-      "No tools.",
       []
     );
 
     expect(systemPrompt).toContain("suggest_prompt_edits");
     expect(systemPrompt).toContain("suggest_tools");
     expect(systemPrompt).toContain("suggest_skills");
+    expect(systemPrompt).toContain("get_available_skills");
+    expect(systemPrompt).toContain("get_available_tools");
   });
 
   it("includes agent configured tools in user message", () => {
@@ -169,7 +132,6 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig({ actions: [action] }),
       "User: hello",
-      "No tools.",
       []
     );
 
@@ -182,7 +144,6 @@ describe("buildAnalysisPrompt", () => {
     const { userMessage } = buildAnalysisPrompt(
       makeAgentConfig(),
       "User: hello",
-      "No tools.",
       [skill]
     );
 

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -1,18 +1,13 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
 import { SHARED_PROMPT_SECTIONS } from "@app/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared";
-import { buildToolsAndSkillsContext } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import {
   type AgentContextSkill,
   formatAgentContext,
 } from "@app/lib/reinforced_agent/format_agent_context";
-import {
-  buildReinforcedLLMParams,
-  runReinforcedAnalysis,
-} from "@app/lib/reinforced_agent/run_reinforced_analysis";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { buildReinforcedLLMParams } from "@app/lib/reinforced_agent/run_reinforced_analysis";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -31,9 +26,22 @@ type SectionKey = (typeof ASSEMBLY_ORDER)[number];
 export const REINFORCED_ANALYSIS_SECTIONS: Record<SectionKey, string> = {
   primary: `You are an AI agent improvement analyst. Your job is to analyze a conversation handled by an AI agent and suggest concrete improvements to the agent's configuration.
 
-You have access to the following tools to suggest improvements to the agent: suggest_prompt_edits, suggest_tools, and suggest_skills.
+You have access to the following tools:
 
-You MUST follow <analysis_workflow>. These steps are enirely focused on identifying potential agent improvements and calling the suggestion tools as an end result. You MUST call at least one tool. If after <analysis_workflow> you have determined no improvements are needed, call suggest_prompt_edits with an empty suggestions array.
+## Exploration tools (optional - use these first if you need more context)
+- get_available_skills: Lists all skills available in the workspace. Use this to discover skills you could suggest adding.
+- get_available_tools: Lists all tools (MCP servers) available in the workspace. Use this to discover tools you could suggest adding.
+
+## Suggestion tools (terminal — the conversation ends after these)
+- suggest_prompt_edits: For suggesting instruction changes.
+- suggest_tools: For suggesting tools to add or remove.
+- suggest_skills: For suggesting skills to add or remove.
+
+You can either:
+1. Call exploration tools first to discover available skills/tools, then make informed suggestions.
+2. Go straight to calling suggestion tools if you already have enough context.
+
+You MUST follow <analysis_workflow>. These steps are entirely focused on identifying potential agent improvements and calling the suggestion tools as an end result. You MUST eventually call at least one suggestion tool. If after <analysis_workflow> you have determined no improvements are needed, call suggest_prompt_edits with an empty suggestions array.
 
 The user will not look at your response. The user ONLY cares about the content of the suggestion tool calls.`,
 
@@ -71,7 +79,7 @@ This is the MOST important signal as it is directly provided by the user and an 
 Example: The user asks, "Create a Gmail draft replying to Thread X". The agent calls gmail__search_messages 4 times with different vague queries, then tries gmail__create_reply_draft twice with different ID fields (Message-ID header, then thread id) and finally succeeds only after trial-and-error.
 This pattern suggests instruction gaps (which identifier to pass, and the expected call chain).
 
-4. Missing capabilities the agent should have. Look at <tools_and_skills_context>. Determine if more information or actions could have been provided to the user to improve satisfaction and increase user productivity. When making these types of suggestions, you MUST ensure that they are inline with the goal/role of the agent.
+4. Missing capabilities the agent should have. Call get_available_tools and get_available_skills to discover what tools and skills are available in the workspace. Determine if more information or actions could have been provided to the user to improve satisfaction and increase user productivity. When making these types of suggestions, you MUST ensure that they are inline with the goal/role of the agent.
 
 A key consideration is that conversations can be user-specific, but agents are usually shared. You MUST ensure that the suggestions are useful for all users of the agent.`,
 
@@ -83,7 +91,7 @@ A key consideration is that conversations can be user-specific, but agents are u
     SHARED_PROMPT_SECTIONS.instructionSuggestionFormatting,
 };
 
-function buildAnalysisSystemPrompt(): string {
+export function buildAnalysisSystemPrompt(): string {
   return ASSEMBLY_ORDER.map((key) => {
     const body = REINFORCED_ANALYSIS_SECTIONS[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
@@ -93,7 +101,6 @@ function buildAnalysisSystemPrompt(): string {
 export function buildAnalysisPrompt(
   agentConfig: AgentConfigurationType,
   conversationText: string,
-  toolsAndSkillsContext: string,
   agentSkills: AgentContextSkill[]
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = buildAnalysisSystemPrompt();
@@ -101,10 +108,6 @@ export function buildAnalysisPrompt(
   const userMessage = `<agent_context>
 ${formatAgentContext(agentConfig, agentSkills)}
 </agent_context>
-
-<tools_and_skills_context>
-${toolsAndSkillsContext}
-</tools_and_skills_context>
 
 <conversation>
 ${conversationText}
@@ -136,10 +139,10 @@ export async function buildConversationAnalysisBatchMap(
     return null;
   }
 
-  const [toolsAndSkillsContext, agentSkills] = await Promise.all([
-    buildToolsAndSkillsContext(auth),
-    SkillResource.listByAgentConfiguration(auth, agentConfig),
-  ]);
+  const agentSkills = await SkillResource.listByAgentConfiguration(
+    auth,
+    agentConfig
+  );
 
   const batchMap = new Map<string, LLMStreamParameters>();
 
@@ -160,7 +163,6 @@ export async function buildConversationAnalysisBatchMap(
     const prompt = buildAnalysisPrompt(
       agentConfig,
       conversationRes.value.text,
-      toolsAndSkillsContext,
       agentSkills
     );
     batchMap.set(conversationId, buildReinforcedLLMParams(prompt));
@@ -169,87 +171,3 @@ export async function buildConversationAnalysisBatchMap(
   return batchMap.size > 0 ? batchMap : null;
 }
 
-/**
- * Analyze a single conversation for reinforcement suggestions.
- * Creates synthetic AgentSuggestion records.
- */
-export async function analyzeConversationForReinforcement(
-  auth: Authenticator,
-  {
-    conversationId,
-    agentConfigurationId,
-  }: {
-    conversationId: string;
-    agentConfigurationId: string;
-  }
-): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const [agentConfig] = await getAgentConfigurations(auth, {
-    agentIds: [agentConfigurationId],
-    variant: "full",
-  });
-  if (!agentConfig) {
-    logger.warn(
-      { agentConfigurationId, workspaceId: owner.sId },
-      "ReinforcedAgent: agent configuration not found"
-    );
-    return;
-  }
-  if (agentConfig.id < 0) {
-    return;
-  }
-
-  const [
-    conversationRes,
-    conversationResource,
-    toolsAndSkillsContext,
-    agentSkills,
-  ] = await Promise.all([
-    getShrinkWrappedConversation(auth, {
-      conversationId,
-      includeFeedback: true,
-    }),
-    ConversationResource.fetchById(auth, conversationId),
-    buildToolsAndSkillsContext(auth),
-    SkillResource.listByAgentConfiguration(auth, agentConfig),
-  ]);
-  if (conversationRes.isErr() || !conversationResource) {
-    logger.warn(
-      {
-        conversationId,
-        error: conversationRes.isErr() && conversationRes.error,
-      },
-      "ReinforcedAgent: conversation not found"
-    );
-    return;
-  }
-
-  const prompt = buildAnalysisPrompt(
-    agentConfig,
-    conversationRes.value.text,
-    toolsAndSkillsContext,
-    agentSkills
-  );
-
-  const createdCount = await runReinforcedAnalysis({
-    auth,
-    agentConfig,
-    prompt,
-    source: "synthetic",
-    operationType: "reinforced_agent_analyze_conversation",
-    contextId: conversationId,
-    conversation: conversationResource,
-  });
-
-  if (createdCount > 0) {
-    logger.info(
-      {
-        conversationId,
-        agentConfigurationId,
-        suggestionsCreated: createdCount,
-      },
-      "ReinforcedAgent: created synthetic suggestions from conversation analysis"
-    );
-  }
-}

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -41,7 +41,7 @@ You can either:
 1. Call exploration tools first to discover available skills/tools, then make informed suggestions.
 2. Go straight to calling suggestion tools if you already have enough context.
 
-You MUST follow <analysis_workflow>. These steps are entirely focused on identifying potential agent improvements and calling the suggestion tools as an end result. You MUST eventually call at least one suggestion tool. If after <analysis_workflow> you have determined no improvements are needed, call suggest_prompt_edits with an empty suggestions array.
+You MUST follow <analysis_workflow>. These steps are entirely focused on identifying potential agent improvements and calling the suggestion tools as an end result. You MUST eventually call at least one suggestion tool. You must do all the suggestions in parallel as after suggestions the conversation will be over. If after <analysis_workflow> you have determined no improvements are needed, call suggest_prompt_edits with an empty suggestions array.
 
 The user will not look at your response. The user ONLY cares about the content of the suggestion tool calls.`,
 
@@ -170,4 +170,3 @@ export async function buildConversationAnalysisBatchMap(
 
   return batchMap.size > 0 ? batchMap : null;
 }
-

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -11,13 +11,19 @@ import {
   writeBatchUserMessages,
 } from "@app/lib/api/llm/batch_llm";
 import type { LLM } from "@app/lib/api/llm/llm";
-import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMEvent, ToolCallEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { ReinforcedOperationType } from "@app/lib/reinforced_agent/types";
-import { getReinforcementMetadata } from "@app/lib/reinforced_agent/types";
+import {
+  type ExploratoryToolCallInfo,
+  type ExploratoryToolName,
+  getReinforcementMetadata,
+  type TerminalToolCallInfo,
+  type TerminalToolName,
+} from "@app/lib/reinforced_agent/types";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -28,15 +34,20 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const SUPPORTED_TOOLS = [
+const TERMINAL_TOOLS: TerminalToolName[] = [
   "suggest_prompt_edits",
   "suggest_tools",
   "suggest_skills",
-] as const;
+];
 
-type SupportedToolName = (typeof SUPPORTED_TOOLS)[number];
+const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
+  "get_available_skills",
+  "get_available_tools",
+];
 
-const TOOL_SCHEMAS: Record<SupportedToolName, z.ZodObject<z.ZodRawShape>> = {
+const ALL_TOOLS = [...TERMINAL_TOOLS, ...EXPLORATORY_TOOLS];
+
+const TOOL_SCHEMAS: Record<TerminalToolName, z.ZodObject<z.ZodRawShape>> = {
   suggest_prompt_edits: z.object(
     AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.schema
   ),
@@ -48,12 +59,50 @@ const TOOL_SCHEMAS: Record<SupportedToolName, z.ZodObject<z.ZodRawShape>> = {
   ),
 };
 
-function buildSpecifications(): AgentActionSpecification[] {
-  return SUPPORTED_TOOLS.map((toolName) => ({
-    name: AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[toolName].name,
-    description: AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[toolName].description,
-    inputSchema: zodToJsonSchema(TOOL_SCHEMAS[toolName]) as JSONSchema,
-  }));
+export function buildReinforcedSpecifications(): AgentActionSpecification[] {
+  return ALL_TOOLS.map((toolName) => {
+    const meta = AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[toolName];
+    const schema = z.object(meta.schema);
+    return {
+      name: meta.name,
+      description: meta.description,
+      inputSchema: zodToJsonSchema(schema) as JSONSchema,
+    };
+  });
+}
+
+interface ClassifiedToolCalls {
+  exploratoryToolCalls: ExploratoryToolCallInfo[];
+  terminalToolCalls: TerminalToolCallInfo[];
+}
+
+export function classifyToolCalls(events: LLMEvent[]): ClassifiedToolCalls {
+  const terminalToolNames = new Set<string>(TERMINAL_TOOLS);
+  const exploratoryToolNames = new Set<string>(EXPLORATORY_TOOLS);
+
+  const toolCallEvents = events.filter(
+    (e): e is ToolCallEvent =>
+      e.type === "tool_call" &&
+      (terminalToolNames.has(e.content.name) ||
+        exploratoryToolNames.has(e.content.name))
+  );
+
+  return {
+    exploratoryToolCalls: toolCallEvents
+      .filter((e) => exploratoryToolNames.has(e.content.name))
+      .map((e) => ({
+        id: e.content.id,
+        name: e.content.name as ExploratoryToolName,
+        arguments: e.content.arguments,
+      })),
+    terminalToolCalls: toolCallEvents
+      .filter((e) => terminalToolNames.has(e.content.name))
+      .map((e) => ({
+        id: e.content.id,
+        name: e.content.name as TerminalToolName,
+        arguments: e.content.arguments,
+      })),
+  };
 }
 
 export const REINFORCEMENT_AGENT_ID = "reinforcement";
@@ -114,7 +163,7 @@ export function buildReinforcedLLMParams({
       ],
     },
     prompt: systemPrompt,
-    specifications: buildSpecifications(),
+    specifications: buildReinforcedSpecifications(),
   };
 }
 
@@ -182,9 +231,9 @@ export async function processReinforcedEvents({
     return 0;
   }
 
-  const supportedToolNames = new Set<string>(SUPPORTED_TOOLS);
+  const terminalToolNames = new Set<string>(TERMINAL_TOOLS);
   const toolCallEvents = events.filter(
-    (e) => e.type === "tool_call" && supportedToolNames.has(e.content.name)
+    (e) => e.type === "tool_call" && terminalToolNames.has(e.content.name)
   );
   if (toolCallEvents.length === 0) {
     logger.warn(
@@ -342,7 +391,12 @@ async function createSuggestionsFromToolCall({
 
 /**
  * Shared helper for both analyze and aggregate phases of reinforced agents.
- * Calls the LLM with the given prompt, parses suggestions, and creates them.
+ * Calls the LLM once with the given prompt, stores the result, and processes
+ * any terminal suggestion tool calls.
+ *
+ * For multi-step conversations (exploratory tools), the loop is handled at the
+ * Temporal workflow level via analyzeConversationStepActivity + runRetryableToolActivity.
+ *
  * Returns the number of suggestions created.
  */
 export async function runReinforcedAnalysis({

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -71,12 +71,12 @@ export function buildReinforcedSpecifications(): AgentActionSpecification[] {
   });
 }
 
-interface ClassifiedToolCalls {
+interface CategorizedToolCalls {
   exploratoryToolCalls: ExploratoryToolCallInfo[];
   terminalToolCalls: TerminalToolCallInfo[];
 }
 
-export function classifyToolCalls(events: LLMEvent[]): ClassifiedToolCalls {
+export function classifyToolCalls(events: LLMEvent[]): CategorizedToolCalls {
   const terminalToolNames = new Set<string>(TERMINAL_TOOLS);
   const exploratoryToolNames = new Set<string>(EXPLORATORY_TOOLS);
 

--- a/front/lib/reinforced_agent/tool_execution.ts
+++ b/front/lib/reinforced_agent/tool_execution.ts
@@ -1,0 +1,138 @@
+import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
+import type { ExploratoryToolCallInfo } from "@app/lib/reinforced_agent/types";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
+import type { ModelId } from "@app/types/shared/model_id";
+
+/**
+ * Info needed by the workflow to call runRetryableToolActivity and
+ * then read back the results.
+ */
+export interface ReinforcedToolActionInfo {
+  authType: AuthenticatorType;
+  agentLoopArgs: {
+    agentMessageId: string;
+    agentMessageVersion: number;
+    conversationId: string;
+    conversationTitle: string | null;
+    conversationBranchId: string | null;
+    userMessageId: string;
+    userMessageVersion: number;
+    initialStartTime: number;
+  };
+  actionIds: ModelId[];
+  exploratoryToolCalls: ExploratoryToolCallInfo[];
+}
+
+/**
+ * Create AgentMCPActionResource records for each exploratory tool call.
+ * Returns the info needed by the workflow to call runRetryableToolActivity.
+ */
+export async function prepareReinforcedToolActions(
+  auth: Authenticator,
+  {
+    exploratoryToolCalls,
+    agentMessageModelId,
+    agentMessageSId,
+    userMessageSId,
+    conversationId,
+  }: {
+    exploratoryToolCalls: ExploratoryToolCallInfo[];
+    agentMessageModelId: ModelId;
+    agentMessageSId: string;
+    userMessageSId: string;
+    conversationId: string;
+  }
+): Promise<ReinforcedToolActionInfo> {
+  // Find step content for each function call.
+  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+    auth,
+    { agentMessageIds: [agentMessageModelId], latestVersionsOnly: true }
+  );
+
+  const functionCallStepContents = stepContents.filter(
+    (
+      s
+    ): s is AgentStepContentResource & {
+      value: AgentFunctionCallContentType;
+    } => s.type === "function_call"
+  );
+
+  const stepContentByCallId = new Map(
+    functionCallStepContents.map((s) => [s.value.value.id, s])
+  );
+
+  // Create AgentMCPActionResource for each exploratory tool call.
+  const actionIds: ModelId[] = [];
+  for (const tc of exploratoryToolCalls) {
+    const stepContent = stepContentByCallId.get(tc.id);
+    if (!stepContent) {
+      throw new Error(
+        `Step content not found for function call ${tc.id} (${tc.name})`
+      );
+    }
+
+    const meta = AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[tc.name];
+
+    const action = await AgentMCPActionResource.makeNew(auth, {
+      agentMessageId: agentMessageModelId,
+      augmentedInputs: tc.arguments,
+      citationsAllocated: 0,
+      mcpServerConfigurationId: "agent_sidekick_context",
+      status: "ready_allowed_explicitly",
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 0,
+        websearchResultCount: 0,
+      },
+      toolConfiguration: {
+        id: -1,
+        sId: generateRandomModelSId(),
+        type: "mcp_configuration",
+        name: tc.name,
+        originalName: tc.name,
+        mcpServerName: "agent_sidekick_context",
+        dataSources: null,
+        tables: null,
+        childAgentId: null,
+        timeFrame: null,
+        jsonSchema: null,
+        additionalConfiguration: {},
+        mcpServerViewId: "",
+        dustAppConfiguration: null,
+        internalMCPServerId: "agent_sidekick_context",
+        secretName: null,
+        dustProject: null,
+        availability: "auto",
+        permission: meta.stake,
+        toolServerId: "agent_sidekick_context",
+        retryPolicy: "no_retry",
+      },
+      version: 0,
+    });
+
+    actionIds.push(action.id);
+  }
+
+  return {
+    authType: auth.toJSON(),
+    agentLoopArgs: {
+      agentMessageId: agentMessageSId,
+      agentMessageVersion: 0,
+      conversationId,
+      conversationTitle: null,
+      conversationBranchId: null,
+      userMessageId: userMessageSId,
+      userMessageVersion: 0,
+      initialStartTime: Date.now(),
+    },
+    actionIds,
+    exploratoryToolCalls,
+  };
+}

--- a/front/lib/reinforced_agent/tool_execution.ts
+++ b/front/lib/reinforced_agent/tool_execution.ts
@@ -36,14 +36,14 @@ export async function prepareReinforcedToolActions(
   {
     exploratoryToolCalls,
     agentMessageModelId,
-    agentMessageSId,
-    userMessageSId,
+    agentMessageId,
+    userMessageId,
     conversationId,
   }: {
     exploratoryToolCalls: ExploratoryToolCallInfo[];
     agentMessageModelId: ModelId;
-    agentMessageSId: string;
-    userMessageSId: string;
+    agentMessageId: string;
+    userMessageId: string;
     conversationId: string;
   }
 ): Promise<ReinforcedToolActionInfo> {
@@ -123,12 +123,12 @@ export async function prepareReinforcedToolActions(
   return {
     authType: auth.toJSON(),
     agentLoopArgs: {
-      agentMessageId: agentMessageSId,
+      agentMessageId: agentMessageId,
       agentMessageVersion: 0,
       conversationId,
       conversationTitle: null,
       conversationBranchId: null,
-      userMessageId: userMessageSId,
+      userMessageId: userMessageId,
       userMessageVersion: 0,
       initialStartTime: Date.now(),
     },

--- a/front/lib/reinforced_agent/types.ts
+++ b/front/lib/reinforced_agent/types.ts
@@ -1,3 +1,30 @@
+export const MAX_REINFORCED_ANALYSIS_STEPS = 4;
+
+export type ExploratoryToolName =
+  | "get_available_skills"
+  | "get_available_tools";
+
+export type TerminalToolName =
+  | "suggest_prompt_edits"
+  | "suggest_tools"
+  | "suggest_skills";
+
+export interface ExploratoryToolCallInfo {
+  id: string;
+  name: ExploratoryToolName;
+  arguments: Record<string, unknown>;
+}
+
+export interface TerminalToolCallInfo {
+  id: string;
+  name: TerminalToolName;
+  arguments: Record<string, unknown>;
+}
+
+export type ReinforcedToolCallInfo =
+  | ExploratoryToolCallInfo
+  | TerminalToolCallInfo;
+
 export type ReinforcedOperationType =
   | "reinforced_agent_analyze_conversation"
   | "reinforced_agent_aggregate_suggestions";

--- a/front/lib/reinforced_agent/utils.ts
+++ b/front/lib/reinforced_agent/utils.ts
@@ -1,0 +1,43 @@
+import type { ExploratoryToolCallInfo } from "@app/lib/reinforced_agent/types";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+
+/**
+ * Build continuation messages from exploratory tool calls and their results.
+ * Returns an assistant function-call message followed by function-result messages.
+ *
+ * Defined in a standalone module (rather than in run_reinforced_analysis.ts) so
+ * that Temporal workflow files can import it without pulling in heavy deps (zod, etc.).
+ */
+export function buildContinuationMessages(
+  exploratoryToolCalls: ExploratoryToolCallInfo[],
+  toolResults: Record<string, string>
+): ModelMessageTypeMultiActionsWithoutContentFragment[] {
+  const messages: ModelMessageTypeMultiActionsWithoutContentFragment[] = [];
+
+  // Assistant message with function calls in `contents` (the format used by
+  // the Anthropic conversion layer).
+  messages.push({
+    role: "assistant" as const,
+    function_calls: [],
+    contents: exploratoryToolCalls.map((tc) => ({
+      type: "function_call" as const,
+      value: {
+        id: tc.id,
+        name: tc.name,
+        arguments: JSON.stringify(tc.arguments),
+      },
+    })),
+  });
+
+  // Function result messages — one per tool call.
+  for (const tc of exploratoryToolCalls) {
+    messages.push({
+      role: "function" as const,
+      name: tc.name,
+      function_call_id: tc.id,
+      content: toolResults[tc.id] ?? "",
+    });
+  }
+
+  return messages;
+}

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -1,11 +1,18 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import type { LlmConversationOptions } from "@app/lib/api/llm/batch_llm";
 import {
   downloadBatchResultFromLlm,
   sendBatchCallToLlm,
+  storeLlmResult,
+  writeBatchUserMessages,
 } from "@app/lib/api/llm/batch_llm";
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { Authenticator } from "@app/lib/auth";
 import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import {
@@ -13,22 +20,35 @@ import {
   buildAggregationBatchMap,
 } from "@app/lib/reinforced_agent/aggregate_suggestions";
 import {
-  analyzeConversationForReinforcement,
+  buildAnalysisPrompt,
+  buildAnalysisSystemPrompt,
   buildConversationAnalysisBatchMap,
 } from "@app/lib/reinforced_agent/analyze_conversation";
 import {
+  buildReinforcedLLMParams,
+  buildReinforcedSpecifications,
+  classifyToolCalls,
   getReinforcedLLM,
   getReinforcementDefaultOptions,
   processReinforcedEvents,
   REINFORCEMENT_AGENT_ID,
   reinforcementConversationTitle,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import {
+  prepareReinforcedToolActions,
+  type ReinforcedToolActionInfo,
+} from "@app/lib/reinforced_agent/tool_execution";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { updateActiveTrace } from "@langfuse/tracing";
 import { ApplicationFailure } from "@temporalio/common";
+
+// Re-export runToolActivity so the reinforced agent worker registers it,
+// allowing the workflow to call it via proxyActivities.
+export { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 
 async function getAuthForWorkspace(
   workspaceId: string
@@ -94,24 +114,199 @@ export async function getRecentConversationsForAgentActivity({
   });
 }
 
+
 /**
- * Analyze a single conversation for a specific agent.
+ * Analyze a single conversation step for reinforcement.
+ *
+ * On the first step (`reinforcementConversationId` is undefined), creates a
+ * reinforcement conversation and stores the analysis prompt as the user message.
+ *
+ * On continuation steps, the reinforcement conversation already contains the full
+ * history (user message, previous LLM tool calls, tool results stored by
+ * runRetryableToolActivity). The conversation is rendered from DB via
+ * `renderConversationForModel`.
+ *
+ * Returns `isTerminal: true` when the LLM calls terminal suggestion tools.
+ * Otherwise returns `toolActionInfo` for the workflow to execute tools.
  */
-export async function analyzeConversationActivity({
+export async function analyzeConversationStepActivity({
   workspaceId,
   agentConfigurationId,
   conversationId,
+  reinforcementConversationId,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   conversationId: string;
-}): Promise<void> {
+  reinforcementConversationId?: string;
+}): Promise<{
+  isTerminal: boolean;
+  reinforcementConversationId?: string;
+  toolActionInfo?: ReinforcedToolActionInfo;
+}> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const owner = auth.getNonNullableWorkspace();
 
-  await analyzeConversationForReinforcement(auth, {
-    conversationId,
-    agentConfigurationId,
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "full",
   });
+  if (!agentConfig || agentConfig.id < 0) {
+    logger.warn(
+      { agentConfigurationId, workspaceId: owner.sId },
+      "ReinforcedAgent: agent configuration not found for step activity"
+    );
+    return { isTerminal: true };
+  }
+
+  // On first step, build the analysis prompt and create a reinforcement conversation.
+  if (!reinforcementConversationId) {
+    const [conversationRes, agentSkills] = await Promise.all([
+      getShrinkWrappedConversation(auth, {
+        conversationId,
+        includeFeedback: true,
+      }),
+      SkillResource.listByAgentConfiguration(auth, agentConfig),
+    ]);
+    if (conversationRes.isErr()) {
+      logger.warn(
+        { conversationId },
+        "ReinforcedAgent: conversation not found for step activity"
+      );
+      return { isTerminal: true };
+    }
+
+    const prompt = buildAnalysisPrompt(
+      agentConfig,
+      conversationRes.value.text,
+      agentSkills
+    );
+    const llmParams = buildReinforcedLLMParams(prompt);
+    const { conversation: llmConversation, ...llmParamsWithoutConversation } =
+      llmParams;
+    const writeResult = await writeBatchUserMessages(auth, {
+      newMessages: llmConversation.messages,
+      title: reinforcementConversationTitle(
+        "reinforced_agent_analyze_conversation",
+        conversationId
+      ),
+      ...llmParamsWithoutConversation,
+      ...getReinforcementDefaultOptions(
+        "reinforced_agent_analyze_conversation",
+        agentConfigurationId
+      ),
+    });
+    if (writeResult.isErr()) {
+      throw writeResult.error;
+    }
+    reinforcementConversationId = writeResult.value.sId;
+  }
+
+  // Fetch the reinforcement conversation and render it for the LLM.
+  // On first step this has just the user message.
+  // On continuations this includes previous assistant tool calls + tool results.
+  const llm = await getReinforcedLLM(
+    auth,
+    "reinforced_agent_analyze_conversation"
+  );
+  if (!llm) {
+    logger.error(
+      { conversationId },
+      "ReinforcedAgent: no LLM available for step activity"
+    );
+    return { isTerminal: true };
+  }
+
+  const conversationRes = await getConversation(
+    auth,
+    reinforcementConversationId
+  );
+  if (conversationRes.isErr()) {
+    throw conversationRes.error;
+  }
+
+  const systemPrompt = buildAnalysisSystemPrompt();
+  const specifications = buildReinforcedSpecifications();
+  const modelConfig = llm.getModelConfig();
+  const toolsJson = JSON.stringify(
+    specifications.map((s) => ({
+      name: s.name,
+      description: s.description,
+      inputSchema: s.inputSchema,
+    }))
+  );
+
+  const renderResult = await renderConversationForModel(auth, {
+    conversation: conversationRes.value,
+    model: modelConfig,
+    prompt: systemPrompt,
+    tools: toolsJson,
+    allowedTokenCount:
+      modelConfig.contextSize - modelConfig.generationTokensCount,
+  });
+  if (renderResult.isErr()) {
+    throw renderResult.error;
+  }
+
+  const llmParams: LLMStreamParameters = {
+    conversation: renderResult.value.modelConversation,
+    prompt: systemPrompt,
+    specifications,
+  };
+
+  const events: LLMEvent[] = [];
+  for await (const event of llm.stream(llmParams)) {
+    events.push(event);
+  }
+
+  // Store agent response in the reinforcement conversation.
+  const reinforcementConv = await ConversationResource.fetchById(
+    auth,
+    reinforcementConversationId
+  );
+  if (!reinforcementConv) {
+    throw new Error(
+      `Reinforcement conversation not found: ${reinforcementConversationId}`
+    );
+  }
+
+  const storedResult = await storeLlmResult(
+    auth,
+    reinforcementConv,
+    events,
+    REINFORCEMENT_AGENT_ID
+  );
+
+  const { exploratoryToolCalls, terminalToolCalls } = classifyToolCalls(events);
+
+  // If terminal tools were called, process suggestions.
+  if (terminalToolCalls.length > 0 || exploratoryToolCalls.length === 0) {
+    const analysedConversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    await processReinforcedEvents({
+      auth,
+      agentConfig,
+      events,
+      source: "synthetic",
+      operationType: "reinforced_agent_analyze_conversation",
+      contextId: conversationId,
+      conversation: analysedConversation ?? undefined,
+    });
+    return { isTerminal: true, reinforcementConversationId };
+  }
+
+  // Prepare tool actions for the workflow to execute via runRetryableToolActivity.
+  const toolActionInfo = await prepareReinforcedToolActions(auth, {
+    exploratoryToolCalls,
+    agentMessageModelId: storedResult.agentMessageModelId,
+    agentMessageSId: storedResult.agentMessageSId,
+    userMessageSId: storedResult.userMessageSId,
+    conversationId: reinforcementConversationId,
+  });
+
+  return { isTerminal: false, reinforcementConversationId, toolActionInfo };
 }
 
 /**
@@ -140,33 +335,33 @@ export async function aggregateSuggestionsActivity({
 // ---------------------------------------------------------------------------
 
 /**
- * Build analysis prompts for all conversations and submit them as a batch.
- * Returns the batch ID, reinforced agent conversation sIds, and the original
- * conversation sIds being analyzed (to map results back).
+ * Build analysis prompts and submit a batch for conversation analysis.
+ *
+ * For first-time conversations (no entry in `existingReinforcementConversationMap`),
+ * builds the analysis prompt and creates a new reinforcement conversation.
+ * For continuation conversations, reuses the existing reinforcement conversation
+ * which already contains the full history (previous LLM calls + tool results).
+ *
+ * In both cases, `sendBatchCallToLlm` fetches the conversation from DB and
+ * calls `renderConversationForModel` to build the LLM parameters.
+ *
  * Returns null if no conversations could be prepared.
  */
 export async function startConversationAnalysisBatchActivity({
   workspaceId,
   agentConfigurationId,
   analysedConversationIds,
+  existingReinforcementConversationMap,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   analysedConversationIds: string[];
+  existingReinforcementConversationMap?: Record<string, string>;
 }): Promise<{
   batchId: string;
-  reinforcementConversationIds: string[];
-  analysedConversationIds: string[];
+  reinforcementConversationMap: Record<string, string>;
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
-
-  const batchMap = await buildConversationAnalysisBatchMap(auth, {
-    agentConfigurationId,
-    conversationIds: analysedConversationIds,
-  });
-  if (!batchMap) {
-    return null;
-  }
 
   const llm = await getReinforcedLLM(
     auth,
@@ -176,23 +371,66 @@ export async function startConversationAnalysisBatchActivity({
     return null;
   }
 
+  // Build the analysis prompt for first-time conversations.
+  // For continuation conversations, the prompt is already in the DB.
+  const firstTimeConversationIds = analysedConversationIds.filter(
+    (id) => !existingReinforcementConversationMap?.[id]
+  );
+
+  let batchMap: Map<string, LLMStreamParameters> | null = null;
+  if (firstTimeConversationIds.length > 0) {
+    batchMap = await buildConversationAnalysisBatchMap(auth, {
+      agentConfigurationId,
+      conversationIds: firstTimeConversationIds,
+    });
+  }
+
+  const systemPrompt = buildAnalysisSystemPrompt();
+  const specifications = buildReinforcedSpecifications();
+
   const batchConversations: LlmConversationOptions[] = [];
   const orderedAnalysedConversationIds: string[] = [];
-  for (const [conversationId, llmParams] of batchMap) {
-    const { conversation, ...llmParamsWithoutConversation } = llmParams;
-    batchConversations.push({
-      newMessages: conversation.messages,
-      title: reinforcementConversationTitle(
-        "reinforced_agent_analyze_conversation",
-        conversationId
-      ),
-      ...llmParamsWithoutConversation,
-      ...getReinforcementDefaultOptions(
-        "reinforced_agent_analyze_conversation",
-        agentConfigurationId
-      ),
-    });
-    orderedAnalysedConversationIds.push(conversationId);
+
+  for (const analysedConvId of analysedConversationIds) {
+    const existingReinforcementConvId =
+      existingReinforcementConversationMap?.[analysedConvId];
+
+    if (existingReinforcementConvId) {
+      // Continuation: reuse existing reinforcement conversation.
+      // No new messages — the conversation already contains the full history.
+      batchConversations.push({
+        newMessages: [],
+        existingConversationId: existingReinforcementConvId,
+        prompt: systemPrompt,
+        specifications,
+        userContextOrigin: "reinforcement",
+      });
+      orderedAnalysedConversationIds.push(analysedConvId);
+    } else {
+      // First time: create a new reinforcement conversation with the analysis prompt.
+      const llmParams = batchMap?.get(analysedConvId);
+      if (!llmParams) {
+        continue;
+      }
+      const { conversation, ...llmParamsWithoutConversation } = llmParams;
+      batchConversations.push({
+        newMessages: conversation.messages,
+        title: reinforcementConversationTitle(
+          "reinforced_agent_analyze_conversation",
+          analysedConvId
+        ),
+        ...llmParamsWithoutConversation,
+        ...getReinforcementDefaultOptions(
+          "reinforced_agent_analyze_conversation",
+          agentConfigurationId
+        ),
+      });
+      orderedAnalysedConversationIds.push(analysedConvId);
+    }
+  }
+
+  if (batchConversations.length === 0) {
+    return null;
   }
 
   const result = await sendBatchCallToLlm(auth, llm, batchConversations);
@@ -200,20 +438,30 @@ export async function startConversationAnalysisBatchActivity({
     throw result.error;
   }
 
+  // Build the map of analysed conversation ID -> reinforcement conversation ID.
+  const reinforcementConversationMap: Record<string, string> = {
+    ...(existingReinforcementConversationMap ?? {}),
+  };
+  for (let i = 0; i < orderedAnalysedConversationIds.length; i++) {
+    reinforcementConversationMap[orderedAnalysedConversationIds[i]] =
+      result.value.conversationIds[i];
+  }
+
   logger.info(
     {
       agentConfigurationId,
       workspaceId,
       batchId: result.value.batchId,
-      conversationCount: batchMap.size,
+      conversationCount: batchConversations.length,
+      continuationCount: Object.keys(existingReinforcementConversationMap ?? {})
+        .length,
     },
     "ReinforcedAgent: started conversation analysis batch"
   );
 
   return {
     batchId: result.value.batchId,
-    reinforcementConversationIds: result.value.conversationIds,
-    analysedConversationIds: orderedAnalysedConversationIds,
+    reinforcementConversationMap,
   };
 }
 
@@ -242,23 +490,31 @@ export async function checkBatchStatusActivity({
   return llm.getBatchStatus(batchId);
 }
 
+export interface ConversationContinuationInfo {
+  analysedConversationId: string;
+  reinforcementConversationId: string;
+  toolActionInfo: ReinforcedToolActionInfo;
+}
+
 /**
  * Download batch results for conversation analysis and create suggestions.
  * Also stores agent messages in the reinforced agent conversations.
+ *
+ * For conversations where the LLM called only terminal tools, creates suggestions.
+ * For conversations where the LLM called exploratory tools, creates tool actions
+ * and returns continuation info for the workflow to execute them.
  */
 export async function processConversationAnalysisBatchResultActivity({
   workspaceId,
   agentConfigurationId,
   batchId,
-  reinforcementConversationIds,
-  analysedConversationIds,
+  reinforcementConversationMap,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   batchId: string;
-  reinforcementConversationIds: string[];
-  analysedConversationIds: string[];
-}): Promise<void> {
+  reinforcementConversationMap: Record<string, string>;
+}): Promise<ConversationContinuationInfo[]> {
   const auth = await getAuthForWorkspace(workspaceId);
 
   const [agentConfig] = await getAgentConfigurations(auth, {
@@ -270,7 +526,7 @@ export async function processConversationAnalysisBatchResultActivity({
       { agentConfigurationId },
       "ReinforcedAgent: agent not found for batch result processing"
     );
-    return;
+    return [];
   }
 
   const llm = await getReinforcedLLM(
@@ -278,28 +534,31 @@ export async function processConversationAnalysisBatchResultActivity({
     "reinforced_agent_analyze_conversation"
   );
   if (!llm) {
-    return;
+    return [];
+  }
+
+  // Invert the map: reinforcementConvId -> analysedConvId.
+  const reinforcementToAnalysed = new Map<string, string>();
+  const reinforcementConversationIds: string[] = [];
+  for (const [analysedId, reinforcementId] of Object.entries(
+    reinforcementConversationMap
+  )) {
+    reinforcementToAnalysed.set(reinforcementId, analysedId);
+    reinforcementConversationIds.push(reinforcementId);
   }
 
   // Download results and store agent messages in reinforcement conversations.
-  const results = await downloadBatchResultFromLlm(
-    auth,
-    llm,
-    batchId,
-    reinforcementConversationIds,
-    REINFORCEMENT_AGENT_ID
-  );
-
-  // Build mapping from reinforcement conversation sIds back to the analysed conversation sIds.
-  const reinforcementToAnalysed = new Map<string, string>();
-  for (let i = 0; i < reinforcementConversationIds.length; i++) {
-    reinforcementToAnalysed.set(
-      reinforcementConversationIds[i],
-      analysedConversationIds[i]
+  const { events: batchEvents, storedResultInfo } =
+    await downloadBatchResultFromLlm(
+      auth,
+      llm,
+      batchId,
+      reinforcementConversationIds,
+      REINFORCEMENT_AGENT_ID
     );
-  }
 
   // Resolve analysed conversations for FK storage.
+  const analysedConversationIds = Object.keys(reinforcementConversationMap);
   const analysedConversations = await ConversationResource.fetchByIds(
     auth,
     analysedConversationIds
@@ -309,30 +568,60 @@ export async function processConversationAnalysisBatchResultActivity({
   );
 
   let totalCreated = 0;
-  for (const [reinforcementConvId, events] of results) {
+  const continuations: ConversationContinuationInfo[] = [];
+
+  for (const [reinforcementConvId, events] of batchEvents) {
     const analysedConvId =
       reinforcementToAnalysed.get(reinforcementConvId) ?? reinforcementConvId;
-    const createdCount = await processReinforcedEvents({
-      auth,
-      agentConfig,
-      events,
-      source: "synthetic",
-      operationType: "reinforced_agent_analyze_conversation",
-      contextId: analysedConvId,
-      conversation: conversationById.get(analysedConvId),
-    });
-    totalCreated += createdCount;
+
+    const { exploratoryToolCalls, terminalToolCalls } =
+      classifyToolCalls(events);
+
+    // If terminal tools were called, process suggestions.
+    if (terminalToolCalls.length > 0 || exploratoryToolCalls.length === 0) {
+      const createdCount = await processReinforcedEvents({
+        auth,
+        agentConfig,
+        events,
+        source: "synthetic",
+        operationType: "reinforced_agent_analyze_conversation",
+        contextId: analysedConvId,
+        conversation: conversationById.get(analysedConvId),
+      });
+      totalCreated += createdCount;
+    } else {
+      // Only exploratory tools — prepare actions for the workflow to execute.
+      const storedInfo = storedResultInfo.get(reinforcementConvId);
+      if (storedInfo) {
+        const toolActionInfo = await prepareReinforcedToolActions(auth, {
+          exploratoryToolCalls,
+          agentMessageModelId: storedInfo.agentMessageModelId,
+          agentMessageSId: storedInfo.agentMessageSId,
+          userMessageSId: storedInfo.userMessageSId,
+          conversationId: reinforcementConvId,
+        });
+
+        continuations.push({
+          analysedConversationId: analysedConvId,
+          reinforcementConversationId: reinforcementConvId,
+          toolActionInfo,
+        });
+      }
+    }
   }
 
   logger.info(
     {
       agentConfigurationId,
       batchId,
-      conversationCount: results.size,
+      conversationCount: batchEvents.size,
       suggestionsCreated: totalCreated,
+      continuationCount: continuations.length,
     },
     "ReinforcedAgent: processed conversation analysis batch results"
   );
+
+  return continuations;
 }
 
 /**
@@ -440,7 +729,7 @@ export async function processAggregationBatchResultActivity({
   }
 
   // Download results and store agent messages in reinforcement conversations.
-  const results = await downloadBatchResultFromLlm(
+  const { events: batchEvents } = await downloadBatchResultFromLlm(
     auth,
     llm,
     batchId,
@@ -449,7 +738,7 @@ export async function processAggregationBatchResultActivity({
   );
 
   // The aggregation batch has a single entry — get the first result.
-  const events = results.values().next().value;
+  const events = batchEvents.values().next().value;
 
   let createdCount = 0;
   if (events) {

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -114,7 +114,6 @@ export async function getRecentConversationsForAgentActivity({
   });
 }
 
-
 /**
  * Analyze a single conversation step for reinforcement.
  *
@@ -281,6 +280,12 @@ export async function analyzeConversationStepActivity({
 
   // If terminal tools were called, process suggestions.
   if (terminalToolCalls.length > 0 || exploratoryToolCalls.length === 0) {
+    if (terminalToolCalls.length > 0 && exploratoryToolCalls.length > 0) {
+      logger.warn(
+        { conversationId },
+        "ReinforcedAgent: LLM is sending both terminal and exploratory tool call."
+      );
+    }
     const analysedConversation = await ConversationResource.fetchById(
       auth,
       conversationId
@@ -301,8 +306,8 @@ export async function analyzeConversationStepActivity({
   const toolActionInfo = await prepareReinforcedToolActions(auth, {
     exploratoryToolCalls,
     agentMessageModelId: storedResult.agentMessageModelId,
-    agentMessageSId: storedResult.agentMessageSId,
-    userMessageSId: storedResult.userMessageSId,
+    agentMessageId: storedResult.agentMessageSId,
+    userMessageId: storedResult.userMessageSId,
     conversationId: reinforcementConversationId,
   });
 
@@ -596,8 +601,8 @@ export async function processConversationAnalysisBatchResultActivity({
         const toolActionInfo = await prepareReinforcedToolActions(auth, {
           exploratoryToolCalls,
           agentMessageModelId: storedInfo.agentMessageModelId,
-          agentMessageSId: storedInfo.agentMessageSId,
-          userMessageSId: storedInfo.userMessageSId,
+          agentMessageId: storedInfo.agentMessageSId,
+          userMessageId: storedInfo.userMessageSId,
           conversationId: reinforcementConvId,
         });
 

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -296,7 +296,7 @@ export async function reinforcedAgentForAgentWorkflow({
 }
 
 /**
- * Multi-step streaming analysis of a single conversation.
+ * Multi-step streaming analysis of a single conversation (non batch mode).
  * Calls the step activity, executes exploratory tools via the agent loop's
  * runRetryableToolActivity, and continues until terminal tools are called.
  *

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -31,10 +31,6 @@ const { getRecentConversationsForAgentActivity } = proxyActivities<
   startToCloseTimeout: "5 minutes",
 });
 
-const { analyzeConversationActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
-});
-
 const { aggregateSuggestionsActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
@@ -64,6 +60,22 @@ const { processAggregationBatchResultActivity } = proxyActivities<
 >({
   startToCloseTimeout: "30 minutes",
 });
+
+const { analyzeConversationStepActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
+// runToolActivity is re-exported from the agent loop so the reinforced agent
+// worker registers it. We proxy it with retry for durability.
+const { runToolActivity: runRetryableToolActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "10 minutes",
+  retry: { maximumAttempts: 3 },
+});
+
+// Duplicated here because Temporal workflow sandbox can't resolve @app/lib imports.
+const MAX_REINFORCED_ANALYSIS_STEPS = 4;
 
 const AGENT_CONCURRENCY = 8;
 const CONVERSATION_ANALYSIS_CONCURRENCY = 4;
@@ -184,26 +196,63 @@ export async function reinforcedAgentForAgentWorkflow({
   });
 
   if (useBatchMode) {
-    // Phase 1: Batch-analyze all conversations.
-    if (conversationIds.length > 0) {
-      const analysisResult = await startConversationAnalysisBatchActivity({
+    // Phase 1: Batch-analyze all conversations with multi-step loop.
+    // Each iteration: submit batch → wait → process results → execute tools.
+    // Conversations that called terminal tools are done; the rest continue.
+    let pendingConversationIds = conversationIds;
+    let reinforcementConversationMap: Record<string, string> | undefined;
+    let step = 0;
+
+    while (
+      step < MAX_REINFORCED_ANALYSIS_STEPS &&
+      pendingConversationIds.length > 0
+    ) {
+      const batchResult = await startConversationAnalysisBatchActivity({
         workspaceId,
         agentConfigurationId,
-        analysedConversationIds: conversationIds,
+        analysedConversationIds: pendingConversationIds,
+        existingReinforcementConversationMap: reinforcementConversationMap,
       });
 
-      if (analysisResult) {
-        await waitForBatch({ workspaceId, batchId: analysisResult.batchId });
+      if (!batchResult) {
+        break;
+      }
 
+      await waitForBatch({ workspaceId, batchId: batchResult.batchId });
+
+      reinforcementConversationMap = batchResult.reinforcementConversationMap;
+
+      const continuations =
         await processConversationAnalysisBatchResultActivity({
           workspaceId,
           agentConfigurationId,
-          batchId: analysisResult.batchId,
-          reinforcementConversationIds:
-            analysisResult.reinforcementConversationIds,
-          analysedConversationIds: analysisResult.analysedConversationIds,
+          batchId: batchResult.batchId,
+          reinforcementConversationMap,
         });
+
+      if (continuations.length === 0) {
+        break;
       }
+
+      // Execute exploratory tools via the agent loop's retryable tool activity.
+      // Results are stored in the reinforcement conversations in DB.
+      for (const c of continuations) {
+        const { authType, agentLoopArgs, actionIds } = c.toolActionInfo;
+        for (const actionId of actionIds) {
+          await runRetryableToolActivity(authType, {
+            actionId,
+            runAgentArgs: agentLoopArgs,
+            step: 0,
+          });
+        }
+      }
+
+      // Next iteration will re-submit only the continuing conversations,
+      // reusing their reinforcement conversations (which now include tool results).
+      pendingConversationIds = continuations.map(
+        (c) => c.analysedConversationId
+      );
+      step++;
     }
 
     // Phase 2: Batch-aggregate synthetic suggestions into pending.
@@ -225,11 +274,11 @@ export async function reinforcedAgentForAgentWorkflow({
       });
     }
   } else {
-    // Phase 1: Analyze all conversations in parallel via streaming.
+    // Phase 1: Analyze all conversations in parallel via streaming (multi-step).
     await concurrentExecutor(
       conversationIds,
       (conversationId) =>
-        analyzeConversationActivity({
+        analyzeConversationWithMultiStep({
           workspaceId,
           agentConfigurationId,
           conversationId,
@@ -243,5 +292,55 @@ export async function reinforcedAgentForAgentWorkflow({
       agentConfigurationId,
       disableNotifications,
     });
+  }
+}
+
+/**
+ * Multi-step streaming analysis of a single conversation.
+ * Calls the step activity, executes exploratory tools via the agent loop's
+ * runRetryableToolActivity, and continues until terminal tools are called.
+ *
+ * Tool results are stored in the reinforcement conversation by runRetryableToolActivity.
+ * On the next step, the step activity renders the full conversation from DB via
+ * renderConversationForModel — no need to pass continuation messages explicitly.
+ */
+async function analyzeConversationWithMultiStep({
+  workspaceId,
+  agentConfigurationId,
+  conversationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  conversationId: string;
+}): Promise<void> {
+  let reinforcementConversationId: string | undefined;
+
+  for (let step = 0; step < MAX_REINFORCED_ANALYSIS_STEPS; step++) {
+    const result = await analyzeConversationStepActivity({
+      workspaceId,
+      agentConfigurationId,
+      conversationId,
+      reinforcementConversationId,
+    });
+
+    reinforcementConversationId = result.reinforcementConversationId;
+
+    if (result.isTerminal || !result.toolActionInfo) {
+      return;
+    }
+
+    const { authType, agentLoopArgs, actionIds } = result.toolActionInfo;
+
+    // Execute each exploratory tool via the agent loop's retryable tool activity.
+    // Results are stored in the reinforcement conversation DB.
+    for (const actionId of actionIds) {
+      await runRetryableToolActivity(authType, {
+        actionId,
+        runAgentArgs: agentLoopArgs,
+        step: 0,
+      });
+    }
+
+    // Next iteration will render the conversation from DB, picking up the tool results.
   }
 }

--- a/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
+++ b/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
@@ -1,12 +1,24 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import {
+  formatAvailableSkills,
+  formatAvailableTools,
+} from "@app/lib/api/assistant/global_agents/sidekick_context";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { buildAggregationPrompt } from "@app/lib/reinforced_agent/aggregate_suggestions";
 import { buildAnalysisPrompt } from "@app/lib/reinforced_agent/analyze_conversation";
-import { buildReinforcedLLMParams } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import {
+  buildReinforcedLLMParams,
+  classifyToolCalls,
+} from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import type { ExploratoryToolName } from "@app/lib/reinforced_agent/types";
+import { MAX_REINFORCED_ANALYSIS_STEPS } from "@app/lib/reinforced_agent/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { buildContinuationMessages } from "@app/lib/reinforced_agent/utils";
 import {
   BATCH_POLL_INTERVAL_MS,
   MODEL_ID,
@@ -20,6 +32,7 @@ import {
   type MockAgentConfig,
   type TestCase,
   type ToolCall,
+  type WorkspaceContext,
 } from "@app/tests/reinforced-agent-evals/lib/types";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
@@ -90,12 +103,7 @@ function buildPromptForTestCase(testCase: TestCase): {
 
   if (isAnalysisTestCase(testCase)) {
     const conversationText = buildConversationText(testCase.conversation);
-    return buildAnalysisPrompt(
-      agentConfig,
-      conversationText,
-      toolsAndSkillsContext,
-      agentSkills
-    );
+    return buildAnalysisPrompt(agentConfig, conversationText, agentSkills);
   }
   return buildAggregationPrompt(
     agentConfig,
@@ -134,6 +142,80 @@ function extractFromEvents(events: LLMEvent[]): ExecutionResult {
   return { toolCalls, responseText };
 }
 
+/**
+ * Simulate an exploratory tool call using the test case's workspace context.
+ */
+function simulateExploratoryTool(
+  toolName: ExploratoryToolName,
+  workspaceContext: WorkspaceContext
+): string {
+  switch (toolName) {
+    case "get_available_skills":
+      return formatAvailableSkills(workspaceContext.skills);
+    case "get_available_tools":
+      return formatAvailableTools(workspaceContext.tools);
+    default:
+      assertNever(toolName);
+  }
+}
+
+/**
+ * Run a multi-step LLM conversation. After each LLM call, if exploratory tools
+ * are called, simulate their responses from workspace context and continue.
+ * Returns accumulated tool calls from all steps.
+ */
+async function executeMultiStep(
+  llm: LLM,
+  initialParams: LLMStreamParameters,
+  workspaceContext: WorkspaceContext
+): Promise<ExecutionResult> {
+  const allToolCalls: ToolCall[] = [];
+  let lastResponseText = "";
+  let currentParams = initialParams;
+
+  for (let step = 0; step < MAX_REINFORCED_ANALYSIS_STEPS; step++) {
+    const events: LLMEvent[] = [];
+    for await (const event of llm.stream(currentParams)) {
+      events.push(event);
+    }
+
+    const stepResult = extractFromEvents(events);
+    allToolCalls.push(...stepResult.toolCalls);
+    lastResponseText = stepResult.responseText;
+
+    const { exploratoryToolCalls } = classifyToolCalls(events);
+
+    // If no exploratory tools were called, we're done.
+    if (exploratoryToolCalls.length === 0) {
+      return { toolCalls: allToolCalls, responseText: lastResponseText };
+    }
+
+    // Simulate exploratory tool responses from workspace context.
+    const toolResults: Record<string, string> = {};
+    for (const tc of exploratoryToolCalls) {
+      toolResults[tc.id] = simulateExploratoryTool(tc.name, workspaceContext);
+    }
+
+    // Build continuation messages and extend conversation.
+    const continuationMessages = buildContinuationMessages(
+      exploratoryToolCalls,
+      toolResults
+    );
+
+    currentParams = {
+      ...currentParams,
+      conversation: {
+        messages: [
+          ...currentParams.conversation.messages,
+          ...continuationMessages,
+        ],
+      },
+    };
+  }
+
+  return { toolCalls: allToolCalls, responseText: lastResponseText };
+}
+
 async function getLLMInstance(auth: Authenticator): Promise<LLM> {
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
@@ -159,33 +241,17 @@ export async function executeReinforced(
   const prompt = buildPromptForTestCase(testCase);
   const params = buildReinforcedLLMParams(prompt);
 
-  const events: LLMEvent[] = [];
-  for await (const event of llm.stream(params)) {
-    events.push(event);
-  }
-
-  return extractFromEvents(events);
+  return executeMultiStep(llm, params, testCase.workspaceContext);
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function executeBatch(
-  auth: Authenticator,
-  testCases: CategorizedTestCase[]
-): Promise<Map<string, ExecutionResult>> {
-  const llm = await getLLMInstance(auth);
-
-  const batchMap = new Map<
-    string,
-    ReturnType<typeof buildReinforcedLLMParams>
-  >();
-  for (const tc of testCases) {
-    const prompt = buildPromptForTestCase(tc);
-    batchMap.set(tc.scenarioId, buildReinforcedLLMParams(prompt));
-  }
-
+async function submitAndWaitForBatch(
+  llm: LLM,
+  batchMap: Map<string, LLMStreamParameters>
+): Promise<Map<string, LLMEvent[]>> {
   const batchId = await llm.sendBatchProcessing(batchMap);
 
   let status = await llm.getBatchStatus(batchId);
@@ -198,17 +264,88 @@ export async function executeBatch(
     throw new Error(`LLM batch was aborted (batchId: ${batchId})`);
   }
 
-  const batchResult = await llm.getBatchResult(batchId);
+  return llm.getBatchResult(batchId);
+}
+
+export async function executeBatch(
+  auth: Authenticator,
+  testCases: CategorizedTestCase[]
+): Promise<Map<string, ExecutionResult>> {
+  const llm = await getLLMInstance(auth);
+
+  const testCaseById = new Map<string, CategorizedTestCase>();
+  for (const tc of testCases) {
+    testCaseById.set(tc.scenarioId, tc);
+  }
+
+  // Build initial params for all test cases.
+  let pendingParams = new Map<string, LLMStreamParameters>();
+  for (const tc of testCases) {
+    const prompt = buildPromptForTestCase(tc);
+    pendingParams.set(tc.scenarioId, buildReinforcedLLMParams(prompt));
+  }
 
   const results = new Map<string, ExecutionResult>();
-  for (const tc of testCases) {
-    const events = batchResult.get(tc.scenarioId);
-    if (!events) {
-      throw new Error(
-        `No batch result for scenario "${tc.scenarioId}" (batchId: ${batchId})`
-      );
+  // Accumulate tool calls across steps for each scenario.
+  const accumulatedToolCalls = new Map<string, ToolCall[]>();
+  let step = 0;
+
+  while (step < MAX_REINFORCED_ANALYSIS_STEPS && pendingParams.size > 0) {
+    const batchResult = await submitAndWaitForBatch(llm, pendingParams);
+
+    const nextPendingParams = new Map<string, LLMStreamParameters>();
+
+    for (const [scenarioId, events] of batchResult) {
+      const stepResult = extractFromEvents(events);
+      const prev = accumulatedToolCalls.get(scenarioId) ?? [];
+      const allToolCalls = [...prev, ...stepResult.toolCalls];
+      accumulatedToolCalls.set(scenarioId, allToolCalls);
+
+      const { exploratoryToolCalls } = classifyToolCalls(events);
+
+      if (exploratoryToolCalls.length === 0) {
+        // Terminal — done for this scenario.
+        results.set(scenarioId, {
+          toolCalls: allToolCalls,
+          responseText: stepResult.responseText,
+        });
+      } else {
+        // Simulate tool responses and prepare continuation params.
+        const tc = testCaseById.get(scenarioId)!;
+        const toolResultsMap: Record<string, string> = {};
+        for (const toolCall of exploratoryToolCalls) {
+          toolResultsMap[toolCall.id] = simulateExploratoryTool(
+            toolCall.name,
+            tc.workspaceContext
+          );
+        }
+
+        const continuationMessages = buildContinuationMessages(
+          exploratoryToolCalls,
+          toolResultsMap
+        );
+
+        const currentParams = pendingParams.get(scenarioId)!;
+        nextPendingParams.set(scenarioId, {
+          ...currentParams,
+          conversation: {
+            messages: [
+              ...currentParams.conversation.messages,
+              ...continuationMessages,
+            ],
+          },
+        });
+      }
     }
-    results.set(tc.scenarioId, extractFromEvents(events));
+
+    pendingParams = nextPendingParams;
+    step++;
+  }
+
+  // Any scenarios still pending after max steps — return what we have.
+  for (const [scenarioId] of pendingParams) {
+    const allToolCalls = accumulatedToolCalls.get(scenarioId) ?? [];
+    results.set(scenarioId, { toolCalls: allToolCalls, responseText: "" });
   }
 
   return results;

--- a/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
+++ b/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
@@ -17,7 +17,6 @@ import {
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
 import type { ExploratoryToolName } from "@app/lib/reinforced_agent/types";
 import { MAX_REINFORCED_ANALYSIS_STEPS } from "@app/lib/reinforced_agent/types";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { buildContinuationMessages } from "@app/lib/reinforced_agent/utils";
 import {
   BATCH_POLL_INTERVAL_MS,
@@ -35,6 +34,7 @@ import {
   type WorkspaceContext,
 } from "@app/tests/reinforced-agent-evals/lib/types";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 function makeAction(input: {
   name: string;


### PR DESCRIPTION
## Description

Support tool calls when doing Reinforced agent, for both streaming and batch calls.

We reuse the existing `runToolActivity` to run activities in order to not duplicate code

FOr batch calls, we send all the conversations, check which one have suggestions (-> these are over) and we do a batch with the other ones which do tool call for clarifications.

## Tests

tested locally (eval tests + running a a manual analysis) 

## Risk

 - Slower conversation
 - Low risk because of feature flag

## Deploy Plan

deploy front 
