### PR TITLE
Add metronome customerId/packageAlias in model

### DIFF
--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -43,6 +43,7 @@ export class PlanModel extends BaseModel<PlanModel> {
   declare isSCIMAllowed: boolean;
   declare isAuditLogsAllowed: boolean;
   declare isByok: boolean;
+  declare metronomePackageAlias: string | null;
   declare maxDataSourcesCount: number;
   declare maxDataSourcesDocumentsCount: number;
   declare maxDataSourcesDocumentsSizeMb: number;
@@ -155,6 +156,11 @@ PlanModel.init(
     isByok: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
+    },
+    metronomePackageAlias: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
     },
     maxDataSourcesCount: {
       type: DataTypes.INTEGER,

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -54,6 +54,7 @@ export const FREE_NO_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: false,
   isByok: false,
+  metronomePackageAlias: null,
 };
 
 /**
@@ -88,6 +89,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: false,
     isByok: false,
+    metronomePackageAlias: null,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,
@@ -116,6 +118,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    metronomePackageAlias: null,
   },
   {
     code: FREE_TRIAL_PHONE_PLAN_CODE,
@@ -144,6 +147,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
+    metronomePackageAlias: null,
   },
 ];
 

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -64,6 +64,10 @@ export function isProOrBusinessPlanCode(plan?: PlanType) {
   return isProPlan(plan) || isBusinessPlan(plan);
 }
 
+export function isMetronomeBilled(plan: PlanType): boolean {
+  return plan.metronomePackageAlias != null;
+}
+
 /**
  * `isUpgraded` returns true if the plan has access to all features of Dust, including large
  * language models (meaning it's either a paid plan or free plan with (eg friends and family, or

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -57,6 +57,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
+    metronomePackageAlias: null,
   });
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_39_CODE,
@@ -85,6 +86,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
+    metronomePackageAlias: null,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_PLAN_CODE,
@@ -113,6 +115,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
+    metronomePackageAlias: null,
   });
 }
 

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -53,6 +53,7 @@ export function renderPlanFromModel({
     trialPeriodDays: plan.trialPeriodDays,
     isByok: plan.isByok,
     isAuditLogsAllowed: plan.isAuditLogsAllowed,
+    metronomePackageAlias: plan.metronomePackageAlias ?? null,
   };
 }
 

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -32,6 +32,7 @@ export class WorkspaceModel extends BaseModel<WorkspaceModel> {
   declare metadata: Record<string, string | number | boolean | object> | null;
   declare sharingPolicy: CreationOptional<WorkspaceSharingPolicy>;
   declare conversationsRetentionDays: number | null;
+  declare metronomeCustomerId: string | null;
 }
 WorkspaceModel.init(
   {
@@ -71,6 +72,11 @@ WorkspaceModel.init(
     conversationsRetentionDays: {
       type: DataTypes.INTEGER,
       allowNull: true,
+    },
+    metronomeCustomerId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
     },
     whiteListedProviders: {
       type: DataTypes.ARRAY(DataTypes.STRING),

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -69,6 +69,7 @@ type CachedWorkspaceData = {
   metadata: Record<string, string | number | boolean | object> | null;
   sharingPolicy: WorkspaceSharingPolicy;
   conversationsRetentionDays: number | null;
+  metronomeCustomerId: string | null;
   createdAt: number;
   updatedAt: number;
 };
@@ -197,6 +198,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       metadata: workspace.metadata,
       sharingPolicy: workspace.sharingPolicy,
       conversationsRetentionDays: workspace.conversationsRetentionDays,
+      metronomeCustomerId: workspace.metronomeCustomerId ?? null,
       createdAt: workspace.createdAt.getTime(),
       updatedAt: workspace.updatedAt.getTime(),
     };
@@ -228,6 +230,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       metadata: data.metadata,
       sharingPolicy: data.sharingPolicy,
       conversationsRetentionDays: data.conversationsRetentionDays,
+      metronomeCustomerId: data.metronomeCustomerId ?? null,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt),
     };
@@ -649,6 +652,15 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     metadata: Record<string, string | number | boolean | object> | null
   ): Promise<Result<void, Error>> {
     return this.updateByModelIdAndCheckExistence(id, { metadata });
+  }
+
+  static async updateMetronomeCustomerId(
+    id: ModelId,
+    metronomeCustomerId: string
+  ): Promise<Result<void, Error>> {
+    return this.updateByModelIdAndCheckExistence(id, {
+      metronomeCustomerId,
+    });
   }
 
   async updateConversationKillSwitch({

--- a/front/migrations/db/migration_551.sql
+++ b/front/migrations/db/migration_551.sql
@@ -1,0 +1,5 @@
+-- Migration: Add metronomePackageAlias to plans and metronomeCustomerId to workspaces
+-- Part of Metronome billing integration (F1: Data model)
+
+ALTER TABLE plans ADD COLUMN IF NOT EXISTS "metronomePackageAlias" VARCHAR(255) DEFAULT NULL;
+ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS "metronomeCustomerId" VARCHAR(255) DEFAULT NULL;

--- a/front/scripts/seed/byok/seed.ts
+++ b/front/scripts/seed/byok/seed.ts
@@ -36,6 +36,7 @@ const FREE_BYOK_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: true,
   isByok: true,
+  metronomePackageAlias: null,
 };
 
 makeScript({}, async ({ execute }, logger) => {

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -70,6 +70,7 @@ export type PlanType = {
   trialPeriodDays: number;
   isByok: boolean;
   isAuditLogsAllowed: boolean;
+  metronomePackageAlias?: string | null;
 };
 
 export type SubscriptionType = {


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#7511

Add foundational data model for Metronome billing integration:

- **`metronomePackageAlias`** on `PlanModel` — determines billing mode (`null` = Stripe, `"business-plan"` = Metronome). Added to all existing plan data objects (free_plans, pro_plans, byok seed) as `null`.
- **`metronomeCustomerId`** on `WorkspaceModel` — workspace-scoped Metronome customer ID, persists across plan changes.
- **`isMetronomeBilled(plan)`** helper in `plan_codes.ts`
- **`updateMetronomeCustomerId`** on `WorkspaceResource` using `updateByModelIdAndCheckExistence` pattern
- **`metronomePackageAlias`** rendered on `PlanType` via `renderers.ts`
- DB migration `migration_551.sql` for both columns

Part of the Metronome billing integration (Pricing Push). See `front/docs/metronome-design-doc.md`.

## Tests

- Type-check passes (`npx tsgo --noEmit`) — no new errors introduced
- Migration is additive (nullable columns with defaults) — safe to run on existing data

## Risk

Low — additive schema change only. Both columns default to `null`, no behavior change until a plan is configured with `metronomePackageAlias` or a workspace gets a `metronomeCustomerId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)