### PR TITLE
[Email Agents] Verify signed SendGrid Parse webhooks

### DIFF
--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -1,0 +1,179 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import {
+  validateSendgridParseWebhookSignature,
+  verifySendgridParseWebhookSignature,
+} from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
+import { describe, expect, it } from "vitest";
+
+const { privateKey, publicKey } = generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+});
+const publicKeyPem = publicKey
+  .export({ format: "pem", type: "spki" })
+  .toString();
+
+function signWebhook({
+  rawBody,
+  timestamp,
+}: {
+  rawBody: Buffer;
+  timestamp: string;
+}): string {
+  return sign(
+    "sha256",
+    Buffer.concat([Buffer.from(timestamp, "utf8"), rawBody]),
+    privateKey
+  ).toString("base64");
+}
+
+describe("verifySendgridParseWebhookSignature", () => {
+  const multipartPayload = Buffer.from(
+    [
+      "--boundary",
+      'Content-Disposition: form-data; name="text"',
+      "",
+      "hello world",
+      "--boundary--",
+      "",
+    ].join("\r\n"),
+    "utf8"
+  );
+  const timestamp = `${Math.floor(Date.now() / 1000)}`;
+
+  it("accepts a valid signature for the exact raw multipart body", () => {
+    const signature = signWebhook({
+      rawBody: multipartPayload,
+      timestamp,
+    });
+
+    expect(
+      verifySendgridParseWebhookSignature({
+        publicKey: publicKeyPem,
+        rawBody: multipartPayload,
+        signature,
+        timestamp,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects the same payload when the raw bytes change", () => {
+    const signature = signWebhook({
+      rawBody: multipartPayload,
+      timestamp,
+    });
+    const normalizedPayload = Buffer.from(
+      multipartPayload.toString("utf8").replaceAll("\r\n", "\n"),
+      "utf8"
+    );
+
+    expect(
+      verifySendgridParseWebhookSignature({
+        publicKey: publicKeyPem,
+        rawBody: normalizedPayload,
+        signature,
+        timestamp,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("validateSendgridParseWebhookSignature", () => {
+  const rawBody = Buffer.from("multipart body", "utf8");
+  const nowMs = Date.now();
+  const freshTimestamp = `${Math.floor(nowMs / 1000)}`;
+  const staleTimestamp = `${Math.floor((nowMs - 10 * 60 * 1000) / 1000)}`;
+  const signature = signWebhook({
+    rawBody,
+    timestamp: freshTimestamp,
+  });
+
+  it("accepts missing headers in optional mode", () => {
+    const result = validateSendgridParseWebhookSignature({
+      mode: "optional",
+      publicKey: publicKeyPem,
+      headers: {},
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects missing headers in required mode", () => {
+    const result = validateSendgridParseWebhookSignature({
+      mode: "required",
+      publicKey: publicKeyPem,
+      headers: {},
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected missing signature headers to be rejected");
+    }
+
+    expect(result.error.statusCode).toBe(401);
+    expect(result.error.apiError.type).toBe("invalid_request_error");
+  });
+
+  it("rejects an invalid signature", () => {
+    const result = validateSendgridParseWebhookSignature({
+      mode: "required",
+      publicKey: publicKeyPem,
+      headers: {
+        "x-twilio-email-event-webhook-signature": "invalid-signature",
+        "x-twilio-email-event-webhook-timestamp": freshTimestamp,
+      },
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected invalid signature to be rejected");
+    }
+
+    expect(result.error.statusCode).toBe(403);
+    expect(result.error.apiError.type).toBe("invalid_request_error");
+  });
+
+  it("rejects stale timestamps", () => {
+    const result = validateSendgridParseWebhookSignature({
+      mode: "required",
+      publicKey: publicKeyPem,
+      headers: {
+        "x-twilio-email-event-webhook-signature": signWebhook({
+          rawBody,
+          timestamp: staleTimestamp,
+        }),
+        "x-twilio-email-event-webhook-timestamp": staleTimestamp,
+      },
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected stale timestamp to be rejected");
+    }
+
+    expect(result.error.statusCode).toBe(403);
+    expect(result.error.apiError.type).toBe("invalid_request_error");
+  });
+
+  it("accepts a valid signature in required mode", () => {
+    const result = validateSendgridParseWebhookSignature({
+      mode: "required",
+      publicKey: publicKeyPem,
+      headers: {
+        "x-twilio-email-event-webhook-signature": signature,
+        "x-twilio-email-event-webhook-timestamp": freshTimestamp,
+      },
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -104,7 +104,9 @@ describe("verifySendgridParseWebhookSignature", () => {
       "content-type": "multipart/form-data; boundary=boundary",
     });
     if (!isSendgridParseFormRequest(req)) {
-      throw new Error("Expected replayed raw body to be parseable by formidable");
+      throw new Error(
+        "Expected replayed raw body to be parseable by formidable"
+      );
     }
     const form = new IncomingForm();
     const [fields, files] = await form.parse(req);
@@ -124,21 +126,25 @@ describe("validateSendgridParseWebhookSignature", () => {
     timestamp: freshTimestamp,
   });
 
-  it("accepts missing headers in optional mode", () => {
+  it("rejects a missing public key", () => {
     const result = validateSendgridParseWebhookSignature({
-      mode: "optional",
-      publicKey: publicKeyPem,
+      publicKey: undefined,
       headers: {},
       rawBody,
       nowMs,
     });
 
-    expect(result.isOk()).toBe(true);
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected missing public key to be rejected");
+    }
+
+    expect(result.error.statusCode).toBe(500);
+    expect(result.error.apiError.type).toBe("internal_server_error");
   });
 
-  it("rejects missing headers in required mode", () => {
+  it("rejects missing headers", () => {
     const result = validateSendgridParseWebhookSignature({
-      mode: "required",
       publicKey: publicKeyPem,
       headers: {},
       rawBody,
@@ -156,7 +162,6 @@ describe("validateSendgridParseWebhookSignature", () => {
 
   it("rejects an invalid signature", () => {
     const result = validateSendgridParseWebhookSignature({
-      mode: "required",
       publicKey: publicKeyPem,
       headers: {
         "x-twilio-email-event-webhook-signature": "invalid-signature",
@@ -177,7 +182,6 @@ describe("validateSendgridParseWebhookSignature", () => {
 
   it("rejects stale timestamps", () => {
     const result = validateSendgridParseWebhookSignature({
-      mode: "required",
       publicKey: publicKeyPem,
       headers: {
         "x-twilio-email-event-webhook-signature": signWebhook({
@@ -199,9 +203,8 @@ describe("validateSendgridParseWebhookSignature", () => {
     expect(result.error.apiError.type).toBe("invalid_request_error");
   });
 
-  it("accepts a valid signature in required mode", () => {
+  it("accepts a valid signature", () => {
     const result = validateSendgridParseWebhookSignature({
-      mode: "required",
       publicKey: publicKeyPem,
       headers: {
         "x-twilio-email-event-webhook-signature": signature,

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -1,8 +1,10 @@
 import { generateKeyPairSync, sign } from "node:crypto";
 import {
+  createBufferedRequestFromRawBody,
   validateSendgridParseWebhookSignature,
   verifySendgridParseWebhookSignature,
 } from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
+import { IncomingForm } from "formidable";
 import { describe, expect, it } from "vitest";
 
 const { privateKey, publicKey } = generateKeyPairSync("ec", {
@@ -74,6 +76,18 @@ describe("verifySendgridParseWebhookSignature", () => {
         timestamp,
       })
     ).toBe(false);
+  });
+
+  it("replays the raw multipart body into formidable without rewriting it first", async () => {
+    const req = createBufferedRequestFromRawBody(multipartPayload, {
+      "content-length": `${multipartPayload.length}`,
+      "content-type": "multipart/form-data; boundary=boundary",
+    });
+    const form = new IncomingForm();
+    const [fields, files] = await form.parse(req);
+
+    expect(fields.text?.[0]).toBe("hello world");
+    expect(Object.keys(files)).toHaveLength(0);
   });
 });
 

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync, sign } from "node:crypto";
+import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
 import {
   createBufferedRequestFromRawBody,
   isSendgridParseFormRequest,
@@ -17,18 +17,27 @@ const publicKeyPem = publicKey
 const publicKeyBase64 = publicKey
   .export({ format: "der", type: "spki" })
   .toString("base64");
+const { privateKey: rsaPrivateKey, publicKey: rsaPublicKey } =
+  generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  });
+const rsaPublicKeyPem = rsaPublicKey
+  .export({ format: "pem", type: "pkcs1" })
+  .toString();
 
 function signWebhook({
+  privateKey: signingKey = privateKey,
   rawBody,
   timestamp,
 }: {
+  privateKey?: KeyObject;
   rawBody: Buffer;
   timestamp: string;
 }): string {
   return sign(
     "sha256",
     Buffer.concat([Buffer.from(timestamp, "utf8"), rawBody]),
-    privateKey
+    signingKey
   ).toString("base64");
 }
 
@@ -71,6 +80,23 @@ describe("verifySendgridParseWebhookSignature", () => {
     expect(
       verifySendgridParseWebhookSignature({
         publicKey: publicKeyBase64,
+        rawBody: multipartPayload,
+        signature,
+        timestamp,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts PEM public keys with non-SPKI headers", () => {
+    const signature = signWebhook({
+      privateKey: rsaPrivateKey,
+      rawBody: multipartPayload,
+      timestamp,
+    });
+
+    expect(
+      verifySendgridParseWebhookSignature({
+        publicKey: rsaPublicKeyPem,
         rawBody: multipartPayload,
         signature,
         timestamp,
@@ -121,6 +147,8 @@ describe("validateSendgridParseWebhookSignature", () => {
   const nowMs = Date.now();
   const freshTimestamp = `${Math.floor(nowMs / 1000)}`;
   const staleTimestamp = `${Math.floor((nowMs - 10 * 60 * 1000) / 1000)}`;
+  const slightlyFutureTimestamp = `${Math.floor((nowMs + 30 * 1000) / 1000)}`;
+  const tooFutureTimestamp = `${Math.floor((nowMs + 2 * 60 * 1000) / 1000)}`;
   const signature = signWebhook({
     rawBody,
     timestamp: freshTimestamp,
@@ -203,12 +231,52 @@ describe("validateSendgridParseWebhookSignature", () => {
     expect(result.error.apiError.type).toBe("invalid_request_error");
   });
 
+  it("rejects timestamps that are too far in the future", () => {
+    const result = validateSendgridParseWebhookSignature({
+      publicKey: publicKeyPem,
+      headers: {
+        "x-twilio-email-event-webhook-signature": signWebhook({
+          rawBody,
+          timestamp: tooFutureTimestamp,
+        }),
+        "x-twilio-email-event-webhook-timestamp": tooFutureTimestamp,
+      },
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected too-far-future timestamp to be rejected");
+    }
+
+    expect(result.error.statusCode).toBe(403);
+    expect(result.error.apiError.type).toBe("invalid_request_error");
+  });
+
   it("accepts a valid signature", () => {
     const result = validateSendgridParseWebhookSignature({
       publicKey: publicKeyPem,
       headers: {
         "x-twilio-email-event-webhook-signature": signature,
         "x-twilio-email-event-webhook-timestamp": freshTimestamp,
+      },
+      rawBody,
+      nowMs,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("accepts a small amount of clock skew", () => {
+    const result = validateSendgridParseWebhookSignature({
+      publicKey: publicKeyPem,
+      headers: {
+        "x-twilio-email-event-webhook-signature": signWebhook({
+          rawBody,
+          timestamp: slightlyFutureTimestamp,
+        }),
+        "x-twilio-email-event-webhook-timestamp": slightlyFutureTimestamp,
       },
       rawBody,
       nowMs,

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -13,6 +13,9 @@ const { privateKey, publicKey } = generateKeyPairSync("ec", {
 const publicKeyPem = publicKey
   .export({ format: "pem", type: "spki" })
   .toString();
+const publicKeyBase64 = publicKey
+  .export({ format: "der", type: "spki" })
+  .toString("base64");
 
 function signWebhook({
   rawBody,
@@ -51,6 +54,22 @@ describe("verifySendgridParseWebhookSignature", () => {
     expect(
       verifySendgridParseWebhookSignature({
         publicKey: publicKeyPem,
+        rawBody: multipartPayload,
+        signature,
+        timestamp,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts the SendGrid base64 public-key format", () => {
+    const signature = signWebhook({
+      rawBody: multipartPayload,
+      timestamp,
+    });
+
+    expect(
+      verifySendgridParseWebhookSignature({
+        publicKey: publicKeyBase64,
         rawBody: multipartPayload,
         signature,
         timestamp,

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSync, sign } from "node:crypto";
 import {
   createBufferedRequestFromRawBody,
+  isSendgridParseFormRequest,
   validateSendgridParseWebhookSignature,
   verifySendgridParseWebhookSignature,
 } from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
@@ -102,6 +103,9 @@ describe("verifySendgridParseWebhookSignature", () => {
       "content-length": `${multipartPayload.length}`,
       "content-type": "multipart/form-data; boundary=boundary",
     });
+    if (!isSendgridParseFormRequest(req)) {
+      throw new Error("Expected replayed raw body to be parseable by formidable");
+    }
     const form = new IncomingForm();
     const [fields, files] = await form.parse(req);
 

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
 import {
   createBufferedRequestFromRawBody,
   isSendgridParseFormRequest,

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
@@ -49,8 +49,18 @@ function hasFreshTimestamp(timestamp: string, nowMs: number): boolean {
   );
 }
 
-function normalizePublicKey(publicKey: string): string {
-  return publicKey.replace(/\\n/g, "\n");
+function createSendgridParseWebhookPublicKey(publicKey: string) {
+  const normalizedPublicKey = publicKey.replace(/\\n/g, "\n").trim();
+
+  if (normalizedPublicKey.includes("BEGIN PUBLIC KEY")) {
+    return createPublicKey(normalizedPublicKey);
+  }
+
+  return createPublicKey({
+    key: Buffer.from(normalizedPublicKey.replace(/\s+/g, ""), "base64"),
+    format: "der",
+    type: "spki",
+  });
 }
 
 export function verifySendgridParseWebhookSignature({
@@ -73,7 +83,7 @@ export function verifySendgridParseWebhookSignature({
   return verify(
     "sha256",
     signedContent,
-    createPublicKey(normalizePublicKey(publicKey)),
+    createSendgridParseWebhookPublicKey(publicKey),
     signatureBytes
   );
 }

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
@@ -1,0 +1,180 @@
+import { createPublicKey, verify } from "node:crypto";
+import type { IncomingHttpHeaders } from "node:http";
+import { Readable } from "node:stream";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type SendgridParseWebhookSignatureMode =
+  | "disabled"
+  | "optional"
+  | "required";
+
+type SignatureValidationError = {
+  statusCode: 401 | 403 | 500;
+  apiError: {
+    type: "invalid_request_error" | "internal_server_error";
+    message: string;
+  };
+};
+
+const SENDGRID_PARSE_WEBHOOK_SIGNATURE_HEADER =
+  "x-twilio-email-event-webhook-signature";
+const SENDGRID_PARSE_WEBHOOK_TIMESTAMP_HEADER =
+  "x-twilio-email-event-webhook-timestamp";
+const SENDGRID_PARSE_WEBHOOK_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
+
+function getHeaderValue(
+  headers: IncomingHttpHeaders,
+  name: string
+): string | undefined {
+  const value = headers[name];
+
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return typeof value === "string" ? value : undefined;
+}
+
+function hasFreshTimestamp(timestamp: string, nowMs: number): boolean {
+  if (!/^\d+$/.test(timestamp)) {
+    return false;
+  }
+
+  const timestampMs = Number(timestamp) * 1000;
+
+  return (
+    timestampMs <= nowMs + SENDGRID_PARSE_WEBHOOK_TIMESTAMP_TOLERANCE_MS &&
+    nowMs - timestampMs <= SENDGRID_PARSE_WEBHOOK_TIMESTAMP_TOLERANCE_MS
+  );
+}
+
+function normalizePublicKey(publicKey: string): string {
+  return publicKey.replace(/\\n/g, "\n");
+}
+
+export function verifySendgridParseWebhookSignature({
+  publicKey,
+  rawBody,
+  signature,
+  timestamp,
+}: {
+  publicKey: string;
+  rawBody: Buffer;
+  signature: string;
+  timestamp: string;
+}): boolean {
+  const signatureBytes = Buffer.from(signature, "base64");
+  const signedContent = Buffer.concat([
+    Buffer.from(timestamp, "utf8"),
+    rawBody,
+  ]);
+
+  return verify(
+    "sha256",
+    signedContent,
+    createPublicKey(normalizePublicKey(publicKey)),
+    signatureBytes
+  );
+}
+
+export function validateSendgridParseWebhookSignature({
+  mode,
+  publicKey,
+  headers,
+  rawBody,
+  nowMs = Date.now(),
+}: {
+  mode: SendgridParseWebhookSignatureMode;
+  publicKey: string | undefined;
+  headers: IncomingHttpHeaders;
+  rawBody: Buffer;
+  nowMs?: number;
+}): Result<void, SignatureValidationError> {
+  if (mode === "disabled") {
+    return new Ok(undefined);
+  }
+
+  if (!publicKey) {
+    return new Err({
+      statusCode: 500,
+      apiError: {
+        type: "internal_server_error",
+        message: "SendGrid Parse webhook public key is not configured.",
+      },
+    });
+  }
+
+  const signature = getHeaderValue(
+    headers,
+    SENDGRID_PARSE_WEBHOOK_SIGNATURE_HEADER
+  );
+  const timestamp = getHeaderValue(
+    headers,
+    SENDGRID_PARSE_WEBHOOK_TIMESTAMP_HEADER
+  );
+  const hasAnySignatureHeaders = Boolean(signature) || Boolean(timestamp);
+
+  if (!signature || !timestamp) {
+    if (mode === "optional" && !hasAnySignatureHeaders) {
+      return new Ok(undefined);
+    }
+
+    return new Err({
+      statusCode: 401,
+      apiError: {
+        type: "invalid_request_error",
+        message: "Missing SendGrid Parse webhook signature headers.",
+      },
+    });
+  }
+
+  if (!hasFreshTimestamp(timestamp, nowMs)) {
+    return new Err({
+      statusCode: 403,
+      apiError: {
+        type: "invalid_request_error",
+        message:
+          "Invalid SendGrid Parse webhook timestamp: signature is stale or malformed.",
+      },
+    });
+  }
+
+  try {
+    if (
+      !verifySendgridParseWebhookSignature({
+        publicKey,
+        rawBody,
+        signature,
+        timestamp,
+      })
+    ) {
+      return new Err({
+        statusCode: 403,
+        apiError: {
+          type: "invalid_request_error",
+          message: "Invalid SendGrid Parse webhook signature.",
+        },
+      });
+    }
+  } catch {
+    return new Err({
+      statusCode: 403,
+      apiError: {
+        type: "invalid_request_error",
+        message: "Invalid SendGrid Parse webhook signature.",
+      },
+    });
+  }
+
+  return new Ok(undefined);
+}
+
+export function createBufferedRequestFromRawBody(
+  rawBody: Buffer,
+  headers: IncomingHttpHeaders
+): Readable & { headers: IncomingHttpHeaders } {
+  return Object.assign(Readable.from([rawBody]), {
+    headers,
+  });
+}

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
@@ -1,5 +1,5 @@
 import { createPublicKey, verify } from "node:crypto";
-import type { IncomingHttpHeaders } from "node:http";
+import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -177,4 +177,14 @@ export function createBufferedRequestFromRawBody(
   return Object.assign(Readable.from([rawBody]), {
     headers,
   });
+}
+
+export function isSendgridParseFormRequest(
+  req: Readable & { headers: IncomingHttpHeaders }
+): req is IncomingMessage {
+  return (
+    typeof req.pause === "function" &&
+    typeof req.resume === "function" &&
+    typeof req.on === "function"
+  );
 }

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
@@ -16,7 +16,8 @@ const SENDGRID_PARSE_WEBHOOK_SIGNATURE_HEADER =
   "x-twilio-email-event-webhook-signature";
 const SENDGRID_PARSE_WEBHOOK_TIMESTAMP_HEADER =
   "x-twilio-email-event-webhook-timestamp";
-const SENDGRID_PARSE_WEBHOOK_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
+const SENDGRID_PARSE_WEBHOOK_MAX_AGE_MS = 5 * 60 * 1000;
+const SENDGRID_PARSE_WEBHOOK_MAX_FUTURE_SKEW_MS = 60 * 1000;
 
 function getHeaderValue(
   headers: IncomingHttpHeaders,
@@ -39,15 +40,15 @@ function hasFreshTimestamp(timestamp: string, nowMs: number): boolean {
   const timestampMs = Number(timestamp) * 1000;
 
   return (
-    timestampMs <= nowMs + SENDGRID_PARSE_WEBHOOK_TIMESTAMP_TOLERANCE_MS &&
-    nowMs - timestampMs <= SENDGRID_PARSE_WEBHOOK_TIMESTAMP_TOLERANCE_MS
+    timestampMs <= nowMs + SENDGRID_PARSE_WEBHOOK_MAX_FUTURE_SKEW_MS &&
+    nowMs - timestampMs <= SENDGRID_PARSE_WEBHOOK_MAX_AGE_MS
   );
 }
 
 function createSendgridParseWebhookPublicKey(publicKey: string) {
   const normalizedPublicKey = publicKey.replace(/\\n/g, "\n").trim();
 
-  if (normalizedPublicKey.includes("BEGIN PUBLIC KEY")) {
+  if (/-----BEGIN [A-Z0-9 ]+-----/.test(normalizedPublicKey)) {
     return createPublicKey(normalizedPublicKey);
   }
 

--- a/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
+++ b/front/lib/api/assistant/email/sendgrid_parse_webhook_signature.ts
@@ -4,11 +4,6 @@ import { Readable } from "node:stream";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-export type SendgridParseWebhookSignatureMode =
-  | "disabled"
-  | "optional"
-  | "required";
-
 type SignatureValidationError = {
   statusCode: 401 | 403 | 500;
   apiError: {
@@ -89,22 +84,16 @@ export function verifySendgridParseWebhookSignature({
 }
 
 export function validateSendgridParseWebhookSignature({
-  mode,
   publicKey,
   headers,
   rawBody,
   nowMs = Date.now(),
 }: {
-  mode: SendgridParseWebhookSignatureMode;
   publicKey: string | undefined;
   headers: IncomingHttpHeaders;
   rawBody: Buffer;
   nowMs?: number;
 }): Result<void, SignatureValidationError> {
-  if (mode === "disabled") {
-    return new Ok(undefined);
-  }
-
   if (!publicKey) {
     return new Err({
       statusCode: 500,
@@ -123,13 +112,8 @@ export function validateSendgridParseWebhookSignature({
     headers,
     SENDGRID_PARSE_WEBHOOK_TIMESTAMP_HEADER
   );
-  const hasAnySignatureHeaders = Boolean(signature) || Boolean(timestamp);
 
   if (!signature || !timestamp) {
-    if (mode === "optional" && !hasAnySignatureHeaders) {
-      return new Ok(undefined);
-    }
-
     return new Err({
       statusCode: 401,
       apiError: {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -453,6 +453,28 @@ const config = {
   getEmailWebhookSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("EMAIL_WEBHOOK_SECRET");
   },
+  getSendgridParseWebhookPublicKey: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "SENDGRID_PARSE_WEBHOOK_PUBLIC_KEY"
+    );
+  },
+  getSendgridParseWebhookSignatureMode: ():
+    | "disabled"
+    | "optional"
+    | "required" => {
+    const mode =
+      EnvironmentConfig.getOptionalEnvVariable(
+        "SENDGRID_PARSE_WEBHOOK_SIGNATURE_MODE"
+      ) ?? "disabled";
+
+    if (mode !== "disabled" && mode !== "optional" && mode !== "required") {
+      throw new Error(
+        "SENDGRID_PARSE_WEBHOOK_SIGNATURE_MODE must be one of: disabled, optional, required."
+      );
+    }
+
+    return mode;
+  },
   getProductionDustWorkspaceId: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "PRODUCTION_DUST_WORKSPACE_ID"

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -458,23 +458,6 @@ const config = {
       "SENDGRID_PARSE_WEBHOOK_PUBLIC_KEY"
     );
   },
-  getSendgridParseWebhookSignatureMode: ():
-    | "disabled"
-    | "optional"
-    | "required" => {
-    const mode =
-      EnvironmentConfig.getOptionalEnvVariable(
-        "SENDGRID_PARSE_WEBHOOK_SIGNATURE_MODE"
-      ) ?? "disabled";
-
-    if (mode !== "disabled" && mode !== "optional" && mode !== "required") {
-      throw new Error(
-        "SENDGRID_PARSE_WEBHOOK_SIGNATURE_MODE must be one of: disabled, optional, required."
-      );
-    }
-
-    return mode;
-  },
   getProductionDustWorkspaceId: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "PRODUCTION_DUST_WORKSPACE_ID"

--- a/front/pages/api/email/webhook.test.ts
+++ b/front/pages/api/email/webhook.test.ts
@@ -1,54 +1,192 @@
-import { shouldRelayToOtherRegion } from "@app/pages/api/email/webhook";
-import { describe, expect, it } from "vitest";
+import { generateKeyPairSync, sign } from "node:crypto";
+import type { NextApiRequestWithContext } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("shouldRelayToOtherRegion", () => {
-  it("relays first-hop user and workspace misses", () => {
-    expect(
-      shouldRelayToOtherRegion({
-        req: { headers: {} },
-        error: {
-          type: "user_not_found",
-          message: "user missing",
-        },
-      })
-    ).toBe(true);
+const {
+  rawBodyMock,
+  formParseMock,
+  evaluateInboundAuthMock,
+  parseSendgridDkimResultsMock,
+} = vi.hoisted(() => ({
+  rawBodyMock: vi.fn(),
+  formParseMock: vi.fn(),
+  evaluateInboundAuthMock: vi.fn(),
+  parseSendgridDkimResultsMock: vi.fn(),
+}));
 
-    expect(
-      shouldRelayToOtherRegion({
-        req: { headers: {} },
-        error: {
-          type: "workspace_not_found",
-          message: "workspace missing",
-        },
-      })
-    ).toBe(true);
+vi.mock("raw-body", () => ({
+  default: rawBodyMock,
+}));
+
+vi.mock("formidable", () => ({
+  IncomingForm: function IncomingForm() {
+    return {
+      parse: formParseMock,
+    };
+  },
+}));
+
+vi.mock("@app/lib/api/assistant/email/inbound_auth", () => ({
+  evaluateInboundAuth: evaluateInboundAuthMock,
+  parseSendgridDkimResults: parseSendgridDkimResultsMock,
+}));
+
+vi.mock("@app/lib/api/assistant/email/email_trigger", () => ({
+  ASSISTANT_EMAIL_SUBDOMAIN: "dust.team",
+  emailAssistantMatcher: vi.fn(),
+  replyToEmail: vi.fn(),
+  triggerFromEmail: vi.fn(),
+  userAndWorkspaceFromEmail: vi.fn(),
+}));
+
+import handler, { type PostResponseBody } from "./webhook";
+
+const { privateKey, publicKey } = generateKeyPairSync("ec", {
+  namedCurve: "prime256v1",
+});
+const publicKeyPem = publicKey
+  .export({ format: "pem", type: "spki" })
+  .toString();
+
+function signWebhook({
+  rawBody,
+  timestamp,
+}: {
+  rawBody: Buffer;
+  timestamp: string;
+}): string {
+  return sign(
+    "sha256",
+    Buffer.concat([Buffer.from(timestamp, "utf8"), rawBody]),
+    privateKey
+  ).toString("base64");
+}
+
+function basicAuthHeader(secret: string): string {
+  return `Basic ${Buffer.from(`sendgrid:${secret}`).toString("base64")}`;
+}
+
+function asLoggedRequest(req: unknown): NextApiRequestWithContext {
+  return req as NextApiRequestWithContext;
+}
+
+function asApiResponse(
+  res: unknown
+): NextApiResponse<WithAPIErrorResponse<PostResponseBody>> {
+  return res as NextApiResponse<WithAPIErrorResponse<PostResponseBody>>;
+}
+
+describe("POST /api/email/webhook", () => {
+  const rawBody = Buffer.from("multipart body", "utf8");
+  const timestamp = `${Math.floor(Date.now() / 1000)}`;
+  const signature = signWebhook({
+    rawBody,
+    timestamp,
   });
 
-  it("does not relay requests that were already forwarded", () => {
-    expect(
-      shouldRelayToOtherRegion({
-        req: {
-          headers: {
-            "x-dust-email-webhook-relayed": "1",
-          },
-        },
-        error: {
-          type: "user_not_found",
-          message: "user missing",
-        },
-      })
-    ).toBe(false);
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    process.env.EMAIL_WEBHOOK_SECRET = "test-email-webhook-secret";
+    process.env.SENDGRID_PARSE_WEBHOOK_PUBLIC_KEY = publicKeyPem;
+    process.env.SENDGRID_PARSE_WEBHOOK_SIGNATURE_MODE = "required";
+
+    rawBodyMock.mockResolvedValue(rawBody);
+    parseSendgridDkimResultsMock.mockReturnValue([]);
+    evaluateInboundAuthMock.mockReturnValue({
+      authenticated: false,
+      reason: "test",
+      headerFromDomain: "company.com",
+      spfResult: "pass",
+      spfEnvelopeDomain: "company.com",
+      dkimEntries: [],
+    });
   });
 
-  it("does not relay unrelated email errors", () => {
-    expect(
-      shouldRelayToOtherRegion({
-        req: { headers: {} },
-        error: {
-          type: "invalid_email_error",
-          message: "bad recipient",
-        },
-      })
-    ).toBe(false);
+  it("rejects missing signature headers before multipart parsing", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
+        "content-type": "multipart/form-data; boundary=boundary",
+      },
+    });
+
+    await handler(asLoggedRequest(req), asApiResponse(res));
+
+    expect(formParseMock).not.toHaveBeenCalled();
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toBe(
+      "Missing SendGrid Parse webhook signature headers."
+    );
+  });
+
+  it("rejects an invalid signature before multipart parsing", async () => {
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
+        "content-type": "multipart/form-data; boundary=boundary",
+        "x-twilio-email-event-webhook-signature": "invalid-signature",
+        "x-twilio-email-event-webhook-timestamp": timestamp,
+      },
+    });
+
+    await handler(asLoggedRequest(req), asApiResponse(res));
+
+    expect(formParseMock).not.toHaveBeenCalled();
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toBe(
+      "Invalid SendGrid Parse webhook signature."
+    );
+  });
+
+  it("accepts a valid signature and parses the multipart body", async () => {
+    formParseMock.mockResolvedValue([
+      {
+        subject: ["hello"],
+        text: ["body"],
+        from: ["Sender <sender@company.com>"],
+        SPF: ["pass"],
+        dkim: ["{@company.com : pass}"],
+        headers: [
+          [
+            "From: Sender <sender@company.com>",
+            "To: agent@dust.team",
+            "Message-ID: <msg-1@example.com>",
+          ].join("\r\n"),
+        ],
+        envelope: [
+          JSON.stringify({
+            from: "bounce@company.com",
+            to: ["agent@dust.team"],
+            cc: [],
+            bcc: [],
+          }),
+        ],
+      },
+      {},
+    ]);
+
+    const { req, res } = createMocks({
+      method: "POST",
+      headers: {
+        authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
+        "content-type": "multipart/form-data; boundary=boundary",
+        "x-twilio-email-event-webhook-signature": signature,
+        "x-twilio-email-event-webhook-timestamp": timestamp,
+      },
+    });
+
+    await handler(asLoggedRequest(req), asApiResponse(res));
+
+    expect(formParseMock).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
   });
 });

--- a/front/pages/api/email/webhook.test.ts
+++ b/front/pages/api/email/webhook.test.ts
@@ -80,9 +80,9 @@ describe("POST /api/email/webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    delete process.env.IS_DEVELOPMENT;
     process.env.EMAIL_WEBHOOK_SECRET = "test-email-webhook-secret";
     process.env.SENDGRID_PARSE_WEBHOOK_PUBLIC_KEY = publicKeyPem;
-    process.env.SENDGRID_PARSE_WEBHOOK_SIGNATURE_MODE = "required";
 
     rawBodyMock.mockResolvedValue(rawBody);
     parseSendgridDkimResultsMock.mockReturnValue([]);
@@ -140,6 +140,52 @@ describe("POST /api/email/webhook", () => {
     expect(res._getJSONData().error.message).toBe(
       "Invalid SendGrid Parse webhook signature."
     );
+  });
+
+  it("skips signature verification in development", async () => {
+    process.env.IS_DEVELOPMENT = "true";
+    formParseMock.mockResolvedValue([
+      {
+        subject: ["hello"],
+        text: ["body"],
+        from: ["Sender <sender@company.com>"],
+        SPF: ["pass"],
+        dkim: ["{@company.com : pass}"],
+        headers: [
+          [
+            "From: Sender <sender@company.com>",
+            "To: agent@dust.team",
+            "Message-ID: <msg-1@example.com>",
+          ].join("\r\n"),
+        ],
+        envelope: [
+          JSON.stringify({
+            from: "bounce@company.com",
+            to: ["agent@dust.team"],
+            cc: [],
+            bcc: [],
+          }),
+        ],
+      },
+      {},
+    ]);
+
+    const { req, res } = createMocks<
+      NextApiRequestWithContext,
+      NextApiResponse<WithAPIErrorResponse<PostResponseBody>>
+    >({
+      method: "POST",
+      headers: {
+        authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
+        "content-type": "multipart/form-data; boundary=boundary",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(formParseMock).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
   });
 
   it("accepts a valid signature and parses the multipart body", async () => {

--- a/front/pages/api/email/webhook.test.ts
+++ b/front/pages/api/email/webhook.test.ts
@@ -69,16 +69,6 @@ function basicAuthHeader(secret: string): string {
   return `Basic ${Buffer.from(`sendgrid:${secret}`).toString("base64")}`;
 }
 
-function asLoggedRequest(req: unknown): NextApiRequestWithContext {
-  return req as NextApiRequestWithContext;
-}
-
-function asApiResponse(
-  res: unknown
-): NextApiResponse<WithAPIErrorResponse<PostResponseBody>> {
-  return res as NextApiResponse<WithAPIErrorResponse<PostResponseBody>>;
-}
-
 describe("POST /api/email/webhook", () => {
   const rawBody = Buffer.from("multipart body", "utf8");
   const timestamp = `${Math.floor(Date.now() / 1000)}`;
@@ -107,7 +97,10 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("rejects missing signature headers before multipart parsing", async () => {
-    const { req, res } = createMocks({
+    const { req, res } = createMocks<
+      NextApiRequestWithContext,
+      NextApiResponse<WithAPIErrorResponse<PostResponseBody>>
+    >({
       method: "POST",
       headers: {
         authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
@@ -115,7 +108,7 @@ describe("POST /api/email/webhook", () => {
       },
     });
 
-    await handler(asLoggedRequest(req), asApiResponse(res));
+    await handler(req, res);
 
     expect(formParseMock).not.toHaveBeenCalled();
     expect(res._getStatusCode()).toBe(401);
@@ -126,7 +119,10 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("rejects an invalid signature before multipart parsing", async () => {
-    const { req, res } = createMocks({
+    const { req, res } = createMocks<
+      NextApiRequestWithContext,
+      NextApiResponse<WithAPIErrorResponse<PostResponseBody>>
+    >({
       method: "POST",
       headers: {
         authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
@@ -136,7 +132,7 @@ describe("POST /api/email/webhook", () => {
       },
     });
 
-    await handler(asLoggedRequest(req), asApiResponse(res));
+    await handler(req, res);
 
     expect(formParseMock).not.toHaveBeenCalled();
     expect(res._getStatusCode()).toBe(403);
@@ -173,7 +169,10 @@ describe("POST /api/email/webhook", () => {
       {},
     ]);
 
-    const { req, res } = createMocks({
+    const { req, res } = createMocks<
+      NextApiRequestWithContext,
+      NextApiResponse<WithAPIErrorResponse<PostResponseBody>>
+    >({
       method: "POST",
       headers: {
         authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
@@ -183,7 +182,7 @@ describe("POST /api/email/webhook", () => {
       },
     });
 
-    await handler(asLoggedRequest(req), asApiResponse(res));
+    await handler(req, res);
 
     expect(formParseMock).toHaveBeenCalledTimes(1);
     expect(res._getStatusCode()).toBe(200);

--- a/front/pages/api/email/webhook.test.ts
+++ b/front/pages/api/email/webhook.test.ts
@@ -34,6 +34,17 @@ vi.mock("@app/lib/api/assistant/email/inbound_auth", () => ({
   parseSendgridDkimResults: parseSendgridDkimResultsMock,
 }));
 
+vi.mock("@app/lib/api/regions/config", () => ({
+  config: {
+    getCurrentRegion: vi.fn(() => "us-central1"),
+    getLookupApiSecret: vi.fn(() => "test-relay-secret"),
+    getOtherRegionInfo: vi.fn(() => ({
+      name: "europe-west1",
+      url: "https://dust-eu.example.com",
+    })),
+  },
+}));
+
 vi.mock("@app/lib/api/assistant/email/email_trigger", () => ({
   ASSISTANT_EMAIL_SUBDOMAIN: "dust.team",
   emailAssistantMatcher: vi.fn(),
@@ -42,7 +53,10 @@ vi.mock("@app/lib/api/assistant/email/email_trigger", () => ({
   userAndWorkspaceFromEmail: vi.fn(),
 }));
 
-import handler, { type PostResponseBody } from "./webhook";
+import handler, {
+  type PostResponseBody,
+  shouldRelayToOtherRegion,
+} from "./webhook";
 
 const { privateKey, publicKey } = generateKeyPairSync("ec", {
   namedCurve: "prime256v1",
@@ -68,6 +82,85 @@ function signWebhook({
 function basicAuthHeader(secret: string): string {
   return `Basic ${Buffer.from(`sendgrid:${secret}`).toString("base64")}`;
 }
+
+function relayAuthHeader(secret: string): string {
+  return `Bearer ${secret}`;
+}
+
+const PARSED_EMAIL_FIELDS = {
+  subject: ["hello"],
+  text: ["body"],
+  from: ["Sender <sender@company.com>"],
+  SPF: ["pass"],
+  dkim: ["{@company.com : pass}"],
+  headers: [
+    [
+      "From: Sender <sender@company.com>",
+      "To: agent@dust.team",
+      "Message-ID: <msg-1@example.com>",
+    ].join("\r\n"),
+  ],
+  envelope: [
+    JSON.stringify({
+      from: "bounce@company.com",
+      to: ["agent@dust.team"],
+      cc: [],
+      bcc: [],
+    }),
+  ],
+};
+
+describe("shouldRelayToOtherRegion", () => {
+  it("relays first-hop user and workspace misses", () => {
+    expect(
+      shouldRelayToOtherRegion({
+        req: { headers: {} },
+        error: {
+          type: "user_not_found",
+          message: "user missing",
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      shouldRelayToOtherRegion({
+        req: { headers: {} },
+        error: {
+          type: "workspace_not_found",
+          message: "workspace missing",
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("does not relay requests that were already forwarded", () => {
+    expect(
+      shouldRelayToOtherRegion({
+        req: {
+          headers: {
+            "x-dust-email-webhook-relayed": "1",
+          },
+        },
+        error: {
+          type: "user_not_found",
+          message: "user missing",
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("does not relay unrelated email errors", () => {
+    expect(
+      shouldRelayToOtherRegion({
+        req: { headers: {} },
+        error: {
+          type: "invalid_email_error",
+          message: "bad recipient",
+        },
+      })
+    ).toBe(false);
+  });
+});
 
 describe("POST /api/email/webhook", () => {
   const rawBody = Buffer.from("multipart body", "utf8");
@@ -144,31 +237,7 @@ describe("POST /api/email/webhook", () => {
 
   it("skips signature verification in development", async () => {
     process.env.IS_DEVELOPMENT = "true";
-    formParseMock.mockResolvedValue([
-      {
-        subject: ["hello"],
-        text: ["body"],
-        from: ["Sender <sender@company.com>"],
-        SPF: ["pass"],
-        dkim: ["{@company.com : pass}"],
-        headers: [
-          [
-            "From: Sender <sender@company.com>",
-            "To: agent@dust.team",
-            "Message-ID: <msg-1@example.com>",
-          ].join("\r\n"),
-        ],
-        envelope: [
-          JSON.stringify({
-            from: "bounce@company.com",
-            to: ["agent@dust.team"],
-            cc: [],
-            bcc: [],
-          }),
-        ],
-      },
-      {},
-    ]);
+    formParseMock.mockResolvedValue([PARSED_EMAIL_FIELDS, {}]);
 
     const { req, res } = createMocks<
       NextApiRequestWithContext,
@@ -188,32 +257,30 @@ describe("POST /api/email/webhook", () => {
     expect(res._getJSONData()).toEqual({ success: true });
   });
 
-  it("accepts a valid signature and parses the multipart body", async () => {
-    formParseMock.mockResolvedValue([
-      {
-        subject: ["hello"],
-        text: ["body"],
-        from: ["Sender <sender@company.com>"],
-        SPF: ["pass"],
-        dkim: ["{@company.com : pass}"],
-        headers: [
-          [
-            "From: Sender <sender@company.com>",
-            "To: agent@dust.team",
-            "Message-ID: <msg-1@example.com>",
-          ].join("\r\n"),
-        ],
-        envelope: [
-          JSON.stringify({
-            from: "bounce@company.com",
-            to: ["agent@dust.team"],
-            cc: [],
-            bcc: [],
-          }),
-        ],
+  it("accepts relayed requests without SendGrid signatures", async () => {
+    formParseMock.mockResolvedValue([PARSED_EMAIL_FIELDS, {}]);
+
+    const { req, res } = createMocks<
+      NextApiRequestWithContext,
+      NextApiResponse<WithAPIErrorResponse<PostResponseBody>>
+    >({
+      method: "POST",
+      headers: {
+        authorization: relayAuthHeader("test-relay-secret"),
+        "content-type": "multipart/form-data; boundary=boundary",
+        "x-dust-email-webhook-relayed": "1",
       },
-      {},
-    ]);
+    });
+
+    await handler(req, res);
+
+    expect(formParseMock).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+  });
+
+  it("accepts a valid SendGrid signature and parses the multipart body", async () => {
+    formParseMock.mockResolvedValue([PARSED_EMAIL_FIELDS, {}]);
 
     const { req, res } = createMocks<
       NextApiRequestWithContext,

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -21,6 +21,10 @@ import {
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
 import {
+  createBufferedRequestFromRawBody,
+  validateSendgridParseWebhookSignature,
+} from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
+import {
   buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
@@ -39,6 +43,9 @@ import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { IncomingForm } from "formidable";
 import { readFile } from "fs/promises";
 import type { NextApiRequest, NextApiResponse } from "next";
+import getRawBody from "raw-body";
+
+const SENDGRID_PARSE_WEBHOOK_MAX_SIZE = "30mb";
 
 // Disabling Next.js's body parser as formidable has its own
 export const config = {
@@ -187,10 +194,12 @@ function parseThreadingHeaders(rawHeaders: string | null) {
 
 // Parses the Sendgrid webhook form data and validates it returning a fully formed InboundEmail.
 const parseSendgridWebhookContent = async (
-  req: NextApiRequest
+  rawBody: Buffer,
+  headers: NextApiRequest["headers"]
 ): Promise<Result<InboundEmail, Error>> => {
+  const req = createBufferedRequestFromRawBody(rawBody, headers);
   const form = new IncomingForm();
-  const [fields, files] = await form.parse(req);
+  const [fields, files] = await form.parse(req as never);
 
   try {
     const subject = fields["subject"] ? fields["subject"][0] : null;
@@ -347,7 +356,44 @@ async function handler(
         });
       }
 
-      const emailRes = await parseSendgridWebhookContent(req);
+      // SendGrid signs the exact multipart bytes, so we must verify the raw body
+      // before formidable parses or rewrites anything.
+      let rawBody: Buffer;
+      try {
+        rawBody = await getRawBody(req, {
+          limit: SENDGRID_PARSE_WEBHOOK_MAX_SIZE,
+        });
+      } catch {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Failed to read raw request body.",
+          },
+        });
+      }
+
+      const signatureValidationRes = validateSendgridParseWebhookSignature({
+        mode: apiConfig.getSendgridParseWebhookSignatureMode(),
+        publicKey: apiConfig.getSendgridParseWebhookPublicKey(),
+        headers: req.headers,
+        rawBody,
+      });
+      if (signatureValidationRes.isErr()) {
+        logger.warn(
+          {
+            errorType: signatureValidationRes.error.apiError.type,
+            message: signatureValidationRes.error.apiError.message,
+          },
+          "[email] Rejected SendGrid Parse webhook before multipart parsing"
+        );
+        return apiError(req, res, {
+          status_code: signatureValidationRes.error.statusCode,
+          api_error: signatureValidationRes.error.apiError,
+        });
+      }
+
+      const emailRes = await parseSendgridWebhookContent(rawBody, req.headers);
       if (emailRes.isErr()) {
         return apiError(req, res, {
           status_code: 401,

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -339,6 +339,8 @@ async function handler(
   switch (req.method) {
     case "POST":
       const authHeader = req.headers.authorization;
+      const isSendgridRequest = hasValidSendgridAuthorization(authHeader);
+      const isRelayRequest = hasValidRelayAuthorization(req);
 
       if (!authHeader) {
         return apiError(req, res, {
@@ -350,10 +352,7 @@ async function handler(
         });
       }
 
-      if (
-        !hasValidSendgridAuthorization(authHeader) &&
-        !hasValidRelayAuthorization(req)
-      ) {
+      if (!isSendgridRequest && !isRelayRequest) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -380,7 +379,10 @@ async function handler(
         });
       }
 
-      if (!isDevelopment()) {
+      // Only the original SendGrid ingress carries the signed raw multipart body.
+      // Cross-region relays rebuild the form-data payload, so the forwarded hop must
+      // trust our relay auth instead of re-running SendGrid signature verification.
+      if (isSendgridRequest && !isDevelopment()) {
         const signatureValidationRes = validateSendgridParseWebhookSignature({
           publicKey: apiConfig.getSendgridParseWebhookPublicKey(),
           headers: req.headers,

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -37,6 +37,7 @@ import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isSupportedFileContentType } from "@app/types/files";
+import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -379,24 +380,25 @@ async function handler(
         });
       }
 
-      const signatureValidationRes = validateSendgridParseWebhookSignature({
-        mode: apiConfig.getSendgridParseWebhookSignatureMode(),
-        publicKey: apiConfig.getSendgridParseWebhookPublicKey(),
-        headers: req.headers,
-        rawBody,
-      });
-      if (signatureValidationRes.isErr()) {
-        logger.warn(
-          {
-            errorType: signatureValidationRes.error.apiError.type,
-            message: signatureValidationRes.error.apiError.message,
-          },
-          "[email] Rejected SendGrid Parse webhook before multipart parsing"
-        );
-        return apiError(req, res, {
-          status_code: signatureValidationRes.error.statusCode,
-          api_error: signatureValidationRes.error.apiError,
+      if (!isDevelopment()) {
+        const signatureValidationRes = validateSendgridParseWebhookSignature({
+          publicKey: apiConfig.getSendgridParseWebhookPublicKey(),
+          headers: req.headers,
+          rawBody,
         });
+        if (signatureValidationRes.isErr()) {
+          logger.warn(
+            {
+              errorType: signatureValidationRes.error.apiError.type,
+              message: signatureValidationRes.error.apiError.message,
+            },
+            "[email] Rejected SendGrid Parse webhook before multipart parsing"
+          );
+          return apiError(req, res, {
+            status_code: signatureValidationRes.error.statusCode,
+            api_error: signatureValidationRes.error.apiError,
+          });
+        }
       }
 
       const emailRes = await parseSendgridWebhookContent(rawBody, req.headers);

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -22,6 +22,7 @@ import {
 } from "@app/lib/api/assistant/email/inbound_auth";
 import {
   createBufferedRequestFromRawBody,
+  isSendgridParseFormRequest,
   validateSendgridParseWebhookSignature,
 } from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
 import {
@@ -198,8 +199,13 @@ const parseSendgridWebhookContent = async (
   headers: NextApiRequest["headers"]
 ): Promise<Result<InboundEmail, Error>> => {
   const req = createBufferedRequestFromRawBody(rawBody, headers);
+  if (!isSendgridParseFormRequest(req)) {
+    return new Err(
+      new Error("Failed to recreate request body for multipart parsing")
+    );
+  }
   const form = new IncomingForm();
-  const [fields, files] = await form.parse(req as never);
+  const [fields, files] = await form.parse(req);
 
   try {
     const subject = fields["subject"] ? fields["subject"][0] : null;


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7233.

Add raw-body verification for SendGrid Inbound Parse webhooks before multipart parsing, backed by a dedicated ECDSA verifier helper, support for SendGrid's base64 public-key format, and a timestamp freshness check to reduce replay risk.

Outside development, signed Parse webhooks are now required. In development, signature verification is skipped so local inbound-email workflows keep working without SendGrid webhook security setup.

## Risks
Blast radius: inbound email-agent webhook authentication and multipart parsing.
Risk: standard

## Deploy Plan
- create or update the SendGrid Parse webhook security policy so signature verification is enabled for the existing Parse webhook
- retrieve the SendGrid Parse webhook public key and store it in front secrets as `SENDGRID_PARSE_WEBHOOK_PUBLIC_KEY`
- attach the security policy to the existing Parse webhook
- deploy front so non-development environments require valid SendGrid signatures before multipart parsing
- send one test email through the Parse webhook and confirm the webhook accepts it in production logs

## Test
- [x] `cd front && NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/api/assistant/email/inbound_auth.test.ts lib/api/assistant/email/header_parsing.test.ts lib/api/assistant/email/sendgrid_parse_webhook_signature.test.ts lib/api/assistant/email/email_trigger.test.ts pages/api/email/webhook.test.ts`
