### PR TITLE
feat: move from blake3 to ... blake3 but node24 compatible

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -47,7 +47,7 @@
     "@types/remove-markdown": "^0.3.4",
     "@types/uuid": "^9.0.2",
     "axios": "^1.7.9",
-    "blake3": "^2.1.7",
+    "@napi-rs/blake-hash": "^1.3.6",
     "body-parser": "^1.20.2",
     "botbuilder": "^4.23.3",
     "crawlee": "3.14.1",

--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -14,8 +14,8 @@ import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { blake3 } from "@napi-rs/blake-hash";
 import assert from "assert";
-import { hash as blake3 } from "blake3";
 import { extname } from "path";
 
 export function hashFileContent(content: Buffer): string {

--- a/connectors/src/connectors/github/lib/utils.ts
+++ b/connectors/src/connectors/github/lib/utils.ts
@@ -1,5 +1,5 @@
+import { blake3 } from "@napi-rs/blake-hash";
 import assert from "assert";
-import { hash as blake3 } from "blake3/esm/node/hash-fn";
 import { join } from "path";
 
 export const GITHUB_CONTENT_NODE_TYPES = [

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -7,7 +7,7 @@ import type { WebCrawlerConfigurationResource } from "@connectors/resources/webc
 import type { ContentNodeType } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
-import { hash as blake3 } from "blake3";
+import { blake3 } from "@napi-rs/blake-hash";
 import { NonRetryableError } from "crawlee";
 import dns from "dns";
 
@@ -48,7 +48,7 @@ export function stableIdForUrl({
       : ressourceType === "table"
         ? "database"
         : "folder";
-  return Buffer.from(blake3(`${typePrefix}-${url}`)).toString("hex");
+  return blake3(`${typePrefix}-${url}`).toString("hex");
 }
 
 export function getParentsForPage(url: string, pageInItsOwnFolder: boolean) {

--- a/front/lib/api/llm/clients/google/utils/google_to_events.ts
+++ b/front/lib/api/llm/clients/google/utils/google_to_events.ts
@@ -7,8 +7,8 @@ import type {
   GenerateContentResponseUsageMetadata,
 } from "@google/genai";
 import { FinishReason } from "@google/genai";
+import { blake3 } from "@napi-rs/blake-hash";
 import assert from "assert";
-import { hash as blake3 } from "blake3";
 import crypto from "crypto";
 import flatMap from "lodash/flatMap";
 

--- a/front/lib/misc.ts
+++ b/front/lib/misc.ts
@@ -1,5 +1,5 @@
 import type { LightWorkspaceType } from "@app/types/user";
-import { hash as blake3 } from "blake3";
+import { blake3 } from "@napi-rs/blake-hash";
 
 // Check this slack thread for more details: https://dust4ai.slack.com/archives/C050SM8NSPK/p1750433286397399.
 // Any change to this function should be reviewed by @spolu.

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -19,7 +19,7 @@ import type { Result } from "@app/types/shared/result";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, RoleType } from "@app/types/user";
 import { formatUserFullName } from "@app/types/user";
-import { hash as blake3 } from "blake3";
+import { blake3 } from "@napi-rs/blake-hash";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
@@ -53,7 +53,7 @@ export class KeyResource extends BaseResource<KeyModel> {
   private user?: UserModel;
 
   static readonly keyCacheKeyResolver = (secret: string) =>
-    `key:secret:${Buffer.from(blake3(secret)).toString("hex")}`;
+    `key:secret:${blake3(secret).toString("hex")}`;
 
   private static async _fetchBySecretUncached(
     secret: string
@@ -148,7 +148,7 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   static createNewSecret() {
-    return `${SECRET_KEY_PREFIX}${Buffer.from(blake3(uuidv4())).toString("hex").slice(0, 32)}`;
+    return `${SECRET_KEY_PREFIX}${blake3(uuidv4()).toString("hex").slice(0, 32)}`;
   }
 
   static async fetchSystemKeyForWorkspace(workspace: LightWorkspaceType) {

--- a/front/lib/resources/string_ids_server.ts
+++ b/front/lib/resources/string_ids_server.ts
@@ -1,4 +1,4 @@
-import { hash as blake3 } from "blake3";
+import { blake3 } from "@napi-rs/blake-hash";
 import { v4 as uuidv4 } from "uuid";
 
 /**
@@ -6,11 +6,8 @@ import { v4 as uuidv4 } from "uuid";
  */
 export function generateRandomModelSId(prefix?: string): string {
   const u = uuidv4();
-  const b = blake3(u, { length: 10 });
-  const sId = Buffer.from(b)
-    .map(uniformByteToCode62)
-    .map(alphanumFromCode62)
-    .toString();
+  const b = blake3(u).subarray(0, 10);
+  const sId = b.map(uniformByteToCode62).map(alphanumFromCode62).toString();
 
   if (prefix) {
     return `${prefix}_${sId}`;
@@ -26,11 +23,14 @@ export function generateRandomModelSId(prefix?: string): string {
  * length: number of characters to return (default 64).
  */
 export function generateSecureSecret(length = 64): string {
-  const digest = blake3(uuidv4(), { length });
-  return Buffer.from(digest)
-    .map(uniformByteToCode62)
-    .map(alphanumFromCode62)
-    .toString();
+  // blake3 produces 32 bytes per call. To support lengths > 32, we hash multiple
+  // fresh UUIDs and concatenate the results before slicing to the desired length.
+  const BLAKE3_OUTPUT_BYTES = 32;
+  const chunksNeeded = Math.ceil(length / BLAKE3_OUTPUT_BYTES);
+  const digest = Buffer.concat(
+    Array.from({ length: chunksNeeded }, () => blake3(uuidv4()))
+  ).subarray(0, length);
+  return digest.map(uniformByteToCode62).map(alphanumFromCode62).toString();
 }
 
 /**

--- a/front/package.json
+++ b/front/package.json
@@ -117,7 +117,7 @@
     "adm-zip": "^0.5.16",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "blake3": "^2.1.7",
+    "@napi-rs/blake-hash": "^1.3.6",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
@@ -222,6 +222,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.3.0",
+    "blake3": "^2.1.7",
     "@google-cloud/storage": "^7.11.2",
     "@next/bundle-analyzer": "^15.5.4",
     "@statoscope/webpack-plugin": "^5.29.0",

--- a/front/workers-build/package-lock.json
+++ b/front/workers-build/package-lock.json
@@ -8,10 +8,10 @@
       "name": "front-worker",
       "version": "0.1.0",
       "dependencies": {
+        "@napi-rs/blake-hash": "^1.3.6",
         "@temporalio/common": "1.12.1",
         "@temporalio/worker": "1.12.1",
-        "blake3": "^2.1.7",
-        "dd-trace": "^5.52.0",
+        "dd-trace": "^5.87.0",
         "isomorphic-dompurify": "^2.32.0",
         "pg": "^8.8.0",
         "tsconfig-paths-webpack-plugin": "^4.1.0"
@@ -204,29 +204,29 @@
       }
     },
     "node_modules/@datadog/flagging-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-0.2.0.tgz",
-      "integrity": "sha512-DocYjr8NFJZfsnqzu3MuBUNqgbJquq1doimkKEXI5UImLmz/tR0LO09dd651pBhoz1Pa4SKcnPaxWFLTqxWtsA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-1.1.0.tgz",
+      "integrity": "sha512-m2BSEmdSd4P5c/l+4C2L32vnnhwr0bF3qnM2Uz0NhWbUxX4SjpUHbb7GPq8bjr0rfZJZefQ7zQjN/cjE+bb7pg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "spark-md5": "^3.0.2"
-      },
-      "peerDependencies": {
-        "@openfeature/core": "^1.8.1"
       }
     },
     "node_modules/@datadog/libdatadog": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.7.0.tgz",
-      "integrity": "sha512-VVZLspzQcfEU47gmGCVoRkngn7RgFRR4CHjw4YaX8eWT+xz4Q4l6PvA45b7CMk9nlt3MNN5MtGdYttYMIpo6Sg==",
-      "license": "Apache-2.0"
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.9.2.tgz",
+      "integrity": "sha512-grOerTYuU3wHuFIOBGg3jB144A3KEthEdVEL3meeiXYo7E7fBXXGRgAOwVE42VXFXfl0r8kDKCL7KupBc511tg==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-10.3.0.tgz",
-      "integrity": "sha512-FjNhxKetbBVGiq+dl8NYoi/95IAYU+W7PjBceNP7Qkvbt8uhy+KTlQVW1A2X67mK0CKHahDTesBMaPwY9zhflw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-11.0.1.tgz",
+      "integrity": "sha512-Y/XfknUmmJcw4hhQVhqzgdQvfjy+EGmXuUBgtVkI1r+/qS00egYu+wD/x7pOvjdbZNqN96znVszAnXvDQAzMDQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
@@ -235,11 +235,12 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.0.0.tgz",
-      "integrity": "sha512-2uF8RnQkJO5bmLi26Zkhxg+RFJn/uEsesYTflScI/Cz/BWv+792bxI+OaCKvhgmpLkm8EElenlpidcJyZm7GYw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.1.0.tgz",
+      "integrity": "sha512-g9K9Ddx1YQfrQIC2hgtfnYUGuzAFvSvhvt2lPZOAWBPo+bkYoW5KEkMHoY5XykCigTfXBYcQicRV0xB22AMkHw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
@@ -250,6 +251,7 @@
       "integrity": "sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^6.1.0",
         "node-gyp-build": "^3.9.0"
@@ -259,31 +261,35 @@
       }
     },
     "node_modules/@datadog/openfeature-node-server": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-0.2.0.tgz",
-      "integrity": "sha512-Jn8lShFyqNji0tiKntLcCRwu3xrhg93fTTJS3gHSPKMfBDBKxjB9uF8Hu5Ayn2k0QuwJexx5atN9GSiWX0h5qg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-1.1.0.tgz",
+      "integrity": "sha512-Qy5sz6vGq3KekoRLw9zko7LsDd97MPjJSnYl7jUq7bMST5p0aFFh/MnILn9/B1UC7RZJ6Kj5F2U0hxqmAWz2dw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "@datadog/flagging-core": "0.2.0",
-        "@openfeature/server-sdk": "~1.18.0"
+        "@datadog/flagging-core": "1.1.0"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@openfeature/server-sdk": "~1.18.0"
+        "@openfeature/server-sdk": ">=1.15.0 <2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@openfeature/server-sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.12.0.tgz",
-      "integrity": "sha512-qX32upm9eqObGVGvqHpjQB2bXVPTX0ccXTW3mUqUWXgJrAKyHtTfo9PqfoXhflYs0WD9el9xl9c0bM1RS4vRmQ==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.14.0.tgz",
+      "integrity": "sha512-bXYptMf0BY3NdKcAmX5aAOnozj7GFdNYE4SIdPF0/Q/Yfb2fYBIYZaN/Le6BhiDIepBvvH/H75d3EIFhB64kOw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
-        "delay": "^5.0.0",
         "node-gyp-build": "<4.0",
-        "p-limit": "^3.1.0",
         "pprof-format": "^2.2.1",
         "source-map": "^0.7.4"
       },
@@ -291,17 +297,12 @@
         "node": ">=16"
       }
     },
-    "node_modules/@datadog/sketches-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@datadog/sketches-js/-/sketches-js-2.1.1.tgz",
-      "integrity": "sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@datadog/wasm-js-rewriter": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-5.0.1.tgz",
       "integrity": "sha512-EzbV3Lrdt3udQEsbDOVC5gB1y7yxfpBbrSIk4jaEsGjyj0Dbv2HGj7tZjs+qXzIzNonHc8h5El2bYZOGfC2wwg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "js-yaml": "^4.1.0",
         "lru-cache": "^7.14.0",
@@ -317,6 +318,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -326,10 +328,45 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -361,15 +398,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@isaacs/ttlcache": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-2.1.3.tgz",
-      "integrity": "sha512-NCnhdBecu8reiXZ067zrpwR+xU2MY9wFTpRGpc7oZ1MwWC3EZmZkuqKdYI1Um5phbH1ql8kfiFjLdFkeuEWhfw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -425,30 +453,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
-      }
-    },
-    "node_modules/@jsep-plugin/assignment": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
-      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.16.0"
-      },
-      "peerDependencies": {
-        "jsep": "^0.4.0||^1.0.0"
-      }
-    },
-    "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
-      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.16.0"
-      },
-      "peerDependencies": {
-        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -565,23 +569,293 @@
         "tslib": "2"
       }
     },
-    "node_modules/@openfeature/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@openfeature/server-sdk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
-      "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
-      "license": "Apache-2.0",
+    "node_modules/@napi-rs/blake-hash": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash/-/blake-hash-1.3.6.tgz",
+      "integrity": "sha512-e8iTevVnczC1ot2iWKur0k8Qu4sqDqitNC7oQ6aVIANtxQzDu8mNXcFnK5LCaYk3v6npikATkN+ErUtthZ8sNA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/blake-hash-android-arm64": "1.3.6",
+        "@napi-rs/blake-hash-darwin-arm64": "1.3.6",
+        "@napi-rs/blake-hash-darwin-x64": "1.3.6",
+        "@napi-rs/blake-hash-freebsd-x64": "1.3.6",
+        "@napi-rs/blake-hash-linux-arm-gnueabihf": "1.3.6",
+        "@napi-rs/blake-hash-linux-arm64-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-arm64-musl": "1.3.6",
+        "@napi-rs/blake-hash-linux-ppc64-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-s390x-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-x64-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-x64-musl": "1.3.6",
+        "@napi-rs/blake-hash-win32-arm64-msvc": "1.3.6",
+        "@napi-rs/blake-hash-win32-ia32-msvc": "1.3.6",
+        "@napi-rs/blake-hash-win32-x64-msvc": "1.3.6"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-android-arm64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-android-arm64/-/blake-hash-android-arm64-1.3.6.tgz",
+      "integrity": "sha512-f0E5KdjXyQbqiDcBIBTv1F+/yCISXOZTVZCk1iteAYFJQ3UzH5N8RReU6+6fY+xVdZYCfs0GdXJJGygV4aKb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-darwin-arm64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-arm64/-/blake-hash-darwin-arm64-1.3.6.tgz",
+      "integrity": "sha512-WFAoJSlrRGnPwn/8bX+KW/8vqDYs85m8ZOoQA0knQcp9DeEseToQu/kyF8KxBrvn0eYa+50ts2L0LeH7GBetTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-darwin-x64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-x64/-/blake-hash-darwin-x64-1.3.6.tgz",
+      "integrity": "sha512-Cb+GAxWW/9Kbu3E4yFPnGAt3pYVpP8JwXIl38k+TjHw2SYN7tl475ZHMz1SbVi6xiwB0/jMychNHjBiH1YpurQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-freebsd-x64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-freebsd-x64/-/blake-hash-freebsd-x64-1.3.6.tgz",
+      "integrity": "sha512-NlgZeGVt487qoJWnIfnoXZP+EufBAKO4VD2JwaWPMsAE/fe+Xg0RWU9hJILhNtgW6d3C1/ktdpqPK4t+mduDfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm-gnueabihf": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm-gnueabihf/-/blake-hash-linux-arm-gnueabihf-1.3.6.tgz",
+      "integrity": "sha512-jIMYFXpgFDT7zY2GyJP/jQqedE1Qj6IFVgdOoM9tPw/KDqCK+HMhPVgZPA4t6NzRys03aS0atpnHCo+gt8BV6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm64-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-gnu/-/blake-hash-linux-arm64-gnu-1.3.6.tgz",
+      "integrity": "sha512-UCkp2YqISRvxk0XXtTOJRoidpTu7dj1xDN7snBFWLzWNe1sX8v3xYx9gV1jcZc8JgnkEaagINhNipM0a5H4NNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm64-musl": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-musl/-/blake-hash-linux-arm64-musl-1.3.6.tgz",
+      "integrity": "sha512-m8w4o5KGtuuLWSHG5qkOUUg56rqRJ1ErVTCxOmX37zGTuLc+d/jG+NwNcsS1BTueqMwMvFatClNRF949h4QR9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-ppc64-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-ppc64-gnu/-/blake-hash-linux-ppc64-gnu-1.3.6.tgz",
+      "integrity": "sha512-7hnpvPpWesgo8gMTwS+HWUWqOgnW4X2k6udOVQFvLeGmrfoU4gvlR7kzLQd8ZKTghsmgWudqLxhJ7hC9peFQnA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-s390x-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-s390x-gnu/-/blake-hash-linux-s390x-gnu-1.3.6.tgz",
+      "integrity": "sha512-D6vPq1xrVw1EaWL0nfKklSGyyft8EPBqEHl++m9EQ+Kr+JN4h5mzpyVgEBekJB2QEa4MeqUjxOySiW097piwFw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-x64-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-gnu/-/blake-hash-linux-x64-gnu-1.3.6.tgz",
+      "integrity": "sha512-13bkj8jaCoQOn8XA8b7QaYCjeiVd4Jgxbp518cnkwD5YU1YS3kw9zZAbSHMJbKbTjP8+kyhgNKAvAV2Dqd5UQw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-x64-musl": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-musl/-/blake-hash-linux-x64-musl-1.3.6.tgz",
+      "integrity": "sha512-lCvBLJ/VAXTM6L0K+8Rpy8gUfx+iJEYpsOXD+BWdpRJGieGcOCavGqUs9fzxAjbVAEUMMeif5mMQLmqheeigww==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-arm64-msvc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-arm64-msvc/-/blake-hash-win32-arm64-msvc-1.3.6.tgz",
+      "integrity": "sha512-b+Mj1Qx1lcz2LXEPQWNgFIbZ/ujUAS/5hy3Dc3/EM1nXaLDyJIFsSTFQPq1eqnfCNHxkyFwBclOpiatYRQZM/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-ia32-msvc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-ia32-msvc/-/blake-hash-win32-ia32-msvc-1.3.6.tgz",
+      "integrity": "sha512-CagNYtaNpjh7zbDa/+yG8ZzAGQaCWa8QPnShZi6QW4S5G0ShrkyZdFMra8tYsBFJB6K6eZ8itDs9WLJSffsSgw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-x64-msvc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-x64-msvc/-/blake-hash-win32-x64-msvc-1.3.6.tgz",
+      "integrity": "sha512-CFdODX0QMu8Mg+7bZSomMT9HgCK9FEYGNpBrEAUUJbsBlsAhIaPwM0iFLDPO5CBNQK4LrYawThvmM5NmCZdVDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@openfeature/core": "^1.7.0"
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -589,6 +863,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -598,6 +873,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
       "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -605,44 +881,358 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.118.0.tgz",
+      "integrity": "sha512-u/fO8WrQ5xiXXe2bCUmiihDaZQi0rvMxBtvPv7/lyQDBcfR81/usWv4ZMaKHkWOUXDoOBw1ptHi+A8+/zWGLGA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.118.0.tgz",
+      "integrity": "sha512-hHUdc9RNh/cDBIyUExTRrGZXlrpcc4W+co+JwH4aR2rBB9Y6Zjsx9tSVdIn9HBF1ZBpOV7XgeZKnqRHNvbEPNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.118.0.tgz",
+      "integrity": "sha512-LHlbZxiUBHdaSmgOTIdkd5WzTddwUGJXjTX5AdvUIC0640z6xP7AQQE46X6FokOKu/PZKM0RegB2MWr2+0kakA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=14"
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.118.0.tgz",
+      "integrity": "sha512-dbVu2TRR8CZ254MT2CIMV5c/U4jSVJ2aLrOUECHNuSZcKZRk0dA51QA+rZeyOy7DfQQ88dOvEvkUhFfmec55Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.118.0.tgz",
+      "integrity": "sha512-TqAHom3L/3AJt72Y5IXvtffCPu9y2xnWVymlH3rmVwA+bFQAw3V8smDm3eQgAsAb4EmE17hYU8xgS/1fA0Nfvg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.118.0.tgz",
+      "integrity": "sha512-lxYDH+fHKX9YFXnRouaI4c4BGRT+XDsNGAtb1ZAPoDbu66+sIXUApXjc4oTM/PRmF29WE+TVhbXeOWeVv8qTSA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.118.0.tgz",
+      "integrity": "sha512-2N54CwMbLoPqsc0VolynVqf6ug9EwNAp/g40BKLAzgReLyktJN5QlfK8DpgWmql6FQE7IavL47eibOMfHD8H8g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.118.0.tgz",
+      "integrity": "sha512-Bg5FKxz3yNAZo6WjaL4A+SDhanffw+hIS5i9kXphL2t4RXaXqFgzFflCxlTtGkETZR2+6xQwH3NsqNhTHm+NiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.118.0.tgz",
+      "integrity": "sha512-u+kIw+WIYyPs69QVcOiXYyerPjWylJLSe+AIy8v16hgaSTImWzN6FV4tiSYvPfeDGQP7svZgBuwv6P3AEPNRpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.118.0.tgz",
+      "integrity": "sha512-H2yOOb9yFCNb7KznDdAkdKg/MXbZ0Txe3xRQjLUCxIncEUoCZlRofPvPeIjQNQei15NVO8IuUCPDUo0i14lRMA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.118.0.tgz",
+      "integrity": "sha512-Ze1d5u/67OtB9HYIQpd/5lrFgPtLm+TyFzE+KnUpl6O1EldJXdOy4+iup5j1M+Ux9pLGJe83z1BLb6suYk1IOQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.118.0.tgz",
+      "integrity": "sha512-41F6DXLZ3D0YzMj3kit6rpnSY+fRlnB+8vpvaccxo+HV/4D0geZWjygfQNR7SYhcyt6Jk2cNIHPYvxZFiqj+Xg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.118.0.tgz",
+      "integrity": "sha512-g5u0mZaJGRlJry28B7o4lcJsGKb1iAyMEToQSjNGi/t/qPrRgG0Rp6bEqFGXzYELniFeIrK0ErmopvEc3p89Mg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.118.0.tgz",
+      "integrity": "sha512-iKRgKEE1qfZNsM6YiZa5sMwDTKX+DIBmHf/pLna4iC4OwPcW0bU0fMXWOkBvt2uXeORdesa3dz3PvDMU0KqNKg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.118.0.tgz",
+      "integrity": "sha512-NpxJD33R6Uwhhhst9Diad8ojoVrObMt1PP/d+0079ukztFWiOG+Sqwmwzl6u3dm2HoenNpfPmz+pRpsuH9G3Fw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.118.0.tgz",
+      "integrity": "sha512-AkX9iorxLg74kXzoSrrcAX2sIzrNGUhXs55QfYWIbIt6VsaH8E4uQTg7yI5qz5+OMVGrB3oxdurWTTjyWGBO3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.118.0.tgz",
+      "integrity": "sha512-32jl5sokXqztJVPPNGArEq3BCh1DYCvhINHB5aFBWq1kumGC22VplMaQOg47AB1P19R1qguTe/rFckg/MN7ymA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.118.0.tgz",
+      "integrity": "sha512-Csqk288t0wmwWap6uTD66S0jKbzCGF0IT+3rj6ZwKHgQIcVILMfzciVZCISSVsH8Crjz+DfRHEFhW1F6hNb09Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.118.0.tgz",
+      "integrity": "sha512-qqaoLkdYfr5vBatMIfmYeE/PpV4SFO+0A4AnTJ8hTV9IhBNPpAhB46YSdfacWjVk0tRIk0OeYDUn8ohFhSYMHg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.118.0.tgz",
+      "integrity": "sha512-sOL5mOLBQT7aHdltfVhRwnDAo4fR4jnxJQU4rBQaGVmsbjK0V/358teokfIwEXNEuY2o7o9PqYnq1TkNzmcirw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.118.0.tgz",
+      "integrity": "sha512-yx4sGEZvH9dcS9AduoKKPWFqxJWrKtElOebwpTV9qYx387KiCoUt+iZBPmxpnnHIFc948kY5O8CJTPOmj+2y6w==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -758,6 +1348,162 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.3.tgz",
+      "integrity": "sha512-p68OeCz1ui+MZYG4wmfJGvcsAcFYb6Sl25H9TxWl+GkBgmNimIiRdnypK9nBGlqMZAcxngNPtnG3kEMNnvoJ2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.3.tgz",
+      "integrity": "sha512-Nuj5iF4JteFgwrai97mUX+xUOl+rQRHqTvnvHMATL/l9xE6/TJfPBpd3hk/PVpClMXG3Uvk1MxUFOEzM1JrMYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.3.tgz",
+      "integrity": "sha512-2Nc/s8jE6mW2EjXWxO/lyQuLKShcmTrym2LRf5Ayp3ICEMX6HwFqB1EzDhwoMa2DcUgmnZIalesq2lG3krrUNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.3.tgz",
+      "integrity": "sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.3.tgz",
+      "integrity": "sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.3.tgz",
+      "integrity": "sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.3.tgz",
+      "integrity": "sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.3.tgz",
+      "integrity": "sha512-B8UtogMzErUPDWUoKONSVBdsgKYd58rRyv2sHJWKOIMCHfZ22FVXICR4O/VwIYtlnZ7ahERcjayBHDlBZpR0aw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.3.tgz",
+      "integrity": "sha512-SpZKMR9QBTecHeqpzJdYEfgw30Oo8b/Xl6rjSzBt1g0ZsXyy60KLXrp6IagQyfTYqNYE/caDvwtF2FPn7pomog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -894,6 +1640,16 @@
       },
       "engines": {
         "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/eslint": {
@@ -1235,7 +1991,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "optional": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.31",
@@ -1254,13 +2011,6 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
-    },
-    "node_modules/blake3": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
-      "integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==",
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.0",
@@ -1368,9 +2118,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -1409,12 +2159,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/crypto-randomuuid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-randomuuid/-/crypto-randomuuid-1.0.0.tgz",
-      "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA==",
       "license": "MIT"
     },
     "node_modules/css-tree": {
@@ -1467,52 +2211,29 @@
       }
     },
     "node_modules/dd-trace": {
-      "version": "5.80.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.80.0.tgz",
-      "integrity": "sha512-v2Iara1zD6Z9sKjg18TLlOOAaX5x9vmmp9D0vdEduYpyyrd+0HWPyxMGvSdg/LkRpEhazg8dOxYW4YQHi3QUkA==",
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.93.0.tgz",
+      "integrity": "sha512-5MXIZuiT3KAILIt3Cb6AGbjH9B/hinwN16ERomn1ylD8/R9rYeKjdxaVBaNnBN0suHlTrO6FqZxqHjlh4Gtm3A==",
       "hasInstallScript": true,
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
-        "@datadog/libdatadog": "0.7.0",
-        "@datadog/native-appsec": "10.3.0",
-        "@datadog/native-iast-taint-tracking": "4.0.0",
-        "@datadog/native-metrics": "3.1.1",
-        "@datadog/openfeature-node-server": "^0.2.0",
-        "@datadog/pprof": "5.12.0",
-        "@datadog/sketches-js": "2.1.1",
-        "@datadog/wasm-js-rewriter": "5.0.1",
-        "@isaacs/ttlcache": "^2.0.1",
-        "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/api-logs": "<1.0.0",
-        "@opentelemetry/core": ">=1.14.0 <1.31.0",
-        "@opentelemetry/resources": ">=1.0.0 <1.31.0",
-        "crypto-randomuuid": "^1.0.0",
         "dc-polyfill": "^0.1.10",
-        "escape-string-regexp": "^5.0.0",
-        "ignore": "^7.0.5",
-        "import-in-the-middle": "^1.14.2",
-        "istanbul-lib-coverage": "^3.2.2",
-        "jest-docblock": "^29.7.0",
-        "jsonpath-plus": "^10.3.0",
-        "limiter": "^1.1.5",
-        "lodash.sortby": "^4.7.0",
-        "lru-cache": "^10.4.3",
-        "module-details-from-path": "^1.0.4",
-        "mutexify": "^1.4.0",
-        "opentracing": ">=0.14.7",
-        "path-to-regexp": "^0.1.12",
-        "pprof-format": "^2.1.1",
-        "protobufjs": "^7.5.3",
-        "retry": "^0.13.1",
-        "rfdc": "^1.4.1",
-        "semifies": "^1.0.0",
-        "shell-quote": "^1.8.2",
-        "source-map": "^0.7.4",
-        "tlhunter-sorted-set": "^0.1.0",
-        "ttl-set": "^1.0.0"
+        "import-in-the-middle": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18 <26"
+      },
+      "optionalDependencies": {
+        "@datadog/libdatadog": "0.9.2",
+        "@datadog/native-appsec": "11.0.1",
+        "@datadog/native-iast-taint-tracking": "4.1.0",
+        "@datadog/native-metrics": "3.1.1",
+        "@datadog/openfeature-node-server": "^1.1.0",
+        "@datadog/pprof": "5.14.0",
+        "@datadog/wasm-js-rewriter": "5.0.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0",
+        "oxc-parser": "^0.118.0"
       }
     },
     "node_modules/debug": {
@@ -1543,27 +2264,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
-    },
-    "node_modules/delay": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
-      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/dompurify": {
       "version": "3.3.0",
@@ -1624,18 +2324,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {
@@ -1703,12 +2391,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -1847,25 +2529,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/import-in-the-middle": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
+      "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -1905,27 +2581,6 @@
         "node": ">=20.19.5"
       }
     },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-docblock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -1945,6 +2600,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1991,15 +2647,6 @@
         }
       }
     },
-    "node_modules/jsep": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
-      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.16.0"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2024,29 +2671,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonpath-plus": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
-      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsep-plugin/assignment": "^1.3.0",
-        "@jsep-plugin/regex": "^1.0.4",
-        "jsep": "^1.4.0"
-      },
-      "bin": {
-        "jsonpath": "bin/jsonpath-cli.js",
-        "jsonpath-plus": "bin/jsonpath-cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/limiter": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
-      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
-    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -2066,23 +2690,11 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-      "license": "MIT"
-    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
     },
     "node_modules/mdn-data": {
       "version": "2.12.2",
@@ -2159,15 +2771,6 @@
         "node": ">=12.13"
       }
     },
-    "node_modules/mutexify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
-      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
-      "license": "MIT",
-      "dependencies": {
-        "queue-tick": "^1.0.0"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -2178,13 +2781,15 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-gyp-build": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
       "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
       "license": "MIT",
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -2197,28 +2802,42 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "license": "MIT"
     },
-    "node_modules/opentracing": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
-      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+    "node_modules/oxc-parser": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.118.0.tgz",
+      "integrity": "sha512-RWcTXXw9rsdlGxPwaL2hVKDtgudMBAUlwqPNl1WhgWQNlp/RZ/XeFHuG8HolZM2dMjLJeD4b2Ywo7/a988X4MQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "@oxc-project/types": "^0.118.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.118.0",
+        "@oxc-parser/binding-android-arm64": "0.118.0",
+        "@oxc-parser/binding-darwin-arm64": "0.118.0",
+        "@oxc-parser/binding-darwin-x64": "0.118.0",
+        "@oxc-parser/binding-freebsd-x64": "0.118.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.118.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.118.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.118.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.118.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.118.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.118.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.118.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.118.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.118.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.118.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.118.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.118.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.118.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.118.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.118.0"
       }
     },
     "node_modules/parse5": {
@@ -2232,12 +2851,6 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.16.3",
@@ -2377,7 +2990,8 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
       "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -2424,12 +3038,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2456,21 +3064,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -2538,12 +3131,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/semifies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
-      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -2551,18 +3138,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/source-map": {
@@ -2626,7 +3201,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-      "license": "(WTFPL OR MIT)"
+      "license": "(WTFPL OR MIT)",
+      "optional": true
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -2805,12 +3381,6 @@
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "license": "MIT"
     },
-    "node_modules/tlhunter-sorted-set": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
-      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw==",
-      "license": "MIT"
-    },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
@@ -2885,15 +3455,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/ttl-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ttl-set/-/ttl-set-1.0.0.tgz",
-      "integrity": "sha512-2fuHn/UR+8Z9HK49r97+p2Ru1b5Eewg2QqPrU14BVCQ9QoyU3+vLLZk2WEiyZ9sgJh6W8G1cZr9I2NBLywAHrA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-fifo": "^1.3.2"
-      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -3188,18 +3749,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/front/workers-build/package.json
+++ b/front/workers-build/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@temporalio/common": "1.12.1",
     "@temporalio/worker": "1.12.1",
-    "blake3": "^2.1.7",
+    "@napi-rs/blake-hash": "^1.3.6",
     "dd-trace": "^5.87.0",
     "isomorphic-dompurify": "^2.32.0",
     "pg": "^8.8.0",

--- a/front/workers-build/scripts/esbuild.worker.ts
+++ b/front/workers-build/scripts/esbuild.worker.ts
@@ -21,7 +21,7 @@ async function buildWorker() {
       external: [
         "@temporalio/worker",
         "@temporalio/common",
-        "blake3",
+        "@napi-rs/blake-hash",
         "dd-trace",
         "isomorphic-dompurify",
         "tsconfig-paths-webpack-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@microsoft/teams-ai": "^1.7.4",
+        "@napi-rs/blake-hash": "^1.3.6",
         "@notionhq/client": "^2.2.15",
         "@octokit/graphql": "^7.0.2",
         "@slack/web-api": "^7.10.0",
@@ -103,7 +104,6 @@
         "@types/remove-markdown": "^0.3.4",
         "@types/uuid": "^9.0.2",
         "axios": "^1.7.9",
-        "blake3": "^2.1.7",
         "body-parser": "^1.20.2",
         "botbuilder": "^4.23.3",
         "crawlee": "3.14.1",
@@ -337,6 +337,7 @@
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@mistralai/mistralai": "^1.10.0",
         "@modelcontextprotocol/sdk": "^1.27.0",
+        "@napi-rs/blake-hash": "^1.3.6",
         "@notionhq/client": "^5.13.0",
         "@novu/api": "^3.13.0",
         "@novu/framework": "^2.9.0",
@@ -394,7 +395,6 @@
         "adm-zip": "^0.5.16",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
-        "blake3": "^2.1.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -530,6 +530,7 @@
         "@typescript/native-preview": "^7.0.0-dev.20260224.1",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.23",
+        "blake3": "^2.1.7",
         "concurrently": "^9.0.1",
         "danger": "^13.0.4",
         "esbuild": "^0.27.3",
@@ -8981,6 +8982,277 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@napi-rs/blake-hash": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash/-/blake-hash-1.3.6.tgz",
+      "integrity": "sha512-e8iTevVnczC1ot2iWKur0k8Qu4sqDqitNC7oQ6aVIANtxQzDu8mNXcFnK5LCaYk3v6npikATkN+ErUtthZ8sNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/blake-hash-android-arm64": "1.3.6",
+        "@napi-rs/blake-hash-darwin-arm64": "1.3.6",
+        "@napi-rs/blake-hash-darwin-x64": "1.3.6",
+        "@napi-rs/blake-hash-freebsd-x64": "1.3.6",
+        "@napi-rs/blake-hash-linux-arm-gnueabihf": "1.3.6",
+        "@napi-rs/blake-hash-linux-arm64-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-arm64-musl": "1.3.6",
+        "@napi-rs/blake-hash-linux-ppc64-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-s390x-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-x64-gnu": "1.3.6",
+        "@napi-rs/blake-hash-linux-x64-musl": "1.3.6",
+        "@napi-rs/blake-hash-win32-arm64-msvc": "1.3.6",
+        "@napi-rs/blake-hash-win32-ia32-msvc": "1.3.6",
+        "@napi-rs/blake-hash-win32-x64-msvc": "1.3.6"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-android-arm64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-android-arm64/-/blake-hash-android-arm64-1.3.6.tgz",
+      "integrity": "sha512-f0E5KdjXyQbqiDcBIBTv1F+/yCISXOZTVZCk1iteAYFJQ3UzH5N8RReU6+6fY+xVdZYCfs0GdXJJGygV4aKb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-darwin-arm64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-arm64/-/blake-hash-darwin-arm64-1.3.6.tgz",
+      "integrity": "sha512-WFAoJSlrRGnPwn/8bX+KW/8vqDYs85m8ZOoQA0knQcp9DeEseToQu/kyF8KxBrvn0eYa+50ts2L0LeH7GBetTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-darwin-x64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-x64/-/blake-hash-darwin-x64-1.3.6.tgz",
+      "integrity": "sha512-Cb+GAxWW/9Kbu3E4yFPnGAt3pYVpP8JwXIl38k+TjHw2SYN7tl475ZHMz1SbVi6xiwB0/jMychNHjBiH1YpurQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-freebsd-x64": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-freebsd-x64/-/blake-hash-freebsd-x64-1.3.6.tgz",
+      "integrity": "sha512-NlgZeGVt487qoJWnIfnoXZP+EufBAKO4VD2JwaWPMsAE/fe+Xg0RWU9hJILhNtgW6d3C1/ktdpqPK4t+mduDfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm-gnueabihf": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm-gnueabihf/-/blake-hash-linux-arm-gnueabihf-1.3.6.tgz",
+      "integrity": "sha512-jIMYFXpgFDT7zY2GyJP/jQqedE1Qj6IFVgdOoM9tPw/KDqCK+HMhPVgZPA4t6NzRys03aS0atpnHCo+gt8BV6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm64-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-gnu/-/blake-hash-linux-arm64-gnu-1.3.6.tgz",
+      "integrity": "sha512-UCkp2YqISRvxk0XXtTOJRoidpTu7dj1xDN7snBFWLzWNe1sX8v3xYx9gV1jcZc8JgnkEaagINhNipM0a5H4NNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm64-musl": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-musl/-/blake-hash-linux-arm64-musl-1.3.6.tgz",
+      "integrity": "sha512-m8w4o5KGtuuLWSHG5qkOUUg56rqRJ1ErVTCxOmX37zGTuLc+d/jG+NwNcsS1BTueqMwMvFatClNRF949h4QR9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-ppc64-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-ppc64-gnu/-/blake-hash-linux-ppc64-gnu-1.3.6.tgz",
+      "integrity": "sha512-7hnpvPpWesgo8gMTwS+HWUWqOgnW4X2k6udOVQFvLeGmrfoU4gvlR7kzLQd8ZKTghsmgWudqLxhJ7hC9peFQnA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-s390x-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-s390x-gnu/-/blake-hash-linux-s390x-gnu-1.3.6.tgz",
+      "integrity": "sha512-D6vPq1xrVw1EaWL0nfKklSGyyft8EPBqEHl++m9EQ+Kr+JN4h5mzpyVgEBekJB2QEa4MeqUjxOySiW097piwFw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-x64-gnu": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-gnu/-/blake-hash-linux-x64-gnu-1.3.6.tgz",
+      "integrity": "sha512-13bkj8jaCoQOn8XA8b7QaYCjeiVd4Jgxbp518cnkwD5YU1YS3kw9zZAbSHMJbKbTjP8+kyhgNKAvAV2Dqd5UQw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-x64-musl": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-musl/-/blake-hash-linux-x64-musl-1.3.6.tgz",
+      "integrity": "sha512-lCvBLJ/VAXTM6L0K+8Rpy8gUfx+iJEYpsOXD+BWdpRJGieGcOCavGqUs9fzxAjbVAEUMMeif5mMQLmqheeigww==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-arm64-msvc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-arm64-msvc/-/blake-hash-win32-arm64-msvc-1.3.6.tgz",
+      "integrity": "sha512-b+Mj1Qx1lcz2LXEPQWNgFIbZ/ujUAS/5hy3Dc3/EM1nXaLDyJIFsSTFQPq1eqnfCNHxkyFwBclOpiatYRQZM/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-ia32-msvc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-ia32-msvc/-/blake-hash-win32-ia32-msvc-1.3.6.tgz",
+      "integrity": "sha512-CagNYtaNpjh7zbDa/+yG8ZzAGQaCWa8QPnShZi6QW4S5G0ShrkyZdFMra8tYsBFJB6K6eZ8itDs9WLJSffsSgw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-x64-msvc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-x64-msvc/-/blake-hash-win32-x64-msvc-1.3.6.tgz",
+      "integrity": "sha512-CFdODX0QMu8Mg+7bZSomMT9HgCK9FEYGNpBrEAUUJbsBlsAhIaPwM0iFLDPO5CBNQK4LrYawThvmM5NmCZdVDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -25497,6 +25769,7 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
       "integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Description

The implementation of the blake3 algo we use is https://github.com/connor4312/blake3. The latest version is from 2021, and it's unclear if it's compatible with node24. 

This PR moves to https://github.com/Brooooooklyn/blake-hash, which is compatible with node24 (and slightly faster seeing the benchmarks).

We have unit tests on where we use the lib, so this should be safe to change

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
