### PR TITLE
Simplify destroyConversation()

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -17,7 +17,7 @@ import {
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { ConversationButlerSuggestionModel } from "@app/lib/resources/storage/models/conversation_butler_suggestion";
@@ -32,7 +32,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import chunk from "lodash/chunk";
 import type { WhereOptions } from "sequelize";
@@ -181,29 +181,12 @@ async function destroyConversationDataSource(
 export async function destroyConversation(
   auth: Authenticator,
   {
-    conversationId,
+    conversation,
   }: {
-    conversationId: string;
+    conversation: ConversationResource;
   }
 ): Promise<Result<void, ConversationError>> {
   const owner = auth.getNonNullableWorkspace();
-
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId,
-      // We skip access checks as some conversations associated with deleted spaces may have become
-      // inaccessible, yet we want to be able to delete them here.
-      {
-        includeDeleted: true,
-        dangerouslySkipPermissionFiltering: true,
-      }
-    );
-  if (conversationRes.isErr()) {
-    return new Err(conversationRes.error);
-  }
-
-  const conversation = conversationRes.value;
 
   // Clean up all branches attached to this conversation before deleting messages.
   await ConversationBranchModel.destroy({
@@ -231,8 +214,12 @@ export async function destroyConversation(
   const messagesChunks = chunk(messages, DESTROY_MESSAGE_BATCH);
   for (const messagesChunk of messagesChunks) {
     const messageIds = messagesChunk.map((m) => m.id);
-    const userMessageIds = removeNulls(messages.map((m) => m.userMessageId));
-    const agentMessageIds = removeNulls(messages.map((m) => m.agentMessageId));
+    const userMessageIds = removeNulls(
+      messagesChunk.map((m) => m.userMessageId)
+    );
+    const agentMessageIds = removeNulls(
+      messagesChunk.map((m) => m.agentMessageId)
+    );
     const messageAndContentFragmentIds = removeNulls(
       messages.map((m) => {
         if (m.contentFragmentId) {
@@ -283,7 +270,9 @@ export async function destroyConversation(
     await destroyMessageRelatedResources(auth, messageIds);
   }
 
-  await destroyConversationDataSource(auth, { conversation });
+  await destroyConversationDataSource(auth, {
+    conversation: conversation.toJSON(),
+  });
 
   await UserProjectDigestModel.destroy({
     where: {
@@ -334,16 +323,9 @@ export async function destroyConversation(
   //     conversationId: conversation.sId,
   //   })
   // );
-
-  const c = await ConversationResource.fetchById(auth, conversation.sId, {
-    includeDeleted: true,
-    dangerouslySkipPermissionFiltering: true,
-  });
-  if (c) {
-    const r = await c.delete(auth);
-    if (r.isErr()) {
-      throw r.error;
-    }
+  const result = await conversation.delete(auth);
+  if (result.isErr()) {
+    throw result.error;
   }
 
   return new Ok(undefined);

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -31,7 +31,7 @@ import {
 } from "@app/types/notification_preferences";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock Novu client for notification sending tests
 vi.mock(import("../../../lib/notifications"), async (importOriginal) => {
@@ -321,6 +321,7 @@ describe("conversation-unread workflow business logic", () => {
     let user: UserResource;
     let auth: Authenticator;
     let conversationId: string;
+    let conversation: ConversationResource | null;
     let messageId: string;
 
     beforeEach(async () => {
@@ -334,33 +335,25 @@ describe("conversation-unread workflow business logic", () => {
         name: "Test Agent",
         description: "Test",
       });
-      const conversation = await ConversationFactory.create(auth, {
+      const conversationType = await ConversationFactory.create(auth, {
         agentConfigurationId: agent.sId,
         messagesCreatedAt: [new Date()],
       });
-      conversationId = conversation.sId;
+      conversationId = conversationType.sId;
 
       // Get the actual message ID from the conversation
-      const conversationResource = await ConversationResource.fetchById(
-        auth,
-        conversationId
-      );
-      if (!conversationResource) {
+      conversation = await ConversationResource.fetchById(auth, conversationId);
+      if (!conversation) {
         throw new Error("Conversation should exist");
       }
-      const messages = await conversationResource.fetchMessagesForPage(auth, {
+
+      const messages = await conversation.fetchMessagesForPage(auth, {
         limit: 10,
       });
       if (messages.messages.length === 0) {
         throw new Error("Conversation should have messages");
       }
       messageId = messages.messages[0].sId;
-    });
-
-    afterEach(async () => {
-      if (conversationId) {
-        await destroyConversation(auth, { conversationId });
-      }
     });
 
     const createPayload = () => ({
@@ -370,7 +363,10 @@ describe("conversation-unread workflow business logic", () => {
     });
 
     it("should return true when conversation is deleted", async () => {
-      await destroyConversation(auth, { conversationId });
+      if (!conversation) {
+        throw new Error("Conversation should exist");
+      }
+      await destroyConversation(auth, { conversation });
       const result = await shouldSkipConversation({
         subscriberId: user.sId,
         payload: {
@@ -479,12 +475,6 @@ describe("conversation-unread workflow business logic", () => {
         throw new Error("Conversation should have messages");
       }
       messageId = messages.messages[0].sId;
-    });
-
-    afterEach(async () => {
-      if (conversationId) {
-        await destroyConversation(auth, { conversationId });
-      }
     });
 
     it("should return Ok when no participants with unread messages", async () => {
@@ -810,14 +800,6 @@ describe("getEmailSummary", () => {
     );
 
     vi.clearAllMocks();
-  });
-
-  afterEach(async () => {
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    await destroyConversation(auth, { conversationId: conversation.sId });
   });
 
   it("should return retention policy message for conversations with retention policy", async () => {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1,6 +1,5 @@
 // biome-ignore-all lint/plugin/noRawSql: test file uses raw SQL for setup and verification
 import { loadAllModels } from "@app/admin/db";
-import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
 import {
   ConversationModel,
@@ -36,15 +35,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  afterEach,
-  assert,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("../../lib/api/redis"), async (importOriginal) => {
   const mod = await importOriginal();
@@ -93,12 +84,10 @@ describe("ConversationResource", () => {
   describe("listAllBeforeDate", () => {
     let auth: Authenticator;
     let convo1Id: string;
-    let convo2Id: string;
     let convo3Id: string;
     let convo4Id: string;
 
     let anotherAuth: Authenticator;
-    let anotherConvoId: string;
 
     beforeEach(async () => {
       const workspace = await WorkspaceFactory.basic();
@@ -114,7 +103,7 @@ describe("ConversationResource", () => {
         messagesCreatedAt: [dateFromDaysAgo(10), dateFromDaysAgo(8)],
         conversationCreatedAt: dateFromDaysAgo(10),
       });
-      const convo2 = await ConversationFactory.create(auth, {
+      const _convo2 = await ConversationFactory.create(auth, {
         agentConfigurationId: agents[1].sId,
         messagesCreatedAt: [dateFromDaysAgo(100), dateFromDaysAgo(1)],
         conversationCreatedAt: dateFromDaysAgo(100),
@@ -131,7 +120,6 @@ describe("ConversationResource", () => {
       });
 
       convo1Id = convo1.sId;
-      convo2Id = convo2.sId;
       convo3Id = convo3.sId;
       convo4Id = convo4.sId;
 
@@ -146,29 +134,10 @@ describe("ConversationResource", () => {
         anotherWorkspace,
         anotherUser
       );
-      const anotherConvo = await ConversationFactory.create(anotherAuth, {
+      await ConversationFactory.create(anotherAuth, {
         agentConfigurationId: anotherAgents[0].sId,
         messagesCreatedAt: [dateFromDaysAgo(800)],
         conversationCreatedAt: dateFromDaysAgo(800),
-      });
-      anotherConvoId = anotherConvo.sId;
-    });
-
-    afterEach(async () => {
-      await destroyConversation(auth, {
-        conversationId: convo1Id,
-      });
-      await destroyConversation(auth, {
-        conversationId: convo2Id,
-      });
-      await destroyConversation(auth, {
-        conversationId: convo3Id,
-      });
-      await destroyConversation(auth, {
-        conversationId: convo4Id,
-      });
-      await destroyConversation(anotherAuth, {
-        conversationId: anotherConvoId,
       });
     });
 
@@ -325,7 +294,6 @@ describe("listConversationWithAgentCreatedBeforeDate", () => {
   let convo4Id: string;
 
   let anotherAuth: Authenticator;
-  let anotherConvoId: string;
 
   let agents: LightAgentConfigurationType[];
 
@@ -372,29 +340,10 @@ describe("listConversationWithAgentCreatedBeforeDate", () => {
       anotherWorkspace.sId
     );
     const anotherAgents = await setupTestAgents(anotherWorkspace, anotherUser);
-    const anotherConvo = await ConversationFactory.create(anotherAuth, {
+    await ConversationFactory.create(anotherAuth, {
       agentConfigurationId: anotherAgents[0].sId,
       messagesCreatedAt: [dateFromDaysAgo(800)],
       conversationCreatedAt: dateFromDaysAgo(10),
-    });
-    anotherConvoId = anotherConvo.sId;
-  });
-
-  afterEach(async () => {
-    await destroyConversation(auth, {
-      conversationId: convo1Id,
-    });
-    await destroyConversation(auth, {
-      conversationId: convo2Id,
-    });
-    await destroyConversation(auth, {
-      conversationId: convo3Id,
-    });
-    await destroyConversation(auth, {
-      conversationId: convo4Id,
-    });
-    await destroyConversation(anotherAuth, {
-      conversationId: anotherConvoId,
     });
   });
 
@@ -721,16 +670,6 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     };
   });
 
-  afterEach(async () => {
-    // Clean up conversations.
-    for (const sId of [
-      ...conversations.accessible,
-      ...conversations.restricted,
-    ]) {
-      await destroyConversation(adminAuth, { conversationId: sId });
-    }
-  });
-
   it("should filter conversations based on user permissions", async () => {
     const userConversations = await ConversationResource.listAll(userAuth);
     const adminConversations = await ConversationResource.listAll(adminAuth);
@@ -825,11 +764,6 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     const conversationIds = allConversations.map((c) => c.sId);
 
     expect(conversationIds).toContain(emptySpaceConvo.sId);
-
-    // Clean up.
-    await destroyConversation(adminAuth, {
-      conversationId: emptySpaceConvo.sId,
-    });
   });
 
   it("should skip permission filtering when dangerouslySkipPermissionFiltering is true", async () => {
@@ -872,26 +806,21 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     });
     const withDeletedIds = withDeleted.map((c) => c.sId);
     expect(withDeletedIds).toContain(deletableConvo.sId);
-
-    // Clean up
-    await destroyConversation(adminAuth, {
-      conversationId: deletableConvo.sId,
-    });
   });
 
   it("should respect limit parameter", async () => {
     // Create multiple conversations
-    const convo1 = await ConversationFactory.create(adminAuth, {
+    await ConversationFactory.create(adminAuth, {
       agentConfigurationId: agents[0].sId,
       requestedSpaceIds: [globalSpace.id],
       messagesCreatedAt: [dateFromDaysAgo(5)],
     });
-    const convo2 = await ConversationFactory.create(adminAuth, {
+    await ConversationFactory.create(adminAuth, {
       agentConfigurationId: agents[0].sId,
       requestedSpaceIds: [globalSpace.id],
       messagesCreatedAt: [dateFromDaysAgo(4)],
     });
-    const convo3 = await ConversationFactory.create(adminAuth, {
+    await ConversationFactory.create(adminAuth, {
       agentConfigurationId: agents[0].sId,
       requestedSpaceIds: [globalSpace.id],
       messagesCreatedAt: [dateFromDaysAgo(3)],
@@ -902,11 +831,6 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     const allConversationsUnlimited =
       await ConversationResource.listAll(adminAuth);
     expect(allConversationsUnlimited.length).toBeGreaterThanOrEqual(5); // At least our test conversations
-
-    // Clean up
-    await destroyConversation(adminAuth, { conversationId: convo1.sId });
-    await destroyConversation(adminAuth, { conversationId: convo2.sId });
-    await destroyConversation(adminAuth, { conversationId: convo3.sId });
   });
 
   it("should return empty array when no conversations exist for workspace", async () => {
@@ -957,12 +881,6 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
       await ConversationResource.listAll(refreshedAdminAuth);
     const conversationIds = conversations.map((c) => c.sId);
     expect(conversationIds).toContain(convoWithSpace.sId);
-
-    // Clean up
-    await destroyConversation(refreshedAdminAuth, {
-      conversationId: convoWithSpace.sId,
-    });
-    await adminSpace.delete(refreshedAdminAuth, { hardDelete: false });
   });
 
   it("should handle conversations with multiple space IDs", async () => {
@@ -983,11 +901,6 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
 
     // Admin should see it.
     expect(adminConvoIds).toContain(multiSpaceConvo.sId);
-
-    // Clean up.
-    await destroyConversation(adminAuth, {
-      conversationId: multiSpaceConvo.sId,
-    });
   });
 
   it("should filter out conversations referencing deleted spaces", async () => {
@@ -1020,11 +933,6 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     allConversations = await ConversationResource.listAll(auth);
     conversationIds = allConversations.map((c) => c.sId);
     expect(conversationIds).not.toContain(tempSpaceConvo.sId);
-
-    // Clean up the conversation.
-    await destroyConversation(auth, {
-      conversationId: tempSpaceConvo.sId,
-    });
   });
 });
 
@@ -1076,14 +984,6 @@ describe("getOptions", () => {
       // Test via countForWorkspace
       const count = await ConversationResource.countForWorkspace(adminAuth);
       expect(count).toBeGreaterThanOrEqual(1);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
     });
 
     it("should include test conversations by default", async () => {
@@ -1112,14 +1012,6 @@ describe("getOptions", () => {
       const countBefore =
         await ConversationResource.countForWorkspace(adminAuth);
       expect(countBefore).toBeGreaterThanOrEqual(2);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: testConvo.sId,
-      });
     });
 
     it("should exclude deleted conversations but include test conversations by default", async () => {
@@ -1151,17 +1043,6 @@ describe("getOptions", () => {
       expect(conversationIds).toContain(normalConvo.sId);
       expect(conversationIds).not.toContain(deletedConvo.sId);
       expect(conversationIds).toContain(testConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: testConvo.sId,
-      });
     });
   });
 
@@ -1206,14 +1087,6 @@ describe("getOptions", () => {
       );
 
       expect(countWithDeleted).toBeGreaterThan(countWithoutDeleted);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
     });
 
     it("should include test conversations when only includeDeleted is true", async () => {
@@ -1247,17 +1120,6 @@ describe("getOptions", () => {
       expect(conversationIds).toContain(normalConvo.sId);
       expect(conversationIds).toContain(deletedConvo.sId);
       expect(conversationIds).toContain(testConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: testConvo.sId,
-      });
     });
   });
 
@@ -1302,14 +1164,6 @@ describe("getOptions", () => {
       );
 
       expect(countWithoutExclude).toBeGreaterThan(countWithExclude);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: testConvo.sId,
-      });
     });
 
     it("should still exclude deleted conversations when only excludeTest is true", async () => {
@@ -1343,17 +1197,6 @@ describe("getOptions", () => {
       expect(conversationIds).toContain(normalConvo.sId);
       expect(conversationIds).not.toContain(deletedConvo.sId);
       expect(conversationIds).not.toContain(testConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: testConvo.sId,
-      });
     });
   });
 
@@ -1397,17 +1240,6 @@ describe("getOptions", () => {
         excludeTest: true,
       });
       expect(count).toBeGreaterThanOrEqual(2);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: testConvo.sId,
-      });
     });
   });
 
@@ -1466,14 +1298,6 @@ describe("getOptions", () => {
         updatedSince: fourDaysAgoMs,
       });
       expect(count).toBeGreaterThanOrEqual(1);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: recentConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: oldConvo.sId,
-      });
     });
 
     it("should include conversations updated exactly at the updatedSince timestamp", async () => {
@@ -1506,11 +1330,6 @@ describe("getOptions", () => {
       const conversationIds = conversations.map((c) => c.sId);
 
       expect(conversationIds).toContain(convo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: convo.sId,
-      });
     });
   });
 
@@ -1582,14 +1401,6 @@ describe("getOptions", () => {
       expect(idsWithDeleted).toContain(recentNormalConvo.sId);
       // oldDeletedConvo was updated 5 days ago, so it won't pass updatedSince filter
       expect(idsWithDeleted).not.toContain(oldDeletedConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: recentNormalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: oldDeletedConvo.sId,
-      });
     });
 
     it("should correctly combine updatedSince with excludeTest", async () => {
@@ -1660,14 +1471,6 @@ describe("getOptions", () => {
       expect(idsWithExclude).toContain(recentNormalConvo.sId);
       // oldTestConvo was updated 5 days ago, so it won't pass updatedSince filter
       expect(idsWithExclude).not.toContain(oldTestConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: recentNormalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: oldTestConvo.sId,
-      });
     });
 
     it("should correctly combine all options together", async () => {
@@ -1749,17 +1552,6 @@ describe("getOptions", () => {
         excludeTest: true,
       });
       expect(count).toBeGreaterThanOrEqual(1);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: recentNormalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: oldDeletedConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: oldTestConvo.sId,
-      });
     });
   });
 
@@ -1791,14 +1583,6 @@ describe("getOptions", () => {
 
       expect(normalResult).toBe("allowed");
       expect(deletedResult).toBe("conversation_not_found");
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: normalConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: deletedConvo.sId,
-      });
     });
   });
 });
@@ -1848,12 +1632,6 @@ describe("listPrivateConversationsForUser", () => {
       action: "posted",
       user: userAuth.getNonNullableUser().toJSON(),
     });
-  });
-
-  afterEach(async () => {
-    for (const sId of conversationIds) {
-      await destroyConversation(adminAuth, { conversationId: sId });
-    }
   });
 
   it("should return only conversations user participates in", async () => {
@@ -1928,8 +1706,6 @@ describe("listPrivateConversationsForUser", () => {
     expect(serializedConvs[0].updated).toBeGreaterThan(
       serializedConvs[1].updated!
     );
-
-    await destroyConversation(adminAuth, { conversationId: recentConvo.sId });
   });
 
   it("should handle empty participation list", async () => {
@@ -1970,9 +1746,6 @@ describe("listPrivateConversationsForUser", () => {
     const conversationIds = userConversations.map((c) => c.sId);
     expect(conversationIds).toContain(conversationIds[0]); // original conversation
     expect(conversationIds).not.toContain(testConvo.sId); // test conversation should be filtered out
-
-    // Clean up
-    await destroyConversation(adminAuth, { conversationId: testConvo.sId });
   });
 
   it("should return only private conversations", async () => {
@@ -2007,9 +1780,6 @@ describe("listPrivateConversationsForUser", () => {
     const privateIds = privateConversations.map((c) => c.sId);
     expect(privateIds).toContain(conversationIds[0]); // original private conversation
     expect(privateIds).not.toContain(spaceConvo.sId); // space conversation should be filtered out
-
-    // Clean up
-    await destroyConversation(adminAuth, { conversationId: spaceConvo.sId });
   });
 });
 
@@ -2083,12 +1853,6 @@ describe("listSpaceUnreadConversationsForUser", () => {
       user: userAuth.getNonNullableUser().toJSON(),
       lastReadAt: dateFromDaysAgo(10), // Mark as read
     });
-  });
-
-  afterEach(async () => {
-    for (const sId of conversationIds) {
-      await destroyConversation(adminAuth, { conversationId: sId });
-    }
   });
 
   it("should return only conversations user participates in as unreadConversations", async () => {
@@ -2212,9 +1976,6 @@ describe("listSpaceUnreadConversationsForUser", () => {
     ].map((c) => c.sId);
     expect(userConversationIds).toContain(conversationIds[0]); // original conversation
     expect(userConversationIds).not.toContain(testConvo.sId); // test conversation should be filtered out
-
-    // Clean up
-    await destroyConversation(adminAuth, { conversationId: testConvo.sId });
   });
 
   it("should return only space conversations", async () => {
@@ -2243,9 +2004,6 @@ describe("listSpaceUnreadConversationsForUser", () => {
     ].map((c) => c.sId);
     expect(spaceConversationIds).toContain(conversationIds[0]); // space conversation should be included
     expect(spaceConversationIds).not.toContain(privateConvo.sId); // private conversation should be filtered out
-
-    // Clean up
-    await destroyConversation(adminAuth, { conversationId: privateConvo.sId });
   });
 });
 
@@ -2948,15 +2706,6 @@ describe("Space Handling", () => {
       };
     });
 
-    afterEach(async () => {
-      await destroyConversation(adminAuth, {
-        conversationId: conversations.accessible,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: conversations.restricted,
-      });
-    });
-
     it("should return 'allowed' when user has access to conversation", async () => {
       const result = await ConversationResource.canAccess(
         userAuth,
@@ -3043,11 +2792,6 @@ describe("Space Handling", () => {
       );
 
       expect(result).toBe("conversation_not_found");
-
-      // Clean up
-      await destroyConversation(anotherAuth, {
-        conversationId: anotherConvo.sId,
-      });
     });
 
     it("should return 'conversation_not_found' when space is deleted", async () => {
@@ -3085,11 +2829,6 @@ describe("Space Handling", () => {
         tempConvo.sId
       );
       expect(result).toBe("conversation_not_found");
-
-      // Clean up
-      await destroyConversation(refreshedAdminAuth, {
-        conversationId: tempConvo.sId,
-      });
     });
 
     it("should handle conversations with multiple space IDs - all spaces must be accessible", async () => {
@@ -3113,11 +2852,6 @@ describe("Space Handling", () => {
         multiSpaceConvo.sId
       );
       expect(adminResult).toBe("allowed");
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: multiSpaceConvo.sId,
-      });
     });
 
     it("should return 'allowed' for conversation with no requested spaces", async () => {
@@ -3133,11 +2867,6 @@ describe("Space Handling", () => {
       );
 
       expect(result).toBe("allowed");
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: emptySpaceConvo.sId,
-      });
     });
   });
 
@@ -3162,12 +2891,6 @@ describe("Space Handling", () => {
       });
 
       conversationIds = [conversation.sId];
-    });
-
-    afterEach(async () => {
-      for (const sId of conversationIds) {
-        await destroyConversation(auth, { conversationId: sId });
-      }
     });
 
     it("should retrieve a user message with the userMessage include", async () => {
@@ -3416,12 +3139,6 @@ describe("Space Handling", () => {
       conversation = await ConversationFactory.create(ownerAuth, {
         agentConfigurationId: agents[0].sId,
         messagesCreatedAt: [dateFromDaysAgo(1)],
-      });
-    });
-
-    afterEach(async () => {
-      await destroyConversation(ownerAuth, {
-        conversationId: conversation.sId,
       });
     });
 
@@ -4162,10 +3879,6 @@ describe("markAsActionRequired", () => {
     conversationId = conversation.sId;
   });
 
-  afterEach(async () => {
-    await destroyConversation(auth, { conversationId });
-  });
-
   it("should set actionRequired to true for the user's participant", async () => {
     const { ConversationParticipantModel } = await import(
       "@app/lib/models/agent/conversation"
@@ -4363,7 +4076,6 @@ describe("markAsActionRequired", () => {
     let workspace: LightWorkspaceType;
     let space: SpaceResource;
     let agents: LightAgentConfigurationType[];
-    let conversationIds: string[];
 
     beforeEach(async () => {
       const {
@@ -4405,14 +4117,6 @@ describe("markAsActionRequired", () => {
         regularUser.sId,
         workspace.sId
       );
-
-      conversationIds = [];
-    });
-
-    afterEach(async () => {
-      for (const sId of conversationIds) {
-        await destroyConversation(adminAuth, { conversationId: sId });
-      }
     });
 
     it("should return conversations in a space", async () => {
@@ -4428,8 +4132,6 @@ describe("markAsActionRequired", () => {
         spaceId: space.id,
         messagesCreatedAt: [dateFromDaysAgo(3)],
       });
-
-      conversationIds = [convo1.sId, convo2.sId];
 
       const conversations = await ConversationResource.listConversationsInSpace(
         adminAuth,
@@ -4457,8 +4159,6 @@ describe("markAsActionRequired", () => {
         spaceId: space.id,
         messagesCreatedAt: [dateFromDaysAgo(3)],
       });
-
-      conversationIds = [convo1.sId, convo2.sId];
 
       // Delete one conversation by updating visibility directly
       await ConversationModel.update(
@@ -4491,8 +4191,6 @@ describe("markAsActionRequired", () => {
         spaceId: space.id,
         messagesCreatedAt: [dateFromDaysAgo(3)],
       });
-
-      conversationIds = [convo1.sId, convo2.sId];
 
       // Delete one conversation by updating visibility directly
       await ConversationModel.update(
@@ -4540,8 +4238,6 @@ describe("markAsActionRequired", () => {
         spaceId: space.id,
         messagesCreatedAt: [twoDaysAgo],
       });
-
-      conversationIds = [convo1.sId, convo2.sId, convo3.sId];
 
       // Set updatedAt on conversations to match their message creation times
       // Use raw SQL to ensure updatedAt is set correctly without Sequelize auto-updating it
@@ -4646,8 +4342,6 @@ describe("markAsActionRequired", () => {
         messagesCreatedAt: [dateFromDaysAgo(5)],
       });
 
-      conversationIds = [convo.sId];
-
       // Regular user should not see conversation without skip permission filtering
       const conversationsWithoutSkip =
         await ConversationResource.listConversationsInSpace(userAuth, {
@@ -4684,8 +4378,6 @@ describe("markAsActionRequired", () => {
         spaceId: space.id,
         messagesCreatedAt: [twoDaysAgo],
       });
-
-      conversationIds = [convo1.sId, convo2.sId];
 
       // Set updatedAt on conversations
       // Use fields option to explicitly specify which fields to update
@@ -4763,10 +4455,6 @@ describe("ConversationResource.isConversationCreator", () => {
       action: "posted",
       user: auth.getNonNullableUser().toJSON(),
     });
-  });
-
-  afterEach(async () => {
-    await destroyConversation(auth, { conversationId });
   });
 
   it("should return true when user is the creator (first participant)", async () => {
@@ -4915,7 +4603,6 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
   let workspace: LightWorkspaceType;
   let space: SpaceResource;
   let agents: LightAgentConfigurationType[];
-  let conversationIds: string[];
 
   const createConvoWithUpdatedAt = async (daysAgo: number) => {
     const convo = await ConversationFactory.create(adminAuth, {
@@ -4964,22 +4651,12 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
       adminUser.sId,
       workspace.sId
     );
-
-    conversationIds = [];
-  });
-
-  afterEach(async () => {
-    for (const sId of conversationIds) {
-      await destroyConversation(adminAuth, { conversationId: sId });
-    }
   });
 
   it("should return first page with hasMore: true when more results exist", async () => {
-    const convo1 = await createConvoWithUpdatedAt(5);
-    const convo2 = await createConvoWithUpdatedAt(3);
-    const convo3 = await createConvoWithUpdatedAt(1);
-
-    conversationIds = [convo1.sId, convo2.sId, convo3.sId];
+    await createConvoWithUpdatedAt(5);
+    await createConvoWithUpdatedAt(3);
+    await createConvoWithUpdatedAt(1);
 
     const result = await ConversationResource.listConversationsInSpacePaginated(
       adminAuth,
@@ -4995,9 +4672,7 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
   });
 
   it("should return hasMore: false when no more results", async () => {
-    const convo1 = await createConvoWithUpdatedAt(1);
-
-    conversationIds = [convo1.sId];
+    await createConvoWithUpdatedAt(1);
 
     const result = await ConversationResource.listConversationsInSpacePaginated(
       adminAuth,
@@ -5012,9 +4687,7 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
   });
 
   it("should return correct lastValue as timestamp string", async () => {
-    const convo1 = await createConvoWithUpdatedAt(1);
-
-    conversationIds = [convo1.sId];
+    await createConvoWithUpdatedAt(1);
 
     const expectedTimestamp = dateFromDaysAgo(1);
     const result = await ConversationResource.listConversationsInSpacePaginated(
@@ -5039,8 +4712,6 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     const convo2 = await createConvoWithUpdatedAt(3);
     const convo3 = await createConvoWithUpdatedAt(2);
     const convo4 = await createConvoWithUpdatedAt(1);
-
-    conversationIds = [convo1.sId, convo2.sId, convo3.sId, convo4.sId];
 
     // First page (newest first by default)
     const page1 = await ConversationResource.listConversationsInSpacePaginated(
@@ -5083,8 +4754,6 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
       convos.push(convo);
     }
 
-    conversationIds = convos.map((c) => c.sId);
-
     // Collect all conversations through pagination
     const allSids: string[] = [];
     let lastValue: string | undefined;
@@ -5121,8 +4790,6 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     const convo1 = await createConvoWithUpdatedAt(3);
     const convo2 = await createConvoWithUpdatedAt(1);
 
-    conversationIds = [convo1.sId, convo2.sId];
-
     const result = await ConversationResource.listConversationsInSpacePaginated(
       adminAuth,
       {
@@ -5140,8 +4807,6 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
   it("should return oldest first when orderDirection is asc", async () => {
     const convo1 = await createConvoWithUpdatedAt(3);
     const convo2 = await createConvoWithUpdatedAt(1);
-
-    conversationIds = [convo1.sId, convo2.sId];
 
     const result = await ConversationResource.listConversationsInSpacePaginated(
       adminAuth,
@@ -5201,8 +4866,6 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
   it("should respect includeDeleted option", async () => {
     const convo1 = await createConvoWithUpdatedAt(2);
     const convo2 = await createConvoWithUpdatedAt(1);
-
-    conversationIds = [convo1.sId, convo2.sId];
 
     // Delete one conversation
     await ConversationModel.update(

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.test.ts
@@ -1,4 +1,3 @@
-import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -182,10 +181,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversation_ids", () => {
     expect(data.conversationIds.length).toBeGreaterThanOrEqual(2);
     expect(data.conversationIds).toContain(convo1.sId);
     expect(data.conversationIds).toContain(convo2.sId);
-
-    // Cleanup
-    await destroyConversation(adminAuth, { conversationId: convo1.sId });
-    await destroyConversation(adminAuth, { conversationId: convo2.sId });
   });
 
   it("should exclude deleted conversations", async () => {
@@ -243,10 +238,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversation_ids", () => {
     expect(Array.isArray(data.conversationIds)).toBe(true);
     expect(data.conversationIds).toContain(convo1.sId);
     expect(data.conversationIds).not.toContain(convo2.sId); // Deleted conversation should be excluded
-
-    // Cleanup
-    await destroyConversation(adminAuth, { conversationId: convo1.sId });
-    await destroyConversation(adminAuth, { conversationId: convo2.sId });
   });
 
   it("should return empty array for space with no conversations", async () => {
@@ -293,7 +284,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversation_ids", () => {
       name: "Test Agent",
     });
 
-    const convo = await ConversationFactory.create(adminAuth, {
+    await ConversationFactory.create(adminAuth, {
       agentConfigurationId: agent.sId,
       requestedSpaceIds: [space.id],
       spaceId: space.id,
@@ -317,8 +308,5 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversation_ids", () => {
 
     // Verify no conversation objects are present
     expect(data.conversations).toBeUndefined();
-
-    // Cleanup
-    await destroyConversation(adminAuth, { conversationId: convo.sId });
   });
 });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.test.ts
@@ -1,5 +1,4 @@
 // biome-ignore-all lint/plugin/noRawSql: test file uses raw SQL for setup and verification
-import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -194,10 +193,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
     expect(firstConvo.sId).toBe(convo1.sId);
     expect(firstConvo.url).toBeDefined();
     expect(firstConvo.url).toContain(convo1.sId);
-
-    // Cleanup
-    await destroyConversation(adminAuth, { conversationId: convo1.sId });
-    await destroyConversation(adminAuth, { conversationId: convo2.sId });
   });
 
   it("should include deleted conversations", async () => {
@@ -254,10 +249,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
     const conversationSIds = data.conversations.map((c: any) => c.sId);
     expect(conversationSIds).toContain(convo1.sId);
     expect(conversationSIds).toContain(convo2.sId); // Deleted conversation should be included
-
-    // Cleanup
-    await destroyConversation(adminAuth, { conversationId: convo1.sId });
-    await destroyConversation(adminAuth, { conversationId: convo2.sId });
   });
 
   it("should filter conversations by updatedSince", async () => {
@@ -356,11 +347,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
     expect(conversationSIds).toContain(convo2.sId); // Updated 4 days ago
     expect(conversationSIds).toContain(convo3.sId); // Updated 2 days ago
     expect(conversationSIds).not.toContain(convo1.sId); // Updated 6 days ago (excluded)
-
-    // Cleanup
-    await destroyConversation(adminAuth, { conversationId: convo1.sId });
-    await destroyConversation(adminAuth, { conversationId: convo2.sId });
-    await destroyConversation(adminAuth, { conversationId: convo3.sId });
   });
 
   it("should return empty array for space with no conversations", async () => {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -240,9 +240,7 @@ async function deleteSpaceConversations(
   await concurrentExecutor(
     conversations,
     async (conversation) => {
-      const result = await destroyConversation(auth, {
-        conversationId: conversation.sId,
-      });
+      const result = await destroyConversation(auth, { conversation });
       if (result.isErr() && result.error.type !== "conversation_not_found") {
         throw result.error;
       }

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -83,16 +83,14 @@ export async function purgeConversationsBatchActivity({
     let deletedCount = 0;
     await concurrentExecutor(
       conversations,
-      async (c) => {
-        const result = await destroyConversation(auth, {
-          conversationId: c.sId,
-        });
+      async (conversation) => {
+        const result = await destroyConversation(auth, { conversation });
         if (result.isErr()) {
           if (result.error.type === "conversation_not_found") {
             logger.warn(
               {
                 workspaceId,
-                conversationId: c.sId,
+                conversationId: conversation.sId,
                 error: result.error,
               },
               "Attempting to delete a non-existing conversation."
@@ -185,9 +183,25 @@ export async function purgeAgentConversationsBatchActivity({
   await concurrentExecutor(
     conversationIds,
     async (conversationId) => {
-      const result = await destroyConversation(auth, {
+      const conversation = await ConversationResource.fetchById(
+        auth,
         conversationId,
-      });
+        {
+          dangerouslySkipPermissionFiltering: true,
+          includeDeleted: true,
+        }
+      );
+      if (!conversation) {
+        logger.warn(
+          {
+            workspaceId,
+            conversationId,
+          },
+          "Conversation not found."
+        );
+        return;
+      }
+      const result = await destroyConversation(auth, { conversation });
       if (result.isErr()) {
         if (result.error.type === "conversation_not_found") {
           logger.warn(

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -191,9 +191,7 @@ export async function deleteAllConversations(auth: Authenticator) {
   await concurrentExecutor(
     uniqueConversations,
     async (conversation) => {
-      const result = await destroyConversation(auth, {
-        conversationId: conversation.sId,
-      });
+      const result = await destroyConversation(auth, { conversation });
       if (result.isErr()) {
         if (result.error.type === "conversation_not_found") {
           logger.warn(
@@ -210,7 +208,7 @@ export async function deleteAllConversations(auth: Authenticator) {
       }
     },
     {
-      concurrency: 8,
+      concurrency: 4,
     }
   );
 }


### PR DESCRIPTION
## Description

Reduce # of operations while deleting a conversation (as DB CPU is super high during workspace deletion).
- Fix a bug in messages deletion where we we operating on all messages instead of the batch
- Remove 2 extra "SELECT" per convo when deleting all workspaces conversations.
- Lower deletion concurrency from 8 to 4

Ideally, we batch the deletion of conversation's resources instead of 1 by 1.

## Tests

Updated to remove useless clean up code, green.

## Risk

Low, worst case, the deletion will raise an error.

## Deploy Plan

Deploy front