### PR TITLE
Remove salesforce_tool_write feature flag

### DIFF
--- a/front/migrations/20260219_disable_update_object_for_existing_salesforce_instances.ts
+++ b/front/migrations/20260219_disable_update_object_for_existing_salesforce_instances.ts
@@ -3,7 +3,6 @@ import { Op } from "sequelize";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
-import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
@@ -22,21 +21,6 @@ async function disableUpdateObjectForWorkspace(
   logger: Logger,
   cutoffDate: Date
 ): Promise<{ processedCount: number }> {
-  // Skip workspaces that had the salesforce_tool_write feature flag enabled.
-  // These workspaces were already using update_object, so we should not disable it.
-  const hasWriteFlag = await FeatureFlagResource.isEnabledForWorkspace(
-    workspace,
-    "salesforce_tool_write"
-  );
-
-  if (hasWriteFlag) {
-    logger.info(
-      { workspaceId: workspace.id },
-      "Skipping workspace: salesforce_tool_write feature flag is enabled."
-    );
-    return { processedCount: 0 };
-  }
-
   // Finding all internal MCP server connections created before deployment for this workspace.
   const connections = await MCPServerConnectionModel.findAll({
     where: {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -126,10 +126,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Salesforce MCP tool (activated by default on most plans, FF to override the plan config)",
     stage: "on_demand",
   },
-  salesforce_tool_write: {
-    description: "Salesforce MCP tool: write operations (update_object)",
-    stage: "on_demand",
-  },
   show_debug_tools: {
     description: "Display debug tools in the interface",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -720,7 +720,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "restrict_agents_publishing"
   | "restrict_agents_publishing_to_admins"
   | "salesforce_synced_queries"
-  | "salesforce_tool_write"
   | "salesforce_tool"
   | "sandbox_tools"
   | "self_created_slack_app_connector_rollout"


### PR DESCRIPTION
## Description

The flag is no longer enforced — write operations work for all workspaces. Clean up the dead flag definition, SDK type, and migration reference.
This PR does not touch the `salesforce_tool` which is still available

## Tests

locally

## Risk

low

## Deploy Plan

front only
