### PR TITLE
[front] feat: add `onConflict` policy on skill import

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -266,12 +266,6 @@ async function uploadAttachment(
   return uploadResult.value;
 }
 
-function hasSourceConflict(
-  source: FileImportSource
-): (existing: SkillResource) => boolean {
-  return (existing) => existing.source !== source;
-}
-
 async function cleanupTempFiles(files: formidable.File[]): Promise<void> {
   await concurrentExecutor(files, (f) => unlink(f.filepath).catch(() => {}), {
     concurrency: 8,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -92,10 +92,7 @@ export async function importSkillsFromFiles(
   );
 
   const uniqueNames = [...new Set(selectedSkills.map((s) => s.name))];
-  const existingSkills = await SkillResource.fetchByNames(
-    auth,
-    uniqueNames
-  );
+  const existingSkills = await SkillResource.fetchByNames(auth, uniqueNames);
 
   if (onConflict === "error") {
     // Validate all skills upfront, fail as a unit on semantic problems.
@@ -108,7 +105,7 @@ export async function importSkillsFromFiles(
     if (validationResult.isErr()) {
       return validationResult;
     }
-  } 
+  }
   if (selectedSkills.length === 0) {
     return new Err(new Error("No matching importable skills found."));
   }
@@ -118,9 +115,7 @@ export async function importSkillsFromFiles(
   const updated: SkillResource[] = [];
   const skipped: { name: string; message: string }[] = [];
 
-  const existingSkillsMap = new Map(
-    existingSkills.map((s) => [s.name, s])
-  );
+  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
   await concurrentExecutor(
     selectedSkills,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -1,4 +1,5 @@
 import { uploadBase64DataToFileStorage } from "@app/lib/api/files/upload";
+import { validateSkillsForImport } from "@app/lib/api/skills/detection/validate_skills";
 import {
   createZipAttachmentReader,
   detectSkillsFromZip,
@@ -24,12 +25,17 @@ type FileImportSource = Extract<SkillSourceType, "api" | "local_file">;
 type ImportSkillsResult = {
   imported: SkillResource[];
   updated: SkillResource[];
-  errored: { name: string; message: string }[];
+  skipped: { name: string; message: string }[];
 };
 
 /**
  * Imports skills from uploaded files. Detects skills from the files,
  * uploads their attachments, then creates or updates SkillResource objects.
+ *
+ * `onConflict` controls what happens when a skill name collides with an
+ * existing skill from a different source:
+ *  - "skip": the conflicting skill is skipped and reported in `skipped`.
+ *  - "error": the entire import is rejected upfront (no partial writes).
  */
 export async function importSkillsFromFiles(
   auth: Authenticator,
@@ -37,10 +43,12 @@ export async function importSkillsFromFiles(
     uploadedFiles,
     names,
     source = "local_file",
+    onConflict = "skip",
   }: {
     uploadedFiles: formidable.File[];
     names?: string[];
     source?: FileImportSource;
+    onConflict?: "error" | "skip";
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const allSkills: ZipDetectedSkill[] = [];
@@ -75,13 +83,32 @@ export async function importSkillsFromFiles(
     }
   }
 
-  const requestedNames = names ? new Set(names) : null;
+  const requestedSet = names ? new Set(names) : null;
   const selectedSkills = allSkills.filter(
     (skill) =>
       skill.name &&
       skill.instructions.trim() &&
-      (!requestedNames || requestedNames.has(skill.name))
+      (!requestedSet || requestedSet.has(skill.name))
   );
+
+  const uniqueNames = [...new Set(selectedSkills.map((s) => s.name))];
+  const existingSkills = await SkillResource.fetchByNames(
+    auth,
+    uniqueNames
+  );
+
+  if (onConflict === "error") {
+    // Validate all skills upfront, fail as a unit on semantic problems.
+    const validationResult = validateSkillsForImport({
+      selectedSkills,
+      requestedNames: names ?? null,
+      existingSkills,
+      isConflicting: (existing) => existing.source !== source,
+    });
+    if (validationResult.isErr()) {
+      return validationResult;
+    }
+  } 
   if (selectedSkills.length === 0) {
     return new Err(new Error("No matching importable skills found."));
   }
@@ -89,15 +116,19 @@ export async function importSkillsFromFiles(
   const user = auth.user();
   const imported: SkillResource[] = [];
   const updated: SkillResource[] = [];
-  const errored: { name: string; message: string }[] = [];
+  const skipped: { name: string; message: string }[] = [];
+
+  const existingSkillsMap = new Map(
+    existingSkills.map((s) => [s.name, s])
+  );
 
   await concurrentExecutor(
     selectedSkills,
     async (skill) => {
-      const existing = await SkillResource.fetchActiveByName(auth, skill.name);
+      const existing = existingSkillsMap.get(skill.name) ?? null;
 
       if (existing && existing.source !== source) {
-        errored.push({
+        skipped.push({
           name: skill.name,
           message: `A different skill named "${skill.name}" already exists.`,
         });
@@ -106,7 +137,7 @@ export async function importSkillsFromFiles(
 
       const readEntry = readerBySkill.get(skill);
       if (!readEntry) {
-        errored.push({
+        skipped.push({
           name: skill.name,
           message: "Internal error: no zip reader for skill.",
         });
@@ -197,7 +228,7 @@ export async function importSkillsFromFiles(
     { concurrency: IMPORT_CONCURRENCY }
   );
 
-  return new Ok({ imported, updated, errored });
+  return new Ok({ imported, updated, skipped });
 }
 
 async function uploadAttachment(
@@ -238,6 +269,12 @@ async function uploadAttachment(
   }
 
   return uploadResult.value;
+}
+
+function hasSourceConflict(
+  source: FileImportSource
+): (existing: SkillResource) => boolean {
+  return (existing) => existing.source !== source;
 }
 
 async function cleanupTempFiles(files: formidable.File[]): Promise<void> {

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -28,7 +28,7 @@ const IMPORT_CONCURRENCY = 4;
 type ImportSkillsResult = {
   imported: SkillResource[];
   updated: SkillResource[];
-  errored: { name: string; message: string }[];
+  skipped: { name: string; message: string }[];
 };
 
 /**
@@ -65,18 +65,24 @@ export async function importSkillsFromGitHub(
       requestedNames.has(skill.name) && skill.name && skill.instructions.trim()
   );
 
+  const uniqueNames = [...new Set(selectedSkills.map((s) => s.name))];
+  const existingByName = await SkillResource.fetchByNames(
+    auth,
+    uniqueNames
+  );
+
   const user = auth.getNonNullableUser();
   const imported: SkillResource[] = [];
   const updated: SkillResource[] = [];
-  const errored: { name: string; message: string }[] = [];
+  const skipped: { name: string; message: string }[] = [];
 
   await concurrentExecutor(
     selectedSkills,
     async (skill) => {
-      const existing = await SkillResource.fetchActiveByName(auth, skill.name);
+      const existing = existingByName.get(skill.name) ?? null;
 
       if (existing && !isSkillFromGitHubRepo(existing, { repoUrl })) {
-        errored.push({
+        skipped.push({
           name: skill.name,
           message: `A different skill named "${skill.name}" already exists.`,
         });
@@ -174,7 +180,7 @@ export async function importSkillsFromGitHub(
     { concurrency: IMPORT_CONCURRENCY }
   );
 
-  return new Ok({ imported, updated, errored });
+  return new Ok({ imported, updated, skipped });
 }
 
 async function uploadAttachment(

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -12,6 +12,7 @@ import type {
   GitHubDetectedSkillAttachment,
   GitHubSkillDetectionError,
 } from "@app/lib/api/skills/detection/github/types";
+import { validateSkillsForImport } from "@app/lib/api/skills/detection/validate_skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -19,7 +20,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { Octokit } from "@octokit/core";
 import path from "path";
 
@@ -40,9 +41,11 @@ export async function importSkillsFromGitHub(
   {
     repoUrl,
     names,
+    onConflict = "skip",
   }: {
     repoUrl: string;
     names: string[];
+    onConflict?: "error" | "skip";
   }
 ): Promise<Result<ImportSkillsResult, GitHubSkillDetectionError>> {
   const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
@@ -67,6 +70,29 @@ export async function importSkillsFromGitHub(
 
   const uniqueNames = [...new Set(selectedSkills.map((s) => s.name))];
   const existingSkills = await SkillResource.fetchByNames(auth, uniqueNames);
+
+  if (onConflict === "error") {
+    const validationResult = validateSkillsForImport({
+      selectedSkills,
+      requestedNames: names,
+      existingSkills,
+      isConflicting: (existing: SkillResource) =>
+        !isSkillFromGitHubRepo(existing, { repoUrl }),
+    });
+    if (validationResult.isErr()) {
+      return new Err({
+        type: "validation_error",
+        message: validationResult.error.message,
+      });
+    }
+  }
+  if (selectedSkills.length === 0) {
+    return new Err({
+      type: "validation_error",
+      message: "No matching importable skills found.",
+    });
+  }
+
   const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
   const user = auth.getNonNullableUser();

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -66,10 +66,8 @@ export async function importSkillsFromGitHub(
   );
 
   const uniqueNames = [...new Set(selectedSkills.map((s) => s.name))];
-  const existingByName = await SkillResource.fetchByNames(
-    auth,
-    uniqueNames
-  );
+  const existingSkills = await SkillResource.fetchByNames(auth, uniqueNames);
+  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
   const user = auth.getNonNullableUser();
   const imported: SkillResource[] = [];
@@ -79,7 +77,7 @@ export async function importSkillsFromGitHub(
   await concurrentExecutor(
     selectedSkills,
     async (skill) => {
-      const existing = existingByName.get(skill.name) ?? null;
+      const existing = existingSkillsMap.get(skill.name) ?? null;
 
       if (existing && !isSkillFromGitHubRepo(existing, { repoUrl })) {
         skipped.push({

--- a/front/lib/api/skills/detection/github/types.ts
+++ b/front/lib/api/skills/detection/github/types.ts
@@ -10,7 +10,8 @@ export type GitHubSkillDetectionError =
   | { type: "invalid_url"; message: string }
   | { type: "auth_error"; message: string }
   | { type: "not_found"; message: string }
-  | { type: "github_api_error"; message: string };
+  | { type: "github_api_error"; message: string }
+  | { type: "validation_error"; message: string };
 
 export type GitHubFileEntry = FileEntry & {
   sha: string;

--- a/front/lib/api/skills/detection/validate_skills.ts
+++ b/front/lib/api/skills/detection/validate_skills.ts
@@ -1,0 +1,63 @@
+import type { DetectedSkill } from "@app/lib/api/skills/detection/types";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Pre-validates detected skills before any writes happen.
+ * Checks: requested names exist, no duplicates, no source conflicts.
+ * Returns the filtered list of valid skills or an Error.
+ */
+export function validateSkillsForImport<T extends DetectedSkill>({
+  selectedSkills,
+  requestedNames,
+  existingSkills,
+  isConflicting,
+}: {
+  selectedSkills: T[];
+  requestedNames: string[] | null;
+  existingSkills:  SkillResource[];
+  isConflicting: (existing: SkillResource) => boolean;
+}): Result<T[], Error> {
+  const messages: string[] = [];
+
+  if (selectedSkills.length === 0) {
+    return new Err(new Error("No matching importable skills found."));
+  }
+
+  // Check for requested names not found among detected skills.
+  if (requestedNames) {
+    const selectedNames = new Set(selectedSkills.map((s) => s.name));
+    for (const name of requestedNames) {
+      if (!selectedNames.has(name)) {
+        messages.push(`Skill "${name}" not found in the archive.`);
+      }
+    }
+  }
+
+  // Check for duplicate names within the selection.
+  const seenNames = new Set<string>();
+  const duplicateNames = new Set<string>();
+  for (const skill of selectedSkills) {
+    if (seenNames.has(skill.name)) {
+      duplicateNames.add(skill.name);
+    }
+    seenNames.add(skill.name);
+  }
+  for (const name of duplicateNames) {
+    messages.push(`Duplicate skill "${name}" in the archive.`);
+  }
+
+  // Check for source conflicts with existing skills.
+  for (const existing of existingSkills) {
+    if (isConflicting(existing)) {
+      messages.push(`A different skill named "${existing.name}" already exists.`);
+    }
+  }
+
+  if (messages.length > 0) {
+    return new Err(new Error(messages.join(" ")));
+  }
+
+  return new Ok(selectedSkills);
+}

--- a/front/lib/api/skills/detection/validate_skills.ts
+++ b/front/lib/api/skills/detection/validate_skills.ts
@@ -1,5 +1,5 @@
 import type { DetectedSkill } from "@app/lib/api/skills/detection/types";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -16,7 +16,7 @@ export function validateSkillsForImport<T extends DetectedSkill>({
 }: {
   selectedSkills: T[];
   requestedNames: string[] | null;
-  existingSkills:  SkillResource[];
+  existingSkills: SkillResource[];
   isConflicting: (existing: SkillResource) => boolean;
 }): Result<T[], Error> {
   const messages: string[] = [];
@@ -51,7 +51,9 @@ export function validateSkillsForImport<T extends DetectedSkill>({
   // Check for source conflicts with existing skills.
   for (const existing of existingSkills) {
     if (isConflicting(existing)) {
-      messages.push(`A different skill named "${existing.name}" already exists.`);
+      messages.push(
+        `A different skill named "${existing.name}" already exists.`
+      );
     }
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -788,6 +788,21 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return resources[0];
   }
 
+  static async fetchByNames(
+    auth: Authenticator,
+    names: string[]
+  ): Promise<SkillResource[]> {
+    if (names.length === 0) {
+      return new Map();
+    }
+    return this.baseFetch(auth, {
+      where: {
+        name: names,
+        status: "active",
+      },
+    });
+  }
+
   /**
    * Fetches skills from rows that reference them via customSkillId or globalSkillId.
    */

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -793,7 +793,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     names: string[]
   ): Promise<SkillResource[]> {
     if (names.length === 0) {
-      return new Map();
+      return [];
     }
     return this.baseFetch(auth, {
       where: {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -441,7 +441,7 @@ function notifyImportResult(
   const importedCount = data.imported.length;
   const updatedCount = data.updated.length;
   const successCount = importedCount + updatedCount;
-  const errors = data.errored.map((e) => e.message);
+  const errors = data.skipped.map((e) => e.message);
 
   if (successCount > 0) {
     const parts: string[] = [];

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -436,12 +436,12 @@ function notifyImportResult(
   sendNotification: ReturnType<typeof useSendNotification>
 ): {
   successCount: number;
-  errors: string[];
+  skipped: string[];
 } {
   const importedCount = data.imported.length;
   const updatedCount = data.updated.length;
   const successCount = importedCount + updatedCount;
-  const errors = data.skipped.map((e) => e.message);
+  const skipped = data.skipped.map((e) => e.message);
 
   if (successCount > 0) {
     const parts: string[] = [];
@@ -451,8 +451,8 @@ function notifyImportResult(
     if (updatedCount > 0) {
       parts.push(`${updatedCount} skill${pluralize(updatedCount)} updated`);
     }
-    if (errors.length > 0) {
-      parts.push(`${errors.length} skill${pluralize(errors.length)} failed`);
+    if (skipped.length > 0) {
+      parts.push(`${skipped.length} skill${pluralize(skipped.length)} skipped`);
     }
     sendNotification({
       type: "success",
@@ -463,11 +463,11 @@ function notifyImportResult(
     sendNotification({
       type: "error",
       title: "Import failed",
-      description: errors[0] ?? "Failed to import skills.",
+      description: skipped[0] ?? "Failed to import skills.",
     });
   }
 
-  return { successCount, errors };
+  return { successCount, skipped };
 }
 
 export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -73,6 +73,7 @@ async function handler(
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
     source: "api",
+    onConflict: "error",
   });
   if (result.isErr()) {
     return apiError(req, res, {
@@ -87,7 +88,7 @@ async function handler(
   return res.status(200).json({
     imported: result.value.imported.map((skill) => skill.toJSON(auth)),
     updated: result.value.updated.map((skill) => skill.toJSON(auth)),
-    errored: result.value.errored,
+    skipped: result.value.skipped,
   });
 }
 

--- a/front/pages/api/w/[wId]/skills/detect/index.ts
+++ b/front/pages/api/w/[wId]/skills/detect/index.ts
@@ -117,6 +117,14 @@ async function handler(
                 message: error.message,
               },
             });
+          case "validation_error":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
           default:
             assertNever(error);
         }

--- a/front/pages/api/w/[wId]/skills/import/index.ts
+++ b/front/pages/api/w/[wId]/skills/import/index.ts
@@ -111,6 +111,14 @@ async function handler(
                 message: error.message,
               },
             });
+          case "validation_error":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
           default:
             assertNever(error);
         }

--- a/front/pages/api/w/[wId]/skills/import/index.ts
+++ b/front/pages/api/w/[wId]/skills/import/index.ts
@@ -24,7 +24,7 @@ export type ImportSkillsRequestBody = t.TypeOf<
 export type ImportSkillsResponseBody = {
   imported: SkillType[];
   updated: SkillType[];
-  errored: { name: string; message: string }[];
+  skipped: { name: string; message: string }[];
 };
 
 async function handler(
@@ -119,7 +119,7 @@ async function handler(
       return res.status(200).json({
         imported: result.value.imported.map((skill) => skill.toJSON(auth)),
         updated: result.value.updated.map((skill) => skill.toJSON(auth)),
-        errored: result.value.errored,
+        skipped: result.value.skipped,
       });
     }
 

--- a/front/pages/api/w/[wId]/skills/import/upload.ts
+++ b/front/pages/api/w/[wId]/skills/import/upload.ts
@@ -102,7 +102,7 @@ async function handler(
       return res.status(200).json({
         imported: result.value.imported.map((skill) => skill.toJSON(auth)),
         updated: result.value.updated.map((skill) => skill.toJSON(auth)),
-        errored: result.value.errored,
+        skipped: result.value.skipped,
       });
     }
 


### PR DESCRIPTION
## Description

- This PR adds an `onConflict` policy on skill import.
- The needs comes from the addition of a public API endpoint, where the expected behavior is slightly different: we'll error and only do either exhaustive imports or none at all, compared to the web app where we'll allow partial imports, flagging skipped skills in the UI.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
