### PR TITLE
feat: unread indicator in projects show more button

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -664,12 +664,26 @@ export function AgentSidebarMenu({
     const projectCountInSummary = summary.length;
     const showCount = isProjectsSectionCollapsed && projectCountInSummary > 0;
 
+    const VISIBLE_PROJECTS = 4;
+    const hiddenSummary = summary.slice(VISIBLE_PROJECTS);
+    const hiddenOverflowCount = hiddenSummary.reduce(
+      (sum, s) => sum + s.unreadConversations.length,
+      0
+    );
+    const hiddenOverflowHasActivity = hiddenSummary.some(
+      (s) =>
+        s.unreadConversations.length > 0 ||
+        s.nonParticipantUnreadConversations.length > 0
+    );
+
     return (
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection
           label={showCount ? `Projects (${projectCountInSummary})` : "Projects"}
           type="collapse"
-          visibleItems={4}
+          visibleItems={VISIBLE_PROJECTS}
+          overflowCount={hiddenOverflowCount}
+          overflowHasActivity={hiddenOverflowHasActivity}
           open={!isProjectsSectionCollapsed}
           onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
           action={

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -338,6 +338,10 @@ interface NavigationListCollapsibleSectionProps
   children: React.ReactNode;
   /** Number of children to show when partially collapsed. undefined = show all (current behavior). */
   visibleItems?: number;
+  /** Count badge to show on the "Show all" button (e.g. total mentions in hidden items). */
+  overflowCount?: number;
+  /** Whether to bold the "Show all" button label (e.g. when hidden items have unread activity). */
+  overflowHasActivity?: boolean;
 }
 
 const collapseableStyles = cva(
@@ -388,6 +392,8 @@ const NavigationListCollapsibleSection = React.forwardRef<
       open,
       onOpenChange,
       visibleItems,
+      overflowCount,
+      overflowHasActivity,
       ...props
     },
     ref
@@ -461,6 +467,11 @@ const NavigationListCollapsibleSection = React.forwardRef<
                   icon={ChevronDownIcon}
                   variant="ghost-secondary"
                   label="Show all"
+                  isCounter={overflowCount !== undefined && overflowCount > 0}
+                  counterValue={String(overflowCount)}
+                  className={
+                    overflowHasActivity ? "[&>div]:s-font-bold" : undefined
+                  }
                   onClick={() => setIsShowingAll(true)}
                 />
               )}


### PR DESCRIPTION
## Description

This PR adds an unread activity indicator to the "Show all" button in the projects sidebar section.

- Displays a counter badge on the "Show all" button showing the number of unread conversations (with mentions) in collapsed projects
- Bolds the "Show all" button label when any hidden projects have unread activity

<img width="317" height="351" alt="Capture d’écran 2026-03-31 à 12 18 35" src="https://github.com/user-attachments/assets/275cf60f-ee83-4a2c-b72e-ff528b72ffc3" />


## Tests

Manually

## Risk

Low. This is a UI-only enhancement that adds visual indicators without changing existing functionality.

## Deploy Plan

Standard deployment - no special considerations needed.
