### PR TITLE
[BYOK] Fix BYOK_TRANSITIONING plan typo and whitelist all providers

### DIFF
--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -1,7 +1,7 @@
 import config from "@app/lib/api/config";
 
 import type { Authenticator } from "@app/lib/auth";
-import { isByokTransitionningPlan } from "@app/lib/plans/plan_codes";
+import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import {
@@ -22,7 +22,7 @@ const BYOK_TRANSITION_BYOK_KEYS_RATIO = 0.2; // 20%
  *
  * - Non-BYOK workspaces: returns Dust-managed keys from environment variables.
  * - BYOK workspaces: resolves customer-provided keys from OAuth credentials.
- *   - For BYOK_TRANSITIONNING plan, fallback on Dust-managed keys if customer keys are not provided.
+ *   - For BYOK_TRANSITIONING plan, fallback on Dust-managed keys if customer keys are not provided.
  *   - For all others, do not fallback.
  *
  * `OPENAI_EMBEDDING_API_KEY` is set separately from `OPENAI_API_KEY` so Dust apps
@@ -81,7 +81,7 @@ export async function getLlmCredentials(
     await ProviderCredentialResource.listByWorkspace(auth);
 
   // Use healthy keys only and fallback on Dust keys for this specific plan only
-  if (isByokTransitionningPlan(plan)) {
+  if (isByokTransitioningPlan(plan)) {
     const healthyCredentials = mapOauthCredentialsToLlmCredentials(
       providerCredentials
         .filter(({ isHealthy }) => isHealthy)

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -61,6 +61,9 @@ export function getWhitelistedProviders(
     return whiteListedProviders;
   }
 
+  // For BYOK_TRANSITIONING workspaces, we fall back on Dust-managed keys for BYOK providers when
+  // the customer hasn't configured their own. Whitelist all BYOK providers so they remain available
+  // even if not yet configured.
   if (isByokTransitioningPlan(plan)) {
     const allByokProviderIds = new Set<ModelProviderIdType>(
       BYOK_MODEL_PROVIDER_IDS

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
+  isByokTransitioningPlan,
   isDustCompanyPlan,
   isEntreprisePlanPrefix,
   isUpgraded,
@@ -22,6 +23,7 @@ import {
   GPT_5_MINI_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
 import {
+  BYOK_MODEL_PROVIDER_IDS,
   isByokProviderId,
   MODEL_PROVIDER_IDS,
 } from "@app/types/assistant/models/providers";
@@ -57,6 +59,15 @@ export function getWhitelistedProviders(
 
   if (!plan.isByok) {
     return whiteListedProviders;
+  }
+
+  if (isByokTransitioningPlan(plan)) {
+    const allByokProviderIds = new Set<ModelProviderIdType>(
+      BYOK_MODEL_PROVIDER_IDS
+    );
+    allByokProviderIds.add("noop");
+
+    return allByokProviderIds;
   }
 
   const providersHealth = auth.providersHealth();

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -13,7 +13,7 @@ export const PRO_PLAN_LARGE_FILES_CODE = "PRO_PLAN_LARGE_FILES";
 export const PRO_PLAN_SEAT_39_CODE = "PRO_PLAN_SEAT_39";
 
 // BYOK plan:
-export const FREE_BYOK_TRANSITIONNING_PLAN_CODE = "FREE_BYOK_TRANSITIONNING";
+export const FREE_BYOK_TRANSITIONING_PLAN_CODE = "FREE_BYOK_TRANSITIONING";
 export const FREE_BYOK_PLAN_CODE = "FREE_BYOK";
 
 /**
@@ -57,8 +57,8 @@ export function isProPlan(plan?: PlanType) {
   );
 }
 
-export const isByokTransitionningPlan = (plan?: PlanType) =>
-  plan?.code === FREE_BYOK_TRANSITIONNING_PLAN_CODE;
+export const isByokTransitioningPlan = (plan?: PlanType) =>
+  plan?.code === FREE_BYOK_TRANSITIONING_PLAN_CODE;
 
 export function isBusinessPlan(plan?: PlanType) {
   return plan?.code === PRO_PLAN_SEAT_39_CODE;

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -145,6 +145,7 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
+    metronomePackageAlias: null,
   });
 }
 

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -1,7 +1,7 @@
 import { PlanModel } from "@app/lib/models/plan";
 import {
   FREE_BYOK_PLAN_CODE,
-  FREE_BYOK_TRANSITIONNING_PLAN_CODE,
+  FREE_BYOK_TRANSITIONING_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
@@ -119,7 +119,7 @@ if (isDevelopment() || isTest()) {
     metronomePackageAlias: null,
   });
   PRO_PLANS_DATA.push({
-    code: FREE_BYOK_TRANSITIONNING_PLAN_CODE,
+    code: FREE_BYOK_TRANSITIONING_PLAN_CODE,
     name: "Free (BYOK Transitioning)",
     maxMessages: -1,
     maxMessagesTimeframe: "lifetime",


### PR DESCRIPTION
## Description

Fixes a typo in the `BYOK_TRANSITIONNING` plan code (double `N` → `BYOK_TRANSITIONING`) introduced in the previous PR, renames the associated constant and helper accordingly. Also whitelists all BYOK providers for the `BYOK_TRANSITIONING` plan so transitioning workspaces can see and use all available providers.

## Tests

Tested manually in dev environment.

## Risk

Low — the typo fix is a rename of a constant and its helper; the plan code string itself was already fixed in the previous PR. The provider whitelisting only affects `BYOK_TRANSITIONING` workspaces.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`